### PR TITLE
Add a default adress if no ip is available in http header

### DIFF
--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -653,4 +653,7 @@ def get_client_ip(request):
         ip = x_forwarded_for.split(',')[0]
     else:
         ip = request.META.get('HTTP_X_REAL_IP')
+        if not ip:
+            #Houston, we have a problem
+            ip = "0.0.0.0"
     return ip


### PR DESCRIPTION
get_client_ip() must always return an ip otherwise save can not be complete and the db will be corrupt.

In this case, a trash ip, easy to recognize, is used instead.
