### PR TITLE
Extended markdown first iteration

### DIFF
--- a/fixtures/forums.yaml
+++ b/fixtures/forums.yaml
@@ -13,6 +13,11 @@
     fields:
         title: Développement Mobile
         slug: developpement-mobile
+-   model: forum.Category
+    pk: 4
+    fields:
+        title: Communauté
+        slug: communaute
 -   model: forum.Forum
     pk: 1
     fields:
@@ -90,3 +95,10 @@
         subtitle: Apprendre d'autres trucs moins cools
         category: 3
         slug: autres
+-   model: forum.Forum
+    pk: 12
+    fields:
+        title: Discussions générales
+        subtitle: Discutez de tout !
+        category: 4
+        slug: discussions-generales

--- a/fixtures/topics.yaml
+++ b/fixtures/topics.yaml
@@ -24,6 +24,14 @@
         author: 3
         pubdate: 2013-12-21T13:20:30+00:00
         last_message: 4
+-   model: forum.Topic
+    pk: 4
+    fields:
+        title: Rédiger sur ZesteDeSavoir
+        forum: 12
+        author: 3
+        pubdate: 2014-01-05T18:20:30+00:00
+        last_message: 5
 -   model: forum.Post
     pk: 1
     fields:
@@ -63,4 +71,181 @@
         like: 0
         dislike: 0
         pubdate: 2013-12-21T13:20:30+00:00
+        position_in_topic: 1
+-   model: forum.Post
+    pk: 5
+    fields:
+        topic: 4
+        author: 3
+        text: "Zeste de Savoir utilise un langage de formatage de\
+    \ texte tr\xE8s proche du Markdown, auquel ont \xE9t\xE9 ajout\xE9s quelques extensions\
+    \ courantes. Ce langage est utilis\xE9 sur ZdS pour \xE9crire les tutoriels, les\
+    \ articles, les messages de forums ou MP, etc.\n\nOn ne pr\xE9sente plus le Markdown,\
+    \ ce langage de formatage alliant la simplicit\xE9 d'\xE9criture \xE0 la facilit\xE9\
+    \ de lecture. Sa syntaxe tr\xE8s l\xE9g\xE8re permet en effet de lire du simple\
+    \ texte de fa\xE7on presque aussi agr\xE9able que s'il \xE9tait r\xE9ellement\
+    \ mis en forme. Mais aussi pratique soit le Markdown, il ne permet pas de tout\
+    \ baliser. Les indices et exposants par exemple, n'ont pas de repr\xE9sentations\
+    \ Markdown. Il existe donc des extensions permettant de compl\xE9ter le Markdown\
+    \ natif. Certaines de ces extensions, tr\xE8s courantes, ont \xE9t\xE9 reprises\
+    \ sur ZdS, d'autres ont \xE9t\xE9 sp\xE9cifiquement impl\xE9ment\xE9es pour r\xE9\
+    pondre aux besoins pr\xE9cis de ZdS. Nous vous pr\xE9sentons donc ici les syntaxes\
+    \ utilisables sur ZdS.\n\n# Mise en forme de texte classique\n\n## Paragraphes\n\
+    \nLes paragraphes s'\xE9crivent naturellement, en sautant une ligne :\n\n```text\n\
+    Ceci est mon premier paragraphe.\n\nCeci est mon second paragraphe.\n```\n\nContrairement\
+    \ au Markdown standard, un retour \xE0 la ligne au sein d'un paragraphe sera bel\
+    \ et bien vu comme un retour \xE0 la ligne (et non pas comme un simple espace)\
+    \ :\n\n```text\nCeci est mon premier paragraphe.\nIci je reviens \xE0 la ligne,\
+    \ je suis toujours dans le premier paragraphe.\n\nCeci est mon second paragraphe.\n\
+    ```\n\nBref, \xE9crivez vos paragraphes naturellement.\n\nDe plus, le Markdown\
+    \ standard autorise l'insertion de HTML, mais pour des raisons de s\xE9curit\xE9\
+    \ nous avons choisi de ne pas laisser cette possibilit\xE9. Si vous \xE9crivez\
+    \ du HTML, celui-ci apparaitra donc tel quel dans votre texte.\n\n## Titres\n\n\
+    Les titres se font en pr\xE9c\xE9dent le texte d'un ou plusieurs croisillons selon\
+    \ leur niveau hi\xE9rarchique. Ainsi un titre de premier niveau s'\xE9crit avec\
+    \ un seul croisillon, un titre de deuxi\xE8me niveau avec deux croisillons, etc.\n\
+    \n```text\n# Titre de niveau 1\n\n## Titre de niveau 2\n\n### Titre de niveau\
+    \ 3\n\n#### Titre de niveau 4\n\n##### Titre de niveau 5\n\n###### Titre de niveau\
+    \ 6\n```\n\nSix niveaux hi\xE9rarchiques sont possibles. J'attire d'ailleurs votre\
+    \ attention sur ce point car il est tr\xE8s important de donner la bonne hi\xE9\
+    rarchie \xE0 vos titres lorsque vous r\xE9digerez vos tutoriels.\n\n## Emphases\n\
+    \nLes emphases permettent de mettre un morceau de votre texte en valeur. Deux\
+    \ types d'emphases sont disponibles : l'italique et le gras.\n\nPour mettre du\
+    \ texte en *italique*, utilisez l'ast\xE9risque ou le soulign\xE9 (*underscore*)\
+    \ :\n\n```text\nLe mot *italique* est en italique.\n```\n\nou\n\n```text\nLe mot\
+    \ _italique_ est en italique.\n```\n\n[[attention]]\n| Si la syntace avec underscore\
+    \ est utilis\xE9e en milieu de mot, alors le texte ne sera pas transform\xE9.\
+    \ Ainsi `truc_bidule_mush` ne sera pas transform\xE9 alors que `truc*bidule*mush`\
+    \ le sera. La raison tient du fait que les expressions avec des underscores sont\
+    \ communes en informatique comme Mon_super_nom_de_fichier.txt par exemple.\n\n\
+    Pour mettre du texte en **gras** le principe est le m\xEAme, en doublant le symbole\
+    \ :\n\n```text\nLe mot **gras** est en gras.\n```\n\nou\n\n```text\nLe mot __gras__\
+    \ est en gras.\n```\n\nPar soucis de simplicit\xE9 et de lisibilit\xE9, vous ne\
+    \ pourrez pas mettre du texte en couleur, le souligner ou bien en changer la police.\n\
+    \n## Barrer\n\nBarrer du texte (~~comme ceci~~) se fait en utilisant deux tildes\
+    \ successifs avant et apr\xE8s la portion de texte concern\xE9e :\n\n```text\n\
+    Le mot ~~barr\xE9~~ est barr\xE9.\n```\n\nPour information, il s'agit de la syntaxe\
+    \ utilis\xE9e par Pandoc.\n\n## Alignement du texte\n\nPar d\xE9faut, le texte\
+    \ est bien \xE9videmment align\xE9 \xE0 gauche. Pour le centrer, on l'entoure\
+    \ de deux petites fl\xE8ches (tiret et chevron) de directions invers\xE9es :\n\
+    \n```text\n-> Ce texte est centr\xE9. <- \n```\n\nPour l'aligner \xE0 droite,\
+    \ on utilise deux fl\xE8ches dirig\xE9es vers la droite :\n\n```text\n-> Ce texte\
+    \ est align\xE9 \xE0 droite. -> \n```\n\nEnfin, sachez qu'il est impossible de\
+    \ justifier du texte sur ZdS.\n\n## Indices et exposants\n\nL\xE0 encore, ce sont\
+    \ les syntaxes de Pandoc qui sont utilis\xE9es pour mettre en indice ou en exposant\
+    \ une portion de texte.\n\nOn utilise l'accent circonflexe pour l'exposant. Si\
+    \ par exemple on veut \xE9crire que 2^10^ vaut 1024, alors on \xE9crira :\n\n\
+    ```text\n2^10^ vaut 1024.\n```\n\nPour l'indice, comme dans H~2~O par exemple,\
+    \ on utilise cette fois le tilde :\n\n```text\nLa mol\xE9cule de l'eau est H~2~O.\n\
+    ```\n\n# Mise en forme avanc\xE9e\n\n## Citations\n\nLes citations permettent\
+    \ de s\xE9parer votre propos de celui que vous rapporter. D'ailleurs, si l'on\
+    \ en croit ce vieux proverbe nous venant d'une petite plan\xE8te quelque part\
+    \ aux confins de B\xE9telgeuse, il ne faut pas s'en priver :\n\n> Les citations,\
+    \ c'est bien.\n\nOn utilise pour cela un chevron devant chaque d\xE9but de ligne\
+    \ :\n\n```text\n> Ceci est une citation\n> sur plusieurs lignes\n```\n\n## Abr\xE9\
+    viations\n\nIl est souvent utile de pr\xE9ciser la signification d'une abr\xE9\
+    viation (notamment d'un acronyme ou d'un sigle), sans toutefois la faire figurer\
+    \ dans le corps du texte. En utilisant la syntaxe suivante, la signification appara\xEE\
+    tra au passage de la souris sur l'abr\xE9viation :\n\n```text\nBienvenue sur ZdS\
+    \ !\n\n*[ZdS]: Zeste de Savoir\n```\n\nBienvenue, donc, sur ZdS !\n\n*[ZdS]: Zeste\
+    \ de Savoir\n\n## Notes de bas de pages\n\nToujours dans l'id\xE9e d'enrichir\
+    \ votre texte[^enrich], vous pouvez utiliser des notes de base de page :\n\n[^enrich]:\
+    \ Sans pour autant l'alourdir.\n\n```text\nMarkdown[^mdown] est une syntaxe l\xE9\
+    g\xE8re d'\xE9criture de documents. Pandoc[^pandoc] est un convertisseur de documents.\n\
+    \n[^mdown]: Plus d'informations sur [Markdown](http://daringfireball.net/projects/markdown/).\n\
+    \n[^pandoc]: Plus d'informations sur [Pandoc](http://johnmacfarlane.net/pandoc/).\n\
+    ```\n\nLes notes sont alors num\xE9rot\xE9es automatiquement. Vous n'avez \xE0\
+    \ vous soucier que du nom que vous donner \xE0 votre note.\n\n## Tableaux et lignes\n\
+    \nPour faire un tableau, la fa\xE7on la plus simple est encore de le dessiner,\
+    \ \xE0 l'aide de barres verticales et de tirets :\n\n```text\nNom     |   Age\n\
+    ------|-----\nFred |   39\nSam |   38\nAlice  |   35\nMathilde  | 35\n```\n\n\
+    L'exemple ci-dessus donnera donc :\n\nNom     |   Age\n------|-----\nFred |  \
+    \ 39\nSam |   38\nAlice  |   35\nMathilde  | 35\n\n\n----\n\nDe la m\xEAme fa\xE7\
+    on, pour faire une ligne horizontale comme ci-dessus, dessinez-l\xE0 en utilisant\
+    \ (au moins) trois tirets :\n\n```\n------\n```\n\n## Formules math\xE9matiques\n\
+    \nUne formule math\xE9matique s'\xE9crit \xE0 l'aide d'expressions TeX Math, en\
+    \ l'entourant de caract\xE8res dollars `$` :\n\n```text\n$a \\cdot x^2 + b \\\
+    cdot x + c = 0 \\quad \\Longrightarrow \\quad x = \frac {-b \\pm \\sqrt{b^2 -\
+    \ 4ac}}{2a}$\n```\n\nCe qui donne :\n\n$a \\cdot x^2 + b \\cdot x + c = 0 \\quad\
+    \ \\Longrightarrow \\quad x = \frac {-b \\pm \\sqrt{b^2 - 4ac}}{2a}$\n\n# Liens\
+    \ et emails\n\nIl existe deux fa\xE7ons d'\xE9crire des liens : avec ou sans texte\
+    \ d'ancrage.\n\n## Liens avec texte d'ancrage\n\nPour faire un [lien](http://www.zestedesavoir.com\
+    \ \"Zeste de Savoir\") sur un morceau de texte (qu'on appelle donc texte d'ancrage,\
+    \ ici le mot \"lien\"), on utilise la syntaxe suivante :\n\n```text\nPour faire\
+    \ un [lien](http://www.zestedesavoir.com \"Zeste de Savoir\") sur un morceau de\
+    \ texte\n```\n\nAttention \xE0 ne pas mettre d'espace entre la partie concernant\
+    \ le texte d'ancrage (entre crochets) et la partie concernant l'URL (entre parenth\xE8\
+    ses).\n\nLe titre du lien (ici \"Zeste de Savoir\" entre guillemets) est optionnel.\
+    \ S'il est renseign\xE9, il appara\xEEt sur le lien au passage de la souris.\n\
+    \n## Liens pr\xE9sent\xE9s sous forme d'URL\n\nSi vous ne souhaitez pas utiliser\
+    \ de texte d'ancrage et ainsi rendre une URL cliquable, alors vous n'avez rien\
+    \ \xE0 faire : une URL sera automatiquement cliquable.\n\n## Emails\n\nLes emails\
+    \ peuvent s'\xE9crire de la m\xEAme fa\xE7on que les liens. Pensez simplement\
+    \ \xE0 ajouter la mention \"mailto:\" :\n\n```text\nPour nous contacter, cliquez\
+    \ [ici](mailto:contact@monsite.com).\n```\n\nVous pouvez \xE9galement entourer\
+    \ l'email de chevrons pour le rendre cliquable :\n\n```text\nPour nous contacter\
+    \ : <contact@monsite.com>\n```\n\n# Listes\n\nVous pouvez utiliser deux types\
+    \ de liste :\n\n- les listes non ordonn\xE9es (comme la pr\xE9sente) ;\n- les\
+    \ listes ordonn\xE9es par chiffres arabes.\n\nC'est peut-\xEAtre la syntaxe la\
+    \ plus intuitive du Markdown ! Il suffit de mat\xE9rialiser les puces par des\
+    \ tirets :\n\n```text\n- Ma tr\xE8s belle ;\n- liste ;\n- \xE0 puces.\n```\n\n\
+    Ou bien par des chiffres :\n\n```text\n1. Mon premier.\n2. Mon second.\n3. Mon\
+    \ troisi\xE8me.\n```\nPrenez simplement garde \xE0 bien sauter une ligne **avant\
+    \ et apr\xE8s** vos listes.\n\nLa syntaxe est tellement naturelle que je ne vous\
+    \ ferai pas l'affront de mettre des exemples.\n\n# Code\n\n## Bloc de code\n\n\
+    Il n'est pas rare d'illustrer son propos d'un petit exemple de code :\n\n```\n\
+    #!/usr/bin/env python3\n\nprint(\"Hello, World!\")\n```\n\nPour cela, il existe\
+    \ plusieurs solutions.\n\nPremi\xE8re solution : entourer votre code de, au moins,\
+    \ trois accents graves (```) ou de trois tildes (~~~), avant et apr\xE8s : \n\n\
+    ````text\n```\n#!/usr/bin/env python3\n\nprint(\"Hello, World!\")\n```\n````\n\
+    \nou\n\n````text\n~~~\n#!/usr/bin/env python3\n\nprint(\"Hello, World!\")\n~~~\n\
+    ````\n\nLe langage utilis\xE9 sera d\xE9tect\xE9 automatiquement et donc color\xE9\
+    \ en cons\xE9quence. Si tel n'est pas le cas, vous pouvez forcer le langage en\
+    \ l'indiquant \xE0 la suite des caract\xE8res ouvrant :\n\n````text\n~~~{.python}\n\
+    #!/usr/bin/env python3\n\nprint(\"Hello, World!\")\n~~~\n````\n\nou \n\n````text\n\
+    ~~~.python\n#!/usr/bin/env python3\n\nprint(\"Hello, World!\")\n~~~\n````\n\n\n\
+    ou \n\n````text\n```python\n#!/usr/bin/env python3\n\nprint(\"Hello, World!\"\
+    )\n```\n````\n\nSeconde solution, faites pr\xE9c\xE9der chaque ligne de quatre\
+    \ espaces ou bien d'une tabulation :\n\n````text\n    #!/usr/bin/env python3\n\
+    \    \n    print(\"Hello, World!\")\n````\n\nPour forcer le langage, utilisez\
+    \ cette fois trois symboles de deux points de suite :\n\n````text\n    :::python\n\
+    \    #!/usr/bin/env python3\n    \n    print(\"Hello, World!\")\n````\n\nA noter\
+    \ qu'actuellement, seule cette syntaxe fonctionne pour imbriquer un bloc de code\
+    \ \xE0 l'int\xE9rieur d'un autre bloc (une citation par exemple) d\xFB \xE0 des\
+    \ limitations du parseur markdown utilis\xE9, mais nous sommes dessus !\n\n##\
+    \ Code inline\n\nEnfin, si vous souhaitez ins\xE9rer un petit \xE9l\xE9ment de\
+    \ code dans votre phrase (comme `print` par exemple), alors un seul accent grave\
+    \ autour du mot suffira :\n\n```text\ncomme `print` par exemple\n```\n\n# M\xE9\
+    dias\n\n## Images\n\nL'insertion d'une image ressemble \xE0 celle d'un lien, \xE0\
+    \ ceci pr\xE8s que le texte d'ancrage doit \xEAtre remplac\xE9 par un texte alternatif\
+    \ :\n\n```text\n![Logo Creative Commons](http://mirrors.creativecommons.org/presskit/logos/cc.logo.png)\n\
+    ```\n\nLe texte alternatif **doit** \xEAtre renseign\xE9. Il sert \xE0 apporter\
+    \ la m\xEAme information que l'image si celle-ci ne peut \xEAtre charg\xE9e ou\
+    \ bien ne peut \xEAtre vue (notamment pour les synth\xE9tiseurs vocaux pour les\
+    \ non-voyants).\n\n## Vid\xE9os\n\nPour ins\xE9rer une vid\xE9o h\xE9berg\xE9\
+    e chez YouTube, Dailymotion ou encore Vimeo, indiquez simplement son URL dans\
+    \ un paragraphe \xE0 part. Le bloc vid\xE9o correspondant sera alors automatiquement\
+    \ charg\xE9.\n\n```text\nhttp://www.youtube.com/watch?v=oavMtUWDBTM\n```\n\nproduira\
+    \ :\n\nhttp://www.youtube.com/watch?v=oavMtUWDBTM\n\n\n# Sp\xE9cifique ZdS\n\n\
+    Certains \xE9l\xE9ments de mise en forme sont sp\xE9cifique \xE0 ZdS. Il aura\
+    \ tout de m\xEAme fallu les impl\xE9menter, voici donc leur syntaxe.\n\n## Touches\n\
+    \nPour repr\xE9senter une touche, utilisez deux barres verticales avant et apr\xE8\
+    s le nom de la touche :\n\n```\nUtilisez ||Ctrl|| + ||C|| pour copier.\n```\n\n\
+    Vous pouvez bien s\xFBr mettre ||ce que vous voulez|| comme nom de touche.\n\n\
+    ## Balises attention, erreur, information, question et secret\n\nLes tutoriels\
+    \ et articles de ZdS sont parsem\xE9s de balises telles que la balise \"information\"\
+    \ :\n\n[[information]]\n| Ceci est une balise d'information.\n|\n| Cool, non ?\n\
+    \nElle se fait avec la syntaxe suivante :\n\n```text\n[[information]]\n| Ceci\
+    \ est une balise d'information.\n|\n| Cool, non ?\n```\n\nOu dans sa version raccourcie\
+    \ :\n\n```text\n[[i]]\n| Ceci est une balise d'information.\n|\n| Cool, non ?\n\
+    ```\n\nLes balises disponibles sont : \n\n- attention\n- erreur\n- information\n\
+    - question\n- secret\n\nLa balise \"secret\" (appel\xE9e \"spoiler\" sur certains\
+    \ sites) a pour effet de masquer son contenu par d\xE9faut et de ne le rendre\
+    \ visible qu'au clic :\n\n[s]\n| Ceci est un secret.\n\n# Caract\xE8res r\xE9\
+    serv\xE9s\n\nSi vous avez besoin d'\xE9crire un caract\xE8re r\xE9serv\xE9 entrant\
+    \ en conflit avec l'une des syntaxes d\xE9crites ici (l'ast\xE9risque par exemple),\
+    \ vous pouvez le faire en le pr\xE9c\xE9dent d'un antislash : `\\*`\n\n"
+        like: 1337
+        dislike: 0
+        pubdate: 2014-01-05T18:20:30+00:00
         position_in_topic: 1

--- a/fixtures/topics.yaml
+++ b/fixtures/topics.yaml
@@ -37,7 +37,7 @@
     fields:
         topic: 1
         author: 3
-        text: Bonjour<br />Je ne comprends pas pourquoi il y a une guerre entre Android et iOS alors que Android est supérieur.<br />Merci pour vos réponses.
+        text: "Bonjour\nJe ne comprends pas pourquoi il y a une guerre entre Android et iOS alors que Android est supérieur.\nMerci pour vos réponses."
         like: 42
         dislike: 0
         pubdate: 2013-12-21T13:20:30+00:00
@@ -47,7 +47,7 @@
     fields:
         topic: 2
         author: 3
-        text: Bonjour<br />Je ne comprends pas les choix technologiques faits pour ZdS.<br />Pourquoi ne pas avoir développé le site avec Symfony comme OpenClassrooms ?<br />Merci de vos réponses.
+        text: "Bonjour\nJe ne comprends pas les choix technologiques faits pour ZdS.\nPourquoi ne pas avoir développé le site avec Symfony comme OpenClassrooms ?\nMerci de vos réponses."
         like: 3
         dislike: 12
         pubdate: 2013-12-21T13:20:30+00:00
@@ -67,7 +67,7 @@
     fields:
         topic: 3
         author: 3
-        text: Bonjour<br />Je ne comprends pas pourquoi il y a encore des développeurs JS alors qu'il existe jQuery...<br />Des éclaircissements ?
+        text: "Bonjour\nJe ne comprends pas pourquoi il y a encore des développeurs JS alors qu'il existe jQuery...\nDes éclaircissements ?"
         like: 0
         dislike: 0
         pubdate: 2013-12-21T13:20:30+00:00

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -13,13 +13,15 @@ from zds.utils.templatetags.mkd_ext.delext import DelExtension
 from zds.utils.templatetags.mkd_ext.urlize import UrlizeExtension
 from zds.utils.templatetags.mkd_ext.kbd import KbdExtension
 from zds.utils.templatetags.mkd_ext.mathjax import MathJaxExtension
+from zds.utils.templatetags.mkd_ext.customblock import CustomBlockExtension
 
-sup_ext = SuperscriptExtension()        # Superscript support
-sub_ext = SubscriptExtension()          # Subscript support
-del_ext = DelExtension()                # Del support
-urlize_ext = UrlizeExtension()          # Autolink support
-kbd_ext = KbdExtension()                # Keyboard support
-mathjax_ext = MathJaxExtension()        # MathJax support
+sup_ext = SuperscriptExtension()            # Superscript support
+sub_ext = SubscriptExtension()              # Subscript support
+del_ext = DelExtension()                    # Del support
+urlize_ext = UrlizeExtension()              # Autolink support
+kbd_ext = KbdExtension()                    # Keyboard support
+mathjax_ext = MathJaxExtension()            # MathJax support
+customblock_ext = CustomBlockExtension()    # CustomBlock support
 
 register = template.Library()
 
@@ -47,6 +49,7 @@ def emarkdown(text):
 							    urlize_ext,                         # Autolink support
                                 kbd_ext,                            # Kbd support
                                 mathjax_ext,                        # Mathjax support
+                                customblock_ext,                    # CustomBlock support
                                 ],
                                 safe_mode           = 'escape',     # Protect use of html by escape it
                                 enable_attributes   = False,        # Disable the conversion of attributes.

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -11,11 +11,13 @@ from zds.utils.templatetags.mkd_ext.superscript import SuperscriptExtension
 from zds.utils.templatetags.mkd_ext.subscript import SubscriptExtension
 from zds.utils.templatetags.mkd_ext.delext import DelExtension
 from zds.utils.templatetags.mkd_ext.urlize import UrlizeExtension
+from zds.utils.templatetags.mkd_ext.kbd import KbdExtension
 
 sup_ext = SuperscriptExtension()        # Superscript support
 sub_ext = SubscriptExtension()          # Subscript support
 del_ext = DelExtension()                # Del support
 urlize_ext = UrlizeExtension()          # Autolink support
+kbd_ext = KbdExtension()                # Keyboard support
 
 register = template.Library()
 
@@ -41,6 +43,8 @@ def emarkdown(text):
                                 sub_ext,                            # Subscript support
                                 del_ext,                            # Del support
 							    urlize_ext,                         # Autolink support
+                                kbd_ext,                            # Kbd support
+
                                 ],
                                 safe_mode           = 'escape',     # Protect use of html by escape it
                                 enable_attributes   = False,        # Disable the conversion of attributes.

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -12,12 +12,14 @@ from zds.utils.templatetags.mkd_ext.subscript import SubscriptExtension
 from zds.utils.templatetags.mkd_ext.delext import DelExtension
 from zds.utils.templatetags.mkd_ext.urlize import UrlizeExtension
 from zds.utils.templatetags.mkd_ext.kbd import KbdExtension
+from zds.utils.templatetags.mkd_ext.mathjax import MathJaxExtension
 
 sup_ext = SuperscriptExtension()        # Superscript support
 sub_ext = SubscriptExtension()          # Subscript support
 del_ext = DelExtension()                # Del support
 urlize_ext = UrlizeExtension()          # Autolink support
 kbd_ext = KbdExtension()                # Keyboard support
+mathjax_ext = MathJaxExtension()        # MathJax support
 
 register = template.Library()
 
@@ -44,7 +46,7 @@ def emarkdown(text):
                                 del_ext,                            # Del support
 							    urlize_ext,                         # Autolink support
                                 kbd_ext,                            # Kbd support
-
+                                mathjax_ext,                        # Mathjax support
                                 ],
                                 safe_mode           = 'escape',     # Protect use of html by escape it
                                 enable_attributes   = False,        # Disable the conversion of attributes.

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -15,10 +15,10 @@ def humane_time(t, conf={}):
     return time.strftime("%d %b %Y, %H:%M:%S", tp)
 
 @register.filter(needs_autoescape=False)
-def emarkdown(value):
+def emarkdown(text):
     return mark_safe('<div class="markdown">{0}</div>'.format(
-            markdown.markdown(  value, 
-                                extensions=[
+            markdown.markdown(  text, 
+                                extensions = [
                                 'abbr',                             # Abbreviation support, included in python-markdown
                                 'footnotes',                        # Footnotes support, included in python-markdown
                                                                     # Footnotes place marker can be set with the PLACE_MARKER option
@@ -26,5 +26,17 @@ def emarkdown(value):
                                 'nl2br',                            # Convert new line to br tags support, included in python markdown
                                 'fenced_code',                      # Extended syntaxe for code block support, included in python-markdown
                                 'codehilite(force_linenos=True)',   # Code hightlight support, with line numbers, included in python-markdwon
-							  ])
+							    ],
+                                safe_mode           = 'escape',     # Protect use of html by escape it
+                                enable_attributes   = False,        # Disable the conversion of attributes.
+                                                                    # This could potentially allow an
+                                                                    # untrusted user to inject JavaScript
+                                                                    # into documents.
+                                tab_length          = 4,            # Length of tabs in the source.
+                                                                    # This is the default value
+                                output_format       = 'xhtml1',     # Xhtml1 output
+                                                                    # This is the default value
+                                smart_emphasis      = True,         # Enable smart emphasis for underscore syntax
+                                lazy_ol             = True,         # Enable smart ordered list start support
+                              )
         .encode('utf-8')))

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -10,11 +10,12 @@ import time
 from zds.utils.templatetags.mkd_ext.superscript import SuperscriptExtension
 from zds.utils.templatetags.mkd_ext.subscript import SubscriptExtension
 from zds.utils.templatetags.mkd_ext.delext import DelExtension
+from zds.utils.templatetags.mkd_ext.urlize import UrlizeExtension
 
 sup_ext = SuperscriptExtension()        # Superscript support
 sub_ext = SubscriptExtension()          # Subscript support
 del_ext = DelExtension()                # Del support
-
+urlize_ext = UrlizeExtension()          # Autolink support
 
 register = template.Library()
 
@@ -39,7 +40,8 @@ def emarkdown(text):
                                 sup_ext,                            # Superscript support
                                 sub_ext,                            # Subscript support
                                 del_ext,                            # Del support
-							    ],
+							    urlize_ext,                         # Autolink support
+                                ],
                                 safe_mode           = 'escape',     # Protect use of html by escape it
                                 enable_attributes   = False,        # Disable the conversion of attributes.
                                                                     # This could potentially allow an

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -6,6 +6,10 @@ from django.utils.safestring import mark_safe
 import markdown
 import time
 
+#Markdowns customs extensions :
+from zds.utils.templatetags.mkd_ext.superscript import SuperscriptExtension
+
+sup_ext = SuperscriptExtension()        # Superscript support
 
 register = template.Library()
 
@@ -26,6 +30,8 @@ def emarkdown(text):
                                 'nl2br',                            # Convert new line to br tags support, included in python markdown
                                 'fenced_code',                      # Extended syntaxe for code block support, included in python-markdown
                                 'codehilite(force_linenos=True)',   # Code hightlight support, with line numbers, included in python-markdwon
+                                # Externs extensions :
+                                sup_ext,                            # Superscript support
 							    ],
                                 safe_mode           = 'escape',     # Protect use of html by escape it
                                 enable_attributes   = False,        # Disable the conversion of attributes.

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -9,9 +9,11 @@ import time
 #Markdowns customs extensions :
 from zds.utils.templatetags.mkd_ext.superscript import SuperscriptExtension
 from zds.utils.templatetags.mkd_ext.subscript import SubscriptExtension
+from zds.utils.templatetags.mkd_ext.delext import DelExtension
 
 sup_ext = SuperscriptExtension()        # Superscript support
 sub_ext = SubscriptExtension()          # Subscript support
+del_ext = DelExtension()                # Del support
 
 
 register = template.Library()
@@ -36,6 +38,7 @@ def emarkdown(text):
                                 # Externs extensions :
                                 sup_ext,                            # Superscript support
                                 sub_ext,                            # Subscript support
+                                del_ext,                            # Del support
 							    ],
                                 safe_mode           = 'escape',     # Protect use of html by escape it
                                 enable_attributes   = False,        # Disable the conversion of attributes.

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -8,8 +8,11 @@ import time
 
 #Markdowns customs extensions :
 from zds.utils.templatetags.mkd_ext.superscript import SuperscriptExtension
+from zds.utils.templatetags.mkd_ext.subscript import SubscriptExtension
 
 sup_ext = SuperscriptExtension()        # Superscript support
+sub_ext = SubscriptExtension()          # Subscript support
+
 
 register = template.Library()
 
@@ -32,6 +35,7 @@ def emarkdown(text):
                                 'codehilite(force_linenos=True)',   # Code hightlight support, with line numbers, included in python-markdwon
                                 # Externs extensions :
                                 sup_ext,                            # Superscript support
+                                sub_ext,                            # Subscript support
 							    ],
                                 safe_mode           = 'escape',     # Protect use of html by escape it
                                 enable_attributes   = False,        # Disable the conversion of attributes.

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -6,10 +6,6 @@ from django.utils.safestring import mark_safe
 import markdown
 import time
 
-import cssstyles
-
-
-md_cssstyle = cssstyles.StyleExtension()
 
 register = template.Library()
 
@@ -20,28 +16,9 @@ def humane_time(t, conf={}):
 
 @register.filter(needs_autoescape=False)
 def emarkdown(value):
-    # Allowed output tags from user raw HTML input and markdown generation
-    allowed_tags = ['div', 'span', 'p', 'pre', 'hr', 'img', 'br',
-                    'strong', 'em', 'i', 'b', 'code', 'sub', 'sup', 'del',
-                    'a', 'abbr', 'blockquote',
-                    'ul', 'ol', 'li',
-                    'table', 'thead', 'tbody', 'tr', 'td', 'th']
-
-    # Add h1…h6 titles, have a more beautiful way to do it?
-    [allowed_tags.append('h{}'.format(i + 1)) for i in range(6)]
-
-    allowed_attrs = {
-        '*': ['class', 'id'],
-        'a': ['href', 'title'],
-        'img': ['src', 'alt'],
-    }
-
     return mark_safe('<div class="markdown">{0}</div>'.format(
-        bleach.clean(
-            markdown.markdown(value, extensions=[
-                              md_cssstyle,
-                              'codehilite(force_linenos=True)',
-                              'extra']),
-            tags=allowed_tags,
-            attributes=allowed_attrs)
+            markdown.markdown(  value, 
+                                extensions=[
+                                'codehilite(force_linenos=True)',
+							  ])
         .encode('utf-8')))

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -19,6 +19,12 @@ def emarkdown(value):
     return mark_safe('<div class="markdown">{0}</div>'.format(
             markdown.markdown(  value, 
                                 extensions=[
-                                'codehilite(force_linenos=True)',
+                                'abbr',                             # Abbreviation support, included in python-markdown
+                                'footnotes',                        # Footnotes support, included in python-markdown
+                                                                    # Footnotes place marker can be set with the PLACE_MARKER option
+                                'tables',                           # Tables support, included in python-markdown
+                                'nl2br',                            # Convert new line to br tags support, included in python markdown
+                                'fenced_code',                      # Extended syntaxe for code block support, included in python-markdown
+                                'codehilite(force_linenos=True)',   # Code hightlight support, with line numbers, included in python-markdwon
 							  ])
         .encode('utf-8')))

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -14,6 +14,8 @@ from zds.utils.templatetags.mkd_ext.urlize import UrlizeExtension
 from zds.utils.templatetags.mkd_ext.kbd import KbdExtension
 from zds.utils.templatetags.mkd_ext.mathjax import MathJaxExtension
 from zds.utils.templatetags.mkd_ext.customblock import CustomBlockExtension
+from zds.utils.templatetags.mkd_ext.center import CenterExtension
+from zds.utils.templatetags.mkd_ext.rightalign import RightAlignExtension
 
 sup_ext = SuperscriptExtension()            # Superscript support
 sub_ext = SubscriptExtension()              # Subscript support
@@ -22,6 +24,8 @@ urlize_ext = UrlizeExtension()              # Autolink support
 kbd_ext = KbdExtension()                    # Keyboard support
 mathjax_ext = MathJaxExtension()            # MathJax support
 customblock_ext = CustomBlockExtension()    # CustomBlock support
+center_ext = CenterExtension()              # Center support
+rightalign_ext = RightAlignExtension()      # CustomBlock support
 
 register = template.Library()
 
@@ -50,6 +54,8 @@ def emarkdown(text):
                                 kbd_ext,                            # Kbd support
                                 mathjax_ext,                        # Mathjax support
                                 customblock_ext,                    # CustomBlock support
+                                center_ext,                         # Center support
+                                rightalign_ext,                     # Right align support
                                 ],
                                 safe_mode           = 'escape',     # Protect use of html by escape it
                                 enable_attributes   = False,        # Disable the conversion of attributes.

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -16,6 +16,7 @@ from zds.utils.templatetags.mkd_ext.mathjax import MathJaxExtension
 from zds.utils.templatetags.mkd_ext.customblock import CustomBlockExtension
 from zds.utils.templatetags.mkd_ext.center import CenterExtension
 from zds.utils.templatetags.mkd_ext.rightalign import RightAlignExtension
+from zds.utils.templatetags.mkd_ext.video import VideoExtension
 
 sup_ext = SuperscriptExtension()            # Superscript support
 sub_ext = SubscriptExtension()              # Subscript support
@@ -26,6 +27,7 @@ mathjax_ext = MathJaxExtension()            # MathJax support
 customblock_ext = CustomBlockExtension()    # CustomBlock support
 center_ext = CenterExtension()              # Center support
 rightalign_ext = RightAlignExtension()      # CustomBlock support
+video_ext = VideoExtension()                # Video support
 
 register = template.Library()
 
@@ -56,6 +58,7 @@ def emarkdown(text):
                                 customblock_ext,                    # CustomBlock support
                                 center_ext,                         # Center support
                                 rightalign_ext,                     # Right align support
+                                video_ext,                          # Video support
                                 ],
                                 safe_mode           = 'escape',     # Protect use of html by escape it
                                 enable_attributes   = False,        # Disable the conversion of attributes.

--- a/zds/utils/templatetags/mkd_ext/center.py
+++ b/zds/utils/templatetags/mkd_ext/center.py
@@ -1,0 +1,52 @@
+#! /usr/bin/env python
+
+import markdown
+#from markdown.inlinepatterns import SimpleTagPattern
+from markdown.blockprocessors import BlockProcessor
+# Small extension to parse `-> center align <-` (cgabard)
+import logging
+import re
+from markdown import util
+
+class CenterProcessor(BlockProcessor):
+    """ Process Center. """
+
+    RE = re.compile(r'(^|\n)->(?P<txtcenter>.*?)<-(\n|$)', re.MULTILINE|re.DOTALL)
+
+    def test(self, parent, block):
+        return bool(self.RE.search(block))
+
+    def run(self, parent, blocks):
+        block = blocks.pop(0)
+        m = self.RE.search(block)
+        if m:
+            before = block[:m.start()] # All lines before header
+            after = block[m.end():]    # All lines after header
+            if before:
+                self.parser.parseBlocks(parent, [before])
+            sibling = self.lastChild(parent)
+            if sibling and sibling.tag == "div" and "align" in sibling.attrib and sibling.attrib["align"] == "center" :
+                h= sibling
+                if h.text:
+                    h.text += '\n'
+            else:
+                h = util.etree.SubElement(parent, 'div')
+                h.set("align","center")
+            #h.text = m.group('txtcenter').strip()
+            self.parser.parseChunk(h, m.group('txtcenter'))
+            if after:
+                blocks.insert(0, after)
+        else:
+            logger.warn("We've got a problem center: %r" % block)
+
+class CenterExtension(markdown.extensions.Extension):
+    """Adds Center extension to Markdown class."""
+
+    def extendMarkdown(self, md, md_globals):
+        """Modifies inline patterns."""
+        md.registerExtension(self)
+        md.parser.blockprocessors.add('center',CenterProcessor(md.parser),'_begin')
+
+def makeExtension(configs={}):
+    return CenterExtension(configs=dict(configs))
+

--- a/zds/utils/templatetags/mkd_ext/customblock.py
+++ b/zds/utils/templatetags/mkd_ext/customblock.py
@@ -1,0 +1,75 @@
+from __future__ import unicode_literals
+from markdown import Extension
+from markdown.blockprocessors import BlockProcessor
+from markdown.util import etree
+import re
+
+
+class CustomBlockExtension(Extension):
+    """ Custom block extension for Python-Markdown. """
+
+    def extendMarkdown(self, md, md_globals):
+        """ Add CustomBlock to Markdown instance. """
+        md.registerExtension(self)
+
+        md.parser.blockprocessors.add('customblock', CustomBlockProcessor(md.parser,{"secret":"spoiler","information":"information ico-after","question":"question ico-after","attention":"attention ico-after","erreur":"erreur ico-after"}), '_begin')
+
+
+class CustomBlockProcessor(BlockProcessor):
+
+    RE = re.compile(r'(?:^|\n)\[\[?([\w\-]+)?\]\](\n|$)')
+    def __init__(self, parser,classType):
+        BlockProcessor.__init__(self,parser)
+        self.classType = classType
+
+    def test(self, parent, block):
+        sibling = self.lastChild(parent)
+        m = self.RE.search(block)
+        if m:
+            classTypeSup = m.group(0).lower().strip()[2:-2]
+        return (m and classTypeSup in self.classType.keys()) or \
+            (block.startswith('|' ) and sibling and \
+                sibling.get('class', '').find("CustomBlock") != -1)
+    def extractBlock(self,m,block):
+        if m:
+            before = block[:m.start()]
+            klass = self.classType[m.group(0).lower().strip()[2:-2]]
+       	    block = block[m.end():]  # removes the first line
+        else:
+            before = None
+            klass = None
+        cblck=[]
+        theRest=[]
+        inBlck=True
+        for line in block.split("\n"):
+            if inBlck and len(line.strip()) >= 1 and line.strip()[0] == "|":
+                cblck.append(line[1:])
+            else:
+                theRest.append(line)
+                inBlck = False
+        return before, klass, "\n".join(cblck), "\n".join(theRest)
+
+    def run(self, parent, blocks):
+        sibling = self.lastChild(parent)
+        block = blocks.pop(0)
+        m = self.RE.search(block)
+
+        before, klass, block, theRest = self.extractBlock(m,block)
+        if before:
+            self.parser.parseBlocks(parent, [before])
+        
+        if m or not sibling:
+            div = etree.SubElement(parent, 'div')
+            div.set('class', '%s' % ( klass,))
+        else:
+            div = sibling
+        #self.parser.state.set("CustomBlock")
+        self.parser.parseChunk(div, block)
+        #self.parser.state.reset()
+        if theRest:
+            blocks.insert(0, theRest)
+
+
+
+def makeExtension(configs={}):
+    return CustomBlockExtension(configs=configs)

--- a/zds/utils/templatetags/mkd_ext/customblock.py
+++ b/zds/utils/templatetags/mkd_ext/customblock.py
@@ -12,7 +12,19 @@ class CustomBlockExtension(Extension):
         """ Add CustomBlock to Markdown instance. """
         md.registerExtension(self)
 
-        md.parser.blockprocessors.add('customblock', CustomBlockProcessor(md.parser,{"secret":"spoiler","information":"information ico-after","question":"question ico-after","attention":"attention ico-after","erreur":"erreur ico-after"}), '_begin')
+        md.parser.blockprocessors.add( 'customblock', CustomBlockProcessor(md.parser,
+            {
+                "secret" : "spoiler",
+                "s" : "spoiler",
+                "information" : "information ico-after",
+                "i" : "information ico-after",
+                "question" : "question ico-after",
+                "q" : "question ico-after",
+                "attention" : "attention ico-after", 
+                "a" : "attention ico-after", 
+                "erreur" : "erreur ico-after",
+                "e" : "erreur ico-after"
+            }), '_begin')
 
 
 class CustomBlockProcessor(BlockProcessor):

--- a/zds/utils/templatetags/mkd_ext/customblock.py
+++ b/zds/utils/templatetags/mkd_ext/customblock.py
@@ -20,10 +20,10 @@ class CustomBlockExtension(Extension):
                 "i" : "information ico-after",
                 "question" : "question ico-after",
                 "q" : "question ico-after",
-                "attention" : "attention ico-after", 
-                "a" : "attention ico-after", 
-                "erreur" : "erreur ico-after",
-                "e" : "erreur ico-after"
+                "attention" : "warning ico-after", 
+                "a" : "warning ico-after", 
+                "erreur" : "error ico-after",
+                "e" : "error ico-after"
             }), '_begin')
 
 

--- a/zds/utils/templatetags/mkd_ext/delext.py
+++ b/zds/utils/templatetags/mkd_ext/delext.py
@@ -1,0 +1,62 @@
+#! /usr/bin/env python
+
+# From https://github.com/aleray/mdx_del_ins/blob/master/mdx_del_ins.py
+# Patched for remove "ins" support by cgabard.
+
+'''
+Del/Ins Extension for Python-Markdown
+=====================================
+
+Wraps the inline content with ins/del tags.
+
+
+Usage
+-----
+
+    >>> import markdown
+    >>> src = """This is ++added content++ and this is ~~deleted content~~""" 
+    >>> html = markdown.markdown(src, ['del_ins'])
+    >>> print(html)
+    <p>This is <ins>added content</ins> and this is <del>deleted content</del>
+    </p>
+
+
+Dependencies
+------------
+
+* [Markdown 2.0+](http://www.freewisdom.org/projects/python-markdown/)
+
+
+Copyright
+---------
+
+2011, 2012 [The active archives contributors](http://activearchives.org/)
+All rights reserved.
+
+This software is released under the modified BSD License. 
+See LICENSE.md for details.
+'''
+
+
+import markdown
+from markdown.inlinepatterns import SimpleTagPattern
+
+
+DEL_RE = r"(\~\~)(.+?)(\~\~)"
+
+
+class DelExtension(markdown.extensions.Extension):
+    """Adds del extension to Markdown class."""
+
+    def extendMarkdown(self, md, md_globals):
+        """Modifies inline patterns."""
+        md.inlinePatterns.add('del', SimpleTagPattern(DEL_RE, 'del'), '<not_strong')
+
+
+def makeExtension(configs={}):
+    return DelExtension(configs=dict(configs))
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/zds/utils/templatetags/mkd_ext/kbd.py
+++ b/zds/utils/templatetags/mkd_ext/kbd.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python
+
+import markdown
+from markdown.inlinepatterns import SimpleTagPattern
+
+# Small extension to parse ||Touche|| in Kbd html tag (cgabard)
+
+KBD_RE = r"(\|\|)(.+?)(\|\|)"
+
+
+class KbdExtension(markdown.extensions.Extension):
+    """Adds kdb extension to Markdown class."""
+
+    def extendMarkdown(self, md, md_globals):
+        """Modifies inline patterns."""
+        md.inlinePatterns.add('kbd', SimpleTagPattern(KBD_RE, 'kbd'), '<not_strong')
+
+
+def makeExtension(configs={}):
+    return KbdExtension(configs=dict(configs))
+

--- a/zds/utils/templatetags/mkd_ext/mathjax.py
+++ b/zds/utils/templatetags/mkd_ext/mathjax.py
@@ -1,0 +1,23 @@
+# From https://github.com/mayoff/python-markdown-mathjax
+
+import markdown
+
+class MathJaxPattern(markdown.inlinepatterns.Pattern):
+
+    def __init__(self):
+        markdown.inlinepatterns.Pattern.__init__(self, r'(?<!\\)(\$\$?)(.+?)\2')
+
+    def handleMatch(self, m):
+        node = markdown.util.etree.Element('mathjax')
+        node.text = markdown.util.AtomicString(m.group(2) + m.group(3) + m.group(2))
+        return node
+
+class MathJaxExtension(markdown.Extension):
+    def extendMarkdown(self, md, md_globals):
+        # Needs to come before escape matching because \ is pretty important in LaTeX
+        md.inlinePatterns.add('mathjax', MathJaxPattern(), '<escape')
+
+def makeExtension(configs=None):
+    return MathJaxExtension(configs)
+
+

--- a/zds/utils/templatetags/mkd_ext/rightalign.py
+++ b/zds/utils/templatetags/mkd_ext/rightalign.py
@@ -1,0 +1,52 @@
+#! /usr/bin/env python
+
+import markdown
+#from markdown.inlinepatterns import SimpleTagPattern
+from markdown.blockprocessors import BlockProcessor
+# Small extension to parse `-> right align ->` (cgabard)
+import logging
+import re
+from markdown import util
+
+class RightAlignProcessor(BlockProcessor):
+    """ Process Center. """
+
+    RE = re.compile(r'(^|\n)->(?P<txtright>.*?)->(\n|$)', re.MULTILINE|re.DOTALL)
+
+    def test(self, parent, block):
+        return bool(self.RE.search(block))
+
+    def run(self, parent, blocks):
+        block = blocks.pop(0)
+        m = self.RE.search(block)
+        if m:
+            before = block[:m.start()] # All lines before header
+            after = block[m.end():]    # All lines after header
+            if before:
+                self.parser.parseBlocks(parent, [before])
+            sibling = self.lastChild(parent)
+            if sibling and sibling.tag == "div" and "align" in sibling.attrib and sibling.attrib["align"] == "right" :
+                h= sibling
+                if h.text:
+                    h.text += '\n'
+            else:
+                h = util.etree.SubElement(parent, 'div')
+                h.set("align","right")
+            #h.text = m.group('txtright').strip()
+            self.parser.parseChunk(h, m.group('txtright'))
+            if after:
+                blocks.insert(0, after)
+        else:
+            logger.warn("We've got a problem center: %r" % block)
+
+class RightAlignExtension(markdown.extensions.Extension):
+    """Adds Rigth align extension to Markdown class."""
+
+    def extendMarkdown(self, md, md_globals):
+        """Modifies inline patterns."""
+        md.registerExtension(self)
+        md.parser.blockprocessors.add('rightalign',RightAlignProcessor(md.parser),'_begin')
+
+def makeExtension(configs={}):
+    return RightAlignExtension(configs=dict(configs))
+

--- a/zds/utils/templatetags/mkd_ext/subscript.py
+++ b/zds/utils/templatetags/mkd_ext/subscript.py
@@ -1,0 +1,49 @@
+# From https://github.com/sgraber/markdown.subscript/blob/master/subscript.py
+# Patched version by cgabard
+
+"""Subscript extension for Markdown.
+
+To subscript something, place a tilde symbol, '~', before and after the
+text that you would like in subscript:  C~6~H~12~O~6~
+The numbers in this example will be subscripted.  See below for more:
+
+Examples:
+
+>>> import markdown
+>>> md = markdown.Markdown(extensions=['subscript'])
+>>> md.convert('This is sugar: C~6~H~12~O~6~')
+u'<p>This is sugar: C<sub>6</sub>H<sub>12</sub>O<sub>6</sub></p>'
+
+Paragraph breaks will nullify subscripts across paragraphs. Line breaks
+within paragraphs will not.
+"""
+
+import markdown
+
+# Global Vars
+SUBSCRIPT_RE = r'(\~)([^\~]*)\2'  # the number is subscript~2~
+
+class SubscriptPattern(markdown.inlinepatterns.Pattern):
+    """ Return a subscript Element: `C~6~H~12~O~6~' """
+    def handleMatch(self, m):
+        subsc = m.group(3)
+        
+        text = subsc
+        
+        el = markdown.util.etree.Element("sub")
+        el.text = markdown.util.AtomicString(text)
+        return el
+
+class SubscriptExtension(markdown.Extension):
+    """ Subscript Extension for Python-Markdown. """
+
+    def extendMarkdown(self, md, md_globals):
+        """ Replace subscript with SubscriptPattern """
+        md.inlinePatterns['subscript'] = SubscriptPattern(SUBSCRIPT_RE, md)
+
+def makeExtension(configs=None):
+    return SubscriptExtension(configs=configs)
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/zds/utils/templatetags/mkd_ext/superscript.py
+++ b/zds/utils/templatetags/mkd_ext/superscript.py
@@ -1,0 +1,59 @@
+# From https://github.com/sgraber/markdown.superscript/blob/master/superscript.py
+# Patched version by cgabard
+
+"""Superscipt extension for Markdown.
+
+To superscript something, place a carat symbol, '^', before and after the
+text that you would like in superscript:  6.02 x 10^23^
+The '23' in this example will be superscripted.  See below.
+
+Examples:
+
+>>> import markdown
+>>> md = markdown.Markdown(extensions=['superscript'])
+>>> md.convert('This is a reference to a footnote^1^.')
+u'<p>This is a reference to a footnote<sup>1</sup>.</p>'
+
+>>> md.convert('This is scientific notation: 6.02 x 10^23^')
+u'<p>This is scientific notation: 6.02 x 10<sup>23</sup></p>'
+
+>>> md.convert('This is scientific notation: 6.02 x 10^23. Note lack of second carat.')
+u'<p>This is scientific notation: 6.02 x 10^23. Note lack of second carat.</p>'
+
+>>> md.convert('Scientific notation: 6.02 x 10^23. Add carat at end of sentence.^')
+u'<p>Scientific notation: 6.02 x 10<sup>23. Add a carat at the end of sentence.</sup>.</p>'
+
+Paragraph breaks will nullify superscripts across paragraphs. Line breaks
+within paragraphs will not.
+
+"""
+
+import markdown
+
+# Global Vars
+SUPERSCRIPT_RE = r'(\^)([^\^]*)\2'  # the number is a superscript^2^
+
+class SuperscriptPattern(markdown.inlinepatterns.Pattern):
+    """ Return a superscript Element (`word^2^`). """
+    def handleMatch(self, m):
+        supr = m.group(3)
+        
+        text = supr
+        
+        el = markdown.util.etree.Element("sup")
+        el.text = markdown.util.AtomicString(text)
+        return el
+
+class SuperscriptExtension(markdown.Extension):
+    """ Superscript Extension for Python-Markdown. """
+
+    def extendMarkdown(self, md, md_globals):
+        """ Replace superscript with SuperscriptPattern """
+        md.inlinePatterns['superscript'] = SuperscriptPattern(SUPERSCRIPT_RE, md)
+
+def makeExtension(configs=None):
+    return SuperscriptExtension(configs=configs)
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/zds/utils/templatetags/mkd_ext/urlize.py
+++ b/zds/utils/templatetags/mkd_ext/urlize.py
@@ -1,0 +1,83 @@
+# From https://github.com/r0wb0t/markdown-urlize/blob/master/urlize.py
+
+"""A more liberal autolinker
+
+Inspired by Django's urlize function.
+
+Positive examples:
+
+>>> import markdown
+>>> md = markdown.Markdown(extensions=['urlize'])
+
+>>> md.convert('http://example.com/')
+u'<p><a href="http://example.com/">http://example.com/</a></p>'
+
+>>> md.convert('go to http://example.com')
+u'<p>go to <a href="http://example.com">http://example.com</a></p>'
+
+>>> md.convert('example.com')
+u'<p><a href="http://example.com">example.com</a></p>'
+
+>>> md.convert('example.net')
+u'<p><a href="http://example.net">example.net</a></p>'
+
+>>> md.convert('www.example.us')
+u'<p><a href="http://www.example.us">www.example.us</a></p>'
+
+>>> md.convert('(www.example.us/path/?name=val)')
+u'<p>(<a href="http://www.example.us/path/?name=val">www.example.us/path/?name=val</a>)</p>'
+
+>>> md.convert('go to <http://example.com> now!')
+u'<p>go to <a href="http://example.com">http://example.com</a> now!</p>'
+
+Negative examples:
+
+>>> md.convert('del.icio.us')
+u'<p>del.icio.us</p>'
+
+"""
+
+import markdown
+
+# Global Vars
+URLIZE_RE = '(%s)' % '|'.join([
+    r'<(?:f|ht)tps?://[^>]*>',
+    r'\b(?:f|ht)tps?://[^)<>\s]+[^.,)<>\s]',
+    r'\bwww\.[^)<>\s]+[^.,)<>\s]',
+    r'[^(<\s]+\.(?:com|net|org)\b',
+])
+
+class UrlizePattern(markdown.inlinepatterns.Pattern):
+    """ Return a link Element given an autolink (`http://example/com`). """
+    def handleMatch(self, m):
+        url = m.group(2)
+        
+        if url.startswith('<'):
+            url = url[1:-1]
+            
+        text = url
+        
+        if not url.split('://')[0] in ('http','https','ftp'):
+            if '@' in url and not '/' in url:
+                url = 'mailto:' + url
+            else:
+                url = 'http://' + url
+    
+        el = markdown.util.etree.Element("a")
+        el.set('href', url)
+        el.text = markdown.util.AtomicString(text)
+        return el
+
+class UrlizeExtension(markdown.Extension):
+    """ Urlize Extension for Python-Markdown. """
+
+    def extendMarkdown(self, md, md_globals):
+        """ Replace autolink with UrlizePattern """
+        md.inlinePatterns['autolink'] = UrlizePattern(URLIZE_RE, md)
+
+def makeExtension(configs=None):
+    return UrlizeExtension(configs=configs)
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/zds/utils/templatetags/mkd_ext/video.py
+++ b/zds/utils/templatetags/mkd_ext/video.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+import markdown
+from markdown.util import etree
+
+
+class VideoExtension(markdown.Extension):
+    def __init__(self, configs={}):
+        self.config = {
+            'dailymotion_width': ['480', 'Width for Dailymotion videos'],
+            'dailymotion_height': ['270', 'Height for Dailymotion videos'],
+            'metacafe_width': ['440', 'Width for Metacafe videos'],
+            'metacafe_height': ['248', 'Height for Metacafe videos'],
+            'veoh_width': ['410', 'Width for Veoh videos'],
+            'veoh_height': ['341', 'Height for Veoh videos'],
+            'vimeo_width': ['500', 'Width for Vimeo videos'],
+            'vimeo_height': ['281', 'Height for Vimeo videos'],
+            'yahoo_width': ['624', 'Width for Yahoo! videos'],
+            'yahoo_height': ['351', 'Height for Yahoo! videos'],
+            'youtube_width': ['560', 'Width for Youtube videos'],
+            'youtube_height': ['315', 'Height for Youtube videos'],
+        }
+
+        # Override defaults with user settings
+        for key, value in configs:
+            self.setConfig(key, value)
+
+    def add_inline(self, md, name, klass, re):
+        pattern = klass(re)
+        pattern.md = md
+        pattern.ext = self
+        md.inlinePatterns.add(name, pattern, "<reference")
+
+    def extendMarkdown(self, md, md_globals):
+        self.add_inline(md, 'dailymotion', Dailymotion,
+            r'([^(]|^)https?://www\.dailymotion\.com/video/(?P<dailymotionid>[a-z0-9]+)(_[\w\-]*)?')
+        self.add_inline(md, 'metacafe', Metacafe,
+            r'([^(]|^)http://www\.metacafe\.com/watch/(?P<metacafeid>\d+)/?(:?.+/?)')
+        self.add_inline(md, 'veoh', Veoh,
+            r'([^(]|^)http://www\.veoh\.com/\S*(#watch%3D|watch/)(?P<veohid>\w+)')
+        self.add_inline(md, 'vimeo', Vimeo,
+            r'([^(]|^)http://(www.|)vimeo\.com/(?P<vimeoid>\d+)\S*')
+        self.add_inline(md, 'yahoo', Yahoo,
+            r'([^(]|^)http://screen\.yahoo\.com/.+/?')
+        self.add_inline(md, 'youtube', Youtube,
+            r'([^(]|^)https?://www\.youtube\.com/watch\?\S*v=(?P<youtubeid>\S[^&/]+)')
+        self.add_inline(md, 'youtube_short', Youtube,
+            r'([^(]|^)https?://youtu\.be/(?P<youtubeid>\S[^?&/]+)?')
+
+
+class Dailymotion(markdown.inlinepatterns.Pattern):
+    def handleMatch(self, m):
+        url = 'http://www.dailymotion.com/embed/video/%s' % m.group('dailymotionid')
+        width = self.ext.config['dailymotion_width'][0]
+        height = self.ext.config['dailymotion_height'][0]
+        return render_iframe(url, width, height)
+
+
+class Metacafe(markdown.inlinepatterns.Pattern):
+    def handleMatch(self, m):
+        url = 'http://www.metacafe.com/embed/%s/' % m.group('metacafeid')
+        width = self.ext.config['metacafe_width'][0]
+        height = self.ext.config['metacafe_height'][0]
+        return render_iframe(url, width, height)
+
+
+class Veoh(markdown.inlinepatterns.Pattern):
+    def handleMatch(self, m):
+        url = 'http://www.veoh.com/videodetails2.swf?permalinkId=%s' % m.group('veohid')
+        width = self.ext.config['veoh_width'][0]
+        height = self.ext.config['veoh_height'][0]
+        return flash_object(url, width, height)
+
+
+class Vimeo(markdown.inlinepatterns.Pattern):
+    def handleMatch(self, m):
+        url = 'http://player.vimeo.com/video/%s' % m.group('vimeoid')
+        width = self.ext.config['vimeo_width'][0]
+        height = self.ext.config['vimeo_height'][0]
+        return render_iframe(url, width, height)
+
+
+class Yahoo(markdown.inlinepatterns.Pattern):
+    def handleMatch(self, m):
+        url = m.string + '?format=embed&player_autoplay=false'
+        width = self.ext.config['yahoo_width'][0]
+        height = self.ext.config['yahoo_height'][0]
+        return render_iframe(url, width, height)
+
+
+class Youtube(markdown.inlinepatterns.Pattern):
+    def handleMatch(self, m):
+        url = 'http://www.youtube.com/embed/%s' % m.group('youtubeid')
+        width = self.ext.config['youtube_width'][0]
+        height = self.ext.config['youtube_height'][0]
+        return render_iframe(url, width, height)
+
+
+def render_iframe(url, width, height):
+    iframe = etree.Element('iframe')
+    iframe.set('width', width)
+    iframe.set('height', height)
+    iframe.set('src', url)
+    iframe.set('allowfullscreen', 'true')
+    iframe.set('frameborder', '0')
+    return iframe
+
+
+def flash_object(url, width, height):
+    obj = etree.Element('object')
+    obj.set('type', 'application/x-shockwave-flash')
+    obj.set('width', width)
+    obj.set('height', height)
+    obj.set('data', url)
+    param = etree.Element('param')
+    param.set('name', 'movie')
+    param.set('value', url)
+    obj.append(param)
+    param = etree.Element('param')
+    param.set('name', 'allowFullScreen')
+    param.set('value', 'true')
+    obj.append(param)
+    return obj
+
+
+def makeExtension(configs=None):
+    return VideoExtension(configs=configs)
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
Une (grosse?) PR pour inclure une version étendue du markdown. Normalement 95% des capacités qu'on voulait sont implémentées. J'ai virée la limitation dans le HTML qui était présente jusque là. Maintenant je refuse toute balise html dans le markdown. 

La majorité des extensions sont soient include dans python- markdown, soit trouvé sur le net. J'ai indiqué systématiquement où dedans et éventuellement si je les ai modifié pour une raison ou une autre.

Les quelques extensions que j'ai faites semblent bien se comporter.

Pour pouvoir tester toutes les fonctionnalités, deux modifs restent à faire : 
- Rajouter mathjax
- rajouter des classes CSS pour les balises attention, erreur, question, information et spoiler

Ce qui reste à faire est : 
- Les listes ordonnées autres que chiffres arabes (non prioritaire)
- Le support de la syntaxe de code "a la github" dans un block : Actuellement cette syntaxe de fonctionne pas dans un bloc citation par exemple. C'est tres genant et va etre ma priorité numéro 1. Le truc est que c'est une issue ouverte depuis 2 ans de Python-markdown et le faire ne va pas etre simple sans patcher python-markdown. Mais j'ai une idée pour.

Enfin j'ai mis a jour les fixture pour rajouter un forum (DG) et y poster un message, rédigé par shigerum, expliquant la syntaxe. A terme l'inclure en tuto ou article serait plus pertinent.

Je pense qu'il serait pas mal de pousser ça sur le serveur rapidement et qu'on demande a tout le monde de le tester a fond car il s'agit d'une fonctionnalité critique.

Je pensais alors qu'on pourrait créer 2 issues pour gérer les retours : 
- une pour répertorier les bugs (dont celui de la syntaxe de code)
- une pour discuter des modifications/ajouts de syntaxes. 

Autant le fichier emarkdown.py est propre et bien commenté, autant celui des extensions est très inégale, dépendant du temps que j'ai eu pour cela. J'en suis conscient, et cela arrivera dans la deuxième ittération.
