### PR TITLE
Extended markdown second iteration

### DIFF
--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -18,16 +18,16 @@ from zds.utils.templatetags.mkd_ext.center import CenterExtension
 from zds.utils.templatetags.mkd_ext.rightalign import RightAlignExtension
 from zds.utils.templatetags.mkd_ext.video import VideoExtension
 
-sup_ext = SuperscriptExtension()            # Superscript support
-sub_ext = SubscriptExtension()              # Subscript support
-del_ext = DelExtension()                    # Del support
-urlize_ext = UrlizeExtension()              # Autolink support
-kbd_ext = KbdExtension()                    # Keyboard support
-mathjax_ext = MathJaxExtension()            # MathJax support
+sup_ext         = SuperscriptExtension()    # Superscript support
+sub_ext         = SubscriptExtension()      # Subscript support
+del_ext         = DelExtension()            # Del support
+urlize_ext      = UrlizeExtension()         # Autolink support
+kbd_ext         = KbdExtension()            # Keyboard support
+mathjax_ext     = MathJaxExtension()        # MathJax support
 customblock_ext = CustomBlockExtension()    # CustomBlock support
-center_ext = CenterExtension()              # Center support
-rightalign_ext = RightAlignExtension()      # CustomBlock support
-video_ext = VideoExtension()                # Video support
+center_ext      = CenterExtension()         # Center support
+rightalign_ext  = RightAlignExtension()     # CustomBlock support
+video_ext       = VideoExtension()          # Video support
 
 register = template.Library()
 
@@ -52,7 +52,7 @@ def emarkdown(text):
                                 sup_ext,                            # Superscript support
                                 sub_ext,                            # Subscript support
                                 del_ext,                            # Del support
-							    urlize_ext,                         # Autolink support
+                                urlize_ext,                         # Autolink support
                                 kbd_ext,                            # Kbd support
                                 mathjax_ext,                        # Mathjax support
                                 customblock_ext,                    # CustomBlock support

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -17,6 +17,7 @@ from zds.utils.templatetags.mkd_ext.customblock import CustomBlockExtension
 from zds.utils.templatetags.mkd_ext.center import CenterExtension
 from zds.utils.templatetags.mkd_ext.rightalign import RightAlignExtension
 from zds.utils.templatetags.mkd_ext.video import VideoExtension
+from zds.utils.templatetags.mkd_ext.preprocessblock import PreprocessBlockExtension
 
 sup_ext         = SuperscriptExtension()    # Superscript support
 sub_ext         = SubscriptExtension()      # Subscript support
@@ -28,6 +29,7 @@ customblock_ext = CustomBlockExtension()    # CustomBlock support
 center_ext      = CenterExtension()         # Center support
 rightalign_ext  = RightAlignExtension()     # CustomBlock support
 video_ext       = VideoExtension()          # Video support
+preprocess_ext  = PreprocessBlockExtension({"preprocess" : ("fenced_code_block",)}) # Preprocess extension
 
 register = template.Library()
 
@@ -59,6 +61,7 @@ def emarkdown(text):
                                 center_ext,                         # Center support
                                 rightalign_ext,                     # Right align support
                                 video_ext,                          # Video support
+                                preprocess_ext,                     # Preprocess support
                                 ],
                                 safe_mode           = 'escape',     # Protect use of html by escape it
                                 enable_attributes   = False,        # Disable the conversion of attributes.

--- a/zds/utils/templatetags/mkd_ext/preprocessblock.py
+++ b/zds/utils/templatetags/mkd_ext/preprocessblock.py
@@ -1,0 +1,40 @@
+#! /usr/bin/env python
+
+import markdown
+
+class PreprocessBlockExtension(markdown.extensions.Extension):
+    """This extension will change the default behaviour of python-markdown and allow to use 
+    pre-processing extensions inside block"""
+    def __init__(self, configs={}):
+        markdown.extensions.Extension.__init__(self)
+        
+        if "preprocess" in configs:
+            self.preprocessNames = configs["preprocess"]
+        else:
+            self.preprocessNames = []
+
+    def extendMarkdown(self, md, md_globals):
+        oldParseChunk = md.parser.parseChunk
+        
+        self.addPreprocessor(md)
+
+        def newParseChunk( parent, text):
+            lines = text.split("\n")
+            for pre in self.preprocess:
+                lines = pre.run(lines)
+            text = "\n".join(lines)
+            return oldParseChunk( parent, text)
+        
+        md.parser.parseChunk = newParseChunk
+    
+    def addPreprocessor(self, md):
+        self.preprocess = []
+        for name in self.preprocessNames:
+            print name
+            
+            if name in md.preprocessors:
+                self.preprocess.append(md.preprocessors[name])
+
+def makeExtension(configs={}):
+    return PreprocessExtension(configs=dict(configs))
+


### PR DESCRIPTION
Nouvelle PR rapide. La correction du bug empechant les syntaxes de code type GitHub dans les citations et blocs a été plus rapide que prévu.

Le prob est que cette extension fonctionnait en pré-process a coup de regexp. De ce fait elle ne chercherait des balises de codes que en début de lignes. Celles dans les citations & blocs perso n'étaient donc pas détecté.

Je propose donc une nouvelle extension qui permet de faire passer les extensions de pré-processing à l'intérieur des sous blocs : Quand le module dédié detecte une citation, il vire les chevrons au débuts de lignes et repasse le morceau parser pour y détecter d'autres blocs éventuels. Malheureusement les pré-process n'étaient pas re-parsés.

Je fais donc un hook pas très joli en changeant la methode du parser chargé de parser un block en le faisant précéder d'un passage des extensions de pré-process qu'on a choisi en config.

Actuellement je ne fais passer que fenced_code car c'est le seul prob qui a été détecté. Mais l'extension reste plus générique et permet de résoudre le prob de passer un pre-process à l'interieur des blocs.

A noter que ce prob est une issue ouverte depuis 2 ans sur le projet officiel de python-markdown : https://github.com/waylan/Python-Markdown/issues/53 . Je leur parlerai de ma solution une fois le projet publique si aucun bugs certains ne viennent poser problèmes.

Cette extension étant assez expérimental, ce serait bien de le pousser en prod avant que je previenne tout le monde de la dispo du markdown sur celui-ci pour pouvoir la tester au passage.
