### PR TITLE
Fix grid tables errors + legend allow blank line between table and legend

### DIFF
--- a/zds/utils/templatetags/mkd_ext/grid_tables.py
+++ b/zds/utils/templatetags/mkd_ext/grid_tables.py
@@ -501,15 +501,19 @@ class GridTableProcessor(markdown.blockprocessors.BlockProcessor):
         Otherwise, it is rendered as a table with the appropriate row and
         column spans.
         """
-        orig_block = [r.strip() for r in blocks.pop(0).split('\n')]
-        body_block = orig_block[:]
-        success, body = self._get_all_cells(body_block)
-        if not success:
-            self._render_as_block(parent, '\n'.join(orig_block))
-            return
-        table = etree.SubElement(parent, 'table')
-        self._render_rows(body, table)
-
+        block = blocks.pop(0)
+        try:
+            orig_block = [r.strip() for r in block.split('\n')]
+            body_block = orig_block[:]
+            success, body = self._get_all_cells(body_block)
+            if not success:
+                self._render_as_block(parent, '\n'.join(orig_block))
+                return
+            table = etree.SubElement(parent, 'table')
+            self._render_rows(body, table)
+        except:
+            blocks.insert(0, block)
+            return False
     def _render_as_block(self, parent, text):
         """
         Renders a table as a block of text instead of a table. This isn't done

--- a/zds/utils/templatetags/mkd_ext/tablelegend.py
+++ b/zds/utils/templatetags/mkd_ext/tablelegend.py
@@ -10,21 +10,12 @@ class TableLegendProcessor(BlockProcessor):
     """ Table legend """
 
     RE = re.compile(r'(^|\n)(Table[ ]{0,1})*\:(?P<txtlegend>.*?)(\n|$)')
-    def __init__(self, parser, totest):
+    def __init__(self, parser):
         BlockProcessor.__init__(self, parser)
-        self.totest = totest
 
     def test(self, parent, block):
         m = self.RE.search(block)
-        if not bool(m):
-            return False
-        
-        sibling = self.lastChild(parent)
-        PreviousWillBeTable = False # sibling and sibling.tag== "table"
-        for extTab in self.totest:
-            PreviousWillBeTable = PreviousWillBeTable or extTab.test(parent,block[:m.start()])
-        
-        return PreviousWillBeTable
+        return bool(m)
 
     def run(self, parent, blocks):
         block = blocks.pop(0)
@@ -34,12 +25,15 @@ class TableLegendProcessor(BlockProcessor):
             after = block[m.end():]    # All lines after header
             sibling = self.lastChild(parent)
             if before:
-                self.parser.parseBlocks(parent,[before])
+                res= self.parser.parseBlocks(parent,[before])
             sibling = self.lastChild(parent)
             if sibling and sibling.tag == "table" :
                 h = util.etree.Element('caption')
                 sibling.insert(0,h)
                 self.parser.parseChunk(h, m.group('txtlegend'))
+            else:
+                blocks.insert(0,block[m.start():])
+                return False
             if after:
                 blocks.insert(0, after)
         else:
@@ -51,12 +45,7 @@ class TableLegendExtension(markdown.extensions.Extension):
     def extendMarkdown(self, md, md_globals):
         """Modifies inline patterns."""
         md.registerExtension(self)
-        toTest=[]
-        if "grid-table" in md.parser.blockprocessors:
-            toTest.append(md.parser.blockprocessors["grid-table"])
-        if "table" in md.parser.blockprocessors:
-            toTest.append(md.parser.blockprocessors["table"])
-        md.parser.blockprocessors.add('table-legend',TableLegendProcessor(md.parser, toTest),'_begin')
+        md.parser.blockprocessors.add('table-legend',TableLegendProcessor(md.parser),'_begin')
 
 def makeExtension(configs={}):
     return TableLegendExtension(configs=dict(configs))


### PR DESCRIPTION
Normalement, plus de crash en cas de grid tables mal formé.

Au passage le fixe autorise la legende à ne pas etre accolée au tableau.
