### PR TITLE
Use updated python markdown version

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,10 @@ Cela va créer plusieurs entitées :
 * 1 mp with 3 participants
 * 3 catégories et 2 sous-catégories
 
+Si vous voulez utiliser la meme version de python-markdown que sur le serveur, incluant la mise en évidence de lignes de codes particulières exécutez :
+
+```console
+cd scripts && ./UseUpdatedPythonMarkdownVersion.sh && cd ..
+```
+
 Pour plus de détails consultez l'[article dans le wiki](https://github.com/Taluu/ZesteDeSavoir/wiki) (pas encore terminé)

--- a/scripts/UseUpdatedPythonMarkdownVersion.sh
+++ b/scripts/UseUpdatedPythonMarkdownVersion.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/sh
+
+mkdir temp
+cd temp
+
+# clone repository
+git clone git://github.com/waylan/Python-Markdown.git python-markdown
+cd python-markdown
+
+# checkout the correct commit
+git checkout 73fdecaf2cf00d85b7c933f5b8d186d74a80ff2a
+
+# install
+python setup.py install --user
+
+# cleanning
+cd ..
+rm -rf python-markdown
+
+cd ..
+rm -rf temp
+
+

--- a/scripts/UseUpdatedPythonMarkdownVersion.sh
+++ b/scripts/UseUpdatedPythonMarkdownVersion.sh
@@ -10,6 +10,9 @@ cd python-markdown
 # checkout the correct commit
 git checkout 73fdecaf2cf00d85b7c933f5b8d186d74a80ff2a
 
+# apply patch for supporting range line numbering
+git apply ../../patchs/python-markdown/0001-Add-range-support-for-HL-in-codehilite.patch
+
 # install
 python setup.py install --user
 

--- a/scripts/patchs/python-markdown/0001-Add-range-support-for-HL-in-codehilite.patch
+++ b/scripts/patchs/python-markdown/0001-Add-range-support-for-HL-in-codehilite.patch
@@ -1,0 +1,103 @@
+From 0d86a317f4d962ff2490604f3b7103a80d2a2fd9 Mon Sep 17 00:00:00 2001
+From: Christophe Gabard <christophe.gabard@gmail.com>
+Date: Sun, 12 Jan 2014 17:54:29 +0100
+Subject: [PATCH] Add range support for HL in codehilite
+
+---
+ markdown/extensions/codehilite.py  | 31 ++++++++++++++++++++++++-------
+ markdown/extensions/fenced_code.py | 10 +++++++++-
+ 2 files changed, 33 insertions(+), 8 deletions(-)
+
+diff --git a/markdown/extensions/codehilite.py b/markdown/extensions/codehilite.py
+index 9f99518..ee9c9d8 100644
+--- a/markdown/extensions/codehilite.py
++++ b/markdown/extensions/codehilite.py
+@@ -35,16 +35,32 @@ except ImportError:
+ def parse_hl_lines(expr):
+     """Support our syntax for emphasizing certain lines of code.
+ 
+-    expr should be like '1 2' to emphasize lines 1 and 2 of a code block.
++    expr should be like '1 2' to emphasize lines 1 and 2 of a code block
++    or contains lines ranges like '1 3-5' to emplasize lines 1 and 3 to
++    5 included.
+     Returns a list of ints, the line numbers to emphasize.
+     """
+     if not expr:
+         return []
+ 
+-    try:
+-        return map(int, expr.split())
+-    except ValueError:
+-        return []
++    listsHL = []
++    for exp in expr.split():
++        lex = exp.split("-")
++        if len(lex) == 1:
++            try:
++                val = int(lex[0])
++                listsHL.append(val)
++            except ValueError:
++                pass
++        elif len(lex) ==2:
++            try:
++                valMin = int(lex[0])
++                valMax = int(lex[1])
++                for val in range(valMin, valMax+1):
++                    listsHL.append(val)
++            except ValueError:
++                pass
++    return listsHL
+ 
+ 
+ # ------------------ The Main CodeHilite Class ----------------------
+@@ -65,7 +81,8 @@ class CodeHilite(object):
+ 
+     * css_class: Set class name of wrapper div ('codehilite' by default).
+ 
+-    * hl_lines: (List of integers) Lines to emphasize, 1-indexed.
++    * hl_lines: (List of integers) Lines to emphasize, 1-indexed. Can also containts elements
++    range.
+ 
+     Low Level Usage:
+         >>> code = CodeHilite()
+@@ -153,7 +170,7 @@ class CodeHilite(object):
+ 
+         Also parses optional list of highlight lines, like:
+ 
+-            :::python hl_lines="1 3"
++            :::python hl_lines="1 3 6-8"
+         """
+ 
+         import re
+diff --git a/markdown/extensions/fenced_code.py b/markdown/extensions/fenced_code.py
+index 39c6540..f5e1dce 100644
+--- a/markdown/extensions/fenced_code.py
++++ b/markdown/extensions/fenced_code.py
+@@ -62,15 +62,23 @@ Optionally backticks instead of tildes as per how github's code block markdown i
+ If the codehighlite extension and Pygments are installed, lines can be highlighted:
+ 
+     >>> text = '''
+-    ... ```hl_lines="1 3"
++    ... ```hl_lines="1 3 5-7"
+     ... line 1
+     ... line 2
+     ... line 3
++    ... line 4
++    ... line 5
++    ... line 6
++    ... line 7
+     ... ```'''
+     >>> print markdown.markdown(text, extensions=['codehilite', 'fenced_code'])
+     <pre><code><span class="hilight">line 1</span>
+     line 2
+     <span class="hilight">line 3</span>
++    line 4
++    <span class="hilight">line 5</span>
++    <span class="hilight">line 6</span>
++    <span class="hilight">line 7</span>
+     </code></pre>
+ 
+ Copyright 2007-2008 [Waylan Limberg](http://achinghead.com/).
+-- 
+1.8.5.2
+


### PR DESCRIPTION
Ajout d'un script, temporaire, pour installer une version a jour de python-markdown permetant la mise en évidence de lignes de codes. Ce code applique avant de l'installer un patch permetant d'ajouter le support d'intervalles à mettre en évidence.

Pour l'installer : 

``` console
cd scripts && ./UseUpdatedPythonMarkdownVersion.sh && cd ..
```

exemple de mise en évidence : 

``````
Mise en évidence des lignes 2 et 4 à 6, incluses :

```python hl_lines="2 4-6"
def Test():
    # je suis en évidence
    print "pas moi"
    print """Moi je le suis
               Et moi aussi
               ainsi que moi"""
    # Et pas moi :(
``````

```
```
