### PR TITLE
Fix committer information

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,16 @@ python manage.py syncdb
 python manage.py migrate
 python manage.py runserver
 ```
-Pour appliquer le pacth de correction du module gitpython, executez :
+Pour appliquer le pacth de correction du module gitpython (obligatoire), executez :
 
 ```console
 cd scripts && ./UseUpdatedGitPython.sh && cd ..
+```
+
+Si vous voulez utiliser la meme version de python-markdown que sur le serveur, incluant la mise en évidence de lignes de codes particulières exécutez :
+
+```console
+cd scripts && ./UseUpdatedPythonMarkdownVersion.sh && cd ..
 ```
 
 Pour bénéficier de données statiques, exécutez les commandes suivantes, dans l'ordre, à la fin des précédentes :
@@ -114,11 +120,5 @@ Cela va créer plusieurs entitées :
 * 3 topics with one answer
 * 1 mp with 3 participants
 * 3 catégories et 2 sous-catégories
-
-Si vous voulez utiliser la meme version de python-markdown que sur le serveur, incluant la mise en évidence de lignes de codes particulières exécutez :
-
-```console
-cd scripts && ./UseUpdatedPythonMarkdownVersion.sh && cd ..
-```
 
 Pour plus de détails consultez l'[article dans le wiki](https://github.com/Taluu/ZesteDeSavoir/wiki) (pas encore terminé)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ python manage.py syncdb
 python manage.py migrate
 python manage.py runserver
 ```
+Pour appliquer le pacth de correction du module gitpython, executez :
+
+```console
+cd scripts && ./UseUpdatedGitPython.sh && cd ..
+```
 
 Pour bénéficier de données statiques, exécutez les commandes suivantes, dans l'ordre, à la fin des précédentes :
 

--- a/scripts/UseUpdatedGitPython.sh
+++ b/scripts/UseUpdatedGitPython.sh
@@ -1,0 +1,27 @@
+#! /usr/bin/sh
+
+mkdir temp
+cd temp
+
+# clone repository
+git clone https://github.com/bu-ist/GitPython.git
+
+cd GitPython
+
+# checkout the correct commit
+git checkout 2fc864356ef1c4a9112dcefbae02a606df59840c
+
+# apply patch for supporting commit by user
+git apply ../../patchs/GitPython/add-commit-by-username.patch
+
+# install
+python setup.py install --user
+
+# cleanning
+cd ..
+rm -rf GitPython
+
+cd ..
+rm -rf temp
+
+

--- a/scripts/patchs/GitPython/add-commit-by-username.patch
+++ b/scripts/patchs/GitPython/add-commit-by-username.patch
@@ -1,0 +1,295 @@
+diff --git a/.project b/.project
+new file mode 100644
+index 0000000..e91beea
+--- /dev/null
++++ b/.project
+@@ -0,0 +1,17 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<projectDescription>
++	<name>GitPython</name>
++	<comment></comment>
++	<projects>
++	</projects>
++	<buildSpec>
++		<buildCommand>
++			<name>org.python.pydev.PyDevBuilder</name>
++			<arguments>
++			</arguments>
++		</buildCommand>
++	</buildSpec>
++	<natures>
++		<nature>org.python.pydev.pythonNature</nature>
++	</natures>
++</projectDescription>
+diff --git a/.pydevproject b/.pydevproject
+new file mode 100644
+index 0000000..40e9f40
+--- /dev/null
++++ b/.pydevproject
+@@ -0,0 +1,5 @@
++<?xml version="1.0" encoding="UTF-8" standalone="no"?>
++<?eclipse-pydev version="1.0"?><pydev_project>
++<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
++<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
++</pydev_project>
+diff --git a/GitPython.egg-info/PKG-INFO b/GitPython.egg-info/PKG-INFO
+new file mode 100644
+index 0000000..f94fa7f
+--- /dev/null
++++ b/GitPython.egg-info/PKG-INFO
+@@ -0,0 +1,19 @@
++Metadata-Version: 1.1
++Name: GitPython
++Version: 0.3.2.RC1
++Summary: Python Git Library
++Home-page: http://gitorious.org/projects/git-python/
++Author: Sebastian Thiel, Michael Trier
++Author-email: byronimo@gmail.com, mtrier@gmail.com
++License: BSD License
++Description: GitPython is a python library used to interact with Git repositories
++Platform: UNKNOWN
++Classifier: Development Status :: 4 - Beta
++Classifier: Intended Audience :: Developers
++Classifier: License :: OSI Approved :: BSD License
++Classifier: Operating System :: OS Independent
++Classifier: Programming Language :: Python
++Classifier: Programming Language :: Python :: 2.5
++Classifier: Programming Language :: Python :: 2.6
++Classifier: Topic :: Software Development :: Libraries :: Python Modules
++Requires: gitdb (>=0.5.1)
+diff --git a/GitPython.egg-info/SOURCES.txt b/GitPython.egg-info/SOURCES.txt
+new file mode 100644
+index 0000000..44f826f
+--- /dev/null
++++ b/GitPython.egg-info/SOURCES.txt
+@@ -0,0 +1,116 @@
++AUTHORS
++CHANGES
++LICENSE
++MANIFEST.in
++README.rst
++VERSION
++setup.py
++GitPython.egg-info/PKG-INFO
++GitPython.egg-info/SOURCES.txt
++GitPython.egg-info/dependency_links.txt
++GitPython.egg-info/not-zip-safe
++GitPython.egg-info/requires.txt
++GitPython.egg-info/top_level.txt
++git/__init__.py
++git/cmd.py
++git/config.py
++git/db.py
++git/diff.py
++git/exc.py
++git/odict.py
++git/remote.py
++git/util.py
++git/index/__init__.py
++git/index/base.py
++git/index/fun.py
++git/index/typ.py
++git/index/util.py
++git/objects/__init__.py
++git/objects/base.py
++git/objects/blob.py
++git/objects/commit.py
++git/objects/fun.py
++git/objects/tag.py
++git/objects/tree.py
++git/objects/util.py
++git/objects/submodule/__init__.py
++git/objects/submodule/base.py
++git/objects/submodule/root.py
++git/objects/submodule/util.py
++git/refs/__init__.py
++git/refs/head.py
++git/refs/log.py
++git/refs/reference.py
++git/refs/remote.py
++git/refs/symbolic.py
++git/refs/tag.py
++git/repo/__init__.py
++git/repo/base.py
++git/repo/fun.py
++git/test/__init__.py
++git/test/test_actor.py
++git/test/test_base.py
++git/test/test_blob.py
++git/test/test_commit.py
++git/test/test_config.py
++git/test/test_db.py
++git/test/test_diff.py
++git/test/test_fun.py
++git/test/test_git.py
++git/test/test_index.py
++git/test/test_reflog.py
++git/test/test_refs.py
++git/test/test_remote.py
++git/test/test_repo.py
++git/test/test_stats.py
++git/test/test_submodule.py
++git/test/test_tree.py
++git/test/test_util.py
++git/test/fixtures/blame
++git/test/fixtures/cat_file_blob
++git/test/fixtures/cat_file_blob_nl
++git/test/fixtures/cat_file_blob_size
++git/test/fixtures/diff_2
++git/test/fixtures/diff_2f
++git/test/fixtures/diff_f
++git/test/fixtures/diff_i
++git/test/fixtures/diff_mode_only
++git/test/fixtures/diff_new_mode
++git/test/fixtures/diff_numstat
++git/test/fixtures/diff_p
++git/test/fixtures/diff_rename
++git/test/fixtures/diff_tree_numstat_root
++git/test/fixtures/for_each_ref_with_path_component
++git/test/fixtures/git_config
++git/test/fixtures/git_config_global
++git/test/fixtures/index
++git/test/fixtures/index_merge
++git/test/fixtures/ls_tree_a
++git/test/fixtures/ls_tree_b
++git/test/fixtures/ls_tree_commit
++git/test/fixtures/reflog_HEAD
++git/test/fixtures/reflog_invalid_date
++git/test/fixtures/reflog_invalid_email
++git/test/fixtures/reflog_invalid_newsha
++git/test/fixtures/reflog_invalid_oldsha
++git/test/fixtures/reflog_invalid_sep
++git/test/fixtures/reflog_master
++git/test/fixtures/rev_list
++git/test/fixtures/rev_list_bisect_all
++git/test/fixtures/rev_list_commit_diffs
++git/test/fixtures/rev_list_commit_idabbrev
++git/test/fixtures/rev_list_commit_stats
++git/test/fixtures/rev_list_count
++git/test/fixtures/rev_list_delta_a
++git/test/fixtures/rev_list_delta_b
++git/test/fixtures/rev_list_single
++git/test/fixtures/rev_parse
++git/test/fixtures/show_empty_commit
++git/test/lib/__init__.py
++git/test/lib/asserts.py
++git/test/lib/helper.py
++git/test/performance/lib.py
++git/test/performance/test_commit.py
++git/test/performance/test_odb.py
++git/test/performance/test_streams.py
++git/test/performance/test_utils.py
+\ No newline at end of file
+diff --git a/GitPython.egg-info/dependency_links.txt b/GitPython.egg-info/dependency_links.txt
+new file mode 100644
+index 0000000..8b13789
+--- /dev/null
++++ b/GitPython.egg-info/dependency_links.txt
+@@ -0,0 +1 @@
++
+diff --git a/GitPython.egg-info/not-zip-safe b/GitPython.egg-info/not-zip-safe
+new file mode 100644
+index 0000000..8b13789
+--- /dev/null
++++ b/GitPython.egg-info/not-zip-safe
+@@ -0,0 +1 @@
++
+diff --git a/GitPython.egg-info/requires.txt b/GitPython.egg-info/requires.txt
+new file mode 100644
+index 0000000..5cfbe86
+--- /dev/null
++++ b/GitPython.egg-info/requires.txt
+@@ -0,0 +1 @@
++gitdb >= 0.5.1
+\ No newline at end of file
+diff --git a/GitPython.egg-info/top_level.txt b/GitPython.egg-info/top_level.txt
+new file mode 100644
+index 0000000..5664e30
+--- /dev/null
++++ b/GitPython.egg-info/top_level.txt
+@@ -0,0 +1 @@
++git
+diff --git a/git/ext/gitdb b/git/ext/gitdb
+deleted file mode 160000
+index 656a2e0..0000000
+--- a/git/ext/gitdb
++++ /dev/null
+-Subproject commit 656a2e0b4da7d60ac638d1615751a89efb3a4eee
+diff --git a/git/index/base.py b/git/index/base.py
+index 354319b..9f76adf 100644
+--- a/git/index/base.py
++++ b/git/index/base.py
+@@ -873,7 +873,7 @@
+ 
+ 		return out
+ 
+-	def commit(self, message, parent_commits=None, head=True):
++	def commit(self, message, parent_commits=None, head=True, author=None, committer=None):
+ 		"""Commit the current default index file, creating a commit object.
+ 
+ 		For more information on the arguments, see tree.commit.
+@@ -884,7 +884,7 @@
+ 		:return:
+ 			Commit object representing the new commit"""
+ 		tree = self.write_tree()
+-		return Commit.create_from_tree(self.repo, tree, message, parent_commits, head)
++		return Commit.create_from_tree(self.repo, tree, message, parent_commits, head, author=author, committer=committer)
+ 
+ 	@classmethod
+ 	def _flush_stdin_and_wait(cls, proc, ignore_stdout = False):
+diff --git a/git/objects/commit.py b/git/objects/commit.py
+index fd4187b..5413059 100644
+--- a/git/objects/commit.py
++++ b/git/objects/commit.py
+@@ -254,7 +254,7 @@
+ 		
+ 		
+ 	@classmethod
+-	def create_from_tree(cls, repo, tree, message, parent_commits=None, head=False):
++	def create_from_tree(cls, repo, tree, message, parent_commits=None, head=False, author=None, committer=None):
+ 		"""Commit the given tree, creating a commit object.
+ 		
+ 		:param repo: Repo object the commit should be part of 
+@@ -299,8 +299,14 @@
+ 		cr = repo.config_reader()
+ 		env = os.environ
+ 		
+-		committer = Actor.committer(cr)
+-		author = Actor.author(cr)
++		if author is None and committer is None:
++			committer = Actor.committer(cr)
++			author = Actor.author(cr)
++		elif author is None:
++			author = Actor.author(cr)
++		elif committer is None:
++			committer = Actor.committer(cr)
++		
+ 		
+ 		# PARSE THE DATES
+ 		unix_time = int(time())
+diff --git a/git/refs/log.py b/git/refs/log.py
+index 0e97772..aca47d5 100644
+--- a/git/refs/log.py
++++ b/git/refs/log.py
+@@ -247,7 +247,7 @@
+ 			raise ValueError("Shas need to be given in binary format")
+ 		#END handle sha type
+ 		assure_directory_exists(filepath, is_file=True)
+-		entry = RefLogEntry((bin_to_hex(oldbinsha), bin_to_hex(newbinsha), Actor.committer(config_reader), (int(time.time()), time.altzone), message))
++		entry = RefLogEntry((bin_to_hex(oldbinsha), bin_to_hex(newbinsha), config_reader, (int(time.time()), time.altzone), message))
+ 		
+ 		lf = LockFile(filepath)
+ 		lf._obtain_lock_or_raise()
+diff --git a/git/refs/symbolic.py b/git/refs/symbolic.py
+index 8556a65..05d12b7 100644
+--- a/git/refs/symbolic.py
++++ b/git/refs/symbolic.py
+@@ -355,7 +355,7 @@
+ 		:param newbinsha: The sha the ref points to now. If None, our current commit sha
+ 			will be used
+ 		:return: added RefLogEntry instance"""
+-		return RefLog.append_entry(self.repo.config_reader(), RefLog.path(self), oldbinsha, 
++		return RefLog.append_entry(self.commit.committer, RefLog.path(self), oldbinsha, 
+ 									(newbinsha is None and self.commit.binsha) or newbinsha, 
+ 									message) 
+ 

--- a/templates/article/history.html
+++ b/templates/article/history.html
@@ -1,6 +1,7 @@
 {% extends "article/base.html" %}
 {% load emarkdown %}
 {% load humane_date %}
+{% load profile %}
 
 {% block title %}
 {{ article.title }}
@@ -69,7 +70,17 @@
               <td><p>{{ log.time.0|humane_time }}</p></td>
               <td><p><a href="{% url "zds.article.views.view" article.pk article.slug %}?version={{ log.newhexsha }}" >{{ log.message }}</a></p></td>
               <td><p><a href="#" >{{ log.newhexsha|truncatechars:8 }}</a></p></td>
-              <td><p>{{ log.actor }}</p></td>
+              <td>
+                {% with u=log.actor.name|user %}
+                  {% if u %}
+                    {% with profile=u|profile %}
+                    <p><a href="{{ profile.get_absolute_url }}">{{ u.username }}</a></p>
+                    {% endwith %}
+                  {% else %}
+                    <p>Inconnu</p>
+                  {% endif %}
+                {% endwith %}
+              </td>
             </tr>
             {% endfor %}
           </tbody>

--- a/templates/tutorial/history_tutorial.html
+++ b/templates/tutorial/history_tutorial.html
@@ -1,6 +1,7 @@
 {% extends "tutorial/base.html" %}
 {% load emarkdown %}
 {% load humane_date %}
+{% load profile %}
 
 {% block title %}
 {{ tutorial.title }}
@@ -69,7 +70,17 @@
               <td><p>{{ log.time.0|humane_time }}</p></td>
               <td><p><a href="{% url "zds.tutorial.views.view_tutorial" tutorial.pk tutorial.slug %}?version={{ log.newhexsha }}" >{{ log.message }}</a></p></td>
               <td><p><a href="{% url "zds.tutorial.views.diff" tutorial.pk tutorial.slug %}?sha={{ log.newhexsha }}" >{{ log.newhexsha|truncatechars:8 }}</a></p></td>
-              <td><p>{{ log.actor }}</p></td>
+              <td>
+                {% with u=log.actor.name|user %}
+                  {% if u %}
+                    {% with profile=u|profile %}
+                    <p><a href="{{ profile.get_absolute_url }}">{{ u.username }}</a></p>
+                    {% endwith %}
+                  {% else %}
+                    <p>Inconnu</p>
+                  {% endif %}
+                {% endwith %}
+              </td>
             </tr>
             {% endfor %}
           </tbody>

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -316,7 +316,8 @@ def new(request):
 
             article.save()
             
-            maj_repo_article(new_slug_path=article.get_path(), 
+            maj_repo_article(request,
+                          new_slug_path=article.get_path(), 
                           article = article,
                           text = data['text'],
                           action = 'add')
@@ -362,7 +363,8 @@ def edit(request):
 
             new_slug = os.path.join(settings.REPO_ARTICLE_PATH, slugify(data['title']))
             
-            maj_repo_article(old_slug_path=old_slug, 
+            maj_repo_article(request,
+                          old_slug_path=old_slug, 
                           new_slug_path=new_slug, 
                           article=article, 
                           text=data['text'],
@@ -468,7 +470,7 @@ def find_article(request, name):
         'articles': articles, 'usr':u,
     })
 
-def maj_repo_article(old_slug_path=None, new_slug_path=None, article=None, text=None, action=None):
+def maj_repo_article(request, old_slug_path=None, new_slug_path=None, article=None, text=None, action=None):
     
     if action == 'del' :
         shutil.rmtree(old_slug_path)
@@ -494,8 +496,14 @@ def maj_repo_article(old_slug_path=None, new_slug_path=None, article=None, text=
         txt.write(smart_str(text).strip())
         txt.close()
         index.add(['text.md'])
-            
-        com = index.commit(msg.encode('utf-8'))
+        
+        aut_user = str(request.user.pk)
+        aut_email = str(request.user.email)
+        if aut_email is None or aut_email.strip() == "":
+            aut_email ="inconnu@zestedesavoir.com"
+        com = index.commit(msg.encode('utf-8'),
+                           author=Actor(aut_user, aut_email),
+                           committer=Actor(aut_user, aut_email))
         article.sha_draft=com.hexsha
         article.save()
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -498,7 +498,8 @@ def add_tutorial(request):
             
             tutorial.save()
             
-            maj_repo_tuto(new_slug_path=tutorial.get_path(), 
+            maj_repo_tuto(request,
+                          new_slug_path=tutorial.get_path(), 
                           tuto = tutorial,
                           action = 'add')
             
@@ -554,7 +555,8 @@ def edit_tutorial(request):
             
             tutorial.save()
             
-            maj_repo_tuto(old_slug_path=old_slug, 
+            maj_repo_tuto(request,
+                          old_slug_path=old_slug, 
                           new_slug_path=new_slug, 
                           tuto=tutorial, 
                           introduction=data['introduction'], 
@@ -676,7 +678,8 @@ def modify_tutorial(request):
         elif 'delete' in request.POST:
             old_slug = os.path.join(settings.REPO_PATH, tutorial.slug)
             
-            maj_repo_tuto(old_slug_path=old_slug,
+            maj_repo_tuto(request,
+                          old_slug_path=old_slug,
                           tuto = tutorial,
                           action = 'del')
             
@@ -861,7 +864,8 @@ def add_part(request):
             
             part.save()
             
-            maj_repo_part(new_slug_path =new_slug, 
+            maj_repo_part(request,
+                          new_slug_path =new_slug, 
                           part = part, 
                           introduction = data['introduction'], 
                           conclusion = data['conclusion'],
@@ -911,7 +915,8 @@ def modify_part(request):
         old_slug = os.path.join(os.path.join(settings.REPO_PATH, part.tutorial.slug), part.slug)
         
         
-        maj_repo_part(old_slug_path=old_slug,
+        maj_repo_part(request,
+                          old_slug_path=old_slug,
                       action ='del')
         # Actually delete the part
         part.delete()
@@ -943,7 +948,8 @@ def edit_part(request):
             
             part.save()
             
-            maj_repo_part(old_slug_path = old_slug, 
+            maj_repo_part(request,
+                          old_slug_path = old_slug, 
                           new_slug_path = new_slug, 
                           part = part, 
                           introduction = data['introduction'], 
@@ -1165,7 +1171,8 @@ def add_chapter(request):
                 
                 chapter.save()
                 
-                maj_repo_chapter(new_slug_path=new_slug, 
+                maj_repo_chapter(request,
+                                 new_slug_path=new_slug, 
                                  chapter=chapter, 
                                  introduction=data['introduction'], 
                                  conclusion=data['conclusion'],
@@ -1229,7 +1236,8 @@ def modify_chapter(request):
                 tut_c.position_in_part = tut_c.position_in_part - 1
                 tut_c.save()
         
-        maj_repo_chapter(new_slug_path=chapter.get_path(),
+        maj_repo_chapter(request,
+                         new_slug_path=chapter.get_path(),
                          action = 'del')
         # Then delete the chapter
         chapter.delete()
@@ -1294,7 +1302,8 @@ def edit_chapter(request):
             
             chapter.save()
             
-            maj_repo_chapter(old_slug_path = old_slug,
+            maj_repo_chapter(request,
+                             old_slug_path = old_slug,
                              new_slug_path = new_slug, 
                              chapter=chapter,
                              introduction=data['introduction'], 
@@ -1347,7 +1356,8 @@ def add_extract(request):
             extract.text = extract.get_path(relative=True)
             extract.save()
             
-            maj_repo_extract(new_slug_path=extract.get_path(), 
+            maj_repo_extract(request,
+                             new_slug_path=extract.get_path(), 
                              extract=extract, 
                              text=data['text'],
                              action='add')
@@ -1402,7 +1412,8 @@ def edit_extract(request):
             
             extract.save()
             
-            maj_repo_extract(old_slug_path=old_slug, 
+            maj_repo_extract(request,
+                             old_slug_path=old_slug, 
                              new_slug_path=new_slug, 
                              extract=extract, 
                              text=data['text'],
@@ -1449,7 +1460,8 @@ def modify_extract(request):
             chapter_path = os.path.join(os.path.join(os.path.join(settings.REPO_PATH, extract.chapter.part.tutorial.slug), extract.chapter.part.slug), extract.chapter.slug)
         old_slug = os.path.join(chapter_path, slugify(extract.title)+'.md')
         
-        maj_repo_extract(old_slug_path=old_slug, 
+        maj_repo_extract(request,
+                         old_slug_path=old_slug, 
                          extract=extract,
                          action = 'del')
         
@@ -1546,10 +1558,11 @@ def import_tuto(request):
                         
                         tutorial.save()
                         
-                        maj_repo_tuto(new_slug_path=tuto_path, 
+                        maj_repo_tuto(request,
+                                      new_slug_path=tuto_path, 
                                       tuto=tutorial, 
-                                      introduction=tuto_to_markdown(tutorial_intro.text), 
-                                      conclusion=tuto_to_markdown(tutorial_conclu.text),
+                                      introduction=tutorial_intro.text, 
+                                      conclusion=tutorial_conclu.text,
                                       action = 'add')
                         
                         tutorial.authors.add(request.user)
@@ -1572,7 +1585,7 @@ def import_tuto(request):
                             
                             part.save()
                             
-                            maj_repo_part(None, part_path, part, tuto_to_markdown(part_intro.text), tuto_to_markdown(part_conclu.text), action='add')
+                            maj_repo_part(request, None, part_path, part, part_intro.text, part_conclu.text, action='add')
                             
                             
                             chapter_count = 1
@@ -1594,10 +1607,11 @@ def import_tuto(request):
                                 
                                 chapter.save()
                                 
-                                maj_repo_chapter(new_slug_path=chapter_path, 
+                                maj_repo_chapter(request,
+                                                 new_slug_path=chapter_path, 
                                                  chapter=chapter, 
-                                                 introduction=tuto_to_markdown(chapter_intro.text), 
-                                                 conclusion=tuto_to_markdown(chapter_conclu.text),
+                                                 introduction=chapter_intro.text, 
+                                                 conclusion=chapter_conclu.text,
                                                  action='add')
                                 
                                 
@@ -1614,7 +1628,7 @@ def import_tuto(request):
                                     extract.text = extract.get_path(relative=True)
                                     extract.save()
 
-                                    maj_repo_extract(new_slug_path=extract.get_path(), extract=extract, text=tuto_to_markdown(extract_text.text), action= 'add')
+                                    maj_repo_extract(request,new_slug_path=extract.get_path(), extract=extract, text=extract_text.text, action= 'add')
                                     
                                     
                                     extract_count += 1
@@ -1654,10 +1668,11 @@ def import_tuto(request):
                         
                         tutorial.save()
                         
-                        maj_repo_tuto(new_slug_path=tuto_path, 
+                        maj_repo_tuto(request,
+                                      new_slug_path=tuto_path, 
                                       tuto=tutorial, 
-                                      introduction=tuto_to_markdown(tutorial_intro.text), 
-                                      conclusion=tuto_to_markdown(tutorial_conclu.text),
+                                      introduction=tutorial_intro.text, 
+                                      conclusion=tutorial_conclu.text,
                                       action = 'add')
                         
                         tutorial.authors.add(request.user)
@@ -1679,7 +1694,7 @@ def import_tuto(request):
                             
                             extract.save()
                             
-                            maj_repo_extract(new_slug_path=extract.get_path(), extract=extract, text=tuto_to_markdown(extract_text.text), action='add')
+                            maj_repo_extract(request,new_slug_path=extract.get_path(), extract=extract, text=extract_text.text, action='add')
                             
                             
                             extract_count += 1
@@ -1718,7 +1733,7 @@ def deprecated_view_chapter_redirect(
 
 # Handling repo
 
-def maj_repo_tuto(old_slug_path=None, new_slug_path=None, tuto=None, introduction=None, conclusion=None, action=None):
+def maj_repo_tuto(request, old_slug_path=None, new_slug_path=None, tuto=None, introduction=None, conclusion=None, action=None):
     
     if action == 'del' :
         shutil.rmtree(old_slug_path)
@@ -1749,13 +1764,20 @@ def maj_repo_tuto(old_slug_path=None, new_slug_path=None, tuto=None, introductio
         conclu.write(smart_str(conclusion).strip())
         conclu.close()
         index.add(['conclusion.md'])
+        
+        aut_user = str(request.user.pk)
+        aut_email = str(request.user.email)
+        if aut_email is None or aut_email.strip() == "":
+            aut_email ="inconnu@zestedesavoir.com"
             
-        com = index.commit(msg.encode('utf-8'))
+        com = index.commit(msg.encode('utf-8'),
+                           author=Actor(aut_user, aut_email),
+                           committer=Actor(aut_user, aut_email))
         tuto.sha_draft=com.hexsha
         tuto.save()
         
     
-def maj_repo_part(old_slug_path=None, new_slug_path=None, part=None, introduction=None, conclusion=None, action=None):
+def maj_repo_part(request, old_slug_path=None, new_slug_path=None, part=None, introduction=None, conclusion=None, action=None):
     
     repo = Repo(part.tutorial.get_path())
     index = repo.index
@@ -1763,16 +1785,16 @@ def maj_repo_part(old_slug_path=None, new_slug_path=None, part=None, introductio
     msg='repo partie'
     if action == 'del' :
         shutil.rmtree(old_slug_path)
-        msg='Suppresion de la partie : '+part.title
+        msg='Suppresion de la partie '
         index.remove([part.get_path(relative=True)])
         
     else:
         if action == 'maj' :
             os.rename(old_slug_path, new_slug_path)
-            msg='Modification de la partie : '+part.title
+            msg='Modification de la partie '
         elif action == 'add' :
             os.makedirs(new_slug_path, mode=0777)
-            msg='Creation de la partie : '+part.title
+            msg='Creation de la partie '
         
         index.add([slugify(part.title)])
         
@@ -1790,13 +1812,19 @@ def maj_repo_part(old_slug_path=None, new_slug_path=None, part=None, introductio
         conclu.close()
         index.add([os.path.join(part.get_path(relative=True),'conclusion.md')])
     
-    com_part = index.commit(msg.encode('utf-8'))
+    aut_user = str(request.user.pk)
+    aut_email = str(request.user.email)
+    if aut_email is None or aut_email.strip() == "":
+        aut_email ="inconnu@zestedesavoir.com"
+    com_part = index.commit(msg.encode('utf-8'),
+                           author=Actor(aut_user, aut_email),
+                           committer=Actor(aut_user, aut_email))
     part.tutorial.sha_draft=com_part.hexsha
     part.tutorial.save()
     
     part.save()
         
-def maj_repo_chapter(old_slug_path=None, new_slug_path=None, chapter=None, introduction=None, conclusion=None, action=None):
+def maj_repo_chapter(request, old_slug_path=None, new_slug_path=None, chapter=None, introduction=None, conclusion=None, action=None):
     if(chapter.tutorial):
         repo = Repo(os.path.join(settings.REPO_PATH, chapter.tutorial.slug))
         ph=chapter.slug
@@ -1809,15 +1837,15 @@ def maj_repo_chapter(old_slug_path=None, new_slug_path=None, chapter=None, intro
     
     if action == 'del' :
         shutil.rmtree(old_slug_path)
-        msg='Suppresion du chapitre : '+chapter.title
+        msg='Suppresion du chapitre  '
         index.remove([ph])
     else:
         if action == 'maj' :
             os.rename(old_slug_path, new_slug_path)
-            msg='Modification du chapitre : '+chapter.title
+            msg='Modification du chapitre '
         elif action == 'add' :
             os.makedirs(new_slug_path, mode=0777)
-            msg='Creation du chapitre : '+chapter.title
+            msg='Creation du chapitre '
 
         
         intro = open(os.path.join(new_slug_path, 'introduction.md'), "w")
@@ -1840,7 +1868,13 @@ def maj_repo_chapter(old_slug_path=None, new_slug_path=None, chapter=None, intro
     
     index.add(['manifest.json'])
 
-    com_ch = index.commit(msg.encode('utf-8'))
+    aut_user = str(request.user.pk)
+    aut_email = str(request.user.email)
+    if aut_email is None or aut_email.strip() == "":
+        aut_email ="inconnu@zestedesavoir.com"
+    com_ch = index.commit(msg.encode('utf-8'),
+                           author=Actor(aut_user, aut_email),
+                           committer=Actor(aut_user, aut_email))
     
     if(chapter.tutorial):
         chapter.tutorial.sha_draft=com_ch.hexsha
@@ -1851,7 +1885,7 @@ def maj_repo_chapter(old_slug_path=None, new_slug_path=None, chapter=None, intro
     
     chapter.save()
     
-def maj_repo_extract(old_slug_path=None, new_slug_path=None, extract=None, text=None, action=None):
+def maj_repo_extract(request, old_slug_path=None, new_slug_path=None, extract=None, text=None, action=None):
     if(extract.chapter.tutorial):
         repo = Repo(os.path.join(settings.REPO_PATH, extract.chapter.tutorial.slug))
         ph=extract.chapter.slug
@@ -1863,16 +1897,16 @@ def maj_repo_extract(old_slug_path=None, new_slug_path=None, extract=None, text=
     
     if action == 'del' :
          os.remove(old_slug_path)
-         msg='Suppression de l\'exrait : '+extract.title
+         msg='Suppression de l\'exrait '
     else:        
         if action == 'maj' :
             os.rename(old_slug_path, new_slug_path)
-            msg='Modification de l\'exrait : '+extract.title
+            msg='Modification de l\'exrait '
         ext = open(new_slug_path, "w")
         ext.write(smart_str(text).strip())
         ext.close()
         index.add([extract.get_path(relative=True)])
-        msg='Mise a jour de l\'exrait : '+extract.title
+        msg='Mise a jour de l\'exrait '
     
     #update manifest
     if(extract.chapter.tutorial):
@@ -1884,7 +1918,13 @@ def maj_repo_extract(old_slug_path=None, new_slug_path=None, extract=None, text=
         
     index.add(['manifest.json'])
     
-    com_ex = index.commit(msg.encode('utf-8'))
+    aut_user = str(request.user.pk)
+    aut_email = str(request.user.email)
+    if aut_email is None or aut_email.strip() == "":
+        aut_email ="inconnu@zestedesavoir.com"
+    com_ex = index.commit(msg.encode('utf-8'),
+                           author=Actor(aut_user, aut_email),
+                           committer=Actor(aut_user, aut_email))
     
     if(extract.chapter.tutorial):
         extract.chapter.tutorial.sha_draft = com_ex.hexsha
@@ -1895,29 +1935,6 @@ def maj_repo_extract(old_slug_path=None, new_slug_path=None, extract=None, text=
         
     extract.save()
 
-def tuto_to_markdown(text):
-    chaine = re.sub(r'(.*)<titre1>(.*)</titre1>(.*)', r'\1##\2\3', text)
-    chaine = re.sub(r'(.*)<titre2>(.*)</titre2>(.*)', r'\1###\2\3', chaine)
-    chaine = re.sub(r'(.*)<gras>(.*)</gras>(.*)', r'\1**\2**\3', chaine)
-    chaine = re.sub(r'(.*)<italique>(.*)</italique>(.*)', r'\1*\2*\3', chaine)
-    chaine = re.sub(r'(.*)<lien(.*)url="(.*)">(.*)</lien>(.*)', r'\1[\4](\3)\5', chaine)
-    chaine = re.sub(r'(.*)<image([\s|\S]*)>(.*)</image>([\s|\S]*)', r'\1![](\3)\4', chaine)
-    chaine = re.sub(r'(.*)<puce>(.*)</puce>(.*)', r'\1- \2\3', chaine)
-    chaine = re.sub(r'(.*)<minicode(.*)type="(.*)"(.*)>(.*)</minicode>(.*)', r'\1`\5`\6', chaine)
-    chaine = re.sub(r'(.*)<code(.*)type="(.*)"(.*)>([\s|\S]*)</code>(.*)', r'\1\r```\3\r\5\r```\r\6', chaine)    
-    chaine = re.sub(r'(.*)<couleur nom="(.*)">(.*)</couleur>(.*)', r'\1\3\4', chaine)
-    chaine = re.sub(r'(.*)<position valeur="(.*)">', r'\1', chaine)
-    chaine = re.sub(r'</position>(.*)', r'\1', chaine)
-    chaine = re.sub(r'(.*)<taille valeur="(.*)">', r'\1', chaine)
-    chaine = re.sub(r'</taille>(.*)', r'\1', chaine)
-    chaine = re.sub(r'(.*)<liste>', r'\1', chaine)
-    chaine = re.sub(r'</liste>(.*)', r'\1', chaine)
-    chaine = re.sub(r'(.*)<information(.*)>(.*)</information>(.*)', r'\1\n[information]\n|\3\n\4', chaine)
-    chaine = re.sub(r'(.*)<question(.*)>(.*)</question>(.*)', r'\1\n[question]\n|\3\n\4', chaine)
-    chaine = re.sub(r'(.*)<erreur(.*)>(.*)</erreur>(.*)', r'\1\n[erreur]\n|\3\n\4', chaine)
-    chaine = re.sub(r'(.*)<attention(.*)>(.*)</attention>(.*)', r'\1\n[attention]\n|\3\n\4', chaine)
-
-    return chaine
 
 @can_read_now
 def download(request):

--- a/zds/utils/templatetags/profile.py
+++ b/zds/utils/templatetags/profile.py
@@ -3,6 +3,7 @@
 from django import template
 
 from zds.member.models import Profile
+from django.contrib.auth.models import User
 
 
 register = template.Library()
@@ -15,6 +16,14 @@ def profile(user):
     except Profile.DoesNotExist:
         profile = None
     return profile
+
+@register.filter('user')
+def user(pk):
+    try:
+        user = User.objects.get(pk=pk)
+    except:
+        user = None
+    return user
 
 @register.filter('mode')
 def mode(mode):


### PR DESCRIPTION
Cette PR vient corriger le problème du marquage des commits par utilisateurs. Désormais, chaque modification est reliée à la clé de l'utilisateur qui fait la modification. Donc si un utilisateur change de pseudo, on retrouve toujours l'auteur.

J'ai du modifier le code source de la lin gitpython pour rajouter cette fonctionnalité. Il faudra donc appliquer ce patch en attendant que le projet officiel accepte ma PR.
