### PR TITLE
fix : Comment after fenced_code_block

### DIFF
--- a/zds/utils/templatetags/mkd_ext/comments.py
+++ b/zds/utils/templatetags/mkd_ext/comments.py
@@ -17,7 +17,7 @@ class CommentsExtension(Extension):
     
     def extendMarkdown(self, md, md_globals):
         md.registerExtension(self)
-        md.preprocessors.add("comments", CommentsProcessor(md, self.config), "_begin")
+        md.preprocessors.add("comments", CommentsProcessor(md, self.config), ">fenced_code_block")
 
 class CommentsProcessor(Preprocessor):
     


### PR DESCRIPTION
Petit fix permetant de faire passer la suppression des commentaires après l'extension d'ajout de la syntaxe de code type GitHub. Cela permet de ne pas supprimer les commentaires dans ces blocs de codes et donc de pouvoir les citer dans les tutos de description de la syntaxe.
