### PR TITLE
provide new emarkdown_inline() filter with separate construction

### DIFF
--- a/templates/forum/topic.html
+++ b/templates/forum/topic.html
@@ -1,5 +1,6 @@
 {% extends "forum/base.html" %}
 {% load emarkdown %}
+{% load emarkdown_inline %}
 {% load markup %}
 {% load humane_date %}
 {% load profile %}
@@ -82,7 +83,7 @@
 
         <div class="message-bottom">
             {% with profile=post.author|profile %}
-                <p class="signature">{{profile.sign|emarkdown}}</p>
+                <p class="signature">{{profile.sign|emarkdown_inline}}</p>
             {% endwith %}
             {% if user.is_authenticated %}
             <div class="message-karma">

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -101,9 +101,9 @@ def humane_time(t, conf={}):
 
 @register.filter(needs_autoescape=False)
 def emarkdown(text):
-    return mark_safe('<div class="markdown">{0}</div>'.format(get_markdown_instance(Inline = False).convert(text).encode('utf-8')))
+    return mark_safe('{0}'.format(get_markdown_instance(Inline = False).convert(text).encode('utf-8')))
 
 
 @register.filter(needs_autoescape=False)
 def emarkdown_inline(text):
-    return mark_safe('<div class="markdown">{0}</div>'.format(get_markdown_instance(Inline = True).convert(text).encode('utf-8')))
+    return mark_safe('{0}'.format(get_markdown_instance(Inline = True).convert(text).encode('utf-8')))

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -88,6 +88,8 @@ def get_markdown_instance(Inline = False):
     if Inline:
         md.parser.blockprocessors.clear()
         md.preprocessors.pop("reference")
+        md.inlinePatterns.pop("image_link")
+        md.inlinePatterns.pop("image_reference")
     return md
     
 register = template.Library()

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -22,27 +22,74 @@ from zds.utils.templatetags.mkd_ext.comments import CommentsExtension
 from zds.utils.templatetags.mkd_ext.smartLegend import SmartLegendExtension
 from zds.utils.templatetags.mkd_ext.headerDec import DownHeaderExtension
 
-sub_ext         = SubSuperscriptExtension() # Sub and Superscript support
-del_ext         = DelExtension()            # Del support
-urlize_ext      = UrlizeExtension()         # Autolink support
-kbd_ext         = KbdExtension()            # Keyboard support
-mathjax_ext     = MathJaxExtension()        # MathJax support
-customblock_ext = CustomBlockExtension(
-    { "s(ecret)?"       : "spoiler",
-      "i(nformation)?"  : "information ico-after",
-      "q(uestion)?"     : "question ico-after",
-      "a(ttention)?"    : "warning ico-after",
-      "e(rreur)?"       : "error ico-after",
-    })                                      # CustomBlock support
-align_ext       = AlignExtension()          # Right align and center support
-video_ext       = VideoExtension()          # Video support
-preprocess_ext  = PreprocessBlockExtension({"preprocess" : ("fenced_code_block",)}) # Preprocess extension
-emo_ext         = EmoticonExtension({"EMOTICONS" : smileys}) # smileys support
-gridtable_ext   = GridTableExtension()      # Grid Table support
-comment_ext     = CommentsExtension({"START_TAG" : "<--COMMENT", "END_TAG" : "COMMENT-->"}) # Comment support
-legend_ext       = SmartLegendExtension({"IGNORING_IMG" : smileys.values(), "PARENTS" : ("div", "blockquote")})       # Smart Legend support
-dheader_ext     = DownHeaderExtension({"OFFSET" : 2, }) # Offset header support
-
+def get_markdown_instance(Inline = False):
+    # create extensions :
+    sub_ext         = SubSuperscriptExtension() # Sub and Superscript support
+    del_ext         = DelExtension()            # Del support
+    urlize_ext      = UrlizeExtension()         # Autolink support
+    kbd_ext         = KbdExtension()            # Keyboard support
+    mathjax_ext     = MathJaxExtension()        # MathJax support
+    emo_ext         = EmoticonExtension({"EMOTICONS" : smileys}) # smileys support
+    if not Inline:
+        customblock_ext = CustomBlockExtension(
+            { "s(ecret)?"       : "spoiler",
+              "i(nformation)?"  : "information ico-after",
+              "q(uestion)?"     : "question ico-after",
+              "a(ttention)?"    : "warning ico-after",
+              "e(rreur)?"       : "error ico-after",
+            })                                      # CustomBlock support
+        align_ext       = AlignExtension()          # Right align and center support
+        video_ext       = VideoExtension()          # Video support
+        preprocess_ext  = PreprocessBlockExtension({"preprocess" : ("fenced_code_block",)}) # Preprocess extension
+        gridtable_ext   = GridTableExtension()      # Grid Table support
+        comment_ext     = CommentsExtension({"START_TAG" : "<--COMMENT", "END_TAG" : "COMMENT-->"}) # Comment support
+        legend_ext      = SmartLegendExtension({"IGNORING_IMG" : smileys.values(), "PARENTS" : ("div", "blockquote")})       # Smart Legend support
+        dheader_ext     = DownHeaderExtension({"OFFSET" : 2, }) # Offset header support
+    # Define used ext
+    exts = [sub_ext,                            # Subscript support
+            del_ext,                            # Del support
+            urlize_ext,                         # Autolink support
+            kbd_ext,                            # Kbd support
+            mathjax_ext,                        # Mathjax support
+            emo_ext,                            # Smileys support
+            ]
+    if not Inline:
+        exts.extend([
+            'abbr',                             # Abbreviation support, included in python-markdown
+            'footnotes',                        # Footnotes support, included in python-markdown
+                                                # Footnotes place marker can be set with the PLACE_MARKER option
+            'tables',                           # Tables support, included in python-markdown
+            'fenced_code',                      # Extended syntaxe for code block support, included in python-markdown
+            'codehilite(linenums=True)',        # Code hightlight support, with line numbers, included in python-markdwon
+            customblock_ext,                    # CustomBlock support
+            video_ext,                          # Video support
+            preprocess_ext,                     # Preprocess support
+            gridtable_ext,                      # Grid tables support
+            comment_ext,                        # Comment support
+            legend_ext,                         # Legend support
+            align_ext,                          # Right align and center support
+            dheader_ext,                        # Down Header support
+            'nl2br',                            # Convert new line to br tags support, included in python markdown
+            ])
+    # Generate parser
+    md = markdown.Markdown( extensions = exts,
+                            safe_mode           = 'escape',     # Protect use of html by escape it
+                            enable_attributes   = False,        # Disable the conversion of attributes.
+                                                                # This could potentially allow an
+                                                                # untrusted user to inject JavaScript
+                                                                # into documents.
+                            tab_length          = 4,            # Length of tabs in the source.
+                                                                # This is the default value
+                            output_format       = 'html5',      # html5 output
+                                                                # This is the default value
+                            smart_emphasis      = True,         # Enable smart emphasis for underscore syntax
+                            lazy_ol             = True,         # Enable smart ordered list start support
+                            )
+    if Inline:
+        md.parser.blockprocessors.clear()
+        md.preprocessors.pop("reference")
+    return md
+    
 register = template.Library()
 
 @register.filter('humane_time')
@@ -52,41 +99,9 @@ def humane_time(t, conf={}):
 
 @register.filter(needs_autoescape=False)
 def emarkdown(text):
-    return mark_safe('<div class="markdown">{0}</div>'.format(
-            markdown.markdown(  text, 
-                                extensions = [
-                                'abbr',                             # Abbreviation support, included in python-markdown
-                                'footnotes',                        # Footnotes support, included in python-markdown
-                                                                    # Footnotes place marker can be set with the PLACE_MARKER option
-                                'tables',                           # Tables support, included in python-markdown
-                                'fenced_code',                      # Extended syntaxe for code block support, included in python-markdown
-                                'codehilite(linenums=True)',        # Code hightlight support, with line numbers, included in python-markdwon
-                                sub_ext,                            # Subscript support
-                                del_ext,                            # Del support
-                                urlize_ext,                         # Autolink support
-                                kbd_ext,                            # Kbd support
-                                mathjax_ext,                        # Mathjax support
-                                customblock_ext,                    # CustomBlock support
-                                video_ext,                          # Video support
-                                preprocess_ext,                     # Preprocess support
-                                emo_ext,                            # Smileys support
-                                gridtable_ext,                      # Grid tables support
-                                comment_ext,                        # Comment support
-                                legend_ext,                         # Legend support
-                                align_ext,                          # Right align and center support
-                                dheader_ext,                        # Down Header support
-                                'nl2br',                            # Convert new line to br tags support, included in python markdown
-                                ],
-                                safe_mode           = 'escape',     # Protect use of html by escape it
-                                enable_attributes   = False,        # Disable the conversion of attributes.
-                                                                    # This could potentially allow an
-                                                                    # untrusted user to inject JavaScript
-                                                                    # into documents.
-                                tab_length          = 4,            # Length of tabs in the source.
-                                                                    # This is the default value
-                                output_format       = 'html5',      # html5 output
-                                                                    # This is the default value
-                                smart_emphasis      = True,         # Enable smart emphasis for underscore syntax
-                                lazy_ol             = True,         # Enable smart ordered list start support
-                              )
-        .encode('utf-8')))
+    return mark_safe('<div class="markdown">{0}</div>'.format(get_markdown_instance(Inline = False).convert(text).encode('utf-8')))
+
+
+@register.filter(needs_autoescape=False)
+def emarkdown_inline(text):
+    return mark_safe('<div class="markdown">{0}</div>'.format(get_markdown_instance(Inline = True).convert(text).encode('utf-8')))


### PR DESCRIPTION
Normalement devrait fournir le emarkdown_inline discuté ici : https://github.com/Taluu/ZesteDeSavoir/issues/131

Je n'ai pas testé (créé sur GitHub) mais devrait passer !
