### PR TITLE
Make flexible urls

### DIFF
--- a/templates/email/confirm_forgot_password.html
+++ b/templates/email/confirm_forgot_password.html
@@ -19,7 +19,7 @@ Si vous n'avez pas demandé une réinitialisation du mot de passe, IGNOREZ et EF
 Instructions d'activation ci-dessous
 <hr>
 <br />
-Cliquez ou recopiez simplement le lien et complétez le reste du formulaire : http://zestedesavoir.com{{url}}.
+Cliquez ou recopiez simplement le lien et complétez le reste du formulaire : {{url}}.
 <br />
 <br />
 <br />

--- a/templates/email/confirm_forgot_password.txt
+++ b/templates/email/confirm_forgot_password.txt
@@ -6,7 +6,7 @@ ATTENTION
 Si vous n'avez pas demandé une réinitialisation du mot de passe, IGNOREZ et EFFACEZ ce courriel immédiatement ! Continuez uniquement si vous souhaitez que votre mot de passe soit réinitialisé !
 
 Instructions d'activation ci-dessous
-Cliquez ou recopiez simplement le lien et complétez le reste du formulaire : http://zestedesavoir.com{{url}}.
+Cliquez ou recopiez simplement le lien et complétez le reste du formulaire : {{url}}.
 
 
 Cordialement,

--- a/templates/email/confirm_register.html
+++ b/templates/email/confirm_register.html
@@ -9,7 +9,7 @@ Bonjour <strong>{{username}}</strong>,
 <br />
 Merci de votre inscription sur <a href="http://zestedesavoir.com">Zeste de Savoir</a>. Pour activer votre profil, cliquez sur le lien client-dessous:
 <br />
-http://zestedesavoir.com{{url}}.
+{{url}}.
 <br />
 Cordialement,
 <br />

--- a/templates/email/confirm_register.txt
+++ b/templates/email/confirm_register.txt
@@ -2,7 +2,7 @@ Bonjour <strong>{{username}}</strong>,
 
 Merci de votre inscription sur <a href="http://zestedesavoir.com">Zeste de Savoir</a>. Pour activer votre profil, cliquez sur le lien client-dessous:
 
-http://zestedesavoir.com{{url}}.
+{{url}}.
 
 Cordialement,
 

--- a/templates/email/mp.html
+++ b/templates/email/mp.html
@@ -10,7 +10,7 @@ Bonjour <strong>{{username}}</strong>,
 <strong>{{author}}</strong> vous a envoyé un message privé sur ZesteDeSavoir.com
 <br />
 <br />
-Pour le lire, <a href="http://zestedesavoir.com{{url}}">cliquez ici</a>
+Pour le lire, <a href="{{url}}">cliquez ici</a>
 <br />
 <br />
 <br />

--- a/templates/email/mp.txt
+++ b/templates/email/mp.txt
@@ -2,7 +2,7 @@ Bonjour {{username}},
 
 {{author}} vous a envoyé un message privé sur ZesteDeSavoir.com
 
-Pour le lire, cliquez sur l'url suivante : http://zestedesavoir.com{{url}}
+Pour le lire, cliquez sur l'url suivante : {{url}}
 
 Cordialement,
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -360,13 +360,13 @@ def register_view(request):
             message_html = get_template('email/confirm_register.html').render(
                             Context({
                                 'username': user.username,
-                                'url': token.get_absolute_url(),
+                                'url': settings.SITE_URL+token.get_absolute_url(),
                             })
                         )
             message_txt = get_template('email/confirm_register.txt').render(
                             Context({
                                 'username': user.username,
-                                'url': token.get_absolute_url(),
+                                'url': settings.SITE_URL+token.get_absolute_url(),
                             })
                         )
 
@@ -407,13 +407,13 @@ def forgot_password(request):
             message_html = get_template('email/confirm_forgot_password.html').render(
                             Context({
                                 'username': usr.username,
-                                'url': token.get_absolute_url(),
+                                'url': settings.SITE_URL+token.get_absolute_url(),
                             })
                         )
             message_txt = get_template('email/confirm_forgot_password.txt').render(
                             Context({
                                 'username': usr.username,
-                                'url': token.get_absolute_url(),
+                                'url': settings.SITE_URL+token.get_absolute_url(),
                             })
                         )
                 

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -182,14 +182,14 @@ def new(request):
                 message_html = get_template('email/mp.html').render(
                                 Context({
                                     'username': part.username,
-                                    'url': n_topic.get_absolute_url(),
+                                    'url': settings.SITE_URL+n_topic.get_absolute_url(),
                                     'author': request.user.username
                                 })
                             )
                 message_txt = get_template('email/mp.txt').render(
                                 Context({
                                     'username': part.username,
-                                    'url': n_topic.get_absolute_url(),
+                                    'url': settings.SITE_URL+n_topic.get_absolute_url(),
                                     'author': request.user.username
                                 })
                             )
@@ -311,14 +311,14 @@ def answer(request):
                         message_html = get_template('email/mp.html').render(
                                         Context({
                                             'username': part.username,
-                                            'url': g_topic.get_absolute_url(),
+                                            'url': settings.SITE_URL+g_topic.get_absolute_url(),
                                             'author': request.user.username
                                         })
                                     )
                         message_txt = get_template('email/mp.txt').render(
                                         Context({
                                             'username': part.username,
-                                            'url': g_topic.get_absolute_url(),
+                                            'url': settings.SITE_URL+g_topic.get_absolute_url(),
                                             'author': request.user.username
                                         })
                                     )

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -15,6 +15,8 @@ DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 #INTERNAL_IPS = ('127.0.0.1',)  # debug toolbar
 
+
+
 ADMINS = (
     ('user', 'mail'),
 )
@@ -56,6 +58,8 @@ USE_L10N = True
 USE_TZ = False
 
 SITE_ROOT = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
+
+SIRE_URL = 'http://zestedesavoir.com'
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"


### PR DESCRIPTION
Permet de centraliser l'url du site dans le fichier des settings, pour pouvoir, lors de l'envoi des mails, envoyer les bon liens par mail.
On s'affranchie ainsi du problème qui fait qu'on doit par exemple remplacer l'url de type `http://zestedesavoir.com/...` par `http://preprod.zestedesavoir.com/...`
