### PR TITLE
Make other output format

### DIFF
--- a/templates/tutorial/base.html
+++ b/templates/tutorial/base.html
@@ -17,6 +17,9 @@
 	{% block headline-actions %}{% endblock %}
 	<h3><span class="wide">Télécharger</span></h3>
     <ul class="sidebar-standalone mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Téléchargements">
+    	{% if perms.tutorial.change_tutorial %}
+    	<li><a href="{% url "zds.tutorial.views.download_markdown" %}?tutoriel={{ tutorial.pk }}">Markdown</a></li>
+    	{% endif %}
         <li><a href="{% url "zds.tutorial.views.download_pdf" %}?tutoriel={{ tutorial.pk }}">PDF</a></li>
         <li><a href="{% url "zds.tutorial.views.download_epub" %}?tutoriel={{ tutorial.pk }}">EPUB</a></li>
     </ul>

--- a/zds/tutorial/urls.py
+++ b/zds/tutorial/urls.py
@@ -55,7 +55,7 @@ urlpatterns = patterns('',
     url(r'^telecharger/$', views.download),
     url(r'^telecharger/pdf/$', views.download_pdf),
     url(r'^telecharger/epub/$', views.download_epub),
-    url(r'^telecharger_pdf/$', views.download_pdf),
+    url(r'^telecharger/md/$', views.download_markdown),
     url(r'^historique/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/$', views.history),
     url(r'^comparaison/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/$', views.diff),
     

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2016,8 +2016,19 @@ def download(request):
     return response
 
 @can_read_now
+def download_markdown(request):
+    '''Download a markdown tutorial'''
+
+    tutorial = get_object_or_404(Tutorial, pk=request.GET['tutoriel'])
+    
+    response = HttpResponse(open(os.path.join(tutorial.get_prod_path(), tutorial.slug+'.md'), "rb").read(), mimetype='application/txt')
+    response['Content-Disposition'] = 'attachment; filename={0}.md'.format(tutorial.slug)
+
+    return response
+    
+@can_read_now
 def download_pdf(request):
-    '''Download a tutorial'''
+    '''Download a pdf tutorial'''
 
     tutorial = get_object_or_404(Tutorial, pk=request.GET['tutoriel'])
     
@@ -2028,7 +2039,7 @@ def download_pdf(request):
 
 @can_read_now
 def download_epub(request):
-    '''Download a tutorial'''
+    '''Download an epub tutorial'''
 
     tutorial = get_object_or_404(Tutorial, pk=request.GET['tutoriel'])
     

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2016,6 +2016,7 @@ def download(request):
     return response
 
 @can_read_now
+@permission_required('tutorial.change_tutorial')
 def download_markdown(request):
     '''Download a markdown tutorial'''
 


### PR DESCRIPTION
Permet de consulter une version compilée de markdown avant conversion vers les autres formats de sortie.
Un besoin qui s'est fait ressentir dans #146 

Fonctionnalité disponible uniquement par le staff pour le moment.
