### PR TITLE
Issue #254 [Tutoriel] Espace insécable dans le titre

### DIFF
--- a/zds/tutorial/forms.py
+++ b/zds/tutorial/forms.py
@@ -18,7 +18,12 @@ from zds.utils.forms import CommonLayoutModalText, CommonLayoutEditor
 class TutorialForm(forms.Form):
     title = forms.CharField(
         label='Titre',
-        max_length=80
+        max_length=80,
+        widget = forms.TextInput(
+            attrs = {
+                'required': 'required',
+            }
+        )
     )
 
     description = forms.CharField(
@@ -60,6 +65,11 @@ class TutorialForm(forms.Form):
         label = "Sous-catégories de votre tuto",
         queryset = SubCategory.objects.all(),
         required = True,
+        widget = forms.SelectMultiple(
+            attrs = {
+                'required': 'required',
+            }
+        )
     )
     
     licence = forms.ModelChoiceField(
@@ -88,6 +98,17 @@ class TutorialForm(forms.Form):
             ),
         )
 
+    def clean(self):
+        cleaned_data = super(TutorialForm, self).clean()
+
+        title = cleaned_data.get('title')
+        
+        if title is not None and title.strip() == '':
+            self._errors['title'] = self.error_class([u'Le champ Titre ne peut être vide'])
+            if 'title' in cleaned_data:
+                del cleaned_data['title']
+        
+        return cleaned_data
 
 class PartForm(forms.Form):
     title = forms.CharField(

--- a/zds/tutorial/forms.py
+++ b/zds/tutorial/forms.py
@@ -15,7 +15,7 @@ from zds.utils.models import Category, SubCategory, Licence
 from zds.utils.forms import CommonLayoutModalText, CommonLayoutEditor
 
 
-class TutorialForm(forms.Form):
+class FormWithTitle(forms.Form):
     title = forms.CharField(
         label='Titre',
         max_length=80,
@@ -25,6 +25,20 @@ class TutorialForm(forms.Form):
             }
         )
     )
+    
+    def clean(self):
+        cleaned_data = super(FormWithTitle, self).clean()
+
+        title = cleaned_data.get('title')
+        
+        if title is not None and title.strip() == '':
+            self._errors['title'] = self.error_class([u'Le champ Titre ne peut être vide'])
+            if 'title' in cleaned_data:
+                del cleaned_data['title']
+        
+        return cleaned_data
+
+class TutorialForm(FormWithTitle):
 
     description = forms.CharField(
         label = 'Description',
@@ -98,23 +112,7 @@ class TutorialForm(forms.Form):
             ),
         )
 
-    def clean(self):
-        cleaned_data = super(TutorialForm, self).clean()
-
-        title = cleaned_data.get('title')
-        
-        if title is not None and title.strip() == '':
-            self._errors['title'] = self.error_class([u'Le champ Titre ne peut être vide'])
-            if 'title' in cleaned_data:
-                del cleaned_data['title']
-        
-        return cleaned_data
-
-class PartForm(forms.Form):
-    title = forms.CharField(
-        label='Titre',
-        max_length=80
-    )
+class PartForm(FormWithTitle):
 
     introduction = forms.CharField(
         label = 'Introduction',
@@ -151,12 +149,8 @@ class PartForm(forms.Form):
             )
         )
 
-class ChapterForm(forms.Form):
-    title = forms.CharField(
-        label='Titre',
-        max_length=80
-    )
-    
+class ChapterForm(FormWithTitle):
+   
     image = forms.ImageField(
         label='Selectionnez le logo du tutoriel (max. '+str(settings.IMAGE_MAX_SIZE/1024)+' Ko)', 
         required=False
@@ -193,6 +187,7 @@ class ChapterForm(forms.Form):
                 StrictButton('Ajouter et continuer', type = 'submit_continue', css_class = 'btn-submit'),
             )
         )
+    
 
 class EmbdedChapterForm(forms.Form):
     introduction = forms.CharField(
@@ -228,11 +223,7 @@ class EmbdedChapterForm(forms.Form):
         super(EmbdedChapterForm, self).__init__(*args, **kwargs)
 
 
-class ExtractForm(forms.Form):
-    title = forms.CharField(
-        label='Titre',
-        max_length=80
-    )
+class ExtractForm(FormWithTitle):
 
     text = forms.CharField(
         label = 'Texte',
@@ -258,6 +249,7 @@ class ExtractForm(forms.Form):
                 StrictButton(u'Aperçu', type = 'submit', css_class = 'btn-submit', name = 'preview'),
             )
         )
+
 
 class ImportForm(forms.Form):
 


### PR DESCRIPTION
Toujours le problème des champs vides / que avec des caractères non-imprimables (issue #254 )

Cette fois-ci, y'a une superclasse pour gérer le champ titre, puisqu'il est géré toujours de la même manière dans les 4 classes qui l'utilisent.
