### PR TITLE
fix 404 error when participants is empty

### DIFF
--- a/templates/mp/new.html
+++ b/templates/mp/new.html
@@ -4,15 +4,15 @@
 {% load crispy_forms_tags %}
 
 {% block title %}
-    Nouvel MP
+    Nouveau Messae Privé
 {% endblock %}
 
 {% block headline %}
-    Nouvel MP
+    <h2>Nouveau Messae Privé</h2>
 {% endblock %}
 
 {% block breadcrumb %}
-    <li class="current"><a href="#">Nouvel MP</a></li>
+    <li class="current"><a href="#">Nouveau Messae Privé</a></li>
 {% endblock %}
 
 {% block content %}
@@ -22,15 +22,11 @@
     </div>
 </div>
 
-{% if text %}
-<div class="row">
-    <div class="large-12 columns">
-        <div class="panel">
-            <h5>Prévisualisation de votre message</h5>
-            {{ text|emarkdown }}
-        </div>
-    </div>
-</div>
+{% if form.text.value %}
+    {% with text=form.text.value %}
+        {% include "forum/previsualization.part.html" %}
+    {% endwith %}
 {% endif %}
+
 
 {% endblock %}

--- a/zds/member/decorator.py
+++ b/zds/member/decorator.py
@@ -2,6 +2,7 @@
 
 from django.http import Http404
 from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
 
 from zds.member.models import Profile
 from django.contrib.auth import logout
@@ -19,7 +20,7 @@ def can_read_now(func):
             if not profile.can_read_now():
                 logout(request)
                 request.session.clear()
-                raise Http404
+                raise PermissionDenied
         return func(request, *args, **kwargs)
     return _can_read_now
 
@@ -28,12 +29,14 @@ def can_write_and_read_now(func):
     def _can_write_and_read_now(request, *args, **kwargs):
         try:
             profile = Profile.objects.get(user__pk = request.user.pk)
+            
         except:
             # The user is a visitor
             profile = None
 
         if profile is not None:
             if not profile.can_read_now() or not profile.can_write_now():
-                raise Http404
+                raise PermissionDenied
+        
         return func(request, *args, **kwargs)
     return _can_write_and_read_now

--- a/zds/member/tests.py
+++ b/zds/member/tests.py
@@ -37,6 +37,7 @@ class MemberTests(TestCase):
                         {'username': 'firm1','password': 'hostel77','remember': 'remember'},
                         follow=False)
         #good password then redirection
+        print(result)
         self.assertEqual(result.status_code, 302)
         
     


### PR DESCRIPTION
Avant on avait une erreur 404 si le nom des participants d'un MP n'était pas bon. Maintenant, on est redirigé sur la bonne page avec le libellé des erreurs.
