### PR TITLE
Issue 357 antispam

### DIFF
--- a/zds/forum/tests.py
+++ b/zds/forum/tests.py
@@ -38,6 +38,7 @@ class ForumMemberTests(TestCase):
             category=self.category2,
             position_in_category=2)
         self.user = UserFactory()
+        self.user2 = UserFactory()
         log = self.client.login(
             username=self.user.username,
             password='hostel77')
@@ -465,8 +466,9 @@ class ForumMemberTests(TestCase):
 
     def test_answer_empty(self):
         """Test behaviour on empty answer."""
-        topic1 = TopicFactory(forum=self.forum11, author=self.user)
-        post1 = PostFactory(topic=topic1, author=self.user, position=1)
+        # Topic and 1st post by another user, to avoid antispam limitation
+        topic1 = TopicFactory(forum=self.forum11, author=self.user2)
+        post1 = PostFactory(topic=topic1, author=self.user2, position=1)
 
         result = self.client.post(
             reverse('zds.forum.views.answer') + '?sujet={0}'.format(topic1.pk),


### PR DESCRIPTION
Issue #357, correction du problème de l'antispam inefficace sur le 1er post pour l'auteur.
Implications : 
- Différentier `get_last_answer` et `get_last_post`
- Corriger un test qui ne fonctionnait que parce que l'antispam était HS :)

Et il faudrait que je décide une bonne fois pour toutes de la langue dans laquelle je fais mes commentaires de commit moi...
