### PR TITLE
Issue #560 - Erreur dans l'URL du membre

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -240,7 +240,7 @@ AUTH_PROFILE_MODULE = 'member.Profile'
 LOGIN_URL = '/membres/connexion'
 
 ABSOLUTE_URL_OVERRIDES = {
-    'auth.user': lambda u: '/membres/voir/{0}'.format(u.username.encode('utf-8'))
+    'auth.user': lambda u: '/membres/voir/{0}/'.format(u.username.encode('utf-8'))
 }
 
 


### PR DESCRIPTION
Y'a une petite subtilité ici : ça c'est l'URL du `Member` de Django, l'URL du Profil ZdS est la même, mais définie dans le fichier d'URLs de l'app.

D'où l'erreur rencontrée, puisque c'est systématiquement l'URL du `Member` et pas du `Profile` qui est appelée.
