### PR TITLE
Issue #500 : Mettre à jour un article/tuto en ligne sans le remonter dans la liste

### DIFF
--- a/templates/article/view.html
+++ b/templates/article/view.html
@@ -76,6 +76,8 @@
                     <a href="#" data-dropdown="valid-article" >Publier l'article</a>
                     <div id="valid-article" class="f-dropdown small content" data-dropdown-content>
                         <textarea name="comment-v" rows="3" placeholder="Vos commentaires de publication"> </textarea>
+                        <input id="id_is_major" name="is_major" type="checkbox">
+                        <label for="id_is_major">Version majeure ?</label>
                         <button type="submit" class="secondary tiny" name="valid-article">Confirmer la publication</button>
                     </div>
                 </li>

--- a/zds/article/tests.py
+++ b/zds/article/tests.py
@@ -51,7 +51,8 @@ class ArticleTests(TestCase):
                 'article': self.article.pk,
                 'comment': u'Valides moi ce bébé',
                 'pending': 'Demander validation',
-                'version': self.article.sha_draft
+                'version': self.article.sha_draft,
+                'is_major': True
             },
             follow=False)
         self.assertEqual(pub.status_code, 302)
@@ -68,7 +69,8 @@ class ArticleTests(TestCase):
             {
                 'article': self.article.pk,
                 'comment-v': u'Cet article est excellent',
-                'valid-article': 'Demander validation'
+                'valid-article': 'Demander validation',
+                'is_major': True
             },
             follow=False)
         self.assertEqual(pub.status_code, 302)

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -519,7 +519,8 @@ def modify(request):
             # So, the user can continue to edit his article in offline.
             article.sha_public = validation.version
             article.sha_validation = None
-            article.pubdate = datetime.now()
+            if request.POST.get('is_major', False):
+                article.pubdate = datetime.now()
             article.save()
 
             # send feedback

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -517,10 +517,10 @@ def modify(request):
             # Update sha_public with the sha of validation.
             # We don't update sha_draft.
             # So, the user can continue to edit his article in offline.
+            if request.POST.get('is_major', False) or article.sha_public == None:
+                article.pubdate = datetime.now()
             article.sha_public = validation.version
             article.sha_validation = None
-            if request.POST.get('is_major', False):
-                article.pubdate = datetime.now()
             article.save()
 
             # send feedback

--- a/zds/tutorial/forms.py
+++ b/zds/tutorial/forms.py
@@ -378,6 +378,7 @@ class ValidForm(forms.Form):
             }
         )
     )
+    is_major = forms.BooleanField(label='Version majeure ?', required=False)
 
     def __init__(self, *args, **kwargs):
         super(ValidForm, self).__init__(*args, **kwargs)
@@ -386,12 +387,12 @@ class ValidForm(forms.Form):
         self.helper.form_method = 'post'
 
         self.helper.layout = Layout(
-            CommonLayoutModalText(), StrictButton(
-                'Publier', type='submit', css_class='button success tiny'),
-            Hidden(
-                'tutorial', '{{ tutorial.pk }}'),
-            Hidden(
-                'version', '{{ version }}'), )
+            CommonLayoutModalText(),
+            Field('is_major'),
+            StrictButton('Publier', type='submit', css_class='button success tiny'),
+            Hidden('tutorial', '{{ tutorial.pk }}'),
+            Hidden('version', '{{ version }}'),
+        )
 
 
 class RejectForm(forms.Form):

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -95,7 +95,8 @@ class BigTutorialTests(TestCase):
             reverse('zds.tutorial.views.valid_tutorial'),
             {
                 'tutorial': self.bigtuto.pk,
-                'text': u'Ce tuto est excellent'
+                'text': u'Ce tuto est excellent',
+                'is_major': True
             },
             follow=False)
         self.assertEqual(pub.status_code, 302)

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -326,10 +326,10 @@ def valid_tutorial(request):
     # Update sha_public with the sha of validation. We don't update sha_draft.
     # So, the user can continue to edit his tutorial in offline.
 
+    if request.POST.get('is_major', False) or tutorial.sha_public == None:
+        tutorial.pubdate = datetime.now()
     tutorial.sha_public = validation.version
     tutorial.sha_validation = None
-    if request.POST.get('is_major', False):
-        tutorial.pubdate = datetime.now()
     tutorial.save()
     messages.success(request, u"Le tutoriel a bien été validé.")
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -328,7 +328,8 @@ def valid_tutorial(request):
 
     tutorial.sha_public = validation.version
     tutorial.sha_validation = None
-    tutorial.pubdate = datetime.now()
+    if request.POST.get('is_major', False):
+        tutorial.pubdate = datetime.now()
     tutorial.save()
     messages.success(request, u"Le tutoriel a bien été validé.")
 


### PR DESCRIPTION
Ajoute une checkbox lors de la validation des tutos et articles. Cette checkbox déclenche ou non la mise à jour de la date de publication, ce qui a pour effet de ne pas remonter le tuto ou l'article sur la home quand la validation est marquée comme mineure.
