### PR TITLE
Ignore les fichiers PyCharm dans Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,9 +78,14 @@ local.properties
 # PDT-specific
 .buildpath
 
+#############
+## PyCharm
+#############
+.idea/
+
 
 #############
-## Windows detritus
+## OS detritus
 #############
 
 # Windows image file caches


### PR DESCRIPTION
Défense : on évite de récupérer de la merde même si le développeur a oublié de mettre ces fichier dans son fichier d'ignore global.
