### PR TITLE
Empeche l'ajout de tag > 20 caractères - fix #590

### DIFF
--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -71,17 +71,17 @@ class TopicForm(forms.Form):
                 self._errors['title'] = self.error_class(
                     [u'Le titre ne peux pas contenir uniquement des tags'])
             else:
-                tags = re.findall(ur"((.*?)\[(.*?)\](.*?))" , title)
+                tags = re.findall(ur"((.*?)\[(.*?)\](.*?))", title)
                 for tag in tags:
-                    if tag[2].strip() == "" :
+                    if tag[2].strip() == "":
                         if 'title' in cleaned_data:
                             self._errors['title'] = self.error_class(
                                 [u'Un tag ne peut être vide'])
-                    
+
                     elif len(tag[2]) > Tag._meta.get_field('title').max_length:
                         if 'title' in cleaned_data:
                             self._errors['title'] = self.error_class(
-                                [(u'Un tag doit faire moins de {0} caractères'). \
+                                [(u'Un tag doit faire moins de {0} caractères').
                                     format(Tag._meta.get_field('title').max_length)])
         if text is not None and text.strip() == '':
             self._errors['text'] = self.error_class(

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -10,7 +10,7 @@ from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML
 from crispy_forms_foundation.layout import Layout, Field, Hidden
-from zds.forum.models import Forum, Topic, sub_tag
+from zds.forum.models import Forum, Topic, sub_tag, Tag
 from zds.utils.forms import CommonLayoutEditor
 
 
@@ -70,6 +70,19 @@ class TopicForm(forms.Form):
                     .strip() == '':
                 self._errors['title'] = self.error_class(
                     [u'Le titre ne peux pas contenir uniquement des tags'])
+            else:
+                tags = re.findall(ur"((.*?)\[(.*?)\](.*?))" , title)
+                for tag in tags:
+                    if tag[2].strip() == "" :
+                        if 'title' in cleaned_data:
+                            self._errors['title'] = self.error_class(
+                                [u'Un tag ne peut être vide'])
+                    
+                    elif len(tag[2]) > Tag._meta.get_field('title').max_length:
+                        if 'title' in cleaned_data:
+                            self._errors['title'] = self.error_class(
+                                [(u'Un tag doit faire moins de {0} caractères'). \
+                                    format(Tag._meta.get_field('title').max_length)])
         if text is not None and text.strip() == '':
             self._errors['text'] = self.error_class(
                 [u'Le champ text ne peut être vide'])

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -184,10 +184,8 @@ def topic(request, topic_pk, topic_slug):
 
 
 def get_tag_by_title(title):
-    regex = ur"(?P<start>)(\[.{1,%s}\])(?P<end>)" \
-        % Tag._meta.get_field('title').max_length
-    tags = re.findall(ur"((.*?)\[(.{1,%s})\](.*?))" \
-        % Tag._meta.get_field('title').max_length, title)
+    regex = ur"(?P<start>)(\[.*?\])(?P<end>)"
+    tags = re.findall(ur"((.*?)\[(.*?)\](.*?))", title)
     title = re.sub(regex, sub_tag, title)
     return (tags, title.strip())
 
@@ -238,14 +236,11 @@ def new(request):
             # add tags
 
             for tag in tags:
-                if tag[2].strip() != "" and \
-                    len(tag[2]) <= Tag._meta.get_field('title').max_length \
-                    :
-                    tg = Tag.objects.filter(slug=slugify(tag[2])).first()
-                    if tg is None:
-                        tg = Tag(title=tag[2])
-                        tg.save()
-                    n_topic.tags.add(tg)
+                tg = Tag.objects.filter(slug=slugify(tag[2])).first()
+                if tg is None:
+                    tg = Tag(title=tag[2])
+                    tg.save()
+                n_topic.tags.add(tg)
             n_topic.save()
 
             # Adding the first message
@@ -625,14 +620,11 @@ def edit_post(request):
                 # add tags
 
                 for tag in tags:
-                    if tag[2].strip() != "" and \
-                        len(tag[2]) <= Tag._meta.get_field('title').max_length \
-                        :
-                        tg = Tag.objects.filter(slug=slugify(tag[2])).first()
-                        if tg is None:
-                            tg = Tag(title=tag[2])
-                            tg.save()
-                        g_topic.tags.add(tg)
+                    tg = Tag.objects.filter(slug=slugify(tag[2])).first()
+                    if tg is None:
+                        tg = Tag(title=tag[2])
+                        tg.save()
+                    g_topic.tags.add(tg)
                 g_topic.save()
         post.save()
         return redirect(post.get_absolute_url())

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -184,8 +184,10 @@ def topic(request, topic_pk, topic_slug):
 
 
 def get_tag_by_title(title):
-    regex = ur"(?P<start>)(\[.*?\])(?P<end>)"
-    tags = re.findall(ur"((.*?)\[(.*?)\](.*?))", title)
+    regex = ur"(?P<start>)(\[.{1,%s}\])(?P<end>)" \
+        % Tag._meta.get_field('title').max_length
+    tags = re.findall(ur"((.*?)\[(.{1,%s})\](.*?))" \
+        % Tag._meta.get_field('title').max_length, title)
     title = re.sub(regex, sub_tag, title)
     return (tags, title.strip())
 
@@ -236,7 +238,9 @@ def new(request):
             # add tags
 
             for tag in tags:
-                if tag[2].strip() != "":
+                if tag[2].strip() != "" and \
+                    len(tag[2]) <= Tag._meta.get_field('title').max_length \
+                    :
                     tg = Tag.objects.filter(slug=slugify(tag[2])).first()
                     if tg is None:
                         tg = Tag(title=tag[2])
@@ -621,7 +625,9 @@ def edit_post(request):
                 # add tags
 
                 for tag in tags:
-                    if tag[2].strip() != "":
+                    if tag[2].strip() != "" and \
+                        len(tag[2]) <= Tag._meta.get_field('title').max_length \
+                        :
                         tg = Tag.objects.filter(slug=slugify(tag[2])).first()
                         if tg is None:
                             tg = Tag(title=tag[2])


### PR DESCRIPTION
| Q | R |
| --- | --- |
| **Correction de bugs ?** | **oui** |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #590 |

Bloque l'ajout de tag dont la taille dépasse les 20 caractères.
Le formulaire est alors annulé avec un message d'erreur.

Il serait de bon ton de rajouter un test front pour éviter un aller-retour vers le serveur ( @Alex-D ).

Syntaxe peut-être à revoir pour pep
