### PR TITLE
Update markdown : upstream + feature

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ factory-boy==2.2.1
 django-discover-runner==0.4
 pygeoip==0.3.1
 pillow
-git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4-zds.2.18
+git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds
 git+https://github.com/zestedesavoir/GitPython.git@0.3.2-RC1.z2
 flake8
 autopep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ factory-boy==2.2.1
 django-discover-runner==0.4
 pygeoip==0.3.1
 pillow
-git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds
+git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds.1
 git+https://github.com/zestedesavoir/GitPython.git@0.3.2-RC1.z2
 flake8
 autopep8


### PR DESCRIPTION
Mise a jour de zmarkdown vers la version 2.4.1 de l'upstream.
- Ajout du support des cardins pour "--" et "---"
