### PR TITLE
Utilisation de gulp-sass au lieu de compass (Plus de Ruby!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ base.db
 /assets/images/sprite*.png
 /assets/.sass-css
 /assets/bower_components
+/assets/scss/_sprite.scss
 
 #############
 ## Python

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -8,11 +8,11 @@ var paths = {
   smileys: "assets/smileys/**",
   copy: "assets/misc/**",
   stylesheet: "assets/scss/main.scss",
-  scss: "assets/scss/**",
-  compass: {
-    sass: "scss",
-    images: "images",
-    css: ".sass-css",
+  sass: {
+    sass: "assets/scss",
+    images: "assets/images",
+    css: "assets/.sass-css",
+    includePaths: ["assets/scss"],
     project: path.join(__dirname, "assets/")
   }
 };
@@ -40,14 +40,14 @@ gulp.task("script", ["test"], function() {
 });
 
 gulp.task("stylesheet", function() {
-  return gulp.src(paths.scss)
+  return gulp.src(paths.stylesheet)
     .pipe($.newer("dist/css/main.css"))
-    .pipe($.filter("main.scss")) // Pour que tous les fichiers soient pris en compte par gulp-newer
-    .pipe($.compass({
-      project: paths.compass.project,
-      css: paths.compass.css,
-      sass: paths.compass.sass,
-      image: paths.compass.images
+    .pipe($.sass({
+      project: paths.sass.project,
+      css: paths.sass.css,
+      sass: paths.sass.sass,
+      imagePath: paths.sass.images,
+      includePaths: paths.sass.includePaths
     }))
     .pipe(gulp.dest("dist/css"))
     .pipe($.rename({ suffix: ".min" })) // génère une version minimifié

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require("gulp"),
     $ = require("gulp-load-plugins")(),
-    path = require("path");
+    path = require("path"),
+    spritesmith = require("gulp.spritesmith");
 
 var paths = {
   scripts: "assets/js/**",
@@ -14,7 +15,8 @@ var paths = {
     css: "assets/.sass-css",
     includePaths: ["assets/scss"],
     project: path.join(__dirname, "assets/")
-  }
+  },
+  sprite: "assets/images/sprite@2x/*.png"
 };
 
 gulp.task("clean-compass", function() {
@@ -53,6 +55,31 @@ gulp.task("stylesheet", function() {
     .pipe($.rename({ suffix: ".min" })) // génère une version minimifié
     .pipe($.minifyCss())
     .pipe(gulp.dest("dist/css"));
+});
+
+gulp.task("sprite", function() {
+  var sprite = gulp.src(paths.sprite)
+    .pipe(spritesmith({
+      imgName: "sprite@2x.png",
+      cssName: "_sprite.scss",
+      cssTemplate: function(params) {
+        var output = "", e;
+        for(var i in params.items) {
+          e = params.items[i];
+          output += "$" + e.name + ": " + e.px.offset_x + " " + e.px.offset_y + ";\n";
+        }
+        if(params.items.length > 0) {
+          output += "\n\n";
+          output += "$sprite_height: " + params.items[0].px.total_height + ";\n";
+          output += "$sprite_width: " + params.items[0].px.total_width + ";";
+        }
+
+        return output;
+      }
+    }));
+  sprite.img.pipe(gulp.dest("dist/images"));
+  sprite.css.pipe(gulp.dest(paths.sass.sass));
+  return sprite;
 });
 
 gulp.task("images", ["stylesheet"], function() {

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -12,19 +12,12 @@ var paths = {
   sass: {
     sass: "assets/scss",
     images: "assets/images",
-    css: "assets/.sass-css",
     includePaths: ["assets/scss"],
-    project: path.join(__dirname, "assets/")
   },
   sprite: "assets/images/sprite@2x/*.png"
 };
 
-gulp.task("clean-compass", function() {
-  return gulp.src(["assets/.sass-css", "assets/images/sprite{,@2x}-*.png"])
-    .pipe($.clean());
-});
-
-gulp.task("clean", ["clean-compass"], function() {
+gulp.task("clean", function() {
   return gulp.src(["dist/*"])
     .pipe($.clean());
 });
@@ -41,16 +34,15 @@ gulp.task("script", ["test"], function() {
     .pipe($.size({ title: "main.min.js" }));
 });
 
-gulp.task("stylesheet", function() {
+gulp.task("stylesheet", ["sprite"], function() {
   return gulp.src(paths.stylesheet)
     .pipe($.newer("dist/css/main.css"))
     .pipe($.sass({
-      project: paths.sass.project,
-      css: paths.sass.css,
       sass: paths.sass.sass,
       imagePath: paths.sass.images,
       includePaths: paths.sass.includePaths
     }))
+    .pipe($.autoprefixer(["last 1 version", "> 1%", "ie 8", "ie 7"], { cascade: true }))
     .pipe(gulp.dest("dist/css"))
     .pipe($.rename({ suffix: ".min" })) // génère une version minimifié
     .pipe($.minifyCss())
@@ -79,7 +71,7 @@ gulp.task("sprite", function() {
     }));
   sprite.img.pipe(gulp.dest("dist/images"));
   sprite.css.pipe(gulp.dest(paths.sass.sass));
-  return sprite;
+  return sprite.css;
 });
 
 gulp.task("images", ["stylesheet"], function() {
@@ -152,6 +144,6 @@ gulp.task("travis", function() {
 });
 
 
-gulp.task("build", ["smileys", "images", "stylesheet", "vendors", "script", "merge-scripts", "copy"]);
+gulp.task("build", ["smileys", "images", "sprite", "stylesheet", "vendors", "script", "merge-scripts", "copy"]);
 
 gulp.task("default", ["build", "watch"]);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -42,7 +42,7 @@ gulp.task("stylesheet", ["sprite"], function() {
       imagePath: paths.sass.images,
       includePaths: paths.sass.includePaths
     }))
-    .pipe($.autoprefixer(["last 1 version", "> 1%", "ff >= 20", "ie >= 8", "opera >= 12", "Android 4"], { cascade: true }))
+    .pipe($.autoprefixer(["last 1 version", "> 1%", "ff >= 20", "ie >= 8", "opera >= 12", "Android >= 2.2"], { cascade: true }))
     .pipe(gulp.dest("dist/css"))
     .pipe($.rename({ suffix: ".min" })) // génère une version minimifié
     .pipe($.minifyCss())

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -42,7 +42,7 @@ gulp.task("stylesheet", ["sprite"], function() {
       imagePath: paths.sass.images,
       includePaths: paths.sass.includePaths
     }))
-    .pipe($.autoprefixer(["last 1 version", "> 1%", "ie 8", "ie 7"], { cascade: true }))
+    .pipe($.autoprefixer(["last 1 version", "> 1%", "ff >= 20", "ie >= 8", "opera >= 12", "Android 4"], { cascade: true }))
     .pipe(gulp.dest("dist/css"))
     .pipe($.rename({ suffix: ".min" })) // génère une version minimifié
     .pipe($.minifyCss())

--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -264,16 +264,16 @@
                 margin: -11px 0 0 -11px;                
 
                 &.ico-messages {
-                    @include sprite-pos($sprite, 'messages');
+                    @include sprite-pos($messages);
                 }
                 &.ico-notifs {
-                    @include sprite-pos($sprite, 'notifications');
+                    @include sprite-pos($notifications);
                 }
                 &.ico-alerts {
-                    @include sprite-pos($sprite, 'alerts');
+                    @include sprite-pos($alerts);
                 }
                 &.ico-params {
-                    @include sprite-pos($sprite, 'params');
+                    @include sprite-pos($params);
                 }
             }
 
@@ -493,7 +493,7 @@
                 margin-left: -8px;
                 height: 16px;
                 width: 16px;
-                @include sprite-pos($sprite, 'search');
+                @include sprite-pos($search);
             }
         }
     }
@@ -869,10 +869,10 @@
             }
         }
         &.ico-articles:after {
-            @include sprite-pos($sprite, 'articles');
+            @include sprite-pos($articles);
         }
         &.ico-tutorials:after {
-            @include sprite-pos($sprite, 'tutorials');
+            @include sprite-pos($tutorials);
         }
 
         &.illu img {
@@ -1529,28 +1529,28 @@
             background: #daeaee;
 
             &.ico-after:after {
-                @include sprite-pos($sprite, 'information');
+                @include sprite-pos($information);
             }
         }
         .question {
             background: #e2daee;
 
             &.ico-after:after {
-                @include sprite-pos($sprite, 'question');
+                @include sprite-pos($question);
             }
         }
         .error {
             background: #eedada;
 
             &.ico-after:after {
-                @include sprite-pos($sprite, 'error');
+                @include sprite-pos($error);
             }
         }
         .warning {
             background: #eee7da;
 
             &.ico-after:after {
-                @include sprite-pos($sprite, 'warning');
+                @include sprite-pos($warning);
             }
         }
         .spoiler-title {
@@ -2294,95 +2294,95 @@ form.topic-message {
 .ico-after {
     &.view {
         &:after {
-            @include sprite-pos($sprite, 'view');
+            @include sprite-pos($view);
         }
         &.blue:after {
-            @include sprite-pos($sprite, 'view-blue');
+            @include sprite-pos($view-blue);
         }
     }
     &.edit:after {
-        @include sprite-pos($sprite, 'edit');
+        @include sprite-pos($edit);
     }
     &.alert:after {
-        @include sprite-pos($sprite, 'alert');
+        @include sprite-pos($alert);
     }
     &.cite:after {
-        @include sprite-pos($sprite, 'cite');
+        @include sprite-pos($cite);
     }
 
     &.tick {
         &:after {
-            @include sprite-pos($sprite, 'tick');
+            @include sprite-pos($tick);
         }
         &.green:after {
-            @include sprite-pos($sprite, 'tick-green');
+            @include sprite-pos($tick-green);
         }
     }
 
     &.upvote {
         &:after {
-            @include sprite-pos($sprite, 'thumb-up');
+            @include sprite-pos($thumb-up);
         }
         &.voted:after {
-            @include sprite-pos($sprite, 'thumb-up-voted');
+            @include sprite-pos($thumb-up-voted);
         }
     }
     &.downvote {
         &:after {
-            @include sprite-pos($sprite, 'thumb-down');
+            @include sprite-pos($thumb-down);
         }
         &.voted:after {
-            @include sprite-pos($sprite, 'thumb-down-voted');
+            @include sprite-pos($thumb-down-voted);
         }
     }
 
     &.lock {
         &:after {
-            @include sprite-pos($sprite, 'lock');
+            @include sprite-pos($lock);
         }
         &.blue:after {
-            @include sprite-pos($sprite, 'lock-blue');
+            @include sprite-pos($lock-blue);
         }
     }
     &.cross {
         &:after {
-            @include sprite-pos($sprite, 'cross');
+            @include sprite-pos($cross);
         }
         &.blue:after {
-            @include sprite-pos($sprite, 'cross-blue');
+            @include sprite-pos($cross-blue);
         }
         &.red:after {
-            @include sprite-pos($sprite, 'cross-red');
+            @include sprite-pos($cross-red);
         }
         &.white:after {
-            @include sprite-pos($sprite, 'cross-white');
+            @include sprite-pos($cross-white);
         }
     }
     &.pin {
         &:after {
-            @include sprite-pos($sprite, 'pin');
+            @include sprite-pos($pin);
         }
         &.blue:after {
-            @include sprite-pos($sprite, 'pin-blue');
+            @include sprite-pos($pin-blue);
         }
     }
     &.arrow-right {
         &:after {
-            @include sprite-pos($sprite, 'arrow-right');
+            @include sprite-pos($arrow-right);
         }
         &.blue:after {
-            @include sprite-pos($sprite, 'arrow-right-blue');
+            @include sprite-pos($arrow-right-blue);
         }
     }
     &.star {
         &:after {
-            @include sprite-pos($sprite, 'star');
+            @include sprite-pos($star);
         }
         &.yellow:after {
-            @include sprite-pos($sprite, 'star-yellow');
+            @include sprite-pos($star-yellow);
         }
         &.blue:after {
-            @include sprite-pos($sprite, 'star-blue');
+            @include sprite-pos($star-blue);
         }
     }
 }

--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -44,8 +44,8 @@
     button {
         text-decoration: none;
         color: #FFF;
-        @include transition-property(background);
-        @include transition-duration;
+        transition-property: background;
+        transition-duration: $default-transition-duration;
 
         &:focus {
             outline: none;
@@ -75,7 +75,7 @@
     }
     &:hover,
     &:focus {
-        @include opacity(.7);
+        opacity: .7;
     }
 }
 
@@ -130,7 +130,7 @@
                     height: 25px;
                     line-height: 25px;
                     color: #95d7f5;
-                    @include transition;
+                    transition: all $default-transition-duration ease;
 
                     &:hover,
                     &:focus {
@@ -150,7 +150,7 @@
         line-height: 30px;
         border-top: 1px solid #274a5a;
         background-color: $header-hover;
-        @include transition-property(color, background-color);
+        transition-property: color, background-color;
 
         &:first-child {
             border-top: 0 !important;
@@ -195,7 +195,7 @@
                 text-transform: uppercase;
                 font-size: 1.5px;
                 font-size: 1.5rem;
-                @include text-shadow(rgba(0, 0, 0, 0.75) 0 0 3px);
+                text-shadow: rgba(0, 0, 0, 0.75) 0 0 3px;
 
                 &:hover,
                 &:focus,
@@ -212,8 +212,8 @@
                         left: 0;
                         right: 0;
                         height: 2px;
-                        @include transition;
-                        @include border-radius(2px 2px 0 0);
+                        transition: all $default-transition-duration ease;
+                        border-radius: 2px 2px 0 0;
                         background-color: $orange;
                     }
                     &.active:before {
@@ -251,7 +251,7 @@
                 height: 16px;
                 line-height: 14px;
                 background: #c0392b;
-                @include border-radius(16px);
+                border-radius: 16px;
             }
             .notif-text {
                 display: block;
@@ -322,15 +322,15 @@
                     &:focus,
                     &.read:hover,
                     &.read:focus {
-                        @include opacity(1);
-                        @include transition-property(opacity, background-color);
+                        opacity: 1;
+                        transition-property: opacity, background-color;
                     }
                     &:hover,
                     &:focus {
                         background-color: $header-hover;
                         
                         .username {
-                            @include text-shadow(rgba(0, 0, 0, .5) 0 0 5px);
+                            text-shadow: rgba(0, 0, 0, .5) 0 0 5px;
                         }
 
                         .date {
@@ -339,7 +339,7 @@
                     }
 
                     &.read {
-                        @include opacity(.5);
+                        opacity: .5;
                     }
                 }
 
@@ -362,7 +362,7 @@
                     color: #5196b6;
                     float: right;
                     padding: 4px 10px 0 0;
-                    @include transition-property(color);
+                    transition-property: color;
                 }
                 .topic {
                     display: block;
@@ -466,8 +466,8 @@
             border: none;
             background: rgba(255, 255, 255, .25);
             height: 40px;
-            @include transition-property(background);
-            @include transition-duration;
+            transition-property: background;
+            transition-duration: $default-transition-duration;
 
             &:hover,
             &:focus {
@@ -511,7 +511,7 @@
         font-size: 24px;
         background: rgba(255, 255, 255, 1);
         color: #084561;
-        @include single-transition(background);
+        transition: background $default-transition-duration ease;
 
         &:hover,
         &:focus {
@@ -593,7 +593,7 @@
         font-size: 1.6rem;
         position: relative;
         color: lighten($blue, 20%);
-        @include transition;
+        transition: all $default-transition-duration ease;
 
         &:first-child {
             margin-top: 31px;
@@ -661,7 +661,7 @@
         li {
             position: relative;
             padding: 0 0 0 2.5%;
-            @include single-transition(background);
+            transition: background $default-transition-duration ease;
 
             &:not(.inactive):hover,
             a:focus {
@@ -716,12 +716,12 @@
                     &:after {
                         top: 7px;
                         left: 0;
-                        @include opacity(.7);
+                        opacity: .7;
                     }
                     &:hover,
                     &:focus {
                         &:after {
-                            @include opacity(1);
+                            opacity: 1;
                         }
                     }
 
@@ -753,7 +753,7 @@
                             text-indent: 0;
                             padding: 0 15px;
                             border: 1px solid #EEE;
-                            @include box-shadow(rgba(0, 0, 0, .5) 0 0 3px);
+                            box-shadow: rgba(0, 0, 0, .5) 0 0 3px;
                         }
 
                         &:after {
@@ -785,7 +785,7 @@
                 a {
                     position: relative;
                     color: #084561;
-                    @include transition;
+                    transition: all $default-transition-duration ease;
 
                     &:hover,
                     &:focus {
@@ -828,9 +828,7 @@
                 padding-bottom: 5px;
                 margin-left: -25px;
                 width: calc(105% + 25px);
-                @include background(
-                    linear-gradient(top, rgba(0, 0, 0, .07), transparent 3px)
-                );
+                background: linear-gradient(top, rgba(0, 0, 0, .07), transparent 3px);
 
                 a {
                     padding-left: 50px;
@@ -986,12 +984,12 @@
         overflow: hidden;
         background-repeat: no-repeat;
         background-position: center center;        
-        @include background-size(cover);
+        background-size: cover;
 
         img {
             width: 100%;
             height: 100%;
-            @include opacity(0);
+            opacity: 0;
         }
     }
     .resume {
@@ -1029,7 +1027,7 @@
             background: #EEE;
             color: #777;
             margin-left: 1px;
-            @include transition;
+            transition: all $default-transition-duration ease;
 
             &:before {
                 content: "#";
@@ -1099,7 +1097,7 @@
                 height: 36px;
                 line-height: 36px;
                 padding: 0 8px;
-                @include transition;
+                transition: all $default-transition-duration ease;
 
                 &.ico-after {
                     padding-left: 30px;
@@ -1149,7 +1147,7 @@
             min-width: 45px;
             height: 40px;
             line-height: 40px;
-            @include transition;
+            transition: all $default-transition-duration ease;
             
             &.current {
                 height: 38px;
@@ -1372,7 +1370,7 @@
             display: block;
             margin-top: 24px;
             color: $blue;
-            @include opacity(.5);
+            opacity: .5;
         }
     }
 }
@@ -1497,7 +1495,7 @@
                 height: 30px;
                 line-height: 30px;
                 margin-left: 3px;
-                @include opacity(.7);
+                opacity: .7;
 
                 &.ico-after:after {
                     margin-top: 7px;
@@ -1505,7 +1503,7 @@
 
                 &:hover,
                 &:focus {
-                    @include opacity(1);
+                    opacity: 1;
                 }
             }
         }
@@ -1736,7 +1734,7 @@ table {
             &[href]:focus {
                 border-color: #FFF;
                 overflow: hidden;
-                @include box-shadow(rgba(0, 0, 0, .3) 0 1px 7px);
+                box-shadow: rgba(0, 0, 0, .3) 0 1px 7px;
             }
 
             img {
@@ -1752,7 +1750,7 @@ table {
             text-align: center;
             text-transform: uppercase;
             color: #EEE;
-            @include text-shadow(rgba(0, 0, 0, .25) 0 0 3px);
+            text-shadow: rgba(0, 0, 0, .25) 0 0 3px;
             background: #777;
 
             &.staff {
@@ -1776,7 +1774,7 @@ table {
                 line-height: 26px;
                 width: 28px;
                 color: #777;
-                @include transition;
+                transition: all $default-transition-duration ease;
 
                 &:first-child {
                     border-right: 0;
@@ -1823,7 +1821,7 @@ table {
                 line-height: 30px;
                 padding: 0 5px;
                 border-bottom: 1px solid #D2D5D6;
-                @include transition;
+                transition: all $default-transition-duration ease;
 
                 &:hover,
                 &:focus {
@@ -1888,7 +1886,7 @@ table {
                 color: #999;
 
                 &:after {
-                    @include opacity(.5);
+                    opacity: .5;
                 }
             }
             .message-hidden {
@@ -1935,7 +1933,7 @@ table {
 
                 a {
                     color: #999;
-                    @include transition;
+                    transition: all $default-transition-duration ease;
 
                     &:hover,
                     &:focus {
@@ -1966,7 +1964,7 @@ table {
                         color: #48a200;
 
                         &:after {
-                            @include opacity(1);
+                            opacity: 1;
                         }
                     }
                 }
@@ -1980,7 +1978,7 @@ table {
                     font-weight: bold;
 
                     &:after {
-                        @include opacity(1);
+                        opacity: 1;
                     }
                 }
             }
@@ -2019,7 +2017,7 @@ table {
                 display: block;
                 float: left;
                 margin-left: 3px;
-                @include transition;
+                transition: all $default-transition-duration ease;
 
                 &.ico-after {
                     padding-left: 30px;
@@ -2028,8 +2026,8 @@ table {
                 &:after {
                     top: 7px;
                     left: 7px;
-                    @include transition;
-                    @include opacity(.5);
+                    transition: all $default-transition-duration ease;
+                    opacity: .5;
                 }
             }
             a,
@@ -2050,7 +2048,7 @@ table {
                     outline: none;
 
                     &:after {
-                        @include opacity(1);
+                        opacity: 1;
                     }
                 }
             }
@@ -2253,7 +2251,7 @@ form.topic-message {
     right: $modal-margin;
     bottom: $modal-margin;
     left: $modal-margin;
-    @include box-shadow(0 0 5px #000);
+    box-shadow: 0 0 5px #000;
 
     &.modal-small {
         top: 50%;

--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -70,7 +70,7 @@ textarea {
 
 a {
     color: lighten($blue, 20%);
-    @include transition;
+    transition: all $default-transition-duration ease;
 
     &:hover {
         color: darken($orange, 15%);

--- a/assets/scss/_form.scss
+++ b/assets/scss/_form.scss
@@ -128,10 +128,10 @@
         border-radius: 50%;
     }
     input[type=radio]:checked {
-        @include sprite-pos($sprite, 'radio');
+        @include sprite-pos($radio);
     }
     input[type=checkbox]:checked {
-        @include sprite-pos($sprite, 'check');
+        @include sprite-pos($check);
     }
 
     [type=submit],

--- a/assets/scss/_form.scss
+++ b/assets/scss/_form.scss
@@ -79,7 +79,7 @@
     button,
     .btn {
         -webkit-appearance: none;
-        @include transition;
+        transition: all $default-transition-duration ease;
     }
 
     input:not([type=submit]):not([type=reset]):not([type=radio]):not([type=checkbox]) {
@@ -122,10 +122,10 @@
         width: 15px;
         border: 1px solid #BBB;
         background: #FCFCFC;
-        @include transition(none);
+        transition: none;
     }
     input[type=radio] {
-        @include border-radius(50%);
+        border-radius: 50%;
     }
     input[type=radio]:checked {
         @include sprite-pos($sprite, 'radio');

--- a/assets/scss/_high-pixel-ratio.scss
+++ b/assets/scss/_high-pixel-ratio.scss
@@ -16,43 +16,44 @@
     .breadcrumb ul li:not(:last-child):after,
     input[type=radio]:checked,
     input[type=checkbox]:checked {
-        background-size: round(image-width(sprite-path($sprite2x)) / 2) round(image-height(sprite-path($sprite2x)) / 2) !important;
+        background-size: round($sprite_width / 2) round($sprite_height / 2) !important;
+        //background-size: 50% 50% !important;
         background-image: $sprite2x !important;
     }
 
     .js.enable-mobile-menu .page-container .mobile-menu-btn:after {
-        @include sprite-pos($sprite2x, 'menu', true);
+        @include sprite-pos($menu, true);
     }
 
     .logbox .notifs-links .ico-link .notif-text {
         &.ico-messages {
-            @include sprite-pos($sprite2x, 'messages', true);
+            @include sprite-pos($messages, true);
         }
         &.ico-notifs {
-            @include sprite-pos($sprite2x, 'notifications', true);
+            @include sprite-pos($notifications, true);
         }
         &.ico-alerts {
-            @include sprite-pos($sprite2x, 'alerts', true);
+            @include sprite-pos($alerts, true);
         }
         &.ico-params {
-            @include sprite-pos($sprite2x, 'params', true);
+            @include sprite-pos($params, true);
         }
     }
 
     .breadcrumb ul li:not(:last-child):after {
-        @include sprite-pos($sprite2x, 'ariane', true);
+        @include sprite-pos($ariane, true);
     }
 
     .search form button:after {
-        @include sprite-pos($sprite2x, 'search', true);
+        @include sprite-pos($search, true);
     }
 
     .main .content-container h2 {
         &.ico-articles:after {
-            @include sprite-pos($sprite2x, 'articles', true);
+            @include sprite-pos($articles, true);
         }
         &.ico-tutorials:after {
-            @include sprite-pos($sprite2x, 'tutorials', true);
+            @include sprite-pos($tutorials, true);
         }
     }
 
@@ -64,10 +65,10 @@
     .content-container,
     #modals {
         input[type=radio]:checked {
-            @include sprite-pos($sprite2x, 'radio', true);
+            @include sprite-pos($radio, true);
         }
         input[type=checkbox]:checked {
-            @include sprite-pos($sprite2x, 'check', true);
+            @include sprite-pos($check, true);
         }
     }
 
@@ -80,16 +81,16 @@
         .article-content,
         .message-content {
             .information.ico-after:after {
-                @include sprite-pos($sprite2x, 'information', true);
+                @include sprite-pos($information, true);
             }
             .question.ico-after:after {
-                @include sprite-pos($sprite2x, 'question', true);
+                @include sprite-pos($question, true);
             }
             .error.ico-after:after {
-                @include sprite-pos($sprite2x, 'error', true);
+                @include sprite-pos($error, true);
             }
             .warning.ico-after:after {
-                @include sprite-pos($sprite2x, 'warning', true);
+                @include sprite-pos($warning, true);
             }
         }
     }
@@ -104,249 +105,249 @@
         &.online,
         &.view {
             &:after {
-                @include sprite-pos($sprite2x, 'view', true);
+                @include sprite-pos($view, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'view-blue', true);
+                @include sprite-pos($view-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'view-light', true);
+                @include sprite-pos($view-light, true);
             }
         }
         &.edit {
             &:after {
-                @include sprite-pos($sprite2x, 'edit', true);
+                @include sprite-pos($edit, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'edit-blue', true);
+                @include sprite-pos($edit-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'edit-light', true);
+                @include sprite-pos($edit-light, true);
             }
         }
         &.alert {
             &:after {
-                @include sprite-pos($sprite2x, 'alert', true);
+                @include sprite-pos($alert, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'alert-blue', true);
+                @include sprite-pos($alert-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'alert-light', true);
+                @include sprite-pos($alert-light, true);
             }
         }
         &.cite {
             &:after {
-                @include sprite-pos($sprite2x, 'cite', true);
+                @include sprite-pos($cite, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'cite-blue', true);
+                @include sprite-pos($cite-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'cite-light', true);
+                @include sprite-pos($cite-light, true);
             }
         }
 
         &.tick {
             &:after {
-                @include sprite-pos($sprite2x, 'tick', true);
+                @include sprite-pos($tick, true);
             }
             &.green:after {
-                @include sprite-pos($sprite2x, 'tick-green', true);
+                @include sprite-pos($tick-green, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'tick-light', true);
+                @include sprite-pos($tick-light, true);
             }
         }
 
         &.upvote {
             &:after {
-                @include sprite-pos($sprite2x, 'thumb-up', true);
+                @include sprite-pos($thumb-up, true);
             }
             &.voted:after {
-                @include sprite-pos($sprite2x, 'thumb-up-voted', true);
+                @include sprite-pos($thumb-up-voted, true);
             }
         }
         &.downvote {
             &:after {
-                @include sprite-pos($sprite2x, 'thumb-down', true);
+                @include sprite-pos($thumb-down, true);
             }
             &.voted:after {
-                @include sprite-pos($sprite2x, 'thumb-down-voted', true);
+                @include sprite-pos($thumb-down-voted, true);
             }
         }
 
         &.lock {
             &:after {
-                @include sprite-pos($sprite2x, 'lock', true);
+                @include sprite-pos($lock, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'lock-blue', true);
+                @include sprite-pos($lock-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'lock-light', true);
+                @include sprite-pos($lock-light, true);
             }
         }
 
         &.more {
             &:after {
-                @include sprite-pos($sprite2x, 'more', true);
+                @include sprite-pos($more, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'more-blue', true);
+                @include sprite-pos($more-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'more-light', true);
+                @include sprite-pos($more-light, true);
             }
         }
         &.cross {
             &:after {
-                @include sprite-pos($sprite2x, 'cross', true);
+                @include sprite-pos($cross, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'cross-blue', true);
+                @include sprite-pos($cross-blue, true);
             }
             &.red:after {
-                @include sprite-pos($sprite2x, 'cross-red', true);
+                @include sprite-pos($cross-red, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'cross-light', true);
+                @include sprite-pos($cross-light, true);
             }
             &.white:after {
-                @include sprite-pos($sprite2x, 'cross-white', true);
+                @include sprite-pos($cross-white, true);
             }
         }
         &.pin {
             &:after {
-                @include sprite-pos($sprite2x, 'pin', true);
+                @include sprite-pos($pin, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'pin-blue', true);
+                @include sprite-pos($pin-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'pin-light', true);
+                @include sprite-pos($pin-light, true);
             }
         }
         &.beta {
             &:after {
-                @include sprite-pos($sprite2x, 'beta', true);
+                @include sprite-pos($beta, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'beta-blue', true);
+                @include sprite-pos($beta-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'beta-light', true);
+                @include sprite-pos($beta-light, true);
             }
         }
         &.gear {
             &:after {
-                @include sprite-pos($sprite2x, 'gear', true);
+                @include sprite-pos($gear, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'gear-blue', true);
+                @include sprite-pos($gear-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'gear-light', true);
+                @include sprite-pos($gear-light, true);
             }
         }
         // TODO : faire une vraie icône offline
         &.offline,
         &.arrow-right {
             &:after {
-                @include sprite-pos($sprite2x, 'arrow-right', true);
+                @include sprite-pos($arrow-right, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'arrow-right-blue', true);
+                @include sprite-pos($arrow-right-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'arrow-right-light', true);
+                @include sprite-pos($arrow-right-light, true);
             }
         }
         &.arrow-left {
             &:after {
-                @include sprite-pos($sprite2x, 'arrow-left', true);
+                @include sprite-pos($arrow-left, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'arrow-left-blue', true);
+                @include sprite-pos($arrow-left-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'arrow-left-light', true);
+                @include sprite-pos($arrow-left-light, true);
             }
         }
         &.move {
             &:after {
-                @include sprite-pos($sprite2x, 'move', true);
+                @include sprite-pos($move, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'move-blue', true);
+                @include sprite-pos($move-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'move-light', true);
+                @include sprite-pos($move-light, true);
             }
         }
         &.star {
             &:after {
-                @include sprite-pos($sprite2x, 'star', true);
+                @include sprite-pos($star, true);
             }
             &.yellow:after {
-                @include sprite-pos($sprite2x, 'star-yellow', true);
+                @include sprite-pos($star-yellow, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'star-blue', true);
+                @include sprite-pos($star-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'star-light', true);
+                @include sprite-pos($star-light, true);
             }
         }
 
         &.download {
             &:after {
-                @include sprite-pos($sprite2x, 'download', true);
+                @include sprite-pos($download, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'download-blue', true);
+                @include sprite-pos($download-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'download-light', true);
+                @include sprite-pos($download-light, true);
             }
         }
 
         &.import {
             &:after {
-                @include sprite-pos($sprite2x, 'import', true);
+                @include sprite-pos($import, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'import-blue', true);
+                @include sprite-pos($import-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'import-light', true);
+                @include sprite-pos($import-light, true);
             }
         }
 
         &.history {
             &:after {
-                @include sprite-pos($sprite2x, 'history', true);
+                @include sprite-pos($history, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'history-blue', true);
+                @include sprite-pos($history-blue, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'history-light', true);
+                @include sprite-pos($history-light, true);
             }
         }
 
         &.rss {
             &:after {
-                @include sprite-pos($sprite2x, 'rss', true);
+                @include sprite-pos($rss, true);
             }
             &.blue:after {
-                @include sprite-pos($sprite2x, 'rss-blue', true);
+                @include sprite-pos($rss-blue, true);
             }
             &.orange:after {
-                @include sprite-pos($sprite2x, 'rss-orange', true);
+                @include sprite-pos($rss-orange, true);
             }
             &.light:after {
-                @include sprite-pos($sprite2x, 'rss-light', true);
+                @include sprite-pos($rss-light, true);
             }
         }
     }

--- a/assets/scss/_mobile-tablet.scss
+++ b/assets/scss/_mobile-tablet.scss
@@ -13,21 +13,21 @@
         &:not(.swipping) {
             .page-container,
             .mobile-menu {
-                @include transition-property(transform);
-                @include transition-duration(.3s);
-                @include transition-timing-function(ease);
+                transition-property: transform;
+                transition-duration: .3s;
+                transition-timing-function: ease;
             }
         }
         &.swipping * {
-            @include user-select(none);
-            @include pointer-events(none);
+            user-select: none;
+            pointer-events: none;
         }
     }
 
     .js .page-container {
         position: absolute;
         z-index: 10;
-        @include transform(translate3d(0, 0, 0));
+        transform: translate3d(0, 0, 0);
     }
     .js .mobile-menu {
         display: block;
@@ -36,12 +36,12 @@
         overflow-x: hidden;
         overflow-y: auto;
         z-index: 1;
-        @include transform(translate3d(-20%, 0, 0));
+        transform: translate3d(-20%, 0, 0);
         width: 90%;
         height: 100%;
         padding-bottom: 20px;
         background: #222;
-        @include user-select(none);
+        user-select: none;
 
         .search {
             height: 50px;
@@ -188,13 +188,13 @@
 
         .page-container {
             height: 100%;
-            @include transform(translate3d(90%, 0, 0));
+            transform: translate3d(90%, 0, 0);
             overflow: hidden;
-            @include box-shadow(0 0 7px rgba(0, 0, 0, .25));
+            box-shadow: 0 0 7px rgba(0, 0, 0, .25);
         }
 
         .mobile-menu {
-            @include transform(translate3d(0, 0, 0));
+            transform: translate3d(0, 0, 0);
         }
     }
 

--- a/assets/scss/_mobile-tablet.scss
+++ b/assets/scss/_mobile-tablet.scss
@@ -233,7 +233,7 @@
                     width: 22px;
                     background-image: $sprite;
                     background-repeat: no-repeat;
-                    @include sprite-pos($sprite, 'menu');
+                    @include sprite-pos($menu);
                 }
             }
         }

--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -8,7 +8,7 @@
 
 @media only screen and (min-width: 760px) {
     .dropdown {
-        @include box-shadow(0 5px 7px rgba(0, 0, 0, .3));
+        box-shadow: 0 5px 7px rgba(0, 0, 0, .3);
     }
 
     .header-right {
@@ -32,7 +32,7 @@
                 &::-webkit-scrollbar-thumb {
                     background-color: #396a81;
                     border: 1px solid #06354a;
-                    @include transition;
+                    transition: all $default-transition-duration ease;
 
                     &:hover {
                         background-color: #5196b6;

--- a/assets/scss/_wide.scss
+++ b/assets/scss/_wide.scss
@@ -35,12 +35,10 @@
     .header-container {
         z-index: 1;
         position: relative;
-        @include box-shadow(0 0 4px rgba(0, 0, 0, .3));
+        box-shadow: 0 0 4px rgba(0, 0, 0, .3);
 
         header {
-            @include background-image(
-                linear-gradient(left, transparent 20%, rgba(255, 255, 255, .07) 40%, rgba(255, 255, 255, .07) 60%, transparent 80%)
-            );
+            background-image: linear-gradient(left, transparent 20%, rgba(255, 255, 255, .07) 40%, rgba(255, 255, 255, .07) 60%, transparent 80%);
         }
     }
 
@@ -126,7 +124,7 @@
             right: 0;
             width: 50px;
             height: 100%;
-            @include background-image(linear-gradient(left, rgba(231, 235, 236, 0), rgba(231, 235, 236, .75)));
+            background-image:linear-gradient(left, rgba(231, 235, 236, 0), rgba(231, 235, 236, .75));
         }
 
         ul {
@@ -165,7 +163,7 @@
                     background-image: $sprite;
                     background-repeat: no-repeat;
                     @include sprite-pos($sprite, 'ariane');
-                    @include opacity(.2);
+                    opacity: .2;
                 }
             }
         }
@@ -179,7 +177,7 @@
             left: -20px;
             height: 30px;
             width: 20px;
-            @include background(linear-gradient(right, rgba(0, 0, 0, .03), rgba(0, 0, 0, 0)));
+            background: linear-gradient(right, rgba(0, 0, 0, .03), rgba(0, 0, 0, 0));
         }
         form {
             input {
@@ -303,9 +301,7 @@
                 ul {
                     margin-left: calc(-11% - 10px);
                     width: calc(111% + 10px);
-                    @include background(
-                        linear-gradient(top, rgba(0, 0, 0, .07), transparent 3px)
-                    );
+                    background: linear-gradient(top, rgba(0, 0, 0, .07), transparent 3px);
 
                     a {
                         padding-left: calc(11% + 30px);
@@ -416,7 +412,7 @@
         Modals boxes
        ============== */
     .enable-mobile-menu #modals .modal {
-        @include box-shadow(0 2px 7px rgba(0, 0, 0, .7));
+        box-shadow: 0 2px 7px rgba(0, 0, 0, .7);
         
         .modal-title {
             line-height: 50px;

--- a/assets/scss/_wide.scss
+++ b/assets/scss/_wide.scss
@@ -162,7 +162,7 @@
                     width: 15px;
                     background-image: $sprite;
                     background-repeat: no-repeat;
-                    @include sprite-pos($sprite, 'ariane');
+                    @include sprite-pos($ariane);
                     opacity: .2;
                 }
             }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -17,7 +17,7 @@
 $default-transition-duration: .15s;
 
 //$sprite: sprite-map("sprite/*.png");
-$sprite2x: sprite-map("sprite@2x/*.png");
+$sprite2x: url("../images/sprite@2x.png");
 $sprite: $sprite2x;
 
 
@@ -49,11 +49,11 @@ $font-monospace-active: "Source Code Pro", $font-monospace;
 /**
  * Custom mixins
  */
-@mixin sprite-pos($map, $_item, $retina: false){
+@mixin sprite-pos($_item, $retina: false){
     @if($retina == false){
-        background-position: sprite-position($map, $_item);
+        background-position: nth($_item, 1) nth($_item, 2);
     } @else {
-        background-position: round(nth(sprite-position($map, $_item), 1)/ 2) round(nth(sprite-position($map, $_item), 2)/ 2);
+        background-position: round(nth($_item, 1)/ 2) round(nth($_item, 2)/ 2);
     }
 }
 
@@ -69,7 +69,10 @@ $font-monospace-active: "Source Code Pro", $font-monospace;
  */
 @import "mixins/display-flex";
 
-
+/**
+ * Import sprite
+ */
+@import "sprite";
 
 /**
  * Import custom styles
@@ -89,7 +92,7 @@ $font-monospace-active: "Source Code Pro", $font-monospace;
 @import "extra-wide";
 
 // Retina-like support
-//@import "high-pixel-ratio";
+@import "high-pixel-ratio";
 
 // Dependencies
 @import "pygments";

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -6,8 +6,8 @@
 
 
 
-@import "compass";
-@import "compass/css3/user-interface";
+//@import "compass";
+//@import "compass/css3/user-interface";
 
 
 
@@ -89,7 +89,7 @@ $font-monospace-active: "Source Code Pro", $font-monospace;
 @import "extra-wide";
 
 // Retina-like support
-@import "high-pixel-ratio";
+//@import "high-pixel-ratio";
 
 // Dependencies
 @import "pygments";

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-sass": "^0.7.2",
     "gulp-size": "^0.3.1",
     "gulp-uglify": "^0.3.0",
+    "gulp.spritesmith": "^1.1.0",
     "jshint-stylish": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/zestedesavoir/zds-site",
   "dependencies": {
     "gulp": "^3.7.0",
+    "gulp-autoprefixer": "0.0.7",
     "gulp-bower-files": "^0.2.4",
     "gulp-cache": "^0.1.11",
     "gulp-clean": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gulp-minify-css": "^0.3.4",
     "gulp-newer": "^0.3.0",
     "gulp-rename": "^1.2.0",
+    "gulp-sass": "^0.7.2",
     "gulp-size": "^0.3.1",
     "gulp-uglify": "^0.3.0",
     "jshint-stylish": "^0.2.0"


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | ... |

:warning: Il s'agit d'une Pull request modifiant beaucoup de choses au niveau du front, autant niveau workflow que code. Il faut impérativement que @Alex-D review avant qu'elle soit merge :warning: 

Utilisation de [gulp-sass](https://github.com/dlmanning/gulp-sass) (qui utilise [node-sass](https://github.com/sass/node-sass), qui implémente [libsass](https://github.com/sass/libsass)), au lieu de l'implémentation Ruby. Concrètement, ça utilise l'implémentation C de SASS (libsass), au lieu de l'implémentation Ruby. Cette implémentation n'est pas encore au niveau de ruby-sass, mais elle est suffisante pour notre utilisation. Cela implique cependant de ne plus utiliser [Compass](http://compass-style.org/), qui ne marche pas (encore) avec libsass (cf. [cette issue](https://github.com/sass/libsass/issues/82))

Tout ici a été adapté pour marcher sans compass, et le préfixage, et la génération de sprite est maintenant faite par Gulp.

Ca y est, plus besoin de Ruby dans le projet! :smile_cat: 
