### PR TITLE
Mathjax ne se declenche que pour les dollars

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -552,7 +552,8 @@
     <script type="text/x-mathjax-config">
         MathJax.Hub.Config({
             tex2jax: {
-                inlineMath: [['$', '$'], ['\\(', '\\)']],
+                inlineMath: [['$', '$']],
+                displayMath: [['$$','$$']],
                 processEscapes: true,
             },
             TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js", "MathZoom.js"] },


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #719 |

Désormais, mathjax ne se déclenchera que lorsque le code est entouré de `$` pour les formules inlines et `$$` pour les formules multilignes.
