### PR TITLE
Ajout de la tâche "gulp pack" qui build + crée un zip du dossier dist/

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -139,6 +139,12 @@ gulp.task("copy", function() {
     .pipe(gulp.dest("dist/"));
 });
 
+gulp.task("pack", ["build"], function() {
+  return gulp.src(["dist/*/**", "!dist/pack.zip"])
+    .pipe($.zip("pack.zip"))
+    .pipe(gulp.dest("dist/"));
+});
+
 gulp.task("travis", function() {
   // @TODO: Configure travis tests
   return true;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gulp-sass": "^0.7.2",
     "gulp-size": "^0.3.1",
     "gulp-uglify": "^0.3.0",
+    "gulp-zip": "^0.3.4",
     "gulp.spritesmith": "^1.1.0",
     "jshint-stylish": "^0.2.0"
   }


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | ... |

`gulp pack` fait un build complet, et crée un `pack.zip` dans `dist/`, contenant toutes les ressources compilées
