### PR TITLE
Ajout du test du mail provider dans maj profile - #895

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -360,12 +360,19 @@ class ChangeUserForm(forms.Form):
                 if User.objects.filter(email=email_new).count() >= 1:
                     self._errors['email_new'] = self.error_class(
                         [u'Votre email est déjà utilisée'])
+            # Chech if email provider is authorized
+            with open(os.path.join(SITE_ROOT,
+                                   'forbidden_email_providers.txt'), 'r') as fh:
+                for provider in fh:
+                    if provider.strip() in email_new:
+                        msg = u'Utilisez un autre fournisseur d\'adresses mail.'
+                        self._errors['email_new'] = self.error_class([msg])
+                        break
 
         return cleaned_data
 
+
 # to update a password
-
-
 class ChangePasswordForm(forms.Form):
     password_new = forms.CharField(
         label='Nouveau mot de passe',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | #895 |
- Ajout d'un test dans le formulaire de maj du profile pour que l'utilisateur ne puisse pas utiliser un provider blacklisté
- Ajout de la couverture de test pour la mise à jour du profile (password, email, pseudo)
