### PR TITLE
Rajoute le bouton pour 'image as avatar' - #724

### DIFF
--- a/templates/gallery/image/edit.html
+++ b/templates/gallery/image/edit.html
@@ -45,5 +45,8 @@
             Code markdown pour insérer cette image : <br>
             <input type="text" value="![{{ image.legend }}]({{ image.physical.url }})" readonly onclick="this.select()">
         </p>
+        
+        {% crispy as_avatar_form %}
+        
     </div>
 {% endblock %}

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -448,7 +448,8 @@ def update_avatar(request):
             return redirect(reverse("zds.member.views.settings_profile"))
         messages.success(request, "L'avatar a correctement été mis à jour.")
 
-    return redirect(reverse("zds.member.views.settings_profile"))
+    return redirect(reverse("zds.member.views.details",
+                            args=[profile.user.username]))
 
 
 @can_write_and_read_now


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | #724 |
- Rajoute le bouton pour 'image as avatar' dans la page d'une image de la galerie
- Redirige ensuite vers le profile de l'utilisateur en cas de succès
