### PR TITLE
Issue #861 : bloque activation si déjà fait

### DIFF
--- a/templates/member/register/token_already_used.html
+++ b/templates/member/register/token_already_used.html
@@ -3,29 +3,26 @@
 
 
 {% block title %}
-    Confirmation d'inscription réussie
+    Compte déjà activé
 {% endblock %}
 
 
 
 {% block headline %}
-    Confirmation d'inscription réussie
+    Compte déjà activé
 {% endblock %}
 
 
 
 {% block breadcrumb %}
     <li><a href="{% url "zds.member.views.register_view" %}">Inscription</a></li>
-    <li>Confirmation</li>
+    <li>Déjà activé</li>
 {% endblock %}
 
 
 
 {% block content %}
     <p>
-        Vous avez confirmé votre email sur le site.
-    </p>
-    <p>
-        Vous pouvez maintenant <a href="{% url "zds.member.views.login_view" %}">vous connecter</a>.
+        Votre email a déjà été activé. Si vous avez oublié votre mot de passe, vous pouvez le retrouver <a href="{% url "zds.member.views.forgot_password" %}">ici</a>.
     </p>
 {% endblock %}

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -712,6 +712,11 @@ def active_account(request):
         return redirect(reverse("zds.pages.views.home"))
     token = get_object_or_404(TokenRegister, token=token)
     usr = token.user
+    
+    # User can't confirm his request if he is already activated.
+
+    if usr.is_active:
+        return render_template("member/register/token_already_used.html")
 
     # User can't confirm his request if it is too late.
 
@@ -748,7 +753,9 @@ def active_account(request):
         u'partage et désire apporter le savoir à tout le monde quelques soit ses moyens.'
         u'\n\n'
         u'En espérant que tu te plaira ici, '
-        u'je te laisse maintenant faire le tour'
+        u'je te laisse maintenant faire un petit tour.'
+        u'\n\n'
+        u'Clem\''
         .format(usr.username,
                 settings.SITE_URL + reverse("zds.tutorial.views.index"),
                 settings.SITE_URL + reverse("zds.article.views.index"),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #861 |

Si le compte est déjà activé, le reste du process n'est pas fait (activation + envoi de MP de bienvenue).

J'en profite pour :
- Modifier le texte de confirmation d'inscription (qui indiquait qu'on pouvait directement poster sur le site).
- Modifier très légèrement le MP de bienvenue qui terminait un peu bizarrement.

Ce n'était pas "bloquant" mais tout de même dans la Milestone "bêta publique" et aussi... dans mes cordes.
