### PR TITLE
Issue #621 : ajout et suppr auteur si staff

### DIFF
--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -14,6 +14,7 @@ from zds.mp.models import PrivateTopic
 from zds.settings import SITE_ROOT
 from zds.tutorial.factories import BigTutorialFactory, MiniTutorialFactory, PartFactory, \
     ChapterFactory, NoteFactory
+from zds.gallery.factories import GalleryFactory
 from zds.tutorial.models import Note, Tutorial, Validation
 from zds.utils.models import Alert
 
@@ -43,6 +44,7 @@ class BigTutorialTests(TestCase):
 
         self.bigtuto = BigTutorialFactory()
         self.bigtuto.authors.add(self.user_author)
+        self.bigtuto.gallery = GalleryFactory()
         self.bigtuto.save()
 
         self.part1 = PartFactory(tutorial=self.bigtuto, position_in_tutorial=1)
@@ -700,6 +702,61 @@ class BigTutorialTests(TestCase):
             1)
         self.assertEquals(len(mail.outbox), 0)
 
+    def test_add_remove_authors(self):
+        user1 = ProfileFactory().user
+
+        # Add and remove author as simple user (not staff):
+        login_check = self.client.login(
+            username=self.user.username,
+            password='hostel77')
+        self.assertEqual(login_check, True)
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_tutorial'),
+            {
+                'author': user1.username,
+                'tutorial': self.bigtuto.pk,
+                'add_author': True,
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_tutorial'),
+            {
+                'author': user1.pk,
+                'tutorial': self.bigtuto.pk,
+                'remove_author': True,
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        # Add and remove author as staff:
+        login_check = self.client.login(
+            username=self.staff.username,
+            password='hostel77')
+        self.assertEqual(login_check, True)
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_tutorial'),
+            {
+                'author': user1.username,
+                'tutorial': self.bigtuto.pk,
+                'add_author': True,
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_tutorial'),
+            {
+                'author': user1.pk,
+                'tutorial': self.bigtuto.pk,
+                'remove_author': True,
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
     def tearDown(self):
         if os.path.isdir(settings.REPO_PATH):
             shutil.rmtree(settings.REPO_PATH)
@@ -736,6 +793,7 @@ class MiniTutorialTests(TestCase):
 
         self.minituto = MiniTutorialFactory()
         self.minituto.authors.add(self.user_author)
+        self.minituto.gallery = GalleryFactory()
         self.minituto.save()
 
         self.chapter = ChapterFactory(
@@ -1217,6 +1275,61 @@ class MiniTutorialTests(TestCase):
                 author=self.user).count(),
             1)
         self.assertEquals(len(mail.outbox), 0)
+
+    def test_add_remove_authors(self):
+        user1 = ProfileFactory().user
+
+        # Add and remove author as simple user (not staff):
+        login_check = self.client.login(
+            username=self.user.username,
+            password='hostel77')
+        self.assertEqual(login_check, True)
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_tutorial'),
+            {
+                'author': user1.username,
+                'tutorial': self.minituto.pk,
+                'add_author': True,
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_tutorial'),
+            {
+                'author': user1.pk,
+                'tutorial': self.minituto.pk,
+                'remove_author': True,
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        # Add and remove author as staff:
+        login_check = self.client.login(
+            username=self.staff.username,
+            password='hostel77')
+        self.assertEqual(login_check, True)
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_tutorial'),
+            {
+                'author': user1.username,
+                'tutorial': self.minituto.pk,
+                'add_author': True,
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_tutorial'),
+            {
+                'author': user1.pk,
+                'tutorial': self.minituto.pk,
+                'remove_author': True,
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
 
     def tearDown(self):
         if os.path.isdir(settings.REPO_PATH):

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -547,7 +547,7 @@ def modify_tutorial(request):
 
     # User actions
 
-    if request.user in tutorial.authors.all():
+    if request.user in tutorial.authors.all() or request.user.has_perm("tutorial.change_tutorial"):
         if "add_author" in request.POST:
             redirect_url = reverse("zds.tutorial.views.view_tutorial", args=[
                 tutorial.pk,
@@ -603,7 +603,7 @@ def modify_tutorial(request):
 
     # No action performed, raise 404
 
-    raise Http404
+    raise PermissionDenied
 
 
 # Tutorials.


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #621 |

L'ajout et la suppression d'auteurs d'un tuto qui ne nous appartient pas renvoyait une 404, même en tant que staff. Le but de cette PR est de transformer cette erreur en 403, sauf pour les comptes ayant la permission de modifier les tutos (dont les staff).

J'ai également ajouté des tests dans ce sens.
