### PR TITLE
Issue #863 : Quitter une conversation MP

### DIFF
--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -122,7 +122,7 @@
                     <input type="hidden" name="topic_pk" value="{{ topic.pk }}">
 
                     {% csrf_token %}
-                    <button type="submit" name="leave" class="btn">Confirmer</button>
+                    <button type="submit" name="leave">Confirmer</button>
                 </form>
             </li>
         </ul>

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -122,7 +122,7 @@
                     <input type="hidden" name="topic_pk" value="{{ topic.pk }}">
 
                     {% csrf_token %}
-                    <button type="submit">Confirmer</button>
+                    <button type="submit" name="leave" class="btn">Confirmer</button>
                 </form>
             </li>
         </ul>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #863 |

Ajout de l’attribut name dans le template pour quitter une conversation privée et ajout des tests associés.
