### PR TITLE
Corrige la police d'écriture des formulaires

### DIFF
--- a/assets/scss/_form.scss
+++ b/assets/scss/_form.scss
@@ -89,7 +89,6 @@
     textarea {
         width: calc(98% - 2px);
         padding: 10px 1%;
-        font-family: Courier, "Lucida Sans Typewriter", "Lucida Typewriter", "DejaVu Sans Mono", monospace;
     }
 
     input,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | Aucun |

La règle suivante "font-family: Courier,"Lucida Sans Typewriter","Lucida Typewriter","DejaVu Sans Mono",monospace;"  affichait la police par défaut des formulaires et non celle du site.
