### PR TITLE
Déplacement des extraits (fix #947 et #962)

### DIFF
--- a/zds/tutorial/factories.py
+++ b/zds/tutorial/factories.py
@@ -252,15 +252,52 @@ class ExtractFactory(factory.DjangoModelFactory):
     @classmethod
     def _prepare(cls, create, **kwargs):
         extract = super(ExtractFactory, cls)._prepare(create, **kwargs)
+        title = kwargs.pop('title', None)
         chapter = kwargs.pop('chapter', None)
         if chapter:
+            extract.chapter = chapter
+            extract.title = title
+            extract.text = extract.get_path(relative=True)
             if chapter.tutorial:
-                chapter.tutorial.sha_draft = 'EXTRACT-AAAA'
-                chapter.tutorial.save()
+                tutorial = chapter.tutorial
             elif chapter.part:
-                chapter.part.tutorial.sha_draft = 'EXTRACT-AAAA'
-                chapter.part.tutorial.save()
+                tutorial = chapter.part.tutorial
+       
+            repo = Repo(tutorial.get_path())
 
+            f = open(
+            os.path.join(
+                tutorial.get_path(),
+                extract.text),
+                "w")
+            f.write(u'Test')
+            f.close()
+
+            extract.save()
+            tutorial.save()    
+            man = export_tutorial(tutorial)
+            f = open(os.path.join(tutorial.get_path(), 'manifest.json'), "w")
+            f.write(
+                json_writer.dumps(
+                    man,
+                    indent=4,
+                    ensure_ascii=False).encode('utf-8'))
+            f.close()
+            repo.index.add(['manifest.json', extract.text])
+
+            cm = repo.index.commit("Add extract")
+
+            if chapter.tutorial:
+                tutorial.sha_draft = cm.hexsha
+                tutorial.save()
+                chapter.save()
+                extract.chapter = chapter
+            elif chapter.part:
+                tutorial.sha_draft = cm.hexsha
+                tutorial.save()
+                extract.chapter.part.save()
+                chapter.save()
+                extract.chapter = chapter
         return extract
 
 

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -615,7 +615,7 @@ class Chapter(models.Model):
     def get_extract_count(self):
         return Extract.objects.all().filter(chapter__pk=self.pk).count()
 
-    def extracts(self):
+    def get_extracts(self):
         return Extract.objects.all()\
             .filter(chapter__pk=self.pk)\
             .order_by('position_in_chapter')

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -614,7 +614,7 @@ class Chapter(models.Model):
     def get_extract_count(self):
         return Extract.objects.all().filter(chapter__pk=self.pk).count()
 
-    def extracts(self):
+    def get_extracts(self):
         return Extract.objects.all()\
             .filter(chapter__pk=self.pk)\
             .order_by('position_in_chapter')

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -13,7 +13,7 @@ from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.mp.models import PrivateTopic
 from zds.settings import SITE_ROOT
 from zds.tutorial.factories import BigTutorialFactory, MiniTutorialFactory, PartFactory, \
-    ChapterFactory, NoteFactory
+    ChapterFactory, NoteFactory, ExtractFactory
 from zds.gallery.factories import GalleryFactory
 from zds.tutorial.models import Note, Tutorial, Validation, Extract
 from zds.utils.models import Alert
@@ -73,6 +73,19 @@ class BigTutorialTests(TestCase):
             position_in_part=2,
             position_in_tutorial=5)
 
+        self.extract2_2_1 = ExtractFactory(
+            chapter=self.chapter2_2,
+            position_in_chapter=1,
+            title='Titre 1')
+        self.extract2_2_2 = ExtractFactory(
+            chapter=self.chapter2_2,
+            position_in_chapter=2,
+            title='Titre 2')
+        self.extract2_2_3 = ExtractFactory(
+            chapter=self.chapter2_2,
+            position_in_chapter=3,
+            title='Titre 3')
+        
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user
 
@@ -756,6 +769,164 @@ class BigTutorialTests(TestCase):
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+    
+    def test_move_extracts(self):
+        """Test if extract can be moved"""
+        old_position = self.extract2_2_1.position_in_chapter
+
+        # logout before
+        self.client.logout()
+        # login with author
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+        # move extract no1 up
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract2_2_1.pk,
+                'move': '',
+                'move_target': 2 # no1 in pos 2, no2 in pos 1 and no3 in pos 3
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_1.pk).position_in_chapter,
+            2)
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_2.pk).position_in_chapter,
+            1)
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_3.pk).position_in_chapter,
+            3)
+        # move extract no1 down
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract2_2_1.pk,
+                'move': '',
+                'move_target': 1 # get back to old situation
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_1.pk).position_in_chapter,
+            1)
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_2.pk).position_in_chapter,
+            2)
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_3.pk).position_in_chapter,
+            3)
+
+        # test impossible deplacements :
+
+        # (1) negative position :
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract2_2_1.pk,
+                'move': '',
+                'move_target': -1
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_1.pk).position_in_chapter,
+            1)
+        # (2) more than chapter.get_extract_count() :
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract2_2_1.pk,
+                'move': '',
+                'move_target': self.chapter2_2.get_extract_count()+1
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_1.pk).position_in_chapter,
+            1)
+        # (3) same position :
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract2_2_1.pk,
+                'move': '',
+                'move_target': 1
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_1.pk).position_in_chapter,
+            1)
+
+        # then logout
+        self.client.logout()
+        # login with staff
+        self.assertEqual(
+            self.client.login(
+                username=self.staff.username,
+                password='hostel77'),
+            True)
+        # move extract no1 up
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract2_2_1.pk,
+                'move': '',
+                'move_target': 2 # staff can move extracts as well
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_1.pk).position_in_chapter,
+            2)
+        # then back
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract2_2_1.pk,
+                'move': '',
+                'move_target': 1
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_1.pk).position_in_chapter,
+            1)
+
+        # then logout
+        self.client.logout()
+        # login with normal user
+        self.assertEqual(
+            self.client.login(
+                username=self.user.username,
+                password='hostel77'),
+            True)
+        # move extract no1 up
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract2_2_1.pk,
+                'move': '',
+                'move_target': 1 # normal user canot move
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403) # PermissionDenied
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2_2_1.pk).position_in_chapter,
+            1)
 
     def tearDown(self):
         if os.path.isdir(settings.REPO_PATH):
@@ -799,6 +970,19 @@ class MiniTutorialTests(TestCase):
         self.chapter = ChapterFactory(
             tutorial=self.minituto,
             position_in_tutorial=1)
+
+        self.extract1 = ExtractFactory(
+            chapter=self.chapter,
+            position_in_chapter=1,
+            title='Titre 1')
+        self.extract2 = ExtractFactory(
+            chapter=self.chapter,
+            position_in_chapter=2,
+            title='Titre 2')
+        self.extract3 = ExtractFactory(
+            chapter=self.chapter,
+            position_in_chapter=3,
+            title='Titre 3')
 
         self.staff = StaffProfileFactory().user
 
@@ -1388,3 +1572,161 @@ class MiniTutorialTests(TestCase):
             shutil.rmtree(settings.REPO_ARTICLE_PATH)
         if os.path.isdir(settings.MEDIA_ROOT):
             shutil.rmtree(settings.MEDIA_ROOT)
+
+    def test_move_extracts(self):
+        """Test if extract can be moved"""
+        old_position = self.extract1.position_in_chapter
+
+        # logout before
+        self.client.logout()
+        # login with author
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+        # move extract no1 up
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract1.pk,
+                'move': '',
+                'move_target': 2 # no1 in pos 2, no2 in pos 1 and no3 in pos 3
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract1.pk).position_in_chapter,
+            2)
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2.pk).position_in_chapter,
+            1)
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract3.pk).position_in_chapter,
+            3)
+        # move extract no1 down
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract1.pk,
+                'move': '',
+                'move_target': 1 # get back to old situation
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract1.pk).position_in_chapter,
+            1)
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract2.pk).position_in_chapter,
+            2)
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract3.pk).position_in_chapter,
+            3)
+
+        # test impossible deplacements :
+
+        # (1) negative position :
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract1.pk,
+                'move': '',
+                'move_target': -1
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract1.pk).position_in_chapter,
+            1)
+        # (2) more than chapter.get_extract_count() :
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract1.pk,
+                'move': '',
+                'move_target': self.chapter.get_extract_count()+1
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract1.pk).position_in_chapter,
+            1)
+        # (3) same position :
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract1.pk,
+                'move': '',
+                'move_target': 1
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract1.pk).position_in_chapter,
+            1)
+
+        # then logout
+        self.client.logout()
+        # login with staff
+        self.assertEqual(
+            self.client.login(
+                username=self.staff.username,
+                password='hostel77'),
+            True)
+        # move extract no1 up
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract1.pk,
+                'move': '',
+                'move_target': 2 # staff can move extracts as well
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract1.pk).position_in_chapter,
+            2)
+        # then back
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract1.pk,
+                'move': '',
+                'move_target': 1
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract1.pk).position_in_chapter,
+            1)
+
+        # then logout
+        self.client.logout()
+        # login with normal user
+        self.assertEqual(
+            self.client.login(
+                username=self.user.username,
+                password='hostel77'),
+            True)
+        # move extract no1 up
+        result = self.client.post(
+            reverse('zds.tutorial.views.modify_extract'),
+            {
+                'extract': self.extract1.pk,
+                'move': '',
+                'move_target': 1 # normal user canot move
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403) # PermissionDenied
+        # check position
+        self.assertEqual(
+            Extract.objects.get(pk=self.extract1.pk).position_in_chapter,
+            1)

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2506,19 +2506,18 @@ def maj_repo_extract(
     
     chap = extract.chapter
 
-    msg="Modification de l'extrait"  
+    msg = "Modification de l'extrait"  
     if action == "del":
-        msg = "Suppression de l'exrait "
+        msg = "Suppression de l'exrait"
         extract.delete()
     else:
         if action == "maj":
             os.rename(old_slug_path, new_slug_path)
-            msg = "Modification de l'exrait"
             ext = open(new_slug_path, "w")
             ext.write(smart_str(text).strip())
             ext.close()
             index.add([extract.get_path(relative=True)])
-            msg = "Mise a jour de l'extrait "
+            msg = "Mise a jour de l'extrait"
         elif action == "move" :
             msg = "Deplacement de l'extrait"
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2486,9 +2486,9 @@ def maj_repo_extract(
             ext.write(smart_str(text).strip())
             ext.close()
             index.add([extract.get_path(relative=True)])
-            msg = "Mise a jour de l'exrait "
+            msg = "Mise a jour de l'extrait "
         elif action == "move" :
-            msg = "Déplacement de l'extrait"
+            msg = "Deplacement de l'extrait"
 
     # update manifest
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1882,7 +1882,7 @@ def modify_extract(request):
         raise Http404
     data = request.POST
     try:
-        extract_pk = request.POST["extract"]
+        extract_pk = data["extract"]
     except KeyError:
         raise Http404
     extract = get_object_or_404(Extract, pk=extract_pk)
@@ -1922,15 +1922,15 @@ def modify_extract(request):
         return redirect(chapter.get_absolute_url())
     elif "move" in data:
         try:
-            new_pos = int(request.POST["move_target"])
+            new_pos = int(data["move_target"])
         except ValueError:
-
             # Error, the user misplayed with the move button
-
             return redirect(extract.get_absolute_url())
         move(extract, new_pos, "position_in_chapter", "chapter", "get_extracts"
              )
         extract.save()
+        maj_repo_extract(request, extract=extract, action="move")
+        
         return redirect(extract.get_absolute_url())
     raise Http404
 
@@ -2492,10 +2492,12 @@ def maj_repo_extract(
         if action == "maj":
             os.rename(old_slug_path, new_slug_path)
             msg = "Modification de l'exrait "
-        ext = open(new_slug_path, "w")
-        ext.write(smart_str(text).strip())
-        ext.close()
-        index.add([extract.get_path(relative=True)])
+            ext = open(new_slug_path, "w")
+            ext.write(smart_str(text).strip())
+            ext.close()
+            index.add([extract.get_path(relative=True)])
+        elif action == "move" :
+            msg = "Déplacement de l'extrait"
         msg = "Mise a jour de l'exrait "
 
     # update manifest

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1921,7 +1921,7 @@ def modify_extract(request):
              )
         extract.save()
         maj_repo_extract(request, extract=extract, action="move")
-        
+
         return redirect(extract.get_absolute_url())
     raise Http404
 
@@ -2486,9 +2486,9 @@ def maj_repo_extract(
             ext.write(smart_str(text).strip())
             ext.close()
             index.add([extract.get_path(relative=True)])
+            msg = "Mise a jour de l'exrait "
         elif action == "move" :
             msg = "Déplacement de l'extrait"
-        msg = "Mise a jour de l'exrait "
 
     # update manifest
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1873,7 +1873,7 @@ def modify_extract(request):
         raise Http404
     data = request.POST
     try:
-        extract_pk = request.POST["extract"]
+        extract_pk = data["extract"]
     except KeyError:
         raise Http404
     extract = get_object_or_404(Extract, pk=extract_pk)
@@ -1913,15 +1913,15 @@ def modify_extract(request):
         return redirect(chapter.get_absolute_url())
     elif "move" in data:
         try:
-            new_pos = int(request.POST["move_target"])
+            new_pos = int(data["move_target"])
         except ValueError:
-
             # Error, the user misplayed with the move button
-
             return redirect(extract.get_absolute_url())
         move(extract, new_pos, "position_in_chapter", "chapter", "get_extracts"
              )
         extract.save()
+        maj_repo_extract(request, extract=extract, action="move")
+        
         return redirect(extract.get_absolute_url())
     raise Http404
 
@@ -2482,10 +2482,12 @@ def maj_repo_extract(
         if action == "maj":
             os.rename(old_slug_path, new_slug_path)
             msg = "Modification de l'exrait "
-        ext = open(new_slug_path, "w")
-        ext.write(smart_str(text).strip())
-        ext.close()
-        index.add([extract.get_path(relative=True)])
+            ext = open(new_slug_path, "w")
+            ext.write(smart_str(text).strip())
+            ext.close()
+            index.add([extract.get_path(relative=True)])
+        elif action == "move" :
+            msg = "Déplacement de l'extrait"
         msg = "Mise a jour de l'exrait "
 
     # update manifest

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2496,9 +2496,9 @@ def maj_repo_extract(
             ext.write(smart_str(text).strip())
             ext.close()
             index.add([extract.get_path(relative=True)])
-            msg = "Mise a jour de l'exrait "
+            msg = "Mise a jour de l'extrait "
         elif action == "move" :
-            msg = "Déplacement de l'extrait"
+            msg = "Deplacement de l'extrait"
 
     # update manifest
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1930,7 +1930,7 @@ def modify_extract(request):
              )
         extract.save()
         maj_repo_extract(request, extract=extract, action="move")
-        
+
         return redirect(extract.get_absolute_url())
     raise Http404
 
@@ -2496,9 +2496,9 @@ def maj_repo_extract(
             ext.write(smart_str(text).strip())
             ext.close()
             index.add([extract.get_path(relative=True)])
+            msg = "Mise a jour de l'exrait "
         elif action == "move" :
             msg = "Déplacement de l'extrait"
-        msg = "Mise a jour de l'exrait "
 
     # update manifest
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1733,6 +1733,7 @@ def edit_chapter(request):
 
 
 
+@can_write_and_read_now
 @login_required
 def add_extract(request):
     """Add extract."""
@@ -1877,6 +1878,7 @@ def edit_extract(request):
 
 
 @can_write_and_read_now
+@login_required
 def modify_extract(request):
     if not request.method == "POST":
         raise Http404
@@ -1885,11 +1887,25 @@ def modify_extract(request):
         extract_pk = data["extract"]
     except KeyError:
         raise Http404
+        
     extract = get_object_or_404(Extract, pk=extract_pk)
     chapter = extract.chapter
+    part = chapter.part
+
+    # Make sure the user is allowed to do that :
+    
+    if part and request.user \
+            not in extract.chapter.part.tutorial.authors.all() or not part \
+            and request.user not in extract.chapter.tutorial.authors.all():
+
+        # If the user isn't an author or a staff, we raise an exception.
+
+        if not request.user.has_perm("tutorial.change_tutorial"):
+            raise PermissionDenied
+        
     if "delete" in data:
         pos_current_extract = extract.position_in_chapter
-        for extract_c in extract.chapter.extracts():
+        for extract_c in extract.chapter.get_extracts():
             if pos_current_extract <= extract_c.position_in_chapter:
                 extract_c.position_in_chapter = extract_c.position_in_chapter \
                     - 1
@@ -1926,8 +1942,23 @@ def modify_extract(request):
         except ValueError:
             # Error, the user misplayed with the move button
             return redirect(extract.get_absolute_url())
-        move(extract, new_pos, "position_in_chapter", "chapter", "get_extracts"
-             )
+        extracts_in_chapter = extract.chapter.get_extract_count()
+        if new_pos < 0 or new_pos > extracts_in_chapter:
+            # error the new position does not exists !
+            messages.error(request,
+                    "Impossible de déplacer l'extrait à cette position")
+            return redirect(extract.get_absolute_url())
+
+        try :
+            move(extract, new_pos, "position_in_chapter", "chapter", 
+                "get_extracts"
+            )
+        except ValueError :
+            # move() raise an error
+            messages.error(request,
+                    "Impossible de déplacer l'extrait à cette position")
+            return redirect(extract.get_absolute_url())
+
         extract.save()
         maj_repo_extract(request, extract=extract, action="move")
 
@@ -2484,14 +2515,15 @@ def maj_repo_extract(
     index = repo.index
     
     chap = extract.chapter
-    
+
+    msg="Modification de l'extrait"  
     if action == "del":
         msg = "Suppression de l'exrait "
         extract.delete()
     else:
         if action == "maj":
             os.rename(old_slug_path, new_slug_path)
-            msg = "Modification de l'exrait "
+            msg = "Modification de l'exrait"
             ext = open(new_slug_path, "w")
             ext.write(smart_str(text).strip())
             ext.close()

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2516,19 +2516,18 @@ def maj_repo_extract(
     
     chap = extract.chapter
 
-    msg="Modification de l'extrait"  
+    msg = "Modification de l'extrait"  
     if action == "del":
-        msg = "Suppression de l'exrait "
+        msg = "Suppression de l'exrait"
         extract.delete()
     else:
         if action == "maj":
             os.rename(old_slug_path, new_slug_path)
-            msg = "Modification de l'exrait"
             ext = open(new_slug_path, "w")
             ext.write(smart_str(text).strip())
             ext.close()
             index.add([extract.get_path(relative=True)])
-            msg = "Mise a jour de l'extrait "
+            msg = "Mise a jour de l'extrait"
         elif action == "move" :
             msg = "Deplacement de l'extrait"
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #947, #962 |

Ce qui a été fait :
- Correction de extracts() en `get_extracts()` pour la class Chapter
  (dans /zds/tutorial/models.py)
- Ajout d'une ligne `maj_repo_extract()` manquante dans
  `modify_extract()` et ajout d'un type "move" pour maj_repo_extract()
  (dans /zds/tutorial/views.py)
- Modification de ExtractFactory dans factories.py, qui n'était
  pas complet: ajout de la partie créattion du *.md et commit
  sur repo (dans /zds/tutorial/)
- Ajout d'un PermissionDenied dans la fonction `modify_extract()`
  dans views.py (dans /zds/tutorial/)
- Ajout d'un catch pour gérer les erreurs retourné par `move()`
  dans la fonction modify_extract() dans views.py (dans /zds/
  tutorial/)
- Ajout d'un test unitaire (`test_move_extracts`) dans tests.py
  pour les bigs et mini-tutos + ajout d'extraits à ces TestCase's
  (dans /zds/tutorial/)

Note : à aucun moment le titre n'est modifié, je ne règle pas #913 et #878 par cette PR. Je résous principalement #962 et #947 a déjà été corrigé par @Alex-D au niveau du front.
