### PR TITLE
Issue 913 : Les conflits dans les noms de parties, chapitre, tuto créent des erreurs 500

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -1808,7 +1808,10 @@ table {
 
     &.repeated {
         .message {
-            background-color: #EEE;
+            &,
+            .is-author {
+                background: #EEE;
+            }
 
             &:after {
                 border-right-color: #EEE;
@@ -1817,26 +1820,24 @@ table {
     }
     &.helpful {
         .message {
-            background-color: $helpful;
+            &,
+            .is-author {
+                background: $helpful;
+            }
 
             &:after {
                 border-right-color: $helpful;
             }
-
-            .is-author {
-                background: $helpful;
-            }
         }
         &.repeated {
             .message {
-                background-color: desaturate($helpful, 50%);
+                &,
+                .is-author {
+                    background: desaturate($helpful, 50%);
+                }
 
                 &:after {
                     border-right-color: desaturate($helpful, 50%);
-                }
-
-                .is-author {
-                    background: desaturate($helpful, 50%);
                 }
             }
         }

--- a/zds/tutorial/factories.py
+++ b/zds/tutorial/factories.py
@@ -117,15 +117,17 @@ class PartFactory(factory.DjangoModelFactory):
         if not os.path.isdir(path):
             os.makedirs(path, mode=0o777)
 
-        part.introduction = os.path.join(part.slug, 'introduction.md')
-        part.conclusion = os.path.join(part.slug, 'conclusion.md')
+        part.introduction = os.path.join(part.get_path(True),
+            'introduction.md')
+        part.conclusion = os.path.join(part.get_path(True),
+            'conclusion.md')
         part.save()
 
-        f = open(os.path.join(tutorial.get_path(), part.introduction), "w")
+        f = open(os.path.join(path, 'introduction.md'), "w")
         f.write(u'Test')
         f.close()
         repo.index.add([part.introduction])
-        f = open(os.path.join(tutorial.get_path(), part.conclusion), "w")
+        f = open(os.path.join(path, 'conclusion.md'), "w")
         f.write(u'Test')
         f.close()
         repo.index.add([part.conclusion])
@@ -187,12 +189,10 @@ class ChapterFactory(factory.DjangoModelFactory):
 
         elif part:
             chapter.introduction = os.path.join(
-                part.slug,
-                chapter.slug,
+                chapter.get_path(),
                 'introduction.md')
             chapter.conclusion = os.path.join(
-                part.slug,
-                chapter.slug,
+                chapter.get_path(),
                 'conclusion.md')
             chapter.save()
             f = open(

--- a/zds/tutorial/factories.py
+++ b/zds/tutorial/factories.py
@@ -18,7 +18,7 @@ import factory
 from zds.tutorial.models import Tutorial, Part, Chapter, Extract, Note,\
     Validation
 from zds.utils.tutorials import export_tutorial
-
+from zds.utils.models import SubCategory
 
 class BigTutorialFactory(factory.DjangoModelFactory):
     FACTORY_FOR = Tutorial
@@ -278,6 +278,11 @@ class NoteFactory(factory.DjangoModelFactory):
             tutorial.save()
         return note
 
+class SubCategoryFactory(factory.DjangoModelFactory):
+    FACTORY_FOR = SubCategory
+    title = factory.Sequence(lambda n: 'Sous-Categorie {0} pour Tuto'.format(n))
+    subtitle = factory.Sequence(lambda n: 'Sous titre de Sous-Categorie {0} pour Tuto'.format(n))
+    slug = factory.Sequence(lambda n: 'sous-categorie-{0}'.format(n))
 
 class VaidationFactory(factory.DjangoModelFactory):
     FACTORY_FOR = Validation

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -169,14 +169,12 @@ class Tutorial(models.Model):
             return ''
         else:
             return os.path.join(
-                settings.REPO_PATH, str(
-                    self.pk) + '_' + self.slug)
+                settings.REPO_PATH, self.slugify_title())
 
     def get_prod_path(self):
         data = self.load_json_for_public()
         return os.path.join(
-            settings.REPO_PATH_PROD,
-            str(self.pk) + '_' + slugify(data['title']))
+            settings.REPO_PATH_PROD,self.slugify_title())
 
     def load_dic(self, mandata):
         mandata['get_absolute_url_online'] = self.get_absolute_url_online()
@@ -667,7 +665,7 @@ class Chapter(models.Model):
                             settings.REPO_PATH,
                             self.part.tutorial.slugify_title()),
                         self.part.slugify_title()
-                        ), self.slugify_title)
+                        ), self.slugify_title())
 
         return chapter_path
 

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -127,6 +127,8 @@ class Tutorial(models.Model):
             ]) + '?version=' + self.sha_beta
         else:
             return self.get_absolute_url()
+    def slugify_title(self):
+        return slugify(str(self.pk)+"_"+self.title)
 
     def get_edit_url(self):
         return reverse('zds.tutorial.views.modify_tutorial') + \
@@ -478,13 +480,14 @@ class Part(models.Model):
 
     def get_path(self, relative=False):
         if relative:
-            return self.slug
+            return self.slugify_title()
         else:
             return os.path.join(
                 os.path.join(
-                    settings.REPO_PATH, str(
-                        self.tutorial.pk) + '_' + self.tutorial.slug),
-                self.slug)
+                    settings.REPO_PATH, self.tutorial.slugify_title(),
+                self.slugify_title()
+                )
+            )
 
     def get_introduction(self):
         intro = open(
@@ -519,6 +522,9 @@ class Part(models.Model):
         conclu.close()
 
         return conclu_contenu.decode('utf-8')
+
+    def slugify_title(self):
+        return slugify(str(self.pk)+"_"+self.title)
 
     def get_conclusion_online(self):
         conclu = open(
@@ -614,7 +620,7 @@ class Chapter(models.Model):
     def get_extract_count(self):
         return Extract.objects.all().filter(chapter__pk=self.pk).count()
 
-    def extracts(self):
+    def get_extracts(self):
         return Extract.objects.all()\
             .filter(chapter__pk=self.pk)\
             .order_by('position_in_chapter')
@@ -642,25 +648,26 @@ class Chapter(models.Model):
     def get_path(self, relative=False):
         if relative:
             if self.tutorial:
-                chapter_path = self.slug
+                chapter_path = self.slugify_title()
             else:
-                chapter_path = os.path.join(self.part.slug, self.slug)
+                chapter_path = os.path.join(
+                    self.part.slugify_title(),
+                    self.slugify_title())
         else:
             if self.tutorial:
                 chapter_path = os.path.join(
                     os.path.join(
-                        settings.REPO_PATH, str(
-                            self.tutorial.pk) + '_' + self.tutorial.slug),
+                        settings.REPO_PATH,
+                        self.tutorial.slugify_title()),
                     self.slug)
             else:
                 chapter_path = os.path.join(
                     os.path.join(
                         os.path.join(
-                            settings.REPO_PATH, str(
-                                self.part.tutorial.pk)
-                            + '_'
-                            + self.part.tutorial.slug),
-                        self.part.slug), self.slug)
+                            settings.REPO_PATH,
+                            self.part.tutorial.slugify_title()),
+                        self.part.slugify_title()
+                        ), self.slugify_title)
 
         return chapter_path
 
@@ -755,6 +762,9 @@ class Chapter(models.Model):
             return conclu_contenu.decode('utf-8')
         else:
             return None
+
+    def slugify_title(self):
+        return slugify(str(self.pk)+"_"+self.title)
 
 
 class Extract(models.Model):
@@ -883,10 +893,7 @@ class Extract(models.Model):
             return None
 
     def slugify_title(self):
-        toEscape = ["introduction","conclusion"]
-        if slugify(self.title) in toEscape :
-            return "p-"+self.title
-        return slugify(self.title)
+        return slugify(str(self.pk)+"_"+self.title)
 
 class Validation(models.Model):
 

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -361,7 +361,7 @@ class BigTutorialTests(TestCase):
         self.assertEqual(Note.objects.get(pk=note3.pk).dislike, 0)
 
     def test_import_tuto(self):
-        """Test import of big tuto."""
+        """Test import d'un big tuto."""
         result = self.client.post(
             reverse('zds.tutorial.views.import_tuto'),
             {
@@ -1135,7 +1135,7 @@ class MiniTutorialTests(TestCase):
         self.assertEqual(Note.objects.get(pk=note3.pk).dislike, 0)
 
     def test_import_tuto(self):
-        """Test import of big tuto."""
+        """Test import d'un mini tuto."""
         result = self.client.post(
             reverse('zds.tutorial.views.import_tuto'),
             {

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -12,10 +12,11 @@ from django.test.utils import override_settings
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.mp.models import PrivateTopic
 from zds.settings import SITE_ROOT
-from zds.tutorial.factories import BigTutorialFactory, MiniTutorialFactory, PartFactory, \
-    ChapterFactory, NoteFactory
+from zds.tutorial.factories import BigTutorialFactory, \
+    MiniTutorialFactory, PartFactory, \
+    ChapterFactory, NoteFactory, SubCategoryFactory
 from zds.gallery.factories import GalleryFactory
-from zds.tutorial.models import Note, Tutorial, Validation, Extract
+from zds.tutorial.models import Note, Tutorial, Validation, Extract, Part
 from zds.utils.models import Alert
 
 
@@ -78,7 +79,7 @@ class BigTutorialTests(TestCase):
 
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user
-
+        self.subcat = SubCategoryFactory()
         login_check = self.client.login(
             username=self.staff.username,
             password='hostel77')
@@ -117,29 +118,30 @@ class BigTutorialTests(TestCase):
 
         mail.outbox = []
 
-    def tert_add_part_named_introduction(self):
-
-        self.client.login(username=selft.user_author,
+    def test_add_part_named_introduction(self):
+        """Test addition of part named introduction because it can
+        cause conflicts"""
+        self.client.login(username=self.user_author,
             password='hostel77')
-        part_number = self.bigtuto.get_parts.count()
+        part_number = self.bigtuto.get_parts().count()
         
         #add a new part
         result = self.client.post(
-            reverse('zds.tutorial.views.add_part'+
+            reverse('zds.tutorial.views.add_part')+
             '?tutoriel={0}'.format(
                 self.bigtuto.pk),
                 {
                     'title':'Introduction',
                     'introduction':'Introduction for test part',
                     'conclusion':'conclusion for test',
-                }, follow = False)
+                }, follow = False
         )
         self.assertEqual(result.status_code,302)
         #check part number
         self.assertEqual(part_number + 1,
-            self.bigtuto.get_parts.count())
+            self.bigtuto.get_parts().count())
         #check no conflict :
-        part = self.bigtuto.get_parts()[-1]
+        part = self.bigtuto.get_parts()[part_number]
         tuto_intro = os.path.join(self.bigtuto.get_path(),
             'introduction.md')
         part_path = part.get_path()
@@ -485,7 +487,65 @@ class BigTutorialTests(TestCase):
                           self.chapter2_1.slug]),
             follow=False)
         self.assertEqual(result.status_code, 302)
+    def test_workflow_tuto(self):
+        """Test workflow of tutorial."""
+        # logout before
+        self.client.logout()
+        # login with simple member
+        self.assertEqual(
+            self.client.login(
+                username=self.user.username,
+                password='hostel77'),
+            True)
+        #add new big tuto
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_tutorial'),
+            {
+                'title': u"Introduction à l'algèbre",
+                'description': "Perçer les mystère de boole",
+                'introduction':"Bienvenue dans le monde binaires",
+                'conclusion': "",
+                'type': "BIG",
+                'subcategory': self.subcat.pk,
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(Tutorial.objects.all().count(), 2)
+        tuto = Tutorial.objects.last()
+        #add part
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_part') + '?tutoriel={}'.format(tuto.pk),
+            {
+                'title': u"Partie 1",
+                'introduction':"Présentation",
+                'conclusion': "",
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
 
+        self.assertEqual(Part.objects.filter(tutorial=tuto).count(), 1)
+        #add part
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_part') + '?tutoriel={}'.format(tuto.pk),
+            {
+                'title': u"Partie 2",
+                'introduction':"Analyse",
+                'conclusion': "",
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(Part.objects.filter(tutorial=tuto).count(), 2)
+        #add part
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_part') + '?tutoriel={}'.format(tuto.pk),
+            {
+                'title': u"Partie 3",
+                'introduction':"Expérimentation",
+                'conclusion': "C'est terminé",
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(Part.objects.filter(tutorial=tuto).count(), 3)
     def test_url_for_member(self):
         """Test simple get request by simple member."""
 

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -47,9 +47,12 @@ class BigTutorialTests(TestCase):
         self.bigtuto.gallery = GalleryFactory()
         self.bigtuto.save()
 
-        self.part1 = PartFactory(tutorial=self.bigtuto, position_in_tutorial=1)
-        self.part2 = PartFactory(tutorial=self.bigtuto, position_in_tutorial=2)
-        self.part3 = PartFactory(tutorial=self.bigtuto, position_in_tutorial=3)
+        self.part1 = PartFactory(tutorial=self.bigtuto,
+           position_in_tutorial=1)
+        self.part2 = PartFactory(tutorial=self.bigtuto,
+            position_in_tutorial=2)
+        self.part3 = PartFactory(tutorial=self.bigtuto,
+            position_in_tutorial=3)
 
         self.chapter1_1 = ChapterFactory(
             part=self.part1,
@@ -113,6 +116,39 @@ class BigTutorialTests(TestCase):
         self.assertEquals(len(mail.outbox), 1)
 
         mail.outbox = []
+
+    def tert_add_part_named_introduction(self):
+
+        self.client.login(username=selft.user_author,
+            password='hostel77')
+        part_number = self.bigtuto.get_parts.count()
+        
+        #add a new part
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_part'+
+            '?tutoriel={0}'.format(
+                self.bigtuto.pk),
+                {
+                    'title':'Introduction',
+                    'introduction':'Introduction for test part',
+                    'conclusion':'conclusion for test',
+                }, follow = False)
+        )
+        self.assertEqual(result.status_code,302)
+        #check part number
+        self.assertEqual(part_number + 1,
+            self.bigtuto.get_parts.count())
+        #check no conflict :
+        part = self.bigtuto.get_parts()[-1]
+        tuto_intro = os.path.join(self.bigtuto.get_path(),
+            'introduction.md')
+        part_path = part.get_path()
+        part_intro = os.path.join(part_path, 'introduction.md')
+        self.assertNotEqual("",part.get_introduction())
+        self.assertNotEqual(part_path,tuto_intro)
+        self.assertNotEqual("Introduction for test part",
+            self.bigtuto.get_introduction())
+        
 
     def test_add_note(self):
         """To test add note for tutorial."""
@@ -361,7 +397,7 @@ class BigTutorialTests(TestCase):
         self.assertEqual(Note.objects.get(pk=note3.pk).dislike, 0)
 
     def test_import_tuto(self):
-        """Test import d'un big tuto."""
+        """Test import big tuto."""
         result = self.client.post(
             reverse('zds.tutorial.views.import_tuto'),
             {
@@ -1135,7 +1171,7 @@ class MiniTutorialTests(TestCase):
         self.assertEqual(Note.objects.get(pk=note3.pk).dislike, 0)
 
     def test_import_tuto(self):
-        """Test import d'un mini tuto."""
+        """Test import  mini tuto."""
         result = self.client.post(
             reverse('zds.tutorial.views.import_tuto'),
             {

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1174,7 +1174,7 @@ def add_part(request):
             part.tutorial = tutorial
             part.title = data["title"]
             part.position_in_tutorial = tutorial.get_parts().count() + 1
-            new_slug = part.get_path(False)
+            
             part.save()
             part.introduction = os.path.join(part.get_path(False),
                 "introduction.md")

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -511,8 +511,7 @@ def delete_tutorial(request, tutorial_pk):
 
         # Delete the tutorial on the repo and on the database.
 
-        old_slug = os.path.join(settings.REPO_PATH, str(tutorial.pk) + "_"
-                                + tutorial.slug)
+        old_slug = tutorial.get_path(False);
         maj_repo_tuto(request, old_slug_path=old_slug, tuto=tutorial,
                       action="del")
         messages.success(request,
@@ -1175,16 +1174,16 @@ def add_part(request):
             part.tutorial = tutorial
             part.title = data["title"]
             part.position_in_tutorial = tutorial.get_parts().count() + 1
-            new_slug = os.path.join(os.path.join(settings.REPO_PATH, str(
-                part.tutorial.pk) + "_" + part.tutorial.slug), slugify(data["title"]))
-            part.introduction = os.path.join(slugify(data["title"]),
-                                             "introduction.md")
-            part.conclusion = os.path.join(slugify(data["title"]),
-                                           "conclusion.md")
+            new_slug = part.get_path(False)
+            part.save()
+            part.introduction = os.path.join(part.get_path(False),
+                "introduction.md")
+            part.conclusion = os.path.join(part.get_path(False),
+                "conclusion.md")
             part.save()
             maj_repo_part(
                 request,
-                new_slug_path=new_slug,
+                new_slug_path=part.get_path(),
                 part=part,
                 introduction=data["introduction"],
                 conclusion=data["conclusion"],
@@ -1267,16 +1266,16 @@ def edit_part(request):
 
             # Update title and his slug.
 
-            part.title = data["title"]
-            new_slug = os.path.join(os.path.join(settings.REPO_PATH, str(
-                part.tutorial.pk) + "_" + part.tutorial.slug), slugify(data["title"]))
             old_slug = part.get_path()
+            part.title = data["title"]
+            new_slug = part.get_path()
+            
 
             # Update path for introduction and conclusion.
 
-            part.introduction = os.path.join(slugify(data["title"]),
+            part.introduction = os.path.join(part.get_path(),
                                              "introduction.md")
-            part.conclusion = os.path.join(slugify(data["title"]),
+            part.conclusion = os.path.join(part.get_path(),
                                            "conclusion.md")
             part.save()
             maj_repo_part(
@@ -2352,7 +2351,7 @@ def maj_repo_part(
             if not os.path.exists(new_slug_path):
                 os.makedirs(new_slug_path, mode=0o777)
             msg = "Creation de la partie "
-        index.add([slugify(part.title)])
+        index.add([part.slugify_title()])
         man_path = os.path.join(part.tutorial.get_path(), "manifest.json")
         part.tutorial.dump_json(path=man_path)
         index.add(["manifest.json"])

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1268,6 +1268,7 @@ def edit_part(request):
 
             old_slug = part.get_path()
             part.title = data["title"]
+            part.save()
             new_slug = part.get_path()
             
 
@@ -2030,8 +2031,7 @@ def import_content(
         userg.save()
         tutorial.gallery = gal
         tutorial.save()
-        tuto_path = os.path.join(settings.REPO_PATH, str(tutorial.pk) + "_"
-                                 + slugify(tutorial.title))
+        tuto_path = tutorial.get_path()
         mapping = upload_images(images, tutorial)
         maj_repo_tuto(
             request,
@@ -2054,14 +2054,11 @@ def import_content(
             part.title = part_title.text.strip()
             part.position_in_tutorial = part_count
             part.tutorial = tutorial
-            part.introduction = os.path.join(slugify(part_title.text.strip()),
+            part.introduction = os.path.join(part.get_path(True),
                                              "introduction.md")
-            part.conclusion = os.path.join(slugify(part_title.text.strip()),
+            part.conclusion = os.path.join(part.get_path(True),
                                            "conclusion.md")
-            part_path = os.path.join(os.path.join(settings.REPO_PATH,
-                                                  str(part.tutorial.pk) + "_"
-                                                  + part.tutorial.slug),
-                                     slugify(part.title))
+            part_path = part.get_path()
             part.save()
             maj_repo_part(
                 request,
@@ -2351,20 +2348,19 @@ def maj_repo_part(
             if not os.path.exists(new_slug_path):
                 os.makedirs(new_slug_path, mode=0o777)
             msg = "Creation de la partie "
-        index.add([part.slugify_title()])
-        man_path = os.path.join(part.tutorial.get_path(), "manifest.json")
+        index.add([new_slug_path])
+        man_path = os.path.join(new_slug_path, "manifest.json")
         part.tutorial.dump_json(path=man_path)
-        index.add(["manifest.json"])
-        intro = open(os.path.join(new_slug_path, "introduction.md"), "w")
+        index.add([os.path.join(new_slug_path,"manifest.json")])
+        intro = open(os.path.join(new_slug_path,
+            "introduction.md"), "w")
         intro.write(smart_str(introduction).strip())
         intro.close()
-        index.add([os.path.join(part.get_path(relative=True), "introduction.md"
-                                )])
+        index.add(["introduction.md"])
         conclu = open(os.path.join(new_slug_path, "conclusion.md"), "w")
         conclu.write(smart_str(conclusion).strip())
         conclu.close()
-        index.add([os.path.join(part.get_path(relative=True), "conclusion.md"
-                                )])
+        index.add(["conclusion.md"])
     aut_user = str(request.user.pk)
     aut_email = str(request.user.email)
     if aut_email is None or aut_email.strip() == "":


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #878, #913, #962 (indirectement, cf la suite) |

Mon but dans cette histoire est de corriger le bug qui arrive quand on a un conflit de nom avec les mots réservés tels que introduction ou conclusion.
Un commit précédent avait partiellement corrigé le bug, au niveau des extraits, grâce à l'utilisation d'une lettre supplémentaire.
Outre qu'un oubli avait créé un bug avec les caractères spéciaux, cette solution était insatisfaisante car elle n'utilisait pas vraiment un nom unique.
Désormais, comme proposé par @firm1, nous gardons pour **toute** l'architecture l'idée de nommer les parties avec id_nom.
Attention, bien que cette fonctionnalité ne soit pas encore implémentée, cela créera forcément des cas à prendre en compte lors de l'_import_ de l'archive _markdown_ (#949). 

Durant ma vérification manuelle du fonctionnement du workflow complet, je me suis heurté à un problème, détaillé dans #942 : une erreur 500 lorsqu'on réordonne les extraits.
J'ai corrigé rapidement l'erreur 500 par un changement de nom de la fonction extracts en get_extracts.
@Alex-D a fait remarquer que l'ancien nom était lui aussi utilisé. Je n'ai pas réussi à reproduire de bug l'utilisant.
