### PR TITLE
Corrections générales dans les tutos et articles

### DIFF
--- a/templates/tutorial/chapter/view_online.html
+++ b/templates/tutorial/chapter/view_online.html
@@ -11,7 +11,7 @@
 
 {% block breadcrumb %}
     <li><a href="{{ chapter.part.tutorial.get_absolute_url_online }}">{{ chapter.part.tutorial.title }}</a></li>
-    <li><a href="{% url "view-part-url-online" chapter.part.tutorial.pk chapter.part.tutorial.slug chapter.part.slug %}">
+    <li><a href="{% url "view-part-url-online" chapter.part.tutorial.pk chapter.part.tutorial.slug chapter.part.pk chapter.part.slug %}">
         {{ chapter.part.title }}
     </a></li>
     <li>{{ chapter.title }}</li>

--- a/templates/tutorial/includes/chapter.part.html
+++ b/templates/tutorial/includes/chapter.part.html
@@ -68,13 +68,7 @@
                         <option disabled>&mdash; Déplacer avant</option>
                         {% for extract_mv in extracts %}
                             {% if extract != extract_mv and extract_mv.position_in_chapter|add:-1 != extract.position_in_chapter %}
-                            <option value="
-                                {% if extract_mv.position_chapter < extract.position_in_chapter %}
-                                    {{ extract_mv.position_in_chapter }}
-                                {% else %}
-                                    {{ extract_mv.position_in_chapter|add:-1 }}
-                                {% endif %}
-                            ">
+                            <option value="{{ extract_mv.position_in_chapter }}">
                                 Extrait {{ extract_mv.position_in_chapter }} : {{ extract_mv.title }}
                             </option>
                             {% endif %}
@@ -83,13 +77,7 @@
                         <option disabled>&mdash; Déplacer après</option>
                         {% for extract_mv in extracts %}
                             {% if extract != extract_mv and extract_mv.position_in_chapter|add:1 != extract.position_in_chapter %}
-                            <option value="
-                                {% if extract_mv.position_chapter < extract.position_in_chapter %}
-                                    {{ extract_mv.position_in_chapter|add:1 }}
-                                {% else %}
-                                    {{ extract_mv.position_in_chapter }}
-                                {% endif %}
-                            ">
+                            <option value="{{ extract_mv.position_in_chapter }}">
                                 Extrait {{ extract_mv.position_in_chapter }} : {{ extract_mv.title }}
                             </option>
                             {% endif %}

--- a/templates/tutorial/includes/part.part.html
+++ b/templates/tutorial/includes/part.part.html
@@ -15,9 +15,9 @@
                         <h3>
                             <a href="
                                 {% if online %}
-                                    {% url "view-chapter-url-online" tutorial.pk tutorial.slug part.slug chapter.slug %}
+                                    {% url "view-chapter-url-online" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}
                                 {% else %}
-                                    {% url "view-chapter-url" tutorial.pk tutorial.slug part.slug chapter.slug %}{% if version %}?version={{version}}{% endif %}
+                                    {% url "view-chapter-url" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}{% if version %}?version={{ version }}{% endif %}
                                 {% endif %}
                             ">
                                 Chapitre {{ chapter.part.position_in_tutorial }}.{{ chapter.position_in_part }} | {{ chapter.title }}
@@ -29,9 +29,9 @@
                                     <h4>
                                         <a href="{% spaceless %}
                                             {% if online %}
-                                                {% url "view-chapter-url-online" tutorial.pk tutorial.slug part.slug chapter.slug %}
+                                                {% url "view-chapter-url-online" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}
                                             {% else %}
-                                                {% url "view-chapter-url" tutorial.pk tutorial.slug part.slug chapter.slug %}{% if version %}?version={{version}}{% endif %}
+                                                {% url "view-chapter-url" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}{% if version %}?version={{ version }}{% endif %}
                                             {% endif %}
                                             {% endspaceless %}#{{ extract.position_in_chapter }}-{{ extract.title|slugify }}">
                                             {{ extract.title }}

--- a/templates/tutorial/includes/part_export.part.html
+++ b/templates/tutorial/includes/part_export.part.html
@@ -20,11 +20,11 @@
             <ul>
                 {% for chapter in chapters %}
                     <li>
-                        <a href="{% url "view-chapter-url-online" tutorial.pk tutorial.slug part.slug chapter.slug %}"><h2>Chapitre {{ chapter.part.position_in_tutorial }}.{{ chapter.position_in_part }} | {{ chapter.title }}</h2></a>
+                        <a href="{% url "view-chapter-url-online" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}"><h2>Chapitre {{ chapter.part.position_in_tutorial }}.{{ chapter.position_in_part }} | {{ chapter.title }}</h2></a>
                         <ul>
                             {% for extract in chapter.extracts %}
                             <li>
-                                <a href="{% url "view-chapter-url-online" tutorial.pk tutorial.slug part.slug chapter.slug %}#{{ extract.position_in_chapter }}-{{ extract.title|slugify }}">
+                                <a href="{% url "view-chapter-url-online" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}#{{ extract.position_in_chapter }}-{{ extract.title|slugify }}">
                                     <h3>{{ extract.title }}</h3>
                                 </a>
                                 {{ extract.txt|safe }}

--- a/templates/tutorial/includes/summary.part.html
+++ b/templates/tutorial/includes/summary.part.html
@@ -30,9 +30,9 @@
                 <h4 data-num="{{ part.position_in_tutorial|roman }}">
                     <a class="mobile-menu-link"
                        {% if online %}
-                           href="{% url "view-part-url-online" tutorial.pk tutorial.slug part.slug %}"
+                           href="{% url "view-part-url-online" tutorial.pk tutorial.slug part.pk part.slug %}"
                        {% else %}
-                           href="{% url "view-part-url" tutorial.pk tutorial.slug part.slug %}{% if version %}?version={{version}}{% endif %}"
+                           href="{% url "view-part-url" tutorial.pk tutorial.slug part.pk part.slug %}"{% if version %}?version={{ version }}{% endif %}
                        {% endif %}
                     >
                         {{ part.title }}
@@ -44,9 +44,9 @@
                         <li {% if chapter_current.pk == chapter.pk %}class="current"{% endif %}>
                             <a data-num="{{ chapter.position_in_part }}"
                                {% if online %}
-                                   href="{% url "view-chapter-url-online" tutorial.pk tutorial.slug part.slug chapter.slug %}"
+                                   href="{% url "view-chapter-url-online" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}"
                                {% else %}
-                                   href="{% url "view-chapter-url" tutorial.pk tutorial.slug part.slug chapter.slug %}{% if version %}?version={{ version }}{% endif %}"
+                                   href="{% url "view-chapter-url" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}"{% if version %}?version={{ version }}{% endif %}
                                {% endif %}
                                class="mobile-menu-link mobile-menu-sublink {% if chapter_current.pk = chapter.pk %}unread{% endif %}"
                             >
@@ -59,9 +59,9 @@
                                         <li>
                                             <a
                                                {% if online %}
-                                                   href="{% url "view-chapter-url-online" tutorial.pk tutorial.slug part.slug chapter.slug %}#{{ extract.position_in_chapter }}-{{ extract.title|slugify }}"
+                                                   href="{% url "view-chapter-url-online" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}#{{ extract.position_in_chapter }}-{{ extract.title|slugify }}"
                                                {% else %}
-                                                   href="{% url "view-chapter-url" tutorial.pk tutorial.slug part.slug chapter.slug %}{% if version %}?version={{ version }}{% endif %}#{{ extract.position_in_chapter }}-{{ extract.title|slugify }}"
+                                                   href="{% url "view-chapter-url" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}#{{ extract.position_in_chapter }}-{{ extract.title|slugify }}"{% if version %}?version={{ version }}{% endif %}
                                                {% endif %}
                                             >
                                                 {{ extract.title }}

--- a/templates/tutorial/part/view.html
+++ b/templates/tutorial/part/view.html
@@ -50,7 +50,7 @@
             {% for chapter in part.chapters %}
                 <li>
                     <h3>
-                        <a href="{% url "view-chapter-url" part.tutorial.pk part.tutorial.slug part.slug chapter.slug %}?version={{ version }}">
+                        <a href="{% url "view-chapter-url" part.tutorial.pk part.tutorial.slug part.pk part.slug chapter.pk chapter.slug %}?version={{version}}">
                             {{ chapter.title }}
                         </a>
                     </h3>

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -69,7 +69,7 @@
 
             {% for part in parts %}
                 <h2>
-                    <a href="{% url "view-part-url" tutorial.pk tutorial.slug part.slug %}{% if version %}?version={{version}}{% endif %}">
+                    <a href="{% url "view-part-url" tutorial.pk tutorial.slug part.pk part.slug %}{%if version %}?version={{version}}{% endif %}">
                         Partie {{ part.position_in_tutorial }} : {{ part.title }}
                     </a>
                 </h2>

--- a/templates/tutorial/tutorial/view_online.html
+++ b/templates/tutorial/tutorial/view_online.html
@@ -52,7 +52,7 @@
         {% if parts %}
             {% for part in parts %}
                 <h2>
-                    <a href="{% url "view-part-url-online" tutorial.pk tutorial.slug part.slug %}">
+                    <a href="{% url "view-part-url-online" tutorial.pk tutorial.slug part.pk part.slug %}">
                         Partie {{ part.position_in_tutorial }} : {{ part.title }}
                     </a>
                 </h2>

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -96,6 +96,9 @@ class Article(models.Model):
         return reverse('zds.article.views.view',
                        kwargs={'article_pk': self.pk,
                                'article_slug': slugify(self.title)})
+    
+    def get_slug(self):
+        return str(self.pk) + "_" + self.slug
 
     def get_absolute_url_online(self):
         return reverse('zds.article.views.view_online',
@@ -119,7 +122,7 @@ class Article(models.Model):
         if relative:
             return None
         else:
-            return os.path.join(settings.REPO_ARTICLE_PATH, self.slug)
+            return os.path.join(settings.REPO_ARTICLE_PATH, self.get_slug())
 
     def load_json(self, path=None, online=False):
         if path is None:

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -97,7 +97,7 @@ class Article(models.Model):
                        kwargs={'article_pk': self.pk,
                                'article_slug': slugify(self.title)})
     
-    def get_slug(self):
+    def get_phy_slug(self):
         return str(self.pk) + "_" + self.slug
 
     def get_absolute_url_online(self):
@@ -122,7 +122,7 @@ class Article(models.Model):
         if relative:
             return None
         else:
-            return os.path.join(settings.REPO_ARTICLE_PATH, self.get_slug())
+            return os.path.join(settings.REPO_ARTICLE_PATH, self.get_phy_slug())
 
     def load_json(self, path=None, online=False):
         if path is None:

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -322,8 +322,7 @@ def edit(request):
 
             new_slug = os.path.join(
                 settings.REPO_ARTICLE_PATH,
-                slugify(
-                    data['title']))
+                article.get_slug())
 
             maj_repo_article(request,
                              old_slug_path=old_slug,
@@ -334,7 +333,7 @@ def edit(request):
 
             return redirect(article.get_absolute_url())
     else:
-        form = ArticleForm({
+        form = ArticleForm(initial={
             'title': json['title'],
             'description': json['description'],
             'text': article.get_text(),
@@ -410,7 +409,7 @@ def download(request):
 
     article = get_object_or_404(Article, pk=request.GET['article'])
 
-    ph = os.path.join(settings.REPO_ARTICLE_PATH, article.slug)
+    ph = os.path.join(settings.REPO_ARTICLE_PATH, article.get_slug())
     repo = Repo(ph)
     repo.archive(open(ph + ".tar", 'w'))
 

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -322,7 +322,7 @@ def edit(request):
 
             new_slug = os.path.join(
                 settings.REPO_ARTICLE_PATH,
-                article.get_slug())
+                article.get_phy_slug())
 
             maj_repo_article(request,
                              old_slug_path=old_slug,
@@ -409,7 +409,7 @@ def download(request):
 
     article = get_object_or_404(Article, pk=request.GET['article'])
 
-    ph = os.path.join(settings.REPO_ARTICLE_PATH, article.get_slug())
+    ph = os.path.join(settings.REPO_ARTICLE_PATH, article.get_phy_slug())
     repo = Repo(ph)
     repo.archive(open(ph + ".tar", 'w'))
 

--- a/zds/tutorial/factories.py
+++ b/zds/tutorial/factories.py
@@ -17,6 +17,7 @@ import factory
 
 from zds.tutorial.models import Tutorial, Part, Chapter, Extract, Note,\
     Validation
+from zds.utils.models import SubCategory 
 from zds.utils.tutorials import export_tutorial
 
 
@@ -118,8 +119,8 @@ class PartFactory(factory.DjangoModelFactory):
         if not os.path.isdir(path):
             os.makedirs(path, mode=0o777)
 
-        part.introduction = os.path.join(part.slug, 'introduction.md')
-        part.conclusion = os.path.join(part.slug, 'conclusion.md')
+        part.introduction = os.path.join(part.get_slug(), 'introduction.md')
+        part.conclusion = os.path.join(part.get_slug(), 'conclusion.md')
         part.save()
 
         f = open(os.path.join(tutorial.get_path(), part.introduction), "w")
@@ -188,12 +189,12 @@ class ChapterFactory(factory.DjangoModelFactory):
 
         elif part:
             chapter.introduction = os.path.join(
-                part.slug,
-                chapter.slug,
+                part.get_slug(),
+                chapter.get_slug(),
                 'introduction.md')
             chapter.conclusion = os.path.join(
-                part.slug,
-                chapter.slug,
+                part.get_slug(),
+                chapter.get_slug(),
                 'conclusion.md')
             chapter.save()
             f = open(
@@ -278,6 +279,13 @@ class NoteFactory(factory.DjangoModelFactory):
             tutorial.last_note = note
             tutorial.save()
         return note
+
+class SubCategoryFactory(factory.DjangoModelFactory):
+    FACTORY_FOR = SubCategory
+
+    title = factory.Sequence(lambda n: 'Sous-Categorie {0} pour Tuto'.format(n))
+    subtitle = factory.Sequence(lambda n: 'Sous titre de Sous-Categorie {0} pour Tuto'.format(n))
+    slug = factory.Sequence(lambda n: 'sous-categorie-{0}'.format(n))
 
 
 class VaidationFactory(factory.DjangoModelFactory):

--- a/zds/tutorial/factories.py
+++ b/zds/tutorial/factories.py
@@ -119,8 +119,8 @@ class PartFactory(factory.DjangoModelFactory):
         if not os.path.isdir(path):
             os.makedirs(path, mode=0o777)
 
-        part.introduction = os.path.join(part.get_slug(), 'introduction.md')
-        part.conclusion = os.path.join(part.get_slug(), 'conclusion.md')
+        part.introduction = os.path.join(part.get_phy_slug(), 'introduction.md')
+        part.conclusion = os.path.join(part.get_phy_slug(), 'conclusion.md')
         part.save()
 
         f = open(os.path.join(tutorial.get_path(), part.introduction), "w")
@@ -189,12 +189,12 @@ class ChapterFactory(factory.DjangoModelFactory):
 
         elif part:
             chapter.introduction = os.path.join(
-                part.get_slug(),
-                chapter.get_slug(),
+                part.get_phy_slug(),
+                chapter.get_phy_slug(),
                 'introduction.md')
             chapter.conclusion = os.path.join(
-                part.get_slug(),
-                chapter.get_slug(),
+                part.get_phy_slug(),
+                chapter.get_phy_slug(),
                 'conclusion.md')
             chapter.save()
             f = open(

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -111,6 +111,9 @@ class Tutorial(models.Model):
     def __unicode__(self):
         return self.title
 
+    def get_slug(self):
+        return str(self.pk) + "_" + self.slug
+
     def get_absolute_url(self):
         return reverse('zds.tutorial.views.view_tutorial', args=[
             self.pk, slugify(self.title)
@@ -167,9 +170,7 @@ class Tutorial(models.Model):
         if relative:
             return ''
         else:
-            return os.path.join(
-                settings.REPO_PATH, str(
-                    self.pk) + '_' + self.slug)
+            return os.path.join(settings.REPO_PATH, self.get_slug())
 
     def get_prod_path(self):
         data = self.load_json_for_public()
@@ -459,6 +460,9 @@ class Part(models.Model):
         return u'<Partie pour {0}, {1}>' \
             .format(self.tutorial.title, self.position_in_tutorial)
 
+    def get_slug(self):
+        return str(self.pk) + "_" + self.slug
+
     def get_absolute_url(self):
         return reverse('zds.tutorial.views.view_part', args=[
             self.tutorial.pk,
@@ -479,13 +483,9 @@ class Part(models.Model):
 
     def get_path(self, relative=False):
         if relative:
-            return self.slug
+            return self.get_slug()
         else:
-            return os.path.join(
-                os.path.join(
-                    settings.REPO_PATH, str(
-                        self.tutorial.pk) + '_' + self.tutorial.slug),
-                self.slug)
+            return os.path.join(settings.REPO_PATH, self.tutorial.get_slug(), self.get_slug())
 
     def get_introduction(self):
         intro = open(
@@ -591,6 +591,9 @@ class Chapter(models.Model):
         else:
             return u'<orphelin>'
 
+    def get_slug(self):
+        return str(self.pk) + "_" + self.slug
+
     def get_absolute_url(self):
         if self.tutorial:
             return self.tutorial.get_absolute_url()
@@ -615,7 +618,7 @@ class Chapter(models.Model):
     def get_extract_count(self):
         return Extract.objects.all().filter(chapter__pk=self.pk).count()
 
-    def extracts(self):
+    def get_extracts(self):
         return Extract.objects.all()\
             .filter(chapter__pk=self.pk)\
             .order_by('position_in_chapter')
@@ -643,25 +646,17 @@ class Chapter(models.Model):
     def get_path(self, relative=False):
         if relative:
             if self.tutorial:
-                chapter_path = self.slug
+                chapter_path = self.get_slug()
             else:
-                chapter_path = os.path.join(self.part.slug, self.slug)
+                chapter_path = os.path.join(self.part.get_slug(), self.get_slug())
         else:
             if self.tutorial:
-                chapter_path = os.path.join(
-                    os.path.join(
-                        settings.REPO_PATH, str(
-                            self.tutorial.pk) + '_' + self.tutorial.slug),
-                    self.slug)
+                chapter_path = os.path.join(settings.REPO_PATH, self.tutorial.get_slug(), self.get_slug())
             else:
-                chapter_path = os.path.join(
-                    os.path.join(
-                        os.path.join(
-                            settings.REPO_PATH, str(
-                                self.part.tutorial.pk)
-                            + '_'
-                            + self.part.tutorial.slug),
-                        self.part.slug), self.slug)
+                chapter_path = os.path.join(settings.REPO_PATH,
+                                            self.part.tutorial.get_slug(),
+                                            self.part.get_slug(),
+                                            self.get_slug())
 
         return chapter_path
 
@@ -798,51 +793,44 @@ class Extract(models.Model):
                 chapter_path = ''
             else:
                 chapter_path = os.path.join(
-                    self.chapter.part.slug,
-                    self.chapter.slug)
+                    self.chapter.part.get_slug(),
+                    self.chapter.get_slug())
         else:
             if self.chapter.tutorial:
-                chapter_path = os.path.join(
-                    settings.REPO_PATH, str(
-                        self.chapter.tutorial.pk)
-                    + '_'
-                    + self.chapter.tutorial.slug)
+                chapter_path = os.path.join(settings.REPO_PATH, self.chapter.tutorial.get_slug())
             else:
-                chapter_path = os.path.join(
-                    os.path.join(
-                        os.path.join(
-                            settings.REPO_PATH,
-                            str(
-                                self.chapter.part.tutorial.pk) +
-                            '_' +
-                            self.chapter.part.tutorial.slug),
-                        self.chapter.part.slug),
-                    self.chapter.slug)
+                chapter_path = os.path.join(settings.REPO_PATH,
+                                            self.chapter.part.tutorial.get_slug(),
+                                            self.chapter.part.get_slug(),
+                                            self.chapter.get_slug())
 
-        return os.path.join(chapter_path, self.slugify_title()) + '.md'
+        return os.path.join(chapter_path, str(self.pk) + "_" + slugify(self.title)) + '.md'
 
     def get_prod_path(self):
+        
         if self.chapter.tutorial:
-            chapter_path = os.path.join(
-                os.path.join(
-                    settings.REPO_PATH_PROD, str(
-                        self.chapter.tutorial.pk)
-                    + '_'
-                    + self.chapter.tutorial.slug), self.chapter.slug)
+            data = self.chapter.tutorial.load_json_for_public()
+            mandata = tutorial.load_dic(data)
+            if "chapter" in mandata:
+                for ext in mandata["chapter"]["extracts"]:
+                    if ext['pk'] == self.pk:
+                        return os.path.join(settings.REPO_PATH_PROD,
+                                            str(self.chapter.tutorial.pk) + '_' + slugify(mandata['title']),
+                                            str(ext['pk']) + "_" + slugify(ext['title'])) \
+                                            + '.md.html'
         else:
-            chapter_path = os.path.join(
-                os.path.join(
-                    os.path.join(
-                        settings.REPO_PATH_PROD,
-                        str(
-                            self.chapter.part.tutorial.pk) +
-                        '_' +
-                        self.chapter.part.tutorial.slug),
-                    self.chapter.part.slug),
-                self.chapter.slug)
-
-        return os.path.join(chapter_path, self.slugify_title()
-             + '.md.html')
+            data = self.chapter.part.tutorial.load_json_for_public()
+            mandata = tutorial.load_dic(data)
+            for part in mandata["parts"]:
+                for chapter in part["chapters"]:
+                    for ext in chapter["extracts"]:
+                        if ext['pk'] == self.pk:
+                            chapter_path = os.path.join(settings.REPO_PATH_PROD,
+                                                        str(mandata['pk']) + '_' + slugify(mandata['title']),
+                                                        str(part['pk']) + "_" + slugify(part['title']),
+                                                        str(chapter['pk']) + "_" + slugify(chapter['title']),
+                                                        str(ext['pk']) + "_" + slugify(ext['title'])) \
+                                                        + '.md.html'
 
     def get_text(self):
         if self.chapter.tutorial:
@@ -882,12 +870,6 @@ class Extract(models.Model):
             return text_contenu.decode('utf-8')
         else:
             return None
-
-    def slugify_title(self):
-        toEscape = ["introduction","conclusion"]
-        if slugify(self.title) in toEscape :
-            return "p-"+self.title
-        return slugify(self.title)
 
 class Validation(models.Model):
 

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -111,7 +111,7 @@ class Tutorial(models.Model):
     def __unicode__(self):
         return self.title
 
-    def get_slug(self):
+    def get_phy_slug(self):
         return str(self.pk) + "_" + self.slug
 
     def get_absolute_url(self):
@@ -170,7 +170,7 @@ class Tutorial(models.Model):
         if relative:
             return ''
         else:
-            return os.path.join(settings.REPO_PATH, self.get_slug())
+            return os.path.join(settings.REPO_PATH, self.get_phy_slug())
 
     def get_prod_path(self):
         data = self.load_json_for_public()
@@ -460,13 +460,14 @@ class Part(models.Model):
         return u'<Partie pour {0}, {1}>' \
             .format(self.tutorial.title, self.position_in_tutorial)
 
-    def get_slug(self):
+    def get_phy_slug(self):
         return str(self.pk) + "_" + self.slug
 
     def get_absolute_url(self):
         return reverse('zds.tutorial.views.view_part', args=[
             self.tutorial.pk,
             self.tutorial.slug,
+            self.pk,
             self.slug,
         ])
 
@@ -474,6 +475,7 @@ class Part(models.Model):
         return reverse('zds.tutorial.views.view_part_online', args=[
             self.tutorial.pk,
             self.tutorial.slug,
+            self.pk,
             self.slug,
         ])
 
@@ -483,9 +485,9 @@ class Part(models.Model):
 
     def get_path(self, relative=False):
         if relative:
-            return self.get_slug()
+            return self.get_phy_slug()
         else:
-            return os.path.join(settings.REPO_PATH, self.tutorial.get_slug(), self.get_slug())
+            return os.path.join(settings.REPO_PATH, self.tutorial.get_phy_slug(), self.get_phy_slug())
 
     def get_introduction(self):
         intro = open(
@@ -591,7 +593,7 @@ class Chapter(models.Model):
         else:
             return u'<orphelin>'
 
-    def get_slug(self):
+    def get_phy_slug(self):
         return str(self.pk) + "_" + self.slug
 
     def get_absolute_url(self):
@@ -599,7 +601,7 @@ class Chapter(models.Model):
             return self.tutorial.get_absolute_url()
 
         elif self.part:
-            return self.part.get_absolute_url() + '{0}/'.format(self.slug)
+            return self.part.get_absolute_url() + '{0}/{1}/'.format(self.pk, self.slug)
 
         else:
             return reverse('zds.tutorial.views.index')
@@ -610,7 +612,7 @@ class Chapter(models.Model):
 
         elif self.part:
             return self.part.get_absolute_url_online(
-            ) + '{0}/'.format(self.slug)
+            ) + '{0}/{1}/'.format(self.pk, self.slug)
 
         else:
             return reverse('zds.tutorial.views.index')
@@ -646,17 +648,17 @@ class Chapter(models.Model):
     def get_path(self, relative=False):
         if relative:
             if self.tutorial:
-                chapter_path = self.get_slug()
+                chapter_path = self.get_phy_slug()
             else:
-                chapter_path = os.path.join(self.part.get_slug(), self.get_slug())
+                chapter_path = os.path.join(self.part.get_phy_slug(), self.get_phy_slug())
         else:
             if self.tutorial:
-                chapter_path = os.path.join(settings.REPO_PATH, self.tutorial.get_slug(), self.get_slug())
+                chapter_path = os.path.join(settings.REPO_PATH, self.tutorial.get_phy_slug(), self.get_phy_slug())
             else:
                 chapter_path = os.path.join(settings.REPO_PATH,
-                                            self.part.tutorial.get_slug(),
-                                            self.part.get_slug(),
-                                            self.get_slug())
+                                            self.part.tutorial.get_phy_slug(),
+                                            self.part.get_phy_slug(),
+                                            self.get_phy_slug())
 
         return chapter_path
 
@@ -793,16 +795,16 @@ class Extract(models.Model):
                 chapter_path = ''
             else:
                 chapter_path = os.path.join(
-                    self.chapter.part.get_slug(),
-                    self.chapter.get_slug())
+                    self.chapter.part.get_phy_slug(),
+                    self.chapter.get_phy_slug())
         else:
             if self.chapter.tutorial:
-                chapter_path = os.path.join(settings.REPO_PATH, self.chapter.tutorial.get_slug())
+                chapter_path = os.path.join(settings.REPO_PATH, self.chapter.tutorial.get_phy_slug())
             else:
                 chapter_path = os.path.join(settings.REPO_PATH,
-                                            self.chapter.part.tutorial.get_slug(),
-                                            self.chapter.part.get_slug(),
-                                            self.chapter.get_slug())
+                                            self.chapter.part.tutorial.get_phy_slug(),
+                                            self.chapter.part.get_phy_slug(),
+                                            self.chapter.get_phy_slug())
 
         return os.path.join(chapter_path, str(self.pk) + "_" + slugify(self.title)) + '.md'
 

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -42,7 +42,7 @@ class BigTutorialTests(TestCase):
         self.user_author = ProfileFactory().user
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user
-        self.souscat = SubCategoryFactory()
+        self.subcat = SubCategoryFactory()
 
         self.bigtuto = BigTutorialFactory()
         self.bigtuto.authors.add(self.user_author)
@@ -410,6 +410,7 @@ class BigTutorialTests(TestCase):
                 args=[
                     self.bigtuto.pk,
                     self.bigtuto.slug,
+                    self.part2.pk,
                     self.part2.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -418,7 +419,9 @@ class BigTutorialTests(TestCase):
             reverse('zds.tutorial.views.view_chapter_online',
                     args=[self.bigtuto.pk,
                           self.bigtuto.slug,
+                          self.part2.pk,
                           self.part2.slug,
+                          self.chapter2_1.pk,
                           self.chapter2_1.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -439,6 +442,7 @@ class BigTutorialTests(TestCase):
                 args=[
                     self.bigtuto.pk,
                     self.bigtuto.slug,
+                    self.part2.pk,
                     self.part2.slug]),
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -447,7 +451,9 @@ class BigTutorialTests(TestCase):
             reverse('zds.tutorial.views.view_chapter',
                     args=[self.bigtuto.pk,
                           self.bigtuto.slug,
+                          self.part2.pk,
                           self.part2.slug,
+                          self.chapter2_1.pk,
                           self.chapter2_1.slug]),
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -473,7 +479,7 @@ class BigTutorialTests(TestCase):
                 'introduction':"Bienvenue dans le monde binaires",
                 'conclusion': "",
                 'type': "BIG",
-                'subcategory': self.souscat.pk,
+                'subcategory': self.subcat.pk,
             },
             follow=False)
         
@@ -491,6 +497,7 @@ class BigTutorialTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Part.objects.filter(tutorial=tuto).count(), 1)
+        p1 = Part.objects.filter(tutorial=tuto).last()
         #add part
         result = self.client.post(
             reverse('zds.tutorial.views.add_part') + '?tutoriel={}'.format(tuto.pk),
@@ -502,17 +509,74 @@ class BigTutorialTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Part.objects.filter(tutorial=tuto).count(), 2)
+        p2 = Part.objects.filter(tutorial=tuto).last()
         #add part
         result = self.client.post(
             reverse('zds.tutorial.views.add_part') + '?tutoriel={}'.format(tuto.pk),
             {
-                'title': u"Partie 3",
+                'title': u"Partie 2",
                 'introduction':"Expérimentation",
                 'conclusion': "C'est terminé",
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Part.objects.filter(tutorial=tuto).count(), 3)
+        p3 = Part.objects.filter(tutorial=tuto).last()
+        #add chapter
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_chapter') + '?partie={}'.format(p2.pk),
+            {
+                'title': u"Chapitre 1",
+                'introduction':"Mon premier chapitre",
+                'conclusion': "",
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(Chapter.objects.filter(part=p1).count(), 0)
+        self.assertEqual(Chapter.objects.filter(part=p2).count(), 1)
+        self.assertEqual(Chapter.objects.filter(part=p3).count(), 0)
+        
+        #add chapter
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_chapter') + '?partie={}'.format(p2.pk),
+            {
+                'title': u"Chapitre 2",
+                'introduction':"Mon deuxième chapitre",
+                'conclusion': "",
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(Chapter.objects.filter(part=p1).count(), 0)
+        self.assertEqual(Chapter.objects.filter(part=p2).count(), 2)
+        self.assertEqual(Chapter.objects.filter(part=p3).count(), 0)
+        
+        #add chapter
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_chapter') + '?partie={}'.format(p2.pk),
+            {
+                'title': u"Chapitre 2",
+                'introduction':"Mon troisième chapitre homonyme",
+                'conclusion': "",
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(Chapter.objects.filter(part=p1).count(), 0)
+        self.assertEqual(Chapter.objects.filter(part=p2).count(), 3)
+        self.assertEqual(Chapter.objects.filter(part=p3).count(), 0)
+        
+        #add chapter
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_chapter') + '?partie={}'.format(p1.pk),
+            {
+                'title': u"Chapitre 1",
+                'introduction':"Mon premier chapitre d'une autre partie",
+                'conclusion': "",
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertEqual(Chapter.objects.filter(part=p1).count(), 1)
+        self.assertEqual(Chapter.objects.filter(part=p2).count(), 3)
+        self.assertEqual(Chapter.objects.filter(part=p3).count(), 0)
 
     def test_url_for_member(self):
         """Test simple get request by simple member."""
@@ -542,6 +606,7 @@ class BigTutorialTests(TestCase):
                 args=[
                     self.bigtuto.pk,
                     self.bigtuto.slug,
+                    self.part2.pk,
                     self.part2.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -550,7 +615,9 @@ class BigTutorialTests(TestCase):
             reverse('zds.tutorial.views.view_chapter_online',
                     args=[self.bigtuto.pk,
                           self.bigtuto.slug,
+                          self.part2.pk,
                           self.part2.slug,
+                          self.chapter2_1.pk,
                           self.chapter2_1.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -571,6 +638,7 @@ class BigTutorialTests(TestCase):
                 args=[
                     self.bigtuto.pk,
                     self.bigtuto.slug,
+                    self.part2.pk,
                     self.part2.slug]),
             follow=True)
         self.assertEqual(result.status_code, 403)
@@ -579,7 +647,9 @@ class BigTutorialTests(TestCase):
             reverse('zds.tutorial.views.view_chapter',
                     args=[self.bigtuto.pk,
                           self.bigtuto.slug,
+                          self.part2.pk,
                           self.part2.slug,
+                          self.chapter2_1.pk,
                           self.chapter2_1.slug]),
             follow=True)
         self.assertEqual(result.status_code, 403)
@@ -612,6 +682,7 @@ class BigTutorialTests(TestCase):
                 args=[
                     self.bigtuto.pk,
                     self.bigtuto.slug,
+                    self.part2.pk,
                     self.part2.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -620,7 +691,9 @@ class BigTutorialTests(TestCase):
             reverse('zds.tutorial.views.view_chapter_online',
                     args=[self.bigtuto.pk,
                           self.bigtuto.slug,
+                          self.part2.pk,
                           self.part2.slug,
+                          self.chapter2_1.pk,
                           self.chapter2_1.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -641,6 +714,7 @@ class BigTutorialTests(TestCase):
                 args=[
                     self.bigtuto.pk,
                     self.bigtuto.slug,
+                    self.part2.pk,
                     self.part2.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -649,7 +723,9 @@ class BigTutorialTests(TestCase):
             reverse('zds.tutorial.views.view_chapter',
                     args=[self.bigtuto.pk,
                           self.bigtuto.slug,
+                          self.part2.pk,
                           self.part2.slug,
+                          self.chapter2_1.pk,
                           self.chapter2_1.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -682,6 +758,7 @@ class BigTutorialTests(TestCase):
                 args=[
                     self.bigtuto.pk,
                     self.bigtuto.slug,
+                    self.part2.pk,
                     self.part2.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -690,7 +767,9 @@ class BigTutorialTests(TestCase):
             reverse('zds.tutorial.views.view_chapter_online',
                     args=[self.bigtuto.pk,
                           self.bigtuto.slug,
+                          self.part2.pk,
                           self.part2.slug,
+                          self.chapter2_1.pk,
                           self.chapter2_1.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -711,6 +790,7 @@ class BigTutorialTests(TestCase):
                 args=[
                     self.bigtuto.pk,
                     self.bigtuto.slug,
+                    self.part2.pk,
                     self.part2.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
@@ -719,7 +799,9 @@ class BigTutorialTests(TestCase):
             reverse('zds.tutorial.views.view_chapter',
                     args=[self.bigtuto.pk,
                           self.bigtuto.slug,
+                          self.part2.pk,
                           self.part2.slug,
+                          self.chapter2_1.pk,
                           self.chapter2_1.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)

--- a/zds/tutorial/urls.py
+++ b/zds/tutorial/urls.py
@@ -12,23 +12,25 @@ urlpatterns = patterns('',
                        url(r'^recherche/(?P<pk_user>.+)/$',
                            'zds.tutorial.views.find_tuto'),
 
-                       url(r'^off/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/' +
-                           r'(?P<part_slug>.+)/' +
-                           r'(?P<chapter_slug>.+)/$', 'zds.tutorial.views.view_chapter', name="view-chapter-url"),
+                       url(r'^off/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/(?P<part_pk>\d+)/(?P<part_slug>.+)/(?P<chapter_pk>\d+)/(?P<chapter_slug>.+)/$',
+                           'zds.tutorial.views.view_chapter',
+                           name="view-chapter-url"),
 
-                       url(r'^off/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/' +
-                           r'(?P<part_slug>.+)/$', 'zds.tutorial.views.view_part', name="view-part-url"),
+                       url(r'^off/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/(?P<part_pk>\d+)/(?P<part_slug>.+)/$',
+                           'zds.tutorial.views.view_part',
+                           name="view-part-url"),
 
                        url(r'^off/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/$',
                            'zds.tutorial.views.view_tutorial'),
 
                        # View online
-                       url(r'^(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/' +
-                           r'(?P<part_slug>.+)/' +
-                           r'(?P<chapter_slug>.+)/$', 'zds.tutorial.views.view_chapter_online', name="view-chapter-url-online"),
+                       url(r'^(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/(?P<part_pk>\d+)/(?P<part_slug>.+)/(?P<chapter_pk>\d+)/(?P<chapter_slug>.+)/$',
+                           'zds.tutorial.views.view_chapter_online',
+                           name="view-chapter-url-online"),
 
-                       url(r'^(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/' +
-                           r'(?P<part_slug>.+)/$', 'zds.tutorial.views.view_part_online', name="view-part-url-online"),
+                       url(r'^(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/(?P<part_pk>\d+)/(?P<part_slug>.+)/$',
+                           'zds.tutorial.views.view_part_online',
+                           name="view-part-url-online"),
 
                        url(r'^(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/$',
                            'zds.tutorial.views.view_tutorial_online'),

--- a/zds/utils/tutorials.py
+++ b/zds/utils/tutorials.py
@@ -264,7 +264,7 @@ def move(obj, new_pos, position_f, parent_f, children_fn):
     """
     old_pos = getattr(obj, position_f)
     objects = getattr(getattr(obj, parent_f), children_fn)()
-
+    
     # Check that asked new position is correct
     if not 1 <= new_pos <= objects.count():
         raise ValueError('Can\'t move object to position {0}'.format(new_pos))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #701, #947, #913, #878, #662 |

Cette PR reprend un peu les PR #913 et #967 en corrigeant le fond du problème qui était que les dossiers correspondant aux chapitres/parties/extrait n'était pas accompagnés d'un id unique. Une situation de conflits s'installait donc.

La correction a été généralisée aux articles donc.

Cependant, lors de la mise en prod, il faudra passer un script à la main sur le serveur pour rajouter les ids aux fichiers déjà existants.
