### PR TITLE
Fix markdown : saut de lignes avant légendes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ factory-boy==2.2.1
 django-discover-runner==0.4
 pygeoip==0.3.1
 pillow
-git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds.1
+git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds.2
 git+https://github.com/zestedesavoir/GitPython.git@0.3.2-RC1.z2
 flake8
 autopep8


### PR DESCRIPTION
Avant ce bug fix et depuis les changements de comportement sur les sauts de lignes, il était obligatoire d'avoir une ligne vide entre un élément et la définition de légende ou source de citations. Ce n'est plus necessaire et résoud donc la regression.

Le bug reste présent pour les légendes de figures quand on veut les préciser en plus du href.

PS pour QA: bien penser a mettre a jour les requierements pour tester.
