### PR TITLE
Fix figure legend in markdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ factory-boy==2.2.1
 django-discover-runner==0.4
 pygeoip==0.3.1
 pillow
-git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds.2
+git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds.3
 git+https://github.com/zestedesavoir/GitPython.git@0.3.2-RC1.z2
 flake8
 autopep8


### PR DESCRIPTION
Derniere regression lié au changement de comportement des sauts de lignes. Il n'était plus possible de spécifier une légende en plus du champ alt. Avec cette mise à jour, les syntaxes suivantes : 

```
![mon alt](image.png)
Figure: ma légende
```

et 

```
![mon alt](image.png)

Figure: ma légende
```

fonctionnent de nouveau. Une image isolé sans `Figure:` est toujours transformé en figure en utilisant le terme alt comme légende. Les smileys ne peuvent pas être transformés en figure (volontaire).

PS: pour les tests QA, penser a mettre a jour les requierements
