### PR TITLE
Accès au tutoriels via profil (fix #989)

### DIFF
--- a/templates/tutorial/chapter/view.html
+++ b/templates/tutorial/chapter/view.html
@@ -4,13 +4,13 @@
 
 
 {% block title %}
-    {{ chapter.title }} - {{ chapter.part.tutorial.title }}
+    {{ chapter.title }} - {{ tutorial.title }}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li><a href="{{ chapter.part.tutorial.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}">{{ chapter.part.tutorial.title }} {{ chapter.tutorial.title }}</a></li>
+    <li><a href="{{ tutorial.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}">{{ tutorial.title }} {{ chapter.tutorial.title }}</a></li>
     <li><a href="{{ chapter.part.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}">{{ chapter.part.title }}</a></li>
     <li>{{ chapter.title }}</li>
 {% endblock %}
@@ -18,44 +18,40 @@
 
 
 {% block headline %}
-    {% with tutorial=chapter.part.tutorial %}
-        {% with authors=tutorial.authors.all %}
-            <h1 {% if chapter.image %}class="illu"{% endif %}>
-                {% if chapter.image %}
-                    <img src="{{ chapter.image.thumb.url }}" alt="">
-                {% endif %}
-                {{ chapter.title }}
-            </h1>
-
-            {% include 'tutorial/includes/tags_authors.part.html' %}
-
-            {% if tutorial.in_beta and tutorial.sha_beta == version %}
-                <div class="content-wrapper">
-                    <div class="alert-box warning">
-                        Attention, cette version du tutoriel est en BETA !
-                    </div>
-                </div>
+    {% with authors=tutorial.authors.all %}
+        <h1 {% if chapter.image %}class="illu"{% endif %}>
+            {% if chapter.image %}
+                <img src="{{ chapter.image.thumb.url }}" alt="">
             {% endif %}
-        {% endwith %}
+            {{ chapter.title }}
+        </h1>
+
+        {% include 'tutorial/includes/tags_authors.part.html' %}
+
+        {% if tutorial.in_beta and tutorial.sha_beta == version %}
+            <div class="content-wrapper">
+                <div class="alert-box warning">
+                    Attention, cette version du tutoriel est en BETA !
+                </div>
+            </div>
+        {% endif %}
     {% endwith %}
 {% endblock %}
 
 
 
 {% block content %}
-    {% with tutorial=chapter.part.tutorial %}
-        {% with authors=tutorial.authors.all %}
-            {% include "tutorial/includes/chapter_pager.part.html" with position="top" %}
-            {% include "tutorial/includes/chapter.part.html" %}
-            {% include "tutorial/includes/chapter_pager.part.html" with position="bottom" %}
-        {% endwith %}
+    {% with authors=tutorial.authors.all %}
+        {% include "tutorial/includes/chapter_pager.part.html" with position="top" %}
+        {% include "tutorial/includes/chapter.part.html" %}
+        {% include "tutorial/includes/chapter_pager.part.html" with position="bottom" %}
     {% endwith %}
 {% endblock %}
 
 
 
 {% block sidebar_new %}
-    {% if user in chapter.part.tutorial.authors.all or perms.tutorial.change_tutorial %}
+    {% if user in tutorial.authors.all or perms.tutorial.change_tutorial %}
         <a href="{% url "zds.tutorial.views.add_extract" %}?chapitre={{ chapter.pk }}"
            class="ico-after more blue new-btn"
         >
@@ -72,7 +68,7 @@
 
 
 {% block sidebar_actions %}
-    {% if user in chapter.part.tutorial.authors.all or perms.tutorial.change_tutorial %}
+    {% if user in tutorial.authors.all or perms.tutorial.change_tutorial %}
         {% if chapter.part %}
             <li>
                 <a href="#move-chapter" class="open-modal ico-after move blue">
@@ -141,10 +137,10 @@
 
 
 {% block sidebar_blocks %}
-    {% include "tutorial/includes/summary.part.html" with tutorial=chapter.part.tutorial chapter_current=chapter %}
+    {% include "tutorial/includes/summary.part.html" with tutorial=tutorial chapter_current=chapter %}
 
     {% if chapter.part %}
-        {% if user in chapter.part.tutorial.authors.all %}
+        {% if user in tutorial.authors.all %}
             <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Suppression">
                 <h3>Suppression</h3>
                 <ul>

--- a/templates/tutorial/member/beta.html
+++ b/templates/tutorial/member/beta.html
@@ -40,3 +40,9 @@
         </p>
     {% endif %}
 {% endblock %}
+
+{% block sidebar_blocks %}
+    <a href="{% url "zds.tutorial.views.find_tuto" usr.pk %}" class="new-btn ico-after view blue">
+        Tutoriels en ligne par {{ usr.username }}
+    </a>
+{% endblock %}

--- a/templates/tutorial/member/online.html
+++ b/templates/tutorial/member/online.html
@@ -19,47 +19,28 @@
     <li>Recherche</li>
 {% endblock %}
 
-
-
 {% block headline %}
-    Tutoriels publiés par {{ usr.username }}
+    <h2 class="ico-after ico-tutorials">Tutoriels publiés par {{ usr.username }}</h2>
 {% endblock %}
 
 
 
 {% block content %}
-    <table>
-        <thead>
-            <tr>
-                <th width="15%">Tutoriels</th>
-                <th width="10%">Quand</th>
-                <th width="30%">Introduction</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for tuto in tutos %}
-                <tr>
-                    <td>
-                        <div>
-                            <img src="{{ tuto.thumbnail.url }}" alt="'">
-                            <a href="{{ tuto.get_absolute_url }}">{{ tuto.title }}</a>
-                            {% if tuto.description %}
-                                <p>
-                                    {{ tuto.description }}
-                                </p>
-                            {% endif %}
-                        </div>
-                    </td>
-                    <td>
-                        {% if tuto.pubdate %}
-                            {{ tuto.pubdate|format_date|captfirst }}
-                        {% endif %}
-                    </td>
-                    <td>
-                        {{ tuto.get_introduction_online|truncatechars:200|emarkdown }}
-                    </td>
-                </tr>
+    {% if tutorials %}
+        <div class="tutorial-list">
+            {% for tutorial in tutorials %}
+                {% include 'tutorial/includes/tutorial_item.part.html' with beta=True %}
             {% endfor %}
-        </tbody>
-    </table>
+        </div>
+    {% else %}
+        <p>
+            Aucun tutoriel disponible.
+        </p>
+    {% endif %}
+{% endblock %}
+
+{% block sidebar_blocks %}
+    <a href="{% url "zds.tutorial.views.find_tuto" usr.pk %}?type=beta" class="new-btn ico-after view blue">
+        Tutoriels en bêta par {{ usr.username }}
+    </a>
 {% endblock %}

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1389,6 +1389,7 @@ def view_chapter(
     next_chapter = (chapter_tab[final_position + 1] if final_position + 1
                     < len(chapter_tab) else None)
     return render_template("tutorial/chapter/view.html", {
+        "tutorial": tutorial,
         "chapter": final_chapter,
         "prev": prev_chapter,
         "next": next_chapter,
@@ -1953,7 +1954,7 @@ def find_tuto(request, pk_user):
             authors__in=[u],
             sha_public__isnull=False).exclude(sha_public="").order_by("-pubdate")
 
-        return render_template("tutorial/member/index.html", {"tutorials": tutorials,
+        return render_template("tutorial/member/online.html", {"tutorials": tutorials,
                                                                "usr": u})
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #989 |

Ce qui a été fait :
- Modifier views.py pour que la bonne template soit appellée  dans `find_tuto()` (`/zds/tutorials/views.py`)
- Modifier les templates correspondantes pour ajouter une fonction "voir les tutoriels [en beta|en ligne] par xxx"
  dans `online.html` et `beta.html` (dans `/templates/tutorial/member/`)
- Modifier le comportement du fil d'Ariane pour qu'il soit  cohérent en tout points (sur `chapter.html`, dans `/templates/tutorial/chapter`).
