### PR TITLE
Add various metrics to Munin

### DIFF
--- a/zds/munin/urls.py
+++ b/zds/munin/urls.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-:
+from django.conf.urls import patterns, url
+
+import views
+
+urlpatterns = patterns(
+    '',
+
+    url(r'^total_topics/$', views.total_topics),
+    url(r'^total_posts/$', views.total_posts),
+    url(r'^total_mps/$', views.total_mps),
+    url(r'^total_tutorials/$', views.total_tutorials),
+    url(r'^total_articles/$', views.total_articles),
+)

--- a/zds/munin/views.py
+++ b/zds/munin/views.py
@@ -1,0 +1,45 @@
+from munin.helpers import muninview
+from zds.forum.models import Topic, Post
+from zds.mp.models import PrivateTopic, PrivatePost
+from zds.tutorial.models import Tutorial
+from zds.article.models import Article
+
+
+@muninview(config="""graph_title Total Topics
+graph_vlabel topics""")
+def total_topics(request):
+    topics = Topic.objects.all()
+    return [("topics", topics.count()),
+            ("solved", topics.filter(is_solved=True).count())]
+
+
+@muninview(config="""graph_title Total Posts
+graph_vlabel posts""")
+def total_posts(request):
+    return [("posts", Post.objects.all().count())]
+
+
+@muninview(config="""graph_title Total MPs
+graph_vlabel count""")
+def total_mps(request):
+    return [("mp", PrivateTopic.objects.all().count()),
+            ("replies", PrivatePost.objects.all().count())]
+
+
+@muninview(config="""graph_title Total Tutorials
+graph_vlabel tutorials""")
+def total_tutorials(request):
+    tutorials = Tutorial.objects.all()
+    return [("tutorials", tutorials.count()),
+            ("offline", tutorials.filter(sha_public__isnull=True).count()),
+            ("online", tutorials.filter(sha_public__isnull=False).count())]
+
+
+
+@muninview(config="""graph_title Total articles
+graph_vlabel articles""")
+def total_articles(request):
+    articles = Article.objects.all()
+    return [("tutorials", articles.count()),
+            ("offline", articles.filter(sha_public__isnull=True).count()),
+            ("online", articles.filter(sha_public__isnull=False).count())]

--- a/zds/munin/views.py
+++ b/zds/munin/views.py
@@ -40,6 +40,6 @@ def total_tutorials(request):
 graph_vlabel articles""")
 def total_articles(request):
     articles = Article.objects.all()
-    return [("tutorials", articles.count()),
+    return [("articles", articles.count()),
             ("offline", articles.filter(sha_public__isnull=True).count()),
             ("online", articles.filter(sha_public__isnull=False).count())]

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -81,6 +81,7 @@ urlpatterns = patterns('',
                        url(r'^galerie/', include('zds.gallery.urls')),
                        url(r'^teasing/', include('zds.newsletter.urls')),
                        url(r'^rechercher/', include('zds.search.urls')),
+                       url(r'^munin/', include('zds.munin.urls')),
 
                        url(r'^captcha/', include('captcha.urls')),
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non¹ |
| Tickets concernés | - |

¹ Il ne s'agit pas d'une feature de ZdS mais d'une feature infrastructure.

[discussion ici : http://zestedesavoir.com/forums/sujet/406/munin-surveillance-presente-et-future/ ]
Code très simple reposant sur Django-Munin, dépendance déjà utilisée par ZdS.

Pour l'ajouter à Munin, une fois mergé, rien de plus simple : ça s'installe comme les autres métriques Django déjà installées actuellement : 

Pour chaque zds.munin.view, exemple: 
1. faire `[sudo] ln -s /usr/share/munin/plugins/django.py /etc/munin/plugins/zds_total_topics`
2. ajouter une section à `/etc/munin/plugin-conf.d/munin-node` : 
   
   [zds_total_topics]
   env.url http://www.zestedesavoir.com/munin/total_topics/
   env.graph_category zds

Bref, celui (ou celle) qui a install django-munin sait déjà. Un peu de copier/collé et tout roule. :)
