### PR TITLE
corrige le chemin des extraits dans le manifest

### DIFF
--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2162,6 +2162,7 @@ def import_content(
                     extract.chapter = chapter
                     extract.save()
                     extract.text = extract.get_path(relative=True)
+                    extract.save()
                     maj_repo_extract(
                         request,
                         new_slug_path=extract.get_path(),
@@ -2230,6 +2231,7 @@ def import_content(
             extract.chapter = chapter
             extract.save()
             extract.text = extract.get_path(relative=True)
+            extract.save()
             maj_repo_extract(request, new_slug_path=extract.get_path(),
                              extract=extract,
                              text=replace_real_url(extract_text.text,

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2160,8 +2160,8 @@ def import_content(
                     extract.title = extract_title.text.strip()
                     extract.position_in_chapter = extract_count
                     extract.chapter = chapter
-                    extract.text = extract.get_path(relative=True)
                     extract.save()
+                    extract.text = extract.get_path(relative=True)
                     maj_repo_extract(
                         request,
                         new_slug_path=extract.get_path(),
@@ -2228,8 +2228,8 @@ def import_content(
             extract.title = extract_title.text.strip()
             extract.position_in_chapter = extract_count
             extract.chapter = chapter
-            extract.text = extract.get_path(relative=True)
             extract.save()
+            extract.text = extract.get_path(relative=True)
             maj_repo_extract(request, new_slug_path=extract.get_path(),
                              extract=extract,
                              text=replace_real_url(extract_text.text,
@@ -2514,7 +2514,6 @@ def maj_repo_extract(
     else:
         chap.part.tutorial.sha_draft = com_ex.hexsha
         chap.part.tutorial.save()
-    #extract.save()
 
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | Le chemin des extraits était mal renseigné dans le manifest.json lorsqu'un tutoriel (big ou mini) était importé. |

**Note pour QA (Quality Assurance):**
- Importer un big tutoriel et un mini tutoriel
- Véifier si vous avez à lire au moins un extrait de chaque tuto (si ça marche pour un ça marche pour tous)

Si ça roule, tout roule.
