### PR TITLE
corrige les fenêtes modales qui ne prennent pas en compte la recherche

### DIFF
--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -36,7 +36,14 @@
     });
     $("#modals").append($overlay);
 
-
+	$(".modal").each(function(){
+		var $this = $(this);
+		var field = $this.attr("data-field");
+		var value = $this.attr("data-other");
+		$this.append('<input type="hidden" name="'+field+
+		'" value="'+value+'"/>');
+		
+	});
 
     $(".open-modal").on("click", function(e){
         $overlay.show();

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -37,13 +37,12 @@
     $("#modals").append($overlay);
 
 	$(".modal").each(function(){
-		var $this = $(this);
-		var field = $this.attr("data-field");
-		var value = $this.attr("data-other");
-		$this.append('<input type="hidden" name="'+field+
-		'" value="'+value+'"/>');
-		
-	});
+        var $this = $(this);
+        $this.append($("<input type=\"hidden\"/>").attr({
+            value: $this.attr("data-other"),
+            name: $this.attr("data-field")
+        }));
+    });
 
     $(".open-modal").on("click", function(e){
         $overlay.show();

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -26,7 +26,8 @@
             {% else %}
                 <li>
                     <a href="#pagination-{{ position }}" class="open-modal">…</a>
-                    <form action="." method="get" class="modal modal-small" id="pagination-{{ position }}" data-modal-title="Aller à la page…">
+                    <form action="." method="get" class="modal modal-small" id="pagination-{{ position }}" data-other="{{ getdata }}"
+						data-field="{{ fieldname }}" data-modal-title="Aller à la page…">
                         <p>
                             Indiquez la page à laquelle vous souhaitez vous rendre.
                         </p>

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -54,7 +54,8 @@
 
 
     {% if query %}
-        {% include "misc/pagination.part.html" with position="top" %}
+		
+        {% include "misc/pagination.part.html" with position="top" fieldname="q" getdata=query %}
 
 
         {% if page.object_list %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | [#953] |

Les fenêtres modales ne prennent pas en compte les paramètres GET existants, du coup, lors d'une recherche, lorsqu'on cliquait sur les points de suspension pour faire apparaitre la modale, elle redirigeait vers une 404.
# Pour la QA

Il est nécessaire d'avoir solr d'installé pour faire la QA.
Par la suite, téléchargez le [script suivant](https://github.com/Eskimon/zds-site/blob/moar_fixtures/dataloader.py) et lancez les commandes

```
python manage.py flush --no-input
python dataloader.py
python manage.py rebuild_index
```
