### PR TITLE
Plus d'erreur 500 lors du post d'un message vide - #995

### DIFF
--- a/zds/article/forms.py
+++ b/zds/article/forms.py
@@ -130,3 +130,21 @@ class ReactionForm(forms.Form):
                 placeholder=u'Cet article est verrouillé.',
                 disabled=True
             )
+            
+    def clean(self):
+        cleaned_data = super(ReactionForm, self).clean()
+
+        text = cleaned_data.get('text')
+
+        if text is None or text.strip() == '':
+            self._errors['text'] = self.error_class(
+                [u'Vous devez écrire une réponse !'])
+            if 'text' in cleaned_data:
+                del cleaned_data['text']
+
+        elif len(text) > settings.MAX_POST_LENGTH:
+            self._errors['text'] = self.error_class(
+                [(u'Ce message est trop long, il ne doit pas dépasser {0} '
+                  u'caractères').format(settings.MAX_POST_LENGTH)])
+
+        return cleaned_data

--- a/zds/article/forms.py
+++ b/zds/article/forms.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from django.conf import settings
+
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Field, Hidden
 from django import forms

--- a/zds/article/tests.py
+++ b/zds/article/tests.py
@@ -184,6 +184,19 @@ class ArticleTests(TestCase):
         user1 = ProfileFactory().user
         self.client.login(username=user1.username, password='hostel77')
 
+        # add empty reaction
+        result = self.client.post(
+            reverse('zds.article.views.answer') +
+            '?article={0}'.format(
+                self.article.pk),
+            {
+                'last_reaction': '0',
+                'text': u''},
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+        # check reactions's number
+        self.assertEqual(Reaction.objects.all().count(), 0)
+
         # add reaction
         result = self.client.post(
             reverse('zds.article.views.answer') +

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -868,7 +868,7 @@ def answer(request):
         # Saving the message
         else:
             form = ReactionForm(article, request.user, request.POST)
-            if form.is_valid() and data['text'].strip() != '':
+            if form.is_valid():
                 data = form.data
 
                 reaction = Reaction()
@@ -886,7 +886,12 @@ def answer(request):
 
                 return redirect(reaction.get_absolute_url())
             else:
-                raise Http404
+                return render_template('article/reaction/new.html', {
+                    'article': article,
+                    'last_reaction_pk': last_reaction_pk,
+                    'newreaction': newreaction,
+                    'form': form
+                })
 
     # Actions from the editor render to new.html.
     else:

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -136,13 +136,13 @@ class PostForm(forms.Form):
 
         text = cleaned_data.get('text')
 
-        if text.strip() == '':
+        if text is None or text.strip() == '':
             self._errors['text'] = self.error_class(
-                [u'Le champ text ne peut être vide'])
+                [u'Vous devez écrire une réponse !'])
             if 'text' in cleaned_data:
                 del cleaned_data['text']
 
-        if len(text) > settings.MAX_POST_LENGTH:
+        elif len(text) > settings.MAX_POST_LENGTH:
             self._errors['text'] = self.error_class(
                 [(u'Ce message est trop long, il ne doit pas dépasser {0} '
                   u'caractères').format(settings.MAX_POST_LENGTH)])

--- a/zds/forum/tests.py
+++ b/zds/forum/tests.py
@@ -130,6 +130,21 @@ class ForumMemberTests(TestCase):
         TopicFollowed(topic=topic1, user=user2, email=True).save()
         TopicFollowed(topic=topic1, user=self.user, email=True).save()
 
+        # check if we send ane empty text
+        result = self.client.post(
+            reverse('zds.forum.views.answer') + '?sujet={0}'.format(topic1.pk),
+            {
+                'last_post': topic1.last_message.pk,
+                'text': u''
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+        # check topic's number
+        self.assertEqual(Topic.objects.all().count(), 1)
+        # check post's number (should be 3 for the moment)
+        self.assertEqual(Post.objects.all().count(), 3)
+
+        # now check what happen if everything is fine
         result = self.client.post(
             reverse('zds.forum.views.answer') + '?sujet={0}'.format(topic1.pk),
             {
@@ -161,6 +176,15 @@ class ForumMemberTests(TestCase):
                 pk=4).text,
             u'C\'est tout simplement l\'histoire de la ville de Paris que je voudrais vous conter ')
         
+        # test antispam return 403
+        result = self.client.post(
+            reverse('zds.forum.views.answer') + '?sujet={0}'.format(topic1.pk),
+            {
+                'last_post': topic1.last_message.pk,
+                'text': u'Testons l\'antispam'
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403)
         
 
     def test_edit_main_post(self):

--- a/zds/tutorial/forms.py
+++ b/zds/tutorial/forms.py
@@ -333,8 +333,26 @@ class NoteForm(forms.Form):
                 disabled=True
             )
 
-# Validations.
+    def clean(self):
+        cleaned_data = super(NoteForm, self).clean()
 
+        text = cleaned_data.get('text')
+
+        if text is None or text.strip() == '':
+            self._errors['text'] = self.error_class(
+                [u'Vous devez écrire une réponse !'])
+            if 'text' in cleaned_data:
+                del cleaned_data['text']
+
+        elif len(text) > settings.MAX_POST_LENGTH:
+            self._errors['text'] = self.error_class(
+                [(u'Ce message est trop long, il ne doit pas dépasser {0} '
+                  u'caractères').format(settings.MAX_POST_LENGTH)])
+
+        return cleaned_data
+
+
+# Validations.
 
 class AskValidationForm(forms.Form):
 

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -121,6 +121,19 @@ class BigTutorialTests(TestCase):
         user1 = ProfileFactory().user
         self.client.login(username=user1.username, password='hostel77')
 
+        # add note with no text = try again !
+        result = self.client.post(
+            reverse('zds.tutorial.views.answer') +
+            '?tutorial={0}'.format(
+                self.bigtuto.pk),
+            {
+                'last_note': '0',
+                'text': u''},
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+        # check notes's number
+        self.assertEqual(Note.objects.all().count(), 0)
+
         # add note
         result = self.client.post(
             reverse('zds.tutorial.views.answer') +

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2859,7 +2859,7 @@ def answer(request):
             # Saving the message
 
             form = NoteForm(tutorial, request.user, request.POST)
-            if form.is_valid() and data["text"].strip() != "":
+            if form.is_valid():
                 data = form.data
                 note = Note()
                 note.tutorial = tutorial
@@ -2874,7 +2874,12 @@ def answer(request):
                 tutorial.save()
                 return redirect(note.get_absolute_url())
             else:
-                raise Http404
+                return render_template("tutorial/comment/new.html", {
+                    "tutorial": tutorial,
+                    "last_note_pk": last_note_pk,
+                    "newnote": newnote,
+                    "form": form,
+                })
     else:
 
         # Actions from the editor render to answer.html.


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | #995 |

On vérifie la validité du formulaire pour s'assurer de la présence de contenu dans le formulaire d'un post.

L'auteur est renvoyé vers le formulaire en cas de champ vide.
##### Note pour la QA

Vérifier que vous ne pouvez pas poster de message vide dans le forum / articles / tutoriels et que vous ne vous prenez pas d'erreur 4xx ou 5xx...
