### PR TITLE
Ajout d'un controle sur le signalement d'un message - #981

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -71,7 +71,7 @@
                                     <p>
                                         Pour quelle raison signalez-vous ce message ?
                                     </p>
-                                    <input type="text" name="signal_text" placeholder="Flood, Troll, Hors sujet, ...">
+                                    <input type="text" name="signal_text" placeholder="Flood, Troll, Hors sujet, ..." pattern=".{3,}" required title ="Minimum 3 caractères pour signaler">
 
                                     <button type="submit" name="signal_message">
                                         Signaler


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [oui] |
| Tickets concernés | #981 |

Ajout d'un contrôle de minimum 3 caractères sur le signalement d'un message.
Ce test est fait via l'input en HTML5, puisque non bloquant sur le back et devant être "naturel et rapide" pour l'utilisateur (pour plus de détail voir la discussion sur le ticket #981)
##### Note pour la QA :

Essayer de faire des signalements farfelus (espace, caractères spéciaux, accents, etc...)

La règle est "trois caractères c'est bon" mais est de toute façon souple car de moindre impact (voir le ticket du bug pour plus de détail)
