### PR TITLE
Retire une extension non disponible

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -512,7 +512,7 @@
                 displayMath: [['$$','$$']],
                 processEscapes: true,
             },
-            TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js", "MathZoom.js"] },
+            TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js"] },
             messageStyle: "none",
         });
     </script>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | Aucun |

Cette extension n'est pas disponible et crée une erreur GET AJAX 404 nuisible lors des debugs JS. A moins que quelqu'un sache comment corriger cela, je pense que la retirer n'est pas gênant.
