### PR TITLE
corrige la valeur par defaut dans les migrations

### DIFF
--- a/zds/utils/migrations/0002_auto__add_field_alert_comment__add_field_alert_scope__chg_field_alert_.py
+++ b/zds/utils/migrations/0002_auto__add_field_alert_comment__add_field_alert_scope__chg_field_alert_.py
@@ -16,7 +16,7 @@ class Migration(SchemaMigration):
             u'utils_alert',
             'comment',
             self.gf('django.db.models.fields.related.ForeignKey')(
-                default=0,
+                default=None,
                 related_name='comments',
                 to=orm['utils.Comment']),
             keep_default=False)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1042 |

**Note pour QA**

Cette branche permet de corriger le bug dans les fichiers de migrations. Pour vérifier qu'elle fonctionne il faut.
- Avoir une base de donnée mysql de disponible
- cloner le dépot
- executer la procédure d'install normale jusqu'au `python manage.py migrate`
- vérifier qu'il n'y a pas d'erreur
- créer ensuite un fichier settings_prod.py au même niveau hierarchique que settings.py
- surcharger la variable de connexion à la base de donnée et renseigner les paramètre de votre base MySQL
- relancer les commandes `python manage.py syncdb` et `python manage.py migrate`

S'il n'y a toujours pas d'erreur, alors la PR est bonne.
