### PR TITLE
MàJ de zMarkdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ factory-boy==2.2.1
 django-discover-runner==0.4
 pygeoip==0.3.1
 pillow
-git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds.5
+git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds.6
 git+https://github.com/zestedesavoir/GitPython.git@0.3.2-RC1.z2
 flake8
 autopep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ factory-boy==2.2.1
 django-discover-runner==0.4
 pygeoip==0.3.1
 pillow
-git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds.6
+git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds.7
 git+https://github.com/zestedesavoir/GitPython.git@0.3.2-RC1.z2
 flake8
 autopep8


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | [zmkd#35](https://github.com/zestedesavoir/Python-ZMarkdown/issues/35) [zmkd#36](https://github.com/zestedesavoir/Python-ZMarkdown/issues/36) |

Précision pour QA - Corrige deux bugs : 
- Les liens auto fonctionnent maintenant quand il y a des arguments type Get à la fin ( `?blalba=truc` ) ou mènent vers des ancres.
- Citer (ou inclure dans un bloc) des références, notes de bas de pages, acronymes, etc. fonctionne. Utile pour les couples citations/réponses sur le forum
