### PR TITLE
Stylise l'infobulle du dernier message dans la sidebar "sujets récents" au survol

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -800,6 +800,7 @@
                         display: none;
                         overflow: visible;
                         top: 0;
+                        left: 10%;
                         padding: 0;
                         z-index: 1;
                         width: 30px;
@@ -815,8 +816,8 @@
                             position: absolute;
                             background: $sidebar-hover;
                             color: #555;
-                            top: 0;
-                            left: 35px;
+                            top: -27px;
+                            left: 0;
                             height: 27px;
                             line-height: 27px;
                             line-height: 2.7rem;

--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -824,7 +824,7 @@
                             text-indent: 0;
                             padding: 0 15px;
                             border: 1px solid #EEE;
-                            box-shadow: rgba(0, 0, 0, .5) 0 0 3px;
+                            box-shadow: rgba(0, 0, 0, .15) 0 0 7px;
                         }
 
                         &:after {
@@ -853,7 +853,46 @@
             }
 
             .last-answer {
-                display: none;
+                display: block;
+                visibility: hidden;
+                position: absolute;
+                top: -13px;
+                left: 102%;
+                width: 250px;
+                height: 40px;
+                background: #FFF;
+                padding: 7px 10px;
+                border: 1px solid #F0F0F0;
+                box-shadow: rgba(0, 0, 0, .1) 2px 2px 2px;
+                opacity: 0;
+                transition: visibility 0s linear 0.15s, opacity 0.15s, left 0.15s;
+
+                .avatar {
+                    height: 40px;
+                    width: 40px;
+                    float: left;
+                    border: 1px solid #F0F0F0;
+                }
+
+                .topic-last-answer {
+                    display: block;
+                    margin-left: 50px;
+                    line-height: 18px;
+                    padding: 3px 0;
+                    color: #555;
+                }
+            }
+
+            a {
+                &:hover,
+                &:focus {
+                    & + .last-answer {
+                        visibility: visible;
+                        left: 100%;
+                        opacity: 1;
+                        transition: visibility 0s linear 0, opacity 0.15s, left 0.15s;
+                    }
+                }
             }
 
             button {

--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -881,6 +881,13 @@
                     padding: 3px 0;
                     color: #555;
                 }
+                .topic-no-last-answer {
+                    display: block;
+                    line-height: 40px;
+                    width: 100%;
+                    text-align: center;
+                    color: #999;
+                }
             }
 
             a {

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -114,7 +114,6 @@
                                         {{ topic.title }}
                                     </a>
 
-                                    {# TODO: Designer ça #}
                                     <span class="last-answer">
                                         {% with answer=topic.get_last_answer %}
                                             {% if answer %}

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -120,10 +120,12 @@
                                                 {% with profile=answer.author|profile %}
                                                     <img src="{{ profile.get_avatar_url }}" alt="" class="avatar">
                                                 {% endwith %}
-                                                Dernière réponse
-                                                {{ answer.pubdate|format_date }}
-                                                par
-                                                {{ answer.author.username }}
+                                                <span class="topic-last-answer">
+                                                    Dernière réponse
+                                                    {{ answer.pubdate|format_date }}
+                                                    par
+                                                    <em>{{ answer.author.username }}</em>
+                                                </span>
                                             {% else %}
                                                 <span class="topic-no-last-answer">
                                                     Aucune réponse


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets concernés | Aucun |

Ce petit bloc n'était pas encore designé, mais était prévu dans les maquettes, je l'ai donc fait. Il affiche l'avatar, la date et le pseudo du dernier message du sujet survolé.

La croix "Ne plus suivre" a été déplacée à gauche (par dessus l'icône étoile) pour laisser la place à cette infobulle.
