### PR TITLE
Ajoute les paramètres manquants à la pagination

### DIFF
--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -27,6 +27,11 @@
                 <li>
                     <a href="#pagination-{{ position }}" class="open-modal">…</a>
                     <form action="." method="get" class="modal modal-small" id="pagination-{{ position }}" data-modal-title="Aller à la page…">
+                        {% for key,val in request.GET.iterlists %}
+                            {% for v in val %}
+                                <input type="hidden" name="{{ key }}" value="{{ v }}">
+                            {% endfor %}
+                        {% endfor %}
                         <p>
                             Indiquez la page à laquelle vous souhaitez vous rendre.
                         </p>

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -28,9 +28,11 @@
                     <a href="#pagination-{{ position }}" class="open-modal">…</a>
                     <form action="." method="get" class="modal modal-small" id="pagination-{{ position }}" data-modal-title="Aller à la page…">
                         {% for key,val in request.GET.iterlists %}
-                            {% for v in val %}
-                                <input type="hidden" name="{{ key }}" value="{{ v }}">
-                            {% endfor %}
+                            {% if key is not "page" %}
+                                {% for v in val %}
+                                    <input type="hidden" name="{{ key }}" value="{{ v }}">
+                                {% endfor %}
+                            {% endif %}
                         {% endfor %}
                         <p>
                             Indiquez la page à laquelle vous souhaitez vous rendre.

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -28,7 +28,7 @@
                     <a href="#pagination-{{ position }}" class="open-modal">…</a>
                     <form action="." method="get" class="modal modal-small" id="pagination-{{ position }}" data-modal-title="Aller à la page…">
                         {% for key,val in request.GET.iterlists %}
-                            {% if key is not "page" %}
+                            {% if key != "page" %}
                                 {% for v in val %}
                                     <input type="hidden" name="{{ key }}" value="{{ v }}">
                                 {% endfor %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #953, #1036, #1056 |

J'ai revert la #1036 avec la #1056.

Cette PR propose un correctif qui gère tous les cas possibles de paramètres pour la modale de la pagination permettant d'aller à la n'importe quelle page que l'on souhaite.

Pour tester : avoir une page où la pagination s'affiche avec le "...", avoir un paramètre dans l'URL, vérifier que le paramètre est toujours présent après la soumission du formulaire (et donc du jump à la page demandée).
