### PR TITLE
Fixe l'erreur 500 lors de l'édition d'un tuto 

### DIFF
--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -774,7 +774,7 @@ class Chapter(models.Model):
         self.conclusion = os.path.join(self.get_phy_slug(), "conclusion.md")
         self.save()
         for extract in self.get_extracts():
-            extract.update_children()
+            extract.save()
 
 class Extract(models.Model):
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2414,7 +2414,7 @@ def maj_repo_chapter(
         msg = "Suppresion du chapitre"
     else:
         if action == "maj":
-            if ld_slug_path != new_slug_path:
+            if old_slug_path != new_slug_path:
                 os.rename(old_slug_path, new_slug_path)
             msg = "Modification du chapitre"
         elif action == "add":
@@ -2485,7 +2485,7 @@ def maj_repo_extract(
             os.remove(old_slug_path)
     else:
         if action == "maj":
-            if ld_slug_path != new_slug_path:
+            if old_slug_path != new_slug_path:
                 os.rename(old_slug_path, new_slug_path)
             msg = "Modification de l'exrait "
         ext = open(new_slug_path, "w")

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2298,8 +2298,9 @@ def maj_repo_tuto(
         shutil.rmtree(old_slug_path)
     else:
         if action == "maj":
-            shutil.move(old_slug_path, new_slug_path)
-            repo = Repo(new_slug_path)
+            if old_slug_path != new_slug_path:
+                shutil.move(old_slug_path, new_slug_path)
+                repo = Repo(new_slug_path)
             msg = "Modification du tutoriel"
         elif action == "add":
             if not os.path.exists(new_slug_path):
@@ -2353,8 +2354,9 @@ def maj_repo_part(
         msg = "Suppresion de la partie "
     else:
         if action == "maj":
-            os.rename(old_slug_path, new_slug_path)
-            msg = "Modification de la partie "
+            if ld_slug_path != new_slug_path:
+                os.rename(old_slug_path, new_slug_path)
+                msg = "Modification de la partie "
         elif action == "add":
             if not os.path.exists(new_slug_path):
                 os.makedirs(new_slug_path, mode=0o777)
@@ -2412,7 +2414,8 @@ def maj_repo_chapter(
         msg = "Suppresion du chapitre"
     else:
         if action == "maj":
-            os.rename(old_slug_path, new_slug_path)
+            if ld_slug_path != new_slug_path:
+                os.rename(old_slug_path, new_slug_path)
             msg = "Modification du chapitre"
         elif action == "add":
             if not os.path.exists(new_slug_path):
@@ -2482,7 +2485,8 @@ def maj_repo_extract(
             os.remove(old_slug_path)
     else:
         if action == "maj":
-            os.rename(old_slug_path, new_slug_path)
+            if ld_slug_path != new_slug_path:
+                os.rename(old_slug_path, new_slug_path)
             msg = "Modification de l'exrait "
         ext = open(new_slug_path, "w")
         ext.write(smart_str(text).strip())


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | [#1058] |

Pour la QA : ce qui est à tester : 
la modification d'un big tuto (big tuto, partie, chapitre) ainsi que la base d'un mini tuto (titre, description, intro, conclusion).
Actuellement une erreur 500 est envoyée sur la prod.
Cette PR corrige l'erreur.
