### PR TITLE
fix 1060 : bouger des extraits détruit les introductions/conclusions

### DIFF
--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -17,7 +17,7 @@ from zds.tutorial.factories import BigTutorialFactory, MiniTutorialFactory, Part
     ChapterFactory, NoteFactory, SubCategoryFactory
 from zds.gallery.factories import GalleryFactory
 from zds.tutorial.models import Note, Tutorial, Validation, Extract, Part, Chapter
-from zds.utils.models import Alert
+from zds.utils.models import SubCategory, Licence, Alert
 
 
 @override_settings(MEDIA_ROOT=os.path.join(SITE_ROOT, 'media-test'))
@@ -998,6 +998,7 @@ class BigTutorialTests(TestCase):
             'title' : "Introduction",
             'text' : u"Le contenu de l'extrait"
             })
+        	
         self.assertEqual(result.status_code, 302)
         self.assertEqual(
             Tutorial.objects.get(pk=self.bigtuto.pk).sha_beta, 
@@ -1755,6 +1756,99 @@ class MiniTutorialTests(TestCase):
         self.assertEqual(1, Tutorial.objects.filter(pk=self.minituto.pk).count())
         self.assertTrue(Tutorial.objects.get(pk=self.minituto.pk).image == None)
 
+    def test_edit_tuto(self):
+        "test that edition work well and avoid issue 1058"
+        sub = SubCategory()
+        sub.title = "toto"
+        sub.save()
+       	# logout before
+        self.client.logout()
+        # first, login with author :
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+        #edit the tuto without slug change
+        response = self.client.post(
+                reverse('zds.tutorial.views.edit_tutorial') + "?tutoriel={0}".format(self.minituto.pk),
+                {
+                    'title': self.minituto.title,
+                    'description': "nouvelle description",
+                    'subcategory': [sub.pk],
+                    'introduction': self.minituto.get_introduction(),
+                    'conclusion': self.minituto.get_conclusion(),
+                },
+                follow=False
+        )
+        self.assertEqual(302, response.status_code)
+        tuto = Tutorial.objects.filter(pk=self.minituto.pk).first()
+        self.assertEqual(tuto.title, self.minituto.title)
+        self.assertEqual(tuto.description, "nouvelle description")
+        #edit tuto with a slug change
+        (introduction, conclusion) = (self.minituto.get_introduction(), self.minituto.get_conclusion())
+        self.client.post(
+                reverse('zds.tutorial.views.edit_tutorial') + "?tutoriel={0}".format(self.minituto.pk),
+                {
+                    'title': "nouveau titre pour nouveau slug",
+                    'description': "nouvelle description",
+                    'subcategory': [sub.pk],
+                    'introduction': self.minituto.get_introduction(),
+                    'conclusion': self.minituto.get_conclusion(),
+                },
+                follow=False
+        )
+        tuto = Tutorial.objects.filter(pk=self.minituto.pk).first()
+        self.assertEqual(tuto.title, "nouveau titre pour nouveau slug")
+        self.assertEqual(tuto.description, "nouvelle description")
+        self.assertEqual(introduction, tuto.get_introduction())
+
+    def test_reorder_tuto(self):
+        "test that reordering makes it good to avoid #1060"
+       	# logout before
+        self.client.logout()
+        # first, login with author :
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+        (introduction, conclusion) = (self.minituto.get_introduction(), self.minituto.get_conclusion())
+        # prepare the extracts
+        self.client.post(
+                reverse('zds.tutorial.views.add_extract') + "?chapitre={0}".format(self.minituto.get_chapter().pk),
+                {
+                    
+                    'title': "extract 1",
+                    'text': "extract 1 text"
+                },
+                follow=False
+        )
+        extract_pk = Tutorial.objects.get(pk=self.minituto.pk).get_chapter().get_extracts()[0].pk
+        self.client.post(
+                reverse('zds.tutorial.views.add_extract') + "?chapitre={0}".format(self.minituto.get_chapter().pk),
+                {
+                    
+                    'title': "extract 2",
+                    'text': "extract 2 text"
+                },
+                follow=False
+        )
+        self.assertEqual(2, self.minituto.get_chapter().get_extracts().count())
+        # reorder
+        self.client.post(
+                reverse('zds.tutorial.views.modify_extract'),
+                {
+                    'move': "",
+                    'move_target': 2,
+                    'extract': self.minituto.get_chapter().get_extracts()[0].pk
+                },
+                follow=False
+        )
+        # this test check issue 1060
+        self.assertEqual(introduction, Tutorial.objects.filter(pk=self.minituto.pk).first().get_introduction())
+        self.assertEqual(2, Extract.objects.get(pk=extract_pk).position_in_chapter)
+    
     def test_workflow_beta_tuto(self) :
         "Ensure the behavior of the beta version of tutorials"
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2312,14 +2312,16 @@ def maj_repo_tuto(
         man_path = os.path.join(new_slug_path, "manifest.json")
         tuto.dump_json(path=man_path)
         index.add(["manifest.json"])
-        intro = open(os.path.join(new_slug_path, "introduction.md"), "w")
-        intro.write(smart_str(introduction).strip())
-        intro.close()
-        index.add(["introduction.md"])
-        conclu = open(os.path.join(new_slug_path, "conclusion.md"), "w")
-        conclu.write(smart_str(conclusion).strip())
-        conclu.close()
-        index.add(["conclusion.md"])
+        if introduction is not None:
+            intro = open(os.path.join(new_slug_path, "introduction.md"), "w")
+            intro.write(smart_str(introduction).strip())
+            intro.close()
+            index.add(["introduction.md"])
+        if conclusion is not None:
+            conclu = open(os.path.join(new_slug_path, "conclusion.md"), "w")
+            conclu.write(smart_str(conclusion).strip())
+            conclu.close()
+            index.add(["conclusion.md"])
         aut_user = str(request.user.pk)
         aut_email = str(request.user.email)
         if aut_email is None or aut_email.strip() == "":
@@ -2354,7 +2356,7 @@ def maj_repo_part(
         msg = "Suppresion de la partie "
     else:
         if action == "maj":
-            if ld_slug_path != new_slug_path:
+            if old_slug_path != new_slug_path:
                 os.rename(old_slug_path, new_slug_path)
                 msg = "Modification de la partie "
         elif action == "add":
@@ -2365,14 +2367,16 @@ def maj_repo_part(
         man_path = os.path.join(part.tutorial.get_path(), "manifest.json")
         part.tutorial.dump_json(path=man_path)
         index.add(["manifest.json"])
-        intro = open(os.path.join(new_slug_path, "introduction.md"), "w")
-        intro.write(smart_str(introduction).strip())
-        intro.close()
-        index.add([os.path.join(part.get_path(relative=True), "introduction.md")])
-        conclu = open(os.path.join(new_slug_path, "conclusion.md"), "w")
-        conclu.write(smart_str(conclusion).strip())
-        conclu.close()
-        index.add([os.path.join(part.get_path(relative=True), "conclusion.md"
+        if introduction is not None:
+            intro = open(os.path.join(new_slug_path, "introduction.md"), "w")
+            intro.write(smart_str(introduction).strip())
+            intro.close()
+            index.add([os.path.join(part.get_path(relative=True), "introduction.md")])
+        if conclusion is not None:
+            conclu = open(os.path.join(new_slug_path, "conclusion.md"), "w")
+            conclu.write(smart_str(conclusion).strip())
+            conclu.close()
+            index.add([os.path.join(part.get_path(relative=True), "conclusion.md"
                                 )])
     aut_user = str(request.user.pk)
     aut_email = str(request.user.email)
@@ -2421,12 +2425,14 @@ def maj_repo_chapter(
             if not os.path.exists(new_slug_path):
                 os.makedirs(new_slug_path, mode=0o777)
             msg = "Creation du chapitre"
-        intro = open(os.path.join(new_slug_path, "introduction.md"), "w")
-        intro.write(smart_str(introduction).strip())
-        intro.close()
-        conclu = open(os.path.join(new_slug_path, "conclusion.md"), "w")
-        conclu.write(smart_str(conclusion).strip())
-        conclu.close()
+        if introduction is not None:
+             intro = open(os.path.join(new_slug_path, "introduction.md"), "w")
+             intro.write(smart_str(introduction).strip())
+             intro.close()
+        if conclusion is not None:
+            conclu = open(os.path.join(new_slug_path, "conclusion.md"), "w")
+            conclu.write(smart_str(conclusion).strip())
+            conclu.close()
         if ph != None:
             index.add([ph])
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | [#1060] |

J'ai ajouté des tests pour vérifier que le déplacement et la modification étaient bien pris en compte.
Pour la QA : le problème vient du fait qu'en déplaçant un extrait/partie/chapitre au sein d'un tuto, le contenu des introduction/conclusion est réinitialisé.
