### PR TITLE
Hotfix mobile header

### DIFF
--- a/assets/js/markdown-help.js
+++ b/assets/js/markdown-help.js
@@ -14,7 +14,7 @@
             "html": "<div class=\"markdown-help-more\">" +
                     "<p>Les simples retours à la ligne ne sont pas pris en compte. Pour créer un nouveau paragraphe, pensez à <em>sauter une ligne</em> !</p>" +
                     "<pre><code>**gras** \n*italique* \n[texte de lien](url du lien) \n> citation \n+ liste a puces </code></pre>" +
-                    "<a href=\"http://zestedesavoir.com/articles/1/rediger-sur-zds/\">Voir la documentation complète</a></div>" +
+                    "<a href=\"http://zestedesavoir.com/articles/29/rediger-sur-zds/\">Voir la documentation complète</a></div>" +
                     "<a href=\"#open-markdown-help\" class=\"open-markdown-help btn btn-grey ico-after view\">"+
                         "<span class=\"close-markdown-help-text\">Masquer</span>" +
                         "<span class=\"open-markdown-help-text\">Afficher</span> l'aide Markdown" +

--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -104,7 +104,6 @@
 .header-container header {
     background: #084561;
     border-bottom: 3px solid $orange;
-    position: relative;
 
     a,
     button {

--- a/assets/scss/_mobile.scss
+++ b/assets/scss/_mobile.scss
@@ -7,6 +7,34 @@
 
 
 @media only screen and (max-width: 760px) {
+    #cookies-banner {
+        display: block;
+        position: absolute;
+        top: 50px;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 10;
+
+        p {
+            margin-top: 40px;
+            padding: 0 20px;
+        }
+
+        a, #accept-cookies {
+            display: block;
+            width: 100%;
+            height: 40px;
+            padding: 0 !important;
+            margin: 15px 0 0 0 !important;
+            text-align: center;
+        }
+        a {
+            margin-top: 40px !important;
+            line-height: 40px;
+        }
+    }
+
     html.dropdown-active {
         overflow: hidden;
 

--- a/templates/500.html
+++ b/templates/500.html
@@ -29,7 +29,7 @@
 {% block content %}
     <p>
         Si vous voyez cette page, c'est que vous avez trouvé un bug. Merci
-        de reporter cette erreur en expliquant comment vous avez procédé
+        de rapporter cette erreur en expliquant comment vous avez procédé
         pour tomber sur cette page.
     </p>
 {% endblock %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | Corrige le bug des notifs signalé en interne |

Pour l'occasion j'ai du revoir le bandeau des cookies qui prend maintenant tout l'espace du contenu de la page en surimpression. Pas d'autre choix pour que ce soit propre et non-bugué suivant les résolutions à cause de position absolues qui sont cassées si on met ce bandeau au dessus du header.

A tester sur mobile ET computers, à valider rapidement car relativement bloquant.
