### PR TITLE
fix #1092 : erreur 500 sur la liste des topics par tag

### DIFF
--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -876,6 +876,7 @@ def find_topic_by_tag(request, tag_pk, tag_slug):
     tag = Tag.objects.filter(pk=tag_pk, slug=tag_slug).first()
     if tag is None:
         return redirect(reverse("zds.forum.views.index"))
+    u = request.user
     if "filter" in request.GET:
         filter = request.GET["filter"]
         if request.GET["filter"] == "solve":


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | [#1092] |

une variable n'était pas initialisée. Je l'ai initialisée avec l'utilisateur grâce aux conseils de @Eskimon et @vhf
