### PR TITLE
Change le lien de l'aide markdown complète

### DIFF
--- a/assets/js/markdown-help.js
+++ b/assets/js/markdown-help.js
@@ -14,7 +14,7 @@
             "html": "<div class=\"markdown-help-more\">" +
                     "<p>Les simples retours à la ligne ne sont pas pris en compte. Pour créer un nouveau paragraphe, pensez à <em>sauter une ligne</em> !</p>" +
                     "<pre><code>**gras** \n*italique* \n[texte de lien](url du lien) \n> citation \n+ liste a puces </code></pre>" +
-                    "<a href=\"http://zestedesavoir.com/articles/29/rediger-sur-zds/\">Voir la documentation complète</a></div>" +
+                    "<a href=\"//zestedesavoir.com/tutoriels/221/rediger-sur-zds/\">Voir la documentation complète</a></div>" +
                     "<a href=\"#open-markdown-help\" class=\"open-markdown-help btn btn-grey ico-after view\">"+
                         "<span class=\"close-markdown-help-text\">Masquer</span>" +
                         "<span class=\"open-markdown-help-text\">Afficher</span> l'aide Markdown" +


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Issue | #1089 |

Cette fois c'est la bonne !

Je retiré le protocole du lien pour garantir que le lien affiché sera bien géré en HTTP et en HTTPS.
