### PR TITLE
Corrige des erreurs de templates diverses

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -1610,6 +1610,17 @@
         }
     }
 
+    .comment-author {
+        background: #EEE;
+        padding: 7px 15px;
+
+        blockquote {
+            margin: 10px 0;
+            border-left: 5px solid  #CCC;
+            padding: 5px 0 5px 15px;
+        }
+    }
+
     .article-content,
     .message-content {
         margin-top: 20px;

--- a/templates/article/member/view.html
+++ b/templates/article/member/view.html
@@ -68,6 +68,18 @@
             </li>
         </ul>
     </div>
+
+    {% if perms.article.change_article and article.sha_validation != None %}
+        <div class="content-wrapper comment-author">
+            <p>
+                Le message suivant à été laissé à destination des validateurs : 
+            </p>
+
+            <blockquote>
+                {{ validation.comment_authors }}
+            </blockquote>
+        </div>
+    {% endif %}
 {% endblock %}
 
 

--- a/templates/article/member/view.html
+++ b/templates/article/member/view.html
@@ -69,7 +69,7 @@
         </ul>
     </div>
 
-    {% if perms.article.change_article and article.sha_validation != None %}
+    {% if perms.article.change_article and article.sha_validation != None and validation.comment_authors %}
         <div class="content-wrapper comment-author">
             <p>
                 Le message suivant à été laissé à destination des validateurs : 

--- a/templates/article/validation/history.html
+++ b/templates/article/validation/history.html
@@ -19,7 +19,7 @@
 
 
 {% block headline %}
-    <h2>Historique de validation de : {{ article.title }}</h2>
+    Historique de validation de : {{ article.title }}
 {% endblock %}
 
 
@@ -32,50 +32,18 @@
 
 {% block content %}
     {% if validations %}
-        <table>
+        <table class="fullwidth">
             <thead>
                 <tr>
-                    <th>Titre</th>
-                    <th width="8%">Catégorie(s)</th>
-                    <th width="8%">Auteur(s)</th>
-                    <th width="8%">Proposé</th>
-                    <th width="24%">Statut</th>
+                    <th width="50%">Proposé</th>
+                    <th width="50%">Statut</th>
                 </tr>
             </thead>
             <tbody>
                 {% for validation in validations %}
                     <tr>
                         <td>
-                            <a href="{% url "zds.article.views.view" validation.article.pk validation.article.slug %}?version={{ validation.version }}" >{{ validation.article.title }}</a>
-                        </td>
-                        <td>
-                            {% for subcategory in validation.article.subcategory.all %}
-                                <a href="{% url "zds.article.views.history_validation" article.pk %}?subcategory={{subcategory.pk}}">
-                                    {{ subcategory.title }}
-                                </a>
-                            {% endfor %}
-                        </td>
-                        <td>
-                            {% for author in validation.article.authors.all %}
-                                <a href="{% url "zds.member.views.details" user.username %}">
-                                    {{ author.username }}
-                                </a>
-                            {% endfor %}
-                        </td>
-                        <td>
-                            <span>{{ validation.date_proposition|format_date|capfirst }}</span>
-                        </td>
-                        <td>
-                            {% if validation.validator %}
-                                <a href="{% url "zds.member.views.details" validation.validator.username %}">
-                                    {{ validation.validator.username }}
-                                </a>
-                            {% endif %}
-                        </td>
-                        <td>
-                            {% if validation.date_reserve %}
-                                <span>{{ validation.date_reserve|format_date|capfirst }}</span>
-                            {% endif %}
+                            {{ validation.date_proposition|format_date|capfirst }}
                         </td>
                         <td>
                             {% captureas reservation_url %}

--- a/templates/article/validation/history.html
+++ b/templates/article/validation/history.html
@@ -19,18 +19,39 @@
 
 
 {% block headline %}
-    Historique de validation de : {{ article.title }}
+    {{ article.title }}
 {% endblock %}
 
 
 
-{% block sidebar_actions %}
-    {% include 'article/includes/sidebar_actions.part.html' %}
+{% block headline_sub %}
+    Historique de validation
 {% endblock %}
 
 
 
 {% block content %}
+    <ul class="taglist">
+        {% for tag in tags.all %}
+            <li>
+                <a href="{% url "zds.article.views.index" %}?tag={{ tag.title }}">
+                    {{ tag.title }}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+    
+    <div class="authors">
+        <span class="authors-label">Contributeurs : </span>
+        <ul>
+            {% for member in authors.all %}
+                <li>
+                    {% include "misc/member_item.part.html" with avatar=True %}
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+
     {% if validations %}
         <table class="fullwidth">
             <thead>

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -140,7 +140,10 @@
 
             {% if message.is_visible = False %}
                 <p class="message-hidden">
-                    Masqué par {{ message.editor }} : {{ message.text_hidden }}
+                    Masqué par {{ message.editor }}
+                    {% if message.text_hidden %}
+                        : {{ message.text_hidden }}
+                    {% endif %}
                 </p>
             {% elif message.update %}
                 <p class="message-edited ico-after edit">

--- a/templates/tutorial/includes/chapter_pager.part.html
+++ b/templates/tutorial/includes/chapter_pager.part.html
@@ -5,7 +5,7 @@
                 {% if online %}
                     href="{{ prev.get_absolute_url_online }}"
                 {% else %}
-                    href="{{ prev.get_absolute_url }}{%if version %}?version={{version}}{% endif %}"
+                    href="{{ prev.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
                 {% endif %}
                 class="ico-after arrow-left"
             >
@@ -20,7 +20,7 @@
                 {% if online %}
                     href="{{ next.get_absolute_url_online }}"
                 {% else %}
-                    href="{{ next.get_absolute_url }}{%if version %}?version={{version}}{% endif %}"
+                    href="{{ next.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
                 {% endif %}
                 class="ico-after arrow-right"
             >

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -43,7 +43,7 @@
         {% include 'tutorial/includes/tags_authors.part.html' with tutorial=tutorial %}
     {% endif %}
 
-    {% if perms.tutorial.change_tutorial and tutorial.in_validation %}
+    {% if perms.tutorial.change_tutorial and tutorial.in_validation and validation.comment_authors %}
         <div class="content-wrapper comment-author">
             <p>
                 Le message suivant à été laissé à destination des validateurs : 

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -263,7 +263,7 @@
 
 
 {% block sidebar_blocks %}
-    {% if user in tutorial.authors.all or perms.tutorial.change_tutorial %}
+    {% if perms.tutorial.change_tutorial %}
         <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Validation">
             <h3>Validation</h3>
             <ul>

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -43,6 +43,18 @@
         {% include 'tutorial/includes/tags_authors.part.html' with tutorial=tutorial %}
     {% endif %}
 
+    {% if perms.tutorial.change_tutorial and tutorial.in_validation %}
+        <div class="content-wrapper comment-author">
+            <p>
+                Le message suivant à été laissé à destination des validateurs : 
+            </p>
+
+            <blockquote>
+                {{ validation.comment_authors }}
+            </blockquote>
+        </div>
+    {% endif %}
+
     {% if tutorial.in_beta and tutorial.sha_beta == version %}
         <div class="content-wrapper">
             <div class="alert-box warning">
@@ -75,7 +87,7 @@
 
             {% for part in parts %}
                 <h2>
-                    <a href="{% url "view-part-url" tutorial.pk tutorial.slug part.pk part.slug %}{%if version %}?version={{version}}{% endif %}">
+                    <a href="{% url "view-part-url" tutorial.pk tutorial.slug part.pk part.slug %}{% if version %}?version={{ version }}{% endif %}">
                         Partie {{ part.position_in_tutorial }} : {{ part.title }}
                     </a>
                 </h2>

--- a/templates/tutorial/validation/history.html
+++ b/templates/tutorial/validation/history.html
@@ -1,5 +1,6 @@
 {% extends "tutorial/validation/index.html" %}
 {% load date %}
+{% load captureas %}
 
 
 
@@ -46,7 +47,10 @@
                             {{ validation.date_proposition|format_date|capfirst }}
                         </td>
                         <td>
-                            {% include "tutorial/includes/validation.part.html" %}
+                            {% captureas reservation_url %}
+                                {% url "zds.tutorial.views.reservation" validation.pk %}
+                            {% endcaptureas %}
+                            {% include "misc/validation.part.html" %}
                         </td>
                     </tr>
                 {% endfor %}

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -745,6 +745,8 @@ def history_validation(request, article_pk):
     return render_template('article/validation/history.html', {
         'validations': validations,
         'article': article,
+        'authors': article.authors,
+        'tags': article.subcategory,
     })
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | OUI |
| Nouvelle Fonctionnalité ? | Non |
| Issue | #1126 (erreur 500) |

Cela corrige : 
- la page d'historique de validation d'un article ;
- un bug qui produisait une erreur 500 dans l'historique de validation des tutos, faute d'une refacto mal terminée ;
- ajoute le message de l'auteur lors de la validation ;
- masque les ":" quand le message masqué l'a été sans motif.
