### PR TITLE
correction des liens précendents et suivants dans la chapitres

### DIFF
--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1387,7 +1387,7 @@ def view_chapter(
             chapter["position_in_part"] = cpt_c
             chapter["position_in_tutorial"] = cpt_c * cpt_p
             chapter["get_absolute_url"] = part["get_absolute_url"] \
-                + "{0}/".format(chapter["slug"])
+                + "{0}/{1}/".format(chapter["pk"], chapter["slug"])
             if chapter_pk == str(chapter["pk"]):
                 chapter["intro"] = get_blob(repo.commit(sha).tree,
                                             chapter["introduction"])
@@ -1471,7 +1471,7 @@ def view_chapter_online(
             chapter["position_in_part"] = cpt_c
             chapter["position_in_tutorial"] = cpt_c * cpt_p
             chapter["get_absolute_url_online"] = part[
-                "get_absolute_url_online"] + "{0}/".format(chapter["slug"])
+                "get_absolute_url_online"] + "{0}/{1}/".format(chapter["pk"], chapter["slug"])
             if chapter_pk == str(chapter["pk"]):
                 intro = open(
                     os.path.join(


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | [Sur le forum](http://zestedesavoir.com/forums/sujet/492/erreur-404-pour-le-tuto-windows-8/) |

**Note pour QA**
Charger un big tuto et utiliser les boutons précédents et suivant pour se ballader. Normalement on ne devrait plus avoir de 404.
