### PR TITLE
ajoute l'attribut pub date aux flux RSS.

### DIFF
--- a/zds/forum/feeds.py
+++ b/zds/forum/feeds.py
@@ -54,6 +54,8 @@ class LastTopicsFeedRSS(Feed):
         topics = Topic.objects.filter(forum__group__isnull=True)\
             .order_by('-pubdate')
         return topics[:5]
+    def item_pubdate(self, item):
+        return item.pubdate
 
     def item_title(self, item):
         return u'{} dans {}'.format(item.title, item.forum.title)

--- a/zds/forum/feeds.py
+++ b/zds/forum/feeds.py
@@ -12,8 +12,8 @@ from .models import Post, Topic
 class LastPostsFeedRSS(Feed):
     title = u'Derniers messages sur Zeste de Savoir'
     link = '/forums/'
-    description = u'Les derniers messages '+ \
-    u'parus sur le forum de Zeste de Savoir.'
+    description = (u'Les derniers messages '
+        u'parus sur le forum de Zeste de Savoir.')
 
     def items(self):
         posts = Post.objects.filter(topic__forum__group__isnull=True)\

--- a/zds/forum/feeds.py
+++ b/zds/forum/feeds.py
@@ -12,7 +12,7 @@ from .models import Post, Topic
 class LastPostsFeedRSS(Feed):
     title = u'Derniers messages sur Zeste de Savoir'
     link = '/forums/'
-    description = u'Les derniers messages '
+    description = u'Les derniers messages '+ \
     u'parus sur le forum de Zeste de Savoir.'
 
     def items(self):
@@ -22,6 +22,9 @@ class LastPostsFeedRSS(Feed):
 
     def item_title(self, item):
         return u'{}, message #{}'.format(item.topic.title, item.pk)
+
+    def item_pubdate(self, item):
+        return item.pubdate
 
     def item_description(self, item):
         # TODO: Use cached Markdown when implemented


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | [#1113] |

Les flux RSS n'avaient pas d'attribut pubdate sur les item.
De plus un mauvaise concaténation venait tronquer le titre du flux
Les flux atom ne sont pas concernés.
