### PR TITLE
Fix 1119 la suppression d'un chapitre n'est pas répercutée sur le sommaire

### DIFF
--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -117,6 +117,18 @@ class BigTutorialTests(TestCase):
         self.assertEquals(len(mail.outbox), 1)
 
         mail.outbox = []
+    def test_remove_chapter(self):
+        """To test the correct removal of a chapter in big tuto"""
+        self.client.login(username=self.user_author, password='hostel77')
+        olddata = self.bigtuto.load_json()
+        result = self.client.post(
+             reverse('zds.tutorial.views.modify_chapter'),
+             {'delete':"", 'chapter': self.chapter1_1.pk}
+        );
+        
+        self.assertEqual(302,result.status_code)
+        jsondata = self.bigtuto.load_json()
+        self.assertNotEqual(len(olddata["parts"][0]["chapters"]), len(jsondata["parts"][0]["chapters"]))
 
     def test_add_note(self):
         """To test add note for tutorial."""

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2417,11 +2417,13 @@ def maj_repo_chapter(
     else:
         repo = Repo(os.path.join(settings.REPO_PATH, chapter.part.tutorial.get_phy_slug()))
         ph = os.path.join(chapter.part.get_phy_slug(), chapter.get_phy_slug())
+
     index = repo.index
     msg = "repo chapitre"
     if action == "del":
         shutil.rmtree(old_slug_path)
         msg = "Suppresion du chapitre"
+        Chapter.objects.filter(pk = chapter.pk).delete()
     else:
         if action == "maj":
             if old_slug_path != new_slug_path:
@@ -2443,7 +2445,6 @@ def maj_repo_chapter(
             index.add([ph])
 
     # update manifest
-
     if chapter.tutorial:
         man_path = os.path.join(chapter.tutorial.get_path(), "manifest.json")
         chapter.tutorial.dump_json(path=man_path)

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2423,7 +2423,7 @@ def maj_repo_chapter(
     if action == "del":
         shutil.rmtree(old_slug_path)
         msg = "Suppresion du chapitre"
-        Chapter.objects.filter(pk = chapter.pk).delete()
+        chapter.delete()
     else:
         if action == "maj":
             if old_slug_path != new_slug_path:


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | [#1119] |
# cette PR touche au back des tuto, la QA doit être faite minutieusement quitte à tout revérifier

Pour la QA : 
il faut avoir un big tuto NON PUBLIE.
Allez vers un chapitre, supprimez-le.
Vérifiez alors que : 
- la redirection est bien faite
- le sommaire est à jour
- le fichier manifest.json est à jour

Le test unitaire que j'ai ajouté vérifie le premier et le second point.
Ajoutons aussi qu'il faut que le reste du workflow ne soit pas touché (déplacement, création).
