### PR TITLE
Hotfix cookies cnil

### DIFF
--- a/assets/js/cookies-banner.js
+++ b/assets/js/cookies-banner.js
@@ -5,7 +5,7 @@
    Manage tracking cookies message
    ========================================================================== */
 
-(function(window, document, undefined) {
+(function(document, undefined) {
     var $banner = $("#cookies-banner");
 
     function checkHasConsent(){
@@ -21,27 +21,27 @@
                 "</script>"
             );
         } else if(document.cookie.indexOf("hasconsent=false") === -1){
-            $banner.show();
             // Accept for the next page
-            setHasConsent(true, false);
+            setHasConsent(true);
+            
+            // Show the banner
+            $banner.show();
         }
     }
     checkHasConsent();
 
 
-    function setHasConsent(hasconsent, hide){
+    function setHasConsent(hasconsent){
         document.cookie = "hasconsent="+hasconsent+"; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/";
-
-        if(hide)
-            $banner.slideUp(200);
     }
 
     $("#reject-cookies").on("click", function(){
-        setHasConsent(false, true);
+        setHasConsent(false);
+        $banner.slideUp(200);
     });
 
     $("#accept-cookies").on("click", function(){
-        setHasConsent(true, true);
         checkHasConsent();
+        $banner.slideUp(200);
     });
-})(window, document);
+})(document);

--- a/assets/js/cookies-banner.js
+++ b/assets/js/cookies-banner.js
@@ -1,34 +1,44 @@
-(function(window, document, undefined) {
-    // Google Analytics ID
-    var gaProperty = "UA-27730868-1";
+/* ===== Zeste de Savoir ====================================================
+   Authors: Sandhose
+            Alex-D / Alexandre Demode
+   ---------------------------------
+   Manage tracking cookies message
+   ========================================================================== */
 
+(function(window, document, undefined) {
     var $banner = $("#cookies-banner");
 
     // Disable tracking if the opt-out cookie exists.
-    if(document.cookie.indexOf("hasconsent=true") > -1){
-        $("#gtm").after(
-            "<script>
-                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-                '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-                })(window,document,'script','dataLayer','GTM-WH7642');
-            </script>"
-        );
-    } else if(document.cookie.indexOf("hasconsent=false") === -1){
-        $banner.show();
+    function checkHasConsent(){
+        if(document.cookie.indexOf("hasconsent=true") > -1){
+            $("#gtm").after(
+                "<script>" +
+                    "dataLayer = [{'gaTrackingId': 'UA-27730868-1'}];" +
+                    "(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':" +
+                    "new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0]," +
+                    "j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=" +
+                    "'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);" +
+                    "})(window,document,'script','dataLayer','GTM-WH7642');" +
+                "</script>"
+            );
+        } else if(document.cookie.indexOf("hasconsent=false") === -1){
+            $banner.show();
+        }
     }
+    checkHasConsent();
 
-    function sethasconsent(hasconsent){
+
+    function setHasConsent(hasconsent){
         document.cookie = "hasconsent="+hasconsent+"; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/";
         $banner.slideUp(200);
     }
 
     $("#reject-cookies").on("click", function(){
-        sethasconsent(false);
+        setHasConsent(false);
     });
 
     $("#accept-cookies").on("click", function(){
-        sethasconsent(true);
+        setHasConsent(true);
+        checkHasConsent();
     });
 })(window, document);

--- a/assets/js/cookies-banner.js
+++ b/assets/js/cookies-banner.js
@@ -5,18 +5,22 @@
     var $banner = $("#cookies-banner");
 
     // Disable tracking if the opt-out cookie exists.
-    var disableStr = "ga-disable-" + gaProperty;
     if(document.cookie.indexOf("hasconsent=true") > -1){
-        window[disableStr] = false;
-    } else if(document.cookie.indexOf("hasconsent=false") > -1){
-        window[disableStr] = true;
-    } else {
+        $("#gtm").after(
+            "<script>
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+                '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-WH7642');
+            </script>"
+        );
+    } else if(document.cookie.indexOf("hasconsent=false") === -1){
         $banner.show();
     }
 
     function sethasconsent(hasconsent){
         document.cookie = "hasconsent="+hasconsent+"; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/";
-        window[disableStr] = !hasconsent;
         $banner.slideUp(200);
     }
 

--- a/assets/js/cookies-banner.js
+++ b/assets/js/cookies-banner.js
@@ -8,7 +8,6 @@
 (function(window, document, undefined) {
     var $banner = $("#cookies-banner");
 
-    // Disable tracking if the opt-out cookie exists.
     function checkHasConsent(){
         if(document.cookie.indexOf("hasconsent=true") > -1){
             $("#gtm").after(
@@ -23,22 +22,26 @@
             );
         } else if(document.cookie.indexOf("hasconsent=false") === -1){
             $banner.show();
+            // Accept for the next page
+            setHasConsent(true, false);
         }
     }
     checkHasConsent();
 
 
-    function setHasConsent(hasconsent){
+    function setHasConsent(hasconsent, hide){
         document.cookie = "hasconsent="+hasconsent+"; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/";
-        $banner.slideUp(200);
+
+        if(hide)
+            $banner.slideUp(200);
     }
 
     $("#reject-cookies").on("click", function(){
-        setHasConsent(false);
+        setHasConsent(false, true);
     });
 
     $("#accept-cookies").on("click", function(){
-        setHasConsent(true);
+        setHasConsent(true, true);
         checkHasConsent();
     });
 })(window, document);

--- a/assets/js/mathjax-config.js
+++ b/assets/js/mathjax-config.js
@@ -1,9 +1,0 @@
-MathJax.Hub.Config({
-    tex2jax: {
-        inlineMath: [['$', '$']],
-        displayMath: [['$$','$$']],
-        processEscapes: true,
-    },
-    TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js"] },
-    messageStyle: "none",
-});

--- a/assets/js/mathjax-config.js
+++ b/assets/js/mathjax-config.js
@@ -1,0 +1,9 @@
+MathJax.Hub.Config({
+    tex2jax: {
+        inlineMath: [['$', '$']],
+        displayMath: [['$$','$$']],
+        processEscapes: true,
+    },
+    TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js"] },
+    messageStyle: "none",
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,10 +25,10 @@
     {% block meta %}{% endblock %}
 
     {% if debug %}
-    <link rel="stylesheet" href="/static/css/main.css" />
+        <link rel="stylesheet" href="/static/css/main.css">
     {% else %}
-    <link rel="stylesheet" href="/static/css/main.min.css" />
-    {% block source_content %}{% endblock %}
+        <link rel="stylesheet" href="/static/css/main.min.css">
+        {% block canonical %}{% endblock %}
     {% endif %}
 
     {# Webfont async loading #}
@@ -55,10 +55,6 @@
     <!-- TEMP : load fonts from Google / Procude FOUT effect (see above) -->
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro:400,700|Merriweather:400,700' rel='stylesheet' type='text/css'>
 
-
-    {# for additionnal css in some pages #}
-    {% block extracss %}{% endblock %}
-
     {# favicons #}
     <link rel="shortcut icon" type="image/png" href="{% static "images/favicon.png" %}">
     <link rel="apple-touch-icon" sizes="144x144" href="{% static "images/apple-touch-icon-144x144-precomposed.png" %}">
@@ -77,8 +73,8 @@
 
 </head>
 <body class="{% block body_class %}{% endblock %}">
-    <!--[if lt IE 7]>
-        <p class="chromeframe">Vous utilisez un navigateur <strong>dépassé</strong>. Merci de <a href="http://browsehappy.com/">mettre à jour celui-ci</a> ou <a href="http://www.google.com/chromeframe/?redirect=true">activer Google Chrome Frame</a> pour améliorer votre expérience.</p>
+    <!--[if lt IE 8]>
+        <p class="chromeframe">Vous utilisez un navigateur <strong>dépassé</strong>. Merci de <a href="http://browsehappy.com/">mettre à jour celui-ci</a> pour améliorer votre expérience.</p>
     <![endif]-->
 
     <div class="mobile-menu" id="mobile-menu"></div>
@@ -499,27 +495,16 @@
 
     {# Javascript stuff start #}
     {% if debug %}
-    <script src="/static/js/vendors.js"></script>
-    <script src="/static/js/main.js"></script>
+        <script src="/static/js/vendors.js"></script>
+        <script src="/static/js/main.js"></script>
     {% else %}
-    <script src="/static/js/vendors.min.js"></script>
-    <script src="/static/js/main.min.js"></script>
+        <script src="/static/js/vendors.min.js"></script>
+        <script src="/static/js/main.min.js"></script>
     {% endif %}
 
 
 
-    {# MathJax #}
-    <script type="text/x-mathjax-config">
-        MathJax.Hub.Config({
-            tex2jax: {
-                inlineMath: [['$', '$']],
-                displayMath: [['$$','$$']],
-                processEscapes: true,
-            },
-            TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js"] },
-            messageStyle: "none",
-        });
-    </script>
+    {# MathJax, see mathjax-config.js for configuration #}
     <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
     

--- a/templates/base.html
+++ b/templates/base.html
@@ -510,16 +510,9 @@
     
 
     {# Google Tag Manager #}
-    <noscript>
+    <noscript id="gtm">
         <iframe src="//www.googletagmanager.com/ns.html?id=GTM-WH7642"
         height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
-    <script>
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-WH7642');
-    </script>
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,7 @@
 
 
 <!DOCTYPE html>
-<html class="no-js enable-mobile-menu wf-active">
+<html class="no-js enable-mobile-menu wf-active" lang="fr">
 <head>
     <meta charset="utf-8">
 
@@ -32,27 +32,6 @@
     {% endif %}
 
     {# Webfont async loading #}
-    {# Do not put this code into a distant file #}
-    <!-- TODO : optimiser ça pour ne pas voir le changement de font à chaque page
-    <script>
-        WebFontConfig = {
-            google: {
-              families: ['Source Sans Pro:400,700', 'Source Code Pro:400,700', 'Merriweather:400,700']
-            }
-        };
-
-        (function() {
-            var wf = document.createElement('script');
-            wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
-                      '://ajax.googleapis.com/ajax/libs/webfont/1.4.7/webfont.js';
-            wf.type = 'text/javascript';
-            wf.async = 'true';
-            var s = document.getElementsByTagName('script')[0];
-            s.parentNode.insertBefore(wf, s);
-        })();
-    </script>
-    -->
-    <!-- TEMP : load fonts from Google / Procude FOUT effect (see above) -->
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro:400,700|Merriweather:400,700' rel='stylesheet' type='text/css'>
 
     {# favicons #}
@@ -68,8 +47,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
 
     {# RSS links #}
-    <link rel="alternate" type="application/rss+xml"
-          title="Forum" href="{% url "post-feed-rss" %}"/>
+    <link rel="alternate" type="application/rss+xml" title="Forum" href="{% url "post-feed-rss" %}">
 
 </head>
 <body class="{% block body_class %}{% endblock %}">
@@ -504,7 +482,18 @@
 
 
 
-    {# MathJax, see mathjax-config.js for configuration #}
+    {# MathJax #}
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+            tex2jax: {
+                inlineMath: [['$', '$']],
+                displayMath: [['$$','$$']],
+                processEscapes: true,
+            },
+            TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js"] },
+            messageStyle: "none",
+        });
+    </script>
     <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
     

--- a/templates/base.html
+++ b/templates/base.html
@@ -73,7 +73,7 @@
 
         <div id="cookies-banner">
             <p>
-                Ce site utilise Google Analytics. En continuant à naviguer, vous nous autorisez à déposer des cookies à des fins de mesure d'audience. Pour s'opposer à ce dépôt vous pouvez cliquer 
+                Ce site utilise Google Analytics. En poursuivant votre navigation sur ce site, vous nous autorisez à déposer des cookies à des fins de mesure d'audience. Pour s'opposer à ce dépôt vous pouvez cliquer 
                 <button id="reject-cookies">ici</button>.
                 <a href="/pages/cookies">En savoir plus</a>
                 <button id="accept-cookies">OK</button>

--- a/templates/tutorial/base_online.html
+++ b/templates/tutorial/base_online.html
@@ -7,9 +7,9 @@
     &#183; Tutoriels
 {% endblock %}
 
-{% block source_content %}
+{% block canonical %}
     {% if tutorial.source and tutorial.source != "" %}
-    <link rel="canonical" href="{{tutorial.source}}" />
+    	<link rel="canonical" href="{{ tutorial.source }}">
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Issues | #1045, #1125, #324 |

Cette fois c'est testé et re-testé. Le comportement attendu est le suivant :
- par défaut : affichage de la bannière, création du cookie hascontent mis à true
- changement de page sans rien toucher : hascontent ayant été mis à true, les cookies d'analytics et GTM sont injectés
- click sur OK : ferme le bandeau et active tout de suite l'analytics et GTM.
- clic sur le lien de refus : changement de hascontent à false, la bannière est masquée, pas d'analytics lancé et pas non plus après changement de page.

Soyez ultra minutieux lors du test, c'est important légalement tout de même.

L'idéal pour le test serait d'être sur la preprod, car en local on ne peux que vérifier la présence ou non des scripts (via votre inspecteur favoris). La preprod étant sur le même domaine que la prod, les cookies seront bien créés contrairement à une copie locale.
