### PR TITLE
Corrige les ancres et la pagination

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -1140,6 +1140,10 @@
     }
     .tutorial-infos {
         margin: 7px 0 0 70px;
+
+        &.no-illu {
+            margin-left: 0;
+        }
     }
 }
 

--- a/templates/article/includes/article_item.part.html
+++ b/templates/article/includes/article_item.part.html
@@ -15,11 +15,17 @@
             <img src="{{ article.image.article_illu.url }}" alt="" class="tutorial-img avatar">
         {% endif %}
 
-        <div class="tutorial-infos">
+        <div class="tutorial-infos {% if not article.image %}no-illu{% endif %}">
             <h3>{{ article.title }}</h3>
             <p class="article-metadata">
-                Publié le {{ article.pubdate|format_date }} -
-                <a href="{{ article.get_last_reaction.get_absolute_url }}">
+                {{ article.pubdate|format_date|capfirst }} -
+                <a href="
+                    {% if article.get_reaction_count == 0 %}
+                        {{ link }}#reactions
+                    {% else %}
+                        {{ article.get_last_reaction.get_absolute_url }}
+                    {% endif %}
+                    ">
                     {% if article.get_reaction_count == 0 %}
                         Aucune réaction
                     {% elif article.get_reaction_count == 1 %}

--- a/templates/article/view.html
+++ b/templates/article/view.html
@@ -51,6 +51,71 @@
 
 
 
+{% block content %}
+    {{ article.txt|safe }}
+
+
+    {% include "article/includes/pager.part.html" %}
+{% endblock %}
+
+
+
+{% block content_after %}
+    <h3 class="reactions-title" id="reactions">Réactions</h3>
+
+
+    {% include "misc/pagination.part.html" with position="top" topic=article is_online=True anchor="reactions" %}
+
+
+    {% for message in reactions %}
+        {% captureas form_action %}
+            {% url "zds.article.views.answer" %}?article={{ article.pk }}
+        {% endcaptureas %}
+
+        {% captureas edit_link %}
+            {% url "zds.article.views.edit_reaction" %}?message={{ message.pk }}
+        {% endcaptureas %}
+
+        {% captureas cite_link %}
+            {% url "zds.article.views.answer" %}?article={{ article.pk }}&amp;cite={{ message.pk }}
+        {% endcaptureas %}
+
+        {% captureas upvote_link %}
+            {% url "zds.article.views.like_reaction" %}?message={{ message.pk }}
+        {% endcaptureas %}
+
+        {% captureas downvote_link %}
+            {% url "zds.article.views.dislike_reaction" %}?message={{ message.pk }}
+        {% endcaptureas %}
+
+        {% captureas alert_solve_link %}
+            {% url "zds.article.views.solve_alert" %}
+        {% endcaptureas %}
+
+        {% if forloop.first and nb > 1 %}
+            {% set True as is_repeated_message %}
+        {% else %}
+            {% set False as is_repeated_message %}
+        {% endif %}
+
+
+        {% include "misc/message.part.html" with perms_change=perms.article.change_reaction topic=article %}
+    {% endfor %}
+
+
+    {% include "misc/pagination.part.html" with position="bottom" topic=article is_online=True anchor="reactions" %}
+
+
+    
+    {% captureas form_action %}
+        {% url 'zds.article.views.answer' %}?article={{ article.pk }}
+    {% endcaptureas %}
+
+    {% include "misc/message_form.html" with member=user topic=article %}
+{% endblock %}
+
+
+
 {% block sidebar_actions %}
     {% if perms.article.change_article %}
         <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Validation">
@@ -107,69 +172,4 @@
             </li>
         </ul>
     </div>
-{% endblock %}
-
-
-
-{% block content %}
-    {{ article.txt|safe }}
-
-
-    {% include "article/includes/pager.part.html" %}
-{% endblock %}
-
-
-
-{% block content_after %}
-    <h3 class="reactions-title">Réactions</h3>
-
-
-    {% include "misc/pagination.part.html" with position="top" topic=article is_online=True %}
-
-
-    {% for message in reactions %}
-        {% captureas form_action %}
-            {% url "zds.article.views.answer" %}?article={{ article.pk }}
-        {% endcaptureas %}
-
-        {% captureas edit_link %}
-            {% url "zds.article.views.edit_reaction" %}?message={{ message.pk }}
-        {% endcaptureas %}
-
-        {% captureas cite_link %}
-            {% url "zds.article.views.answer" %}?article={{ article.pk }}&amp;cite={{ message.pk }}
-        {% endcaptureas %}
-
-        {% captureas upvote_link %}
-            {% url "zds.article.views.like_reaction" %}?message={{ message.pk }}
-        {% endcaptureas %}
-
-        {% captureas downvote_link %}
-            {% url "zds.article.views.dislike_reaction" %}?message={{ message.pk }}
-        {% endcaptureas %}
-
-        {% captureas alert_solve_link %}
-            {% url "zds.article.views.solve_alert" %}
-        {% endcaptureas %}
-
-        {% if forloop.first and nb > 1 %}
-            {% set True as is_repeated_message %}
-        {% else %}
-            {% set False as is_repeated_message %}
-        {% endif %}
-
-
-        {% include "misc/message.part.html" with perms_change=perms.article.change_reaction topic=article %}
-    {% endfor %}
-
-
-    {% include "misc/pagination.part.html" with position="bottom" topic=article is_online=True %}
-
-
-    
-    {% captureas form_action %}
-        {% url 'zds.article.views.answer' %}?article={{ article.pk }}
-    {% endcaptureas %}
-
-    {% include "misc/message_form.html" with member=user topic=article %}
 {% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -36,7 +36,7 @@
                             <img src="{{ article.image.article_illu.url }}" alt="" class="tutorial-img avatar">
                         </a>
                     {% endif %}
-                    <div class="tutorial-infos">
+                    <div class="tutorial-infos {% if not article.image %}no-illu{% endif %}">
                         <h3>
                             <a href="{{ article.get_absolute_url_online }}" title="{{ article.title }}">
                                 {{ article.title }}
@@ -45,7 +45,13 @@
                         
                         <span class="article-metadata">
                             {{ article.pubdate|format_date|capfirst }} -
-                            <a href="{{ article.get_last_reaction.get_absolute_url }}">
+                            <a href="
+                                {% if article.get_reaction_count == 0 %}
+                                    {{ link }}#reactions
+                                {% else %}
+                                    {{ article.get_last_reaction.get_absolute_url }}
+                                {% endif %}
+                            ">
                                 {% if article.get_reaction_count == 0 %}
                                     Aucune réaction
                                 {% elif article.get_reaction_count == 1 %}
@@ -73,7 +79,6 @@
                 {% include 'tutorial/includes/tutorial_item.part.html' %}
             {% endfor %}
         {% endif %}
-        
     </section>
 {% endblock %}
 

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -14,7 +14,7 @@
         {% ifnotequal nb 1 %}
             <li class="prev">
                 {% with prev=nb|add:-1 %}
-                    <a href="{% append_to_get page=prev %}" class="ico-after arrow-left blue">
+                    <a href="{% append_to_get page=prev %}{{ full_anchor }}" class="ico-after arrow-left blue">
                         Précédente
                     </a>
                 {% endwith %}
@@ -25,7 +25,7 @@
         {% for page in pages %}
             {% if page %}
                 <li>
-                    <a {% ifnotequal page nb %}href="{% append_to_get page=page %}"{% else %}class="current"{% endifnotequal %}>
+                    <a {% ifnotequal page nb %}href="{% append_to_get page=page %}{{ full_anchor }}"{% else %}class="current"{% endifnotequal %}>
                         {{ page }}
                     </a>
                 </li>
@@ -55,7 +55,7 @@
         {% if pages|last > 0 and pages|last != nb %}
             <li class="next">
                 {% with next=nb|add:1 %}
-                    <a href="{% append_to_get page=next %}" class="ico-after arrow-right blue">
+                    <a href="{% append_to_get page=next %}{{ full_anchor }}" class="ico-after arrow-right blue">
                         Suivante
                     </a>
                 {% endwith %}

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -4,6 +4,12 @@
 
 
 {% if pages|length > 1 %}
+    {% captureas full_anchor %}
+        {% if anchor %}
+            #{{ anchor }}
+        {% endif %}
+    {% endcaptureas %}
+
     <ul class="pagination pagination-{{ position }}">
         {% ifnotequal nb 1 %}
             <li class="prev">

--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -8,8 +8,10 @@
             {{ tutorial.get_absolute_url_online }}
         {% endif %}
     ">
-        <img src="{{ tutorial.image.physical.tutorial_illu.url }}" alt="" class="tutorial-img avatar">
-        <div class="tutorial-infos">
+        {% if tutorial.image.physical.tutorial_illu.url %}
+            <img src="{{ tutorial.image.physical.tutorial_illu.url }}" alt="" class="tutorial-img avatar">
+        {% endif %}
+        <div class="tutorial-infos {% if not tutorial.image.physical.tutorial_illu.url %}no-illu{% endif %}">
             <h3>{{ tutorial.title }}</h3>
             
             <span class="article-metadata">

--- a/templates/tutorial/tutorial/view_online.html
+++ b/templates/tutorial/tutorial/view_online.html
@@ -82,10 +82,10 @@
 
 
 {% block content_after %}
-    <h2 class="reactions-title">Commentaires</h2>
+    <h2 class="reactions-title" id="comments">Commentaires</h2>
 
 
-    {% include "misc/pagination.part.html" with position="top" topic=tutorial is_online=True %}
+    {% include "misc/pagination.part.html" with position="top" topic=tutorial is_online=True anchor="comments" %}
 
 
     {% for message in notes %}
@@ -120,7 +120,7 @@
     {% endfor %}
 
 
-    {% include "misc/pagination.part.html" with position="bottom" topic=tutorial is_online=True %}
+    {% include "misc/pagination.part.html" with position="bottom" topic=tutorial is_online=True anchor="comments" %}
 
 
     


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1115, #1114 |

Au passage, j'ai masqué l'image des tutos/articles s'il n'y en a pas (le titre est aligné à gauche, sans marge). C'était particulièrement moche d'avoir une zone vide.

Pour tester : utilisez la pagination des articles et tutos, vérifiez que le lien mène bien directement aux réactions via l'ancre.
