### PR TITLE
Issue #5: Script de base pour déployer en prod - sans doute très amélior...

### DIFF
--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -3,6 +3,10 @@
 # Zeste de Savoir deployment script
 #
 # Deploys specified version of Zeste de Savoir
+#
+# Usage:
+# - This script must be run by zds user
+# - This script has exactly 1 parameter: the tag name to deploy
 
 if [ "$(whoami)" != "zds" ]; then
 	echo "This script must be run by zds user" >&2
@@ -28,7 +32,7 @@ gulp pack
 
 # Update application data
 source ../bin/activate
-pip install --upgrade -r requirements.txt
+pip install --upgrade --use-mirrors -r requirements.txt
 python manage.py migrate
 deactivate
 

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -25,7 +25,6 @@ git checkout -b $1
 # Compute front stuff
 source /usr/local/nvm/nvm.sh
 gulp pack
-gulp build
 
 # Update application data
 source ../bin/activate

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -19,17 +19,24 @@ if [ "$#" -ne 1 ]; then
 fi
 cd /opt/zdsenv/ZesteDeSavoir/
 
+# Maintenance mode
+sudo rm /etc/nginx/sites-enabled/zestedesavoir
+sudo ln -s /etc/nginx/sites-available/zds-maintenance /etc/nginx/sites-enabled/zds-maintenance
+sudo service nginx reload
+
 # Switch to new tag
 git fetch --tags
 # Server has git < 1.9, git fetch --tags doesn't retrieve commits...
 git fetch
-# -b is required to have version data in footer
+# Checkout the tag
+git checkout $1
+# Create a branch with the same name - required to have version data in footer
 git checkout -b $1
 
 # Compute front stuff
 source /usr/local/nvm/nvm.sh
 npm update
-npm update bower gulp -g
+sudo npm update bower gulp -g
 gulp pack
 
 # Update application data
@@ -40,3 +47,8 @@ deactivate
 
 # Restart zds
 sudo supervisorctl restart zds
+
+# Exit maintenance mode
+sudo rm /etc/nginx/sites-enabled/zds-maintenance
+sudo ln -s /etc/nginx/sites-available/zestedesavoir /etc/nginx/sites-enabled/zestedesavoir
+sudo service nginx reload

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -24,6 +24,9 @@ sudo rm /etc/nginx/sites-enabled/zestedesavoir
 sudo ln -s /etc/nginx/sites-available/zds-maintenance /etc/nginx/sites-enabled/zds-maintenance
 sudo service nginx reload
 
+# Delete old branch if exists
+git checkout prod
+git branch -D $1
 # Switch to new tag
 git fetch --tags
 # Server has git < 1.9, git fetch --tags doesn't retrieve commits...
@@ -35,8 +38,8 @@ git checkout -b $1
 
 # Compute front stuff
 source /usr/local/nvm/nvm.sh
-sudo npm update
-sudo npm update bower gulp -g
+sudo npm -q update
+sudo npm -q update bower gulp -g
 gulp pack
 
 # Update application data
@@ -52,3 +55,7 @@ sudo supervisorctl restart zds
 sudo rm /etc/nginx/sites-enabled/zds-maintenance
 sudo ln -s /etc/nginx/sites-available/zestedesavoir /etc/nginx/sites-enabled/zestedesavoir
 sudo service nginx reload
+
+# Display current branch and commit
+git status
+echo "Commit deployé : `git rev-parse HEAD`"

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -35,7 +35,7 @@ git checkout -b $1
 
 # Compute front stuff
 source /usr/local/nvm/nvm.sh
-npm update
+sudo npm update
 sudo npm update bower gulp -g
 gulp pack
 

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Zeste de Savoir deployment script
+#
+# Deploys specified version of Zeste de Savoir
+
+if [ "$(whoami)" != "zds" ]; then
+	echo "This script must be run by zds user" >&2
+	exit 1
+fi
+
+if [ "$#" -ne 1 ]; then
+	echo "Usage: $0 <tag name>" >&2
+	exit 1
+fi
+cd /opt/zdsenv/ZesteDeSavoir/
+
+# Switch to new tag
+git fetch
+# -b is required to have version data in footer
+git checkout -b $1
+
+# Compute front stuff
+source /usr/local/nvm/nvm.sh
+gulp pack
+gulp build
+
+# Update application data
+source ../bin/activate
+pip install --upgrade -r requirements.txt
+python manage.py migrate
+deactivate
+
+# Restart zds
+sudo supervisorctl restart zds

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -16,6 +16,8 @@ fi
 cd /opt/zdsenv/ZesteDeSavoir/
 
 # Switch to new tag
+git fetch --tags
+# Server has git < 1.9, git fetch --tags doesn't retrieve commits...
 git fetch
 # -b is required to have version data in footer
 git checkout -b $1

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -28,6 +28,8 @@ git checkout -b $1
 
 # Compute front stuff
 source /usr/local/nvm/nvm.sh
+npm update
+npm update bower gulp -g
 gulp pack
 
 # Update application data


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui, mais urgente |
| Tickets concernés | #5 (il n'y a pas de faute de frappe) |

Ajout d'un script pour déployer en prod sans se prendre la tête.

Je pars du principe que c'est l'utilisateur zds qui fait tout le boulot.

On pourrait pas mal l'améliorer dans une version suivante. Avec la mise en place d'une page de maintenance au début et retrait à la fin, par exemple.

Comment QA cette chose ?

Ben... c'est pas facile en fait :
- Ceux qui ont accès à la préprod peuvent l'y jouer. Mais la préprod n'est pas strictement identique à la prod.
- En me faisant une revue de code paranoïaque
