### PR TITLE
Issue #1146 : corrige les flux des articles

### DIFF
--- a/zds/article/feeds.py
+++ b/zds/article/feeds.py
@@ -30,7 +30,7 @@ class LastArticlesFeedRSS(Feed):
         authors_list = item.authors.all()
         authors = []
         for authors_obj in authors_list:
-            authors.append(str(authors_obj))
+            authors.append(authors_obj.username)
         authors = ", ".join(authors).decode('utf-8')
         return authors
 

--- a/zds/article/feeds.py
+++ b/zds/article/feeds.py
@@ -31,7 +31,7 @@ class LastArticlesFeedRSS(Feed):
         authors = []
         for authors_obj in authors_list:
             authors.append(authors_obj.username)
-        authors = ", ".join(authors).decode('utf-8')
+        authors = ", ".join(authors)
         return authors
 
     def item_link(self, item):

--- a/zds/article/feeds.py
+++ b/zds/article/feeds.py
@@ -14,20 +14,25 @@ class LastArticlesFeedRSS(Feed):
 
     def items(self):
         return Article.objects\
-            .filter(is_visible=True)\
+            .filter(sha_public__isnull=False)\
             .order_by('-pubdate')[:5]
 
     def item_title(self, item):
         return item.title
 
+    def item_pubdate(self, item):
+        return item.pubdate
+
     def item_description(self, item):
         return item.description
 
     def item_author_name(self, item):
-        return item.author.username
-
-    def item_author_link(self, item):
-        return item.author.get_absolute_url()
+        authors_list = item.authors.all()
+        authors = []
+        for authors_obj in authors_list:
+            authors.append(str(authors_obj))
+        authors = ", ".join(authors).decode('utf-8')
+        return authors
 
     def item_link(self, item):
         return item.get_absolute_url()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1146 |

Cette PR ajoute toutes les informations des articles aux flux. Ceux-ci étaient auparavant quasiment vides. J'ai profité de la PR pour ajouter la pubDate. J'ai supprimé la méthode "item_author_name" qui n'apparaît pas de toute façon dans les flux (voir [ici](https://code.djangoproject.com/ticket/1294)).

**Note pour la QA** :
- Vérifier que les flux des articles comportent bien titre, lien, description, auteur(s) et date de publication.
- Vérifier que la structure d'un flux est bien respectée.
- Vérifier que les articles non validés n'apparaissent pas dans les flux.
