### PR TITLE
Issue #1159 : rétablit la bonne police sur les liens

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -1611,7 +1611,7 @@
         a,
         ul:not(.pagination),
         ol {
-            font-family: $font-serif;
+            font-family: $font-serif-active;
         }
     }
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1159 |

Cette PR rétablit l'utilisation par défaut de la police "Merriweather" sur les liens. Plus d'informations sur le ticket #1159.

**Note pour la QA** :
- Vérifier que pour les liens sur les pages articles, tutos et statiques, la police "Merriweather" est bien utilisée et non pas "Liberation Serif".
