### PR TITLE
Issue #1123 galeries

### DIFF
--- a/templates/gallery/gallery/details.html
+++ b/templates/gallery/gallery/details.html
@@ -65,7 +65,7 @@
         </ul>
     </div>
     
-    <form id="form" name="form" method="post" action="{% url "zds.gallery.views.modify_image" %}">
+    <form id="form" name="form" method="post" action="{% url "zds.gallery.views.delete_image" %}">
         <input type="hidden" name="gallery" value="{{ gallery.pk }}">
         <button class="btn btn-cancel" name="delete_multi">Supprimer la sélection</button>
         <button class="toggle-gallery-view btn btn-grey" type="button" title="Alterner entre les modes de vue grille et liste">

--- a/zds/gallery/forms.py
+++ b/zds/gallery/forms.py
@@ -121,9 +121,7 @@ class ImageForm(forms.Form):
     physical = forms.ImageField(
         label=u'Sélectionnez votre image',
         required=True,
-        help_text='Taille maximum : '
-        + str(settings.IMAGE_MAX_SIZE)
-        + ' megabytes'
+        help_text='Taille maximum : ' + str(settings.IMAGE_MAX_SIZE / 1024) + ' <abbr title="kibioctet">Kio</abbr>'
     )
 
     def __init__(self, *args, **kwargs):
@@ -143,6 +141,27 @@ class ImageForm(forms.Form):
             ),
         )
 
+
+class UpdateImageForm(ImageForm):
+    def __init__(self, *args, **kwargs):
+        super(ImageForm, self).__init__(*args, **kwargs)
+
+        self.fields['physical'].required = False
+
+        self.helper = FormHelper()
+        self.helper.form_class = 'clearfix'
+        self.helper.form_method = 'post'
+
+        self.helper.layout = Layout(
+            Field('title'),
+            Field('legend'),
+            Field('physical'),
+            ButtonHolder(
+                StrictButton(u'Mettre à jour', type='submit'),
+                HTML('<a class="btn btn-cancel" '
+                u'href="{{ gallery.get_absolute_url }}">Annuler</a>'),
+            ),
+        )
 
 class ImageAsAvatarForm(forms.Form):
     """"Form to add current image as avatar"""

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -365,17 +365,17 @@ class EditImageViewTest(TestCase):
         with open(os.path.join(settings.SITE_ROOT, 'fixtures', 'logo.png'), 'r') as fp:
 
             response = self.client.post(
-                    reverse(
-                        'zds.gallery.views.edit_image',
-                        args=[self.gallery.pk, self.image.pk]
-                    ),
-                    {
-                        'title': 'edit title',
-                        'legend': 'dit legend',
-                        'slug': 'edit-slug',
-                        'physical': fp
-                    },
-                    follow=True
+                reverse(
+                    'zds.gallery.views.edit_image',
+                    args=[self.gallery.pk, self.image.pk]
+                ),
+                {
+                    'title': 'edit title',
+                    'legend': 'dit legend',
+                    'slug': 'edit-slug',
+                    'physical': fp
+                },
+                follow=True
             )
         self.assertEqual(200, response.status_code)
         image_test = Image.objects.get(pk=self.image.pk)
@@ -415,17 +415,17 @@ class ModifyImageTest(TestCase):
         self.image3.delete()
 
     def test_denies_anonymous(self):
-        response = self.client.get(reverse('zds.gallery.views.modify_image'), follow=True)
+        response = self.client.get(reverse('zds.gallery.views.delete_image'), follow=True)
         self.assertRedirects(response,
                 reverse('zds.member.views.login_view')
-                + '?next=' + urllib.quote(reverse('zds.gallery.views.modify_image'), ''))
+                + '?next=' + urllib.quote(reverse('zds.gallery.views.delete_image'), ''))
 
     def test_fail_modify_image_with_no_permission(self):
         login_check = self.client.login(username=self.profile3.user.username, password='hostel77')
         self.assertTrue(login_check)
 
         response = self.client.post(
-                reverse('zds.gallery.views.modify_image'),
+                reverse('zds.gallery.views.delete_image'),
                 {
                     'gallery': self.gallery1.pk,
                 },
@@ -445,7 +445,7 @@ class ModifyImageTest(TestCase):
         self.assertTrue(login_check)
 
         self.client.post(
-                reverse('zds.gallery.views.modify_image'),
+                reverse('zds.gallery.views.delete_image'),
                 {
                     'gallery': self.gallery1.pk,
                     'delete': '',
@@ -462,7 +462,7 @@ class ModifyImageTest(TestCase):
         self.assertTrue(login_check)
 
         response = self.client.post(
-                reverse('zds.gallery.views.modify_image'),
+                reverse('zds.gallery.views.delete_image'),
                 {
                     'gallery': self.gallery1.pk,
                     'delete': '',
@@ -479,7 +479,7 @@ class ModifyImageTest(TestCase):
         self.assertTrue(login_check)
 
         response = self.client.post(
-                reverse('zds.gallery.views.modify_image'),
+                reverse('zds.gallery.views.delete_image'),
                 {
                     'gallery': self.gallery1.pk,
                     'delete_multi': '',
@@ -497,7 +497,7 @@ class ModifyImageTest(TestCase):
         self.assertTrue(login_check)
 
         response = self.client.post(
-                reverse('zds.gallery.views.modify_image'),
+                reverse('zds.gallery.views.delete_image'),
                 {
                     'gallery': self.gallery1.pk,
                     'delete': '',

--- a/zds/gallery/urls.py
+++ b/zds/gallery/urls.py
@@ -18,7 +18,7 @@ urlpatterns = patterns('',
                        url(r'^image/ajouter/(?P<gal_pk>\d+)/$',
                            'zds.gallery.views.new_image'),
                        url(r'^image/modifier/$',
-                           'zds.gallery.views.modify_image'),
+                           'zds.gallery.views.delete_image'),
                        url(r'^image/editer/(?P<gal_pk>\d+)/(?P<img_pk>\d+)/$',
                            'zds.gallery.views.edit_image'),
                        )

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect, get_object_or_404
-from zds.gallery.forms import ImageForm, GalleryForm, UserGalleryForm, ImageAsAvatarForm
+from zds.gallery.forms import ImageForm, UpdateImageForm, GalleryForm, UserGalleryForm, ImageAsAvatarForm
 from zds.gallery.models import UserGallery, Image, Gallery
 from zds.tutorial.models import Tutorial
 from zds.member.decorator import can_write_and_read_now
@@ -170,12 +170,12 @@ def modify_gallery(request):
 
 @login_required
 def edit_image(request, gal_pk, img_pk):
-    """Creates a new image."""
+    """Edit an existing image."""
 
     gal = get_object_or_404(Gallery, pk=gal_pk)
     img = get_object_or_404(Image, pk=img_pk)
 
-    # check if user can edit image
+    # Check if user can edit image
     try:
         permission = UserGallery.objects.get(user=request.user, gallery=gal)
         if permission.mode != 'W':
@@ -183,17 +183,17 @@ def edit_image(request, gal_pk, img_pk):
     except:
         raise PermissionDenied
 
-    # check if the image belong to the gallery
+    # Check if the image belong to the gallery
     if img.gallery != gal:
         raise PermissionDenied
-    
-    
+
     if request.method == "POST":
-        form = ImageForm(request.POST, request.FILES)
+        form = UpdateImageForm(request.POST, request.FILES)
         if form.is_valid():
             if "physical" in request.FILES:
                 if request.FILES["physical"].size > settings.IMAGE_MAX_SIZE:
-                    messages.error(request, "Votre image est beaucoup trop lourde, réduidez sa taille à moins de {} avant de l'envoyer".format(str(settings.IMAGE_MAX_SIZE/1024*1024)))
+                    messages.error(request, "Votre image est beaucoup trop lourde, réduidez sa taille à moins de {} \
+                    <abbr title=\"kibioctet\">Kio</abbr> avant de l'envoyer".format(str(settings.IMAGE_MAX_SIZE/1024)))
                 else:
                     img.title = request.POST["title"]
                     img.legend = request.POST["legend"]
@@ -201,19 +201,24 @@ def edit_image(request, gal_pk, img_pk):
                     img.slug = slugify(request.FILES["physical"])
                     img.update = datetime.now()
                     img.save()
-                    # Redirect to the document list after POST
-                    return redirect(gal.get_absolute_url())
+                    # Redirect to the newly uploaded image edit page after POST
+                    return redirect(reverse("zds.gallery.views.edit_image", args=[gal.pk, img.pk]))
             else:
                 img.title = request.POST["title"]
                 img.legend = request.POST["legend"]
                 img.update = datetime.now()
                 img.save()
+                # Redirect to the newly uploaded image edit page after POST
+                return redirect(reverse("zds.gallery.views.edit_image", args=[gal.pk, img.pk]))
 
-                # Redirect to the document list after POST
-                return redirect(gal.get_absolute_url())
     else:
-        form = ImageForm(initial={"title": img.title, "legend": img.legend, "physical": img.physical})
-    
+        form = UpdateImageForm(initial={
+            "title": img.title,
+            "legend": img.legend,
+            "physical": img.physical,
+            "new_image": False,
+        })
+
     as_avatar_form = ImageAsAvatarForm()
     return render_template(
         "gallery/image/edit.html", {
@@ -275,8 +280,7 @@ def new_image(request, gal_pk):
 
     if request.method == "POST":
         form = ImageForm(request.POST, request.FILES)
-        if form.is_valid() and request.FILES["physical"].size \
-                < settings.IMAGE_MAX_SIZE:
+        if form.is_valid() and request.FILES["physical"].size < settings.IMAGE_MAX_SIZE:
             img = Image()
             img.physical = request.FILES["physical"]
             img.gallery = gal
@@ -287,13 +291,12 @@ def new_image(request, gal_pk):
             img.save()
 
             # Redirect to the newly uploaded image edit page after POST
-
             return redirect(reverse("zds.gallery.views.edit_image",
                                     args=[gal.pk, img.pk]))
         else:
             return render_template("gallery/image/new.html", {"form": form,
                                                               "gallery": gal})
     else:
-        form = ImageForm()  # A empty, unbound form
+        form = ImageForm(initial={"new_image": True})  # A empty, unbound form
         return render_template("gallery/image/new.html", {"form": form,
                                                           "gallery": gal})

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -193,7 +193,7 @@ def edit_image(request, gal_pk, img_pk):
         if form.is_valid():
             if "physical" in request.FILES:
                 if request.FILES["physical"].size > settings.IMAGE_MAX_SIZE:
-                    messages.error(request, "Votre image est beaucoup trop lourde, réduidez sa taille à moins de {} \
+                    messages.error(request, "Votre image est beaucoup trop lourde, réduisez sa taille à moins de {} \
                     <abbr title=\"kibioctet\">Kio</abbr> avant de l'envoyer".format(str(settings.IMAGE_MAX_SIZE/1024)))
                 else:
                     img.title = request.POST["title"]

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -169,6 +169,7 @@ def modify_gallery(request):
 
 
 @login_required
+@can_write_and_read_now
 def edit_image(request, gal_pk, img_pk):
     """Edit an existing image."""
 
@@ -231,12 +232,9 @@ def edit_image(request, gal_pk, img_pk):
 
 @can_write_and_read_now
 @login_required
-def modify_image(request):
+@require_POST
+def delete_image(request):
 
-    # We only handle secured POST actions
-
-    if request.method != "POST":
-        raise Http404
     try:
         gal_pk = request.POST["gallery"]
     except KeyError:
@@ -246,7 +244,6 @@ def modify_image(request):
         gal_mode = UserGallery.objects.get(gallery=gal, user=request.user)
 
         # Only allow RW users to modify images
-
         if gal_mode.mode != "W":
             raise PermissionDenied
     except:

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -936,7 +936,7 @@ class BigTutorialTests(TestCase):
         # Delete the image of the bigtuto.
 
         response = self.client.post(
-                reverse('zds.gallery.views.modify_image'),
+                reverse('zds.gallery.views.delete_image'),
                 {
                     'gallery': self.bigtuto.gallery.pk,
                     'delete_multi': '',
@@ -1759,7 +1759,7 @@ class MiniTutorialTests(TestCase):
         # Delete the image of the minituto.
 
         response = self.client.post(
-                reverse('zds.gallery.views.modify_image'),
+                reverse('zds.gallery.views.delete_image'),
                 {
                     'gallery': self.minituto.gallery.pk,
                     'delete_multi': '',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1123 |

Maintenant on peut éditer les métadonnées d'une image sans avoir à réuploader l'image.
Bonus : corrections de typo, renommage d'une méthode mal nommée qui rendait le code difficilement compréhensible, éditer une image nous renvoie vers l'image et plus sur la galerie

**Instructions de QA**
Vérifier que les galeries fonctionnent encore, notamment :
- On peut éditer une image (titre et légende) sans avoir à réuploader l'image
- Le champ de l'image elle-même est toujours obligatoire à la création
- On peut toujours supprimer une seule image
- On peut toujours supprimer plusieurs images à la fois
- On peut toujours définir l'image courante comme avatar
