### PR TITLE
Corrige l'affichage des boutons dans l'éditeur

### DIFF
--- a/assets/scss/_editor.scss
+++ b/assets/scss/_editor.scss
@@ -6,7 +6,6 @@
     margin: 0;
     padding: 2px;
     list-style-position: initial;
-    list-style-image: none;
     list-style-type: none;
     border-bottom: none;
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | Aucun |

Lorsque le projet est lancé en local avec DEBUG = False, les boutons de l'éditeur ne s'affichent pas correctement. Gulp génère en fait un fichier minifié incorrect car il n'a pas l'air d'aimer la propriété list-style-image. Cette PR supprime donc cette propriété qui est de toute façon inutile puisqu'elle est par défaut à none.

Screen du problème :

![affichage](https://cloud.githubusercontent.com/assets/761168/3482023/e71ca62e-037a-11e4-92fc-5066854f842b.png)

**Note pour la QA** :

Vérifier qu'en local avec le debug désactivé, les boutons de l'éditeur s'affichent désormais correctement.

NB : Peut-être que chez certains, le bug était généralisé, debug activé ou non.
