### PR TITLE
permet l'edition d'un message après lock du topic

### DIFF
--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -125,11 +125,12 @@ class PostForm(forms.Form):
                     u'afin de limiter le flood.',
                     disabled=True)
         elif topic.is_locked:
-            self.helper['text'].wrap(
-                Field,
-                placeholder=u'Ce topic est verrouillé.',
-                disabled=True
-            )
+            if 'text' not in self.initial:
+                self.helper['text'].wrap(
+                    Field,
+                    placeholder=u'Ce topic est verrouillé.',
+                    disabled=True
+                )
 
     def clean(self):
         cleaned_data = super(PostForm, self).clean()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1160 |

Cette PR permet de vérifier que les messages d'un topic vérouillé sont encore éditables (cas de FAQ, etc.).

Note pour QA : 
- creer un topic, rajouter des message d'un simple membre
- se connecter en admin et locker le dit topic
- se reconnecter en simple membre et vérifier que les message sont toujours éditables
