### PR TITLE
corrige le problème d'initialisation de la bd

### DIFF
--- a/zds/utils/migrations/0002_auto__add_field_alert_comment__add_field_alert_scope__chg_field_alert_.py
+++ b/zds/utils/migrations/0002_auto__add_field_alert_comment__add_field_alert_scope__chg_field_alert_.py
@@ -16,7 +16,7 @@ class Migration(SchemaMigration):
             u'utils_alert',
             'comment',
             self.gf('django.db.models.fields.related.ForeignKey')(
-                default=0,
+                default=1,
                 related_name='comments',
                 to=orm['utils.Comment']),
             keep_default=False)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | #1042 |

Règle le problème d'initialisation de la BD sous mysql.

*_Note pour la QA *_: 

Exécuter la procédure d'install et de création d'une base de donnée vierge. Avec les paramètres de base sqlite, et avec des paramètres de base mysql.

Pour info, pour mysql il faut modifier dans votre fichier settings la variable database ainsi : 

```
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.mysql',
        'NAME': 'base_mysql',
        'USER': 'user',
        'PASSWORD': 'password',
        'HOST': 'localhost',
        'PORT': '3306',
    }
}
```
