### PR TITLE
rend accessible un sujet en cas de double post

### DIFF
--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -243,11 +243,8 @@ class Topic(models.Model):
         if user is None:
             user = get_current_user()
 
-        try:
-            TopicFollowed.objects.get(topic=self, user=user)
-        except TopicFollowed.DoesNotExist:
-            return False
-        return True
+        return TopicFollowed.objects.filter(topic=self, user=user).exists()
+
 
     def is_email_followed(self, user=None):
         """Check if the topic is currently email followed by the user.


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1129 |

Ce PR est particulière car elle résoud le problème d'inaccessibilité du sujet du membre qui sans doute crée un double post. (Voir l'issue)

**Note pour QA**

Vérifier qu'on peut toujours créer un sujet, suivre le sujet, se désabonner du suivi. Bref, checker tout le workflow du forum.
