### PR TITLE
fix #1109 (licence sur articles)

### DIFF
--- a/templates/article/member/view.html
+++ b/templates/article/member/view.html
@@ -42,6 +42,12 @@
         {% endif %}
         {{ article.title }}
     </h1>
+    
+    {% if article.licence %}
+        <p class="license">
+            {{ article.licence }}
+        </p>
+    {% endif %}
 
     <ul class="taglist">
         {% for tag in tags.all %}

--- a/templates/article/member/view_online.html
+++ b/templates/article/member/view_online.html
@@ -26,6 +26,12 @@
         {% endif %}
         {{ article.title }}
     </h1>
+    
+    {% if article.licence %}
+        <p class="license">
+            {{ article.licence }}
+        </p>
+    {% endif %}
 
     <ul class="taglist">
         {% for tag in tags.all %}
@@ -53,9 +59,6 @@
 
 {% block content %}
     {{ article.txt|safe }}
-
-
-    {% include "article/includes/pager.part.html" %}
 {% endblock %}
 
 

--- a/templates/article/member/view_online.html
+++ b/templates/article/member/view_online.html
@@ -59,6 +59,9 @@
 
 {% block content %}
     {{ article.txt|safe }}
+
+ 
+     {% include "article/includes/pager.part.html" %}
 {% endblock %}
 
 

--- a/zds/article/factories.py
+++ b/zds/article/factories.py
@@ -14,7 +14,7 @@ except:
 import json as json_writer
 import os
 from zds.article.models import Article, Reaction, \
-    Validation
+    Validation, Licence
 from zds.utils.articles import export_article
 
 
@@ -70,3 +70,15 @@ class ReactionFactory(factory.DjangoModelFactory):
 
 class VaidationFactory(factory.DjangoModelFactory):
     FACTORY_FOR = Validation
+
+class LicenceFactory(factory.DjangoModelFactory):
+    FACTORY_FOR = Licence
+    
+    code = u'GNU_GPL'
+    title = u'GNU General Public License'
+
+    @classmethod
+    def _prepare(cls, create, **kwargs):
+        licence = super(LicenceFactory, cls)._prepare(create, **kwargs)
+        return licence
+    

--- a/zds/article/forms.py
+++ b/zds/article/forms.py
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse
 
 from zds.article.models import Article
 from zds.utils.forms import CommonLayoutEditor
-from zds.utils.models import SubCategory
+from zds.utils.models import SubCategory, Licence
 
 
 class ArticleForm(forms.Form):
@@ -52,6 +52,12 @@ class ArticleForm(forms.Form):
         queryset=SubCategory.objects.all(),
         required=False
     )
+    
+    licence = forms.ModelChoiceField(
+        label="Licence de votre publication",
+        queryset=Licence.objects.all(),
+        required=False,
+    )
 
     def __init__(self, *args, **kwargs):
         super(ArticleForm, self).__init__(*args, **kwargs)
@@ -64,6 +70,7 @@ class ArticleForm(forms.Form):
             Field('description', autocomplete='off'),
             Field('image'),
             Field('subcategory'),
+            Field('licence'),
             CommonLayoutEditor(),
         )
 

--- a/zds/article/migrations/0003_auto__del_field_article_thumbnail__add_field_article_licence.py
+++ b/zds/article/migrations/0003_auto__del_field_article_thumbnail__add_field_article_licence.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Article.thumbnail'
+        db.delete_column(u'article_article', 'thumbnail')
+
+        # Adding field 'Article.licence'
+        db.add_column(u'article_article', 'licence',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['utils.Licence'], null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Adding field 'Article.thumbnail'
+        db.add_column(u'article_article', 'thumbnail',
+                      self.gf('django.db.models.fields.files.ImageField')(max_length=100, null=True, blank=True),
+                      keep_default=False)
+
+        # Deleting field 'Article.licence'
+        db.delete_column(u'article_article', 'licence_id')
+
+
+    models = {
+        u'article.article': {
+            'Meta': {'object_name': 'Article'},
+            'authors': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'db_index': 'True', 'symmetrical': 'False'}),
+            'create_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'is_locked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'last_reaction': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'last_reaction'", 'null': 'True', 'to': u"orm['article.Reaction']"}),
+            'licence': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.Licence']", 'null': 'True', 'blank': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'sha_draft': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'sha_public': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'sha_validation': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'subcategory': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['utils.SubCategory']", 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'article.articleread': {
+            'Meta': {'object_name': 'ArticleRead'},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['article.Article']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'reaction': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['article.Reaction']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'reactions_read'", 'to': u"orm['auth.User']"})
+        },
+        u'article.reaction': {
+            'Meta': {'object_name': 'Reaction', '_ormbases': [u'utils.Comment']},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['article.Article']"}),
+            u'comment_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['utils.Comment']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'article.validation': {
+            'Meta': {'object_name': 'Validation'},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['article.Article']", 'null': 'True', 'blank': 'True'}),
+            'comment_authors': ('django.db.models.fields.TextField', [], {}),
+            'comment_validator': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'date_proposition': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'date_reserve': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_validation': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'PENDING'", 'max_length': '10'}),
+            'validator': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'articles_author_validations'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'version': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'utils.comment': {
+            'Meta': {'object_name': 'Comment'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': u"orm['auth.User']"}),
+            'dislike': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'comments-editor'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.CharField', [], {'max_length': '39'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'like': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'text_hidden': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '80'}),
+            'text_html': ('django.db.models.fields.TextField', [], {}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'utils.licence': {
+            'Meta': {'object_name': 'Licence'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'utils.subcategory': {
+            'Meta': {'object_name': 'SubCategory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        }
+    }
+
+    complete_apps = ['article']

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -26,7 +26,7 @@ from django.utils import timezone
 from zds.utils import get_current_user
 from zds.utils import slugify
 from zds.utils.articles import export_article
-from zds.utils.models import SubCategory, Comment
+from zds.utils.models import SubCategory, Comment, Licence
 from django.core.urlresolvers import reverse
 
 
@@ -87,6 +87,10 @@ class Article(models.Model):
                                       related_name='last_reaction',
                                       verbose_name='Derniere réaction')
     is_locked = models.BooleanField('Est verrouillé', default=False)
+
+    licence = models.ForeignKey(Licence,
+                                verbose_name='Licence',
+                                blank=True, null=True, db_index=True)
 
     def __unicode__(self):
         return self.title

--- a/zds/article/tests.py
+++ b/zds/article/tests.py
@@ -8,8 +8,9 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from zds.article.factories import ArticleFactory, ReactionFactory
-from zds.article.models import Validation, Reaction, Article
+from zds.article.factories import ArticleFactory, ReactionFactory,   \
+    LicenceFactory
+from zds.article.models import Validation, Reaction, Article, Licence
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.mp.models import PrivateTopic
 from zds.settings import SITE_ROOT
@@ -33,9 +34,12 @@ class ArticleTests(TestCase):
         self.user_author = ProfileFactory().user
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user
+        
+        self.licence = LicenceFactory()
 
         self.article = ArticleFactory()
         self.article.authors.add(self.user_author)
+        self.article.licence = self.licence
         self.article.save()
 
         # connect with user
@@ -370,6 +374,134 @@ class ArticleTests(TestCase):
                     self.article.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
+
+    def test_workflow_licence(self):
+        '''Ensure the behavior of licence on articles'''
+
+        # create a new licence
+        new_licence = LicenceFactory(code='CC_BY', title='Creative Commons BY')
+        new_licence = Licence.objects.get(pk=new_licence.pk)
+
+        # check value first
+        article = Article.objects.get(pk=self.article.pk)
+        self.assertEqual(article.licence.pk, self.licence.pk)
+
+        # logout before
+        self.client.logout()
+        # login with author
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        # change licence (get 302) :
+        result = self.client.post(
+            reverse('zds.article.views.edit') + 
+                '?article={}'.format(self.article.pk),
+            {
+                'title': self.article.title,
+                'description': self.article.description,
+                'text': self.article.get_text(),
+                'subcategory': self.article.subcategory.all(),
+                'licence' : new_licence.pk
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # test change :
+        article = Article.objects.get(pk=self.article.pk)
+        self.assertNotEqual(article.licence.pk, self.licence.pk)
+        self.assertEqual(article.licence.pk, new_licence.pk)
+
+        # test change in JSON :
+        json = article.load_json()
+        self.assertEquals(json['licence'], new_licence.code)
+
+        # then logout ...
+        self.client.logout()
+        # ... and login with staff
+        self.assertEqual(
+            self.client.login(
+                username=self.staff.username,
+                password='hostel77'),
+            True)
+
+        # change licence back to old one (get 302, staff can change licence) :
+        result = self.client.post(
+            reverse('zds.article.views.edit') + 
+                '?article={}'.format(self.article.pk),
+            {
+                'title': self.article.title,
+                'description': self.article.description,
+                'text': self.article.get_text(),
+                'subcategory': self.article.subcategory.all(),
+                'licence' : self.licence.pk
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # test change :
+        article = Article.objects.get(pk=self.article.pk)
+        self.assertEqual(article.licence.pk, self.licence.pk)
+        self.assertNotEqual(article.licence.pk, new_licence.pk)
+
+        # test change in JSON :
+        json = article.load_json()
+        self.assertEquals(json['licence'], self.licence.code)
+
+        # then logout ...
+        self.client.logout()
+
+        # change licence (get 302, redirection to login page) :
+        result = self.client.post(
+            reverse('zds.article.views.edit') + 
+                '?article={}'.format(self.article.pk),
+            {
+                'title': self.article.title,
+                'description': self.article.description,
+                'text': self.article.get_text(),
+                'subcategory': self.article.subcategory.all(),
+                'licence' : new_licence.pk
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # test change (normaly, nothing has) :
+        article = Article.objects.get(pk=self.article.pk)
+        self.assertEqual(article.licence.pk, self.licence.pk)
+        self.assertNotEqual(article.licence.pk, new_licence.pk)
+        
+        # login with random user
+        self.assertEqual(
+            self.client.login(
+                username=self.user.username,
+                password='hostel77'),
+            True)
+
+        # change licence (get 403, random user cannot edit article if not in
+        # authors list) :
+        result = self.client.post(
+            reverse('zds.article.views.edit') + 
+                '?article={}'.format(self.article.pk),
+            {
+                'title': self.article.title,
+                'description': self.article.description,
+                'text': self.article.get_text(),
+                'subcategory': self.article.subcategory.all(),
+                'licence' : new_licence.pk
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        # test change (normaly, nothing has) :
+        article = Article.objects.get(pk=self.article.pk)
+        self.assertEqual(article.licence.pk, self.licence.pk)
+        self.assertNotEqual(article.licence.pk, new_licence.pk)
+
+        # test change in JSON (normaly, nothing has) :
+        json = article.load_json()
+        self.assertEquals(json['licence'], self.licence.code)
 
     def tearDown(self):
         if os.path.isdir(settings.REPO_ARTICLE_PATH):

--- a/zds/article/tests.py
+++ b/zds/article/tests.py
@@ -389,11 +389,11 @@ class ArticleTests(TestCase):
         # logout before
         self.client.logout()
         # login with author
-        self.assertEqual(
+        self.assertTrue(
             self.client.login(
                 username=self.user_author.username,
-                password='hostel77'),
-            True)
+                password='hostel77')
+        )
 
         # change licence (get 302) :
         result = self.client.post(
@@ -421,11 +421,11 @@ class ArticleTests(TestCase):
         # then logout ...
         self.client.logout()
         # ... and login with staff
-        self.assertEqual(
+        self.assertTrue(
             self.client.login(
                 username=self.staff.username,
-                password='hostel77'),
-            True)
+                password='hostel77')
+        )
 
         # change licence back to old one (get 302, staff can change licence) :
         result = self.client.post(
@@ -473,11 +473,11 @@ class ArticleTests(TestCase):
         self.assertNotEqual(article.licence.pk, new_licence.pk)
         
         # login with random user
-        self.assertEqual(
+        self.assertTrue(
             self.client.login(
                 username=self.user.username,
-                password='hostel77'),
-            True)
+                password='hostel77')
+        )
 
         # change licence (get 403, random user cannot edit article if not in
         # authors list) :

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -110,7 +110,6 @@ def view(request, article_pk, article_slug):
     article_version['pk'] = article.pk
     article_version['slug'] = article.slug
     article_version['image'] = article.image
-    article_version['licence'] = article.licence
     article_version['sha_draft'] = article.sha_draft
     article_version['sha_validation'] = article.sha_validation
     article_version['sha_public'] = article.sha_public
@@ -321,9 +320,13 @@ def edit(request):
             for subcat in form.cleaned_data['subcategory']:
                 article.subcategory.add(subcat)
 
-            if "licence" in data and data["licence"] != "":
-                lc = Licence.objects.filter(pk=data["licence"]).all()[0]
-                article.licence = lc
+            if "licence" in data:
+                if data["licence"] != "":
+                    lc = Licence.objects.filter(pk=data["licence"]).all()[0]
+                    article.licence = lc
+                else:
+                    article.licence = None
+            
 
             article.save()
 

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -385,8 +385,9 @@ def maj_repo_article(
         shutil.rmtree(old_slug_path)
     else:
         if action == 'maj':
-            shutil.move(old_slug_path, new_slug_path)
-            repo = Repo(new_slug_path)
+            if old_slug_path != new_slug_path:
+                shutil.move(old_slug_path, new_slug_path)
+                repo = Repo(new_slug_path)
             msg = 'Modification de l\'article'
         elif action == 'add':
             os.makedirs(new_slug_path, mode=0o777)

--- a/zds/utils/articles.py
+++ b/zds/utils/articles.py
@@ -15,6 +15,8 @@ def export_article(article):
     dct['description'] = article.description
     dct['type'] = 'article'
     dct['text'] = article.text
+    if article.licence:
+        dct['licence'] = article.licence.code
 
     return dct
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1109 |

Ce qui a été fait :
- Ajouter un champ "licence" dans la base de donnée sur la table article (donc faire un `manage.py migrate`)
- Faire en sorte que ce champ licence se retrouve dans le manifest.json
- Ajout de la possibilité d'éditer la licence dans les formulaires correspondants.
- Visualisation de la licence dans les templates correspondants.

(le tout largement inspiré de ce qui se fait pour les tutos)

Mais aussi : 
- Déplacement de `template/article/view.html` vers `/templates/articles/user/view_online.html`, pour garder le même workflow que sur les tutoriaux
- ~~Retirer le `pager` de `view_online.html`, qui n'as rien à y faire, un article ne fera jamais plusieurs pages.~~ **je n'avais pas le droit de faire ça.**
# Note pour QA

Ce n'est pas absolument urgent, l'issue a le label "V1" et pas "RCx"

Il faut tester tout le _workflow_ des articles, donc : 
- **Migrer la base** avec `manage.py migrate`
- **Tenter de créer un nouvel article**, vérifier qu'on sais bien lui assigner une licence. **Faire une prévisualisation avant de créer l'article** et vérifier qu'on retombe bien sur le formulaire et que la licence reste bonne (ce n'était pas le cas avant) ;
- **Vérifier la présence de la licence** sur la preview en _off_ de l'article, à droite du titre
- **Modifier la licence** et vérifier que ça impacte bien l'affichage en _off_. **Regarder le manifest.JSON**, vérifier que la licence y est bien, et qu'elle change si on en change.
- **Valider l'article** et vérifier que la licence est présente sur la page en _online_.
- Si c'était possible, **regarder si le comportement d'anciens articles n'est pas affecté** par la mise à jour de la base. J'espère que non, mais je n'ais pas d'ancien articles pour le vérifier.

(et avant toute chose, [n'oubliez pas de créer des licences bidons sur votre version locale](http://zestedesavoir.com/forums/sujet/665/gestion-des-licences/), ou vous n'aurez pas grand chose à QA)
