### PR TITLE
Corrige le bug des cookies #1184

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -471,6 +471,18 @@
 
 
 
+    
+
+    {# Google Tag Manager #}
+    <noscript id="gtm">
+        <iframe src="//www.googletagmanager.com/ns.html?id=GTM-WH7642"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+
+
+
+
+
     {# Javascript stuff start #}
     {% if debug %}
         <script src="/static/js/vendors.js"></script>
@@ -495,13 +507,5 @@
         });
     </script>
     <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-
-    
-
-    {# Google Tag Manager #}
-    <noscript id="gtm">
-        <iframe src="//www.googletagmanager.com/ns.html?id=GTM-WH7642"
-        height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
 </body>
 </html>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1184 |

Cette fois, c'est garanti sans pépins ! C'était un soucis du au fait que je n'attends pas que le DOM soit chargé à fond pour lancer le JS, car le JS est tout en bas de la page. Seulement, GTM était en dessous du JS, je l'ai donc remonté et tout fonctionne désormais !
