### PR TITLE
Corrige les erreurs 500 sur la page Tuto/Articles publiés par x

### DIFF
--- a/templates/article/find.html
+++ b/templates/article/find.html
@@ -27,7 +27,7 @@
     {% endwith %}
 
     <li>
-        <a href="{% url "zds.article.views.find_article" usr.username %}">
+        <a href="{% url "zds.article.views.find_article" usr.pk %}">
             Articles rédigés
         </a>
     </li>

--- a/templates/tutorial/member/online.html
+++ b/templates/tutorial/member/online.html
@@ -13,11 +13,13 @@
 
 {% block breadcrumb %}
     {% with profile=usr|profile %}
-        <li ><a href="{{ profile.get_absolute_url }}">{{ usr.username }}</a></li>
+        <li><a href="{{ profile.get_absolute_url }}">{{ usr.username }}</a></li>
     {% endwith %}
-    <li><a href="{% url "zds.tutorial.views.find_tuto" usr.username %}">Tutoriels publiés</a></li>
+    <li><a href="{% url "zds.tutorial.views.find_tuto" usr.pk %}">Tutoriels publiés</a></li>
     <li>Recherche</li>
 {% endblock %}
+
+
 
 {% block headline %}
     <h2 class="ico-after ico-tutorials">Tutoriels publiés par {{ usr.username }}</h2>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | #1187 |

Cette PR corrige les erreurs 500 provoqué lorsque l'on veut voir les tutos/articles en ligne d'un membre. Le champ username était utilisé au lieu de la pk.
##### Note pour QA
- S'assurer que les liens de la sidebar dans un profil fontionne tous sans erreur 500
- Si le membre observé a des tutos en beta/publié ils doivent etre affiché quand ils sont demandé
- Si le membre a publié des articles ils doivent s'afficher quand ils sont demandé
