### PR TITLE
Fix #1182 & complète ma précédente PR

### DIFF
--- a/templates/tutorial/includes/chapter.part.html
+++ b/templates/tutorial/includes/chapter.part.html
@@ -7,7 +7,7 @@
     {% if not chapter.type = 'MINI' %}
         {% if chapter.intro and chapter.intro != "None" %}
             {{ chapter.intro|emarkdown }}
-        {% else %}
+        {% elif not tutorial.in_beta or tutorial.sha_beta != version %}
             <p class="ico-after warning">
                 Il n'y a pas d'introduction.
             </p>
@@ -112,7 +112,7 @@
     {% if not chapter.type = 'MINI' %}
         {% if chapter.conclu and chapter.conclu != "None" %}
             {{ chapter.conclu|emarkdown }}
-        {% else %} 
+        {% elif not tutorial.in_beta or tutorial.sha_beta != version %} 
             <p class="ico-after warning">
                 Il n'y a pas de conclusion.
             </p>

--- a/templates/tutorial/part/view.html
+++ b/templates/tutorial/part/view.html
@@ -37,7 +37,7 @@
 {% block content %}
     {% if part.intro and part.intro != "None" %}
         {{ part.intro|emarkdown }}
-    {% else %}
+    {% elif not tutorial.in_beta or tutorial.sha_beta != version %}
         <p class="ico-after warning">
             Il n'y a pas d'introduction.
         </p>
@@ -84,7 +84,7 @@
 
     {% if part.conclu and part.conclu != "None" %}
         {{ part.conclu|emarkdown }}
-    {% else %}
+    {% elif not tutorial.in_beta or tutorial.sha_beta != version %}
         <p class="ico-after warning">
             Il n'y a pas de conclusion.
         </p>

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -52,7 +52,7 @@
     {% with tuto_version=tutorial|repo_tuto:version %}
         {% if tuto_version.introduction and tuto_version.introduction != "None" %}
             {{ tuto_version.introduction|emarkdown }}
-        {% else %}
+        {% elif not tutorial.in_beta or tutorial.sha_beta != version %}
             <p class="ico-after warning">
                 Il n'y a pas d'introduction.
             </p>
@@ -86,7 +86,7 @@
 
         {% if tuto_version.conclusion and tuto_version.conclusion != "None" %}
             {{ tuto_version.conclusion|emarkdown }}
-        {% else %}
+        {% elif not tutorial.in_beta or tutorial.sha_beta != version %}
             <p class="ico-after warning">
                 Il n'y a pas de conclusion.
             </p>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bug ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Ticket Concerné ? | [#1182](https://github.com/zestedesavoir/zds-site/issues/1182) |

Bon, voilà, ma (seconde) PR, pour compléter la précédente. Je rappelle ce qu'elle fait.

Elle permet dès lors qu'un tutoriel se trouve en bêta, et qu'aucune introduction ou conclusion n'est mises, que les bandeaux oranges qui se trouvent lors de l'édition côté auteur, n’apparaissent pas.
## Note pour la QA
### Pour les big tutoriels
- Créer un tutoriel
- Ne lui donner **pas d'introduction** et **pas de conclusion**
- Rajouter lui une partie
- À cette partie encore une fois ne lui rajouter **pas d'introduction ni de conclusion**
- Rajouter un chapitre
- Ne lui donner pas d'introduction ni de conclusion
- Rajouter un extrait
- Passer le tutoriel en bêta
- Vérifier que les bandeaux n’apparaissent pas
### Pour les minis tutoriels
- Créer un tutoriel
- Ne lui donner **pas d'introduction** et **pas de conclusion**
- Rajouter un extrait
- Passer le tutoriel en bêta
- Vérifier que les bandeaux n’apparaissent pas
