### PR TITLE
Fix #1197

### DIFF
--- a/templates/forum/find/topic.html
+++ b/templates/forum/find/topic.html
@@ -54,6 +54,10 @@
                     {{ topic.first_post.text|truncatechars:200|emarkdown|striptags }}
                 </td>
             </tr>
+            {% empty %}
+            <p>
+                Aucun sujet disponible.
+            </p>
             {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
Quand on va sur le profil d'un utilisateur qui n'a encore créé aucun sujet, au lieu d'avoir un message l'indiquant, le tableau apparait.
