### PR TITLE
Allège le téléchargement de GitPython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ django-discover-runner==0.4
 pygeoip==0.3.1
 pillow
 git+https://github.com/zestedesavoir/Python-ZMarkdown.git@2.4.1-zds.7
-git+https://github.com/zestedesavoir/GitPython.git@0.3.2-RC1.z2
+https://github.com/zestedesavoir/GitPython/archive/0.3.2-RC1.z2.zip
 flake8
 autopep8
 easy-thumbnails


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | [Installation allégée](http://zestedesavoir.com/forums/sujet/595/creer-un-repo-pip-pour-nos-dependances-ou-les-mettre-sur-les-repos-officiels/) |

Suffit de faire un `pip install --upgrade -r requirements.txt` et de vérifier qu'après ça, GitPython est toujours là et fonctionnel.

L'idéal serait de tester sur une installation vierge.

Le but de la PR est d'éviter de devoir cloner tout le repo, et de simplement télécharger une archive qui contient le repo à la version mentionné, sans l'historique.
