### PR TITLE
Corrige les dropdown sur Firefox et sur mobile (navigateur natif Android)

### DIFF
--- a/assets/js/data-click.js
+++ b/assets/js/data-click.js
@@ -7,7 +7,19 @@
 (function($){
     "use strict";
     
-    $("[data-click]").on("click focus", function(e){
+    var dropdownMouseDown = false;
+    
+    $("[data-click]")
+    .on("mousedown", function(){
+        dropdownMouseDown = true;
+    })
+    .on("mouseup", function(){
+        dropdownMouseDown = false;
+    })
+    .on("click focus", function(e){
+        if(e.type === "focus" && !dropdownMouseDown)
+            return false;
+
         if(!($(this).hasClass("dont-click-if-sidebar") && $(".header-container .mobile-menu-btn").is(":visible"))){
             e.preventDefault();
             e.stopPropagation();

--- a/assets/js/data-click.js
+++ b/assets/js/data-click.js
@@ -17,7 +17,7 @@
         dropdownMouseDown = false;
     })
     .on("click focus", function(e){
-        if(e.type === "focus" && !dropdownMouseDown)
+        if(e.type === "focus" && dropdownMouseDown)
             return false;
 
         if(!($(this).hasClass("dont-click-if-sidebar") && $(".header-container .mobile-menu-btn").is(":visible"))){

--- a/assets/js/dropdown-menu.js
+++ b/assets/js/dropdown-menu.js
@@ -23,6 +23,9 @@
             dropdownMouseDown = false;
         })
         .on("click", function(e){
+            if(($(this).parents(".header-menu-list").length > 0 && parseInt($("html").css("width")) < 960))
+                return true;
+
             e.preventDefault();
             e.stopPropagation();
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |

Pour tester : 
- sur le navigateur natif d'Android, il était impossible de cliquer sur "Forum" et "Tutoriels". Normalement avec cette PR ça doit fonctionner
- sur Firefox, en tant que membre, la roue dentée -- avant la PR -- ouvrait et fermait aussitôt le menu déroulant la première fois. Après cette PR, le menu doit fonctionner normalement.
