### PR TITLE
Permet le versionage des thumbnails des articles

### DIFF
--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -164,13 +164,13 @@ class Article(models.Model):
     def save(self, *args, **kwargs):
         self.slug = slugify(self.title)
         
-        if has_changed(self, 'image') and self.image:
+        '''if has_changed(self, 'image') and self.image:
             old = get_old_field_value(self, 'image', 'objects')
             
             if old is not None and len(old.name) > 0:
                 root = settings.MEDIA_ROOT
                 name = os.path.join(root, old.name)
-                os.remove(name)
+                os.remove(name)'''
 
         super(Article, self).save(*args, **kwargs)
 

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -163,14 +163,6 @@ class Article(models.Model):
 
     def save(self, *args, **kwargs):
         self.slug = slugify(self.title)
-        
-        '''if has_changed(self, 'image') and self.image:
-            old = get_old_field_value(self, 'image', 'objects')
-            
-            if old is not None and len(old.name) > 0:
-                root = settings.MEDIA_ROOT
-                name = os.path.join(root, old.name)
-                os.remove(name)'''
 
         super(Article, self).save(*args, **kwargs)
 

--- a/zds/article/tests.py
+++ b/zds/article/tests.py
@@ -89,8 +89,8 @@ class ArticleTests(TestCase):
         self.assertEquals(len(mail.outbox), 1)
         mail.outbox = []
 
-    def test_delete_image_on_change(self):
-        """test que l'image est bien supprimée quand on la change"""
+    def test_not_delete_image_on_change(self):
+        '''test if image IS NOT deleted on change (for versioning)'''
 
         root = settings.SITE_ROOT
         if not os.path.isdir(settings.MEDIA_ROOT):
@@ -108,32 +108,29 @@ class ArticleTests(TestCase):
 
         self.article.image = self.logo1
         self.article.save()
-        self.assertEqual(
+        self.assertTrue(
             os.path.exists(
                 os.path.join(
                     settings.MEDIA_ROOT, self.article.image.name
                 )
-            ),
-            True
+            )
         )
         # now that we have a first image, let's change it
 
         oldAddress = self.article.image.name
         self.article.image = self.logo2
         self.article.save()
-        self.assertEqual(
+        self.assertTrue(
             os.path.exists(
                 os.path.join(
                     settings.MEDIA_ROOT, self.article.image.name
                 )
-            ),
-            True
+            )
         )
-        self.assertEqual(
+        self.assertTrue(
             os.path.exists(
                 os.path.join(settings.MEDIA_ROOT, oldAddress)
-            ),
-            False
+            )
         )
         os.unlink(self.logo2)
         # shutil.rmtree(settings.MEDIA_ROOT)

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -957,10 +957,9 @@ def answer(request):
             for line in reaction_cite.text.splitlines():
                 text = text + '> ' + line + '\n'
 
-            text = u'{0}Source:[{1}]({2}{3})'.format(
+            text = u'{0}Source:[{1}]({2})'.format(
                 text,
                 reaction_cite.author.username,
-                settings.SITE_URL,
                 reaction_cite.get_absolute_url())
 
         form = ReactionForm(article, request.user, initial={

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -939,9 +939,10 @@ def answer(request):
             for line in reaction_cite.text.splitlines():
                 text = text + '> ' + line + '\n'
 
-            text = u'{0}Source:[{1}]({2})'.format(
+            text = u'{0}Source:[{1}]({2}{3})'.format(
                 text,
                 reaction_cite.author.username,
+                settings.SITE_URL,
                 reaction_cite.get_absolute_url())
 
         form = ReactionForm(article, request.user, initial={

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -957,9 +957,10 @@ def answer(request):
             for line in reaction_cite.text.splitlines():
                 text = text + '> ' + line + '\n'
 
-            text = u'{0}Source:[{1}]({2})'.format(
+            text = u'{0}Source:[{1}]({2}{3})'.format(
                 text,
                 reaction_cite.author.username,
+                settings.SITE_URL,
                 reaction_cite.get_absolute_url())
 
         form = ReactionForm(article, request.user, initial={

--- a/zds/utils/articles.py
+++ b/zds/utils/articles.py
@@ -17,6 +17,9 @@ def export_article(article):
     dct['text'] = article.text
     if article.licence:
         dct['licence'] = article.licence.code
+    dct['image_url'] = ''
+    if article.image:
+        dct['image_url'] = article.image.name
 
     return dct
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1195 (en partie) #754 |

Ce qui a été fait :  
- Rajouter la prise en compte du versionage dans `view_online()`  de /zds/articles/view.py
- Lever une erreur 404 si la version publique n'existe pas.
- Empêcher la suppression des thumbnails précédents, ce qui était le cas avant (dans `save()` de /zds/article/models.py)
- Ajout d'un champ supplémentaire, `image_url` au manifest.json des articles (dans `exort_article()` de /zds/utils/articles.py)
- Aller effectivement rechercher l'url du thumbnail dans le JSON  (avec mécanisme pour gérer les articles créé AVANT ce commit et qui n'ont pas le champ `image_url`)
- Modification d'un test unitaire existant : Les thumbnails ne doivent plus être supprimée si on en change, ou
  alors, le versionnage ne sert à rien. Le test est donc modifié pour tester que l'image N'EST PAS supprimée ((`zds.article.tests.ArticleTests.test_not_delete_image_on_change`).
- Ajout d'un nouveau test untaire  pour savoir si les thumbnails sont effectivement bien
  versionnées (`zds.article.tests.ArticleTests.test_versionning_image`)
# Note pour QA

Attention, cet PR modifie la structure interne des articles, elle doit donc être testée avec le plus grand soin. La QA **doit** donc ce faire en 2 étapes : 

**AVANT d'intéger ma branche :**
- Créer un article avec pour titre "validé-1", lui donner une image, le faire valider
- Créer un second article avec pour titre "validé-2", ne pas lui donner d'image, le faire valider
- Créer un troisième article avec pour titre "brouillon", lui donner une image, le garder en brouillon

**PUIS SEULEMENT intégrer ma branche**, et faire les tests suivant : 
- Tester que les trois articles précédemment créé sont toujours accessibles, d'une part en brouillon, d'autre part dans leur version publique pour "validé-1" et "validé-2". 
- Changer le titre de "validé-1" en "validé-1-titre-modifié". Vérifier que le changement c'est bien fait sur le brouillon mais pas sur la version publique.
- Changer la thumbnail de "validé-1-titre-modifié". Constater que cette thumbnail a bien changé sur la version brouillon, MAIS AUSSI sur la version publique. C'est normal, c'est le mécanisme de protection contre ce qui se passait AVANT versionnage de la thumbnail.
- Valider "validé-1-titre-modifié". Vérifier que le titre a bien changé sur la version publique (versionnage des titre effectivement actif, fix #1195), et que la thumbnail est toujours la bonne.
- Changer une fois encore l'image de "validé-1-titre-modifié". Constater qu'elle est bien modifiée sur la version brouillon, mais cette fois PAS SUR LA VERSION PUBLIQUE. C'est normal, puisque le versionnage de l'image est désormais actif (si ce test plante, la PR tombe, puisque fix #754). Éventuellement, jouer avec "l'historique de modification" pour vérifier qu'entre la version actuelle et la précédente, la modification est bien active.
- Envoyer une une fois encore "validé-1-titre-modifié" en validation MAIS NE PAS LA VALIDER TOUT DE SUITE. Changer alors une fois encore la thumbnail de "validé-1-titre-modifié" en brouillon, et le titre en "validé-1-titre-modifié-encore-une-fois".
- Vérifier que la thumbnail de la validation correspond bien à celle qu'elle devrait être (donc pas la dernière en date, mais celle d'avant). Vérifié que le titre en validation est toujours "validé-1-titre-modifié". Valider et vérifier que la thumbnail est toujours la même qu'en validation (et ne correspond donc toujours pas à la dernière version en date, qui a été modifiée entre temps), et pareil pour le titre.

Pour faire cette PR, je vous conseille de prendre comme image des images avec des numéros dessus, au moins ça saute aux yeux.

**NOTE TRÈS IMPORTANTE :**  il y a des incohérence de titre sur la page d'accueil, sur la page de listing des articles publiés de l'auteur et sur la page de listing des articles publiés de manière générale. Je le sais très bien et "c'est normal", dans le sens ou c'est du au fait que c'est le titre de la dernière version  qui est stocké en BDD. Cette PR n'as pas pour but de régler ce problème, inutile donc de me faire remarquer ça (**c'est le but de l'issue #1212** !!!)
