### PR TITLE
Corrige la Lecture zen

### DIFF
--- a/assets/scss/_wide.scss
+++ b/assets/scss/_wide.scss
@@ -247,6 +247,7 @@
                 }
 
                 .reactions-title,
+                .pagination:not(.pagination-chapter),
                 .topic-message {
                     display: none;
                 }

--- a/templates/article/view.html
+++ b/templates/article/view.html
@@ -61,7 +61,7 @@
     {{ article.txt|safe }}
 
  
-     {% include "article/includes/pager.part.html" %}
+    {% include "article/includes/pager.part.html" %}
 {% endblock %}
 
 

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -203,7 +203,7 @@ def view_online(request, article_pk, article_slug):
     # Build form to send a reaction for the current article.
     form = ReactionForm(article, request.user)
 
-    return render_template('article/member/view_online.html', {
+    return render_template('article/view.html', {
         'article': article_version,
         'authors': article.authors,
         'tags': article.subcategory,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1196 |

*_Pour la QA : *_ Aller sur un article ou un tutoriel avec une pagination sur les réactions/commentaires, et activer la lecture zen. Il faut alors vérifier que la pagination n'est pas visible, mais qu'elle le reste quand on retire la lecture zen.
