### PR TITLE
ne plus rediriger en cas de modification de titre

### DIFF
--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -638,11 +638,6 @@ def view_tutorial(request, tutorial_pk, tutorial_slug):
         if not request.user.has_perm("tutorial.change_tutorial"):
             raise PermissionDenied
 
-    # Make sure the URL is well-formed
-
-    if not tutorial_slug == slugify(tutorial.title):
-        return redirect(tutorial.get_absolute_url())
-
 
     # Two variables to handle two distinct cases (large/small tutorial)
 
@@ -1367,11 +1362,6 @@ def view_chapter(
     if request.user not in tutorial.authors.all() and not is_beta:
         if not request.user.has_perm("tutorial.change_tutorial"):
             raise PermissionDenied
-
-    if not tutorial_slug == slugify(tutorial.title) or not part_slug \
-            == slugify(chapter.part.title) or not chapter_slug \
-            == slugify(chapter.title):
-        return redirect(chapter.get_absolute_url())
 
     # find the good manifest file
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1228 |

Cette PR s'assure que lorsqu'on modifie le titre d'un tutoriel, d'un chapitre ou d'une partie, la consultation d'une version historisée ne ramène plus à la dernière version en date.

**Note pour QA**
- Créer un tutoriel, avec une partie.
- Dans cette partie, créer un chapitre
- Renommer la partie
- Via l'historique de modification, remonter à la version précédente : vérifiez qu'on peut encore accéder à la partie avec son nom non modifié
- Vérifiez que si on tente d'acceder à un chapitre, on a bien la version correspondante et non la dernière version en date.
