### PR TITLE
Masque les topics privés dans le sitemap

### DIFF
--- a/zds/urls.py
+++ b/zds/urls.py
@@ -60,7 +60,7 @@ sitemaps = {
         priority=0.7
     ),
     'topics': GenericSitemap(
-        {'queryset': Topic.objects.filter(is_locked=False), 'date_field': 'pubdate'},
+        {'queryset': Topic.objects.filter(is_locked=False, forum__group__isnull=True), 'date_field': 'pubdate'},
         changefreq='hourly',
         priority=0.7
     ),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1230 |

Cette PR vient masquer les topics privés dans le sitemaps.xml

**Note pour QA**

Il faut crée des topics privés et publics et consulter le fichier `/sitemap-topics.xml` pour constater qu'il n'y a pas de topic privés qui apparait dans celui-ci.
