### PR TITLE
fix 843 : les conflits d'éditions simultanés donnent lieu à un écrasement

### DIFF
--- a/templates/tutorial/chapter/edit.html
+++ b/templates/tutorial/chapter/edit.html
@@ -41,7 +41,9 @@
 
 {% block content %}
     {% if new_version %}
-        <p>Une nouvelle version a été postée</p>
+        <p class="ico-after warning">
+            Une nouvelle version a été postée avant que vous ne validiez.
+        </p>
     {% endif%}
     {% crispy form %}
 {% endblock %}

--- a/templates/tutorial/chapter/edit.html
+++ b/templates/tutorial/chapter/edit.html
@@ -40,5 +40,8 @@
 
 
 {% block content %}
+    {% if new_version %}
+        <p>Une nouvelle version a été postée</p>
+    {% endif%}
     {% crispy form %}
 {% endblock %}

--- a/templates/tutorial/chapter/edit.html
+++ b/templates/tutorial/chapter/edit.html
@@ -44,6 +44,6 @@
         <p class="ico-after warning">
             Une nouvelle version a été postée avant que vous ne validiez.
         </p>
-    {% endif%}
+    {% endif %}
     {% crispy form %}
 {% endblock %}

--- a/templates/tutorial/extract/edit.html
+++ b/templates/tutorial/extract/edit.html
@@ -29,6 +29,9 @@
 
 
 {% block content %}
+    {% if new_version %}
+        <p>Une nouvelle version a été postée</p>
+    {% endif%}
     {% crispy form %}
 
     {% if form.text.value %}

--- a/templates/tutorial/extract/edit.html
+++ b/templates/tutorial/extract/edit.html
@@ -30,7 +30,9 @@
 
 {% block content %}
     {% if new_version %}
-        <p>Une nouvelle version a été postée</p>
+        <p class="ico-after warning">
+            Une nouvelle version a été postée avant que vous ne validiez.
+        </p>
     {% endif%}
     {% crispy form %}
 

--- a/templates/tutorial/extract/edit.html
+++ b/templates/tutorial/extract/edit.html
@@ -33,7 +33,7 @@
         <p class="ico-after warning">
             Une nouvelle version a été postée avant que vous ne validiez.
         </p>
-    {% endif%}
+    {% endif %}
     {% crispy form %}
 
     {% if form.text.value %}

--- a/templates/tutorial/part/edit.html
+++ b/templates/tutorial/part/edit.html
@@ -35,5 +35,8 @@
 
 
 {% block content %}
+    {% if new_version %}
+        <p>Une nouvelle version a été postée</p>
+    {% endif%}
    {% crispy form %}
 {% endblock %}

--- a/templates/tutorial/part/edit.html
+++ b/templates/tutorial/part/edit.html
@@ -36,7 +36,9 @@
 
 {% block content %}
     {% if new_version %}
-        <p>Une nouvelle version a été postée</p>
-    {% endif%}
+        <p class="ico-after warning">
+            Une nouvelle version a été postée avant que vous ne validiez.
+        </p>
+    {% endif %}
    {% crispy form %}
 {% endblock %}

--- a/templates/tutorial/tutorial/edit.html
+++ b/templates/tutorial/tutorial/edit.html
@@ -32,9 +32,9 @@
 
 {% block content %}
     {% if new_version %}
-    <p class="ico-after warning">
-        Une nouvelle version a été postée avant que vous ne validiez.
-    </p>
+        <p class="ico-after warning">
+            Une nouvelle version a été postée avant que vous ne validiez.
+        </p>
     {% endif %}
     {% crispy form %}
 {% endblock %}

--- a/templates/tutorial/tutorial/edit.html
+++ b/templates/tutorial/tutorial/edit.html
@@ -21,23 +21,20 @@
 
 
 {% block headline_sub %}
-    {{ tutorial.description }}
+   {{ tutorial.description }}
 {% endblock %}
-
-
-
 {% block breadcrumb %}
     <li><a href="{{ tutorial.get_absolute_url }}">{{ tutorial.title }}</a></li>
     <li>Éditer le tutoriel</li>
-    
-
 {% endblock %}
 
 
 
 {% block content %}
     {% if new_version %}
-        <p>Une nouvelle version a été postée</p>
-    {% endif%}
+    <p class="ico-after warning">
+        Une nouvelle version a été postée avant que vous ne validiez.
+    </p>
+    {% endif %}
     {% crispy form %}
 {% endblock %}

--- a/templates/tutorial/tutorial/edit.html
+++ b/templates/tutorial/tutorial/edit.html
@@ -29,10 +29,15 @@
 {% block breadcrumb %}
     <li><a href="{{ tutorial.get_absolute_url }}">{{ tutorial.title }}</a></li>
     <li>Éditer le tutoriel</li>
+    
+
 {% endblock %}
 
 
 
 {% block content %}
+    {% if new_version %}
+        <p>Une nouvelle version a été postée</p>
+    {% endif%}
     {% crispy form %}
 {% endblock %}

--- a/zds/tutorial/forms.py
+++ b/zds/tutorial/forms.py
@@ -108,6 +108,7 @@ class TutorialForm(FormWithTitle):
             Field('image'),
             Field('introduction', css_class='md-editor'),
             Field('conclusion', css_class='md-editor'),
+            Hidden('last_hash', '{{ last_hash }}'),
             Field('subcategory'),
             Field('licence'),
             ButtonHolder(
@@ -153,6 +154,7 @@ class PartForm(FormWithTitle):
             Field('title'),
             Field('introduction', css_class='md-editor'),
             Field('conclusion', css_class='md-editor'),
+            Hidden('last_hash', '{{ last_hash }}'),
             ButtonHolder(
                 StrictButton(
                     'Valider',
@@ -200,6 +202,7 @@ class ChapterForm(FormWithTitle):
             Field('image'),
             Field('introduction', css_class='md-editor'),
             Field('conclusion', css_class='md-editor'),
+            Hidden('last_hash', '{{ last_hash }}'),
             ButtonHolder(
                 StrictButton(
                     'Valider',
@@ -236,7 +239,8 @@ class EmbdedChapterForm(forms.Form):
                 u'Contenu',
                 Field('image'),
                 Field('introduction', css_class='md-editor'),
-                Field('conclusion', css_class='md-editor')
+                Field('conclusion', css_class='md-editor'),
+                Hidden('last_hash', '{{ last_hash }}'),
             ),
             ButtonHolder(
                 Submit('submit', 'Valider')
@@ -265,6 +269,7 @@ class ExtractForm(FormWithTitle):
 
         self.helper.layout = Layout(
             Field('title'),
+            Hidden('last_hash', '{{ last_hash }}'),
             CommonLayoutEditor()
         )
 
@@ -387,8 +392,9 @@ class AskValidationForm(forms.Form):
             StrictButton(
                 'Confirmer',
                 type='submit'),
-            Hidden('tutorial', '{{ tutorial.pk }}'), 
-            Hidden('version', '{{ version }}'), )
+            Hidden(
+                'tutorial', '{{ tutorial.pk }}'), Hidden(
+                'version', '{{ version }}'), )
 
 
 class ValidForm(forms.Form):

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -722,7 +722,8 @@ class BigTutorialTests(TestCase):
                 'title': u"Chapitre 3 : edition de titre",
                 'introduction': u"Edition d'introduction",
                 'conclusion': u"Edition de conlusion",
-                "last_hash": compute_hash([os.path.join(c3.get_path(),"introduction.md"),os.path.join(c3.get_path(),"conclusion.md")])
+                "last_hash": compute_hash([os.path.join(c3.get_path(),"introduction.md"),
+				    os.path.join(c3.get_path(),"conclusion.md")])
             },
             follow=True)
         self.assertContains(response=result, text = u"Chapitre 3 : edition de titre")
@@ -753,7 +754,8 @@ class BigTutorialTests(TestCase):
                 'title': u"Chapitre 2 : edition de titre",
                 'introduction': u"Edition d'introduction",
                 'conclusion': u"Edition de conlusion",
-                "last_hash": compute_hash([os.path.join(c2.get_path(),"introduction.md"),os.path.join(c2.get_path(),"conclusion.md")])
+                "last_hash": compute_hash([os.path.join(c2.get_path(),"introduction.md"),
+				    os.path.join(c2.get_path(),"conclusion.md")])
             },
             follow=True)
         self.assertContains(response=result, text = u"Chapitre 2 : edition de titre")
@@ -797,6 +799,112 @@ class BigTutorialTests(TestCase):
             follow=True)
         self.assertEqual(Chapter.objects.filter(part__tutorial=tuto.pk).count(), 2)
         self.assertEqual(Part.objects.filter(tutorial=tuto.pk).count(), 2)
+
+    def test_conflict_does_not_destroy(self):
+        """tests that simultaneous edition does not conflict"""
+        sub = SubCategory()
+        sub.title = "toto"
+        sub.save()
+       	# logout before
+        self.client.logout()
+        # first, login with author :
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+        # test tuto
+        (introduction_path, conclusion_path) =(os.path.join(self.bigtuto.get_path(),"introduction.md"), os.path.join(self.bigtuto.get_path(),"conclusion.md"))
+        hash = compute_hash([introduction_path, conclusion_path])
+        self.client.post(
+            reverse('zds.tutorial.views.edit_tutorial')+'?tutoriel={0}'.format(self.bigtuto.pk),
+            {
+                'title': self.bigtuto.title,
+                'description': "nouvelle description",
+                'subcategory': [sub.pk],
+                'introduction': self.bigtuto.get_introduction() +" un essai",
+                'conclusion': self.bigtuto.get_conclusion(),
+                'last_hash': hash 
+            }, follow= True)
+        conflict_result = self.client.post(
+            reverse('zds.tutorial.views.edit_tutorial')+'?tutoriel={0}'.format(self.bigtuto.pk),
+            {
+                'title': self.bigtuto.title,
+                'description': "nouvelle description",
+                'subcategory': [sub.pk],
+                'introduction': self.bigtuto.get_introduction() +" conflictual",
+                'conclusion': self.bigtuto.get_conclusion(),
+                'last_hash': hash 
+            }, follow= False)
+        self.assertEqual(conflict_result.status_code, 200)
+        self.assertContains(response=conflict_result, text = u"nouvelle version")
+
+        # test parts
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_part') + '?tutoriel={}'.format(self.bigtuto.pk),
+            {
+                'title': u"Partie 2",
+                'introduction': u"Analyse",
+                'conclusion': u"Fin de l'analyse",
+            },
+            follow=False)
+        p1 = Part.objects.last()
+        hash = compute_hash([os.path.join(p1.tutorial.get_path(), p1.introduction),
+                    os.path.join(p1.tutorial.get_path(), p1.conclusion)])        
+        self.client.post(
+            reverse('zds.tutorial.views.edit_part') + '?partie={}'.format(p1.pk),
+            {
+                'title': u"Partie 2 : edition de titre",
+                'introduction': u"Expérimentation : edition d'introduction",
+                'conclusion': u"C'est terminé : edition de conlusion",
+                "last_hash": hash
+            },
+            follow=False)
+        conflict_result = self.client.post(
+            reverse('zds.tutorial.views.edit_part') + '?partie={}'.format(p1.pk),
+            {
+                'title': u"Partie 2 : edition de titre",
+                'introduction': u"Expérimentation : edition d'introduction conflit",
+                'conclusion': u"C'est terminé : edition de conlusion",
+                "last_hash": hash
+            },
+            follow=False)
+        self.assertEqual(conflict_result.status_code, 200)
+        self.assertContains(response=conflict_result, text = u"nouvelle version")
+
+        # test chapter
+        result = self.client.post(
+            reverse('zds.tutorial.views.add_chapter') + '?partie={}'.format(p1.pk),
+            {
+                'title': u"Chapitre 1",
+                'introduction':"Mon premier chapitre",
+                'conclusion': "Fin de mon premier chapitre",
+            },
+            follow=False)
+        c1 = Chapter.objects.last()
+        hash = compute_hash([os.path.join(c1.get_path(),"introduction.md"),
+		    os.path.join(c1.get_path(),"conclusion.md")])
+        self.client.post(
+            reverse('zds.tutorial.views.edit_chapter') + '?chapitre={}'.format(c1.pk),
+            {
+                'title': u"Chapitre 3 : edition de titre",
+                'introduction': u"Edition d'introduction",
+                'conclusion': u"Edition de conlusion",
+                "last_hash": hash
+            },
+            follow=True)
+        conflict_result = self.client.post(
+            reverse('zds.tutorial.views.edit_chapter') + '?chapitre={}'.format(c1.pk),
+            {
+                'title': u"Chapitre 3 : edition de titre",
+                'introduction': u"Edition d'introduction conflict",
+                'conclusion': u"Edition de conlusion",
+                "last_hash": hash
+            },
+            follow=True)
+        self.assertEqual(conflict_result.status_code, 200)
+        self.assertContains(response=conflict_result, text = u"nouvelle version")
 
     def test_url_for_member(self):
         """Test simple get request by simple member."""
@@ -1337,6 +1445,8 @@ class BigTutorialTests(TestCase):
                 'introduction': self.bigtuto.introduction,
                 'description': self.bigtuto.description,
                 'conclusion': self.bigtuto.conclusion,
+                'last_hash': compute_hash([os.path.join(self.bigtuto.get_path(),"introduction.md"),
+					    os.path.join(self.bigtuto.get_path(),"conclusion.md")])
             },
             follow=True)
 
@@ -2028,6 +2138,8 @@ class MiniTutorialTests(TestCase):
                     'subcategory': [sub.pk],
                     'introduction': self.minituto.get_introduction(),
                     'conclusion': self.minituto.get_conclusion(),
+                    'last_hash': compute_hash([os.path.join(self.minituto.get_path(),"introduction.md"),
+					    os.path.join(self.minituto.get_path(),"conclusion.md")])
                 },
                 follow=False
         )
@@ -2045,6 +2157,8 @@ class MiniTutorialTests(TestCase):
                     'subcategory': [sub.pk],
                     'introduction': self.minituto.get_introduction(),
                     'conclusion': self.minituto.get_conclusion(),
+                    'last_hash': compute_hash([os.path.join(self.minituto.get_path(),"introduction.md"),
+					    os.path.join(self.minituto.get_path(),"conclusion.md")])
                 },
                 follow=False
         )

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -706,6 +706,7 @@ class BigTutorialTests(TestCase):
                 'title': u"Partie 2 : edition de titre",
                 'introduction': u"Expérimentation : edition d'introduction",
                 'conclusion': u"C'est terminé : edition de conlusion",
+                "last_hash": compute_hash([os.path.join(p2.get_path(),"introduction.md"),os.path.join(p2.get_path(),"conclusion.md")])
             },
             follow=True)
         self.assertContains(response=result, text = u"Partie 2 : edition de titre")
@@ -720,6 +721,7 @@ class BigTutorialTests(TestCase):
                 'title': u"Chapitre 3 : edition de titre",
                 'introduction': u"Edition d'introduction",
                 'conclusion': u"Edition de conlusion",
+                "last_hash": compute_hash([os.path.join(c3.get_path(),"introduction.md"),os.path.join(c3.get_path(),"conclusion.md")])
             },
             follow=True)
         self.assertContains(response=result, text = u"Chapitre 3 : edition de titre")
@@ -734,6 +736,7 @@ class BigTutorialTests(TestCase):
                 'title': u"Partie 2 : seconde edition de titre",
                 'introduction': u"Expérimentation : seconde edition d'introduction",
                 'conclusion': u"C'est terminé : seconde edition de conlusion",
+                "last_hash": compute_hash([os.path.join(p2.get_path(),"introduction.md"),os.path.join(p2.get_path(),"conclusion.md")])
             },
             follow=True)
         self.assertContains(response=result, text = u"Partie 2 : seconde edition de titre")
@@ -748,6 +751,7 @@ class BigTutorialTests(TestCase):
                 'title': u"Chapitre 2 : edition de titre",
                 'introduction': u"Edition d'introduction",
                 'conclusion': u"Edition de conlusion",
+                "last_hash": compute_hash([os.path.join(c2.get_path(),"introduction.md"),os.path.join(c2.get_path(),"conclusion.md")])
             },
             follow=True)
         self.assertContains(response=result, text = u"Chapitre 2 : edition de titre")
@@ -791,53 +795,6 @@ class BigTutorialTests(TestCase):
             follow=True)
         self.assertEqual(Chapter.objects.filter(part__tutorial=tuto.pk).count(), 2)
         self.assertEqual(Part.objects.filter(tutorial=tuto.pk).count(), 2)
-
-    def test_available_tuto(self):
-        """ Test that all page of big tutorial is available"""
-        parts = self.bigtuto.get_parts()
-        for part in parts:
-            result = self.client.get(reverse(
-                                        'zds.tutorial.views.view_part_online',
-                                        args=[
-                                            self.bigtuto.pk,
-                                            self.bigtuto.slug,
-                                            part.pk,
-                                            part.slug]),
-                                    follow=True)
-            self.assertEqual(result.status_code, 200)
-            result = self.client.get(reverse(
-                                        'zds.tutorial.views.view_part',
-                                        args=[
-                                            self.bigtuto.pk,
-                                            self.bigtuto.slug,
-                                            part.pk,
-                                            part.slug]),
-                                    follow=True)
-            self.assertEqual(result.status_code, 200)
-            chapters = part.get_chapters()
-            for chapter in chapters:
-                result = self.client.get(reverse(
-                                            'zds.tutorial.views.view_chapter_online',
-                                            args=[
-                                                self.bigtuto.pk,
-                                                self.bigtuto.slug,
-                                                part.pk,
-                                                part.slug,
-                                                chapter.pk,
-                                                chapter.slug]),
-                                        follow=True)
-                self.assertEqual(result.status_code, 200)
-                result = self.client.get(reverse(
-                                            'zds.tutorial.views.view_chapter',
-                                            args=[
-                                                self.bigtuto.pk,
-                                                self.bigtuto.slug,
-                                                part.pk,
-                                                part.slug,
-                                                chapter.pk,
-                                                chapter.slug]),
-                                        follow=True)
-                self.assertEqual(result.status_code, 200)
 
     def test_url_for_member(self):
         """Test simple get request by simple member."""
@@ -2411,6 +2368,7 @@ class MiniTutorialTests(TestCase):
             {
                 'title': u"Extrait 2 : edition de titre",
                 'text': u"Edition d'introduction",
+                "last_hash": compute_hash([e2.get_path(), e2.get_path()])
             },
             follow=True)
         self.assertEqual(result.status_code, 200)

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -3,7 +3,7 @@
 import os
 import string
 import uuid
-
+import hashlib
 
 THUMB_MAX_WIDTH = 80
 THUMB_MAX_HEIGHT = 80
@@ -11,6 +11,22 @@ THUMB_MAX_HEIGHT = 80
 MEDIUM_MAX_WIDTH = 200
 MEDIUM_MAX_HEIGHT = 200
 
+def compute_hash(filenames):
+    """returns a md5 hexdigest of group of files to check if they have change"""
+    md5_hash = hashlib.md5()
+    for filename in filenames:
+        file_handle = open(filename, 'rb')
+        must_continue = True
+        while must_continue:
+            read_bytes = file_handle.read(8096)
+            if not read_bytes:
+                must_continue = False
+            else:
+                md5_hash.update(read_bytes)
+    return md5_hash.hexdigest()
+
+def content_has_changed(filenames, md5):
+    return md5 != compute_hash(filenames)
 
 def image_path(instance, filename):
     """Return path to an image."""

--- a/zds/utils/tutorials.py
+++ b/zds/utils/tutorials.py
@@ -9,7 +9,6 @@ from git import *
 
 from zds.utils import slugify
 
-
 # Export-to-dict functions
 def export_chapter(chapter, export_all=True):
     from zds.tutorial.models import Extract
@@ -289,3 +288,5 @@ def move(obj, new_pos, position_f, parent_f, children_fn):
     # All objects have been updated except the current one we want to move, so
     # we can do it now
     setattr(obj, position_f, new_pos)
+
+


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #843 |

Suite à la discussion sur #843 j'ai fixé ce bug en redonnant simplement au membre la version qui avait été posée avant qu'il ne valide avec juste un avertissement "une version plus récente a été postée".

Si la QA et les membres valident le concept, j'étendrais ce correctif aux articles qui subissent le même problème, même si l'issue n'en parle pas.
# Note pour la QA
- la PR ne doit pas casser le workflow habituel (i.e ajout/édition suppression) 
- Comment tester sur les big tutos : 
  - créez un big tuto
  - ajoutez-lui une partie (avec ou sans intro, peu importe)
  - ajoutez-lui un chapitre
  - ajoutez lui un extrait
  - ouvrez l'édition de l'extrait  dans deux onglet. Validez l'édition dans un onglet, puis éditez dans un second, un avertissement apparait
  - refaites de même mais cette fois-ci, dans le premier onglet NE FAITES AUCUN CHANGEMENT AVANT VALIDATION, éditez dans le second onglet, vérifiez qu'aucun message n'arrive
  - pour le chapitre et l'extrait : faites les vérifications identiques mais avec les permutations suivante : modification de l'intro, modification de la ccl, modification des deux
- Pour un mini tuto : 
  - tester les extraits comme pour le big
  - tester l'intro/ccl comme pour le big
