### PR TITLE
Pluriel sur les tags (fix #1238)

### DIFF
--- a/templates/article/member/history.html
+++ b/templates/article/member/history.html
@@ -33,7 +33,7 @@
     </h1>
     
     <div class="authors">
-        <span class="authors-label">Contributeurs : </span>
+        <span class="authors-label">Contributeur{{ article.authors.all|pluralize }} : </span>
         <ul>
             {% for member in article.authors.all %}
                 <li>

--- a/templates/article/member/view.html
+++ b/templates/article/member/view.html
@@ -60,7 +60,7 @@
     </ul>
     
     <div class="authors">
-        <span class="authors-label">Contributeurs : </span>
+        <span class="authors-label">Contributeur{{ authors.all|pluralize }} : </span>
         <ul>
             {% for member in authors.all %}
                 <li>

--- a/templates/article/validation/history.html
+++ b/templates/article/validation/history.html
@@ -42,7 +42,7 @@
     </ul>
     
     <div class="authors">
-        <span class="authors-label">Contributeurs : </span>
+        <span class="authors-label">Contributeur{{ authors.all|pluralize }} : </span>
         <ul>
             {% for member in authors.all %}
                 <li>

--- a/templates/article/view.html
+++ b/templates/article/view.html
@@ -44,7 +44,7 @@
     </ul>
     
     <div class="authors">
-        <span class="authors-label">Contributeurs : </span>
+        <span class="authors-label">Contributeur{{ authors.all|pluralize }} : </span>
         <ul>
             {% for member in authors.all %}
                 <li>

--- a/templates/email/mp/new.html
+++ b/templates/email/mp/new.html
@@ -9,7 +9,7 @@
     <strong>{{ author }}</strong> vous a envoyé un message privé sur Zeste de Savoir.
     <br />
     <br />
-    Pour le lire, <a href="{{ url }}">cliquez ici</a>
+    Pour le lire, <a href="{{ url }}">cliquez ici</a>.
     <br />
     <br />
     <br />

--- a/templates/forum/includes/topic_row.part.html
+++ b/templates/forum/includes/topic_row.part.html
@@ -42,7 +42,7 @@
     <p class="topic-answers">
         {% with nb_post=topic.get_post_count %}
             {% if nb_post > 1 %}
-                {{ nb_post|add:"-1" }} réponse{% if nb_post > 2 %}s{% endif %}
+                {{ nb_post|add:"-1" }} réponse{{ nb_post|add:"-1"|pluralize }}
             {% endif %}
         {% endwith %}
     </p>

--- a/templates/forum/includes/topic_row.part.html
+++ b/templates/forum/includes/topic_row.part.html
@@ -31,7 +31,7 @@
                     {% include "misc/member_item.part.html" with member=topic.author %}
                 </em>
                 {% if topic.tags.all %}
-                    - Tags : 
+                    - Tag{{ topic.tags.all|pluralize }} : 
                     {% for tag in topic.tags.all %}
                         <a href="{% url "zds.forum.views.find_topic_by_tag" tag.pk tag.slug %}" class="topic-tag">{{ tag.title }}</a>
                     {% endfor %}

--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -38,7 +38,7 @@
                         {% endspaceless %}</a>
 
                         <p class="topic-members">
-                            <span class="topic-members-label">Participants :</span>
+                            <span class="topic-members-label">Participant{{ topic.participants.all|length|add:"1"|pluralize }} :</span>
                             <em>
                                 {% include "misc/member_item.part.html" with member=topic.author avatar=True %}
                             </em>{% spaceless %}

--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -51,7 +51,7 @@
                 {% endwith %}
                 <p class="topic-answers">
                     {% if topic.get_post_count > 1 %}
-                        {{ topic.get_post_count|add:"-1" }} réponse{% if topic.get_post_count > 2 %}s{% endif %}
+                        {{ topic.get_post_count|add:"-1" }} réponse{{ topic.get_post_count|add:"-1"|pluralize }}
                     {% endif %}
                 </p>
                 <p class="topic-last-answer">

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -32,7 +32,7 @@
 
 {% block content %}
     <div class="authors">
-        <span class="authors-label">Participants : </span>
+        <span class="authors-label">Participant{{ topic.participants.all|length|add:"1"|pluralize }} : </span>
         <ul>
             <li>
                 {% include 'misc/member_item.part.html' with member=topic.author avatar=True %}

--- a/templates/tutorial/includes/tags_authors.part.html
+++ b/templates/tutorial/includes/tags_authors.part.html
@@ -7,7 +7,7 @@
 {% endif %}
 
 <div class="authors">
-    <span class="authors-label">Auteurs : </span>
+    <span class="authors-label">Auteur{{ tutorial.authors.all|pluralize }} : </span>
     <ul>
         {% for member in tutorial.authors.all %}
             <li>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1238 |
- \+ Pluriel également sur les messages privés (nombre de participants et de réponses).
- \+ Un point manquant dans le template du mail de nouveau MP.
### QA
- 1. Créer un sujet avec un tag
- 2. Créer un sujet avec plusieurs tags
- 3. Vérifier s'il y a bien un « s » s'il y a plusieurs tags
