### PR TITLE
Enlève le bouton "Supprimer la sélection" quand il n'y a pas de galerie (#1240)

### DIFF
--- a/templates/gallery/base.html
+++ b/templates/gallery/base.html
@@ -21,5 +21,6 @@
         <a href="{% url "zds.gallery.views.new_gallery" %}" class="new-btn ico-after more blue">
             Ajouter une galerie
         </a>
+        {% block sidebar_actions %}{% endblock %}
     </aside>
 {% endblock %}

--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -81,7 +81,7 @@
                 
                 <form action="{% url "zds.gallery.views.modify_gallery" %}" method="post" id="delete-galleries" class="modal modal-small">
                     <p>
-                        Attention, vous vous appretez à supprimer toutes les galleries sélectionnées.
+                        Attention, vous vous appretez à supprimer toutes les galeries sélectionnées.
                     </p>
                     
                     {% csrf_token %}

--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -21,55 +21,74 @@
 
 
 {% block content %}
-    <form id="form" name="form" method="post" action="{% url "zds.gallery.views.modify_gallery" %}">
-        <div class="topic-list topic-list-small navigable-list">
-            {% for gallery in galleries %}
-                <div class="topic navigable-elem">
-                    <div class="topic-infos">
-                        <input
-                            name="items"
-                            type="checkbox"
-                            {% if not gallery.is_write %}
-                                disabled="true"
-                            {% endif %}
-                            value="{{ gallery.gallery.pk }}"
-                        >
-                    </div>
-                    <div class="topic-description">
-                        <a href="{{ gallery.gallery.get_absolute_url }}" class="topic-title-link navigable-link">
-                            <span class="topic-title">
-                                {{ gallery.gallery.title }}
-                            </span>
-                            <span class="topic-subtitle">
-                                {{ gallery.gallery.subtitle|default:"Pas de description" }}
-                            </span>
-                        </a>
-                    </div>
-                    <p class="topic-answers">
-                        {% with img_count=gallery.gallery.get_images.count %}
-                            {% if img_count == 0 %}
-                                Aucune image
-                            {% elif img_count == 1 %}
-                                1 image
-                            {% else %}
-                                {{ img_count }} images
-                            {% endif %}
-                        {% endwith %}
-                    </p>
+    <div class="topic-list topic-list-small navigable-list">
+        {% for gallery in galleries %}
+            <div class="topic navigable-elem">
+                <div class="topic-infos">
+                    <input
+                        name="items"
+                        type="checkbox"
+                        {% if not gallery.is_write %}
+                            disabled="true"
+                        {% endif %}
+                        value="{{ gallery.gallery.pk }}"
+                        form="delete-galleries"
+                    >
                 </div>
-            {% endfor %}
-        </div>
+                <div class="topic-description">
+                    <a href="{{ gallery.gallery.get_absolute_url }}" class="topic-title-link navigable-link">
+                        <span class="topic-title">
+                            {{ gallery.gallery.title }}
+                        </span>
+                        <span class="topic-subtitle">
+                            {{ gallery.gallery.subtitle|default:"Pas de description" }}
+                        </span>
+                    </a>
+                </div>
+                <p class="topic-answers">
+                    {% with img_count=gallery.gallery.get_images.count %}
+                        {% if img_count == 0 %}
+                            Aucune image
+                        {% elif img_count == 1 %}
+                            1 image
+                        {% else %}
+                            {{ img_count }} images
+                        {% endif %}
+                    {% endwith %}
+                </p>
+            </div>
+        {% endfor %}
+    </div>
 
-        {% if galleries|length > 0 %}
-            <button type="submit" name="delete_multi" class="btn btn-cancel">
-                Supprimer la séléction
-            </button>
-        {% else %}
-            <p>
-                Vous n'avez pas encore <a href="{% url "zds.gallery.views.new_gallery" %}">ajouter de galerie</a>.
-            </p>
-        {% endif %}
+    {% if galleries|length = 0 %}
+        <p>
+            Vous n'avez pas encore <a href="{% url "zds.gallery.views.new_gallery" %}">ajouté de galerie</a>.
+        </p>
+    {% endif %}
+{% endblock %}
 
-        {% csrf_token %}
-    </form>
+
+
+{% block sidebar_actions %}
+    {% if galleries|length > 0 %}
+    <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Actions">
+        <h3>Actions</h3>
+        <ul>
+            <li>
+                <a href="#delete-galleries" class="open-modal ico-after cross red">
+                    Supprimer les galeries sélectionnées
+                </a>
+                
+                <form action="{% url "zds.gallery.views.modify_gallery" %}" method="post" id="delete-galleries" class="modal modal-small">
+                    <p>
+                        Attention, vous vous appretez à supprimer toutes les galleries sélectionnées.
+                    </p>
+                    
+                    {% csrf_token %}
+                    <button type="submit" name="delete_multi" class="btn">Confirmer</button>
+                </form>
+            </li>
+        </ul>
+    </div>
+    {% endif %}
 {% endblock %}

--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -64,6 +64,10 @@
         <button type="submit" name="delete_multi" class="btn btn-cancel">
             Supprimer la séléction
         </button>
+        {% else %}
+        <p>
+            Vous n'avez pas encore <a href="{% url "zds.gallery.views.new_gallery" %}">ajouter de galerie</a>.
+        </p>
         {% endif %}
 
         {% csrf_token %}

--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -61,13 +61,13 @@
         </div>
 
         {% if galleries|length > 0 %}
-        <button type="submit" name="delete_multi" class="btn btn-cancel">
-            Supprimer la séléction
-        </button>
+            <button type="submit" name="delete_multi" class="btn btn-cancel">
+                Supprimer la séléction
+            </button>
         {% else %}
-        <p>
-            Vous n'avez pas encore <a href="{% url "zds.gallery.views.new_gallery" %}">ajouter de galerie</a>.
-        </p>
+            <p>
+                Vous n'avez pas encore <a href="{% url "zds.gallery.views.new_gallery" %}">ajouter de galerie</a>.
+            </p>
         {% endif %}
 
         {% csrf_token %}

--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -60,9 +60,11 @@
             {% endfor %}
         </div>
 
+        {% if galleries|length > 0 %}
         <button type="submit" name="delete_multi" class="btn btn-cancel">
             Supprimer la séléction
         </button>
+        {% endif %}
 
         {% csrf_token %}
     </form>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1240 |

Corrige #1240.

**Pour QA :** 
- Aller dans Galerie d'images
- Supprimer toutes les galeries (ou connectez-vous avec un nouvel utilisateur, qui n'a donc pas d'image)
- Vérifier que le bouton "Supprimer la sélection" n'apparait pas, mais qu'un texte invitant à en créer apparait (vérifier l'orthographe et la mise en forme).
- Créer une galerie et vérifier que le bouton apparaît correctement.
