### PR TITLE
fix 1259: la visualisation d'un extrait déclanche un conflit

### DIFF
--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1929,26 +1929,30 @@ def edit_extract(request):
 
     if request.method == "POST":
         data = request.POST
-        if content_has_changed([extract.get_path()], data["last_hash"]):
-            form = form = ExtractForm(initial={
-                "title": extract.title,
-                "text": extract.get_text()})
-            return render_template("tutorial/extract/edit.html", 
-                {
-                     "extract": extract,
-                     "last_hash": compute_hash([extract.get_path()]),
-                     "new_version":True,
-                     "form": form
-                })
         # Using the « preview button »
 
         if "preview" in data:
-            form = ExtractForm(initial={"title": data["title"],
-                                        "text": data["text"]})
+            form = ExtractForm(initial={
+                                           "title": data["title"],
+                                           "text": data["text"]
+                                       })
             return render_template("tutorial/extract/edit.html",
-                                   {"extract": extract, "form": form})
+                                   {
+                                       "extract": extract, "form": form,
+                                       "last_hash": compute_hash([extract.get_path()])
+                                   })
         else:
-
+            if content_has_changed([extract.get_path()], data["last_hash"]):
+                form = ExtractForm(initial={
+                    "title": extract.title,
+                    "text": extract.get_text()})
+                return render_template("tutorial/extract/edit.html", 
+                    {
+                         "extract": extract,
+                         "last_hash": compute_hash([extract.get_path()]),
+                         "new_version":True,
+                         "form": form
+                    })
             # Edit extract.
 
             form = ExtractForm(request.POST)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1259 |

Lorsqu'on édite un extrait et qu'on essaie de le visualiser, puis de le re visualiser voire tout simplement de le poster le message indiquant un conflit apparait.  
Cette PR résoud cette situation.
# Pour la QA
- l'issue #843 (ne pas écraser les modifications faites pendant que nous éditons) doit être toujours d'actualité
- lancez l'édition d'un extrait. Faites des changement, visualisez-lez. Validez. Le message ne doit pas apparaître.
- lancez l'édition d'un extrait, faites des changement, visualisez-les, re visualisez-les. Le message ne doit pas apparaître.
