### PR TITLE
 corrige les liens next/prev entre deux parties

### DIFF
--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1412,10 +1412,7 @@ def view_chapter(
 ):
     """View chapter."""
 
-    chapter = get_object_or_404(Chapter, pk=chapter_pk,
-                                part__pk=part_pk,
-                                part__tutorial__pk=tutorial_pk)
-    tutorial = chapter.get_tutorial()
+    tutorial = get_object_or_404(Tutorial, pk=tutorial_pk)
     
     try:
         sha = request.GET["version"]
@@ -1449,7 +1446,7 @@ def view_chapter(
             args=[
                 tutorial.pk,
                 tutorial.slug,
-                part_pk,
+                part["pk"],
                 part["slug"]])
         part["tutorial"] = tutorial
         for chapter in part["chapters"]:
@@ -1538,7 +1535,7 @@ def view_chapter_online(
             args=[
                 tutorial.pk,
                 tutorial.slug,
-                part_pk,
+                part["pk"],
                 part["slug"]])
         part["tutorial"] = mandata
         part["position_in_tutorial"] = cpt_p


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | [Sur le forum](http://zestedesavoir.com/forums/sujet/800/navigation-entre-les-chapitres-dun-tuto-offline/) |

Cette PR corrige le problème signalé dans le forum

**Note pour QA**

Créez ou importez un big tutos et parcourez le du début jusqu'a la fin à l'aide des flèches (voir image) de chapitres suivants et précédent, jusqu'au bout. Faire une aller/retour complet.

![capture](https://cloud.githubusercontent.com/assets/6066015/3675585/be25c980-127f-11e4-9d3e-bccab1613c08.PNG)
