### PR TITLE
Ré-ajout de la méthode get_last_reaction

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -90,7 +90,7 @@
                         {{ article.pubdate|format_date|capfirst }} -
                         <a href="
                             {% if article.get_reaction_count == 0 %}
-                                {{ article.get_absolute_url }}#reactions
+                                {{ article.get_absolute_url_online }}#reactions
                             {% else %}
                                 {{ article.get_last_reaction.get_absolute_url }}
                             {% endif %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -90,7 +90,7 @@
                         {{ article.pubdate|format_date|capfirst }} -
                         <a href="
                             {% if article.get_reaction_count == 0 %}
-                                {{ link }}#reactions
+                                {{ article.get_absolute_url }}#reactions
                             {% else %}
                                 {{ article.get_last_reaction.get_absolute_url }}
                             {% endif %}

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -154,11 +154,12 @@ class Article(models.Model):
         article_version['sha_draft'] = self.sha_draft
         article_version['sha_validation'] = self.sha_validation
         article_version['sha_public'] = self.sha_public
+        article_version['get_last_reaction'] = self.get_last_reaction
         article_version['get_reaction_count'] = self.get_reaction_count
         article_version['get_absolute_url'] = reverse('zds.article.views.view', 
                                                       args=[self.pk, self.slug])
         article_version['get_absolute_url_online'] = reverse('zds.article.views.view_online', 
-                                                             args=[self.pk,slugify(article_version['title'])])
+                                                             args=[self.pk, slugify(article_version['title'])])
         
         return article_version
         


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1273, PR #1261 |

Correction de la variable `link` qui n'existait pas + rajout de la méthode get_last_reaction.
