### PR TITLE
Corrige l'interface de validation

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -1048,8 +1048,6 @@
     }
 
     .member-item {
-        margin-right: 7px;
-
         .avatar {
             margin-top: -2px;
             height: 20px;
@@ -1057,9 +1055,16 @@
             border: 1px solid #CCC;
         }
 
+        .avatar + span {
+            padding-left: 3px;
+        }
+
         &:hover .avatar {
             border-color: #999;
         }
+    }
+    .member-item + .member-item {
+        margin-left: 7px;
     }
     .authors .member-item {
         margin-right: 0;
@@ -2368,10 +2373,6 @@ table {
             .message-helpful {
                 color: #48A200;
                 text-indent: 20px;
-            }
-
-            .member-item {
-                margin: 0;
             }
 
             textarea {

--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -1774,9 +1774,11 @@
         }
     }
 
+    .content-wrapper.comment-author,
     .comment-author {
         background: #EEE;
         padding: 7px 15px;
+        margin-bottom: 20px;
 
         blockquote {
             margin: 10px 0;

--- a/templates/article/includes/sidebar_actions.part.html
+++ b/templates/article/includes/sidebar_actions.part.html
@@ -1,7 +1,13 @@
 {% if user in authors.all or perms.article.change_article %}
-    <a href="{% url "zds.article.views.edit" %}?article={{ article.pk }}" class="ico-after edit blue new-btn">
-        Éditer
-    </a>
+    {% if article.sha_draft = version %}
+        <a href="{% url "zds.article.views.edit" %}?article={{ article.pk }}" class="ico-after edit blue new-btn">
+            Éditer
+        </a>
+    {% else %}
+        <a href="{{ article.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
+            Version brouillon
+        </a>
+    {% endif %}
 
     <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Gestion">
         <h3>Gestion</h3>

--- a/templates/article/includes/sidebar_actions.part.html
+++ b/templates/article/includes/sidebar_actions.part.html
@@ -60,23 +60,30 @@
 
             {% if article.sha_validation = None %}
                 <li>
-                    <a href="#valid" class="open-modal ico-after tick green">Demander la validation</a>
-                    <form action="{% url "zds.article.views.modify" %}" method="post" class="modal modal-medium" id="valid">
-                        <textarea name="comment" rows="3" placeholder="Vos commentaires de validation"></textarea>
-
-                        <input type="hidden" name="article" value="{{ article.pk }}">
-                        <input type="hidden" name="version" value="{{ version }}">
-                        {% csrf_token %}
-                        <button type="submit" name="pending">
-                            Confirmer
-                        </button>
-                    </form>
+                    <a href="#ask-validation" class="open-modal ico-after tick green">Demander la validation</a>
                 </li>
             {% else %}
+                {% if article.sha_validation != version %}
+                    <li>
+                        <a href="#ask-validation" class="open-modal ico-after tick green">
+                            Mettre à jour la version en validation
+                        </a>
+                    </li>
+                {% endif %}
                 <li class="inactive">
-                    <span class="ico-after tick">En attente de validation</span>
+                    <span class="ico-after tick disabled">En attente de validation</span>
                 </li>
             {% endif %}
+            <form action="{% url "zds.article.views.modify" %}" method="post" class="modal modal-medium" id="ask-validation">
+                <textarea name="comment" rows="3" placeholder="Vos commentaires de validation"></textarea>
+
+                <input type="hidden" name="article" value="{{ article.pk }}">
+                <input type="hidden" name="version" value="{{ version }}">
+                {% csrf_token %}
+                <button type="submit" name="pending">
+                    Confirmer
+                </button>
+            </form>
         </ul>
     </div>
 {% endif %}
@@ -198,7 +205,7 @@
                 </li>
             {% else %}
                 <li class="inactive">
-                    <span class="disabled">Impossible, car publié</span>
+                    <span class="disabled ico-after cross">Impossible, car publié</span>
                 </li>
             {% endif %}
         </ul>

--- a/templates/article/includes/sidebar_actions.part.html
+++ b/templates/article/includes/sidebar_actions.part.html
@@ -99,13 +99,25 @@
                     Historique de validation
                 </a>
             </li>
+            <li>
+                <a  href="{% url "zds.mp.views.new" %}?{% for username in authors.all %}&amp;username={{ username }}{% endfor %}"
+                    class="ico-after cite blue"
+                >
+                    Envoyer un MP 
+                    {% if authors.all|length > 1 %}
+                        aux auteurs
+                    {% else %}
+                        à l'auteur
+                    {% endif %}
+                </a>
+            </li>
 
             {% if not article.sha_validation = None %}
                 {% if validation.is_pending %}
                     <li>
                         <form action="{% url "zds.article.views.reservation" validation.pk %}" method="post">
                             {% csrf_token %}
-                            <button type="submit" class="ico-after lock blue">
+                            <button type="submit" class="ico-after lock blue unread">
                                 Réserver
                             </button>
                         </form>

--- a/templates/article/includes/sidebar_actions.part.html
+++ b/templates/article/includes/sidebar_actions.part.html
@@ -198,7 +198,7 @@
                 </li>
             {% else %}
                 <li class="inactive">
-                    <span class="disabled">Impossible, car en publié</span>
+                    <span class="disabled">Impossible, car publié</span>
                 </li>
             {% endif %}
         </ul>

--- a/templates/article/member/view.html
+++ b/templates/article/member/view.html
@@ -95,20 +95,29 @@
         </ul>
     </div>
 
-    {% if perms.article.change_article and article.sha_validation != None %}
-        <p class="content-wrapper alert-box info">
-            Cet article est en attente de validation
-        </p>
-        {% if validation.comment_authors %}
-            <div class="content-wrapper comment-author">
-                <p>
-                    Le message suivant a été laissé à destination des validateurs : 
+    {% if user in article.authors.all or perms.article.change_article %}
+        {% if article.sha_validation != None %}
+            {% if validation.validator == None %}
+                <p class="content-wrapper alert-box alert">
+                    Cet article est en attente d'un validateur
                 </p>
+            {% else %}
+                <p class="content-wrapper alert-box info">
+                    L'article est en cours de validation par
+                    {% include "misc/member_item.part.html" with member=validation.validator %}
+                </p>
+            {% endif %}
+            {% if validation.comment_authors %}
+                <div class="content-wrapper comment-author">
+                    <p>
+                        Le message suivant a été laissé à destination des validateurs :
+                    </p>
 
-                <blockquote>
-                    {{ validation.comment_authors }}
-                </blockquote>
-            </div>
+                    <blockquote>
+                        {{ validation.comment_authors }}
+                    </blockquote>
+                </div>
+            {% endif %}
         {% endif %}
     {% endif %}
 {% endblock %}

--- a/templates/article/member/view.html
+++ b/templates/article/member/view.html
@@ -97,26 +97,43 @@
 
     {% if user in authors.all or perms.article.change_article %}
         {% if article.sha_validation != None %}
-            {% if validation.validator == None %}
-                <p class="content-wrapper alert-box alert">
-                    Cet article est en attente d'un validateur
-                </p>
-            {% else %}
-                <p class="content-wrapper alert-box info">
-                    L'article est en cours de validation par
-                    {% include "misc/member_item.part.html" with member=validation.validator %}
-                </p>
-            {% endif %}
-            {% if validation.comment_authors %}
-                <div class="content-wrapper comment-author">
-                    <p>
-                        Le message suivant a été laissé à destination des validateurs :
+            {% if validation.version == version %}
+                {% if validation.validator == None %}
+                    <p class="content-wrapper alert-box alert">
+                        Cet article est en attente d'un validateur
                     </p>
+                {% else %}
+                    <p class="content-wrapper alert-box info">
+                        L'article est en cours de validation par
+                        {% include "misc/member_item.part.html" with member=validation.validator %}
+                    </p>
+                {% endif %}
+                {% if validation.comment_authors %}
+                    <div class="content-wrapper comment-author">
+                        <p>
+                            Le message suivant a été laissé à destination des validateurs :
+                        </p>
 
-                    <blockquote>
-                        {{ validation.comment_authors }}
-                    </blockquote>
-                </div>
+                        <blockquote>
+                            {{ validation.comment_authors }}
+                        </blockquote>
+                    </div>
+                {% endif %}
+            {% else %}
+                {% if validation.validator == None %}
+                    <p class="content-wrapper alert-box alert">
+                        <a href="{{ article.get_absolute_url }}?version={{ validation.version }}">
+                            Une autre version de cet article</a>
+                        est en attente d'un validateur
+                    </p>
+                {% else %}
+                    <p class="content-wrapper alert-box info">
+                        <a href="{{ article.get_absolute_url }}?version={{ validation.version }}">
+                            Une autre version de cet article</a>
+                        est en cours de validation par
+                        {% include "misc/member_item.part.html" with member=validation.validator %}
+                    </p>
+                {% endif %}
             {% endif %}
         {% endif %}
     {% endif %}

--- a/templates/article/member/view.html
+++ b/templates/article/member/view.html
@@ -95,7 +95,7 @@
         </ul>
     </div>
 
-    {% if user in article.authors.all or perms.article.change_article %}
+    {% if user in authors.all or perms.article.change_article %}
         {% if article.sha_validation != None %}
             {% if validation.validator == None %}
                 <p class="content-wrapper alert-box alert">

--- a/templates/article/validation/history.html
+++ b/templates/article/validation/history.html
@@ -67,10 +67,10 @@
                             {{ validation.date_proposition|format_date|capfirst }}
                             {% if validation.comment_authors %}
                                 <br>
-                                <a href="#view-comment-authors-{{ validation.version }}" class="open-modal">
+                                <a href="#view-comment-authors-{{ validation.pk }}" class="open-modal">
                                     Message laissé à la validation
                                 </a>
-                                <div class="modal modal-big" id="view-comment-authors-{{ validation.version }}" data-modal-close="Fermer">
+                                <div class="modal modal-big" id="view-comment-authors-{{ validation.pk }}" data-modal-close="Fermer">
                                     <p>
                                         {{ validation.comment_authors }}
                                     </p>

--- a/templates/article/validation/history.html
+++ b/templates/article/validation/history.html
@@ -65,6 +65,17 @@
                     <tr>
                         <td>
                             {{ validation.date_proposition|format_date|capfirst }}
+                            {% if validation.comment_authors %}
+                                <br>
+                                <a href="#view-comment-authors-{{ validation.version }}" class="open-modal">
+                                    Message laissé à la validation
+                                </a>
+                                <div class="modal modal-big" id="view-comment-authors-{{ validation.version }}" data-modal-close="Fermer">
+                                    <p>
+                                        {{ validation.comment_authors }}
+                                    </p>
+                                </div>
+                            {% endif %}
                         </td>
                         <td>
                             {% captureas reservation_url %}

--- a/templates/article/validation/index.html
+++ b/templates/article/validation/index.html
@@ -54,13 +54,12 @@
 
         {% block content %}
             {% if validations %}
-                <table>
+                <table class="fullwidth">
                     <thead>
                         <tr>
                             <th>Titre</th>
-                            <th width="8%">Catégorie(s)</th>
-                            <th width="8%">Auteur(s)</th>
-                            <th width="8%">Proposé</th>
+                            <th width="10%">Auteur(s)</th>
+                            <th width="10%">Proposé</th>
                             <th width="24%">Statut</th>
                         </tr>
                     </thead>
@@ -71,15 +70,19 @@
                                     <a href="{% url "zds.article.views.view" validation.article.pk validation.article.slug %}?version={{ validation.version }}" >
                                         {{ validation.article.title }}
                                     </a>
-                                </td>
-                                <td>
-                                    {% for tag in validation.article.subcategory.all %}
-                                        <p>
-                                            <a href="{% url "zds.article.views.list_validation" %}?subcategory={{subcategory.pk}}">
-                                                {{ tag.title }}
-                                            </a>
-                                        <p>
-                                    {% endfor %}
+                                    <br>
+                                    {% if validation.article.subcategory.all %}
+                                        Catégorie{{ validation.article.subcategory.all|pluralize }} : 
+                                        {% for subcategory in validation.article.subcategory.all %}
+                                            {% if not forloop.first %}
+                                                -
+                                            {% endif %}
+                                            <a href="{% url "zds.article.views.list_validation" %}?subcategory={{ subcategory.pk }}">
+                                                {{ subcategory.title }}</a>
+                                        {% endfor %}
+                                    {% else %}
+                                        <em>Aucune catégorie</em>
+                                    {% endif %}
                                 </td>
                                 <td>
                                     {% for author in validation.article.authors.all %}
@@ -87,7 +90,7 @@
                                     {% endfor %}
                                 </td>
                                 <td>
-                                    <span>{{ validation.date_proposition|format_date|capfirst }}</span>
+                                    <span>{{ validation.date_proposition|format_date:True|capfirst }}</span>
                                 </td>
                                 <td>
                                     {% captureas reservation_url %}

--- a/templates/article/validation/index.html
+++ b/templates/article/validation/index.html
@@ -49,6 +49,7 @@
         <h2>
             {% block headline %}
                 Validation des articles
+                ({{ validations|length }})
             {% endblock %}
         </h2>
 
@@ -72,7 +73,7 @@
                                     </a>
                                     <br>
                                     {% if validation.article.subcategory.all %}
-                                        Catégorie{{ validation.article.subcategory.all|pluralize }} : 
+                                        Catégories : 
                                         {% for subcategory in validation.article.subcategory.all %}
                                             {% if not forloop.first %}
                                                 -

--- a/templates/base.html
+++ b/templates/base.html
@@ -412,13 +412,13 @@
 
                                         {% if perms.tutorial.change_tutorial %}
                                             <li>
-                                                <a href="{% url "zds.tutorial.views.list_validation" %}">Administration des tutoriels</a>
+                                                <a href="{% url "zds.tutorial.views.list_validation" %}">Validation des tutoriels</a>
                                             </li>
                                         {% endif %}
 
                                         {% if perms.article.change_article %}
                                             <li>
-                                                <a href="{% url "zds.article.views.list_validation" %}">Administration des articles</a>
+                                                <a href="{% url "zds.article.views.list_validation" %}">Validation des articles</a>
                                             </li>
                                         {% endif %}
 

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -152,7 +152,7 @@
             <h3>Actions</h3>
             <ul>
                 <li>
-                    <a href="{% url "zds.mp.views.new"%}?username={{ usr.username }}" class="ico-after cite blue">
+                    <a href="{% url "zds.mp.views.new" %}?username={{ usr.username }}" class="ico-after cite blue">
                         Envoyer un message privé
                     </a>
                 </li>

--- a/templates/misc/member_item.part.html
+++ b/templates/misc/member_item.part.html
@@ -12,13 +12,11 @@
             itemprop="author"
         {% endif %}
     >{% spaceless %}
-    	{% if avatar %}
-        	<img src="{{ profile.get_avatar_url }}" alt="" class="avatar" itemprop="image">
-    	{% endif %}
-    	
-        <span itemprop="name">
-        	{{ member.username }}
-        </span>
+        {% if avatar %}
+            <img src="{{ profile.get_avatar_url }}" alt="" class="avatar" itemprop="image">
+        {% endif %}
+
+        <span itemprop="name">{{ member.username }}</span>
 
         {% if info %}
             <span class="info">({{ info }})</span>

--- a/templates/misc/validation.part.html
+++ b/templates/misc/validation.part.html
@@ -2,14 +2,7 @@
 
 
 
-{% if validation.validator %}
-    Réservé par {% include "misc/member_item.part.html" with member=validation.validator avatar=True %}
 
-    {% if validation.date_reserve %}
-        {{ validation.date_reserve|format_date:True|capfirst }}
-        <br>
-    {% endif %}
-{% endif %}
 
 
 
@@ -20,22 +13,55 @@
             Réserver
         </button>
     </form>
-{% elif validation.is_pending_valid %}
-    <a href="#unreservation-{{ validation.pk }}" class="open-modal btn btn-cancel">
-        Annuler la réservation
-    </a>
-    <form action="{{ reservation_url }}" method="post" class="modal modal-small" id="unreservation-{{ validation.pk }}">
-    	{% csrf_token %}
-        <p>
-            Actuellement réservé par {% include "misc/member_item.part.html" with member=validation.validator %}. <br>
-            Êtes-vous certains de vouloir <strong>annuler la réservation</strong> ?
-        </p>
-        <button type="submit">
-            Confirmer
-        </button>
-    </form>
-{% elif validation.is_accept %}
-    Accepté
-{% elif validation.is_reject %}
-    Rejeté
+{% else %}
+    {% if validation.validator %}
+        Réservé par {% include "misc/member_item.part.html" with member=validation.validator avatar=True %}
+
+        {% if validation.date_reserve %}
+            {{ validation.date_reserve|format_date:True }}
+            <br>
+        {% endif %}
+    {% endif %}
+
+    {% if validation.is_pending_valid %}
+        <a href="#unreservation-{{ validation.pk }}" class="open-modal">
+            Annuler la réservation
+        </a>
+        <form action="{{ reservation_url }}" method="post" class="modal modal-small" id="unreservation-{{ validation.pk }}">
+        	{% csrf_token %}
+            <p>
+                Actuellement réservé par {% include "misc/member_item.part.html" with member=validation.validator %}. <br>
+                Êtes-vous certains de vouloir <strong>annuler la réservation</strong> ?
+            </p>
+            <button type="submit">
+                Confirmer
+            </button>
+        </form>
+    {% elif validation.is_accept %}
+        Accepté {{ validation.date_validation|format_date:True }}
+        {% if validation.comment_validator %}
+            -
+            <a href="#view-comment-validator-{{ validation.version }}" class="open-modal">
+                Commentaire du validateur
+            </a>
+            <div class="modal modal-big" id="view-comment-validator-{{ validation.version }}" data-modal-close="Fermer">
+                <p>
+                    {{ validation.comment_validator }}
+                </p>
+            </div>
+        {% endif %}
+    {% elif validation.is_reject %}
+        Rejeté {{ validation.date_validation|format_date:True }}
+        {% if validation.comment_validator %}
+            -
+            <a href="#view-comment-validator-{{ validation.version }}" class="open-modal">
+                Motif du rejet
+            </a>
+            <div class="modal modal-big" id="view-comment-validator-{{ validation.version }}" data-modal-close="Fermer">
+                <p>
+                    {{ validation.comment_validator }}
+                </p>
+            </div>
+        {% endif %}
+    {% endif %}
 {% endif %}

--- a/templates/misc/validation.part.html
+++ b/templates/misc/validation.part.html
@@ -41,10 +41,10 @@
         Accepté {{ validation.date_validation|format_date:True }}
         {% if validation.comment_validator %}
             -
-            <a href="#view-comment-validator-{{ validation.version }}" class="open-modal">
+            <a href="#view-comment-validator-{{ validation.pk }}" class="open-modal">
                 Commentaire du validateur
             </a>
-            <div class="modal modal-big" id="view-comment-validator-{{ validation.version }}" data-modal-close="Fermer">
+            <div class="modal modal-big" id="view-comment-validator-{{ validation.pk }}" data-modal-close="Fermer">
                 <p>
                     {{ validation.comment_validator }}
                 </p>
@@ -54,10 +54,10 @@
         Rejeté {{ validation.date_validation|format_date:True }}
         {% if validation.comment_validator %}
             -
-            <a href="#view-comment-validator-{{ validation.version }}" class="open-modal">
+            <a href="#view-comment-validator-{{ validation.pk }}" class="open-modal">
                 Motif du rejet
             </a>
-            <div class="modal modal-big" id="view-comment-validator-{{ validation.version }}" data-modal-close="Fermer">
+            <div class="modal modal-big" id="view-comment-validator-{{ validation.pk }}" data-modal-close="Fermer">
                 <p>
                     {{ validation.comment_validator }}
                 </p>

--- a/templates/tutorial/chapter/view.html
+++ b/templates/tutorial/chapter/view.html
@@ -18,30 +18,28 @@
 
 
 {% block headline %}
-    {% with authors=tutorial.authors.all %}
-        <h1 {% if chapter.image %}class="illu"{% endif %}>
-            {% if chapter.image %}
-                <img src="{{ chapter.image.physical.tutorial_illu.url }}" alt="">
-            {% endif %}
-            {{ chapter.title }}
-        </h1>
-
-        {% if tutorial.licence %}
-            <p class="license">
-                {{ tutorial.licence }}
-            </p>
+    <h1 {% if chapter.image %}class="illu"{% endif %}>
+        {% if chapter.image %}
+            <img src="{{ chapter.image.physical.tutorial_illu.url }}" alt="">
         {% endif %}
+        {{ chapter.title }}
+    </h1>
 
-        {% include 'tutorial/includes/tags_authors.part.html' %}
+    {% if tutorial.licence %}
+        <p class="license">
+            {{ tutorial.licence }}
+        </p>
+    {% endif %}
 
-        {% if tutorial.in_beta and tutorial.sha_beta == version %}
-            <div class="content-wrapper">
-                <div class="alert-box warning">
-                    Attention, cette version du tutoriel est en BETA !
-                </div>
+    {% include 'tutorial/includes/tags_authors.part.html' %}
+
+    {% if tutorial.in_beta and tutorial.sha_beta == version %}
+        <div class="content-wrapper">
+            <div class="alert-box warning">
+                Cette version du tutoriel est en <strong>BÊTA</strong> !
             </div>
-        {% endif %}
-    {% endwith %}
+        </div>
+    {% endif %}
 {% endblock %}
 
 

--- a/templates/tutorial/includes/chapter.part.html
+++ b/templates/tutorial/includes/chapter.part.html
@@ -7,7 +7,7 @@
     {% if not chapter.type = 'MINI' %}
         {% if chapter.intro and chapter.intro != "None" %}
             {{ chapter.intro|emarkdown }}
-        {% else %}
+        {% elif not tutorial.in_beta %}
             <p class="ico-after warning">
                 Il n'y a pas d'introduction.
             </p>
@@ -112,7 +112,7 @@
     {% if not chapter.type = 'MINI' %}
         {% if chapter.conclu and chapter.conclu != "None" %}
             {{ chapter.conclu|emarkdown }}
-        {% else %}
+        {% elif not tutorial.in_beta %}
             <p class="ico-after warning">
                 Il n'y a pas de conclusion.
             </p>

--- a/templates/tutorial/includes/chapter.part.html
+++ b/templates/tutorial/includes/chapter.part.html
@@ -7,7 +7,7 @@
     {% if not chapter.type = 'MINI' %}
         {% if chapter.intro and chapter.intro != "None" %}
             {{ chapter.intro|emarkdown }}
-        {% elif not tutorial.in_beta or tutorial.sha_beta != version %}
+        {% else %}
             <p class="ico-after warning">
                 Il n'y a pas d'introduction.
             </p>
@@ -46,7 +46,7 @@
                     <p>
                         Êtes-vous certain de vouloir supprimer <strong>définitivement</strong> l'extrait <em>{{ extract.title }}</em> ?
                     </p>
-                    <input type="hidden" name="extract" value="{{ extract.pk }}" />
+                    <input type="hidden" name="extract" value="{{ extract.pk }}">
                     {% csrf_token %}
                     <button type="submit" name="delete">
                         Confirmer
@@ -68,18 +68,18 @@
                         <option disabled>&mdash; Déplacer avant</option>
                         {% for extract_mv in extracts %}
                             {% if extract != extract_mv and extract_mv.position_in_chapter|add:-1 != extract.position_in_chapter %}
-                            <option value="{{ extract_mv.position_in_chapter }}">
-                                Extrait {{ extract_mv.position_in_chapter }} : {{ extract_mv.title }}
-                            </option>
+                                <option value="{{ extract_mv.position_in_chapter }}">
+                                    Extrait {{ extract_mv.position_in_chapter }} : {{ extract_mv.title }}
+                                </option>
                             {% endif %}
                         {% endfor %}
 
                         <option disabled>&mdash; Déplacer après</option>
                         {% for extract_mv in extracts %}
                             {% if extract != extract_mv and extract_mv.position_in_chapter|add:1 != extract.position_in_chapter %}
-                            <option value="{{ extract_mv.position_in_chapter }}">
-                                Extrait {{ extract_mv.position_in_chapter }} : {{ extract_mv.title }}
-                            </option>
+                                <option value="{{ extract_mv.position_in_chapter }}">
+                                    Extrait {{ extract_mv.position_in_chapter }} : {{ extract_mv.title }}
+                                </option>
                             {% endif %}
                         {% endfor %}
                     </select>
@@ -112,7 +112,7 @@
     {% if not chapter.type = 'MINI' %}
         {% if chapter.conclu and chapter.conclu != "None" %}
             {{ chapter.conclu|emarkdown }}
-        {% elif not tutorial.in_beta or tutorial.sha_beta != version %} 
+        {% else %}
             <p class="ico-after warning">
                 Il n'y a pas de conclusion.
             </p>

--- a/templates/tutorial/includes/chapter.part.html
+++ b/templates/tutorial/includes/chapter.part.html
@@ -5,7 +5,7 @@
 
 {% with extracts=chapter.extracts %}
     {% if not chapter.type = 'MINI' %}
-        {% if chapter.intro and chapter.intro != "None" %}
+        {% if chapter.intro and chapter.intro != None %}
             {{ chapter.intro|emarkdown }}
         {% elif not tutorial.in_beta %}
             <p class="ico-after warning">
@@ -13,6 +13,8 @@
             </p>
         {% endif %}
     {% endif %}
+    
+    <hr />
 
     {% if extracts %}
         <ul>
@@ -110,7 +112,7 @@
     <hr />
 
     {% if not chapter.type = 'MINI' %}
-        {% if chapter.conclu and chapter.conclu != "None" %}
+        {% if chapter.conclu and chapter.conclu != None %}
             {{ chapter.conclu|emarkdown }}
         {% elif not tutorial.in_beta %}
             <p class="ico-after warning">

--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -17,6 +17,9 @@
             <span class="article-metadata">
                 {% if tutorial.subcategory %}
                     {% for category in tutorial.subcategory.all %}
+                        {% if not forloop.first %}
+                            -
+                        {% endif %}
                         {{ category.title }}                                    
                     {% endfor %}
                 {% endif %}

--- a/templates/tutorial/part/view.html
+++ b/templates/tutorial/part/view.html
@@ -32,7 +32,7 @@
     {% if part.tutorial.in_beta and part.tutorial.sha_beta == version %}
         <div class="content-wrapper">
             <div class="alert-box warning">
-                Attention, cette version du tutoriel est en BETA !
+                Cette version du tutoriel est en <strong>BÊTA</strong> !
             </div>
         </div>
     {% endif %}
@@ -43,7 +43,7 @@
 {% block content %}
     {% if part.intro and part.intro != "None" %}
         {{ part.intro|emarkdown }}
-    {% elif not tutorial.in_beta or tutorial.sha_beta != version %}
+    {% else %}
         <p class="ico-after warning">
             Il n'y a pas d'introduction.
         </p>
@@ -90,7 +90,7 @@
 
     {% if part.conclu and part.conclu != "None" %}
         {{ part.conclu|emarkdown }}
-    {% elif not tutorial.in_beta or tutorial.sha_beta != version %}
+    {% else %}
         <p class="ico-after warning">
             Il n'y a pas de conclusion.
         </p>
@@ -109,6 +109,7 @@
         </a>
     {% endif %}
 {% endblock %}
+
 
 
 {% block sidebar_actions %}
@@ -195,6 +196,8 @@
         {% endif %}
     {% endif %}
 {% endblock %}
+
+
 
 {% block sidebar_blocks %}
     {% include "tutorial/includes/summary.part.html" with tutorial=part.tutorial parts=part.tutorial.get_parts %}

--- a/templates/tutorial/part/view.html
+++ b/templates/tutorial/part/view.html
@@ -43,7 +43,7 @@
 {% block content %}
     {% if part.intro and part.intro != "None" %}
         {{ part.intro|emarkdown }}
-    {% else %}
+    {% elif not tutorial.in_beta %}
         <p class="ico-after warning">
             Il n'y a pas d'introduction.
         </p>
@@ -90,7 +90,7 @@
 
     {% if part.conclu and part.conclu != "None" %}
         {{ part.conclu|emarkdown }}
-    {% else %}
+    {% elif not tutorial.in_beta %}
         <p class="ico-after warning">
             Il n'y a pas de conclusion.
         </p>

--- a/templates/tutorial/tutorial/history.html
+++ b/templates/tutorial/tutorial/history.html
@@ -49,6 +49,7 @@
                 <th>Version</th>
                 <th width="10%">Diff.</th>
                 <th width="15%">Auteur</th>
+                <th width="12%">Bêta</th>
             </tr>
         </thead>
         <tbody>
@@ -57,11 +58,13 @@
                     <td>
                         {% if tutorial.sha_validation = log.newhexsha %}
                             Validation
-                        {% elif tutorial.sha_beta = log.newhexsha %}
+                        {% endif %}
+                        {% if tutorial.sha_beta = log.newhexsha %}
                             Beta
-                        {% elif tutorial.sha_draft =  log.newhexsha %}
-                            Draft 
-                        {% endif%}
+                        {% endif %}
+                        {% if tutorial.sha_draft = log.newhexsha %}
+                            Draft
+                        {% endif %}
                     </td>
                     <td>
                         {{ log.time.0|humane_time }}
@@ -84,6 +87,47 @@
                                 <em>Inconnu</em>
                             {% endif %}
                         {% endwith %}
+                    </td>
+                    <td>
+                        {% if not tutorial.sha_beta = log.newhexsha %}
+                            {% if not tutorial.sha_beta %}
+                                <a href="#activ-beta" class="open-modal">
+                                    Activer
+                                </a>
+                                <form action="{% url "zds.tutorial.views.modify_tutorial" %}" method="post" class="modal modal-small" id="activ-beta">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="tutorial" value="{{ tutorial.pk }}">
+                                    <input type="hidden" name="activ_beta">
+                                    <input type="hidden" name="version" value="{{ log.newhexsha }}">
+                                    <p>
+                                        Êtes-vous certain de vouloir <strong>activer</strong> la bêta sur le tutoriel 
+                                        "<em>{{ tutorial.title }}</em>" dans sa version du {{ log.time.0|humane_time }} ?
+                                    </p>
+                                    <button type="submit">
+                                        Confirmer
+                                    </button>
+                                </form>
+                            {% else %}
+                                <a href="#activ-beta" class="open-modal">
+                                    Mettre à jour
+                                </a>
+                                <form action="{% url "zds.tutorial.views.modify_tutorial" %}" method="post" class="modal modal-small" id="activ-beta">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="tutorial" value="{{ tutorial.pk }}">
+                                    <input type="hidden" name="update_beta">
+                                    <input type="hidden" name="version" value="{{ log.newhexsha }}">
+                                    <p>
+                                        Êtes-vous certain de vouloir <strong>mettre à jour</strong> la bêta du tutoriel 
+                                        "<em>{{ tutorial.title }}</em>" dans sa version du {{ log.time.0|humane_time }} ?
+                                    </p>
+                                    <button type="submit">
+                                        Confirmer
+                                    </button>
+                                </form>
+                            {% endif %}
+                        {% else %}
+                            <em>En bêta</em>
+                        {% endif %}
                     </td>
                 </tr>
             {% endfor %}

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -305,6 +305,18 @@
                         Historique validation
                     </a>
                 </li>
+                <li>
+                    <a  href="{% url "zds.mp.views.new" %}?{% for username in tutorial.authors.all %}&amp;username={{ username }}{% endfor %}"
+                        class="ico-after cite blue"
+                    >
+                        Envoyer un MP 
+                        {% if tutorial.authors.all|length > 1 %}
+                            aux auteurs
+                        {% else %}
+                            à l'auteur
+                        {% endif %}
+                    </a>
+                </li>
 
                 {% if tutorial.on_line %}
                     <li>

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -43,20 +43,29 @@
         {% include 'tutorial/includes/tags_authors.part.html' with tutorial=tutorial %}
     {% endif %}
 
-    {% if perms.tutorial.change_tutorial and tutorial.sha_validation %}
-        <p class="content-wrapper alert-box info">
-            Ce tutoriel est en attente de validation
-        </p>
-        {% if validation.comment_authors %}
-            <div class="content-wrapper comment-author">
-                <p>
-                    Le message suivant a été laissé à destination des validateurs : 
+    {% if user in tutorial.authors.all or perms.tutorial.change_tutorial %}
+        {% if tutorial.in_validation %}
+            {% if validation.is_pending %}
+                <p class="content-wrapper alert-box alert">
+                    Ce tutoriel est en attente d'un validateur
                 </p>
+            {% elif validation.is_pending_valid %}
+                <p class="content-wrapper alert-box info">
+                    Le tutoriel est en cours de validation par
+                    {% include "misc/member_item.part.html" with member=validation.validator %}
+                </p>
+            {% endif %}
+            {% if validation.comment_authors %}
+                <div class="content-wrapper comment-author">
+                    <p>
+                        Le message suivant a été laissé à destination des validateurs :
+                    </p>
 
-                <blockquote>
-                    {{ validation.comment_authors }}
-                </blockquote>
-            </div>
+                    <blockquote>
+                        {{ validation.comment_authors }}
+                    </blockquote>
+                </div>
+            {% endif %}
         {% endif %}
     {% endif %}
 

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -84,7 +84,7 @@
     {% with tuto_version=tutorial|repo_tuto:version %}
         {% if tuto_version.introduction and tuto_version.introduction != "None" %}
             {{ tuto_version.introduction|emarkdown }}
-        {% elif not tutorial.in_beta or tutorial.sha_beta != version %}
+        {% elif not tutorial.in_beta %}
             <p class="ico-after warning">
                 Il n'y a pas d'introduction.
             </p>
@@ -118,7 +118,7 @@
 
         {% if tuto_version.conclusion and tuto_version.conclusion != "None" %}
             {{ tuto_version.conclusion|emarkdown }}
-        {% else %}
+        {% elif not tutorial.in_beta %}
             <p class="ico-after warning">
                 Il n'y a pas de conclusion.
             </p>

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -274,24 +274,22 @@
                 <a href="#ask-validation" class="open-modal ico-after tick green">
                     Demander la validation
                 </a>
-                <div id="ask-validation" class="modal modal-medium">
-                    {% crispy formAskValidation %}
-                </div>
-            </li>
-        {% elif tutorial.sha_validation != version %}
-            <li>
-                <a href="#ask-validation" class="open-modal ico-after tick green">
-                    Mettre à jour la version en validation
-                </a>
-                <div id="ask-validation" class="modal modal-medium">
-                    {% crispy formAskValidation %}
-                </div>
             </li>
         {% else %}
+            {% if tutorial.sha_validation != version %}
+                <li>
+                    <a href="#ask-validation" class="open-modal ico-after tick green">
+                        Mettre à jour la version en validation
+                    </a>
+                </li>
+            {% endif %}
             <li class="inactive">
                 <span class="ico-after tick disabled">En attente de validation</span>
             </li>
         {% endif %}
+        <div id="ask-validation" class="modal modal-medium">
+            {% crispy formAskValidation %}
+        </div>
      {% endif %}
 {% endblock %}
 

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -69,7 +69,7 @@
                 {% endif %}
             {% else %}
                 {% if validation.is_pending %}
-                    <p class="content-wrapper alert-box info">
+                    <p class="content-wrapper alert-box alert">
                         <a href="{{ tutorial.get_absolute_url }}?version={{ validation.version }}">
                             Une autre version de ce tutoriel</a>
                         est en attente d'un validateur

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -72,7 +72,7 @@
     {% if tutorial.in_beta and tutorial.sha_beta == version %}
         <div class="content-wrapper">
             <div class="alert-box warning">
-                Attention, cette version du tutoriel est en <strong>BÊTA</strong> !
+                Cette version du tutoriel est en <strong>BÊTA</strong> !
             </div>
         </div>
     {% endif %}
@@ -118,7 +118,7 @@
 
         {% if tuto_version.conclusion and tuto_version.conclusion != "None" %}
             {{ tuto_version.conclusion|emarkdown }}
-        {% elif not tutorial.in_beta or tutorial.sha_beta != version %}
+        {% else %}
             <p class="ico-after warning">
                 Il n'y a pas de conclusion.
             </p>

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -230,7 +230,7 @@
         {% if not tutorial.in_beta %}
             <li>
                 <a href="#activ-beta" class="open-modal ico-after beta blue">
-                    Activer la bêta
+                    Mettre cette version en bêta
                 </a>
                 <form action="{% url "zds.tutorial.views.modify_tutorial" %}" method="post" class="modal modal-small" id="activ-beta">
                     {% csrf_token %}
@@ -238,7 +238,8 @@
                     <input type="hidden" name="activ_beta">
                     <input type="hidden" name="version" value="{{ version }}">
                     <p>
-                        Êtes-vous certain de vouloir <strong>activer</strong> la bêta sur le tutoriel "<em>{{ tutorial.title }}</em>" ?
+                        Êtes-vous certain de vouloir <strong>activer</strong> la bêta du tutoriel 
+                        "<em>{{ tutorial.title }}</em>" dans la version que vous voyez actuellement ?
                     </p>
                     <button type="submit">
                         Confirmer
@@ -248,8 +249,13 @@
         {% else %}
             {% if tutorial.sha_beta != version %}
                 <li>
+                    <a href="{{ tutorial.get_absolute_url }}?version={{ tutorial.sha_beta }}" class="ico-after view blue">
+                        Voir <span class="wide">la version</span> en bêta
+                    </a>
+                </li>
+                <li>
                     <a href="#update-beta" class="open-modal ico-after beta blue">
-                        Mettre à jour la bêta
+                        Mettre à jour la bêta avec cette version
                     </a>
                     <form action="{% url "zds.tutorial.views.modify_tutorial" %}" method="post" class="modal modal-small" id="update-beta">
                         {% csrf_token %}
@@ -257,12 +263,19 @@
                         <input type="hidden" name="update_beta">
                         <input type="hidden" name="version" value="{{ version }}">
                         <p>
-                            Êtes-vous certain de vouloir <strong>mettre à jour</strong> la bêta sur le tutoriel "<em>{{ tutorial.title }}</em>" ?
+                            Êtes-vous certain de vouloir <strong>mettre à jour</strong> la bêta du tutoriel 
+                            "<em>{{ tutorial.title }}</em>" dans la version que vous voyez actuellement ?
                         </p>
                         <button type="submit">
                             Confirmer
                         </button>
                     </form>
+                </li>
+            {% else %}
+                <li class="inactive">
+                    <span class="ico-after beta disabled">
+                        Cette version est déjà en bêta
+                    </span>
                 </li>
             {% endif %}
             <li>
@@ -275,7 +288,7 @@
                     <input type="hidden" name="desactiv_beta">
                     <input type="hidden" name="version" value="{{ version }}">
                     <p>
-                        Êtes-vous certain de vouloir <strong>désactiver</strong> la bêta sur le tutoriel "<em>{{ tutorial.title }}</em>" ?
+                        Êtes-vous certain de vouloir <strong>désactiver</strong> la bêta du tutoriel "<em>{{ tutorial.title }}</em>" ?
                     </p>
                     <button type="submit">
                         Confirmer

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -205,8 +205,8 @@
                 <form action="{% url "zds.tutorial.views.modify_tutorial" %}" method="post" class="modal modal-small" id="activ-beta">
                     {% csrf_token %}
                     <input type="hidden" name="tutorial" value="{{ tutorial.pk }}">
-                    <input type="hidden" name="activ_beta" />
-                    <input type="hidden" name="version" value="{{version}}" />
+                    <input type="hidden" name="activ_beta">
+                    <input type="hidden" name="version" value="{{ version }}">
                     <p>
                         Êtes-vous certain de vouloir <strong>activer</strong> la bêta sur le tutoriel "<em>{{ tutorial.title }}</em>" ?
                     </p>
@@ -218,14 +218,14 @@
         {% else %}
             {% if tutorial.sha_beta != version %}
                 <li>
-                    <a href="#update-beta" class="open-modal ico-after history blue">
+                    <a href="#update-beta" class="open-modal ico-after beta blue">
                         Mettre à jour la bêta
                     </a>
                     <form action="{% url "zds.tutorial.views.modify_tutorial" %}" method="post" class="modal modal-small" id="update-beta">
                         {% csrf_token %}
                         <input type="hidden" name="tutorial" value="{{ tutorial.pk }}">
-                        <input type="hidden" name="update_beta" />
-                        <input type="hidden" name="version" value="{{version}}" />
+                        <input type="hidden" name="update_beta">
+                        <input type="hidden" name="version" value="{{ version }}">
                         <p>
                             Êtes-vous certain de vouloir <strong>mettre à jour</strong> la bêta sur le tutoriel "<em>{{ tutorial.title }}</em>" ?
                         </p>
@@ -242,8 +242,8 @@
                 <form action="{% url "zds.tutorial.views.modify_tutorial" %}" method="post" class="modal modal-small" id="desactiv-beta">
                     {% csrf_token %}
                     <input type="hidden" name="tutorial" value="{{ tutorial.pk }}">
-                    <input type="hidden" name="desactiv_beta" />
-                    <input type="hidden" name="version" value="{{version}}" />
+                    <input type="hidden" name="desactiv_beta">
+                    <input type="hidden" name="version" value="{{ version }}">
                     <p>
                         Êtes-vous certain de vouloir <strong>désactiver</strong> la bêta sur le tutoriel "<em>{{ tutorial.title }}</em>" ?
                     </p>

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -45,26 +45,43 @@
 
     {% if user in tutorial.authors.all or perms.tutorial.change_tutorial %}
         {% if tutorial.in_validation %}
-            {% if validation.is_pending %}
-                <p class="content-wrapper alert-box alert">
-                    Ce tutoriel est en attente d'un validateur
-                </p>
-            {% elif validation.is_pending_valid %}
-                <p class="content-wrapper alert-box info">
-                    Le tutoriel est en cours de validation par
-                    {% include "misc/member_item.part.html" with member=validation.validator %}
-                </p>
-            {% endif %}
-            {% if validation.comment_authors %}
-                <div class="content-wrapper comment-author">
-                    <p>
-                        Le message suivant a été laissé à destination des validateurs :
+            {% if validation.version == version %}
+                {% if validation.is_pending %}
+                    <p class="content-wrapper alert-box alert">
+                        Ce tutoriel est en attente d'un validateur
                     </p>
+                {% elif validation.is_pending_valid %}
+                    <p class="content-wrapper alert-box info">
+                        Le tutoriel est en cours de validation par
+                        {% include "misc/member_item.part.html" with member=validation.validator %}
+                    </p>
+                {% endif %}
+                {% if validation.comment_authors %}
+                    <div class="content-wrapper comment-author">
+                        <p>
+                            Le message suivant a été laissé à destination des validateurs :
+                        </p>
 
-                    <blockquote>
-                        {{ validation.comment_authors }}
-                    </blockquote>
-                </div>
+                        <blockquote>
+                            {{ validation.comment_authors }}
+                        </blockquote>
+                    </div>
+                {% endif %}
+            {% else %}
+                {% if validation.is_pending %}
+                    <p class="content-wrapper alert-box info">
+                        <a href="{{ tutorial.get_absolute_url }}?version={{ validation.version }}">
+                            Une autre version de ce tutoriel</a>
+                        est en attente d'un validateur
+                    </p>
+                {% elif validation.is_pending_valid %}
+                    <p class="content-wrapper alert-box info">
+                        <a href="{{ tutorial.get_absolute_url }}?version={{ validation.version }}">
+                            Une autre version de ce tutoriel</a>
+                        est en cours de validation par
+                        {% include "misc/member_item.part.html" with member=validation.validator %}
+                    </p>
+                {% endif %}
             {% endif %}
         {% endif %}
     {% endif %}
@@ -130,22 +147,26 @@
 
 {% block sidebar_new %}
     {% if user in tutorial.authors.all or perms.tutorial.change_tutorial %}
-        {% if not tutorial.is_mini %}
-            <a href="{% url "zds.tutorial.views.add_part" %}?tutoriel={{ tutorial.pk }}" class="ico-after more blue new-btn">
-                Ajouter une partie
-            </a>
-        {% else %}
-            <a href="{% url "zds.tutorial.views.add_extract" %}?chapitre={{ tutorial.get_chapter.pk }}" class="ico-after more blue new-btn">
-                Ajouter un extrait
-            </a>
-        {% endif %}
-
         {% if tutorial.sha_draft = version %}
+            {% if not tutorial.is_mini %}
+                <a href="{% url "zds.tutorial.views.add_part" %}?tutoriel={{ tutorial.pk }}" class="ico-after more blue new-btn">
+                    Ajouter une partie
+                </a>
+            {% else %}
+                <a href="{% url "zds.tutorial.views.add_extract" %}?chapitre={{ tutorial.get_chapter.pk }}" class="ico-after more blue new-btn">
+                    Ajouter un extrait
+                </a>
+            {% endif %}
+
             <a href="{% url "zds.tutorial.views.edit_tutorial" %}?tutoriel={{ tutorial.pk }}" class="ico-after edit blue new-btn">
                 Éditer
             </a>
+        {% else %}
+            <a href="{{ tutorial.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
+                Version brouillon
+            </a>
         {% endif %}
-     {% endif %}
+    {% endif %}
 {% endblock %}
 
 
@@ -290,7 +311,7 @@
         <div id="ask-validation" class="modal modal-medium">
             {% crispy formAskValidation %}
         </div>
-     {% endif %}
+    {% endif %}
 {% endblock %}
 
 

--- a/templates/tutorial/validation/history.html
+++ b/templates/tutorial/validation/history.html
@@ -45,6 +45,17 @@
                     <tr>
                         <td>
                             {{ validation.date_proposition|format_date|capfirst }}
+                            {% if validation.comment_authors %}
+                                <br>
+                                <a href="#view-comment-authors-{{ validation.version }}" class="open-modal">
+                                    Message laissé à la validation
+                                </a>
+                                <div class="modal modal-big" id="view-comment-authors-{{ validation.version }}" data-modal-close="Fermer">
+                                    <p>
+                                        {{ validation.comment_authors }}
+                                    </p>
+                                </div>
+                            {% endif %}
                         </td>
                         <td>
                             {% captureas reservation_url %}

--- a/templates/tutorial/validation/history.html
+++ b/templates/tutorial/validation/history.html
@@ -47,10 +47,10 @@
                             {{ validation.date_proposition|format_date|capfirst }}
                             {% if validation.comment_authors %}
                                 <br>
-                                <a href="#view-comment-authors-{{ validation.version }}" class="open-modal">
+                                <a href="#view-comment-authors-{{ validation.pk }}" class="open-modal">
                                     Message laissé à la validation
                                 </a>
-                                <div class="modal modal-big" id="view-comment-authors-{{ validation.version }}" data-modal-close="Fermer">
+                                <div class="modal modal-big" id="view-comment-authors-{{ validation.pk }}" data-modal-close="Fermer">
                                     <p>
                                         {{ validation.comment_authors }}
                                     </p>

--- a/templates/tutorial/validation/index.html
+++ b/templates/tutorial/validation/index.html
@@ -31,6 +31,7 @@
                 {% elif request.GET.type == "orphan" %}
                     / Non-reservés
                 {% endif %}
+                ({{ validations|length }})
             {% endblock %}
         </h1>
 
@@ -61,7 +62,7 @@
                                     </a>
                                     <br>
                                     {% if validation.tutorial.subcategory.all %}
-                                        Catégorie{{ validation.article.subcategory.all|pluralize }} : 
+                                        Catégories : 
                                         {% for subcategory in validation.tutorial.subcategory.all %}
                                             {% if not forloop.first %}
                                                 -

--- a/templates/tutorial/validation/index.html
+++ b/templates/tutorial/validation/index.html
@@ -61,7 +61,7 @@
                                     </a>
                                     <br>
                                     {% if validation.tutorial.subcategory.all %}
-                                        Catégories : 
+                                        Catégorie{{ validation.article.subcategory.all|pluralize }} : 
                                         {% for subcategory in validation.tutorial.subcategory.all %}
                                             {% if not forloop.first %}
                                                 -

--- a/templates/tutorial/validation/index.html
+++ b/templates/tutorial/validation/index.html
@@ -47,9 +47,8 @@
                     <thead>
                         <tr>
                             <th>Titre</th>
-                            <th width="8%">Catégorie(s)</th>
-                            <th width="8%">Auteur(s)</th>
-                            <th width="8%">Proposé</th>
+                            <th width="15%">Auteur(s)</th>
+                            <th width="10%">Proposé</th>
                             <th width="24%">Statut</th>
                         </tr>
                     </thead>
@@ -60,13 +59,19 @@
                                     <a href="{% url "zds.tutorial.views.view_tutorial" validation.tutorial.pk validation.tutorial.slug %}?version={{ validation.version }}">
                                         {{ validation.tutorial.title }}
                                     </a>
-                                </td>
-                                <td>
-                                    {% for subcategory in validation.tutorial.subcategory.all %}
-                                        <a href="{% url "zds.tutorial.views.list_validation" %}?subcategory={{subcategory.pk}}">
-                                            {{ subcategory.title }}
-                                        </a>
-                                    {% endfor %}
+                                    <br>
+                                    {% if validation.tutorial.subcategory.all %}
+                                        Catégories : 
+                                        {% for subcategory in validation.tutorial.subcategory.all %}
+                                            {% if not forloop.first %}
+                                                -
+                                            {% endif %}
+                                            <a href="{% url "zds.tutorial.views.list_validation" %}?subcategory={{ subcategory.pk }}">
+                                                {{ subcategory.title }}</a>
+                                        {% endfor %}
+                                    {% else %}
+                                        <em>Aucune catégorie</em>
+                                    {% endif %}
                                 </td>
                                 <td>
                                     {% for author in validation.tutorial.authors.all %}
@@ -74,7 +79,7 @@
                                     {% endfor %}
                                 </td>
                                 <td>
-                                    <span>{{ validation.date_proposition|format_date|capfirst }}</span>
+                                    <span>{{ validation.date_proposition|format_date:True|capfirst }}</span>
                                 </td>
                                 <td>
                                     {% captureas reservation_url %}

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -588,7 +588,7 @@ def modify(request):
                     validation.version)
 
     # User actions
-    if request.user in article.authors.all():
+    if request.user in article.authors.all() or request.user.has_perm('article.change_article'):
         if 'delete' in data:
             if article.authors.count() == 1:
                 article.delete()
@@ -599,7 +599,12 @@ def modify(request):
 
         # User would like to validate his article. So we must save the
         # current sha (version) of the article to his sha_validation.
-        elif 'pending' in request.POST and article.sha_validation is None:
+        elif 'pending' in request.POST:
+            #delete old pending validation
+            Validation.objects.filter(article__pk=article_pk,
+                                      status__in=['PENDING','PENDING_V'])\
+                                      .delete()
+
             validation = Validation()
             validation.status = 'PENDING'
             validation.article = article

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -600,11 +600,12 @@ def modify(request):
         # User would like to validate his article. So we must save the
         # current sha (version) of the article to his sha_validation.
         elif 'pending' in request.POST:
-            #delete old pending validation
+            # Delete old pending validation
             Validation.objects.filter(article__pk=article_pk,
                                       status__in=['PENDING','PENDING_V'])\
                                       .delete()
 
+            # Create new validation
             validation = Validation()
             validation.status = 'PENDING'
             validation.article = article

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -110,8 +110,7 @@ def view(request, article_pk, article_slug):
     article_version['txt'] = get_blob(repo.commit(sha).tree, article_version['text'])
     article_version = article.load_dic(article_version)
 
-    validation = Validation.objects.filter(article__pk=article.pk,
-                                            version=sha)\
+    validation = Validation.objects.filter(article__pk=article.pk)\
                                     .order_by("-date_proposition")\
                                     .first()
 

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -787,7 +787,10 @@ def reservation(request, validation_pk):
         validation.date_reserve = datetime.now()
         validation.status = 'RESERVED'
         validation.save()
-        return redirect(validation.article.get_absolute_url())
+        return redirect(
+            validation.article.get_absolute_url() +
+            '?version=' + validation.version
+        )
 
 
 @login_required

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -189,7 +189,10 @@ def reservation(request, validation_pk):
         messages.info(request,
                       u"Le tutoriel a bien été \
                       réservé par {0}.".format(request.user.username))
-        return redirect(validation.tutorial.get_absolute_url())
+        return redirect(
+            validation.tutorial.get_absolute_url() +
+            "?version=" + validation.version
+        )
 
 
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -711,8 +711,7 @@ def view_tutorial(request, tutorial_pk, tutorial_slug):
                     cpt_e += 1
                 cpt_c += 1
             cpt_p += 1
-    validation = Validation.objects.filter(tutorial__pk=tutorial.pk,
-                                           version=sha)\
+    validation = Validation.objects.filter(tutorial__pk=tutorial.pk)\
                                     .order_by("-date_proposition")\
                                     .first()
     formAskValidation = AskValidationForm()

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -601,16 +601,16 @@ def modify_tutorial(request):
                              .format(author.username))
             return redirect(redirect_url)
         elif "activ_beta" in request.POST:
-            if "version" in request.POST and tutorial.sha_draft == request.POST['version'] :
-                tutorial.sha_beta = tutorial.sha_draft
+            if "version" in request.POST:
+                tutorial.sha_beta = request.POST['version']
                 tutorial.save()
                 messages.success(request, u"La BETA sur ce tutoriel est bien activée.")
             else:
                 messages.error(request, u"Impossible d'activer la BETA sur ce tutoriel.")
             return redirect(tutorial.get_absolute_url_beta())
         elif "update_beta" in request.POST:
-            if "version" in request.POST and tutorial.sha_draft == request.POST['version'] :
-                tutorial.sha_beta = tutorial.sha_draft
+            if "version" in request.POST:
+                tutorial.sha_beta = request.POST['version']
                 tutorial.save()
                 messages.success(request, u"La BETA sur ce tutoriel a bien été mise à jour.")
             else:


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | (Oui) |
| Tickets concernés | #1200, #1289, #1293 |

Correction des bugs suivants :
- quand on réserve un tutoriel, puis qu'on annule la réservation, un autre doit pouvoir réserver de nouveau le tutoriel (il doit avoir les bons boutons) ;
- les messages type "Pas d'introduction" sont visibles par tous pendant la beta (ça avait l'air de buguer)

But secondaire de la PR : réorganiser l'interface de validation, affichage de plein de données qui sont dispos mais pas affichées jusqu'ici, notamment :
- affiche un bandeau orange pour dire que le tuto/article est en attente d'un validateur
- affiche quel valido a réservé le tutoriel/article
- message de l'auteur sur le tuto (c'était déjà fait, mais maintenant c'est affiché à l'auteur également, pas seulement aux validos)
- message de l'auteur et motif de refus/publication visible sur l'historique de validation (pour les validos) via des liens qui ouvrent des modales

_EDIT : Nouvelles choses_ : 
- quand on est sur un article/tuto qui est en cours de validation, mais qu'on est pas sur la version en validation : présence d'un lien vers la version en validation
- quand on n'est pas sur la version brouillon : 
  - le bouton éditer n'est plus accessible (car ça édite la version brouillon et non celle qu'on regarde)
  - les boutons ajout de chapitre/partie/extrait ne sont plus visibles non plus
  - un bouton "Version brouillon" est visible à la place des autres pour mener vers la version éditable

**QA** : revérifier tout le workflow beta, validation, publication. Seules les versions hors lignes sont touchées (interface de rédaction + interface de validation, pas la version publique).
