### PR TITLE
creation auto de sujets pour les tuto en beta

### DIFF
--- a/zds/forum/migrations/0006_auto__add_field_topic_key.py
+++ b/zds/forum/migrations/0006_auto__add_field_topic_key.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Topic.key'
+        db.add_column(u'forum_topic', 'key',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Topic.key'
+        db.delete_column(u'forum_topic', 'key')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'forum.category': {
+            'Meta': {'object_name': 'Category'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '80'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'forum.forum': {
+            'Meta': {'object_name': 'Forum'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['forum.Category']"}),
+            'group': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['auth.Group']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'position_in_category': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '80'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'forum.post': {
+            'Meta': {'object_name': 'Post', '_ormbases': [u'utils.Comment']},
+            u'comment_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['utils.Comment']", 'unique': 'True', 'primary_key': 'True'}),
+            'is_useful': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'topic': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['forum.Topic']"})
+        },
+        u'forum.topic': {
+            'Meta': {'object_name': 'Topic'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'topics'", 'to': u"orm['auth.User']"}),
+            'forum': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['forum.Forum']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_locked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_solved': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'is_sticky': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'key': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'last_message': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_message'", 'null': 'True', 'to': u"orm['forum.Post']"}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'tags': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['utils.Tag']", 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'forum.topicfollowed': {
+            'Meta': {'object_name': 'TopicFollowed'},
+            'email': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'topic': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['forum.Topic']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'topics_followed'", 'to': u"orm['auth.User']"})
+        },
+        u'forum.topicread': {
+            'Meta': {'object_name': 'TopicRead'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'post': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['forum.Post']"}),
+            'topic': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['forum.Topic']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'topics_read'", 'to': u"orm['auth.User']"})
+        },
+        u'utils.comment': {
+            'Meta': {'object_name': 'Comment'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': u"orm['auth.User']"}),
+            'dislike': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'comments-editor'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.CharField', [], {'max_length': '39'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'like': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'text_hidden': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '80'}),
+            'text_html': ('django.db.models.fields.TextField', [], {}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'utils.tag': {
+            'Meta': {'object_name': 'Tag'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        }
+    }
+
+    complete_apps = ['forum']

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -157,6 +157,8 @@ class Topic(models.Model):
         null=True,
         blank=True,
         db_index=True)
+    
+    key = models.IntegerField('cle', null=True, blank=True)
 
     def __unicode__(self):
         """Textual form of a thread."""

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -272,7 +272,11 @@ SPAM_LIMIT_SECONDS = 60 * 15
 SPAM_LIMIT_PARTICIPANT = 2
 FOLLOWED_TOPICS_PER_PAGE = 21
 
+#username of the bot who send MP
 BOT_ACCOUNT = 'admin'
+
+#primary key of beta forum
+BETA_FORUM_ID = 1
 
 PANDOC_LOC = ''
 # LOG PATH FOR PANDOC LOGGING

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -9,6 +9,7 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from zds.forum.factories import CategoryFactory, ForumFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.gallery.factories import GalleryFactory, UserGalleryFactory, ImageFactory
 from zds.mp.models import PrivateTopic
@@ -1362,7 +1363,9 @@ class BigTutorialTests(TestCase):
 
     def test_workflow_beta_tuto(self) :
         "Ensure the behavior of the beta version of tutorials"
-
+        forum = ForumFactory(
+            category=CategoryFactory(position=1),
+            position_in_category=1)
         # logout before
         self.client.logout()
         # first, login with author :
@@ -2312,6 +2315,10 @@ class MiniTutorialTests(TestCase):
     
     def test_workflow_beta_tuto(self) :
         "Ensure the behavior of the beta version of tutorials"
+
+        forum = ForumFactory(
+            category=CategoryFactory(position=1),
+            position_in_category=1)
 
         # logout before
         self.client.logout()

--- a/zds/utils/forums.py
+++ b/zds/utils/forums.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+
+from datetime import datetime
+from zds.forum.models import Topic, Post, follow
+from zds.forum.views import get_tag_by_title
+from django.core.mail import EmailMultiAlternatives
+from django.conf import settings
+from django.template import Context
+from django.template.loader import get_template
+from zds.utils.templatetags.emarkdown import emarkdown
+
+def create_topic(
+        author,
+        forum,
+        title,
+        subtitle,
+        text,
+        key):
+    """create topic in forum"""
+    
+    (tags, title_only) = get_tag_by_title(title[:80])
+
+    # Creating the thread
+    n_topic = Topic()
+    n_topic.forum = forum
+    n_topic.title = title_only
+    n_topic.subtitle = subtitle
+    n_topic.pubdate = datetime.now()
+    n_topic.author = author
+    n_topic.key = key
+    n_topic.save()
+    n_topic.add_tags(tags)
+    n_topic.save()
+
+    # Add the first message
+    post = Post()
+    post.topic = n_topic
+    post.author = author
+    post.text = text
+    post.text_html = emarkdown(text)
+    post.pubdate = datetime.now()
+    post.position = 1
+    post.save()
+
+    n_topic.last_message = post
+    n_topic.save()
+
+    follow(n_topic, user=author)
+
+    return n_topic
+
+def send_post(topic, text):
+    
+    post = Post()
+    post.topic = topic
+    post.author = topic.author
+    post.text = text
+    post.text_html = emarkdown(text)
+    post.pubdate = datetime.now()
+    post.position = topic.last_message.position+1
+    post.save()
+    
+    topic.last_message = post
+    topic.save()
+
+def lock_topic(topic):
+    topic.is_locked = True
+    topic.save()
+
+def unlock_topic(topic):
+    topic.is_locked = False
+    topic.save()
+    


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #991 |

Cette PR permet de faire ceci:
- Lorsqu'on mets en beta une version de notre tuto, un sujet est crée dans le forum beta (paramètrable dans le settings), et l'auteur de la mise en beta follow automatiquement le topic
- On peut donc commenter la version beta sur le topic
- Lorsqu'on arrête la beta sur une version de notre tutoriel, le sujet en question est locké
- Si on réactive la beta sur la même version, le sujet est dévérouillé
- Si on mets à jour la beta sur une autre version, un message est posté sur le topic pour prévénir de la nouvelle version.

_Note pour la QA_

Vérifiez que ça se passe bien comme prévu.
