### PR TITLE
Corrige le lien "X réactions" des articles

### DIFF
--- a/templates/article/includes/article_item.part.html
+++ b/templates/article/includes/article_item.part.html
@@ -10,36 +10,40 @@
         {% endcaptureas %}
     {% endif %}
 
-    <a href="{{ link }}">
-        {% if article.image %}
+    {% if article.image %}
+        <a href="{{ link }}" tabindex="-1">
             <img src="{{ article.image.article_illu.url }}" alt="" class="tutorial-img avatar">
-        {% endif %}
+        </a>
+    {% endif %}
 
-        <div class="tutorial-infos {% if not article.image %}no-illu{% endif %}">
-            <h3 itemprop="itemListElement">{{ article.title }}</h3>
-            <p class="article-metadata">
-                {% if article.sha_public %}
-                    {{ article.pubdate|format_date|capfirst }}
-                    -
-                    <a href="
-                        {% if article.last_read_reaction %}
-                            {{ article.last_read_reaction.get_absolute_url }}
-                        {% else %}
-                            {{ article.get_absolute_url_online }}#reactions
-                        {% endif %}
-                    ">
-                        {% if article.get_reaction_count == 0 %}
-                            Aucune réaction
-                        {% else %}
-                            {{ article.get_reaction_count }} réaction{{ article.get_reaction_count|pluralize }}
-                        {% endif %}
-                    </a>
-                {% elif article.sha_validation %}
-                    En validation
-                {% else %}
-                    Brouillon
-                {% endif %}
-            </p>
-        </div>
-    </a>
+    <div class="tutorial-infos {% if not article.image %}no-illu{% endif %}">
+        <h3 itemprop="itemListElement">
+            <a href="{{ link }}">
+                {{ article.title }}
+            </a>
+        </h3>
+        <p class="article-metadata">
+            {% if article.sha_public %}
+                {{ article.pubdate|format_date|capfirst }}
+                -
+                <a href="
+                    {% if article.last_read_reaction %}
+                        {{ article.last_read_reaction.get_absolute_url }}
+                    {% else %}
+                        {{ article.get_absolute_url_online }}#reactions
+                    {% endif %}
+                ">
+                    {% if article.get_reaction_count == 0 %}
+                        Aucune réaction
+                    {% else %}
+                        {{ article.get_reaction_count }} réaction{{ article.get_reaction_count|pluralize }}
+                    {% endif %}
+                </a>
+            {% elif article.sha_validation %}
+                En validation
+            {% else %}
+                Brouillon
+            {% endif %}
+        </p>
+    </div>
 </article>

--- a/templates/article/includes/article_item.part.html
+++ b/templates/article/includes/article_item.part.html
@@ -19,7 +19,7 @@
             <h3 itemprop="itemListElement">{{ article.title }}</h3>
             <p class="article-metadata">
                 {% if article.sha_public %}
-                    Publié {{ article.pubdate|format_date:True }}
+                    {{ article.pubdate|format_date|capfirst }}
                     -
                     <a href="
                         {% if article.last_read_reaction %}

--- a/templates/article/includes/article_item.part.html
+++ b/templates/article/includes/article_item.part.html
@@ -18,22 +18,27 @@
         <div class="tutorial-infos {% if not article.image %}no-illu{% endif %}">
             <h3 itemprop="itemListElement">{{ article.title }}</h3>
             <p class="article-metadata">
-                {{ article.pubdate|format_date|capfirst }} -
-                <a href="
-                    {% if article.get_reaction_count == 0 %}
-                        {{ link }}#reactions
-                    {% else %}
-                        {{ article.get_last_reaction.get_absolute_url }}
-                    {% endif %}
+                {% if article.sha_public %}
+                    Publié {{ article.pubdate|format_date:True }}
+                    -
+                    <a href="
+                        {% if article.last_read_reaction %}
+                            {{ article.last_read_reaction.get_absolute_url }}
+                        {% else %}
+                            {{ article.get_absolute_url_online }}#reactions
+                        {% endif %}
                     ">
-                    {% if article.get_reaction_count == 0 %}
-                        Aucune réaction
-                    {% elif article.get_reaction_count == 1 %}
-                        1 réaction
-                    {% else %}
-                        {{ article.get_reaction_count }} réactions
-                    {% endif %}
-                </a>
+                        {% if article.get_reaction_count == 0 %}
+                            Aucune réaction
+                        {% else %}
+                            {{ article.get_reaction_count }} réaction{{ article.get_reaction_count|pluralize }}
+                        {% endif %}
+                    </a>
+                {% elif article.sha_validation %}
+                    En validation
+                {% else %}
+                    Brouillon
+                {% endif %}
             </p>
         </div>
     </a>

--- a/templates/home.html
+++ b/templates/home.html
@@ -89,10 +89,10 @@
                     <span class="article-metadata">
                         {{ article.pubdate|format_date|capfirst }} -
                         <a href="
-                            {% if article.get_reaction_count == 0 %}
-                                {{ article.get_absolute_url_online }}#reactions
+                            {% if article.last_read_reaction %}
+                                {{ article.last_read_reaction.get_absolute_url }}
                             {% else %}
-                                {{ article.get_last_reaction.get_absolute_url }}
+                                {{ article.get_absolute_url_online }}#reactions
                             {% endif %}
                         ">
                             {% if article.get_reaction_count == 0 %}

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -154,7 +154,7 @@ class Article(models.Model):
         article_version['sha_draft'] = self.sha_draft
         article_version['sha_validation'] = self.sha_validation
         article_version['sha_public'] = self.sha_public
-        article_version['get_last_reaction'] = self.get_last_reaction
+        article_version['last_read_reaction'] = self.last_read_reaction
         article_version['get_reaction_count'] = self.get_reaction_count
         article_version['get_absolute_url'] = reverse('zds.article.views.view', 
                                                       args=[self.pk, self.slug])
@@ -225,8 +225,8 @@ class Article(models.Model):
                 .select_related()\
                 .filter(article=self, user=get_current_user())\
                 .latest('reaction__pubdate').reaction
-        except Reaction.DoesNotExist:
-            return self.first_post()
+        except:
+            return self.first_reaction()
     
     def first_unread_reaction(self):
         """Return the first reaction the user has unread."""


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1273 |

Cette PR corrige la forme des listes d'articles, et principalement le lien vers la dernière réaction lue.

**QA** :
- Créer 4 articles :
  - Publier le premier
  - Publier et commenter le second
  - Demander la validation du troisième
  - Laisser le dernier en tant que simple brouillon
- Aller dans "Mes articles"
  - Le premier doit afficher la date de parution et "Aucun commentaire". Le lien redirige vers l'ancre #reactions de la version publique de l'article
  - Le second doit afficher la date de parution et le nombre de commentaire, le lien vers les réactions va vers la version publique et pointe sur la dernière réactions lue, tandis que le lien de l'article est la version éditable
  - L'article en validation est indiqué sans date, sans nombre de commentaire mais avec la mention "En validation"
  - Pareil que validation mais avec la mention "Brouillon"
- Aller sur l'accueil, vérifier que tous les liens des articles et leurs commentaires fonctionnent dans les deux cas publiés
- Aller dans la liste des articles (via le header) et vérifier que tous les liens fonctionnent également.
