### PR TITLE
Corrige une incohérence des métadonnées des sujets

### DIFF
--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -103,9 +103,9 @@
             {% endif %}
 
             {% if forloop.first and nb = 1 %}
-                {% set True as answer_schema %}
-            {% else %}
                 {% set False as answer_schema %}
+            {% else %}
+                {% set True as answer_schema %}
             {% endif %}
 
             {% include "misc/message.part.html" with perms_change=perms.forum.change_topic answer_schema=answer_schema %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |

Avant, la question avait la métadonnée réponse et les réponses n'avaient rien. Du coup ça fiche en l'air l'ensemble des métadonnées du forum. Avec cette simple modification, les réponses sur le forum doivent être englobées d'une métadonnées Anwser tandis que la question est dans le wrapper global Question.
