### PR TITLE
rajoute les filtres aux topics epinglés

### DIFF
--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -444,3 +444,22 @@ def get_last_topics(user):
         if cpt > 5:
             break
     return tops
+
+def get_topics(forum_pk, is_sticky, is_solved=None):
+    """ Get topics according to parameters """
+
+    if is_solved is not None:
+        return Topic.objects.filter(
+                    forum__pk=forum_pk,
+                    is_sticky=is_sticky,
+                    is_solved=is_solved).order_by("-last_message__pubdate").prefetch_related(
+                    "author",
+                    "last_message",
+                    "tags").all()
+    else:
+        return Topic.objects.filter(
+                    forum__pk=forum_pk,
+                    is_sticky=is_sticky).order_by("-last_message__pubdate").prefetch_related(
+                    "author",
+                    "last_message",
+                    "tags").all()

--- a/zds/forum/tests.py
+++ b/zds/forum/tests.py
@@ -13,7 +13,7 @@ from zds.utils.models import CommentLike, CommentDislike, Alert
 from django.core import mail
 
 from .models import Post, Topic, TopicFollowed, TopicRead
-from zds.forum.views import get_tag_by_title
+from zds.forum.views import get_tag_by_title, get_topics
 
 class ForumMemberTests(TestCase):
 
@@ -971,3 +971,27 @@ class ForumGuestTests(TestCase):
                     slugify(topic1.title)]),
             follow=True)
         self.assertEqual(result.status_code, 200)
+
+    def test_filter_topic(self):
+        """Test filters for solved topic or not"""
+        user1 = ProfileFactory().user
+        topic = TopicFactory(forum=self.forum11, author=self.user, is_solved=False, is_sticky=False)
+        topic_solved = TopicFactory(forum=self.forum11, author=self.user, is_solved=True, is_sticky=False)
+        topic_sticky = TopicFactory(forum=self.forum11, author=self.user, is_solved=False, is_sticky=True)
+        topic_solved_sticky = TopicFactory(forum=self.forum11, author=self.user, is_solved=True, is_sticky=True)
+
+        self.assertEqual(len(get_topics(forum_pk=self.forum11.pk, is_sticky=False, is_solved=False)), 1)
+        self.assertEqual(get_topics(forum_pk=self.forum11.pk, is_sticky=False, is_solved=False)[0], topic)
+
+        self.assertEqual(len(get_topics(forum_pk=self.forum11.pk, is_sticky=False, is_solved=True)), 1)
+        self.assertEqual(get_topics(forum_pk=self.forum11.pk, is_sticky=False, is_solved=True)[0], topic_solved)
+
+        self.assertEqual(len(get_topics(forum_pk=self.forum11.pk, is_sticky=True, is_solved=False)), 1)
+        self.assertEqual(get_topics(forum_pk=self.forum11.pk, is_sticky=True, is_solved=False)[0], topic_sticky)
+
+        self.assertEqual(len(get_topics(forum_pk=self.forum11.pk, is_sticky=True, is_solved=True)), 1)
+        self.assertEqual(get_topics(forum_pk=self.forum11.pk, is_sticky=True, is_solved=True)[0], topic_solved_sticky)
+        
+        self.assertEqual(len(get_topics(forum_pk=self.forum11.pk, is_sticky=False)), 2)
+        self.assertEqual(len(get_topics(forum_pk=self.forum11.pk, is_sticky=True)), 2)
+        

--- a/zds/forum/tests.py
+++ b/zds/forum/tests.py
@@ -13,7 +13,8 @@ from zds.utils.models import CommentLike, CommentDislike, Alert
 from django.core import mail
 
 from .models import Post, Topic, TopicFollowed, TopicRead
-from zds.forum.views import get_tag_by_title, get_topics
+from zds.forum.views import get_tag_by_title
+from zds.forum.models import get_topics
 
 class ForumMemberTests(TestCase):
 

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -54,11 +54,13 @@ def details(request, cat_slug, forum_slug):
     forum = get_object_or_404(Forum, slug=forum_slug)
     if not forum.can_read(request.user):
         raise PermissionDenied
-    sticky_topics = Topic.objects.filter(forum__pk=forum.pk, is_sticky=True).order_by(
-        "-last_message__pubdate").prefetch_related("author", "last_message", "tags").all()
     if "filter" in request.GET:
         filter = request.GET["filter"]
         if request.GET["filter"] == "solve":
+        	sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True,is_solved=True)\
+        						.order_by("-last_message__pubdate")\
+        						.prefetch_related("author", "last_message", "tags")\
+        						.all()
             topics = Topic.objects.filter(
                 forum__pk=forum.pk,
                 is_sticky=False,
@@ -67,6 +69,10 @@ def details(request, cat_slug, forum_slug):
                 "last_message",
                 "tags").all()
         else:
+        	sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True,is_solved=False)\
+        						.order_by("-last_message__pubdate")\
+        						.prefetch_related("author", "last_message", "tags")\
+        						.all()
             topics = Topic.objects.filter(
                 forum__pk=forum.pk,
                 is_sticky=False,
@@ -76,6 +82,10 @@ def details(request, cat_slug, forum_slug):
                 "tags").all()
     else:
         filter = None
+        sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True)\
+        						.order_by("-last_message__pubdate")\
+        						.prefetch_related("author", "last_message", "tags")\
+        						.all()
         topics = Topic.objects.filter(forum__pk=forum.pk, is_sticky=False) .order_by(
             "-last_message__pubdate").prefetch_related("author", "last_message", "tags").all()
 
@@ -885,7 +895,6 @@ def find_topic_by_tag(request, tag_pk, tag_slug):
         if request.GET["filter"] == "solve":
             topics = Topic.objects.filter(
                 tags__in=[tag],
-                is_sticky=False,
                 is_solved=True).order_by("-last_message__pubdate").prefetch_related(
                 "author",
                 "last_message",
@@ -895,7 +904,6 @@ def find_topic_by_tag(request, tag_pk, tag_slug):
         else:
             topics = Topic.objects.filter(
                 tags__in=[tag],
-                is_sticky=False,
                 is_solved=False).order_by("-last_message__pubdate").prefetch_related(
                 "author",
                 "last_message",
@@ -904,8 +912,7 @@ def find_topic_by_tag(request, tag_pk, tag_slug):
                 .all()
     else:
         filter = None
-        topics = Topic.objects.filter(tags__in=[tag], is_sticky=False) .order_by(
-            "-last_message__pubdate")\
+        topics = Topic.objects.filter(tags__in=[tag]).order_by("-last_message__pubdate")\
             .exclude(Q(forum__group__isnull=False) & ~Q(forum__group__in=u.groups.all()))\
             .prefetch_related("author", "last_message", "tags").all()
     # Paginator

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -56,38 +56,16 @@ def details(request, cat_slug, forum_slug):
         raise PermissionDenied
     if "filter" in request.GET:
         filter = request.GET["filter"]
-        if request.GET["filter"] == "solve":
-            sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True,is_solved=True)\
-                                    .order_by("-last_message__pubdate")\
-                                    .prefetch_related("author", "last_message", "tags")\
-                                    .all()
-            topics = Topic.objects.filter(
-                forum__pk=forum.pk,
-                is_sticky=False,
-                is_solved=True).order_by("-last_message__pubdate").prefetch_related(
-                "author",
-                "last_message",
-                "tags").all()
+        if filter == "solve":
+            sticky_topics = get_topics(forum_pk=forum.pk, is_sticky=True, is_solved=True)
+            topics = get_topics(forum_pk=forum.pk, is_sticky=False, is_solved=True)
         else:
-            sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True,is_solved=False)\
-                                    .order_by("-last_message__pubdate")\
-                                    .prefetch_related("author", "last_message", "tags")\
-                                    .all()
-            topics = Topic.objects.filter(
-                forum__pk=forum.pk,
-                is_sticky=False,
-                is_solved=False).order_by("-last_message__pubdate").prefetch_related(
-                "author",
-                "last_message",
-                "tags").all()
+            sticky_topics = get_topics(forum_pk=forum.pk, is_sticky=True, is_solved=False)
+            topics = get_topics(forum_pk=forum.pk, is_sticky=False, is_solved=False)
     else:
         filter = None
-        sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True)\
-                                    .order_by("-last_message__pubdate")\
-                                    .prefetch_related("author", "last_message", "tags")\
-                                    .all()
-        topics = Topic.objects.filter(forum__pk=forum.pk, is_sticky=False) .order_by(
-            "-last_message__pubdate").prefetch_related("author", "last_message", "tags").all()
+        sticky_topics = get_topics(forum_pk=forum.pk, is_sticky=True)
+        topics = get_topics(forum_pk=forum.pk, is_sticky=False)
 
     # Paginator
 
@@ -221,7 +199,7 @@ def get_tag_by_title(title):
     continue_parsing_tags = True
     original_title = title
     for char in title:
-		
+        
         if char == u"[" and nb_bracket == 0 and continue_parsing_tags:
             nb_bracket += 1
         elif nb_bracket > 0 and char != u"]" and continue_parsing_tags:
@@ -1050,3 +1028,21 @@ def complete_topic(request):
     the_data = json.dumps(suggestions)
 
     return HttpResponse(the_data, content_type='application/json')
+
+def get_topics(forum_pk, is_sticky, is_solved=None):
+    if is_solved is not None:
+        return Topic.objects.filter(
+                    forum__pk=forum_pk,
+                    is_sticky=is_sticky,
+                    is_solved=is_solved).order_by("-last_message__pubdate").prefetch_related(
+                    "author",
+                    "last_message",
+                    "tags").all()
+    else:
+        return Topic.objects.filter(
+                    forum__pk=forum_pk,
+                    is_sticky=is_sticky).order_by("-last_message__pubdate").prefetch_related(
+                    "author",
+                    "last_message",
+                    "tags").all()
+

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -57,10 +57,10 @@ def details(request, cat_slug, forum_slug):
     if "filter" in request.GET:
         filter = request.GET["filter"]
         if request.GET["filter"] == "solve":
-        	sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True,is_solved=True)\
-        						.order_by("-last_message__pubdate")\
-        						.prefetch_related("author", "last_message", "tags")\
-        						.all()
+            sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True,is_solved=True)\
+                                    .order_by("-last_message__pubdate")\
+                                    .prefetch_related("author", "last_message", "tags")\
+                                    .all()
             topics = Topic.objects.filter(
                 forum__pk=forum.pk,
                 is_sticky=False,
@@ -69,10 +69,10 @@ def details(request, cat_slug, forum_slug):
                 "last_message",
                 "tags").all()
         else:
-        	sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True,is_solved=False)\
-        						.order_by("-last_message__pubdate")\
-        						.prefetch_related("author", "last_message", "tags")\
-        						.all()
+            sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True,is_solved=False)\
+                                    .order_by("-last_message__pubdate")\
+                                    .prefetch_related("author", "last_message", "tags")\
+                                    .all()
             topics = Topic.objects.filter(
                 forum__pk=forum.pk,
                 is_sticky=False,
@@ -83,9 +83,9 @@ def details(request, cat_slug, forum_slug):
     else:
         filter = None
         sticky_topics = Topic.objects.filter(forum__pk=forum.pk,is_sticky=True)\
-        						.order_by("-last_message__pubdate")\
-        						.prefetch_related("author", "last_message", "tags")\
-        						.all()
+                                    .order_by("-last_message__pubdate")\
+                                    .prefetch_related("author", "last_message", "tags")\
+                                    .all()
         topics = Topic.objects.filter(forum__pk=forum.pk, is_sticky=False) .order_by(
             "-last_message__pubdate").prefetch_related("author", "last_message", "tags").all()
 

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -26,7 +26,7 @@ from haystack.query import SearchQuerySet
 
 from forms import TopicForm, PostForm, MoveTopicForm
 from models import Category, Forum, Topic, Post, follow, follow_by_email, never_read, \
-    mark_read, TopicFollowed, sub_tag
+    mark_read, TopicFollowed, sub_tag, get_topics
 from zds.forum.models import TopicRead
 from zds.member.decorator import can_write_and_read_now
 from zds.member.views import get_client_ip
@@ -1028,21 +1028,3 @@ def complete_topic(request):
     the_data = json.dumps(suggestions)
 
     return HttpResponse(the_data, content_type='application/json')
-
-def get_topics(forum_pk, is_sticky, is_solved=None):
-    if is_solved is not None:
-        return Topic.objects.filter(
-                    forum__pk=forum_pk,
-                    is_sticky=is_sticky,
-                    is_solved=is_solved).order_by("-last_message__pubdate").prefetch_related(
-                    "author",
-                    "last_message",
-                    "tags").all()
-    else:
-        return Topic.objects.filter(
-                    forum__pk=forum_pk,
-                    is_sticky=is_sticky).order_by("-last_message__pubdate").prefetch_related(
-                    "author",
-                    "last_message",
-                    "tags").all()
-


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1285, #1284 |

Cette PR corrige le bug signalé dans l'issue et un autre que bug qui faisait qu'en parcourant les forums par tags, les sujets épinglés n'était pas répertoriés. Exemple, en allant sur [cette url](http://zestedesavoir.com/forums/sujets/tag/51/zep/) pour trouver toutes les zep, je ne voyais pas la zep1 car la zep1 est épinglée.

_Note pour QA_

Vérifier que les filtres résolu/non résolu fonctionne bien avec tous les topics.
