### PR TITLE
Ajoute la possibilité MP multiples utilisateurs via lien

### DIFF
--- a/zds/mp/tests.py
+++ b/zds/mp/tests.py
@@ -39,6 +39,25 @@ class MPTests(TestCase):
         # Check username in new MP page
         self.assertContains(result, user2.username)
 
+    def test_mp_multiple_users_from_link(self):
+        """Test: Send a MP to multiple users by link."""
+        # Users to send the MP
+        user2 = ProfileFactory().user
+        user3 = ProfileFactory().user
+
+        # Test if user is correctly added to the MP
+        result = self.client.get(
+            reverse('zds.mp.views.new') +
+            '?username={0}&username={1}'.format(
+                user2.username,
+                user3.username
+            ),
+        )
+
+        # Check username in new MP page
+        self.assertContains(result, user2.username)
+        self.assertContains(result, user3.username)
+
     def test_view_mp(self):
         """check mp is readable."""
         ptopic1 = PrivateTopicFactory(author=self.user1)

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -190,18 +190,19 @@ def new(request):
                 'form': form,
             })
     else:
+        dest = None
         if 'username' in request.GET:
-            try:
-                # check that username in url is in the database
-                dest = User.objects.get(
-                    username=request.GET['username']).username
-            except:
-                dest = None
-        else:
-            dest = None
+            destList = []
+            # check that usernames in url is in the database
+            for username in request.GET.getlist('username'):
+                try:
+                    destList.append(User.objects.get(username=username).username)
+                except:
+                    pass
+            dest = ', '.join(destList)
 
         form = PrivateTopicForm(initial={
-            'participants': dest
+            'participants': dest,
         })
         return render_template('mp/topic/new.html', {
             'form': form,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets concernés | Aucune, besoin pour améliorer l'interface de validation |

Le but de cette PR est de permettre d'ajouter plusieurs destinataires à un MP à travers un lien. Jusqu'ici on avait la possibilité de faire comme ceci : 

```
http://zestedesavoir.com/mp/nouveau/?username=Alex-D
```

Cette PR propose de pouvoir faire comme ceci :

```
http://zestedesavoir.com/mp/nouveau/?username=Alex-D&username=Talus&username=firm1
```

J'ai également rajouté un test unitaire en m'inspirant de ce qui était présent.

L'intérêt de cette PR est de pouvoir mettre un lien dans l'interface de validation pour contacter tous les auteurs d'un tutoriel / article, via un simple lien.

**QA** :
- Ayez au mois 3 utilisateurs disponibles
- Construisez le lien à la main avec les différents pseudos des utilisateurs, puis vérifiez qu'ils sont bien ajouté avec une virgule entre chaque pseudo
- Un pseudo qui n'existe pas sera ignoré : c'était le comportement appliqué sur un seul pseudo, je l'ai appliqué sur l'ensemble des utilisateurs.

Avis aux devs back : j'ai du mal à saisir l'intérêt de ce test. Lors que l'on envoie un MP, le formulaire le dira de toute façon que le membre n'existe pas, non ? Ping @firm1 je pense.
