### PR TITLE
On ne peut plus s'envoyer de MP a soi même - #1298

### DIFF
--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -47,11 +47,12 @@ class PrivateTopicForm(forms.Form):
         )
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, username, *args, **kwargs):
         super(PrivateTopicForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_class = 'content-wrapper'
         self.helper.form_method = 'post'
+        self.username = username
 
         self.helper.layout = Layout(
             Field('participants', autocomplete='off'),
@@ -77,6 +78,9 @@ class PrivateTopicForm(forms.Form):
                 if User.objects.filter(username=receiver.strip()).count() == 0 and receiver.strip() != '':
                     self._errors['participants'] = self.error_class(
                         [u'Un des participants saisi est introuvable'])
+                elif receiver.strip() == self.username:
+                    self._errors['participants'] = self.error_class(
+                        [u'Vous ne pouvez pas vous écrire à vous-même !'])
 
         if title is not None and title.strip() == '':
             self._errors['title'] = self.error_class(

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -147,17 +147,18 @@ def new(request):
     if request.method == 'POST':
         # If the client is using the "preview" button
         if 'preview' in request.POST:
-            form = PrivateTopicForm(initial={
-                'participants': request.POST['participants'],
-                'title': request.POST['title'],
-                'subtitle': request.POST['subtitle'],
-                'text': request.POST['text'],
-            })
+            form = PrivateTopicForm(request.user.username, 
+                initial={
+                    'participants': request.POST['participants'],
+                    'title': request.POST['title'],
+                    'subtitle': request.POST['subtitle'],
+                    'text': request.POST['text'],
+                })
             return render_template('mp/topic/new.html', {
                 'form': form,
             })
 
-        form = PrivateTopicForm(request.POST)
+        form = PrivateTopicForm(request.user.username, request.POST)
 
         if form.is_valid():
             data = form.data
@@ -201,9 +202,10 @@ def new(request):
                     pass
             dest = ', '.join(destList)
 
-        form = PrivateTopicForm(initial={
-            'participants': dest,
-        })
+        form = PrivateTopicForm(username=request.user.username,
+                                initial={
+                                    'participants': dest,
+                                })
         return render_template('mp/topic/new.html', {
             'form': form,
         })


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1298 |

Cette PR vise a régler la situation où un membre chercher a s'ecrire a lui-même. Dans telle situation, le formulaire refuse l'envoi en précisant pourquoi.
#### QA

Vérifier que l'on ne peut plus s'envoyer de MP a soi meme:
- Que l'on soit seul dans la liste
- Que l'on soit au début/milieu/fin d'une liste a plusieurs membres
  Vérifier aussi que l’aperçu a toujours le bon comportement.

Note: Je n'ai pas fait de tests unitaires, il sera fait plus tard lorsque les modifs de tests MP de poulp seront mergées.
