### PR TITLE
Un message d'erreur et des pseudos vides - #1296

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -151,9 +151,8 @@ class RegisterForm(forms.Form):
 
         # Check that the user doesn't exist yet
         username = cleaned_data.get('username')
-        username = username.strip();
         
-        if username == '':
+        if username.strip() == '':
             msg = u'Le nom d\'utilisateur ne peut-être vide'
             self._errors['username'] = self.error_class([msg])
         elif User.objects.filter(username=username).count() > 0:
@@ -162,6 +161,9 @@ class RegisterForm(forms.Form):
         # Forbid the use of comma in the username
         elif username is not None and "," in username:
             msg = u'Le nom d\'utilisateur ne peut contenir de virgules'
+            self._errors['username'] = self.error_class([msg])
+        elif username != username.strip():
+            msg = u'Le nom d\'utilisateur ne peut commencer/finir par des espaces'
             self._errors['username'] = self.error_class([msg])
 
         # Check that password != username
@@ -360,15 +362,17 @@ class ChangeUserForm(forms.Form):
         username_new = cleaned_data.get('username_new')
         email_new = cleaned_data.get('email_new')
 
-        username_new = username_new.strip()
         if username_new is not None:
-            if username_new != '':
-                if User.objects.filter(username=username_new).count() >= 1:
+            if username_new.strip() != '':
+                if User.objects.filter(username=username_new.strip()).count() >= 1:
                     self._errors['username_new'] = self.error_class(
                         [u'Ce nom d\'utilisateur est déjà utilisé'])
             else:
                 self._errors['username_new'] = self.error_class(
                         [u'Le nom d\'utilisateur ne peut-être vide'])
+            if username_new != username_new.strip():
+                msg = u'Le nom d\'utilisateur ne peut commencer/finir par des espaces'
+                self._errors['username_new'] = self.error_class([msg])
 
         if email_new is not None:
             if email_new.strip() != '':

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -151,14 +151,18 @@ class RegisterForm(forms.Form):
 
         # Check that the user doesn't exist yet
         username = cleaned_data.get('username')
-        if User.objects.filter(username=username).count() > 0:
+        username = username.strip();
+        
+        if username == '':
+            msg = u'Le nom d\'utilisateur ne peut-être vide'
+            self._errors['username'] = self.error_class([msg])
+        elif User.objects.filter(username=username).count() > 0:
             msg = u'Ce nom d\'utilisateur est déjà utilisé'
             self._errors['username'] = self.error_class([msg])
         # Forbid the use of comma in the username
         elif username is not None and "," in username:
             msg = u'Le nom d\'utilisateur ne peut contenir de virgules'
             self._errors['username'] = self.error_class([msg])
-        
 
         # Check that password != username
         if password == username:
@@ -360,6 +364,9 @@ class ChangeUserForm(forms.Form):
                 if User.objects.filter(username=username_new).count() >= 1:
                     self._errors['username_new'] = self.error_class(
                         [u'Ce nom d\'utilisateur est déjà utilisé'])
+            else:
+                self._errors['username_new'] = self.error_class(
+                        [u'Le nom d\'utilisateur ne peut-être vide'])
 
         if email_new is not None:
             if email_new.strip() != '':

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -152,28 +152,29 @@ class RegisterForm(forms.Form):
         # Check that the user doesn't exist yet
         username = cleaned_data.get('username')
         
-        if username.strip() == '':
-            msg = u'Le nom d\'utilisateur ne peut-être vide'
-            self._errors['username'] = self.error_class([msg])
-        elif User.objects.filter(username=username).count() > 0:
-            msg = u'Ce nom d\'utilisateur est déjà utilisé'
-            self._errors['username'] = self.error_class([msg])
-        # Forbid the use of comma in the username
-        elif username is not None and "," in username:
-            msg = u'Le nom d\'utilisateur ne peut contenir de virgules'
-            self._errors['username'] = self.error_class([msg])
-        elif username != username.strip():
-            msg = u'Le nom d\'utilisateur ne peut commencer/finir par des espaces'
-            self._errors['username'] = self.error_class([msg])
+        if username is not None :
+            if username.strip() == '':
+                msg = u'Le nom d\'utilisateur ne peut-être vide'
+                self._errors['username'] = self.error_class([msg])
+            elif User.objects.filter(username=username).count() > 0:
+                msg = u'Ce nom d\'utilisateur est déjà utilisé'
+                self._errors['username'] = self.error_class([msg])
+            # Forbid the use of comma in the username
+            elif username is not None and "," in username:
+                msg = u'Le nom d\'utilisateur ne peut contenir de virgules'
+                self._errors['username'] = self.error_class([msg])
+            elif username != username.strip():
+                msg = u'Le nom d\'utilisateur ne peut commencer/finir par des espaces'
+                self._errors['username'] = self.error_class([msg])
 
-        # Check that password != username
-        if password == username:
-            msg = u'Le mot de passe doit être différent du pseudo'
-            self._errors['password'] = self.error_class([msg])
-            if 'password' in cleaned_data:
-                del cleaned_data['password']
-            if 'password_confirm' in cleaned_data:
-                del cleaned_data['password_confirm']
+            # Check that password != username
+            if password == username:
+                msg = u'Le mot de passe doit être différent du pseudo'
+                self._errors['password'] = self.error_class([msg])
+                if 'password' in cleaned_data:
+                    del cleaned_data['password']
+                if 'password_confirm' in cleaned_data:
+                    del cleaned_data['password_confirm']
 
         email = cleaned_data.get('email')
         if email:
@@ -363,16 +364,13 @@ class ChangeUserForm(forms.Form):
         email_new = cleaned_data.get('email_new')
 
         if username_new is not None:
-            if username_new.strip() != '':
+            if username_new != '':
                 if User.objects.filter(username=username_new.strip()).count() >= 1:
                     self._errors['username_new'] = self.error_class(
                         [u'Ce nom d\'utilisateur est déjà utilisé'])
-            else:
-                self._errors['username_new'] = self.error_class(
-                        [u'Le nom d\'utilisateur ne peut-être vide'])
-            if username_new != username_new.strip():
-                msg = u'Le nom d\'utilisateur ne peut commencer/finir par des espaces'
-                self._errors['username_new'] = self.error_class([msg])
+                elif username_new != username_new.strip():
+                    msg = u'Le nom d\'utilisateur ne peut commencer/finir par des espaces'
+                    self._errors['username_new'] = self.error_class([msg])
 
         if email_new is not None:
             if email_new.strip() != '':

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -360,7 +360,7 @@ class ChangeUserForm(forms.Form):
         username_new = cleaned_data.get('username_new')
         email_new = cleaned_data.get('email_new')
 
-        username = username_new.strip()
+        username_new = username_new.strip()
         if username_new is not None:
             if username_new != '':
                 if User.objects.filter(username=username_new).count() >= 1:

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -334,7 +334,8 @@ class ChangeUserForm(forms.Form):
             attrs={
                 'placeholder': 'Ne mettez rien pour conserver l\'ancien'
             }
-        )
+        ),
+        error_messages = {'invalid': u'Veuillez entrer une adresse email valide.',}
     )
 
     def __init__(self, *args, **kwargs):

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -360,8 +360,9 @@ class ChangeUserForm(forms.Form):
         username_new = cleaned_data.get('username_new')
         email_new = cleaned_data.get('email_new')
 
+        username = username_new.strip()
         if username_new is not None:
-            if username_new.strip() != '':
+            if username_new != '':
                 if User.objects.filter(username=username_new).count() >= 1:
                     self._errors['username_new'] = self.error_class(
                         [u'Ce nom d\'utilisateur est déjà utilisé'])

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -496,7 +496,7 @@ def settings_user(request):
         if form.is_valid():
             old = User.objects.filter(pk=request.user.pk).all()[0]
             if form.data["username_new"]:
-                old.username = form.data["username_new"].strip()
+                old.username = form.data["username_new"]
             elif form.data["email_new"]:
                 if form.data["email_new"].strip() != "":
                     old.email = form.data["email_new"]
@@ -587,7 +587,7 @@ def register_view(request):
         form = RegisterForm(request.POST)
         if form.is_valid():
             data = form.data
-            user = User.objects.create_user(data["username"].strip(), data["email"],
+            user = User.objects.create_user(data["username"], data["email"],
                                             data["password"])
             user.is_active = False
             user.save()

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -496,7 +496,7 @@ def settings_user(request):
         if form.is_valid():
             old = User.objects.filter(pk=request.user.pk).all()[0]
             if form.data["username_new"]:
-                old.username = form.data["username_new"]
+                old.username = form.data["username_new"].strip()
             elif form.data["email_new"]:
                 if form.data["email_new"].strip() != "":
                     old.email = form.data["email_new"]
@@ -587,7 +587,7 @@ def register_view(request):
         form = RegisterForm(request.POST)
         if form.is_valid():
             data = form.data
-            user = User.objects.create_user(data["username"], data["email"],
+            user = User.objects.create_user(data["username"].strip(), data["email"],
                                             data["password"])
             user.is_active = False
             user.save()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | #1296 + remarque perso |

Cette PR vise à corriger initialement un message d'erreur erroné (probablement du a Django) lorsque l'on veut changer l'email apres inscription.
Une deuxieme chose corrigée et plus critique, l'utilisateur ne peut plus utiliser un pseudo vide ou commencant/finissant par des espaces.
#### À QA et mettre en prod' assez rapidement.
