### PR TITLE
Corrige un petit détail dans les ML

### DIFF
--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -199,7 +199,8 @@ def new(request):
                     destList.append(User.objects.get(username=username).username)
                 except:
                     pass
-            dest = ', '.join(destList)
+            if len(destList) > 0:
+                dest = ', '.join(destList)
 
         form = PrivateTopicForm(initial={
             'participants': dest,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1315 |

Ca a pour simple effet de garder `dest = None` plutôt qu'une chaîne vide. C'est plus propre et ça permet à tous les tests de passer (cf issue #1315).
