### PR TITLE
Safe les métadonnées

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -489,7 +489,7 @@
                         {% captureas schema %}
                             {% block schema %}{% endblock %}
                         {% endcaptureas %}
-                        <section class="content-wrapper" {{ schema }}>
+                        <section class="content-wrapper" {{ schema|safe }}>
                             <h1 {% if schema %}itemprop="name"{% endif %}>
                                 {% block headline %}{% endblock %}
                             </h1>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |

Sur certaines pages il y a des métadonnées, par exemple sur un sujet de forum on pouvait voir : 

```
<section class="content-wrapper" itemscope itemtype=&quot;http://schema.org/Question&quot;>
```

qui doit maintenant être :

```
<section class="content-wrapper" itemscope itemtype="http://schema.org/Question">
```
