### PR TITLE
Issue #983: Indexer uniquement les posts publics

### DIFF
--- a/zds/forum/search_indexes.py
+++ b/zds/forum/search_indexes.py
@@ -15,6 +15,10 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
     def get_model(self):
         return Topic
 
+    def index_queryset(self, using=None):
+        # Index only public topics
+        return self.get_model().objects.filter(forum__group=None)
+
 
 class PostIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
@@ -24,3 +28,7 @@ class PostIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return Post
+
+    def index_queryset(self, using=None):
+        # Index only public posts
+        return self.get_model().objects.filter(topic__forum__group=None)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #983 |

Correction bête et méchante : on indexe uniquement les posts et topics publics. Ça empêche la fuite de données.

On pourra améliorer le truc en indexant le groupe et en filtrant dessus, mais c'est moins urgent.

**Comment QAtiser cette chose ?**

C'est un peu laborieux mais c'est simple.
1. [Installez Solr](https://github.com/zestedesavoir/zds-site/pull/1313) en suivant la doc dans la PR liée (elle est mergeable à quelques détails, vous pouvez y aller !)
2. Dans l'interface d'admin, créez un forum privé (groupe = staff).
3. Réinitialiser l'index complet : `python manage.py rebuild_index`
4. Créez 3 topics, chacun avec un mot-clé que vous n'avez nulle part dans le site pour pouvoir les retrouver facilement. L'un est public, le 2ème public est deviendra privé, le 3ème est directement privé (créé dans le forum privé donc).
5. Mettez l'index Solr à jour : `python manage.py update_index`
6. Vérifiez que vous trouvez les 2 topics publics et pas le privé
7. Déplacez l'un des topics publics en privé
8. Mettez l'index Solr à jour : `python manage.py update_index`
9. Vérifiez que les 2 topics privés sont introuvables et que le topic public est toujours là

(Dans les vrais environnements un cron met à jour l'index périodiquement).
