### PR TITLE
Issue #1353 : Toutes les dates sont forcées en français dans le code

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -1,15 +1,6 @@
 # coding: utf-8
 
-import locale
 import os
-import platform
-
-
-# Python is platform-independent...or is it?
-if platform.system() == "Windows":
-    locale.setlocale(locale.LC_TIME, 'fra')
-else:
-    locale.setlocale(locale.LC_TIME, 'fr_FR.UTF-8')
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -51,7 +42,7 @@ USE_I18N = True
 
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale.
-USE_L10N = True
+USE_L10N = False
 
 # If you set this to False, Django will not use timezone-aware datetimes.
 USE_TZ = False


### PR DESCRIPTION
--> Définir la locale ne sert qu'à faire planter Django (cf https://code.djangoproject.com/ticket/23265)
Donc on supprime les définitions de locale.

| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1353 |

QA :
- **Sous windows**, vérifier que Django se lance sans erreur
- Sous n'importe quel OS, lancer le serveur et naviguer partout. Traquer les dates et vérifier qu'elles s'affichent bien en français.

On peut lancer les tests automatiques. Ils sont sensés passer "normalement" (i.e. à 100% sous Linux, et avec 3 erreurs sous Windows). Mais ces tests ne vont pas à la chasse aux dates :(

Oui, je sais, mes dernières PR sont chiantes à QAtiser :(
