### PR TITLE
Hotfix correctif de #1322

### DIFF
--- a/templates/tutorial/chapter/view.html
+++ b/templates/tutorial/chapter/view.html
@@ -33,7 +33,7 @@
 
     {% include 'tutorial/includes/tags_authors.part.html' %}
 
-    {% if tutorial.in_beta and tutorial.sha_beta == version %}
+    {% if tutorial.is_beta %}
         <div class="content-wrapper">
             <div class="alert-box warning">
                 Cette version du tutoriel est en <strong>BÊTA</strong> !

--- a/templates/tutorial/includes/chapter.part.html
+++ b/templates/tutorial/includes/chapter.part.html
@@ -7,7 +7,7 @@
     {% if not chapter.type = 'MINI' %}
         {% if chapter.intro and chapter.intro != None %}
             {{ chapter.intro|emarkdown }}
-        {% elif not tutorial.in_beta %}
+        {% elif not tutorial.is_beta %}
             <p class="ico-after warning">
                 Il n'y a pas d'introduction.
             </p>
@@ -114,7 +114,7 @@
     {% if not chapter.type = 'MINI' %}
         {% if chapter.conclu and chapter.conclu != None %}
             {{ chapter.conclu|emarkdown }}
-        {% elif not tutorial.in_beta %}
+        {% elif not tutorial.is_beta %}
             <p class="ico-after warning">
                 Il n'y a pas de conclusion.
             </p>

--- a/templates/tutorial/part/view.html
+++ b/templates/tutorial/part/view.html
@@ -29,7 +29,7 @@
 
     {% include 'tutorial/includes/tags_authors.part.html' with tutorial=part.tutorial %}
 
-    {% if part.tutorial.in_beta and part.tutorial.sha_beta == version %}
+    {% if tutorial.is_beta %}
         <div class="content-wrapper">
             <div class="alert-box warning">
                 Cette version du tutoriel est en <strong>BÊTA</strong> !
@@ -43,7 +43,7 @@
 {% block content %}
     {% if part.intro and part.intro != "None" %}
         {{ part.intro|emarkdown }}
-    {% elif not tutorial.in_beta %}
+    {% elif not tutorial.is_beta %}
         <p class="ico-after warning">
             Il n'y a pas d'introduction.
         </p>
@@ -90,7 +90,7 @@
 
     {% if part.conclu and part.conclu != "None" %}
         {{ part.conclu|emarkdown }}
-    {% elif not tutorial.in_beta %}
+    {% elif not tutorial.is_beta %}
         <p class="ico-after warning">
             Il n'y a pas de conclusion.
         </p>

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -86,7 +86,7 @@
         {% endif %}
     {% endif %}
 
-    {% if tutorial.in_beta and tutorial.sha_beta == version %}
+    {% if tutorial.is_beta %}
         <div class="content-wrapper">
             <div class="alert-box warning">
                 Cette version du tutoriel est en <strong>BÊTA</strong> !
@@ -99,7 +99,7 @@
 {% block content %}
     {% if tutorial.get_introduction and tutorial.get_introduction != "None" %}
         {{ tutorial.get_introduction|emarkdown }}
-    {% elif not tutorial.in_beta %}
+    {% elif not tutorial.is_beta %}
         <p class="ico-after warning">
             Il n'y a pas d'introduction.
         </p>
@@ -133,7 +133,7 @@
 
     {% if tutorial.get_conclusion and tutorial.get_conclusion != "None" %}
         {{ tutorial.get_conclusion|emarkdown }}
-    {% elif not tutorial.in_beta %}
+    {% elif not tutorial.is_beta %}
         <p class="ico-after warning">
             Il n'y a pas de conclusion.
         </p>
@@ -244,7 +244,7 @@
                 </form>
             </li>
         {% else %}
-            {% if tutorial.sha_beta != version %}
+            {% if not tutorial.is_beta %}
                 <li>
                     <a href="{{ tutorial.get_absolute_url }}?version={{ tutorial.sha_beta }}" class="ico-after view blue">
                         Voir <span class="wide">la version</span> en bêta
@@ -307,7 +307,7 @@
                 </a>
             </li>
         {% else %}
-            {% if tutorial.sha_validation != version %}
+            {% if not tutorial.is_validation %}
                 <li>
                     <a href="#ask-validation" class="open-modal ico-after tick green">
                         Mettre à jour la version en validation

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -187,7 +187,7 @@ class Tutorial(models.Model):
 
         fns = [
             'is_big', 'is_mini', 'have_markdown','have_html', 'have_pdf', 
-            'have_epub', 'get_path'
+            'have_epub', 'get_path', 'in_beta', 'in_validation', 'on_line'
             ]
 
         attrs = [
@@ -203,10 +203,10 @@ class Tutorial(models.Model):
 
         # general information
         mandata['slug'] = slugify(mandata['title'])
-        mandata['in_beta'] = self.in_beta() and self.sha_beta == sha
-        mandata['in_validation'] = self.in_validation() \
+        mandata['is_beta'] = self.in_beta() and self.sha_beta == sha
+        mandata['is_validation'] = self.in_validation() \
             and self.sha_validation == sha
-        mandata['on_line'] = self.on_line() and self.sha_public == sha
+        mandata['is_on_line'] = self.on_line() and self.sha_public == sha
 
         #url:
         mandata['get_absolute_url'] = reverse(

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1112,6 +1112,8 @@ def view_part(
     repo = Repo(tutorial.get_path())
     manifest = get_blob(repo.commit(sha).tree, "manifest.json")
     mandata = json_reader.loads(manifest)
+    tutorial.load_dic(mandata, sha=sha)
+
     parts = mandata["parts"]
     find = False
     cpt_p = 1
@@ -1150,7 +1152,7 @@ def view_part(
         raise Http404
     
     return render_template("tutorial/part/view.html",
-                           {"tutorial": tutorial,
+                           {"tutorial": mandata,
                             "part": final_part,
                             "version": sha})
 
@@ -1440,6 +1442,8 @@ def view_chapter(
     repo = Repo(tutorial.get_path())
     manifest = get_blob(repo.commit(sha).tree, "manifest.json")
     mandata = json_reader.loads(manifest)
+    tutorial.load_dic(mandata, sha=sha)
+
     parts = mandata["parts"]
     cpt_p = 1
     final_chapter = None
@@ -1497,7 +1501,7 @@ def view_chapter(
                     < len(chapter_tab) else None)
     
     return render_template("tutorial/chapter/view.html", {
-        "tutorial": tutorial,
+        "tutorial": mandata,
         "chapter": final_chapter,
         "prev": prev_chapter,
         "next": next_chapter,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1322 #1366 |
- Ajout de is_beta/is_validation, qui sont vraie quand la version visualisée correspond à la béta/validation, qui deviennent  différentes de in_beta/in_validation, qui signifient qu'une  version (peu importe laquelle) du tutoriel est en béta/validation.
- Correction des templates pour tenir compte de ces nouvelles variables, corrigeant le bug signalé.
# Note pour QA

Bon, on va essayer de faire un minimum attention, donc ...
- Créer un big-tutoriel, lui ajouter une partie, contenant un chapitre, contenant un extrait.
- Mettre en béta, et vérifier que ça affiche bien "cette version est déjà en béta"
- Demander une validation et vérifier que le tuto affiche bien ensuite "En attente de validation", mais sans proposer de mettre à jour celle-ci
- Faire une modification, par exemple ajouter un extrait.
- Vériez que sur la page principale du tutoriel, le "Une autre version de ce tutoriel est en attente d'un validateur" est apparu
- Vérifier que sont apparu les boutons suivant : "voir la version en béta", "mettre à jour la béta avec cette version" et "mettre à jour la version en validation". Vérifiez également que ses boutons font ce qu'ils sont censé faire.

Faire le même genre de teste pour les mini-tutoriels :)
