### PR TITLE
Minor changes

### DIFF
--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -11,6 +11,8 @@ import string
 import uuid
 from easy_thumbnails.fields import ThumbnailerImageField
 
+from zds.utils import misc
+
 try:
     import ujson as json_reader
 except:
@@ -177,11 +179,7 @@ class Article(models.Model):
 
     def get_text(self):
         path = os.path.join(self.get_path(), self.text)
-        txt = open(path, "r")
-        txt_contenu = txt.read()
-        txt.close()
-
-        return txt_contenu.decode('utf-8')
+        return misc.read_path(path, utf8=True)
 
     def save(self, *args, **kwargs):
         self.slug = slugify(self.title)

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -31,8 +31,7 @@ from git import *
 
 from zds.member.decorator import can_write_and_read_now
 from zds.member.views import get_client_ip
-from zds.utils import render_template
-from zds.utils import slugify
+from zds.utils import render_template, slugify, misc
 from zds.utils.articles import *
 from zds.utils.mps import send_mp
 from zds.utils.models import SubCategory, Category, CommentLike, \
@@ -129,11 +128,9 @@ def view_online(request, article_pk, article_slug):
 
     # Load the article.
     article_version = article.load_json_for_public()
-    txt = open(os.path.join(article.get_path(),
-                            article_version['text'] + '.html'),
-               "r")
-    article_version['txt'] = txt.read()
-    txt.close()
+    txt = os.path.join(article.get_path(),
+                       article_version['text'] + '.html')
+    article_version['txt'] = misc.read_path(txt)
     article_version = article.load_dic(article_version)
 
     # If the user is authenticated
@@ -439,10 +436,7 @@ def download(request):
     repo.archive(open(ph + ".tar", 'w'))
 
     response = HttpResponse(
-        open(
-            ph +
-            ".tar",
-            'rb').read(),
+        misc.read_path(ph+".tar", binary=True),
         mimetype='application/tar')
     response[
         'Content-Disposition'] = 'attachment; filename={0}.tar' \

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -182,6 +182,9 @@ class Tutorial(models.Model):
             settings.REPO_PATH_PROD,
             str(self.pk) + '_' + slugify(data['title']))
 
+    def get_prod_file(self, basename, ext='html'):
+        return os.path.join(self.get_prod_path(), basename+'.'+ext)
+
     def load_dic(self, mandata):
         mandata['get_absolute_url_online'] = reverse('zds.tutorial.views.view_tutorial_online',
                                                      args=[self.pk, slugify(mandata["title"])])

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -265,9 +265,7 @@ class Tutorial(models.Model):
             return None
 
     def get_introduction_online(self):
-        intro = os.path.join(
-            self.get_prod_path(),
-            self.introduction+'.html')
+        intro = self.get_prod_file(self.introduction)
         return misc.read_path(intro, utf8=True)
 
     def get_conclusion(self, sha=None):
@@ -287,9 +285,7 @@ class Tutorial(models.Model):
             return None
 
     def get_conclusion_online(self):
-        conclu = os.path.join(
-            self.get_prod_path(),
-            self.conclusion+'.html')
+        conclu = self.get_prod_file(self.conclusion)
         return misc.read_path(conclu, utf8=True)
 
     def save(self, *args, **kwargs):
@@ -374,22 +370,18 @@ class Tutorial(models.Model):
         if chapter:
             chapter.update_children()
 
+    def have_format(self, file_ext):
+        return os.path.isfile(
+            self.get_prod_file(self.slug, ext=file_ext))
+
     def have_markdown(self):
-        return os.path.isfile(os.path.join(self.get_prod_path(),
-                                           self.slug +
-                                           ".md"))
+        return self.have_format("md")
     def have_html(self):
-        return os.path.isfile(os.path.join(self.get_prod_path(),
-                                           self.slug +
-                                           ".html"))
+        return self.have_format("html")
     def have_pdf(self):
-        return os.path.isfile(os.path.join(self.get_prod_path(),
-                                           self.slug +
-                                           ".pdf"))
+        return self.have_format("pdf")
     def have_epub(self):
-        return os.path.isfile(os.path.join(self.get_prod_path(),
-                                           self.slug +
-                                           ".epub"))
+        return self.have_format("epub")
 
 def get_last_tutorials():
     tutorials = Tutorial.objects.all()\
@@ -529,10 +521,14 @@ class Part(models.Model):
             .filter(part=self).order_by('position_in_part')
 
     def get_path(self, relative=False):
-        if relative:
-            return self.get_phy_slug()
-        else:
-            return os.path.join(settings.REPO_PATH, self.tutorial.get_phy_slug(), self.get_phy_slug())
+        return os.path.join(self.tutorial.get_path(relative),
+                            self.get_phy_slug())
+
+    def get_prod_path(self):
+        return self.tutorial.get_prod_path()
+
+    def get_prod_file(self, basename, ext='html'):
+        return os.path.join(self.get_prod_path(), basename+'.'+ext)
 
     def get_introduction(self, sha=None):
         
@@ -557,9 +553,7 @@ class Part(models.Model):
             return None
 
     def get_introduction_online(self):
-        intro = os.path.join(
-            self.tutorial.get_prod_path(),
-            self.introduction + '.html')
+        intro = self.get_prod_file(self.introduction)
         return misc.read_path(intro, utf8=True)
 
     def get_conclusion(self, sha=None):
@@ -585,9 +579,7 @@ class Part(models.Model):
             return None
 
     def get_conclusion_online(self):
-        conclu = os.path.join(
-            self.tutorial.get_prod_path(),
-            self.conclusion + '.html')
+        conclu = self.get_prod_file(self.conclusion)
         return misc.read_path(conclu, utf8=True)
 
     def update_children(self):
@@ -687,7 +679,17 @@ class Chapter(models.Model):
             .filter(chapter__pk=self.pk)\
             .order_by('position_in_chapter')
 
+
+    def get_parent(self):
+        """Parent structure,
+           either tutorial (for mini-tutos) or part (for big-tutos)"""
+        if self.tutorial:
+            return self.tutorial
+        else:
+            return self.part
+
     def get_tutorial(self):
+        """Putorial ancestor"""
         if self.part:
             return self.part.tutorial
         return self.tutorial
@@ -707,29 +709,14 @@ class Chapter(models.Model):
                         position += 1
         self.position_in_tutorial = position
 
-    def get_path(self, relative=False):
-        if relative:
-            if self.tutorial:
-                chapter_path = self.get_phy_slug()
-            else:
-                chapter_path = os.path.join(self.part.get_phy_slug(), self.get_phy_slug())
-        else:
-            if self.tutorial:
-                chapter_path = os.path.join(settings.REPO_PATH, self.tutorial.get_phy_slug(), self.get_phy_slug())
-            else:
-                chapter_path = os.path.join(settings.REPO_PATH,
-                                            self.part.tutorial.get_phy_slug(),
-                                            self.part.get_phy_slug(),
-                                            self.get_phy_slug())
 
-        return chapter_path
+    def get_path(self, relative=False):
+        return os.path.join(self.get_parent().get_path(relative),
+                            self.get_phy_slug())
 
     def get_introduction(self, sha=None):
 
-        if self.tutorial:
-            tutorial = self.tutorial
-        else:
-            tutorial = self.part.tutorial        
+        tutorial = self.get_tutorial()
         repo = Repo(tutorial.get_path())
 
         # find hash code
@@ -756,31 +743,20 @@ class Chapter(models.Model):
             return None
 
     def get_introduction_online(self):
-        if self.introduction:
-            if self.tutorial:
-                path = os.path.join(
-                    self.tutorial.get_path(),
-                    self.introduction +
-                    '.html')
-            else:
-                path = os.path.join(
-                    self.part.tutorial.get_path(),
-                    self.introduction +
-                    '.html')
-
-            if os.path.isfile(path):
-                return misc.read_path(path, utf8=True)
-            else:
-                return None
-        else:
+        if not self.introduction:
             return None
 
-    def get_conclusion(self, sha=None):
+        path = os.path.join(
+            self.parent.get_path(),
+            self.introduction +'.html')
 
-        if self.tutorial:
-            tutorial = self.tutorial
-        else:
-            tutorial = self.part.tutorial        
+        if not os.path.isfile(path):
+            return None
+
+        return misc.read_path(path, utf8=True)
+
+    def get_conclusion(self, sha=None):
+        tutorial = self.get_tutorial()
         repo = Repo(tutorial.get_path())
 
         # find hash code
@@ -807,32 +783,21 @@ class Chapter(models.Model):
             return None
 
     def get_conclusion_online(self):
-        if self.conclusion:
-            if self.tutorial:
-                path = os.path.join(
-                    self.tutorial.get_path(),
-                    self.conclusion +
-                    '.html')
-            else:
-                path = os.path.join(
-                    self.part.tutorial.get_path(),
-                    self.conclusion +
-                    '.html')
+        if not self.conclusion:
+            return None
+        path = os.path.join(self.parent().get_path(),
+                            self.conclusion + '.html')
 
-            if os.path.isfile(path):
-                return misc.read_path(path, utf8=True)
-            else:
-                return None
-        else:
+        if not os.path.isfile(path):
             return None
 
+        return misc.read_path(path, utf8=True)
+
     def update_children(self):
-        if self.part:
-            self.introduction = os.path.join(self.part.get_phy_slug(), self.get_phy_slug(), "introduction.md")
-            self.conclusion = os.path.join(self.part.get_phy_slug(), self.get_phy_slug(), "conclusion.md")
-        else:
-            self.introduction = os.path.join("introduction.md")
-            self.conclusion = os.path.join("conclusion.md")
+        self.introduction = os.path.join(self.get_path(relative=True),
+                                         "introduction.md")
+        self.conclusion = os.path.join(self.get_path(relative=True),
+                                       "conclusion.md")
         self.save()
 
         for extract in self.get_extracts():
@@ -873,24 +838,16 @@ class Extract(models.Model):
             slugify(self.title)
         )
 
-    def get_path(self, relative=False):
-        if relative:
-            if self.chapter.tutorial:
-                chapter_path = ''
-            else:
-                chapter_path = os.path.join(
-                    self.chapter.part.get_phy_slug(),
-                    self.chapter.get_phy_slug())
-        else:
-            if self.chapter.tutorial:
-                chapter_path = os.path.join(settings.REPO_PATH, self.chapter.tutorial.get_phy_slug())
-            else:
-                chapter_path = os.path.join(settings.REPO_PATH,
-                                            self.chapter.part.tutorial.get_phy_slug(),
-                                            self.chapter.part.get_phy_slug(),
-                                            self.chapter.get_phy_slug())
+    def get_phy_slug(self):
+        return str(self.pk) + "_" + slugify(self.title)
 
-        return os.path.join(chapter_path, str(self.pk) + "_" + slugify(self.title)) + '.md'
+    def get_path(self, relative=False):
+        if self.chapter.tutorial:
+            chapter_path = self.chapter.tutorial.get_path(relative)
+        else:
+            chapter_path = self.chapter.get_path(relative)
+
+        return os.path.join(chapter_path, self.get_phy_slug()) + '.md'
 
     def get_prod_path(self):
 
@@ -911,12 +868,15 @@ class Extract(models.Model):
                 for chapter in part["chapters"]:
                     for ext in chapter["extracts"]:
                         if ext['pk'] == self.pk:
-                            chapter_path = os.path.join(settings.REPO_PATH_PROD,
-                                                        str(mandata['pk']) + '_' + slugify(mandata['title']),
-                                                        str(part['pk']) + "_" + slugify(part['title']),
-                                                        str(chapter['pk']) + "_" + slugify(chapter['title']),
-                                                        str(ext['pk']) + "_" + slugify(ext['title'])) \
-                                                        + '.md.html'
+                            return os.path.join(settings.REPO_PATH_PROD,
+                                                str(mandata['pk']) + '_' + slugify(mandata['title']),
+                                                str(part['pk']) + "_" + slugify(part['title']),
+                                                str(chapter['pk']) + "_" + slugify(chapter['title']),
+                                                str(ext['pk']) + "_" + slugify(ext['title'])) \
+                                                + '.md.html'
+
+    def get_prod_file(self, basename, ext='html'):
+        return os.path.join(self.get_prod_path(), basename+'.'+ext)
 
     def get_text(self, sha=None):
         
@@ -955,21 +915,12 @@ class Extract(models.Model):
             return None
 
     def get_text_online(self):
-        if self.chapter.tutorial:
-            path = os.path.join(
-                self.chapter.tutorial.get_prod_path(),
-                self.text +
-                '.html')
-        else:
-            path = os.path.join(
-                self.chapter.part.tutorial.get_prod_path(),
-                self.text +
-                '.html')
+        path = self.chapter.get_parent().get_prod_file(self.text)
 
-        if os.path.isfile(path):
-            return misc.read_path(path, utf8=True)
-        else:
+        if not os.path.isfile(path):
             return None
+
+        return misc.read_path(path, utf8=True)
 
 class Validation(models.Model):
 

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -746,9 +746,7 @@ class Chapter(models.Model):
         if not self.introduction:
             return None
 
-        path = os.path.join(
-            self.parent.get_path(),
-            self.introduction +'.html')
+        path = self.parent.get_prod_file(self.introduction)
 
         if not os.path.isfile(path):
             return None
@@ -785,8 +783,7 @@ class Chapter(models.Model):
     def get_conclusion_online(self):
         if not self.conclusion:
             return None
-        path = os.path.join(self.parent().get_path(),
-                            self.conclusion + '.html')
+        path = self.parent().get_prod_file(self.conclusion)
 
         if not os.path.isfile(path):
             return None

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -20,7 +20,7 @@ from django.utils import timezone
 from git.repo import Repo
 
 from zds.gallery.models import Image, Gallery
-from zds.utils import slugify, get_current_user
+from zds.utils import slugify, get_current_user, misc
 from zds.utils.models import SubCategory, Licence, Comment
 from zds.utils.tutorials import get_blob, export_tutorial
 
@@ -262,16 +262,10 @@ class Tutorial(models.Model):
             return None
 
     def get_introduction_online(self):
-        intro = open(
-            os.path.join(
-                self.get_prod_path(),
-                self.introduction +
-                '.html'),
-            "r")
-        intro_contenu = intro.read()
-        intro.close()
-
-        return intro_contenu.decode('utf-8')
+        intro = os.path.join(
+            self.get_prod_path(),
+            self.introduction+'.html')
+        return misc.read_path(intro, utf8=True)
 
     def get_conclusion(self, sha=None):
         # find hash code
@@ -290,16 +284,10 @@ class Tutorial(models.Model):
             return None
 
     def get_conclusion_online(self):
-        conclu = open(
-            os.path.join(
-                self.get_prod_path(),
-                self.conclusion +
-                '.html'),
-            "r")
-        conclu_contenu = conclu.read()
-        conclu.close()
-
-        return conclu_contenu.decode('utf-8')
+        conclu = os.path.join(
+            self.get_prod_path(),
+            self.conclusion+'.html')
+        return misc.read_path(conclu, utf8=True)
 
     def save(self, *args, **kwargs):
         self.slug = slugify(self.title)
@@ -566,16 +554,10 @@ class Part(models.Model):
             return None
 
     def get_introduction_online(self):
-        intro = open(
-            os.path.join(
-                self.tutorial.get_prod_path(),
-                self.introduction +
-                '.html'),
-            "r")
-        intro_contenu = intro.read()
-        intro.close()
-
-        return intro_contenu.decode('utf-8')
+        intro = os.path.join(
+            self.tutorial.get_prod_path(),
+            self.introduction + '.html')
+        return misc.read_path(intro, utf8=True)
 
     def get_conclusion(self, sha=None):
 
@@ -600,16 +582,10 @@ class Part(models.Model):
             return None
 
     def get_conclusion_online(self):
-        conclu = open(
-            os.path.join(
-                self.tutorial.get_prod_path(),
-                self.conclusion +
-                '.html'),
-            "r")
-        conclu_contenu = conclu.read()
-        conclu.close()
-
-        return conclu_contenu.decode('utf-8')
+        conclu = os.path.join(
+            self.tutorial.get_prod_path(),
+            self.conclusion + '.html')
+        return misc.read_path(conclu, utf8=True)
 
     def update_children(self):
         self.introduction = os.path.join(self.get_phy_slug(), "introduction.md")
@@ -790,11 +766,7 @@ class Chapter(models.Model):
                     '.html')
 
             if os.path.isfile(path):
-                intro = open(path, "r")
-                intro_contenu = intro.read()
-                intro.close()
-
-                return intro_contenu.decode('utf-8')
+                return misc.read_path(path, utf8=True)
             else:
                 return None
         else:
@@ -845,15 +817,9 @@ class Chapter(models.Model):
                     '.html')
 
             if os.path.isfile(path):
-                conclu = open(path, "r")
-                conclu_contenu = conclu.read()
-                conclu.close()
-
-                return conclu_contenu.decode('utf-8')
+                return misc.read_path(path, utf8=True)
             else:
                 return None
-
-            return conclu_contenu.decode('utf-8')
         else:
             return None
 
@@ -986,7 +952,6 @@ class Extract(models.Model):
             return None
 
     def get_text_online(self):
-
         if self.chapter.tutorial:
             path = os.path.join(
                 self.chapter.tutorial.get_prod_path(),
@@ -999,11 +964,7 @@ class Extract(models.Model):
                 '.html')
 
         if os.path.isfile(path):
-            text = open(path, "r")
-            text_contenu = text.read()
-            text.close()
-
-            return text_contenu.decode('utf-8')
+            return misc.read_path(path, utf8=True)
         else:
             return None
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1095,11 +1095,11 @@ def view_part(
     manifest = get_blob(tree, "manifest.json")
     mandata = json_reader.loads(manifest)
     parts = mandata["parts"]
-    find = False
+    found = False
     cpt_p = 1
     for part in parts:
         if part_pk == str(part["pk"]):
-            find = True
+            found = True
             part["tutorial"] = tutorial
             part["path"] = tutorial.get_path()
             part["slug"] = slugify(part["title"])
@@ -1121,8 +1121,8 @@ def view_part(
             break
         cpt_p += 1
     
-    # if part can't find
-    if not find:
+    # if part can't be found
+    if not found:
         raise Http404
     
     return render_template("tutorial/part/view.html",
@@ -1155,14 +1155,14 @@ def view_part_online(
     parts = mandata["parts"]
     cpt_p = 1
     final_part= None
-    find = False
+    found = False
     for part in parts:
         part["tutorial"] = mandata
         part["path"] = tutorial.get_path()
         part["slug"] = slugify(part["title"])
         part["position_in_tutorial"] = cpt_p
         if part_pk == str(part["pk"]):
-            find = True
+            found = True
             intro = tutorial.get_prod_file(part["introduction"])
             part["intro"] = misc.read_path(intro)
             conclu = tutorial.get_prod_file(part["conclusion"])
@@ -1182,8 +1182,8 @@ def view_part_online(
         part["get_chapters"] = part["chapters"]
         cpt_p += 1
 
-    # if part can't find
-    if not find:
+    # if part can't be found
+    if not found:
         raise Http404
     
     return render_template("tutorial/part/view_online.html", {"part": final_part})
@@ -1413,7 +1413,7 @@ def view_chapter(
     final_chapter = None
     chapter_tab = []
     final_position = 0
-    find = False
+    found = False
     for part in parts:
         cpt_c = 1
         part["slug"] = slugify(part["title"])
@@ -1435,7 +1435,7 @@ def view_chapter(
             chapter["get_absolute_url"] = part["get_absolute_url"] \
                 + "{0}/{1}/".format(chapter["pk"], chapter["slug"])
             if chapter_pk == str(chapter["pk"]):
-                find = True
+                found = True
                 chapter["intro"] = get_blob(tree, chapter["introduction"])
                 chapter["conclu"] = get_blob(tree, chapter["conclusion"])
                 fetch_extracts(tutorial, chapter, fetch_txt=True,
@@ -1447,8 +1447,8 @@ def view_chapter(
             cpt_c += 1
         cpt_p += 1
     
-    # if chapter can't find
-    if not find:
+    # if chapter can't be found
+    if not found:
         raise Http404
 
     prev_chapter = (chapter_tab[final_position - 1] if final_position
@@ -1494,7 +1494,7 @@ def view_chapter_online(
     chapter_tab = []
     final_position = 0
     
-    find = False
+    found = False
     for part in parts:
         cpt_c = 1
         part["slug"] = slugify(part["title"])
@@ -1518,7 +1518,7 @@ def view_chapter_online(
             chapter["get_absolute_url_online"] = part[
                 "get_absolute_url_online"] + "{0}/{1}/".format(chapter["pk"], chapter["slug"])
             if chapter_pk == str(chapter["pk"]):
-                find = True
+                found = True
                 intro = tutorial.get_prod_file(chapter["introduction"])
                 chapter["intro"] = misc.read_path(intro)
                 conclu = tutorial.get_prod_file(chapter["conclusion"])
@@ -1534,8 +1534,8 @@ def view_chapter_online(
             cpt_c += 1
         cpt_p += 1
     
-    # if chapter can't find
-    if not find:
+    # if chapter can't be found
+    if not found:
         raise Http404
 
     prev_chapter = (chapter_tab[final_position - 1] if final_position > 0 else None)

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2855,16 +2855,19 @@ def markdown_to_out(md_text):
                   md_text)
 
 
-def MEP(tutorial, sha):
-    (output, err) = (None, None)
-    repo = Repo(tutorial.get_path())
-    manifest = get_blob(repo.commit(sha).tree, "manifest.json")
-    tutorial_version = json_reader.loads(manifest)
+def clear_prod_path(tutorial):
     if os.path.isdir(tutorial.get_prod_path()):
         try:
             shutil.rmtree(tutorial.get_prod_path())
         except:
             shutil.rmtree(u"\\\\?\{0}".format(tutorial.get_prod_path()))
+
+def MEP(tutorial, sha):
+    (output, err) = (None, None)
+    repo = Repo(tutorial.get_path())
+    manifest = get_blob(repo.commit(sha).tree, "manifest.json")
+    tutorial_version = json_reader.loads(manifest)
+    clear_prod_path(tutorial)
     shutil.copytree(tutorial.get_path(), tutorial.get_prod_path())
     repo.head.reset(commit = sha, index=True, working_tree=True)
     
@@ -2957,12 +2960,7 @@ def MEP(tutorial, sha):
 
 
 def UNMEP(tutorial):
-    if os.path.isdir(tutorial.get_prod_path()):
-        try:
-            shutil.rmtree(tutorial.get_prod_path())
-        except:
-            shutil.rmtree(u"\\\\?\{0}".format(tutorial.get_prod_path()))
-
+    clear_prod_path(tutorial)
 
 @can_write_and_read_now
 @login_required

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2698,77 +2698,33 @@ def download(request):
 
 
 @permission_required("tutorial.change_tutorial", raise_exception=True)
-def download_markdown(request):
-    """Download a markdown tutorial."""
+
+def download_format(request, file_ext, mimetype):
+    """Download a speciic format for a tutorial."""
 
     tutorial = get_object_or_404(Tutorial, pk=request.GET["tutoriel"])
-    phy_path = os.path.join(
-                tutorial.get_prod_path(),
-                tutorial.slug +
-                ".md") 
+    filename = tutorial.slug+'.'+file_ext
+    phy_path = os.path.join(tutorial.get_prod_path(), filename)
+    if not os.path.isfile(phy_path):
+        raise Http404
     response = HttpResponse(
         open(phy_path, "rb").read(),
-        mimetype="application/txt")
+        mimetype=mimetype)
     response["Content-Disposition"] = \
-        "attachment; filename={0}.md".format(tutorial.slug)
+        "attachment; filename={0}".format(filename)
     return response
 
-
+def download_markdown(request):
+    return download_format(request, "md", "application/txt")
 
 def download_html(request):
-    """Download a pdf tutorial."""
-
-    tutorial = get_object_or_404(Tutorial, pk=request.GET["tutoriel"])
-    phy_path = os.path.join(
-                tutorial.get_prod_path(),
-                tutorial.slug +
-                ".html")
-    if not os.path.isfile(phy_path):
-        raise Http404
-    response = HttpResponse(
-        open(phy_path, "rb").read(),
-        mimetype="text/html")
-    response["Content-Disposition"] = \
-        "attachment; filename={0}.html".format(tutorial.slug)
-    return response
-
-
+    return download_format(request, "html", "text/html")
 
 def download_pdf(request):
-    """Download a pdf tutorial."""
-
-    tutorial = get_object_or_404(Tutorial, pk=request.GET["tutoriel"])
-    phy_path = os.path.join(
-                tutorial.get_prod_path(),
-                tutorial.slug +
-                ".pdf")
-    if not os.path.isfile(phy_path):
-        raise Http404
-    response = HttpResponse(
-        open(phy_path, "rb").read(),
-        mimetype="application/pdf")
-    response["Content-Disposition"] = \
-        "attachment; filename={0}.pdf".format(tutorial.slug)
-    return response
-
-
+    return download_format(request, "pdf", "application/pdf")
 
 def download_epub(request):
-    """Download an epub tutorial."""
-
-    tutorial = get_object_or_404(Tutorial, pk=request.GET["tutoriel"])
-    phy_path = os.path.join(
-                tutorial.get_prod_path(),
-                tutorial.slug +
-                ".epub")
-    if not os.path.isfile(phy_path):
-        raise Http404
-    response = HttpResponse(
-        open(phy_path, "rb").read(),
-        mimetype="application/epub")
-    response["Content-Disposition"] = \
-        "attachment; filename={0}.epub".format(tutorial.slug)
-    return response
+    return download_format(request, "epub", "application/epub")
 
 
 def get_url_images(md_text, pt):

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -638,8 +638,8 @@ def fetch_extracts(tutorial, chapter, fetch_txt=True, online=False, tree=None):
                assert tree
                ext["txt"] = get_blob(tree, ext["text"])
            else:
-                text = os.path.join(path, ext["text"] + ".html")
-                ext["txt"] = misc.read_path(text)
+               txt = tutorial.get_prod_file(ext["text"])
+               ext["txt"] = misc.read_path(txt)
        position += 1
 
 
@@ -768,11 +768,9 @@ def view_tutorial_online(request, tutorial_pk, tutorial_slug):
             chapter = mandata["chapter"]
             chapter["path"] = tutorial.get_prod_path()
             chapter["type"] = "MINI"
-            intro = os.path.join(tutorial.get_prod_path(),
-                                 mandata["introduction"] + ".html")
+            intro = tutorial.get_prod_file(mandata["introduction"])
             chapter["intro"] = misc.read_path(intro)
-            conclu = os.path.join(tutorial.get_prod_path(),
-                                       mandata["conclusion"] + ".html")
+            conclu = tutorial.get_prod_file(mandata["conclusion"])
             chapter["conclu"] = misc.read_path(conclu)
             fetch_extracts(tutorial, chapter, online=True, fetch_txt=True)
         else:
@@ -1165,11 +1163,9 @@ def view_part_online(
         part["position_in_tutorial"] = cpt_p
         if part_pk == str(part["pk"]):
             find = True
-            intro = os.path.join(tutorial.get_prod_path(),
-                                 part["introduction"] + ".html")
+            intro = tutorial.get_prod_file(part["introduction"])
             part["intro"] = misc.read_path(intro)
-            conclu = os.path.join(tutorial.get_prod_path(),
-                                  part["conclusion"] + ".html")
+            conclu = tutorial.get_prod_file(part["conclusion"])
             part["conclu"] = misc.read_path(conclu)
             final_part=part
         cpt_c = 1
@@ -1523,13 +1519,9 @@ def view_chapter_online(
                 "get_absolute_url_online"] + "{0}/{1}/".format(chapter["pk"], chapter["slug"])
             if chapter_pk == str(chapter["pk"]):
                 find = True
-                intro = os.path.join(
-                    tutorial.get_prod_path(),
-                    chapter["introduction"] + ".html")
+                intro = tutorial.get_prod_file(chapter["introduction"])
                 chapter["intro"] = misc.read_path(intro)
-                conclu = os.path.join(
-                    tutorial.get_prod_path(),
-                    chapter["conclusion"] + ".html")
+                conclu = tutorial.get_prod_file(chapter["conclusion"])
                 chapter["conclu"] = misc.read_path(conclu)
                 fetch_extracts(tutorial, chapter, online=True, fetch_txt=True)
             else:

--- a/zds/utils/articles.py
+++ b/zds/utils/articles.py
@@ -4,6 +4,8 @@ from collections import OrderedDict
 
 from git import *
 
+from zds.utils import misc
+
 import os
 
 
@@ -24,8 +26,7 @@ def export_article(article):
 def get_blob(tree, chemin):
     for bl in tree.blobs:
         if os.path.abspath(bl.path) == os.path.abspath(chemin):
-            data = bl.data_stream.read()
-            return data.decode('utf-8')
+            return misc.read_blob(bl)
     if len(tree.trees) > 0:
         for tr in tree.trees:
             result = get_blob(tr, chemin)

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -57,3 +57,15 @@ def has_changed(instance, field, manager='objects'):
     manager = getattr(instance.__class__, manager)
     old = getattr(manager.get(pk=instance.pk), field)
     return not getattr(instance, field) == old
+
+def read_path(path, utf8=False, binary=False):
+    fd = open(path, 'rb' if binary else 'r')
+    content = fd.read()
+    fd.close()
+    if utf8:
+        content = content.decode('utf-8')
+    return content
+
+def read_blob(blob):
+    ds = blob.data_stream
+    return ds.read().decode('utf-8')

--- a/zds/utils/templatetags/repo_reader.py
+++ b/zds/utils/templatetags/repo_reader.py
@@ -5,7 +5,7 @@ from django import template
 
 from git import *
 
-from zds.utils import slugify
+from zds.utils import slugify, misc
 
 
 register = template.Library()
@@ -22,13 +22,13 @@ def repo_tuto(tutorial, sha=None):
         bls = repo.commit(sha).tree.blobs
         for bl in bls:
             if bl.path == 'introduction.md':
-                intro = bl.data_stream.read()
+                intro = misc.read_blob(bl)
             if bl.path == 'conclusion.md':
-                conclu = bl.data_stream.read()
+                conclu = misc.read_blob(bl)
 
         return {
-            'introduction': intro.decode('utf-8'),
-            'conclusion': conclu.decode('utf-8')}
+            'introduction': intro,
+            'conclusion': conclu}
 
 
 @register.filter('repo_part')
@@ -41,13 +41,13 @@ def repo_part(part, sha=None):
         bls = repo.commit(sha).tree.blobs
         for bl in bls:
             if bl.path == 'introduction.md':
-                intro = bl.data_stream.read()
+                intro = misc.read_blob(bl)
             if bl.path == 'conclusion.md':
-                conclu = bl.data_stream.read()
+                conclu = misc.read_blob(bl)
 
         return {
-            'introduction': intro.decode('utf-8'),
-            'conclusion': conclu.decode('utf-8')}
+            'introduction': intro,
+            'conclusion': conclu}
 
 
 @register.filter('repo_chapter')
@@ -63,12 +63,12 @@ def repo_chapter(chapter, sha=None):
             bls = repo.commit(sha).tree.blobs
             for bl in bls:
                 if bl.path == 'introduction.md':
-                    intro = bl.data_stream.read()
+                    intro = misc.read_blob(bl)
                 if bl.path == 'conclusion.md':
-                    conclu = bl.data_stream.read()
+                    conclu = misc.read_blob(bl)
             return {
-                'introduction': intro.decode('utf-8'),
-                'conclusion': conclu.decode('utf-8')}
+                'introduction': intro,
+                'conclusion': conclu}
 
 
 @register.filter('repo_extract')
@@ -81,16 +81,14 @@ def repo_extract(extract, sha=None):
 
         for bl in bls_e:
             if bl.path == slugify(extract['title']) + '.md':
-                text = bl.data_stream.read()
-                return {'text': text.decode('utf-8')}
+                text = misc.read_blob(bl)
+                return {'text': text}
     return {'text': ''}
 
 
 @register.filter('repo_blob')
 def repo_blob(blob):
-    contenu = blob.data_stream.read()
-
-    return contenu.decode('utf-8')
+    return misc.read_blob(blob)
 
 
 @register.filter('diff_text')

--- a/zds/utils/tutorials.py
+++ b/zds/utils/tutorials.py
@@ -7,7 +7,7 @@ from django.template import Context
 from django.template.loader import get_template
 from git import *
 
-from zds.utils import slugify
+from zds.utils import slugify, misc
 
 # Export-to-dict functions
 def export_chapter(chapter, export_all=True):
@@ -93,8 +93,7 @@ def get_blob(tree, chemin):
     for bl in tree.blobs:
         try:
             if os.path.abspath(bl.path) == os.path.abspath(chemin):
-                data = bl.data_stream.read()
-                return data.decode('utf-8')
+                return misc.read_blob(bl)
         except:
             return ""
     if len(tree.trees) > 0:
@@ -113,19 +112,11 @@ def export_tutorial_to_md(tutorial):
     parts = None
     tuto = OrderedDict()
 
-    i = open(
-        os.path.join(
-            tutorial.get_prod_path(),
-            tutorial.introduction),
-        "r")
-    i_contenu = i.read()
-    i.close()
-    tuto['intro'] = i_contenu
+    i = os.path.join(tutorial.get_prod_path(), tutorial.introduction)
+    tuto['intro'] = misc.read_path(i,utf8=False)
 
-    c = open(os.path.join(tutorial.get_prod_path(), tutorial.conclusion), "r")
-    c_contenu = c.read()
-    c.close()
-    tuto['conclu'] = c_contenu
+    c = os.path.join(tutorial.get_prod_path(), tutorial.conclusion)
+    tuto['conclu'] = misc.read_path(c,utf8=False)
 
     tuto['image'] = tutorial.image
     tuto['title'] = tutorial.title
@@ -146,31 +137,22 @@ def export_tutorial_to_md(tutorial):
             chapter = mandata['chapter']
             chapter['path'] = tutorial.get_prod_path()
             chapter['type'] = 'MINI'
-            intro = open(
-                os.path.join(
+            intro = os.path.join(
+                tutorial.get_prod_path(),
+                mandata['introduction'])
+            chapter['intro'] = misc.read_path(intro,utf8=False)
+            conclu = os.path.join(
                     tutorial.get_prod_path(),
-                    mandata['introduction']),
-                "r")
-            chapter['intro'] = intro.read()
-            intro.close()
-            conclu = open(
-                os.path.join(
-                    tutorial.get_prod_path(),
-                    mandata['conclusion']),
-                "r")
-            chapter['conclu'] = conclu.read()
-            conclu.close()
+                    mandata['conclusion'])
+            chapter['conclu'] = misc.read_path(conclu,utf8=False)
             cpt = 1
             for ext in chapter['extracts']:
                 ext['position_in_chapter'] = cpt
                 ext['path'] = tutorial.get_prod_path()
-                text = open(
-                    os.path.join(
-                        tutorial.get_prod_path(),
-                        ext['text']),
-                    "r")
-                ext['txt'] = text.read()
-                text.close()
+                text = os.path.join(
+                    tutorial.get_prod_path(),
+                    ext['text'])
+                ext['txt'] = misc.read_path(text,utf8=False)
                 cpt += 1
         else:
             chapter = None
@@ -182,20 +164,14 @@ def export_tutorial_to_md(tutorial):
             part['path'] = tutorial.get_path()
             part['slug'] = slugify(part['title'])
             part['position_in_tutorial'] = cpt_p
-            intro = open(
-                os.path.join(
+            intro = os.path.join(
                     tutorial.get_prod_path(),
-                    part['introduction']),
-                "r")
-            part['intro'] = intro.read()
-            intro.close()
-            conclu = open(
-                os.path.join(
-                    tutorial.get_prod_path(),
-                    part['conclusion']),
-                "r")
-            part['conclu'] = conclu.read()
-            conclu.close()
+                    part['introduction'])
+            part['intro'] = misc.read_path(intro,utf8=False)
+            conclu = os.path.join(
+                tutorial.get_prod_path(),
+                part['conclusion'])
+            part['conclu'] = misc.read_path(conclu,utf8=False)
 
             cpt_c = 1
             for chapter in part['chapters']:
@@ -205,31 +181,23 @@ def export_tutorial_to_md(tutorial):
                 chapter['type'] = 'BIG'
                 chapter['position_in_part'] = cpt_c
                 chapter['position_in_tutorial'] = cpt_c * cpt_p
-                intro = open(
-                    os.path.join(
-                        tutorial.get_prod_path(),
-                        chapter['introduction']),
-                    "r")
-                chapter['intro'] = intro.read()
-                intro.close()
-                conclu = open(
-                    os.path.join(
-                        tutorial.get_prod_path(),
-                        chapter['conclusion']),
-                    "r")
-                chapter['conclu'] = conclu.read()
+                intro = os.path.join(
+                    tutorial.get_prod_path(),
+                    chapter['introduction'])
+                chapter['intro'] = misc.read_path(intro,utf8=False)
+                conclu = os.path.join(
+                    tutorial.get_prod_path(),
+                    chapter['conclusion'])
+                chapter['conclu'] = misc.read_path(conclu,utf8=False)
                 cpt_e = 1
                 for ext in chapter['extracts']:
                     ext['chapter'] = chapter
                     ext['position_in_chapter'] = cpt_e
                     ext['path'] = tutorial.get_path()
-                    text = open(
-                        os.path.join(
-                            tutorial.get_prod_path(),
-                            ext['text']),
-                        "r")
-                    ext['txt'] = text.read()
-                    text.close()
+                    text = os.path.join(
+                        tutorial.get_prod_path(),
+                        ext['text'])
+                    ext['txt'] = misc.read_path(text,utf8=False)
                     cpt_e += 1
                 cpt_c += 1
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés |  |

J'ai essayé de regarder [ZEP-05](http://zestedesavoir.com/forums/sujet/676/zep-05-refonte-du-traitement-markdown-pour-lexport/) mais il faut lire le code de `tutorial/{models,views}.py`, donc j'ai essayé de m'y familiariser en le modifiant un peu.

Cette série de patch factorise le code pour qu'il soit plus lisible. Je pense qu'il y a encore beaucoup à faire pour retirer les redondances, mais il y a des irrégularités dans le code (par exemple certains remplissages de chapitre fournissent une clé `get_absolute_url{,_online}`, d'autres non) qui rendent cela plus difficile à moins de régulariser le comportement. Les patches joints essaient de préserver absolument le comportement existant (sauf bug manifeste), et n'essaient donc pas de factoriser ça.

Je n'ai pas du tout testé le code, puisque je n'ai pas encore réussi à installer ZdS en local (issue #1350).
