### PR TITLE
Update install-linux.md

### DIFF
--- a/doc/install-linux.md
+++ b/doc/install-linux.md
@@ -31,7 +31,7 @@ easy_install pip
 
 ```console
 pip install virtualenv
-virtualenv zdsenv
+virtualenv zdsenv --python=python2
 ```
 
 **À chaque fois** que vous souhaitez travailler dans votre environement, activez le via la commande suivante :


### PR DESCRIPTION
Chez moi j'ai python3 et python2 installé et virtualenv choisit python3 par défaut. Passer l'option `--python=python2` permet de s'assurer que c'est bien un virtualenv python2 qui est utilisé par la suite. (On pourrait mettre `=python2.7` mais ça crée une dépendance inutile sur la version précise de l'utilisateur, qui est déjà demandée plus haut dans le document.)
