### PR TITLE
`emarkdown_inline` pour la signature

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -75,7 +75,7 @@
 
         {% if profile.sign %}
             <h2 id="signature">Signature</h2>
-            {{ profile.sign|emarkdown }}
+            {{ profile.sign|emarkdown_inline }}
         {% endif %}
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1361 |

`emarkdown_inline` pour la signature (dans `templates/member/profile.html`)

**Pour la QA (attention, nécéssite d'avoir mis à jour sa version de markdown, voir #1361 )** : mettre comme signature des choses qui y sont non-autorisées (smileys, alignement de texte, liste, ...). Vérifier que le rendu est pareil pour la signature sur le forum et sur le profil.
