### PR TITLE
Issue #983 : Solution TEMPORAIRE au bug de la recherche

### DIFF
--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -3,6 +3,7 @@
 {% load emarkdown %}
 {% load model_name %}
 {% load highlight %}
+{% load topbar %}
 
 
 {% block title %}
@@ -60,83 +61,87 @@
             <div class="topic-list navigable-list">
                 {% for result in page.object_list %}
                     {% if result and result.object %}
-                        <div class="topic navigable-elem">
-                            <div class="topic-infos">
-                            </div>
-                            <div class="topic-description">
-                                {% if result.object.first_post %}
-                                    <a href="{{ result.object.get_absolute_url }}" class="topic-title-link navigable-link">
-                                        <div class="topic-title">
-                                            {% highlight result.object.title with query html_tag "mark" %}
+                        {% if result.object.forum and not result.object.forum|auth_forum:user %}
+                        {% elif result.object.topic.forum and not result.object.topic.forum|auth_forum:user %}
+                        {% else %}
+                            <div class="topic navigable-elem">
+                                <div class="topic-infos">
+                                </div>
+                                <div class="topic-description">
+                                    {% if result.object.first_post %}
+                                        <a href="{{ result.object.get_absolute_url }}" class="topic-title-link navigable-link">
+                                            <div class="topic-title">
+                                                {% highlight result.object.title with query html_tag "mark" %}
+                                            </div>
+                                    {% elif result.object.get_text_online %}
+                                        <a href="{{ result.object.get_absolute_url_online }}" class="topic-title-link navigable-link">
+                                            <div class="topic-title">
+                                                {% highlight result.object.title with query html_tag "mark" %}
+                                            </div>
+                                    {% elif result.object.topic %}
+                                        <a href="{{ result.object.get_absolute_url }}" class="topic-title-link navigable-link">
+                                            <div class="topic-title">
+                                                {% highlight result.object.topic.title with query html_tag "mark" %}
+                                            </div>
+                                    {% else %}
+                                        <a href="{{ result.object.get_absolute_url_online }}" class="topic-title-link navigable-link">
+                                            <div class="topic-title">
+                                                {% highlight result.object.title with query html_tag "mark" %}
+                                            </div>
+                                    {% endif %}
+                                            <div class="topic-subtitle">
+                                                {% if result.object.first_post %}
+                                                    {% with text=result.object.first_post.text|emarkdown|striptags|safe %}
+                                                        {% highlight text with query html_tag "mark" %}
+                                                    {% endwith %}
+                                                {% elif result.object.get_text_online %}
+                                                    {% with text=result.object.get_text_online|striptags|safe %}
+                                                        {% highlight text with query html_tag "mark" %}
+                                                    {% endwith %}
+                                                {% elif result.object.topic %}
+                                                    {% with text=result.object.text|emarkdown|striptags|safe %}
+                                                        {% highlight text with query html_tag "mark" %}
+                                                    {% endwith %}
+                                                {% else %}
+                                                    {% with text=result.object.get_introduction_online|striptags|safe %}
+                                                        {% highlight text with query html_tag "mark" %}
+                                                    {% endwith %}
+                                                {% endif %}
+                                            </div>
+                                        </a>
+                                        <div class="topic-members">
+                                            {% model_name result.app_label result.model_name False %}
                                         </div>
-                                {% elif result.object.get_text_online %}
-                                    <a href="{{ result.object.get_absolute_url_online }}" class="topic-title-link navigable-link">
-                                        <div class="topic-title">
-                                            {% highlight result.object.title with query html_tag "mark" %}
-                                        </div>
-                                {% elif result.object.topic %}
-                                    <a href="{{ result.object.get_absolute_url }}" class="topic-title-link navigable-link">
-                                        <div class="topic-title">
-                                            {% highlight result.object.topic.title with query html_tag "mark" %}
-                                        </div>
-                                {% else %}
-                                    <a href="{{ result.object.get_absolute_url_online }}" class="topic-title-link navigable-link">
-                                        <div class="topic-title">
-                                            {% highlight result.object.title with query html_tag "mark" %}
-                                        </div>
-                                {% endif %}
-                                        <div class="topic-subtitle">
+                                </div>
+                                <div class="topic-last-answer">
+                                    {% if result.object.pubdate %}
+                                        <a href="
                                             {% if result.object.first_post %}
-                                                {% with text=result.object.first_post.text|emarkdown|striptags|safe %}
-                                                    {% highlight text with query html_tag "mark" %}
-                                                {% endwith %}
-                                            {% elif result.object.get_text_online %}
-                                                {% with text=result.object.get_text_online|striptags|safe %}
-                                                    {% highlight text with query html_tag "mark" %}
-                                                {% endwith %}
-                                            {% elif result.object.topic %}
-                                                {% with text=result.object.text|emarkdown|striptags|safe %}
-                                                    {% highlight text with query html_tag "mark" %}
-                                                {% endwith %}
+                                                {{ result.object.get_absolute_url }}
+                                            {% elif result.object.get_introduction_online %}
+                                                {{ result.object.get_absolute_url_online }}
                                             {% else %}
-                                                {% with text=result.object.get_introduction_online|striptags|safe %}
-                                                    {% highlight text with query html_tag "mark" %}
-                                                {% endwith %}
+                                                {{ result.object.get_absolute_url }}
                                             {% endif %}
-                                        </div>
-                                    </a>
-                                    <div class="topic-members">
-                                        {% model_name result.app_label result.model_name False %}
-                                    </div>
+                                        ">
+                                            {{ result.object.pubdate|format_date|capfirst }}
+                                        </a>
+                                    {% elif result.object.tutorial.pubdate %}
+                                        <a href="{{ result.object.get_absolute_url_online }}">
+                                            {{ result.object.tutorial.pubdate|format_date|capfirst }}
+                                        </a>
+                                    {% elif result.object.part.tutorial.pubdate %}
+                                        <a href="{{ result.object.get_absolute_url_online }}">
+                                            {{ result.object.part.tutorial.pubdate|format_date|capfirst }}
+                                        </a>
+                                    {% elif result.object.chapter.part.tutorial.pubdate %}
+                                        <a href="{{ result.object.get_absolute_url_online }}">
+                                            {{ result.object.chapter.part.tutorial.pubdate|format_date|capfirst }}
+                                        </a>
+                                    {% endif %}
+                                </div>
                             </div>
-                            <div class="topic-last-answer">
-                                {% if result.object.pubdate %}
-                                    <a href="
-                                        {% if result.object.first_post %}
-                                            {{ result.object.get_absolute_url }}
-                                        {% elif result.object.get_introduction_online %}
-                                            {{ result.object.get_absolute_url_online }}
-                                        {% else %}
-                                            {{ result.object.get_absolute_url }}
-                                        {% endif %}
-                                    ">
-                                        {{ result.object.pubdate|format_date|capfirst }}
-                                    </a>
-                                {% elif result.object.tutorial.pubdate %}
-                                    <a href="{{ result.object.get_absolute_url_online }}">
-                                        {{ result.object.tutorial.pubdate|format_date|capfirst }}
-                                    </a>
-                                {% elif result.object.part.tutorial.pubdate %}
-                                    <a href="{{ result.object.get_absolute_url_online }}">
-                                        {{ result.object.part.tutorial.pubdate|format_date|capfirst }}
-                                    </a>
-                                {% elif result.object.chapter.part.tutorial.pubdate %}
-                                    <a href="{{ result.object.get_absolute_url_online }}">
-                                        {{ result.object.chapter.part.tutorial.pubdate|format_date|capfirst }}
-                                    </a>
-                                {% endif %}
-                            </div>
-                        </div>
+                        {% endif %}
                     {% endif %}
                 {% endfor %}
             </div>

--- a/zds/utils/templatetags/topbar.py
+++ b/zds/utils/templatetags/topbar.py
@@ -54,3 +54,9 @@ def top_categories_tuto(user):
         else:
             cats[key] = [csc.subcategory]
     return cats
+
+
+@register.filter('auth_forum')
+def auth_forum(forum, user):
+    return forum.can_read(user)
+


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #983 |

Correction **temporaire** bête et méchante : on réapplique le filtre qui existait au commit [bfb65a96843d3c6a936d87feb02ec679792d0eb9](https://github.com/zestedesavoir/zds-site/commit/bfb65a96843d3c6a936d87feb02ec679792d0eb9#diff-f6c85e73cf25dd5ab80c5fd5fdab7a48R99). Ça empêche la fuite de données.

À faire en version propre : indexer l'information de visibilité des topics et filtrer dessus en fonction de l'utilisateur.

**Comment QAtiser cette chose ?**

C'est un peu laborieux mais c'est simple.
1. [Installez Solr](https://github.com/zestedesavoir/zds-site/blob/master/doc/install-solr.md)
2. Dans l'interface d'admin, créez un forum privé (groupe = staff).
3. Réinitialiser l'index complet : `python manage.py rebuild_index`
4. Créez 3 topics, chacun avec un mot-clé que vous n'avez nulle part dans le site pour pouvoir les retrouver facilement. L'un est public, le 2ème public est deviendra privé, le 3ème est directement privé (créé dans le forum privé donc).
5. Mettez l'index Solr à jour : `python manage.py update_index`
6. Vérifiez que vous trouvez les 2 topics publics et pas le privé
7. Déplacez l'un des topics publics en privé
8. (Pas besoin de réindexer Solr ici)
9. Vérifiez que les 2 topics privés sont introuvables et que le topic public est toujours là

(Dans les vrais environnements un cron met à jour l'index périodiquement).

Attention, relecteur de code, Github et très con dans la présentation du diff, il manque une option "ignore les espaces".
