### PR TITLE
Ajout des tops tags dans la top bar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -215,8 +215,8 @@
                                     </a>
 
                                     <ul class="dropdown-list">
-                                        {% with categories=user|top_categories %}
-                                            {% for title, forums in categories.items %}
+                                        {% with top=user|top_categories %}
+                                            {% for title, forums in top.categories.items %}
                                                 <li>
                                                     <ul>
                                                         <li class="dropdown-title">
@@ -228,6 +228,18 @@
                                                     </ul>
                                                 </li>
                                             {% endfor %}
+                                            {% if top.tags %}
+                                            <li>
+                                                <ul>
+                                                    <li class="dropdown-title">
+                                                        Tags les plus utilisés
+                                                    </li>
+                                                    {% for tag in top.tags %}
+                                                        <li><a href="{{ tag.get_absolute_url }}">{{ tag.title }}</a></li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </li>
+                                            {% endif %}
                                         {% endwith %}
                                     </ul>
                                 </div>

--- a/templates/forum/index.html
+++ b/templates/forum/index.html
@@ -37,7 +37,7 @@
     <div class="content-wrapper topic-list topic-list-small forum-list navigable-list" itemscope itemtype="http://schema.org/ItemList">
         <meta itemprop="itemListOrder" content="Unordered">
 
-        {% for title, forums in categories.items %}
+        {% for title, forums in categories.categories.items %}
             <h2 class="group-title content-wrapper">
                 {{ title }}
             </h2>

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -261,6 +261,9 @@ REPO_PATH = os.path.join(SITE_ROOT, 'tutoriels-private')
 REPO_PATH_PROD = os.path.join(SITE_ROOT, 'tutoriels-public')
 REPO_ARTICLE_PATH = os.path.join(SITE_ROOT, 'articles-data')
 
+# Constant for tags
+TOP_TAG_MAX = 2
+
 # Constants for pagination
 POSTS_PER_PAGE = 21
 TOPICS_PER_PAGE = 21

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -275,6 +275,11 @@ class Tag(models.Model):
     def __unicode__(self):
         """Textual Link Form."""
         return u"{0}".format(self.title)
+    
+    def get_absolute_url(self):
+        return reverse('zds.forum.views.find_topic_by_tag',
+           kwargs={'tag_pk': self.pk,
+                   'tag_slug': self.slug})
 
     def save(self, *args, **kwargs):
         self.title = smart_text(self.title).lower()

--- a/zds/utils/templatetags/topbar.py
+++ b/zds/utils/templatetags/topbar.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 
 from django import template
-
-from zds.forum.models import Category as fCategory, Forum
+from django.conf import settings
+from django.db.models import Count
+import itertools
+from zds.forum.models import Category as fCategory, Forum, Topic
 from zds.tutorial.models import Tutorial
-from zds.utils.models import Category, SubCategory, CategorySubCategory
+from zds.utils.models import Category, SubCategory, CategorySubCategory, Tag
 
 
 register = template.Library()
@@ -31,8 +33,31 @@ def top_categories(user):
         else:
             cats[key] = [forum]
     
-    return cats
+    topics = Topic.objects.filter(forum__in=forums)
+    tgs = Topic.objects\
+        .values('tags', 'pk')\
+        .distinct()\
+        .filter(forum__in=forums, tags__isnull=False)
+    
+    #for tg in tgs:
+    #    print tg
+    cts = {}
+    for key, group in itertools.groupby(tgs, lambda item: item["tags"]):
+        for thing in group:
+            if key in cts: cts[key]+=1
+            else: cts[key]=1
 
+    cpt=0
+    top_tag =[]
+    sort_list = reversed(sorted(cts.iteritems(), key=lambda (k,v): (v,k)))
+    for key, value in sort_list:
+        top_tag.append(key)
+        cpt+=1
+        if cpt >=settings.TOP_TAG_MAX : break
+    
+    tags=Tag.objects.filter(pk__in=top_tag)
+    
+    return {"tags":tags, "categories":cats}
 
 @register.filter('top_categories_tuto')
 def top_categories_tuto(user):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | Aucun |

Cette PR a pour objectif, afin d'augmenter légèrement la visibilité des tags, et en même temps de combler le vide actuel dans la barre du haut, de rajouter dans la barre du haut, une colonne "Tag les plus utilisés" qui liste l'ensemble des tags du site les plus utilisés.

Le nombre de top tag est paramétrable dans le fichier settings.py (je l'ai indiqué à 5 ici) et aussi surchargeable en fonction de l'activité dans le settings_prod.py en production.

**Note pour QA**
- Créez des topics avec un ou plusieurs tags
- Vérifiez que les 5 tags affichés dans la barre du haut sont bien les tags avec le plus de sujet
- Vérifiez qu'un tag appartenant à un topic privé uniquement n'est pas visible par un membre qui n'a pas accès à ce topic.
