### PR TITLE
correction erreur 500 des notifications

### DIFF
--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -107,6 +107,8 @@ def interventions_topics(user):
 
     for top in topics_never_read:
         content = top.topic.first_unread_post()
+        if content is None:
+            content = top.topic.last_message
         posts_unread.append({'pubdate':content.pubdate, 'author':content.author, 'title':top.topic.title, 'url':content.get_absolute_url()})
 
     posts_unread.sort(cmp = comp)    


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | Erreur 500 vue dans les logs serveurs |

Cette PR corrige une erreur 500 qui n'arrive pas tous les jours et difficilement reproductible, car un concours de circonstance peut les créer dans les notifications.

**Note pour QA**

Vérifier que les notifications marche toujours (nombre de notifications et liens vers ces notifications)
