### PR TITLE
corrige les erreurs dans les paramètres GET

### DIFF
--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -151,9 +151,13 @@ def topic(request, topic_pk, topic_slug):
     # The category list is needed to move threads
 
     categories = Category.objects.all()
-    try:
-        page_nbr = int(request.GET["page"])
-    except:
+    if "page" in request.GET:
+        try:
+            page_nbr = int(request.GET["page"])
+        except:
+            # problem in variable format
+            raise Http404
+    else:
         page_nbr = 1
     try:
         posts = paginator.page(page_nbr)
@@ -234,6 +238,7 @@ def new(request):
     try:
         forum_pk = request.GET["forum"]
     except:
+        # problem in variable format
         raise Http404
     forum = get_object_or_404(Forum, pk=forum_pk)
     if not forum.can_read(request.user):
@@ -345,6 +350,7 @@ def move_topic(request):
     try:
         topic_pk = request.GET["sujet"]
     except:
+        # problem in variable format
         raise Http404
     forum = get_object_or_404(Forum, pk=request.POST["forum"])
     if not forum.can_read(request.user):
@@ -375,11 +381,17 @@ def edit(request):
     try:
         topic_pk = request.POST["topic"]
     except:
+        # problem in variable format
         raise Http404
-    try:
-        page = int(request.POST["page"])
-    except:
+    if "page" in request.POST:
+        try:
+            page = int(request.POST["page"])
+        except:
+            #problem in vairable format
+            raise Http404
+    else:
         page = 1
+
     data = request.POST
     resp = {}
     g_topic = get_object_or_404(Topic, pk=topic_pk)
@@ -410,6 +422,7 @@ def edit(request):
             try:
                 forum_pk = int(request.POST["move_target"])
             except:
+                # problem in variable format
                 raise Http404
             forum = get_object_or_404(Forum, pk=forum_pk)
             g_topic.forum = forum
@@ -433,6 +446,7 @@ def answer(request):
     try:
         topic_pk = request.GET["sujet"]
     except:
+        # problem in variable format
         raise Http404
 
     # Retrieve current topic.
@@ -590,6 +604,7 @@ def edit_post(request):
     try:
         post_pk = request.GET["message"]
     except:
+        # problem in variable format
         raise Http404
     post = get_object_or_404(Post, pk=post_pk)
     if not post.topic.forum.can_read(request.user):
@@ -716,6 +731,7 @@ def useful_post(request):
     try:
         post_pk = request.GET["message"]
     except:
+        # problem in variable format
         raise Http404
     post = get_object_or_404(Post, pk=post_pk)
 
@@ -742,6 +758,7 @@ def unread_post(request):
     try:
         post_pk = request.GET["message"]
     except:
+        # problem in variable format
         raise Http404
     post = get_object_or_404(Post, pk=post_pk)
 
@@ -776,6 +793,7 @@ def like_post(request):
     try:
         post_pk = request.GET["message"]
     except:
+        # problem in variable format
         raise Http404
     resp = {}
     post = get_object_or_404(Post, pk=post_pk)
@@ -823,6 +841,7 @@ def dislike_post(request):
     try:
         post_pk = request.GET["message"]
     except:
+        # problem in variable format
         raise Http404
     resp = {}
     post = get_object_or_404(Post, pk=post_pk)

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -153,7 +153,7 @@ def topic(request, topic_pk, topic_slug):
     categories = Category.objects.all()
     try:
         page_nbr = int(request.GET["page"])
-    except KeyError:
+    except:
         page_nbr = 1
     try:
         posts = paginator.page(page_nbr)
@@ -233,7 +233,7 @@ def new(request):
 
     try:
         forum_pk = request.GET["forum"]
-    except KeyError:
+    except:
         raise Http404
     forum = get_object_or_404(Forum, pk=forum_pk)
     if not forum.can_read(request.user):
@@ -344,7 +344,7 @@ def move_topic(request):
         raise PermissionDenied
     try:
         topic_pk = request.GET["sujet"]
-    except KeyError:
+    except:
         raise Http404
     forum = get_object_or_404(Forum, pk=request.POST["forum"])
     if not forum.can_read(request.user):
@@ -374,11 +374,11 @@ def edit(request):
 
     try:
         topic_pk = request.POST["topic"]
-    except KeyError:
+    except:
         raise Http404
     try:
         page = int(request.POST["page"])
-    except KeyError:
+    except:
         page = 1
     data = request.POST
     resp = {}
@@ -409,7 +409,7 @@ def edit(request):
         if "move" in data:
             try:
                 forum_pk = int(request.POST["move_target"])
-            except KeyError:
+            except:
                 raise Http404
             forum = get_object_or_404(Forum, pk=forum_pk)
             g_topic.forum = forum
@@ -432,7 +432,7 @@ def answer(request):
 
     try:
         topic_pk = request.GET["sujet"]
-    except KeyError:
+    except:
         raise Http404
 
     # Retrieve current topic.
@@ -589,7 +589,7 @@ def edit_post(request):
 
     try:
         post_pk = request.GET["message"]
-    except KeyError:
+    except:
         raise Http404
     post = get_object_or_404(Post, pk=post_pk)
     if not post.topic.forum.can_read(request.user):
@@ -715,7 +715,7 @@ def useful_post(request):
 
     try:
         post_pk = request.GET["message"]
-    except KeyError:
+    except:
         raise Http404
     post = get_object_or_404(Post, pk=post_pk)
 
@@ -741,7 +741,7 @@ def unread_post(request):
 
     try:
         post_pk = request.GET["message"]
-    except KeyError:
+    except:
         raise Http404
     post = get_object_or_404(Post, pk=post_pk)
 
@@ -775,7 +775,7 @@ def like_post(request):
 
     try:
         post_pk = request.GET["message"]
-    except KeyError:
+    except:
         raise Http404
     resp = {}
     post = get_object_or_404(Post, pk=post_pk)
@@ -822,7 +822,7 @@ def dislike_post(request):
 
     try:
         post_pk = request.GET["message"]
-    except KeyError:
+    except:
         raise Http404
     resp = {}
     post = get_object_or_404(Post, pk=post_pk)

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -387,7 +387,7 @@ def edit(request):
         try:
             page = int(request.POST["page"])
         except:
-            #problem in vairable format
+            #problem in variable format
             raise Http404
     else:
         page = 1


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1389 |

Cette PR corrige le problème des erreurs 500.

**Note pour QA**

Vérifier que les urls dont le paramètre n'est pas numérique alors que ça devrait l'être ne donne plus d'erreur 500.
