### PR TITLE
Ajout d'un id unique pour les notes de bas de page

### DIFF
--- a/templates/forum/find/post.html
+++ b/templates/forum/find/post.html
@@ -45,7 +45,7 @@
                 <tr>
                     <td>
                         <div class="forum-entry-title {% if user.is_authenticated %} {% if topic.never_read %} unread {% endif %} {% endif %}">
-                            <a href="{{ post.get_absolute_url }}">{{ post.topic.title }} </a> 
+                            <a href="{{ post.get_absolute_url }}">{{ post.topic.title }} </a>
                             {% if post.topic.subtitle %} <p> {{ post.topic.subtitle }} </p> {% endif %}
                         </div>
                     </td>
@@ -53,7 +53,7 @@
                         {{ post.pubdate|format_date }}
                     </td>
                     <td>
-                        {{ post.text|truncatechars:200|emarkdown|striptags }}
+                        {{ post.text|truncatechars:200|emarkdown:post.pk|striptags }}
                     </td>
                 </tr>
                 {% endfor %}

--- a/templates/forum/find/topic.html
+++ b/templates/forum/find/topic.html
@@ -44,7 +44,7 @@
                 <tr>
                     <td>
                         <div class="forum-entry-title {% if user.is_authenticated %} {% if topic.never_read %} unread {% endif %} {% endif %}">
-                        <a href="{{ topic.get_absolute_url }}">{{ topic.title }} </a> 
+                        <a href="{{ topic.get_absolute_url }}">{{ topic.title }} </a>
                             {% if topic.subtitle %} <p> {{ topic.subtitle }} </p> {% endif %}
                         </div>
                     </td>
@@ -52,7 +52,7 @@
                         {{ topic.pubdate|format_date }}
                     </td>
                     <td>
-                        {{ topic.first_post.text|truncatechars:200|emarkdown|striptags }}
+                        {{ topic.first_post.text|truncatechars:200|emarkdown:topic.pk|striptags }}
                     </td>
                 </tr>
                 {% endfor %}

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -56,7 +56,7 @@
 
         {% if profile.sign %}
             <h3>Signature</h3>
-            {{ profile.sign|emarkdown }}
+            {{ profile.sign|emarkdown:"sign" }}
         {% endif %}
 
 
@@ -93,7 +93,7 @@
     {% if profile.biography %}
         <section class="full-content-wrapper">
             <h2>Biographie</h2>
-            {{ profile.biography|emarkdown }}
+            {{ profile.biography|emarkdown:"bio" }}
         </section>
     {% endif %}
 

--- a/templates/tutorial/includes/chapter.part.html
+++ b/templates/tutorial/includes/chapter.part.html
@@ -6,14 +6,14 @@
 {% with extracts=chapter.extracts %}
     {% if not chapter.type = 'MINI' %}
         {% if chapter.intro and chapter.intro != None %}
-            {{ chapter.intro|emarkdown }}
+            {{ chapter.intro|emarkdown:"intro" }}
         {% elif not tutorial.in_beta %}
             <p class="ico-after warning">
                 Il n'y a pas d'introduction.
             </p>
         {% endif %}
     {% endif %}
-    
+
     <hr />
 
     {% if extracts %}
@@ -101,7 +101,7 @@
         {% endif %}
 
         {% if extract.txt %}
-            {{ extract.txt|emarkdown }}
+            {{ extract.txt|emarkdown:"extract" }}
         {% else %}
             <p class="ico-after warning">
                 Cet extrait est vide.
@@ -113,7 +113,7 @@
 
     {% if not chapter.type = 'MINI' %}
         {% if chapter.conclu and chapter.conclu != None %}
-            {{ chapter.conclu|emarkdown }}
+            {{ chapter.conclu|emarkdown:"conclu" }}
         {% elif not tutorial.in_beta %}
             <p class="ico-after warning">
                 Il n'y a pas de conclusion.

--- a/templates/tutorial/part/view.html
+++ b/templates/tutorial/part/view.html
@@ -42,7 +42,7 @@
 
 {% block content %}
     {% if part.intro and part.intro != "None" %}
-        {{ part.intro|emarkdown }}
+        {{ part.intro|emarkdown:"intro" }}
     {% elif not tutorial.in_beta %}
         <p class="ico-after warning">
             Il n'y a pas d'introduction.
@@ -85,11 +85,11 @@
             {% endfor %}
         </ul>
     {% endif %}
-    
+
     <hr />
 
     {% if part.conclu and part.conclu != "None" %}
-        {{ part.conclu|emarkdown }}
+        {{ part.conclu|emarkdown:"conclu" }}
     {% elif not tutorial.in_beta %}
         <p class="ico-after warning">
             Il n'y a pas de conclusion.

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -100,7 +100,7 @@
 {% block content %}
     {% with tuto_version=tutorial|repo_tuto:version %}
         {% if tuto_version.introduction and tuto_version.introduction != "None" %}
-            {{ tuto_version.introduction|emarkdown }}
+            {{ tuto_version.introduction|emarkdown:"intro" }}
         {% elif not tutorial.in_beta %}
             <p class="ico-after warning">
                 Il n'y a pas d'introduction.
@@ -134,7 +134,7 @@
         {% endif %}
 
         {% if tuto_version.conclusion and tuto_version.conclusion != "None" %}
-            {{ tuto_version.conclusion|emarkdown }}
+            {{ tuto_version.conclusion|emarkdown:"conclu" }}
         {% elif not tutorial.in_beta %}
             <p class="ico-after warning">
                 Il n'y a pas de conclusion.
@@ -263,7 +263,7 @@
                         <input type="hidden" name="update_beta">
                         <input type="hidden" name="version" value="{{ version }}">
                         <p>
-                            Êtes-vous certain de vouloir <strong>mettre à jour</strong> la bêta du tutoriel 
+                            Êtes-vous certain de vouloir <strong>mettre à jour</strong> la bêta du tutoriel
                             "<em>{{ tutorial.title }}</em>" dans la version que vous voyez actuellement ?
                         </p>
                         <button type="submit">

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -66,12 +66,12 @@ def index(request):
             .filter(sha_public__isnull=False, subcategory__in=[tag])\
             .exclude(sha_public="").order_by('-pubdate')\
             .all()
-    
+
     article_versions = []
     for article in articles:
         article_version = article.load_json_for_public()
         article_version = article.load_dic(article_version)
-        article_versions.append(article_version) 
+        article_versions.append(article_version)
 
     return render_template('article/index.html', {
         'articles': article_versions,
@@ -214,7 +214,7 @@ def new(request):
                 'description': request.POST['description'],
                 'text': request.POST['text'],
                 'image': image,
-                'subcategory': request.POST.getlist('subcategory'), 
+                'subcategory': request.POST.getlist('subcategory'),
                 'licence': request.POST['licence']
             })
             return render_template('article/member/new.html', {
@@ -301,7 +301,7 @@ def edit(request):
                 'description': request.POST['description'],
                 'text': request.POST['text'],
                 'image': image,
-                'subcategory': request.POST.getlist('subcategory'), 
+                'subcategory': request.POST.getlist('subcategory'),
                 'licence': licence
             })
             return render_template('article/member/edit.html', {
@@ -330,7 +330,7 @@ def edit(request):
                     article.licence = lc
                 else:
                     article.licence = None
-            
+
 
             article.save()
 
@@ -371,12 +371,12 @@ def find_article(request, pk_user):
         .filter(authors__in=[user], sha_public__isnull=False).exclude(sha_public="")\
         .order_by('-pubdate')\
         .all()
-    
+
     article_versions = []
     for article in articles:
         article_version = article.load_json_for_public()
         article_version = article.load_dic(article_version)
-        article_versions.append(article_version) 
+        article_versions.append(article_version)
 
     # Paginator
     return render_template('article/find.html', {
@@ -918,10 +918,14 @@ def answer(request):
                 reaction.article = article
                 reaction.author = request.user
                 reaction.text = data['text']
-                reaction.text_html = emarkdown(data['text'])
                 reaction.pubdate = datetime.now()
                 reaction.position = article.get_reaction_count() + 1
                 reaction.ip_address = get_client_ip(request)
+                # need a unique id (footnotes), we will use reaction.pk, we need to save first
+                reaction.text_html = 'tmp'
+                reaction.save()
+                # parse markdown and then save again (with unique_id=reaction.pk)
+                reaction.text_html = emarkdown(data["text"], '-'.join(('com', str(reaction.pk))))
                 reaction.save()
 
                 article.last_reaction = reaction
@@ -1082,7 +1086,7 @@ def edit_reaction(request):
             # The user just sent data, handle them
             if request.POST['text'].strip() != '':
                 reaction.text = request.POST['text']
-                reaction.text_html = emarkdown(request.POST['text'])
+                reaction.text_html = emarkdown(request.POST['text'], '-'.join(('com', str(reaction.pk))))
                 reaction.update = datetime.now()
                 reaction.editor = request.user
 

--- a/zds/forum/feeds.py
+++ b/zds/forum/feeds.py
@@ -28,7 +28,7 @@ class LastPostsFeedRSS(Feed):
 
     def item_description(self, item):
         # TODO: Use cached Markdown when implemented
-        return emarkdown(item.text)
+        return emarkdown(item.text, item.pk)
 
     def item_author_name(self, item):
         return item.author.username

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -297,9 +297,13 @@ def answer(request):
                 post.privatetopic = g_topic
                 post.author = request.user
                 post.text = data['text']
-                post.text_html = emarkdown(data['text'])
                 post.pubdate = datetime.now()
                 post.position_in_topic = g_topic.get_post_count() + 1
+                # need a unique id (footnotes), we will use post.pk, we need to save first
+                post.text_html = 'tmp'
+                post.save()
+                # parse markdown and then save again (with unique_id=post.pk)
+                post.text_html = emarkdown(data["text"], post.pk)
                 post.save()
 
                 g_topic.last_message = post
@@ -434,7 +438,7 @@ def edit_post(request):
 
         # The user just sent data, handle them
         post.text = request.POST['text']
-        post.text_html = emarkdown(request.POST['text'])
+        post.text_html = emarkdown(request.POST['text'], post.pk)
         post.update = datetime.now()
         post.save()
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -89,7 +89,7 @@ def index(request):
         tutorials = Tutorial.objects.filter(
             sha_public__isnull=False,
             subcategory__in=[tag]).exclude(sha_public="").order_by("-pubdate").all()
-    
+
     tuto_versions = []
     for tutorial in tutorials:
         mandata = tutorial.load_json_for_public()
@@ -464,8 +464,8 @@ def ask_validation(request):
                               status__in=['PENDING','PENDING_V'])\
                               .delete()
     # We create and save validation object of the tutorial.
-    
-    
+
+
     validation = Validation()
     validation.tutorial = tutorial
     validation.date_proposition = datetime.now()
@@ -643,7 +643,7 @@ def view_tutorial(request, tutorial_pk, tutorial_slug):
         sha = request.GET["version"]
     except KeyError:
         sha = tutorial.sha_draft
-    
+
     is_beta = sha == tutorial.sha_beta and tutorial.in_beta()
 
     # Only authors of the tutorial and staff can view tutorial in offline.
@@ -1005,7 +1005,7 @@ def edit_tutorial(request):
                                "tutorial": tutorial, "form": form,
                                "last_hash": compute_hash([introduction, conclusion]),
                                "new_version": True
-                           })        
+                           })
             old_slug = tutorial.get_path()
             tutorial.title = data["title"]
             tutorial.description = data["description"]
@@ -1039,7 +1039,7 @@ def edit_tutorial(request):
             tutorial.update_children()
 
             new_slug = os.path.join(settings.REPO_PATH, tutorial.get_phy_slug())
-            
+
             maj_repo_tuto(
                 request,
                 old_slug_path=old_slug,
@@ -1139,11 +1139,11 @@ def view_part(
             final_part = part
             break
         cpt_p += 1
-    
+
     # if part can't find
     if not find:
         raise Http404
-    
+
     return render_template("tutorial/part/view.html",
                            {"tutorial": tutorial,
                             "part": final_part,
@@ -1213,7 +1213,7 @@ def view_part_online(
     # if part can't find
     if not find:
         raise Http404
-    
+
     return render_template("tutorial/part/view_online.html", {"part": final_part})
 
 
@@ -1249,7 +1249,7 @@ def add_part(request):
             part.introduction = os.path.join(part.get_phy_slug(), "introduction.md")
             part.conclusion = os.path.join(part.get_phy_slug(), "conclusion.md")
             part.save()
-            
+
             new_slug = os.path.join(settings.REPO_PATH, part.tutorial.get_phy_slug(), part.get_phy_slug())
 
             maj_repo_part(
@@ -1296,9 +1296,9 @@ def modify_part(request):
 
         move(part, new_pos, "position_in_tutorial", "tutorial", "get_parts")
         part.save()
-        
+
         new_slug_path = os.path.join(settings.REPO_PATH, part.tutorial.get_phy_slug())
-        
+
         maj_repo_tuto(request,
                       old_slug_path = new_slug_path,
                       new_slug_path = new_slug_path,
@@ -1322,8 +1322,8 @@ def modify_part(request):
         new_slug_tuto_path = os.path.join(settings.REPO_PATH, part.tutorial.get_phy_slug())
         # Actually delete the part
         part.delete()
-        
-        
+
+
         maj_repo_tuto(request,
                       old_slug_path = new_slug_tuto_path,
                       new_slug_path = new_slug_tuto_path,
@@ -1357,7 +1357,7 @@ def edit_part(request):
                 form = PartForm({"title": part.title,
                          "introduction": part.get_introduction(),
                          "conclusion": part.get_conclusion()})
-                return render_template("tutorial/part/edit.html", 
+                return render_template("tutorial/part/edit.html",
                     {
                          "part": part,
                          "last_hash": compute_hash([introduction, conclusion]),
@@ -1375,9 +1375,9 @@ def edit_part(request):
             part.conclusion = os.path.join(part.get_phy_slug(), "conclusion.md")
             part.save()
             part.update_children()
-            
+
             new_slug = os.path.join(settings.REPO_PATH, part.tutorial.get_phy_slug(), part.get_phy_slug())
-            
+
             maj_repo_part(
                 request,
                 old_slug_path=old_slug,
@@ -1416,12 +1416,12 @@ def view_chapter(
     """View chapter."""
 
     tutorial = get_object_or_404(Tutorial, pk=tutorial_pk)
-    
+
     try:
         sha = request.GET["version"]
     except KeyError:
         sha = tutorial.sha_draft
-    
+
     is_beta = sha == tutorial.sha_beta and tutorial.in_beta()
 
     # Only authors of the tutorial and staff can view tutorial in offline.
@@ -1467,7 +1467,7 @@ def view_chapter(
                                             chapter["introduction"])
                 chapter["conclu"] = get_blob(repo.commit(sha).tree,
                                              chapter["conclusion"])
-                
+
                 cpt_e = 1
                 for ext in chapter["extracts"]:
                     ext["chapter"] = chapter
@@ -1481,7 +1481,7 @@ def view_chapter(
                 final_position = len(chapter_tab) - 1
             cpt_c += 1
         cpt_p += 1
-    
+
     # if chapter can't find
     if not find:
         raise Http404
@@ -1490,7 +1490,7 @@ def view_chapter(
                     > 0 else None)
     next_chapter = (chapter_tab[final_position + 1] if final_position + 1
                     < len(chapter_tab) else None)
-    
+
     return render_template("tutorial/chapter/view.html", {
         "tutorial": tutorial,
         "chapter": final_chapter,
@@ -1528,7 +1528,7 @@ def view_chapter_online(
     final_chapter = None
     chapter_tab = []
     final_position = 0
-    
+
     find = False
     for part in parts:
         cpt_c = 1
@@ -1589,14 +1589,14 @@ def view_chapter_online(
                 final_position = len(chapter_tab) - 1
             cpt_c += 1
         cpt_p += 1
-    
+
     # if chapter can't find
     if not find:
         raise Http404
 
     prev_chapter = (chapter_tab[final_position - 1] if final_position > 0 else None)
     next_chapter = (chapter_tab[final_position + 1] if final_position + 1 < len(chapter_tab) else None)
-    
+
     return render_template("tutorial/chapter/view_online.html", {
         "chapter": final_chapter,
         "parts": parts,
@@ -1641,7 +1641,7 @@ def add_chapter(request):
                 img.pubdate = datetime.now()
                 img.save()
                 chapter.image = img
-            
+
             chapter.save()
             if chapter.tutorial:
                 chapter_path = os.path.join(
@@ -1652,9 +1652,9 @@ def add_chapter(request):
                 chapter.conclusion = os.path.join(chapter.get_phy_slug(),
                                                   "conclusion.md")
             else:
-                chapter_path = os.path.join(settings.REPO_PATH, 
+                chapter_path = os.path.join(settings.REPO_PATH,
                                             chapter.part.tutorial.get_phy_slug(),
-                                            chapter.part.get_phy_slug(), 
+                                            chapter.part.get_phy_slug(),
                                             chapter.get_phy_slug())
                 chapter.introduction = os.path.join(chapter.part.get_phy_slug(),chapter.get_phy_slug(),"introduction.md")
                 chapter.conclusion = os.path.join(chapter.part.get_phy_slug(),chapter.get_phy_slug(),"conclusion.md")
@@ -1710,25 +1710,25 @@ def modify_chapter(request):
         move(chapter, new_pos, "position_in_part", "part", "get_chapters")
         chapter.update_position_in_tutorial()
         chapter.save()
-        
+
         new_slug_path = os.path.join(settings.REPO_PATH, chapter.part.tutorial.get_phy_slug())
-        
+
         maj_repo_part(request,
                       old_slug_path = new_slug_path,
                       new_slug_path = new_slug_path,
                       part = chapter.part,
                       action = "maj")
-        
+
         messages.info(request, u"Le chapitre a bien été déplacé.")
     elif "delete" in data:
         old_pos = chapter.position_in_part
         old_tut_pos = chapter.position_in_tutorial
-        
+
         if chapter.part:
             parent = chapter.part
         else:
             parent = chapter.tutorial
-        
+
         # Move other chapters first
 
         for tut_c in chapter.part.get_chapters():
@@ -1748,7 +1748,7 @@ def modify_chapter(request):
                 Chapter.objects.filter(position_in_tutorial__gt=old_tut_pos):
             tut_c.update_position_in_tutorial()
             tut_c.save()
-        
+
         maj_repo_part(request,
                       old_slug_path = new_slug_path_part,
                       new_slug_path = new_slug_path_part,
@@ -1783,7 +1783,7 @@ def edit_chapter(request):
     introduction = os.path.join(chapter.get_path(), "introduction.md")
     conclusion = os.path.join(chapter.get_path(), "conclusion.md")
     if request.method == "POST":
-        
+
         if chapter.part:
             form = ChapterForm(request.POST, request.FILES)
             gal = chapter.part.tutorial.gallery
@@ -1795,7 +1795,7 @@ def edit_chapter(request):
             # avoid collision
             if content_has_changed([introduction, conclusion], data["last_hash"]):
                 form = render_chapter_form(chapter)
-                return render_template("tutorial/part/edit.html", 
+                return render_template("tutorial/part/edit.html",
                     {
                          "chapter": chapter,
                          "last_hash": compute_hash([introduction, conclusion]),
@@ -1803,11 +1803,11 @@ def edit_chapter(request):
                          "form": form
                     })
             chapter.title = data["title"]
-            
+
             old_slug = chapter.get_path()
             chapter.save()
             chapter.update_children()
-            
+
             if chapter.part:
                 if chapter.tutorial:
                     new_slug = os.path.join(settings.REPO_PATH, chapter.tutorial.get_phy_slug(), chapter.get_phy_slug())
@@ -1946,7 +1946,7 @@ def edit_extract(request):
                 form = ExtractForm(initial={
                     "title": extract.title,
                     "text": extract.get_text()})
-                return render_template("tutorial/extract/edit.html", 
+                return render_template("tutorial/extract/edit.html",
                     {
                          "extract": extract,
                          "last_hash": compute_hash([extract.get_path()]),
@@ -1979,7 +1979,7 @@ def edit_extract(request):
                 # Use path retrieve before and use it to create the new slug.
                 extract.save()
                 new_slug = extract.get_path()
-                
+
                 maj_repo_extract(
                     request,
                     old_slug_path=old_slug,
@@ -1992,7 +1992,7 @@ def edit_extract(request):
     else:
         form = ExtractForm({"title": extract.title,
                             "text": extract.get_text()})
-    return render_template("tutorial/extract/edit.html", 
+    return render_template("tutorial/extract/edit.html",
         {
             "extract": extract,
             "last_hash": compute_hash([extract.get_path()]),
@@ -2036,7 +2036,7 @@ def modify_extract(request):
         # Use path retrieve before and use it to create the new slug.
 
         old_slug = extract.get_path()
-        
+
         if extract.chapter.tutorial:
             new_slug_path_chapter = os.path.join(settings.REPO_PATH,
                                          extract.chapter.tutorial.get_phy_slug())
@@ -2048,7 +2048,7 @@ def modify_extract(request):
 
         maj_repo_extract(request, old_slug_path=old_slug, extract=extract,
                          action="del")
-        
+
         maj_repo_chapter(request,
                          old_slug_path = new_slug_path_chapter,
                          new_slug_path = new_slug_path_chapter,
@@ -2061,10 +2061,10 @@ def modify_extract(request):
         except ValueError:
             # Error, the user misplayed with the move button
             return redirect(extract.get_absolute_url())
-        
+
         move(extract, new_pos, "position_in_chapter", "chapter", "get_extracts")
         extract.save()
-        
+
         if extract.chapter.tutorial:
             new_slug_path = os.path.join(settings.REPO_PATH,
                                          extract.chapter.tutorial.get_phy_slug())
@@ -2094,7 +2094,7 @@ def find_tuto(request, pk_user):
         tutorials = Tutorial.objects.all().filter(
             authors__in=[display_user],
             sha_beta__isnull=False).exclude(sha_beta="").order_by("-pubdate")
-        
+
         tuto_versions = []
         for tutorial in tutorials:
             mandata = tutorial.load_json_for_public(sha=tutorial.sha_beta)
@@ -2107,7 +2107,7 @@ def find_tuto(request, pk_user):
         tutorials = Tutorial.objects.all().filter(
             authors__in=[display_user],
             sha_public__isnull=False).exclude(sha_public="").order_by("-pubdate")
-        
+
         tuto_versions = []
         for tutorial in tutorials:
             mandata = tutorial.load_json_for_public()
@@ -2631,9 +2631,9 @@ def maj_repo_extract(
     else:
         repo = Repo(os.path.join(settings.REPO_PATH, extract.chapter.part.tutorial.get_phy_slug()))
     index = repo.index
-    
+
     chap = extract.chapter
-    
+
     if action == "del":
         msg = "Suppression de l'exrait "
         extract.delete()
@@ -2705,7 +2705,7 @@ def download_markdown(request):
     phy_path = os.path.join(
                 tutorial.get_prod_path(),
                 tutorial.slug +
-                ".md") 
+                ".md")
     response = HttpResponse(
         open(phy_path, "rb").read(),
         mimetype="application/txt")
@@ -2818,9 +2818,9 @@ def get_url_images(md_text, pt):
                         os.makedirs(dstdir)
                     shutil.copy(srcfile, dstroot)
                     ext = dstroot.split(".")[-1]
-    
+
                     # if image is gif, convert to png
-    
+
                     if ext == "gif":
                         im = ImagePIL.open(dstroot)
                         im.save(os.path.join(dstroot.split(".")[0] + ".png"))
@@ -2867,7 +2867,7 @@ def MEP(tutorial, sha):
             shutil.rmtree(u"\\\\?\{0}".format(tutorial.get_prod_path()))
     shutil.copytree(tutorial.get_path(), tutorial.get_prod_path())
     repo.head.reset(commit = sha, index=True, working_tree=True)
-    
+
     # collect md files
 
     fichiers = []
@@ -2892,6 +2892,7 @@ def MEP(tutorial, sha):
 
     # convert markdown file to html file
 
+    unique_id = 0
     for fichier in fichiers:
         md_file_contenu = get_blob(repo.commit(sha).tree, fichier)
 
@@ -2915,8 +2916,10 @@ def MEP(tutorial, sha):
             target = u"\\\\?\{0}".format(target)
             html_file = open(target, "w")
         if md_file_contenu is not None:
-            html_file.write(emarkdown(md_file_contenu))
+            html_file.write(emarkdown(md_file_contenu, unique_id))
         html_file.close()
+
+        unique_id += 1
 
     # load markdown out
 
@@ -2926,11 +2929,11 @@ def MEP(tutorial, sha):
     out_file.close()
 
     # define whether to log pandoc's errors
-    
+
     pandoc_debug_str = ""
     if settings.PANDOC_LOG_STATE:
         pandoc_debug_str = " 2>&1 | tee -a "+settings.PANDOC_LOG
-    
+
     # load pandoc
 
     os.chdir(tutorial.get_prod_path())
@@ -3027,11 +3030,16 @@ def answer(request):
                 note.tutorial = tutorial
                 note.author = request.user
                 note.text = data["text"]
-                note.text_html = emarkdown(data["text"])
                 note.pubdate = datetime.now()
                 note.position = tutorial.get_note_count() + 1
                 note.ip_address = get_client_ip(request)
+                # need a unique id (footnotes), we will use note.pk, we need to save first
+                note.text_html = 'tmp'
                 note.save()
+                # parse markdown and then save again (with unique_id=note.pk)
+                note.text_html = emarkdown(data["text"], '-'.join(('com', str(note.pk))))
+                note.save()
+
                 tutorial.last_note = note
                 tutorial.save()
                 return redirect(note.get_absolute_url())
@@ -3174,7 +3182,7 @@ def edit_note(request):
 
             if request.POST["text"].strip() != "":
                 note.text = request.POST["text"]
-                note.text_html = emarkdown(request.POST["text"])
+                note.text_html = emarkdown(request.POST["text"], '-'.join(('com', str(note.pk))))
                 note.update = datetime.now()
                 note.editor = request.user
         note.save()

--- a/zds/utils/mps.py
+++ b/zds/utils/mps.py
@@ -32,14 +32,18 @@ def send_mp(
     for part in users:
         n_topic.participants.add(part)
 
-    # Addi the first message
+    # Add the first message
     post = PrivatePost()
     post.privatetopic = n_topic
     post.author = author
     post.text = text
-    post.text_html = emarkdown(text)
     post.pubdate = datetime.now()
     post.position_in_topic = 1
+    # need a unique id (footnotes), we will use post.pk, we need to save first
+    post.text_html = 'tmp'
+    post.save()
+    # parse markdown and then save again (with unique_id=post.pk)
+    post.text_html = emarkdown(text, post.pk)
     post.save()
 
     n_topic.last_message = post

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -45,11 +45,18 @@ def humane_time(t, conf={}):
 
 
 @register.filter(needs_autoescape=False)
-def emarkdown(text):
+def emarkdown(text, unique_id=None):
     try:
-        return mark_safe(
-            get_markdown_instance(
-                Inline=False).convert(text).encode('utf-8'))
+        md = get_markdown_instance(Inline=False).convert(text).encode('utf-8')
+
+        if unique_id is not None:
+            if not isinstance(unique_id, str):
+                unique_id = str(unique_id)
+            # Hack to avoid double replacement of "fn" (while handling "fnref")
+            md = md.replace("fnref", "fanref" + "-" + unique_id)  # hack 1/2
+            md = md.replace("fn", "fn" + "-" + unique_id)
+            md = md.replace("fan", "fn")  # hack 2/2
+        return mark_safe(md)
     except:
         return mark_safe(u'<div class="error ico-after"><p>Une erreur est survenue dans la génération de texte Markdown. Veuillez rapporter le bug</p>')
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | issue #1164 |

Edit pour la QA :

Cette PR ne concerne que le markdown parsé, donc sur chaque page susceptible d'afficher du markdown parsé, chaque bloc de markdown doit avoir un identifiant unique.
Exemple :  [templates/tutorial/includes/chapter.part.html L.9 et L.116](https://github.com/zestedesavoir/zds-site/pull/1399/files#diff-6c317c2b6e2b2b49d4a0e9e70c7e4f60R9)
Remarque : Si, par exemple, il y a 2 extrait, il leur faut 2 id unique : "extrait1" et "extrait2"

Ps : sur une page n'ayant qu'un seul bloc de markdown, je n'ai pas ajouté d'identifiant ([exemple](https://github.com/zestedesavoir/zds-site/blob/master/templates/misc/previsualization.part.html#L9))

Pps @pierre-24 : oula je sais pas si c'est ce que tu voulais, ça fais un gros pâté imbuvable et j'ai pas l'impression de répondre à ta remarque, désolé.
