### PR TITLE
Ajout de l'activation de compte dans l'interface de promotion

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -586,6 +586,11 @@ class PromoteMemberForm(forms.Form):
         label="Super-user",
         required=False,    
     )
+    
+    activation = forms.BooleanField(
+        label="Compte actif",
+        required=False,
+    )
 
     def __init__(self, *args, **kwargs):
         super(PromoteMemberForm, self).__init__(*args, **kwargs)
@@ -596,5 +601,6 @@ class PromoteMemberForm(forms.Form):
         self.helper.layout = Layout(
             Field('groups'),
             Field('superuser'),
+            Field('activation'),
             StrictButton('Valider', type='submit'),
         )

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -943,6 +943,15 @@ def settings_promote(request, user_pk):
                     messages.warning(request, u'{0} n\'est maintenant plus super-utilisateur'
                                                 .format(user.username))
 
+        if 'activation' in data and u'on' in data['activation']:
+            user.is_active = True
+            messages.success(request, u'{0} est maintenant activé'
+                                        .format(user.username))
+        else:
+            user.is_active = False
+            messages.warning(request, u'{0} est désactivé'
+                                        .format(user.username))
+
         user.save()
         
         usergroups = user.groups.all()
@@ -973,7 +982,8 @@ def settings_promote(request, user_pk):
         return redirect(profile.get_absolute_url())
 
     form = PromoteMemberForm(initial={'superuser': user.is_superuser,
-                                      'groups': user.groups.all()
+                                      'groups': user.groups.all(),
+                                      'activation': user.is_active
                                      })
     
     return render_template('member/settings/promote.html', {


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [oui] |
| Tickets concernés | #54 |

Encore un tout petit bout venant compléter une PR précédente pour pouvoir gérer les comptes à caractères spéciaux. Cette PR rajoute juste la faculté d'activer (ou pas) un compte depuis son profil.
#### QA
- Essayer d'activer (ou non) un compte via un super utilisateur

(cf cette PR : https://github.com/zestedesavoir/zds-site/pull/1344)

PS : Je ne sais pas si je dois pusher sur dev ou master, car on est a cheval entre de la feature et de la résolution de ticket bug... En tout cas c'est vraiment simple à QAtiser...
