### PR TITLE
Amélioration des flux RSS

### DIFF
--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -158,10 +158,7 @@
         <div class="mobile-menu-bloc mobile-all-links" data-title="Flux">
             <h3>Flux</h3>
             <ul>
-                <li><a href="{% url "post-feed-rss" %}" class="ico-after rss blue">Nouveaux messages (RSS)</a></li>
-                <li><a href="{% url "post-feed-atom" %}" class="ico-after rss blue">Nouveaux messages (ATOM)</a></li>
-                <li><a href="{% url "topic-feed-rss" %}" class="ico-after rss blue">Nouveaux sujets (RSS)</a></li>
-                <li><a href="{% url "topic-feed-atom" %}" class="ico-after rss blue">Nouveaux sujets (ATOM)</a></li>
+                {% block feeds_rss %}{% endblock %}
             </ul>
         </div>
     </aside>

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -155,11 +155,6 @@
             </div>
         {% endif %}
 
-        <div class="mobile-menu-bloc mobile-all-links" data-title="Flux">
-            <h3>Flux</h3>
-            <ul>
-                {% block feeds_rss %}{% endblock %}
-            </ul>
-        </div>
+        {% block feeds_rss %} {% endblock %}
     </aside>
 {% endblock %}

--- a/templates/forum/category/forum.html
+++ b/templates/forum/category/forum.html
@@ -12,10 +12,7 @@
 {% endblock %}
 
 {% block feeds_rss %}
-    <li><a href="{% url "post-feed-rss" %}?forum={{forum.pk}}" class="ico-after rss blue">Nouveaux messages (RSS)</a></li>
-    <li><a href="{% url "post-feed-atom" %}?forum={{forum.pk}}" class="ico-after rss blue">Nouveaux messages (ATOM)</a></li>
-    <li><a href="{% url "topic-feed-rss" %}?forum={{forum.pk}}" class="ico-after rss blue">Nouveaux sujets (RSS)</a></li>
-    <li><a href="{% url "topic-feed-atom" %}?forum={{forum.pk}}" class="ico-after rss blue">Nouveaux sujets (ATOM)</a></li>
+    {% include "forum/includes/feed.part.html" with param="?forum=" value=forum.pk %}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/templates/forum/category/forum.html
+++ b/templates/forum/category/forum.html
@@ -11,7 +11,12 @@
     {% endif %}
 {% endblock %}
 
-
+{% block feeds_rss %}
+    <li><a href="{% url "post-feed-rss" %}?forum={{forum.pk}}" class="ico-after rss blue">Nouveaux messages (RSS)</a></li>
+    <li><a href="{% url "post-feed-atom" %}?forum={{forum.pk}}" class="ico-after rss blue">Nouveaux messages (ATOM)</a></li>
+    <li><a href="{% url "topic-feed-rss" %}?forum={{forum.pk}}" class="ico-after rss blue">Nouveaux sujets (RSS)</a></li>
+    <li><a href="{% url "topic-feed-atom" %}?forum={{forum.pk}}" class="ico-after rss blue">Nouveaux sujets (ATOM)</a></li>
+{% endblock %}
 
 {% block breadcrumb %}
     <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb">

--- a/templates/forum/category/index.html
+++ b/templates/forum/category/index.html
@@ -25,3 +25,10 @@
 	    {% include "forum/includes/forums.part.html" %}
 	</div>
 {% endblock %}
+
+{% block feeds_rss %}
+    <li><a href="{% url "post-feed-rss" %}" class="ico-after rss blue">Nouveaux messages (RSS)</a></li>
+    <li><a href="{% url "post-feed-atom" %}" class="ico-after rss blue">Nouveaux messages (ATOM)</a></li>
+    <li><a href="{% url "topic-feed-rss" %}" class="ico-after rss blue">Nouveaux sujets (RSS)</a></li>
+    <li><a href="{% url "topic-feed-atom" %}" class="ico-after rss blue">Nouveaux sujets (ATOM)</a></li>
+{% endblock %}

--- a/templates/forum/category/index.html
+++ b/templates/forum/category/index.html
@@ -27,8 +27,5 @@
 {% endblock %}
 
 {% block feeds_rss %}
-    <li><a href="{% url "post-feed-rss" %}" class="ico-after rss blue">Nouveaux messages (RSS)</a></li>
-    <li><a href="{% url "post-feed-atom" %}" class="ico-after rss blue">Nouveaux messages (ATOM)</a></li>
-    <li><a href="{% url "topic-feed-rss" %}" class="ico-after rss blue">Nouveaux sujets (RSS)</a></li>
-    <li><a href="{% url "topic-feed-atom" %}" class="ico-after rss blue">Nouveaux sujets (ATOM)</a></li>
+    {% include "forum/includes/feed.part.html" %}
 {% endblock %}

--- a/templates/forum/find/topic_by_tag.html
+++ b/templates/forum/find/topic_by_tag.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block feeds_rss %}
-    {% include "forum/includes/feed.part.html" with with param="?tag=" value=tag.pk %}
+    {% include "forum/includes/feed.part.html" with param="?tag=" value=tag.pk %}
 {% endblock %}
 
 {% block content %}

--- a/templates/forum/find/topic_by_tag.html
+++ b/templates/forum/find/topic_by_tag.html
@@ -20,7 +20,12 @@
     Tag : {{ tag.title }}
 {% endblock %}
 
-
+{% block feeds_rss %}
+    <li><a href="{% url "post-feed-rss" %}?tag={{tag.pk}}" class="ico-after rss blue">Nouveaux messages (RSS)</a></li>
+    <li><a href="{% url "post-feed-atom" %}?tag={{tag.pk}}" class="ico-after rss blue">Nouveaux messages (ATOM)</a></li>
+    <li><a href="{% url "topic-feed-rss" %}?tag={{tag.pk}}" class="ico-after rss blue">Nouveaux sujets (RSS)</a></li>
+    <li><a href="{% url "topic-feed-atom" %}?tag={{tag.pk}}" class="ico-after rss blue">Nouveaux sujets (ATOM)</a></li>
+{% endblock %}
 
 {% block content %}
     {% include "misc/pagination.part.html" with position="top" %}

--- a/templates/forum/find/topic_by_tag.html
+++ b/templates/forum/find/topic_by_tag.html
@@ -21,10 +21,7 @@
 {% endblock %}
 
 {% block feeds_rss %}
-    <li><a href="{% url "post-feed-rss" %}?tag={{tag.pk}}" class="ico-after rss blue">Nouveaux messages (RSS)</a></li>
-    <li><a href="{% url "post-feed-atom" %}?tag={{tag.pk}}" class="ico-after rss blue">Nouveaux messages (ATOM)</a></li>
-    <li><a href="{% url "topic-feed-rss" %}?tag={{tag.pk}}" class="ico-after rss blue">Nouveaux sujets (RSS)</a></li>
-    <li><a href="{% url "topic-feed-atom" %}?tag={{tag.pk}}" class="ico-after rss blue">Nouveaux sujets (ATOM)</a></li>
+    {% include "forum/includes/feed.part.html" with with param="?tag=" value=tag.pk %}
 {% endblock %}
 
 {% block content %}

--- a/templates/forum/includes/feed.part.html
+++ b/templates/forum/includes/feed.part.html
@@ -1,0 +1,9 @@
+<div class="mobile-menu-bloc mobile-all-links" data-title="Flux">
+    <h3>Flux</h3>
+    <ul>    
+        <li><a href="{% url "post-feed-rss" %}{{param}}{{value}}" class="ico-after rss blue">Nouveaux messages (RSS)</a></li>
+        <li><a href="{% url "post-feed-atom" %}{{param}}{{value}}" class="ico-after rss blue">Nouveaux messages (ATOM)</a></li>
+        <li><a href="{% url "topic-feed-rss" %}{{param}}{{value}}" class="ico-after rss blue">Nouveaux sujets (RSS)</a></li>
+        <li><a href="{% url "topic-feed-atom" %}{{param}}{{value}}" class="ico-after rss blue">Nouveaux sujets (ATOM)</a></li>
+    </ul>
+</div>

--- a/templates/forum/index.html
+++ b/templates/forum/index.html
@@ -47,8 +47,5 @@
 {% endblock %}
 
 {% block feeds_rss %}
-    <li><a href="{% url "post-feed-rss" %}" class="ico-after rss blue">Nouveaux messages (RSS)</a></li>
-    <li><a href="{% url "post-feed-atom" %}" class="ico-after rss blue">Nouveaux messages (ATOM)</a></li>
-    <li><a href="{% url "topic-feed-rss" %}" class="ico-after rss blue">Nouveaux sujets (RSS)</a></li>
-    <li><a href="{% url "topic-feed-atom" %}" class="ico-after rss blue">Nouveaux sujets (ATOM)</a></li>
+    {% include "forum/includes/feed.part.html" %}
 {% endblock %}

--- a/templates/forum/index.html
+++ b/templates/forum/index.html
@@ -45,3 +45,10 @@
         {% endfor %}
     </div>
 {% endblock %}
+
+{% block feeds_rss %}
+    <li><a href="{% url "post-feed-rss" %}" class="ico-after rss blue">Nouveaux messages (RSS)</a></li>
+    <li><a href="{% url "post-feed-atom" %}" class="ico-after rss blue">Nouveaux messages (ATOM)</a></li>
+    <li><a href="{% url "topic-feed-rss" %}" class="ico-after rss blue">Nouveaux sujets (RSS)</a></li>
+    <li><a href="{% url "topic-feed-atom" %}" class="ico-after rss blue">Nouveaux sujets (ATOM)</a></li>
+{% endblock %}

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -11,8 +11,6 @@
     {% if topic.is_solved %}[Résolu]{% endif %} {{ topic.title }}
 {% endblock %}
 
-
-
 {% block breadcrumb %}
     <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
         <a href="{{ topic.forum.category.get_absolute_url }}" itemprop="url">

--- a/templates/tutorial/index.html
+++ b/templates/tutorial/index.html
@@ -88,5 +88,20 @@
                 </ul>
             {% endfor %}
         {% endwith %}
+        <div class="mobile-menu-bloc mobile-all-links" data-title="Flux">
+            <h3>Flux</h3>
+            <ul>
+                <li>
+                    <a href="{% url "tutorial-feed-rss" %}" class="ico-after rss blue">
+                        Nouveaux tutoriels (RSS)
+                    </a>
+                </li>
+                <li>
+                    <a href="{% url "tutorial-feed-atom" %}" class="ico-after rss blue">
+                        Nouveaux tutoriels (ATOM)
+                    </a>
+                </li>
+            </ul>
+        </div>
     </aside>
 {% endblock %}

--- a/zds/forum/feeds.py
+++ b/zds/forum/feeds.py
@@ -3,6 +3,7 @@
 from django.contrib.syndication.views import Feed
 
 from django.utils.feedgenerator import Atom1Feed
+from django.conf import settings
 
 from zds.utils.templatetags.emarkdown import emarkdown
 
@@ -14,11 +15,34 @@ class LastPostsFeedRSS(Feed):
     link = '/forums/'
     description = (u'Les derniers messages '
         u'parus sur le forum de Zeste de Savoir.')
+    
+    def get_object(self, request):
+        obj = {}
+        if "forum" in request.GET:
+            obj['forum']=request.GET["forum"]
+        if "tag" in request.GET:
+            obj['tag']=request.GET["tag"]
+        return obj
 
-    def items(self):
-        posts = Post.objects.filter(topic__forum__group__isnull=True)\
+    def items(self, obj):
+        if "forum" in obj and "tag" in obj:
+            posts = Post.objects.filter(topic__forum__group__isnull=True,
+                                        topic__forum__pk=obj['forum'],
+                                        topic__tags__pk__in=[obj['tag']])\
             .order_by('-pubdate')
-        return posts[:5]
+        elif "forum" in obj and "tag" not in obj:
+            posts = Post.objects.filter(topic__forum__group__isnull=True,
+                                        topic__forum__pk=obj['forum'])\
+            .order_by('-pubdate')
+        elif "forum" not in obj and "tag" in obj:
+            posts = Post.objects.filter(topic__forum__group__isnull=True,
+                                        topic__tags__pk__in=[obj['tag']])\
+            .order_by('-pubdate')
+        if "forum" not in obj and "tag" not in obj:
+            posts = Post.objects.filter(topic__forum__group__isnull=True)\
+                .order_by('-pubdate')
+
+        return posts[:settings.POSTS_PER_PAGE]
 
     def item_title(self, item):
         return u'{}, message #{}'.format(item.topic.title, item.pk)
@@ -49,11 +73,34 @@ class LastTopicsFeedRSS(Feed):
     title = u'Derniers sujets sur Zeste de Savoir'
     link = '/forums/'
     description = u'Les derniers sujets créés sur le forum de Zeste de Savoir.'
+    
+    def get_object(self, request):
+        obj = {}
+        if "forum" in request.GET:
+            obj['forum']=request.GET["forum"]
+        if "tag" in request.GET:
+            obj['tag']=request.GET["tag"]
+        return obj
 
-    def items(self):
-        topics = Topic.objects.filter(forum__group__isnull=True)\
+    def items(self, obj):
+        if "forum" in obj and "tag" in obj:
+            topics = Topic.objects.filter(forum__group__isnull=True,
+                                          forum__pk=obj['forum'],
+                                          tags__pk__in=[obj['tag']])\
             .order_by('-pubdate')
-        return topics[:5]
+        elif "forum" in obj and "tag" not in obj:
+            topics = Topic.objects.filter(forum__group__isnull=True,
+                                          forum__pk=obj['forum'])\
+            .order_by('-pubdate')
+        elif "forum" not in obj and "tag" in obj:
+            topics = Topic.objects.filter(forum__group__isnull=True,
+                                          tags__pk__in=[obj['tag']])\
+            .order_by('-pubdate')
+        if "forum" not in obj and "tag" not in obj:
+            topics = Topic.objects.filter(forum__group__isnull=True)\
+                .order_by('-pubdate')
+
+        return topics[:settings.POSTS_PER_PAGE]
     def item_pubdate(self, item):
         return item.pubdate
 

--- a/zds/forum/tests.py
+++ b/zds/forum/tests.py
@@ -9,12 +9,12 @@ from zds.utils import slugify
 from zds.forum.factories import CategoryFactory, ForumFactory, \
     TopicFactory, PostFactory, TagFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory
-from zds.utils.models import CommentLike, CommentDislike, Alert
+from zds.utils.models import CommentLike, CommentDislike, Alert, Tag
 from django.core import mail
 
 from .models import Post, Topic, TopicFollowed, TopicRead
 from zds.forum.views import get_tag_by_title
-from zds.forum.models import get_topics
+from zds.forum.models import get_topics, Forum
 
 class ForumMemberTests(TestCase):
 
@@ -48,6 +48,25 @@ class ForumMemberTests(TestCase):
             password='hostel77')
         self.assertEqual(log, True)
 
+    def feed_rss_display(self):
+        """Test each rss feed feed"""
+        response = self.client.get(reverse('post-feed-rss'), follow=False)
+        self.assertEqual(response.status_code, 200)
+
+        for forum in Forum.objects.all():
+            response = self.client.get(reverse('post-feed-rss')+"?forum={}".format(forum.pk), follow=False)
+            self.assertEqual(response.status_code, 200)
+        
+        for tag in Tag.objects.all():
+            response = self.client.get(reverse('post-feed-rss')+"?tag={}".format(tag.pk), follow=False)
+            self.assertEqual(response.status_code, 200)
+        
+        for forum in Forum.objects.all():
+            for tag in Tag.objects.all():
+                response = self.client.get(reverse('post-feed-rss')+"?tag={}&forum={}".format(tag.pk, forum.pk), follow=False)
+                self.assertEqual(response.status_code, 200)
+
+        
     def test_display(self):
         """Test forum display (full: root, category, forum) Topic display test
         is in creation topic test."""
@@ -674,6 +693,24 @@ class ForumGuestTests(TestCase):
             category=self.category2,
             position_in_category=2)
         self.user = ProfileFactory().user
+
+    def feed_rss_display(self):
+        """Test each rss feed feed"""
+        response = self.client.get(reverse('post-feed-rss'), follow=False)
+        self.assertEqual(response.status_code, 200)
+
+        for forum in Forum.objects.all():
+            response = self.client.get(reverse('post-feed-rss')+"?forum={}".format(forum.pk), follow=False)
+            self.assertEqual(response.status_code, 200)
+        
+        for tag in Tag.objects.all():
+            response = self.client.get(reverse('post-feed-rss')+"?tag={}".format(tag.pk), follow=False)
+            self.assertEqual(response.status_code, 200)
+        
+        for forum in Forum.objects.all():
+            for tag in Tag.objects.all():
+                response = self.client.get(reverse('post-feed-rss')+"?tag={}&forum={}".format(tag.pk, forum.pk), follow=False)
+                self.assertEqual(response.status_code, 200)
 
     def test_display(self):
         """Test forum display (full: root, category, forum) Topic display test

--- a/zds/forum/urls.py
+++ b/zds/forum/urls.py
@@ -9,13 +9,9 @@ from . import views
 urlpatterns = patterns('',
 
                        # Feeds
-                       url(r'^flux/messages/rss/$',
-                           feeds.LastPostsFeedRSS(),
-                           name='post-feed-rss'),
-                       url(r'^flux/messages/atom/$',
-                           feeds.LastPostsFeedATOM(),
-                           name='post-feed-atom'),
-
+                       url(r'^flux/messages/rss/$', feeds.LastPostsFeedRSS(), name='post-feed-rss'),
+                       url(r'^flux/messages/atom/$', feeds.LastPostsFeedATOM(), name='post-feed-atom'),
+                       
                        url(r'^flux/sujets/rss/$',
                            feeds.LastTopicsFeedRSS(),
                            name='topic-feed-rss'),

--- a/zds/tutorial/feeds.py
+++ b/zds/tutorial/feeds.py
@@ -1,0 +1,43 @@
+# coding: utf-8
+
+from django.contrib.syndication.views import Feed
+
+from django.utils.feedgenerator import Atom1Feed
+
+from .models import Tutorial
+
+
+class LastTutorialsFeedRSS(Feed):
+    title = "Tutoriels sur Zeste de Savoir"
+    link = "/tutoriels/"
+    description = "Les derniers tutoriels parus sur Zeste de Savoir."
+
+    def items(self):
+        return Tutorial.objects\
+            .filter(sha_public__isnull=False)\
+            .order_by('-pubdate')[:5]
+
+    def item_title(self, item):
+        return item.title
+
+    def item_pubdate(self, item):
+        return item.pubdate
+
+    def item_description(self, item):
+        return item.description
+
+    def item_author_name(self, item):
+        authors_list = item.authors.all()
+        authors = []
+        for authors_obj in authors_list:
+            authors.append(authors_obj.username)
+        authors = ", ".join(authors)
+        return authors
+
+    def item_link(self, item):
+        return item.get_absolute_url()
+
+
+class LastTutorialsFeedATOM(LastTutorialsFeedRSS):
+    feed_type = Atom1Feed
+    subtitle = LastTutorialsFeedRSS.description

--- a/zds/tutorial/urls.py
+++ b/zds/tutorial/urls.py
@@ -3,10 +3,12 @@
 from django.conf.urls import patterns, url
 
 from . import views
-
+from . import feeds
 
 urlpatterns = patterns('',
                        # Viewing
+                       url(r'^flux/rss/$', feeds.LastTutorialsFeedRSS(), name='tutorial-feed-rss'),
+                       url(r'^flux/atom/$', feeds.LastTutorialsFeedATOM(), name='tutorial-feed-atom'),
 
                        # Current URLs
                        url(r'^recherche/(?P<pk_user>\d+)/$',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets concernés | #1282 |

Cette PR ajoute quelques améliorations aux flux rss, telles que : 
- Le nombre de RSS pour les nouveaux sujets/messages passe de 5 à 21 (nombre de message d'une page)
- des RSS par forum
- des RSS par tag
- des RSS pour les nouveaux tutoriels ?

Pour l'aspect visuel, si on se trouve sur un forum particulier, c'est le RSS du forum en question qui est concerné, ainsi de suite pour le RSS par tag.

**Note pour QA**

Vérifier le contenu des nouveaux RSS rajoutés
