### PR TITLE
Intégration de la police Merriweather dans les PDF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
   # Add fonts
   - sudo wget -P /usr/share/fonts/truetype https://www.dropbox.com/s/ema28tjn52960mq/Merriweather.zip
-  - unzip /usr/share/fonts/truetype/Merriweather.zip -d /usr/share/fonts/truetype/Merriweather/
+  - sudo unzip /usr/share/fonts/truetype/Merriweather.zip -d /usr/share/fonts/truetype/Merriweather/
   - sudo chmod a+r /usr/share/fonts/truetype/Merriweather/*.ttf
   - sudo fc-cache -f -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,17 @@ install:
   - sudo apt-get update
   - sudo echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
   - sudo apt-get install ttf-mscorefonts-installer
+  - sudo apt-get install unzip
   - sudo apt-get install texlive
   - sudo apt-get install texlive-xetex
   - sudo apt-get install texlive-lang-french
   - sudo apt-get install texlive-latex-extra
+
+  # Add fonts
+  - sudo wget -P /usr/share/fonts/truetype https://www.dropbox.com/s/ema28tjn52960mq/Merriweather.zip
+  - unzip /usr/share/fonts/truetype/Merriweather.zip -d /usr/share/fonts/truetype/Merriweather/
+  - sudo chmod a+r /usr/share/fonts/truetype/Merriweather/*.ttf
+  - sudo fc-cache -f -v
 
   # Cabal + Pandoc stuff
   - sudo mkdir -p ~/cabal/bin

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2942,7 +2942,7 @@ def MEP(tutorial, sha):
     os.system(settings.PANDOC_LOC + "pandoc " + "--latex-engine=xelatex "
               + "--template=../../assets/tex/template.tex " + "-s " + "-S "
               + "-N " + "--toc " + "-V documentclass=scrbook "
-              + "-V lang=francais " + "-V mainfont=Verdana "
+              + "-V lang=francais " + "-V mainfont=Merriweather "
               + "-V monofont=\"Andale Mono\" " + "-V fontsize=12pt "
               + "-V geometry:margin=1in "
               + os.path.join(tutorial.get_prod_path(), tutorial.slug) + ".md "


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #315 |

Cette PR change la police contenu dans les PDF (anciennement verdana) pour la remplacer par une police avec sérification (Merriweather) qui est là même que celle utilisé pour le contenu du site.

**Note pour QA**
Pour tester ceci, il suffit d'installer la police [Merriweather](https://www.google.com/fonts#UsePlace:use/Collection:Merriweather) sur votre poste.

Créer un tutoriel et publier le. Télécharger le PDF et vérifier que la police dans le PDF est bien Merriweather.
