### PR TITLE
Correction de la detection trop souple des pseudos dans les MPs

### DIFF
--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -75,7 +75,7 @@ class PrivateTopicForm(forms.Form):
         if participants is not None and participants.strip() != '':
             receivers = participants.strip().split(',')
             for receiver in receivers:
-                if User.objects.filter(username=receiver.strip()).count() == 0 and receiver.strip() != '':
+                if User.objects.filter(username__exact=receiver.strip()).count() == 0 and receiver.strip() != '':
                     self._errors['participants'] = self.error_class(
                         [u'Un des participants saisi est introuvable'])
                 elif receiver.strip() == self.username:

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -491,7 +491,7 @@ def add_participant(request):
 
     try:
         # user_pk or user_username ?
-        part = User.objects.get(username=request.POST['user_pk'])
+        part = User.objects.get(username__exact=request.POST['user_pk'])
         if part.pk == ptopic.author.pk or part in ptopic.participants.all():
             messages.warning(
                 request,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #738 |

Cette PR, corrige le bug décrit dans l'issue.

**Note pour QA**
- Vérifier que si on un utilisateur nommé "user" dans la base, on ne puisse pas l'envoyer de Mp en saisissant manuellement "User" dans le champ des destinataires.
