### PR TITLE
Améliore le système de signalement des messages

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -587,7 +587,7 @@
    ============== */
 .alert-box {
     position: relative;
-    padding: 8px 75px 8px 15px;
+    padding: 8px 15px;
     margin: 0 0 15px 2%;
     color: #FFF;
     text-shadow: rgba(0, 0, 0, 0.2) 0 0 2px;

--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -587,10 +587,14 @@
    ============== */
 .alert-box {
     position: relative;
-    padding: 8px 15px;
+    padding: 8px 75px 8px 15px;
     margin: 0 0 15px 2%;
     color: #FFF;
     text-shadow: rgba(0, 0, 0, 0.2) 0 0 2px;
+
+    .alert-box-text {
+        display: block;
+    }
 
     .close-alert-box {
         display: block;

--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -58,4 +58,10 @@
             }
         }
     }
+
+    .alert-box {
+        .alert-box-text {
+            display: inline;
+        }
+    }
 }

--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -59,9 +59,10 @@
         }
     }
 
-    .alert-box {
-        .alert-box-text {
-            display: inline;
-        }
+    .alert-box .alert-box-text {
+        display: inline;
+    }
+    .topic-message .alert-box {
+        padding: 8px 75px 8px 15px;
     }
 }

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -90,7 +90,7 @@
                                     <label for="signal-message-{{ message.id }}-field">
                                         Pour quelle raison signalez-vous ce message ?
                                     </label>
-                                    <textarea type="text" name="signal_text" id="signal-message-{{ message.id }}-field" placeholder="Flood, Troll, Hors sujet, ..." pattern=".{3,}" required title="Minimum 3 caractères pour signaler" rows="5"></textarea>
+                                    <textarea type="text" name="signal_text" id="signal-message-{{ message.id }}-field" placeholder="Flood, Troll, Hors sujet, ..." pattern=".{3,}" required title="Minimum 3 caractères pour signaler" rows="4"></textarea>
 
                                     <button type="submit" name="signal_message">
                                         Signaler
@@ -191,7 +191,7 @@
                 <div class="alert-box error">
                     {{ alert.pubdate|format_date|capfirst }} par 
                     {% include "misc/member_item.part.html" with member=alert.author %} : 
-                    <em>{{ alert.text }}</em>
+                    <em class="alert-box-text">{{ alert.text }}</em>
 
                     <a href="#solve-alert-{{ alert.pk }}" class="open-modal close-alert-box close-alert-box-text">Résoudre</a>
                     <form id="solve-alert-{{ alert.pk }}" method="post" action="{{ alert_solve_link }}" class="modal modal-medium">

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -85,12 +85,12 @@
                                 <a href="#signal-message-{{ message.id }}" class="ico-after alert open-modal">
                                     Signaler
                                 </a>
-                                <form action="{{ edit_link|safe }}" method="post" id="signal-message-{{ message.id }}" class="modal modal-medium">
+                                <form action="{{ edit_link|safe }}" method="post" id="signal-message-{{ message.id }}" class="modal modal-big">
                                     {% csrf_token %}
-                                    <p>
+                                    <label for="signal-message-{{ message.id }}-field">
                                         Pour quelle raison signalez-vous ce message ?
-                                    </p>
-                                    <input type="text" name="signal_text" placeholder="Flood, Troll, Hors sujet, ..." pattern=".{3,}" required title ="Minimum 3 caractères pour signaler">
+                                    </label>
+                                    <textarea type="text" name="signal_text" id="signal-message-{{ message.id }}-field" placeholder="Flood, Troll, Hors sujet, ..." pattern=".{3,}" required title="Minimum 3 caractères pour signaler" rows="5"></textarea>
 
                                     <button type="submit" name="signal_message">
                                         Signaler


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1422 |

QA : 
- vérifier que le champ est bien un textarea et non plus un input
- vérifier que lorsque le texte justificatif est long, celui-ci ne passe plus par dessus "Résoudre" (à tester sur mobile également, si possible)
