### PR TITLE
Clem' n'est plus coupée sur Firefox \o/

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -16,7 +16,7 @@
     {% if user.is_authenticated %}
         <section class="home-quote home-simple-quote">
             <div class="home-wrapper">
-                <img src="{% static "images/clem-home-quote.png" %}" alt="">
+                <img src="{% static "images/clem-home-quote.png" %}" alt="" width="39" height="80">
                 <blockquote>
                     «&nbsp;{{ quote }}&nbsp;»
                 </blockquote>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1324 |

QA : tester sur Firefox que Clem', en mode membre, n'est pas coupée sur son côté droit.
