### PR TITLE
Améliore le comportement des archives de tuto/article

### DIFF
--- a/templates/article/view.html
+++ b/templates/article/view.html
@@ -230,7 +230,7 @@
         <h3>Télécharger</h3>
         <ul>
             <li>
-                <a href="{% url "zds.article.views.download" %}?article={{ article.pk }}"
+                <a href="{% url "zds.article.views.download" %}?article={{ article.pk }}&online"
                    class="ico-after download blue"
                 >
                     Archive

--- a/templates/tutorial/base.html
+++ b/templates/tutorial/base.html
@@ -92,7 +92,7 @@
                     {% endif %}
 
                     <li>
-                        <a href="{% url "zds.tutorial.views.download" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
+                        <a href="{% url "zds.tutorial.views.download" %}?tutoriel={{ tutorial.pk }}{% if tutorial.is_on_line %}&online{% endif %}" class="ico-after download blue">
                             Archive
                         </a>
                     </li>

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -110,7 +110,7 @@ class Article(models.Model):
             '?article={0}'.format(self.pk)
 
     def on_line(self):
-        return self.sha_public is not None
+        return (self.sha_public is not None) and (self.sha_public.strip() != '')
 
     def in_validation(self):
         return self.sha_validation is not None

--- a/zds/article/tests.py
+++ b/zds/article/tests.py
@@ -578,7 +578,7 @@ class ArticleTests(TestCase):
         draft_manifest= json_reader.loads(draft_zip.read('manifest.json'))
         self.assertNotEqual(online_manifest['title'], article_title) # title has not changed in online version
 
-        self.assertNotEqual(online_zip.read(online_manifest['text']), article_content)  # content is good in draft
+        self.assertNotEqual(online_zip.read(online_manifest['text']), article_content)
         self.assertEqual(draft_zip.read(draft_manifest['text']), article_content)  # content is good in draft
 
         draft_zip.close()
@@ -587,7 +587,7 @@ class ArticleTests(TestCase):
         # then logout and test access
         self.client.logout()
 
-        # public cannot access to draft version of tutorial
+        # public cannot access to draft version of article
         result = self.client.get(
             reverse('zds.article.views.download') +
             '?article={0}'.format(
@@ -609,7 +609,7 @@ class ArticleTests(TestCase):
                 password='hostel77'),
             True)
 
-        # cannot access to draft version of tutorial (if not author or staff)
+        # cannot access to draft version of article (if not author or staff)
         result = self.client.get(
             reverse('zds.article.views.download') +
             '?article={0}'.format(
@@ -632,7 +632,7 @@ class ArticleTests(TestCase):
                 password='hostel77'),
             True)
 
-        # staff can access to draft version of tutorial
+        # staff can access to draft version of article
         result = self.client.get(
             reverse('zds.article.views.download') +
             '?article={0}'.format(

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -14,6 +14,7 @@ import json as json_writer
 import os
 import shutil
 import zipfile
+import tempfile
 
 from django.conf import settings
 from django.contrib import messages
@@ -461,7 +462,7 @@ def download(request):
     elif request.user not in article.authors.all():
         if not request.user.has_perm('article.change_article'):
             raise PermissionDenied # Only authors can download draft version
-    zip_path = os.path.join('/tmp/',article.slug+'.zip')
+    zip_path = os.path.join(tempfile.gettempdir(),article.slug+'.zip')
     zip_file = zipfile.ZipFile(zip_path, 'w')
     insert_into_zip(zip_file, repo.commit(sha).tree)
     zip_file.close()

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -462,10 +462,8 @@ def download(request):
     zip_file = zipfile.ZipFile(zip_path, 'w')
     insert_into_zip(zip_file, repo.commit(sha).tree)
     zip_file.close()
-    response = HttpResponse(open(zip_path , "rb").read(),
-                            content_type="application/zip")
-    response["Content-Disposition"] = \
-        "attachment; filename={0}.zip".format(article.slug)
+    response = HttpResponse(open(zip_path , "rb").read(), content_type="application/zip")
+    response["Content-Disposition"] = "attachment; filename={0}.zip".format(article.slug)
     os.remove(zip_path) # TODO: caching (at least for the public version?)
     return response
 

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -458,10 +458,9 @@ def download(request):
     sha = article.sha_draft
     if 'online' in request.GET and article.sha_public is not None:
         sha = article.sha_public
-    git_tree = repo.commit(sha).tree
     zip_path = os.path.join('/tmp/',article.slug+'.zip')
     zip_file = zipfile.ZipFile(zip_path, 'w')
-    insert_into_zip(zip_file, git_tree)
+    insert_into_zip(zip_file, repo.commit(sha).tree)
     zip_file.close()
     response = HttpResponse(open(zip_path , "rb").read(),
                             content_type="application/zip")

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -467,6 +467,7 @@ def download(request):
                             content_type="application/zip")
     response["Content-Disposition"] = \
         "attachment; filename={0}.zip".format(article.slug)
+    os.remove(zip_path) # TODO: caching (at least for the public version?)
     return response
 
 # Validation

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -451,20 +451,23 @@ def insert_into_zip(zip_file, git_tree):
 
 
 def download(request):
-    """Download a tutorial."""
+    """Download an article."""
     article = get_object_or_404(Article, pk=request.GET["article"])
     repo_path = os.path.join(settings.REPO_ARTICLE_PATH, article.get_phy_slug())
     repo = Repo(repo_path)
     sha = article.sha_draft
     if 'online' in request.GET and article.sha_public is not None:
         sha = article.sha_public
+    elif request.user not in article.authors.all():
+        if not request.user.has_perm('article.change_article'):
+            raise PermissionDenied # Only authors can download draft version
     zip_path = os.path.join('/tmp/',article.slug+'.zip')
     zip_file = zipfile.ZipFile(zip_path, 'w')
     insert_into_zip(zip_file, repo.commit(sha).tree)
     zip_file.close()
     response = HttpResponse(open(zip_path , "rb").read(), content_type="application/zip")
     response["Content-Disposition"] = "attachment; filename={0}.zip".format(article.slug)
-    os.remove(zip_path) # TODO: caching (at least for the public version?)
+    os.remove(zip_path)
     return response
 
 # Validation

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -457,7 +457,7 @@ def download(request):
     repo_path = os.path.join(settings.REPO_ARTICLE_PATH, article.get_phy_slug())
     repo = Repo(repo_path)
     sha = article.sha_draft
-    if 'online' in request.GET and article.sha_public is not None:
+    if 'online' in request.GET and article.on_line():
         sha = article.sha_public
     elif request.user not in article.authors.all():
         if not request.user.has_perm('article.change_article'):

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -19,6 +19,7 @@ import os.path
 import re
 import shutil
 import zipfile
+import tempfile
 
 from PIL import Image as ImagePIL
 from django.conf import settings
@@ -2841,7 +2842,7 @@ def download(request):
     elif request.user not in tutorial.authors.all():
         if not request.user.has_perm('tutorial.change_article'):
             raise PermissionDenied # Only authors can download draft version
-    zip_path = os.path.join('/tmp/',tutorial.slug+'.zip')
+    zip_path = os.path.join(tempfile.gettempdir(),tutorial.slug+'.zip')
     zip_file = zipfile.ZipFile(zip_path, 'w')
     insert_into_zip(zip_file, repo.commit(sha).tree)
     zip_file.close()

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2837,7 +2837,7 @@ def download(request):
     repo_path = os.path.join(settings.REPO_PATH, tutorial.get_phy_slug())
     repo = Repo(repo_path)
     sha = tutorial.sha_draft
-    if 'online' in request.GET and tutorial.sha_public is not None:
+    if 'online' in request.GET and tutorial.on_line():
         sha = tutorial.sha_public
     elif request.user not in tutorial.authors.all():
         if not request.user.has_perm('tutorial.change_article'):

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2838,10 +2838,9 @@ def download(request):
     sha = tutorial.sha_draft
     if 'online' in request.GET and tutorial.sha_public is not None:
         sha = tutorial.sha_public
-    git_tree = repo.commit(sha).tree
     zip_path = os.path.join('/tmp/',tutorial.slug+'.zip')
     zip_file = zipfile.ZipFile(zip_path, 'w')
-    insert_into_zip(zip_file, git_tree)
+    insert_into_zip(zip_file, repo.commit(sha).tree)
     zip_file.close()
     response = HttpResponse(open(zip_path , "rb").read(),
                             content_type="application/zip")

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2847,6 +2847,7 @@ def download(request):
                             content_type="application/zip")
     response["Content-Disposition"] = \
         "attachment; filename={0}.zip".format(tutorial.slug)
+    os.remove(zip_path) # TODO: caching (at least for the public version?)
     return response
 
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2821,17 +2821,31 @@ def maj_repo_extract(
 
 
 
+def insert_into_zip(zip_file, git_tree):
+    """recursively add files from a git_tree to a zip archive"""
+    for blob in git_tree.blobs: # first, add files :
+        zip_file.writestr(blob.path, blob.data_stream.read())
+    if len(git_tree.trees) is not 0: # then, recursively add dirs :
+        for subtree in git_tree.trees:
+            insert_into_zip(zip_file, subtree)
+
 def download(request):
     """Download a tutorial."""
-
     tutorial = get_object_or_404(Tutorial, pk=request.GET["tutoriel"])
-    ph = os.path.join(settings.REPO_PATH, tutorial.get_phy_slug())
-    repo = Repo(ph)
-    repo.archive(open(ph + ".tar", "w"))
-    response = HttpResponse(open(ph + ".tar", "rb").read(),
-                            mimetype="application/tar")
+    repo_path = os.path.join(settings.REPO_PATH, tutorial.get_phy_slug())
+    repo = Repo(repo_path)
+    sha = tutorial.sha_draft
+    if 'online' in request.GET and tutorial.sha_public is not None:
+        sha = tutorial.sha_public
+    git_tree = repo.commit(sha).tree
+    zip_path = os.path.join('/tmp/',tutorial.slug+'.zip')
+    zip_file = zipfile.ZipFile(zip_path, 'w')
+    insert_into_zip(zip_file, git_tree)
+    zip_file.close()
+    response = HttpResponse(open(zip_path , "rb").read(),
+                            content_type="application/zip")
     response["Content-Disposition"] = \
-        "attachment; filename={0}.tar".format(tutorial.slug)
+        "attachment; filename={0}.zip".format(tutorial.slug)
     return response
 
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2842,10 +2842,8 @@ def download(request):
     zip_file = zipfile.ZipFile(zip_path, 'w')
     insert_into_zip(zip_file, repo.commit(sha).tree)
     zip_file.close()
-    response = HttpResponse(open(zip_path , "rb").read(),
-                            content_type="application/zip")
-    response["Content-Disposition"] = \
-        "attachment; filename={0}.zip".format(tutorial.slug)
+    response = HttpResponse(open(zip_path , "rb").read(), content_type="application/zip")
+    response["Content-Disposition"] = "attachment; filename={0}.zip".format(tutorial.slug)
     os.remove(zip_path) # TODO: caching (at least for the public version?)
     return response
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2829,6 +2829,7 @@ def insert_into_zip(zip_file, git_tree):
         for subtree in git_tree.trees:
             insert_into_zip(zip_file, subtree)
 
+
 def download(request):
     """Download a tutorial."""
     tutorial = get_object_or_404(Tutorial, pk=request.GET["tutoriel"])

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2838,13 +2838,16 @@ def download(request):
     sha = tutorial.sha_draft
     if 'online' in request.GET and tutorial.sha_public is not None:
         sha = tutorial.sha_public
+    elif request.user not in tutorial.authors.all():
+        if not request.user.has_perm('tutorial.change_article'):
+            raise PermissionDenied # Only authors can download draft version
     zip_path = os.path.join('/tmp/',tutorial.slug+'.zip')
     zip_file = zipfile.ZipFile(zip_path, 'w')
     insert_into_zip(zip_file, repo.commit(sha).tree)
     zip_file.close()
     response = HttpResponse(open(zip_path , "rb").read(), content_type="application/zip")
     response["Content-Disposition"] = "attachment; filename={0}.zip".format(tutorial.slug)
-    os.remove(zip_path) # TODO: caching (at least for the public version?)
+    os.remove(zip_path)
     return response
 
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2840,7 +2840,7 @@ def download(request):
     if 'online' in request.GET and tutorial.on_line():
         sha = tutorial.sha_public
     elif request.user not in tutorial.authors.all():
-        if not request.user.has_perm('tutorial.change_article'):
+        if not request.user.has_perm('tutorial.change_tutorial'):
             raise PermissionDenied # Only authors can download draft version
     zip_path = os.path.join(tempfile.gettempdir(),tutorial.slug+'.zip')
     zip_file = zipfile.ZipFile(zip_path, 'w')


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | ~oui |
| Tickets concernés | #1458, #1460 |

Cette PR vise à régler deux choses fortement liées : les archives des tutoriels ou articles sont en TAR qui n'est pas un forma facilement lisible, et elles ne sont pas versionnées, ce qui signifie que n'importe qui peut télécharger une archive correspondant à la dernière version _draft_. 

Je règle cela en mettant le format des archives en ZIP et en les versionnant, tout du moins pour la version publique.
# Notes de QA

Il faut donc cette fois tester que l'archive contient ce qu'elle doit contenir, donc ...
- Créer un article, le publier, puis le modifier sans publier les changements. Télécharger l'archive de la version publique, vérifier que ça correspontd. Télécharger l'archive de la version _draft_ et vérifier que les changement sont bien présent dans cette archive mais pas dans celle de la version publique !!
- Faire de même pour les tutoriels. Pas besoin de sortir la grosse artillerie, un mini-tuto suffira

**Attention** que cette PR doit aussi être testée sous windows, les archives étant normalement directement lisible par cet OS sans besoin d'installer de programme externe.
