### PR TITLE
[PR Désinscription] Débug les MP et ajoute la documentation

### DIFF
--- a/doc/sphinx/source/member/member.rst
+++ b/doc/sphinx/source/member/member.rst
@@ -10,7 +10,9 @@ L'inscription d'un membre se déroule en deux phases :
 - le membre crée son compte et fournit un pseudo, un mot de passe et une adresse mail.
 - un mail de confirmation est envoyé avec un jeton qui permettra d'activer le compte.
 
-Attention, les virgules ne sont pas autorisées dans le pseudonyme
+.. attention::
+
+    les virgules ne sont pas autorisées dans le pseudonyme
 
 
 Désinscription
@@ -39,5 +41,39 @@ __________________________________
           - si le tutoriel/article est publié*, il passe sur le compte "Auteur externe", une demande expresse sera nécessaire au retrait complet de ses contenus ;
           - si le tutoriel/article n'est pas publié (brouillon, bêta, validation) il est supprimé ainsi que la galerie associée.
 
+
+Les membres dans les environnement de test et de développement
+==============================================================
+
+Afin de faciliter les procédures de tests en local, plusieurs utilisateurs ont été créés avec leurs profiles.
+
+- user/user : Utilisateur normal
+- staff/staff : Utilisateur avec les droits d'un staff
+- admin/admin : Utilisateur avec les droits d'un staff et d'un admin
+- anonymous/anonymous : Utilisateur qui permet l'anonymisation des messages sur les forums
+- Auteur externe/external : Utilisateur qui permet de récupérer les tutoriels d'anciens membres et/ou de publier des tutoriels externes.
+
+Pour que ces membres soient ajoutés à la base de données, il vous faudra exécuter la commande, à la racine du site
+
+.. sourcecode:: bash
+
+    python manage.py loaddata fixtures/users.yaml
+
+.. attention::
+
+    Les utilisateurs `anonymous` et `Auteur externe` **doivent** être présents dans la base de données.
+
+
+Le cas des utilisateurs `anonymous` et `Auteur externe` est particulier car ils permettent le processus d'anonymisation en cas de désinscription ou de demande expresse du membre.
+
+Ces derniers sont totalement paramétrables dans le fichiers `zds/settings.py`.
+Pour changer le *username* (nom d'utilisateur) considéré comme `anonymous` ou `Auteur externe`, agissez sur ces constantes :
+
+.. soucecode:: python
+
+# Constant for anonymisation
+
+ANONYMOUS_USER = "anonymous"
+EXTERNAL_USER = "Auteur externe"
 
 

--- a/doc/sphinx/source/member/member.rst
+++ b/doc/sphinx/source/member/member.rst
@@ -2,7 +2,42 @@
 Les Membres
 ===========
 
-A venir
-=======
+Inscription
+===========
+
+L'inscription d'un membre se déroule en deux phases :
+
+- le membre crée son compte et fournit un pseudo, un mot de passe et une adresse mail.
+- un mail de confirmation est envoyé avec un jeton qui permettra d'activer le compte.
+
+Attention, les virgules ne sont pas autorisées dans le pseudonyme
+
+
+Désinscription
+==============
+
+Interface utilisateur (front)
+_____________________________
+
+- Lien de désinscription accessible via Paramètres (en en haut à droite de toute les pages sur l'avatar / roue dentée) puis Désinscription dans la barre latérale ;
+- Le lien mène alors vers une page expliquant les conséquences de sa désinscription avec un bouton rouge en bas de celle-ci ;
+- Le clic sur le bouton rouge ouvre une boite modale qui constitue le dernier avertissement avant le déclenchement du processus de désinscription.
+
+Effets de la désinscription (back)
+__________________________________
+
+- Suppression du profil, libèrant le pseudo et l'adresse courriel pour les futures inscriptions ;
+- Le membre est déconnecté ;
+- Les données du membre sont anonymisées :
+     - messages du forum ayant comme pseudo "Anonyme" ;
+          - les sujets du forum restent ouverts mais ont comme auteur "Anonyme" ;
+          - les galeries non liées à un tutoriel sont données à "Auteur externe" (puisque l'image peut être considérée comme venant d'un "auteur") avec droit de lecture et d'écriture ;
+          - les MP sont anonymisés et le membre quitte les discussions auxquelles il participait ;
+     - les commentaires de tutoriels/articles ont comme pseudo "Anonyme" ;
+     - les articles et tutoriels suivent ces règles :
+          - si le tutoriel/article a été écrit par plusieurs personne; le membre est retiré de la liste des auteurs ;
+          - si le tutoriel/article est publié*, il passe sur le compte "Auteur externe", une demande expresse sera nécessaire au retrait complet de ses contenus ;
+          - si le tutoriel/article n'est pas publié (brouillon, bêta, validation) il est supprimé ainsi que la galerie associée.
+
 
 

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -291,11 +291,8 @@ class MemberTests(TestCase):
         editedAnswer.save()
         privateTopic = PrivateTopicFactory(author=user.user)
         privateTopic.participants.add(user2.user)
-        privateTopic.participants.add(user.user)
         privateTopic.save()
-
         PrivatePostFactory(author=user.user, privatetopic=privateTopic, position_in_topic=1)
-        a = privateTopic.participants.count()
         login_check = self.client.login(
             username=user.user.username,
             password='hostel77')

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -323,7 +323,7 @@ class MemberTests(TestCase):
         self.assertFalse(os.path.exists(writingTutorialAlonePath))
         self.assertIsNotNone(Topic.objects.get(pk=authoredTopic.pk))
         self.assertIsNotNone(PrivateTopic.objects.get(pk=privateTopic.pk))
-        self.assertEqual(privateTopic.participants.count(), 1)
+
 
     def test_sanctions(self):
         """Test various sanctions."""

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -13,7 +13,7 @@ from shutil import rmtree
 from zds.settings import ANONYMOUS_USER, EXTERNAL_USER, SITE_ROOT
 
 from zds.member.factories import ProfileFactory, StaffProfileFactory, NonAsciiProfileFactory, UserFactory
-from zds.member.forms import RegisterForm, ChangeUserForm, ChangePasswordForm
+from zds.mp.factories import  PrivateTopicFactory, PrivatePostFactory
 from zds.member.models import Profile
 from zds.mp.models import PrivatePost, PrivateTopic
 from zds.member.models import TokenRegister, Ban
@@ -289,6 +289,13 @@ class MemberTests(TestCase):
         editedAnswer = PostFactory(topic=answeredTopic, author=user.user, position=3)
         editedAnswer.editor = user.user
         editedAnswer.save()
+        privateTopic = PrivateTopicFactory(author=user.user)
+        privateTopic.participants.add(user2.user)
+        privateTopic.participants.add(user.user)
+        privateTopic.save()
+
+        PrivatePostFactory(author=user.user, privatetopic=privateTopic, position_in_topic=1)
+        a = privateTopic.participants.count()
         login_check = self.client.login(
             username=user.user.username,
             password='hostel77')
@@ -317,6 +324,9 @@ class MemberTests(TestCase):
         self.assertEqual(PrivatePost.objects.filter(author__username=user.user.username).count(),0)
         self.assertEqual(PrivateTopic.objects.filter(author__username=user.user.username).count(),0)
         self.assertFalse(os.path.exists(writingTutorialAlonePath))
+        self.assertIsNotNone(Topic.objects.get(pk=authoredTopic.pk))
+        self.assertIsNotNone(PrivateTopic.objects.get(pk=privateTopic.pk))
+        self.assertEqual(privateTopic.participants.count(), 1)
 
     def test_sanctions(self):
         """Test various sanctions."""
@@ -440,6 +450,7 @@ class MemberTests(TestCase):
         self.assertEqual(ban.type, 'Ban Temporaire')
         self.assertEqual(ban.text, 'Texte de test pour BAN TEMP')
         self.assertEquals(len(mail.outbox), 6)
+
 
     def test_nonascii(self):
         user = NonAsciiProfileFactory()

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -136,13 +136,12 @@ def unregister(request):
         topic.participants.remove(current)
         if topic.participants.count() > 0:
             topic.author = topic.participants.first()
+            topic.participants.remove(topic.author)
             topic.save()
         else:
             topic.delete()
     for topic in PrivateTopic.objects.filter(participants__in =[current]):
         topic.participants.remove(current)
-        if topic.author.username == current.username:
-            topic.author=anonymous
         topic.save()
     for topic in Topic.objects.filter(author = current):
         topic.author = anonymous

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -132,6 +132,13 @@ def unregister(request):
     for message in Comment.objects.filter(editor = current):
         message.editor = anonymous
         message.save()
+    for topic in PrivateTopic.objects.filter(author=current):
+        topic.participants.remove(current)
+        if topic.participants.count() > 0:
+            topic.author = topic.participants.first()
+            topic.save()
+        else:
+            topic.delete()
     for topic in PrivateTopic.objects.filter(participants__in =[current]):
         topic.participants.remove(current)
         if topic.author.username == current.username:

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -125,8 +125,17 @@ def unregister(request):
         if message.editor is not None and message.editor.username == current.username:
             message.editor = anonymous
         message.save()
+    for message in PrivatePost.objects.filter(author = current):
+        message.author = anonymous
+        message.save()
+    # in case current has been moderator in his old day
+    for message in Comment.objects.filter(editor = current):
+        message.editor = anonymous
+        message.save()
     for topic in PrivateTopic.objects.filter(participants__in =[current]):
         topic.participants.remove(current)
+        if topic.author.username == current.username:
+            topic.author=anonymous
         topic.save()
     for topic in Topic.objects.filter(author = current):
         topic.author = anonymous


### PR DESCRIPTION
> PR vers la branche desinscription, voir #1469.

Il s'agit d'un correctif qui doit pouvoir permettre de ne plus supprimer les MP.
Il ajoute aussi de la documentation.
