### PR TITLE
Ajout de l'activation de compte dans l'interface de promotion

### DIFF
--- a/doc/sphinx/source/member/member.rst
+++ b/doc/sphinx/source/member/member.rst
@@ -2,7 +2,19 @@
 Les Membres
 ===========
 
-A venir
-=======
 
+L'interface de promotion
+------------------------
 
+Afin de pouvoir gérer les membres directement depuis le site (c'est à dire sans avoir besoin de passer par l'interface d'administration de Django), une interface de promotion a été développée.
+Cette interface permet de :
+1. Ajouter/Supprimer un membre dans un/des groupe(s)
+2. Ajouter/Supprimer le statut super-utilisateur à un membre
+3. (Dés)activer un compte
+
+Le premier point permet notamment de passer un membre dans le groupe staff ou développeur. Si d'autres groupes voient le jour (valido ?) alors il sera possible ici aussi de le changer.
+Le second point permet de donner accès au membre à l'interface Django et à cette interface de promotion.
+Enfin, le dernier point concerne simplement l'activation du compte (normalement faite par le membre à l'inscription).
+
+Elle est géré par le formulaire `PromoteMemberForm` présent dans le fichier `zds/member/forms.py`.
+Elle est ensuite visible via le template `member/settings/promote.html` qui peut-être accédé en tant que super-utilisateur via le profil de n'importe quel membre.

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -577,6 +577,11 @@ class PromoteMemberForm(forms.Form):
         required=False,
     )
 
+    activation = forms.BooleanField(
+        label="Compte actif",
+        required=False,
+    )
+
     def __init__(self, *args, **kwargs):
         super(PromoteMemberForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
@@ -586,5 +591,6 @@ class PromoteMemberForm(forms.Form):
         self.helper.layout = Layout(
             Field('groups'),
             Field('superuser'),
+            Field('activation'),
             StrictButton('Valider', type='submit'),
         )

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -6,6 +6,8 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
+from zds.forum.factories import CategoryFactory, ForumFactory, TopicFactory
+from zds.forum.models import TopicFollowed
 from zds.member.factories import ProfileFactory, StaffProfileFactory, NonAsciiProfileFactory
 from zds.member.models import Profile
 
@@ -206,15 +208,38 @@ class MemberTests(TestCase):
     def test_promote_interface(self):
         """Test promotion interface"""
 
+        # create users (one regular and one staff and superuser)
         tester = ProfileFactory()
         staff = StaffProfileFactory()
-
-        group = Group.objects.create(name="DummyGroup")
-
         tester.user.is_active = False
         tester.user.save()
         staff.user.is_superuser = True
         staff.user.save()
+
+        # create groups
+        group = Group.objects.create(name="DummyGroup_1")
+        groupbis = Group.objects.create(name="DummyGroup_2")
+
+        # create Forums, Posts and subscribe member to them
+        category1 = CategoryFactory(position=1)
+        forum1 = ForumFactory(
+            category=category1,
+            position_in_category=1)
+        forum1.group.add(group)
+        forum1.save()
+        forum2 = ForumFactory(
+            category=category1,
+            position_in_category=2)
+        forum2.group.add(groupbis)
+        forum2.save()
+        forum3 = ForumFactory(
+            category=category1,
+            position_in_category=3)
+        topic1 = TopicFactory(forum=forum1, author=staff.user)
+        topic2 = TopicFactory(forum=forum2, author=staff.user)
+        topic3 = TopicFactory(forum=forum3, author=staff.user)
+
+        # LET THE TEST BEGIN !
 
         # tester shouldn't be able to connect
         login_check = self.client.login(
@@ -228,13 +253,40 @@ class MemberTests(TestCase):
             password='hostel77')
         self.assertEqual(login_check, True)
 
-        # give user rights and groups thanks to staff
+        # check that we can go through the page
+        result = self.client.get(
+            reverse('zds.member.views.settings_promote',
+                    kwargs={'user_pk': tester.user.id}), follow=False)
+        self.assertEqual(result.status_code, 200)
+
+        # give user rights and groups thanks to staff (but account still not activated)
+        result = self.client.post(
+            reverse('zds.member.views.settings_promote',
+                    kwargs={'user_pk': tester.user.id}),
+            {
+                'groups': [group.id, groupbis.id],
+                'superuser': "on",
+            }, follow=False)
+        self.assertEqual(result.status_code, 302)
+        tester = Profile.objects.get(id=tester.id)  # refresh
+
+        self.assertEqual(len(tester.user.groups.all()), 2)
+        self.assertFalse(tester.user.is_active)
+        self.assertTrue(tester.user.is_superuser)
+
+        # Now our tester is going to follow one post in every forum (3)
+        TopicFollowed(topic=topic1, user=tester.user).save()
+        TopicFollowed(topic=topic2, user=tester.user).save()
+        TopicFollowed(topic=topic3, user=tester.user).save()
+
+        self.assertEqual(TopicFollowed.objects.filter(user=tester).count(), 3)
+
+        # retract all right, keep one group only and activate account
         result = self.client.post(
             reverse('zds.member.views.settings_promote',
                     kwargs={'user_pk': tester.user.id}),
             {
                 'groups': [group.id],
-                'superuser': "on",
                 'activation': "on"
             }, follow=False)
         self.assertEqual(result.status_code, 302)
@@ -242,9 +294,10 @@ class MemberTests(TestCase):
 
         self.assertEqual(len(tester.user.groups.all()), 1)
         self.assertTrue(tester.user.is_active)
-        self.assertTrue(tester.user.is_superuser)
+        self.assertFalse(tester.user.is_superuser)
+        self.assertEqual(TopicFollowed.objects.filter(user=tester).count(), 2)
 
-        # retract all right but not activation
+        # no groups specified
         result = self.client.post(
             reverse('zds.member.views.settings_promote',
                     kwargs={'user_pk': tester.user.id}),
@@ -253,10 +306,7 @@ class MemberTests(TestCase):
             }, follow=False)
         self.assertEqual(result.status_code, 302)
         tester = Profile.objects.get(id=tester.id)  # refresh
-
-        self.assertEqual(len(tester.user.groups.all()), 0)
-        self.assertTrue(tester.user.is_active)
-        self.assertFalse(tester.user.is_superuser)
+        self.assertEqual(TopicFollowed.objects.filter(user=tester).count(), 1)
 
         # check that staff can't take away it's own super user rights
         result = self.client.post(

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -937,11 +937,11 @@ def settings_promote(request, user_pk):
                u'Un administrateur vient de modifier les groupes '
                u'auxquels vous appartenez.  \n'.format(user.username))
         if len(usergroups) > 0:
-            msg += u'Voici la liste des groupes dont vous faites dorénavant partis :\n\n'
+            msg += u'Voici la liste des groupes dont vous faites dorénavant partie :\n\n'
             for group in usergroups:
                 msg += u'* {0}\n'.format(group.name)
         else:
-            msg += u'* Vous ne faites partis d\'aucun groupe'
+            msg += u'* Vous ne faites partie d\'aucun groupe'
         msg += u'\n\n'
         if user.is_superuser:
             msg += (u'Vous avez aussi rejoint le rang des super utilisateurs. '

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -923,11 +923,11 @@ def settings_promote(request, user_pk):
         if 'activation' in data and u'on' in data['activation']:
             user.is_active = True
             messages.success(request, u'{0} est maintenant activé'
-                                        .format(user.username))
+                             .format(user.username))
         else:
             user.is_active = False
             messages.warning(request, u'{0} est désactivé'
-                                        .format(user.username))
+                             .format(user.username))
 
         user.save()
 
@@ -959,16 +959,9 @@ def settings_promote(request, user_pk):
         return redirect(profile.get_absolute_url())
 
     form = PromoteMemberForm(initial={'superuser': user.is_superuser,
-<<<<<<< HEAD
-                                      'groups': user.groups.all()
-                                      })
-
-=======
                                       'groups': user.groups.all(),
                                       'activation': user.is_active
-                                     })
-    
->>>>>>> Ajout de l'activation de compte dans l'interface de promotion
+                                      })
     return render_template('member/settings/promote.html', {
         "usr": user,
         "profile": profile,

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -920,6 +920,15 @@ def settings_promote(request, user_pk):
                     messages.warning(request, u'{0} n\'est maintenant plus super-utilisateur'
                                      .format(user.username))
 
+        if 'activation' in data and u'on' in data['activation']:
+            user.is_active = True
+            messages.success(request, u'{0} est maintenant activé'
+                                        .format(user.username))
+        else:
+            user.is_active = False
+            messages.warning(request, u'{0} est désactivé'
+                                        .format(user.username))
+
         user.save()
 
         usergroups = user.groups.all()
@@ -950,9 +959,16 @@ def settings_promote(request, user_pk):
         return redirect(profile.get_absolute_url())
 
     form = PromoteMemberForm(initial={'superuser': user.is_superuser,
+<<<<<<< HEAD
                                       'groups': user.groups.all()
                                       })
 
+=======
+                                      'groups': user.groups.all(),
+                                      'activation': user.is_active
+                                     })
+    
+>>>>>>> Ajout de l'activation de compte dans l'interface de promotion
     return render_template('member/settings/promote.html', {
         "usr": user,
         "profile": profile,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | ~oui |
| Tickets concernés | #54 |

Encore un tout petit bout venant compléter une PR précédente pour pouvoir gérer les comptes à caractères spéciaux. Cette PR rajoute juste la faculté d'activer (ou pas) un compte depuis son profil.
#### QA
- Essayer d'activer (ou non) un compte via un super utilisateur

(cf cette PR : https://github.com/zestedesavoir/zds-site/pull/1344)
