### PR TITLE
[PR Désinscription] Permet de nettoyer complètement les objets attachés à l'utilisateur

### DIFF
--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -92,8 +92,10 @@ class Article(models.Model):
     def __unicode__(self):
         return self.title
 
-    def delete_entity_and_tree(self, using=None):
+    def delete_entity_and_tree(self):
+        """deletes the entity and its filesystem counterpart"""
         shutil.rmtree(self.get_path(), 0)
+        Validation.objects.filter(article=self).delete()
         if self.on_line():
             shutil.rmtree(self.get_prod_path())
         self.delete()

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -225,10 +225,12 @@ class Profile(models.Model):
         return Topic.objects.filter(topicfollowed__user=self.user)\
             .order_by('-last_message__pubdate')
 
+
 @receiver(models.signals.post_delete, sender=User)
 def auto_delete_token_on_unregistering(sender, instance, **kwargs):
     TokenForgotPassword.objects.filter(user=instance).delete()
     TokenRegister.objects.filter(user=instance).delete()
+
 
 class TokenForgotPassword(models.Model):
 

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -11,6 +11,7 @@ import os
 
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from django.dispatch import receiver
 
 import pygeoip
 from zds.article.models import Article
@@ -224,6 +225,10 @@ class Profile(models.Model):
         return Topic.objects.filter(topicfollowed__user=self.user)\
             .order_by('-last_message__pubdate')
 
+@receiver(models.signals.post_delete, sender=User)
+def auto_delete_token_on_unregistering(sender, instance, **kwargs):
+    TokenForgotPassword.objects.filter(user=instance).delete()
+    TokenRegister.objects.filter(user=instance).delete()
 
 class TokenForgotPassword(models.Model):
 

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -334,8 +334,11 @@ class Tutorial(models.Model):
 
             return conclu_contenu.decode('utf-8')
 
-    def delete_entity_and_tree(self, using=None):
+    def delete_entity_and_tree(self):
+        """deletes the entity and its filesystem counterpart"""
         shutil.rmtree(self.get_path(), 0)
+        Validation.objects.filter(tutorial=self).delete()
+
         if self.gallery is not None:
             self.gallery.delete()
         if self.on_line():


### PR DESCRIPTION
PR vers la #1469 qui concerne la désinscription

---

Voici les erreurs corrigées par cette PR : 

> - Tuto et articles de U en draft, béta et validation : disparu de la BDD, OK. À noter que les objets "Validation" ne sont eux pas supprimés de la BDD si le tuto était déjà réservé : éventuellement pas OK (peut poser des problèmes par la suite)
> - À noter que les tokens d'inscriptions ne disparaissent pas de la base de donnée, éventuellement pas OK (peut poser problème par la suite). 
> - [ce commentaire](https://github.com/zestedesavoir/zds-site/pull/1469#discussion_r17417871)
> - [ce commentaire](https://github.com/zestedesavoir/zds-site/pull/1469#discussion_r17418099)
