### PR TITLE
Zep-3 : Page résumant les tutos en rédaction

### DIFF
--- a/doc/sphinx/source/tutorial/tutorial.rst
+++ b/doc/sphinx/source/tutorial/tutorial.rst
@@ -72,12 +72,12 @@ On pourrait le représenter ainsi :
 
  Tutoriels  -> chapitre  -
                          |-> introduction
-                         |-> 
+                         |->
                          |-> extrait 1
                          |-> extrait 2
                          |-> extrait ...
                          |-> extrait n
-                         |-> 
+                         |->
                          |-> conclusion
 
 
@@ -186,7 +186,7 @@ adéquate.
 La beta
 -------
 
-Lorsque les auteurs estiment que leur tutoriel est arrivé à un certain niveau de maturité, et qu'ils souhaitent 
+Lorsque les auteurs estiment que leur tutoriel est arrivé à un certain niveau de maturité, et qu'ils souhaitent
 recuillir les premiers retours de lecteurs, ils se doivent de mettre à disposition de la communauté le tutoriel en
 lecture seule. C'est le mode beta.
 
@@ -197,7 +197,7 @@ en beta, en postant le lien version la version beta du tutoriel.
 
     Le lien de la beta, peut être trouvé via votre profil utilisateur, vous devez recopier tout le lien avec la partie `?version=blablabla`. Et pensez bien à modifier ce lien lorsque vous mettez à jour votre version beta.
 
-En fait lorsqu'un tutoriel est en mode beta, il s'agit d'une version précise qui est mise 
+En fait lorsqu'un tutoriel est en mode beta, il s'agit d'une version précise qui est mise
 dans ce mode. On peut continuer à mettre à jour la version brouillon pour rajouter de nouveaux chapitres
 à notre tutriel, pendant ce temps, la communauté lit une version figée de notre tutoriel. L'avantage étant que
 si le tutoriel prend beaucoup de temps à lire, le lecteur n'a pas de mauvaise surprise de mise à jour
@@ -216,7 +216,7 @@ votre tutoriel, il devra recommencer son travail si vous faites une mise à jour
 ralentir le processus de validation de votre tutoriel, mais décourager aussi le validateur. Donc un conseil a donner serait
 de n'envoyer que du contenu sûr en validation.
 
-Comme pour la beta, la version brouillon du tutoriel peut continuer à être améliorée pendant que la version 
+Comme pour la beta, la version brouillon du tutoriel peut continuer à être améliorée pendant que la version
 de validation reste figée. Auteurs et validateurs peuvent donc continuer à travailler chacun de son coté.
 
 La publication
@@ -302,3 +302,17 @@ Les tutoriels en *offline* sont tous versionnés, et sont dans le répertoire `t
 - On stocke les fichiers html sur le serveur.
 
 Ainsi, pour lire un tutoriel public, on a juste besoin de lire les fichiers html déjà convertis.
+
+Et si un auteur a besoin d'aide ?
++++++++++++++++++++++++++++++++++
+
+Afin d'aider les auteurs de tutoriels à rédiger ces derniers, des options lors de la création/édition de ce dernier sont disponibles. L'auteur peut ainsi faire aisément une demande d'aide pour les compétences suivantes (liste non exhaustive) :
+
+- Besoin d'aide à l'écriture
+- Besoin d'aide à la correction/relecture
+- Besoin d'aide pour illustrer
+- Désir d'abandonner le tutoriel et recherche d'un repreneur
+
+L'ensemble des tutoriels à la recherche d'aide est visible via la page "help.html" (template dans le fichier `templates/tutorial/tutorial/help.html`). Cette page génère un tableau récapitulatif de toutes les demandes d'aides pour les différents tutoriels et des filtres peuvent être appliqués. Toutes les données servant à peupler ce tableau sont renvoyées via la méthode `help_tutorial` dans le fichier `zds/tutorial/views.py`. Cette méthode peut prendre en compte un argument en GET nommé type désignant le filtre à appliquer. Cet argument représente le slug d'une des options de la liste précédentes.
+En cas d'absence du paramètre, tout les tutoriels ayant au moins une demande d'aide d'activées ou en bêta sont renvoyé au template.
+De nouveau type de demande d'aide peuvent-être rajouté via l'interface d'administration Django dans la classe `Utils.HelpWriting`.

--- a/fixtures/aidestutos.yaml
+++ b/fixtures/aidestutos.yaml
@@ -3,7 +3,6 @@
     fields:
         title: "Redacteur"
         tablelabel: "Besoin d'aide pour la rédaction"
-        imagename: "dummy_redacteur.png"
         slug: "redacteur"
 
 -   model: utils.HelpWriting
@@ -11,7 +10,6 @@
     fields:
         title: "Correcteur"
         tablelabel: "Besoin d'aide pour la correction"
-        imagename: "dummy_correcteur.png"
         slug: "correcteur"
 
 -   model: utils.HelpWriting
@@ -19,7 +17,6 @@
     fields:
         title: "Illustrateur"
         tablelabel: "Besoin d'aide pour l'illustration"
-        imagename: "dummy_illustrateur.png"
         slug: "illustrateur"
 
 -   model: utils.HelpWriting
@@ -27,5 +24,4 @@
     fields:
         title: "Repreneur"
         tablelabel: "Cherche un repreneur"
-        imagename: "dummy_repreneur.png"
         slug: "repreneur"

--- a/fixtures/aidestutos.yaml
+++ b/fixtures/aidestutos.yaml
@@ -1,0 +1,31 @@
+-   model: utils.HelpWriting
+    pk: 1
+    fields:
+        title: "Redacteur"
+        tablelabel: "Besoin d'aide pour la rédaction"
+        imagename: "dummy_redacteur.png"
+        slug: "redacteur"
+
+-   model: utils.HelpWriting
+    pk: 2
+    fields:
+        title: "Correcteur"
+        tablelabel: "Besoin d'aide pour la correction"
+        imagename: "dummy_correcteur.png"
+        slug: "correcteur"
+
+-   model: utils.HelpWriting
+    pk: 3
+    fields:
+        title: "Illustrateur"
+        tablelabel: "Besoin d'aide pour l'illustration"
+        imagename: "dummy_illustrateur.png"
+        slug: "illustrateur"
+
+-   model: utils.HelpWriting
+    pk: 4
+    fields:
+        title: "Repreneur"
+        tablelabel: "Cherche un repreneur"
+        imagename: "dummy_repreneur.png"
+        slug: "repreneur"

--- a/templates/tutorial/index.html
+++ b/templates/tutorial/index.html
@@ -17,7 +17,7 @@
     {% if tag %}
         Découvrez tous nos tutoriels sur {{ tag }}. Vous pourrez également découvrir divers sujets tous plus intéressants les uns que les autres.
     {% else %}
-        Les tutoriels vous permettent d'apprendre divers sujets tous plus intéressants 
+        Les tutoriels vous permettent d'apprendre divers sujets tous plus intéressants
         les uns que les autres.
     {% endif %}
 {% endblock %}
@@ -45,7 +45,7 @@
                 {% endif %}
             {% endblock %}
         </h1>
-        
+
         <meta itemprop="itemListOrder" content="Unordered">
 
         {% if tutorials %}
@@ -70,6 +70,10 @@
     >
         <a href="{% url "zds.tutorial.views.add_tutorial" %}" class="new-btn ico-after more blue">
             Nouveau tutoriel
+        </a>
+
+        <a href="{% url "zds.tutorial.views.help_tutorial" %}" class="new-btn ico-after help blue">
+            Aider les rédacteurs
         </a>
 
         <h3>Catégories <span class="wide">de tutoriels</span></h3>

--- a/templates/tutorial/tutorial/help.html
+++ b/templates/tutorial/tutorial/help.html
@@ -72,7 +72,7 @@
                         {% endfor %}
                     </tbody>
                 </table>
-
+                {% include "misc/pagination.part.html" with position='bottom' %}
                 <!-- I'm a Legend -->
                 <ul id="legend">
                     <li><img src="dummy_tutobeta.png" alt=""> Tutoriel en beta</li>

--- a/templates/tutorial/tutorial/help.html
+++ b/templates/tutorial/tutorial/help.html
@@ -55,8 +55,8 @@
                                 </td>
                                 {% for help in helps %}
                                     <td>
-                                        {% if help in tutorial.helps %}
-                                            <img src="{{ help.imagepath }}" alt="">
+                                        {% if help in tutorial.helps.all %}
+                                            <img src="{{ help.image.url }}" alt="">
                                         {% endif %}
                                     </td>
                                 {% endfor %}
@@ -78,7 +78,7 @@
                     <li><img src="dummy_tutobeta.png" alt=""> Tutoriel en beta</li>
                     <li><img src="dummy_tutopublic.png" alt=""> Tutoriel en ligne</li>
                     {% for help in helps %}
-                        <li><img src="{{ help.imagepath }}" alt=""> {{ help.tablelabel }}</li>
+                        <li><img src="{{ help.image.url }}" alt=""> {{ help.tablelabel }}</li>
                     {% endfor %}
                     <li><img src="dummy_contactmp.png" alt=""> Contacter le(s) auteur(s)</li>
                 </ul>

--- a/templates/tutorial/tutorial/help.html
+++ b/templates/tutorial/tutorial/help.html
@@ -1,0 +1,117 @@
+{% extends "tutorial/base_online.html" %}
+{% load captureas %}
+
+
+
+{% block title %}
+    Aider les auteurs
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    <li>Aider les auteurs</li>
+{% endblock %}
+
+
+
+{% block content_out %}
+    <section class="full-content-wrapper">
+        <h1 class="ico-after ico-tutorials">
+            {% block headline %}
+                Aider les auteurs de tutoriels ({{ tutorials|length }})
+            {% endblock %}
+        </h1>
+
+        {% block content %}
+            {% if tutorials %}
+                (Légende des icones <a href="#legend">en bas du tableau</a>)
+                <table class="fullwidth">
+                    <thead>
+                        <tr>
+                            <th scope="col" title="Tutoriel en bêta"><img src="" alt=""></th>
+                            <th scope="col" title="Tutoriel en ligne"><img src="" alt=""></th>
+                            {% for help in helps %}
+                                <th scope="col" title="{{ help.tablelabel }}"><img src="" alt=""></th>
+                            {% endfor %}
+                            <th scope="col" title="Contacter le(s) auteur(s)">MP Auteur(s)</th>
+                            <th scope="col" title="Titre du tutoriel">Titre du tutoriel</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for tutorial in tutorials %}
+                            <tr>
+                                <!-- tuto en beta -->
+                                <td>
+                                    {% if tutorial.sha_beta %}
+                                        <a title="oui" href="{{ tutorial.get_absolute_url_beta }}"><img src="dummy_tutobeta.png" alt=""></a>
+                                    {% endif %}
+                                </td>
+                                <!-- tuto en ligne -->
+                                <td>
+                                    {% if tutorial.sha_public %}
+                                        <a title="oui" href="{{ tutorial.get_absolute_url_online }}"><img src="dummy_tutopublic.png" alt=""></a>
+                                    {% endif %}
+                                </td>
+                                {% for help in helps %}
+                                    <td>
+                                        {% if help in tutorial.helps %}
+                                            <img src="{{ help.imagepath }}" alt="">
+                                        {% endif %}
+                                    </td>
+                                {% endfor %}
+                                <!-- Contacter le(s) auteur(s) -->
+                                <td>
+                                    <a  href="{% url "zds.mp.views.new" %}?{% for username in tutorial.authors.all %}&amp;username={{ username }}{% endfor %}" title="Ecrire aux auteurs"><img src="dummy_contactmp.png" alt=""></a>
+                                </td>
+                                <!-- Titre du tuto -->
+                                <td>
+                                    {{ tutorial.title }}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+
+                <!-- I'm a Legend -->
+                <ul id="legend">
+                    <li><img src="dummy_tutobeta.png" alt=""> Tutoriel en beta</li>
+                    <li><img src="dummy_tutopublic.png" alt=""> Tutoriel en ligne</li>
+                    {% for help in helps %}
+                        <li><img src="{{ help.imagepath }}" alt=""> {{ help.tablelabel }}</li>
+                    {% endfor %}
+                    <li><img src="dummy_contactmp.png" alt=""> Contacter le(s) auteur(s)</li>
+                </ul>
+            {% else %}
+                <p>
+                    Aucun rédacteur n'a l'air d'avoir besoin d'aide !
+                </p>
+            {% endif %}
+        {% endblock %}
+    </section>
+{% endblock %}
+
+
+
+{% block sidebar_new %}{% endblock %}
+{% block sidebar_blocks %}
+    <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Besoin">
+        <h3>Besoin</h3>
+        <ul>
+            {% for help in helps %}
+                <li>
+                    <a href="{% url "zds.tutorial.views.help_tutorial" %}?type={{ help.slug }}" class="ico-after tick green {% if request.GET.type == "help.title" %}unread{% endif %}">
+                        {{ help.title }}
+                    </a>
+                </li>
+            {% endfor %}
+            {% if request.GET.type %}
+                <li>
+                    <a href="{% url "zds.tutorial.views.help_tutorial" %}" class="ico-after cross blue">
+                        Annuler le filtre
+                    </a>
+                </li>
+            {% endif %}
+        </ul>
+    </div>
+{% endblock %}

--- a/templates/tutorial/tutorial/help.html
+++ b/templates/tutorial/tutorial/help.html
@@ -84,7 +84,7 @@
                 </ul>
             {% else %}
                 <p>
-                    Aucun rédacteur n'a l'air d'avoir besoin d'aide !
+                    Aucun rédacteur n'a l'air d'avoir besoin d'un {{ request.GET.type|lower }} !
                 </p>
             {% endif %}
         {% endblock %}

--- a/templates/tutorial/tutorial/help.html
+++ b/templates/tutorial/tutorial/help.html
@@ -43,13 +43,13 @@
                             <tr>
                                 <!-- tuto en beta -->
                                 <td>
-                                    {% if tutorial.sha_beta %}
+                                    {% if tutorial.in_beta %}
                                         <a title="oui" href="{{ tutorial.get_absolute_url_beta }}"><img src="dummy_tutobeta.png" alt=""></a>
                                     {% endif %}
                                 </td>
                                 <!-- tuto en ligne -->
                                 <td>
-                                    {% if tutorial.sha_public %}
+                                    {% if tutorial.on_line %}
                                         <a title="oui" href="{{ tutorial.get_absolute_url_online }}"><img src="dummy_tutopublic.png" alt=""></a>
                                     {% endif %}
                                 </td>
@@ -62,7 +62,7 @@
                                 {% endfor %}
                                 <!-- Contacter le(s) auteur(s) -->
                                 <td>
-                                    <a  href="{% url "zds.mp.views.new" %}?{% for username in tutorial.authors.all %}&amp;username={{ username }}{% endfor %}" title="Ecrire aux auteurs"><img src="dummy_contactmp.png" alt=""></a>
+                                    <a  href="{% url "zds.mp.views.new" %}?{% for author in tutorial.authors.all %}&amp;username={{ author.username }}{% endfor %}" title="Ecrire aux auteurs"><img src="dummy_contactmp.png" alt=""></a>
                                 </td>
                                 <!-- Titre du tuto -->
                                 <td>

--- a/zds/tutorial/forms.py
+++ b/zds/tutorial/forms.py
@@ -9,7 +9,7 @@ from crispy_forms.layout import Layout, Fieldset, Submit, Field, \
     ButtonHolder, Hidden
 from django.core.urlresolvers import reverse
 
-from zds.tutorial.models import TYPE_CHOICES
+from zds.tutorial.models import TYPE_CHOICES, HelpWriting
 from zds.utils.forms import CommonLayoutModalText, CommonLayoutEditor
 from zds.utils.models import SubCategory, Licence
 from zds.tutorial.models import Tutorial
@@ -96,6 +96,13 @@ class TutorialForm(FormWithTitle):
         empty_label=None
     )
 
+    helps = forms.ModelMultipleChoiceField(
+        label="J'ai besoin d'aide avec un...",
+        queryset=HelpWriting.objects.all(),
+        required=False,
+        widget=forms.SelectMultiple()
+    )
+
     def __init__(self, *args, **kwargs):
         super(TutorialForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
@@ -112,6 +119,7 @@ class TutorialForm(FormWithTitle):
             Hidden('last_hash', '{{ last_hash }}'),
             Field('subcategory'),
             Field('licence'),
+            Field('helps'),
             ButtonHolder(
                 StrictButton('Valider', type='submit'),
             ),

--- a/zds/tutorial/migrations/0005_auto.py
+++ b/zds/tutorial/migrations/0005_auto.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding M2M table for field helps on 'Tutorial'
+        m2m_table_name = db.shorten_name(u'tutorial_tutorial_helps')
+        db.create_table(m2m_table_name, (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('tutorial', models.ForeignKey(orm[u'tutorial.tutorial'], null=False)),
+            ('helpwriting', models.ForeignKey(orm[u'utils.helpwriting'], null=False))
+        ))
+        db.create_unique(m2m_table_name, ['tutorial_id', 'helpwriting_id'])
+
+
+    def backwards(self, orm):
+        # Removing M2M table for field helps on 'Tutorial'
+        db.delete_table(db.shorten_name(u'tutorial_tutorial_helps'))
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'gallery.gallery': {
+            'Meta': {'object_name': 'Gallery'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'gallery.image': {
+            'Meta': {'object_name': 'Image'},
+            'gallery': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gallery.Gallery']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'legend': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'physical': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'tutorial.chapter': {
+            'Meta': {'object_name': 'Chapter'},
+            'conclusion': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gallery.Image']", 'null': 'True', 'blank': 'True'}),
+            'introduction': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'part': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Part']", 'null': 'True', 'blank': 'True'}),
+            'position_in_part': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'position_in_tutorial': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'tutorial': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Tutorial']", 'null': 'True', 'blank': 'True'})
+        },
+        u'tutorial.extract': {
+            'Meta': {'object_name': 'Extract'},
+            'chapter': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Chapter']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position_in_chapter': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'tutorial.note': {
+            'Meta': {'object_name': 'Note', '_ormbases': [u'utils.Comment']},
+            u'comment_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['utils.Comment']", 'unique': 'True', 'primary_key': 'True'}),
+            'tutorial': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Tutorial']"})
+        },
+        u'tutorial.part': {
+            'Meta': {'object_name': 'Part'},
+            'conclusion': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'introduction': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'position_in_tutorial': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'tutorial': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Tutorial']"})
+        },
+        u'tutorial.tutorial': {
+            'Meta': {'object_name': 'Tutorial'},
+            'authors': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'db_index': 'True', 'symmetrical': 'False'}),
+            'conclusion': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'create_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'gallery': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gallery.Gallery']", 'null': 'True', 'blank': 'True'}),
+            'helps': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['utils.HelpWriting']", 'db_index': 'True', 'symmetrical': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gallery.Image']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'images': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'introduction': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'is_locked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_note': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'last_note'", 'null': 'True', 'to': u"orm['tutorial.Note']"}),
+            'licence': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.Licence']", 'null': 'True', 'blank': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'sha_beta': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'sha_draft': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'sha_public': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'sha_validation': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'subcategory': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['utils.SubCategory']", 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'tutorial.tutorialread': {
+            'Meta': {'object_name': 'TutorialRead'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'note': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Note']"}),
+            'tutorial': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Tutorial']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'tuto_notes_read'", 'to': u"orm['auth.User']"})
+        },
+        u'tutorial.validation': {
+            'Meta': {'object_name': 'Validation'},
+            'comment_authors': ('django.db.models.fields.TextField', [], {}),
+            'comment_validator': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'date_proposition': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'date_reserve': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_validation': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'PENDING'", 'max_length': '10'}),
+            'tutorial': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Tutorial']", 'null': 'True', 'blank': 'True'}),
+            'validator': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'author_validations'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'version': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'utils.comment': {
+            'Meta': {'object_name': 'Comment'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': u"orm['auth.User']"}),
+            'dislike': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'comments-editor'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.CharField', [], {'max_length': '39'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'like': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'text_hidden': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '80'}),
+            'text_html': ('django.db.models.fields.TextField', [], {}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'utils.helpwriting': {
+            'Meta': {'object_name': 'HelpWriting'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'imagename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'tablelabel': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'utils.licence': {
+            'Meta': {'object_name': 'Licence'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'utils.subcategory': {
+            'Meta': {'object_name': 'SubCategory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        }
+    }
+
+    complete_apps = ['tutorial']

--- a/zds/tutorial/migrations/0005_auto.py
+++ b/zds/tutorial/migrations/0005_auto.py
@@ -182,7 +182,7 @@ class Migration(SchemaMigration):
         u'utils.helpwriting': {
             'Meta': {'object_name': 'HelpWriting'},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'imagename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
             'slug': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'tablelabel': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '20'})

--- a/zds/tutorial/migrations/0005_auto.py
+++ b/zds/tutorial/migrations/0005_auto.py
@@ -183,7 +183,7 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'HelpWriting'},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'imagename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
-            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'tablelabel': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '20'})
         },

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -21,7 +21,7 @@ from git.repo import Repo
 
 from zds.gallery.models import Image, Gallery
 from zds.utils import slugify, get_current_user
-from zds.utils.models import SubCategory, Licence, Comment
+from zds.utils.models import SubCategory, Licence, Comment, HelpWriting
 from zds.utils.tutorials import get_blob, export_tutorial
 
 
@@ -108,6 +108,8 @@ class Tutorial(models.Model):
                                   related_name='last_note',
                                   verbose_name='Derniere note')
     is_locked = models.BooleanField('Est verrouillé', default=False)
+
+    helps = models.ManyToManyField(HelpWriting, verbose_name='Aides', db_index=True)
 
     def __unicode__(self):
         return self.title

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -3727,9 +3727,29 @@ class MiniTutorialTests(TestCase):
         tutos = response.context['tutorials']
         self.assertEqual(len(tutos), 0)
 
-        # if we give the tuto a beta it should return 1
-        self.minituto.sha_beta = "whatever"
-        self.minituto.save()
+        # then active the beta on tutorial :
+        ForumFactory(
+            category=CategoryFactory(position=1),
+            position_in_category=1)
+        # first, login with author :
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+        sha_draft = Tutorial.objects.get(pk=self.minituto.pk).sha_draft
+        response = self.client.post(
+            reverse('zds.tutorial.views.modify_tutorial'),
+            {
+                'tutorial': self.minituto.pk,
+                'activ_beta': True,
+                'version': sha_draft
+            },
+            follow=False
+        )
+        self.assertEqual(302, response.status_code)
+        sha_beta = Tutorial.objects.get(pk=self.minituto.pk).sha_beta
+        self.assertEqual(sha_draft, sha_beta)
         response = self.client.post(
             reverse('zds.tutorial.views.help_tutorial'),
             follow=False

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -2401,7 +2401,7 @@ class MiniTutorialTests(TestCase):
 
         mail.outbox = []
 
-    def add_test_extract_named_introduction(self):
+    def test_add_extract_named_introduction(self):
         """test the use of an extract named introduction"""
 
         self.client.login(username=self.user_author,
@@ -2425,7 +2425,7 @@ class MiniTutorialTests(TestCase):
         self.assertTrue(os.path.isfile(intro_path))
         self.assertTrue(os.path.isfile(extract_path))
 
-    def add_test_extract_named_conclusion(self):
+    def test_add_extract_named_conclusion(self):
         """test the use of an extract named introduction"""
 
         self.client.login(username=self.user_author,

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -29,7 +29,7 @@ from zds.tutorial.factories import BigTutorialFactory, MiniTutorialFactory, Part
     ChapterFactory, NoteFactory, SubCategoryFactory, LicenceFactory
 from zds.gallery.factories import GalleryFactory
 from zds.tutorial.models import Note, Tutorial, Validation, Extract, Part, Chapter
-from zds.utils.models import SubCategory, Licence, Alert
+from zds.utils.models import SubCategory, Licence, Alert, HelpWriting
 from zds.utils.misc import compute_hash
 
 
@@ -3710,6 +3710,60 @@ class MiniTutorialTests(TestCase):
         # finally, clean up things:
         os.remove(draft_zip_path)
         os.remove(online_zip_path)
+
+    def test_help_to_perfect_tuto(self):
+        """ This test aim to unit test the "help me to write my tutorial"
+        interface. It is testing if the back-end is always sending back
+        good datas """
+
+        helps = HelpWriting.objects.all()
+
+        # currently the tutorial is published with no beta, so back-end should return 0 tutorial
+        response = self.client.post(
+            reverse('zds.tutorial.views.help_tutorial'),
+            follow=False
+        )
+        self.assertEqual(200, response.status_code)
+        tutos = response.context['tutorials']
+        self.assertEqual(len(tutos), 0)
+
+        # if we give the tuto a beta it should return 1
+        self.minituto.sha_beta = "whatever"
+        self.minituto.save()
+        response = self.client.post(
+            reverse('zds.tutorial.views.help_tutorial'),
+            follow=False
+        )
+        self.assertEqual(200, response.status_code)
+        tutos = response.context['tutorials']
+        self.assertEqual(len(tutos), 1)
+
+        # However if we ask with a filter we will still get 0
+        for helping in helps:
+            response = self.client.post(
+                reverse('zds.tutorial.views.help_tutorial') +
+                u'?type={}'.format(helping.slug),
+                follow=False
+            )
+            self.assertEqual(200, response.status_code)
+            tutos = response.context['tutorials']
+            self.assertEqual(len(tutos), 0)
+
+        # now tutorial is positive for every options
+        # if we ask for any help we should get a positive answer for every filter
+        for helping in helps:
+            self.minituto.helps.add(helping)
+        self.minituto.save()
+
+        for helping in helps:
+            response = self.client.post(
+                reverse('zds.tutorial.views.help_tutorial') +
+                u'?type={}'.format(helping.slug),
+                follow=False
+            )
+            self.assertEqual(200, response.status_code)
+            tutos = response.context['tutorials']
+            self.assertEqual(len(tutos), 1)
 
     def tearDown(self):
         if os.path.isdir(settings.REPO_PATH):

--- a/zds/tutorial/urls.py
+++ b/zds/tutorial/urls.py
@@ -116,6 +116,6 @@ urlpatterns = patterns('',
                            'zds.tutorial.views.solve_alert'),
 
                        # Help
-                       url(r'^aider/tutoriels/$',
+                       url(r'^aides/$',
                            'zds.tutorial.views.help_tutorial'),
                        )

--- a/zds/tutorial/urls.py
+++ b/zds/tutorial/urls.py
@@ -114,4 +114,8 @@ urlpatterns = patterns('',
                        # Moderation
                        url(r'^resolution_alerte/$',
                            'zds.tutorial.views.solve_alert'),
+
+                       # Help
+                       url(r'^aider/tutoriels/$',
+                           'zds.tutorial.views.help_tutorial'),
                        )

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -42,7 +42,7 @@ from lxml import etree
 from forms import TutorialForm, PartForm, ChapterForm, EmbdedChapterForm, \
     ExtractForm, ImportForm, NoteForm, AskValidationForm, ValidForm, RejectForm
 from models import Tutorial, Part, Chapter, Extract, Validation, never_read, \
-    mark_read, Note
+    mark_read, Note, HelpWriting
 from zds.gallery.models import Gallery, UserGallery, Image
 from zds.member.decorator import can_write_and_read_now
 from zds.member.models import get_info_old_tuto, Profile
@@ -1105,6 +1105,10 @@ def add_tutorial(request):
             for subcat in form.cleaned_data["subcategory"]:
                 tutorial.subcategory.add(subcat)
 
+            # Add helps if needed
+            for helpwriting in form.cleaned_data["helps"]:
+                tutorial.helps.add(helpwriting)
+
             # We need to save the tutorial before changing its author list
             # since it's a many-to-many relationship
 
@@ -1169,7 +1173,7 @@ def edit_tutorial(request):
                     "subcategory": tutorial.subcategory.all(),
                     "introduction": tutorial.get_introduction(),
                     "conclusion": tutorial.get_conclusion(),
-
+                    "helps": tutorial.helps.all(),
                 })
                 return render_template("tutorial/tutorial/edit.html",
                                        {
@@ -1245,6 +1249,7 @@ def edit_tutorial(request):
             "subcategory": tutorial.subcategory.all(),
             "introduction": tutorial.get_introduction(),
             "conclusion": tutorial.get_conclusion(),
+            "helps": tutorial.helps.all(),
         })
     return render_template("tutorial/tutorial/edit.html",
                            {"tutorial": tutorial, "form": form, "last_hash": compute_hash([introduction, conclusion])})
@@ -3463,3 +3468,26 @@ def dislike_note(request):
         return HttpResponse(json_writer.dumps(resp))
     else:
         return redirect(note.get_absolute_url())
+
+
+def help_tutorial(request):
+    """fetch all tutorials that needs help"""
+
+    # Retrieve type of the help. Default value is any help
+    try:
+        type = request.GET['type']
+    except KeyError:
+        type = None
+
+    if type is not None:
+        aide = get_object_or_404(HelpWriting, slug=type)
+        tutos = Tutorial.objects.filter(helps=aide) \
+                                .all()
+    else:
+        tutos = Tutorial.objects.filter(sha_beta__isnull=False) \
+                                .exclude(sha_beta="") \
+                                .all()
+
+    aides = HelpWriting.objects.all()
+
+    return render_template("tutorial/tutorial/help.html", {"tutorials": tutos, "helps": aides})

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1228,9 +1228,15 @@ def edit_tutorial(request):
                 conclusion=data["conclusion"],
                 action="maj",
             )
+
             tutorial.subcategory.clear()
             for subcat in form.cleaned_data["subcategory"]:
                 tutorial.subcategory.add(subcat)
+
+            tutorial.helps.clear()
+            for help in form.cleaned_data["helps"]:
+                tutorial.helps.add(help)
+
             tutorial.save()
             return redirect(tutorial.get_absolute_url())
     else:

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -31,7 +31,7 @@ from django.core.files import File
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.core.urlresolvers import reverse
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Q, Count
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.encoding import smart_str
@@ -3474,18 +3474,15 @@ def help_tutorial(request):
     """fetch all tutorials that needs help"""
 
     # Retrieve type of the help. Default value is any help
-    try:
-        type = request.GET['type']
-    except KeyError:
-        type = None
+    type = request.GET.get('type', None)
 
     if type is not None:
         aide = get_object_or_404(HelpWriting, slug=type)
         tutos = Tutorial.objects.filter(helps=aide) \
                                 .all()
     else:
-        tutos = Tutorial.objects.filter(sha_beta__isnull=False) \
-                                .exclude(sha_beta="") \
+        tutos = Tutorial.objects.annotate(total=Count('helps')) \
+                                .filter((Q(sha_beta__isnull=False) & Q(sha_beta="")) | Q(total__gt=0)) \
                                 .all()
 
     aides = HelpWriting.objects.all()

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3481,8 +3481,8 @@ def help_tutorial(request):
         tutos = Tutorial.objects.filter(helps=aide) \
                                 .all()
     else:
-        tutos = Tutorial.objects.annotate(total=Count('helps')) \
-                                .filter((Q(sha_beta__isnull=False) & Q(sha_beta="")) | Q(total__gt=0)) \
+        tutos = Tutorial.objects.annotate(total=Count('helps'), shasize=Count('sha_beta')) \
+                                .filter((Q(sha_beta__isnull=False) & Q(shasize__gt=0)) | Q(total__gt=0)) \
                                 .all()
 
     # Paginator

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3485,6 +3485,25 @@ def help_tutorial(request):
                                 .filter((Q(sha_beta__isnull=False) & Q(sha_beta="")) | Q(total__gt=0)) \
                                 .all()
 
+    # Paginator
+    paginator = Paginator(tutos, settings.TOPICS_PER_PAGE)
+    page = request.GET.get('page')
+
+    try:
+        shown_tutos = paginator.page(page)
+        page = int(page)
+    except PageNotAnInteger:
+        shown_tutos = paginator.page(1)
+        page = 1
+    except EmptyPage:
+        shown_tutos = paginator.page(paginator.num_pages)
+        page = paginator.num_pages
+
     aides = HelpWriting.objects.all()
 
-    return render_template("tutorial/tutorial/help.html", {"tutorials": tutos, "helps": aides})
+    return render_template("tutorial/tutorial/help.html", {
+        "tutorials": shown_tutos,
+        "helps": aides,
+        "pages": paginator_range(page, paginator.num_pages),
+        "nb": page
+    })

--- a/zds/utils/admin.py
+++ b/zds/utils/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 
-from zds.utils.models import Alert, Licence, Category, SubCategory, CategorySubCategory, Tag
+from zds.utils.models import Alert, Licence, Category, SubCategory, \
+    CategorySubCategory, Tag, HelpWriting
 
 
 admin.site.register(Alert)
@@ -9,3 +10,4 @@ admin.site.register(Licence)
 admin.site.register(Category)
 admin.site.register(SubCategory)
 admin.site.register(CategorySubCategory)
+admin.site.register(HelpWriting)

--- a/zds/utils/migrations/0006_auto__add_helpwriting.py
+++ b/zds/utils/migrations/0006_auto__add_helpwriting.py
@@ -14,7 +14,7 @@ class Migration(SchemaMigration):
             ('title', self.gf('django.db.models.fields.CharField')(max_length=20)),
             ('slug', self.gf('django.db.models.fields.SlugField')(max_length=20)),
             ('tablelabel', self.gf('django.db.models.fields.CharField')(max_length=150)),
-            ('imagename', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('image', self.gf('django.db.models.fields.files.ImageField')(max_length=100, null=True, blank=True)),
         ))
         db.send_create_signal(u'utils', ['HelpWriting'])
 
@@ -115,7 +115,7 @@ class Migration(SchemaMigration):
         u'utils.helpwriting': {
             'Meta': {'object_name': 'HelpWriting'},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'imagename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
             'slug': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'tablelabel': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '20'})

--- a/zds/utils/migrations/0006_auto__add_helpwriting.py
+++ b/zds/utils/migrations/0006_auto__add_helpwriting.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'HelpWriting'
+        db.create_table(u'utils_helpwriting', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=20)),
+            ('slug', self.gf('django.db.models.fields.SlugField')(max_length=80)),
+            ('tablelabel', self.gf('django.db.models.fields.CharField')(max_length=150)),
+            ('imagename', self.gf('django.db.models.fields.CharField')(max_length=100)),
+        ))
+        db.send_create_signal(u'utils', ['HelpWriting'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'HelpWriting'
+        db.delete_table(u'utils_helpwriting')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'utils.alert': {
+            'Meta': {'object_name': 'Alert'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'alerts'", 'to': u"orm['auth.User']"}),
+            'comment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'alerts'", 'to': u"orm['utils.Comment']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'scope': ('django.db.models.fields.CharField', [], {'max_length': '1', 'db_index': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        },
+        u'utils.category': {
+            'Meta': {'object_name': 'Category'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'utils.categorysubcategory': {
+            'Meta': {'object_name': 'CategorySubCategory'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.Category']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_main': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'subcategory': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.SubCategory']"})
+        },
+        u'utils.comment': {
+            'Meta': {'object_name': 'Comment'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': u"orm['auth.User']"}),
+            'dislike': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'comments-editor'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.CharField', [], {'max_length': '39'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'like': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'text_hidden': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '80'}),
+            'text_html': ('django.db.models.fields.TextField', [], {}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'utils.commentdislike': {
+            'Meta': {'object_name': 'CommentDislike'},
+            'comments': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.Comment']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'post_disliked'", 'to': u"orm['auth.User']"})
+        },
+        u'utils.commentlike': {
+            'Meta': {'object_name': 'CommentLike'},
+            'comments': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.Comment']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'post_liked'", 'to': u"orm['auth.User']"})
+        },
+        u'utils.helpwriting': {
+            'Meta': {'object_name': 'HelpWriting'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'imagename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'tablelabel': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'utils.licence': {
+            'Meta': {'object_name': 'Licence'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'utils.subcategory': {
+            'Meta': {'object_name': 'SubCategory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'utils.tag': {
+            'Meta': {'object_name': 'Tag'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        }
+    }
+
+    complete_apps = ['utils']

--- a/zds/utils/migrations/0006_auto__add_helpwriting.py
+++ b/zds/utils/migrations/0006_auto__add_helpwriting.py
@@ -12,7 +12,7 @@ class Migration(SchemaMigration):
         db.create_table(u'utils_helpwriting', (
             (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('title', self.gf('django.db.models.fields.CharField')(max_length=20)),
-            ('slug', self.gf('django.db.models.fields.SlugField')(max_length=80)),
+            ('slug', self.gf('django.db.models.fields.SlugField')(max_length=20)),
             ('tablelabel', self.gf('django.db.models.fields.CharField')(max_length=150)),
             ('imagename', self.gf('django.db.models.fields.CharField')(max_length=100)),
         ))
@@ -116,7 +116,7 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'HelpWriting'},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'imagename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
-            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
             'tablelabel': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '20'})
         },

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -285,3 +285,32 @@ class Tag(models.Model):
         self.title = smart_text(self.title).lower()
         self.slug = slugify(self.title)
         super(Tag, self).save(*args, **kwargs)
+
+
+class HelpWriting(models.Model):
+
+    """Tutorial Help"""
+    class Meta:
+        verbose_name = u'Aide à la rédaction'
+        verbose_name_plural = u'Aides à la rédaction'
+
+    # A name for this help
+    title = models.CharField('Name', max_length=20, null=False)
+    slug = models.SlugField(max_length=80)
+
+    # tablelabel: Used for the accessibility "This tutoriel need help for writing"
+    tablelabel = models.CharField('TableLabel', max_length=150, null=False)
+
+    # The image to use to illustrate this role
+    imagename = models.CharField('Illustration', max_length=100, null=False)
+
+    def __unicode__(self):
+        """Textual Licence Form."""
+        return self.title
+
+    def get_phy_slug(self):
+        return str(self.pk) + "_" + self.slug
+
+    def save(self, *args, **kwargs):
+        self.slug = slugify(self.title)
+        super(HelpWriting, self).save(*args, **kwargs)

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -20,6 +20,13 @@ def image_path_category(instance, filename):
     return os.path.join('categorie/normal', str(instance.pk), filename)
 
 
+def image_path_help(instance, filename):
+    """Return path to an image."""
+    ext = filename.split('.')[-1]
+    filename = u'{}.{}'.format(str(uuid.uuid4()), string.lower(ext))
+    return os.path.join('helps/normal', str(instance.pk), filename)
+
+
 class Category(models.Model):
 
     """Common category for several concepts of the application."""
@@ -302,7 +309,10 @@ class HelpWriting(models.Model):
     tablelabel = models.CharField('TableLabel', max_length=150, null=False)
 
     # The image to use to illustrate this role
-    imagename = models.CharField('Illustration', max_length=100, null=False)
+    image = models.ImageField(
+        upload_to=image_path_help,
+        blank=True,
+        null=True)
 
     def __unicode__(self):
         """Textual Help Form."""

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -296,7 +296,7 @@ class HelpWriting(models.Model):
 
     # A name for this help
     title = models.CharField('Name', max_length=20, null=False)
-    slug = models.SlugField(max_length=80)
+    slug = models.SlugField(max_length=20)
 
     # tablelabel: Used for the accessibility "This tutoriel need help for writing"
     tablelabel = models.CharField('TableLabel', max_length=150, null=False)
@@ -305,11 +305,8 @@ class HelpWriting(models.Model):
     imagename = models.CharField('Illustration', max_length=100, null=False)
 
     def __unicode__(self):
-        """Textual Licence Form."""
+        """Textual Help Form."""
         return self.title
-
-    def get_phy_slug(self):
-        return str(self.pk) + "_" + self.slug
 
     def save(self, *args, **kwargs):
         self.slug = slugify(self.title)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | [ZEP-3](http://zestedesavoir.com/forums/sujet/666/zep-03-page-resumant-les-tutos-en-redaction/) , https://github.com/zestedesavoir/zds-site/issues/531 |

La voici la voila, la ZEP-3 !! Ce n'est pas tout a fait finit, mais suffisant pour montrer quelque chose qui marche.
### Ce qui est OK
- Le formulaire dans les tutos pour gérer les nouvelles options
- La page qui résume tout ca (via le bouton "tutoriels" dans la liste)
- Les filtres pour n'afficher que ce qui nous intéresse
- Le peuplage du tableau
- Création de nouveau besoin via l'admin Django
- La doc. technico-fonctionnel
- La pagination
- Les tests unitaires du back-end
### Ce qui n'est pas fini
- Pas d'images donc c'est moche

Donc finalement,
# QA can start !

(puisque les points manquants n'influence pas le comportement global). 
- **Il vous faudra faire un migrate** (`python manage.py migrate`).
- Il ne faut pas non plus oublié de tester l'interface admin de Django pour ajouter de nouvelles possibilités.
- Il faudrait aussi tester qu'un tuto existant **avant** le migrate n'est pas cassé ;)

Précision:
Pour être affiché dans le tableau, un tutoriel doit répondre à **au moins une** des conditions suivantes:
- Etre en beta
- Chercher un rédacteur
- Chercher un correcteur
- Chercher un illustrateur
- Chercher un repreneur
# WIP, ne pas merger !
