### PR TITLE
MiniFix: Plus de MP sur résolution vide

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -1071,24 +1071,31 @@ def solve_alert(request):
 
     alert = get_object_or_404(Alert, pk=request.POST['alert_pk'])
     reaction = Reaction.objects.get(pk=alert.comment.id)
-    bot = get_object_or_404(User, username=settings.BOT_ACCOUNT)
-    msg = (u'Bonjour {0},\n\nVous recevez ce message car vous avez '
-           u'signalé le message de *{1}*, dans l\'article [{2}]({3}). '
-           u'Votre alerte a été traitée par **{4}** et il vous a laissé '
-           u'le message suivant :\n\n> {5}\n\nToute l\'équipe de '
-           u'la modération vous remercie !'.format(
-               alert.author.username,
-               reaction.author.username,
-               reaction.article.title,
-               settings.SITE_URL +
-               reaction.get_absolute_url(),
-               request.user.username,
-               request.POST['text']))
-    send_mp(
-        bot, [
-            alert.author], u"Résolution d'alerte : {0}".format(reaction.article.title), "", msg, False)
-    alert.delete()
 
+    if request.POST["text"] != "":
+        bot = get_object_or_404(User, username=settings.BOT_ACCOUNT)
+        msg = (u'Bonjour {0},\n\nVous recevez ce message car vous avez '
+               u'signalé le message de *{1}*, dans l\'article [{2}]({3}). '
+               u'Votre alerte a été traitée par **{4}** et il vous a laissé '
+               u'le message suivant :\n\n> {5}\n\nToute l\'équipe de '
+               u'la modération vous remercie !'.format(
+                   alert.author.username,
+                   reaction.author.username,
+                   reaction.article.title,
+                   settings.SITE_URL +
+                   reaction.get_absolute_url(),
+                   request.user.username,
+                   request.POST['text']))
+        send_mp(
+            bot,
+            [alert.author],
+            u"Résolution d'alerte : {0}".format(reaction.article.title),
+            "",
+            msg,
+            False
+        )
+
+    alert.delete()
     messages.success(
         request,
         u'L\'alerte a bien été résolue')

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -304,29 +304,33 @@ def solve_alert(request):
 
     if not request.user.has_perm("forum.change_post"):
         raise PermissionDenied
+
     alert = get_object_or_404(Alert, pk=request.POST["alert_pk"])
     post = Post.objects.get(pk=alert.comment.id)
-    bot = get_object_or_404(User, username=settings.BOT_ACCOUNT)
-    msg = \
-        (u'Bonjour {0},'
-         u'Vous recevez ce message car vous avez signalé le message de *{1}*, '
-         u'dans le sujet [{2}]({3}). Votre alerte a été traitée par **{4}** '
-         u'et il vous a laissé le message suivant :'
-         u'\n\n> {5}\n\nToute l\'équipe de la modération vous remercie !'.format(
-             alert.author.username,
-             post.author.username,
-             post.topic.title,
-             settings.SITE_URL + post.get_absolute_url(),
-             request.user.username,
-             request.POST["text"],))
-    send_mp(
-        bot,
-        [alert.author],
-        u"Résolution d'alerte : {0}".format(post.topic.title),
-        "",
-        msg,
-        False,
-    )
+
+    if request.POST["text"] != "":
+        bot = get_object_or_404(User, username=settings.BOT_ACCOUNT)
+        msg = \
+            (u'Bonjour {0},'
+             u'Vous recevez ce message car vous avez signalé le message de *{1}*, '
+             u'dans le sujet [{2}]({3}). Votre alerte a été traitée par **{4}** '
+             u'et il vous a laissé le message suivant :'
+             u'\n\n> {5}\n\nToute l\'équipe de la modération vous remercie !'.format(
+                 alert.author.username,
+                 post.author.username,
+                 post.topic.title,
+                 settings.SITE_URL + post.get_absolute_url(),
+                 request.user.username,
+                 request.POST["text"],))
+        send_mp(
+            bot,
+            [alert.author],
+            u"Résolution d'alerte : {0}".format(post.topic.title),
+            "",
+            msg,
+            False,
+        )
+
     alert.delete()
     messages.success(request, u"L'alerte a bien été résolue")
     return redirect(post.get_absolute_url())

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3290,29 +3290,33 @@ def solve_alert(request):
 
     if not request.user.has_perm("tutorial.change_note"):
         raise PermissionDenied
+
     alert = get_object_or_404(Alert, pk=request.POST["alert_pk"])
     note = Note.objects.get(pk=alert.comment.id)
-    bot = get_object_or_404(User, username=settings.BOT_ACCOUNT)
-    msg = \
-        (u'Bonjour {0},'
-         u'Vous recevez ce message car vous avez signalé le message de *{1}*, '
-         u'dans le tutoriel [{2}]({3}). Votre alerte a été traitée par **{4}** '
-         u'et il vous a laissé le message suivant :'
-         u'\n\n> {5}\n\nToute l\'équipe de la modération vous remercie !'.format(
-             alert.author.username,
-             note.author.username,
-             note.tutorial.title,
-             settings.SITE_URL + note.get_absolute_url(),
-             request.user.username,
-             request.POST["text"],))
-    send_mp(
-        bot,
-        [alert.author],
-        u"Résolution d'alerte : {0}".format(note.tutorial.title),
-        "",
-        msg,
-        False,
-    )
+
+    if request.POST["text"] != "":
+        bot = get_object_or_404(User, username=settings.BOT_ACCOUNT)
+        msg = \
+            (u'Bonjour {0},'
+             u'Vous recevez ce message car vous avez signalé le message de *{1}*, '
+             u'dans le tutoriel [{2}]({3}). Votre alerte a été traitée par **{4}** '
+             u'et il vous a laissé le message suivant :'
+             u'\n\n> {5}\n\nToute l\'équipe de la modération vous remercie !'.format(
+                 alert.author.username,
+                 note.author.username,
+                 note.tutorial.title,
+                 settings.SITE_URL + note.get_absolute_url(),
+                 request.user.username,
+                 request.POST["text"],))
+        send_mp(
+            bot,
+            [alert.author],
+            u"Résolution d'alerte : {0}".format(note.tutorial.title),
+            "",
+            msg,
+            False,
+        )
+
     alert.delete()
     messages.success(request, u"L'alerte a bien été résolue")
     return redirect(note.get_absolute_url())


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | - |

Lorsqu'une résolution est résolu ( \o/ ) par un modo, un MP est automatiquement envoyé à l'auteur de l'alerte pour le prévenir de la résolution et avec le message de résolution. Ce MP est un peu inutile si le message de résolution est vide. Ce correctif évite donc ainsi l'envoi d'une résolution "spam".
### QA
- Tester la résolution d'une alerte avec et sans message de résolution
  - Dans les forums
  - Dans les commentaires d'articles
  - Dans les commentaires de tutos
