### PR TITLE
[PR désinscription] Fix la documentation sur remarques de Firm1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ python manage.py loaddata fixtures/*.yaml
 
 Cela va créer plusieurs entitées :
 
-* 5 utilisateurs (utilisateur/mot de passe) :
+* 6 utilisateurs (utilisateur/mot de passe) :
 	* user/user : Utilisateur normal
 	* staff/staff : Utilisateur avec les droits d'un staff
 	* admin/admin : Utilisateur avec les droits d'un staff et d'un admin
 	* anonymous/anonymous : Utilisateur qui permet l'anonymisation des messages sur les forums
 	* Auteur externe/external : Utilisateur qui permet de récupérer les tutoriels d'anciens membres et/ou de publier des tutoriels externes.
+	* ïtrema/ïtrema : Utilisateur de test supplémentaire sans droit
 * 3 catégories
 * 11 forums
 * 3 sujets avec une réponse

--- a/doc/sphinx/source/member/member.rst
+++ b/doc/sphinx/source/member/member.rst
@@ -70,13 +70,14 @@ Le clic sur "me désinscrire" entraîne alors une série d'action (qui sont **ir
 Les membres dans les environnement de test et de développement
 ==============================================================
 
-Afin de faciliter les procédures de tests en local, plusieurs utilisateurs ont été créés via la fixture ``users.yaml`` :
+Afin de faciliter les procédures de tests en local, 6 utilisateurs ont été créés via la fixture ``users.yaml`` (utilisateur/mot de passe):
 
 - user/user : Utilisateur normal
 - staff/staff : Utilisateur avec les droits d'un staff
 - admin/admin : Utilisateur avec les droits d'un staff et d'un admin
 - anonymous/anonymous : Utilisateur qui permet l'anonymisation des messages sur les forums, dans les commentaires d'articles et de tutoriels ainsi que dans les MPs
 - Auteur externe/external : Utilisateur qui permet de récupérer les tutoriels d'anciens membres et/ou de publier des tutoriels externes.
+- ïtrema/ïtrema : Utilisateur de test supplémentaire sans droit
 
 Pour que ces membres soient ajoutés à la base de données, il est donc nécéssaire d'exécuter la commande, suivante, à la racine du site
 


### PR DESCRIPTION
PR vers la #1469 qui concerne la désinscription

---

| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1469 |

Tient compte de [cette remarque](https://github.com/zestedesavoir/zds-site/pull/1469#discussion_r17633549) et de [celle-ci](https://github.com/zestedesavoir/zds-site/pull/1469#discussion_r17633328) faites sur la PR #1469.

Corrige la fixture des utilisateurs.
# Note de QA

Avant de merger, vérifier l'absence de fautes d'orthographes dans la doc', ainsi **que la connexion avec TOUT les utilisateurs repris dans la documentation**  après `python manage.py loaddata fixtures/users.yaml` (!)
