### PR TITLE
[PR Désinscription] Termine les tests

### DIFF
--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -139,7 +139,7 @@ class MemberTests(TestCase):
         writingTutorialAlone = MiniTutorialFactory(light=True)
         writingTutorialAlone.authors.add(user.user)
         writingTutorialAlone.save()
-        writingTutorialAloneGallerPath = os.path.join(MEDIA_ROOT, writingTutorialAlone.gallery.slug);
+        writingTutorialAloneGallerPath = os.path.join(MEDIA_ROOT, writingTutorialAlone.gallery.slug)
         writingTutorialAlonePath = writingTutorialAlone.get_path()
         # fourth case : a private tutorial with at least two authors
         writingTutorial2 = MiniTutorialFactory(light=True)
@@ -322,15 +322,11 @@ class MemberTests(TestCase):
         self.assertEqual(self.client.get(
             reverse('zds.tutorial.views.view_tutorial_online', args=[
                     publishedTutorialAlone.pk,
-                    publishedTutorialAlone.slug])
-        , follow=False
-        ).status_code, 200)
+                    publishedTutorialAlone.slug]), follow=False).status_code, 200)
         self.assertEqual(self.client.get(
             reverse('zds.tutorial.views.view_tutorial_online', args=[
                     publishedTutorial2.pk,
-                    publishedTutorial2.slug])
-        , follow=False
-        ).status_code, 200)
+                    publishedTutorial2.slug]), follow=False).status_code, 200)
         self.assertTrue(os.path.exists(publishedArticleAlone.get_path()))
         self.assertEqual(self.client.get(
             reverse(


### PR DESCRIPTION
PR vers la #1469 qui concerne la désinscription

---

Permet de tester les assertions suivantes : 
- pour un article en rédaction, lorsqu'on se désinscrit, on ne vérifie pas que le tutoriel n'existe plus physiquement
- pour un tuto/article publié, lorsqu'on se désinscrit on ne vérifie pas que le tutoriel existe encore physiquement et est toujours accessible sur son lien public.
- pour les tutoriels, lorsqu'on se désinscrit on ne vérifie pas que les galleries associées sont supprimées (de manière logique et physique) en même temps que le tutoriel et conservées si le tutoriel n'est pas supprimé.

il ne reste plus que les cas "en cours de validation" et "en béta" qui -actuellement- sont strictement équivalents à "non publiés" et donc "en écriture".
