### PR TITLE
[PR Désinscription] Fix bug de suppression de gallery dans un tuto privé

### DIFF
--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -133,4 +133,6 @@ class Gallery(models.Model):
 @receiver(models.signals.post_delete, sender=Gallery)
 def auto_delete_image_on_delete(sender, instance, **kwargs):
     """Deletes image from filesystem when corresponding object is deleted."""
+    for image in instance.get_images():
+        image.delete()
     shutil.rmtree(instance.get_gallery_path())

--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -3,7 +3,6 @@
 import os
 import string
 import uuid
-import shutil
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -12,6 +11,7 @@ from django.db import models
 from django.dispatch import receiver
 from easy_thumbnails.fields import ThumbnailerImageField
 from zds.settings import MEDIA_ROOT
+
 
 def image_path(instance, filename):
     """Return path to an image."""
@@ -135,4 +135,3 @@ def auto_delete_image_on_delete(sender, instance, **kwargs):
     """Deletes image from filesystem when corresponding object is deleted."""
     for image in instance.get_images():
         image.delete()
-    shutil.rmtree(instance.get_gallery_path())

--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -3,6 +3,7 @@
 import os
 import string
 import uuid
+import shutil
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -10,7 +11,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.dispatch import receiver
 from easy_thumbnails.fields import ThumbnailerImageField
-
+from zds.settings import MEDIA_ROOT
 
 def image_path(instance, filename):
     """Return path to an image."""
@@ -109,6 +110,10 @@ class Gallery(models.Model):
         return reverse('zds.gallery.views.gallery_details',
                        args=[self.pk, self.slug])
 
+    def get_gallery_path(self):
+        """get the physical path to this gallery root"""
+        return os.path.join(MEDIA_ROOT, 'galleries', str(self.pk))
+
     # TODO rename function to get_users_galleries
     def get_users(self):
         return UserGallery.objects.all()\
@@ -128,5 +133,4 @@ class Gallery(models.Model):
 @receiver(models.signals.post_delete, sender=Gallery)
 def auto_delete_image_on_delete(sender, instance, **kwargs):
     """Deletes image from filesystem when corresponding object is deleted."""
-    for image in instance.get_images():
-        image.delete()
+    shutil.rmtree(instance.get_gallery_path())

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -10,7 +10,7 @@ from django.test.utils import override_settings
 
 from shutil import rmtree
 
-from zds.settings import ANONYMOUS_USER, EXTERNAL_USER, SITE_ROOT, MEDIA_ROOT
+from zds.settings import ANONYMOUS_USER, EXTERNAL_USER, SITE_ROOT
 from zds.forum.models import TopicFollowed
 from zds.member.factories import ProfileFactory, StaffProfileFactory, NonAsciiProfileFactory, UserFactory
 from zds.mp.factories import PrivateTopicFactory, PrivatePostFactory

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -139,7 +139,7 @@ class MemberTests(TestCase):
         writingTutorialAlone = MiniTutorialFactory(light=True)
         writingTutorialAlone.authors.add(user.user)
         writingTutorialAlone.save()
-        writingTutorialAloneGallerPath = os.path.join(MEDIA_ROOT, writingTutorialAlone.gallery.slug)
+        writingTutorialAloneGallerPath = writingTutorialAlone.gallery.get_gallery_path()
         writingTutorialAlonePath = writingTutorialAlone.get_path()
         # fourth case : a private tutorial with at least two authors
         writingTutorial2 = MiniTutorialFactory(light=True)


### PR DESCRIPTION
PR vers la PR #1469 pour la désinscription.

---

Corrige cette remarque : 

> En regardant la nomencalture d'une gallerie, on se rend compte que le morceau de code writingTutorialAloneGallerPath = os.path.join(MEDIA_ROOT, writingTutorialAlone.gallery.slug) ne donne pas vraiment le chemin prévu pour la gallerie.
> 
> Ce qui rend donc cette partie du test ainsi que cette ligne invalide.
> 
> Tu dois le remplacer par quelque chose du genre writingTutorialAloneGallerPath = os.path.join(MEDIA_ROOT, os.path.join('galleries', str(writingTutorialAlone.gallery.pk))) et vérifier que ce répertoire existe avant désinscription.

et le bug qui va avec
