### PR TITLE
Fix l'url d'avertissement de désinscription

### DIFF
--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -1,4 +1,4 @@
-# Configuration des serveurs
+﻿# Configuration des serveurs
 
 Zeste de Savoir est installe en 1 tiers (sur un seul serveur donc).
 
@@ -367,6 +367,19 @@ source /usr/local/nvm/nvm.sh
 gulp clean
 gulp build
 ```
+
+Modification du `settings_prod.py` :
+
+Si un utilisateur anonyme et un utilisateur permettant de récupérer les tutoriels venant de l'extérieur
+existent déjà, configurez les constantes `ANONYMOUS_USER` et `EXTERNAL_USER` pour que ces dernières
+aient pour valeur le pseudo desdits utilisateurs.
+
+Sinon, utilisez au choix le shell django ou bien
+
+```
+python manage.py loaddata fixtures/users.py #crée aussi un utilisateur admin, staff et user, donc utilisez cette commande avec précaution.
+```
+
 
 Réindexation Solr :
 

--- a/doc/sphinx/source/member/member.rst
+++ b/doc/sphinx/source/member/member.rst
@@ -1,4 +1,4 @@
-===========
+﻿===========
 Les membres
 ===========
 
@@ -22,7 +22,7 @@ Désinscription
 L'inscription se fait via l'interface utilisateur.
 
 -  Le lien de désinscription est accessible via paramètres (``/membres/parametres/profil/``) puis “Se désinscrire” dans la barre
-   latérale (``/membres/desinscrire/attention``) :
+   latérale (``/membres/desinscrire/avertissement/``) :
 
    .. figure:: images/desinscription-1.png
       :align:   center

--- a/zds/member/urls.py
+++ b/zds/member/urls.py
@@ -7,8 +7,8 @@ from . import views
 
 urlpatterns = patterns('',
                        url(r'^$', 'zds.member.views.index'),
-                       url(r'^desinscrire/$', 'zds.member.views.unregister'),
-                       url(r'^desinscrire/attention$', 'zds.member.views.warning_unregister'),
+                       url(r'^desinscrire/valider/$', 'zds.member.views.unregister'),
+                       url(r'^desinscrire/avertissement/$', 'zds.member.views.warning_unregister'),
                        url(r'^voir/(?P<user_name>.+)/$',
                            'zds.member.views.details'),
                        url(r'^profil/modifier/(?P<user_pk>\d+)/$',


### PR DESCRIPTION
| Question | Réponse |
| --- | --- |
| Correction de bug | [oui] |
| NOuvelle fonctionnalités | [non] |
| Ticket | #1532 |

il manquait un slash sur l'url d'avertissement. De plus l'url de désinscription n'était pas cohérente avec le reste du site.
