### PR TITLE
Designer le chapitrage des tutoriels

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -1780,7 +1780,7 @@
         > a,
         p a,
         ul:not(.pagination),
-        ol {
+        ol:not(.summary-part) {
             font-family: $font-serif-active;
         }
     }
@@ -1798,6 +1798,40 @@
         }
     }
 
+    .article-content .summary-part {
+        font-size: 20px;
+        color: darken($secondary, 11%);
+
+        h3,
+        h4 {
+            font-weight: normal;
+
+            a {
+                text-decoration: none;
+
+                &:hover,
+                &:focus {
+                    text-decoration: underline;
+                }
+            }
+        }
+        h3 {
+            font-size: 20px;
+            margin: 0 0 5px;
+        }
+
+        .summary-part {
+            list-style: none;
+            padding-left: 0;
+            margin-bottom: 15px;
+
+            h4 {
+                font-size: 14px;
+                margin: 2px 0;
+            }
+        }
+    }
+
     .article-content,
     .message-content {
         margin-top: 20px;
@@ -1806,9 +1840,11 @@
 
         h2,
         h3 {
+            clear: both;
+
             &,
             a {
-                color: #ee8709;
+                color: darken($secondary, 11%);
                 margin-top: 40px;
                 text-decoration: none;
             }
@@ -2070,7 +2106,7 @@
     .article-content {
         p,
         ul:not(.pagination),
-        ol {
+        ol:not(.summary-part) {
             font-family: $font-serif-active;
         }
         figcaption p {

--- a/assets/scss/_wide.scss
+++ b/assets/scss/_wide.scss
@@ -278,6 +278,15 @@
                     margin: 0;
                 }
             }
+
+            .article-content > .summary-part > li {
+                float: left;
+                width: 50%;
+
+                &:nth-child(2n+1) {
+                    clear: both;
+                }
+            }
         }
 
         .sidebar {

--- a/templates/tutorial/includes/chapter.part.html
+++ b/templates/tutorial/includes/chapter.part.html
@@ -16,17 +16,7 @@
     
     <hr />
 
-    {% if extracts %}
-        <ul>
-            {% for extract in extracts %}
-                <li>
-                    <a href="#{{ extract.position_in_chapter }}-{{ extract.title|slugify }}">
-                        {{ extract.title }}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-    {% else %}
+    {% if not extracts %}
         <p class="ico-after warning">
             Il n'y a aucun extrait.
         </p>

--- a/templates/tutorial/includes/part.part.html
+++ b/templates/tutorial/includes/part.part.html
@@ -9,7 +9,7 @@
                 {{ part.intro|safe }}
             {% endif %}
 
-            <ol>
+            <ol class="summary-part">
                 {% for chapter in chapters %}
                     <li>
                         <h3>
@@ -20,10 +20,10 @@
                                     {% url "view-chapter-url" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}{% if version %}?version={{ version }}{% endif %}
                                 {% endif %}
                             ">
-                                Chapitre {{ chapter.part.position_in_tutorial }}.{{ chapter.position_in_part }} | {{ chapter.title }}
+                                {{ chapter.title }}
                             </a>
                         </h3>
-                        <ol>
+                        <ol class="summary-part">
                             {% for extract in chapter.extracts %}
                                 <li>
                                     <h4>
@@ -43,6 +43,8 @@
                     </li>
                 {% endfor %}
             </ol>
+
+            <hr class="clearfix" />
 
             {% if part.conclu %}
                 {{ part.conclu|safe }}

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -3,6 +3,7 @@
 {% load repo_reader %}
 {% load crispy_forms_tags %}
 {% load thumbnail %}
+{% load roman %}
 
 
 {% block title %}
@@ -117,7 +118,7 @@
         {% for part in parts %}
             <h2>
                 <a href="{% url "view-part-url" tutorial.pk tutorial.slug part.pk part.slug %}{% if version %}?version={{ version }}{% endif %}">
-                    Partie {{ part.position_in_tutorial }} : {{ part.title }}
+                    {{ part.position_in_tutorial|roman }} - {{ part.title }}
                 </a>
             </h2>
             {% include "tutorial/includes/part.part.html" %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1170 |

**QA** : vérifier que le sommaire (côté page, sur l'accueil d'un tutoriel, ça ne concerne pas la sidebar) s'affiche correctement sur ordinateur et mobile.

J'ai volontairement retiré le chapitrage interne à un chapitre car il était redondant avec la sidebar. L'interface est déjà très chargée, inutile d'en rajouter de partout.

Ca doit ressembler à ça : https://www.dropbox.com/s/3gn5b2y1gyi4wyu/Capture%20d%27%C3%A9cran%202014-09-25%2018.26.10.png?dl=0
