### PR TITLE
Règle l'accès à un article non publié (404 aulieu de 500)

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -129,6 +129,10 @@ def view_online(request, article_pk, article_slug):
     """Show the given article if exists and is visible."""
     article = get_object_or_404(Article, pk=article_pk)
 
+    # article is not online = 404
+    if not article.on_line():
+        raise Http404
+
     # Load the article.
     article_version = article.load_json_for_public()
     txt = open(os.path.join(article.get_path(),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1518 |

Cette PR corrige l'accès improbable à une version en ligne d'un article qui n'est pas encore publié.
Ainsi, une 404 est retourné à la place d'une 500.
### QA
- Créer un article mais ne le publiez pas.
- Récupérer le lien d'accès à l'article "offline"
- Coller ce lien dans le navigateur et virer le "/off" pour essayer d'accéder à la version en ligne
- Tadaaaaa une 404 arrive !
