### PR TITLE
Corrige le placement du bouton d'aide Markdown

### DIFF
--- a/assets/js/markdown-help.js
+++ b/assets/js/markdown-help.js
@@ -16,7 +16,7 @@
                         "<p>Les simples retours à la ligne ne sont pas pris en compte. Pour créer un nouveau paragraphe, pensez à <em>sauter une ligne</em> !</p>" +
                         "<pre><code>**gras** \n*italique* \n[texte de lien](url du lien) \n> citation \n+ liste a puces </code></pre>" +
                         "<a href=\"//zestedesavoir.com/tutoriels/221/rediger-sur-zds/\">Voir la documentation complète</a></div>" +
-                        "<a href=\"#open-markdown-help\" class=\"open-markdown-help btn btn-grey ico-after view\">"+
+                        "<a href=\"#open-markdown-help\" class=\"open-markdown-help btn btn-grey ico-after help\">"+
                             "<span class=\"close-markdown-help-text\">Masquer</span>" +
                             "<span class=\"open-markdown-help-text\">Afficher</span> l'aide Markdown" +
                         "</a>"

--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -2870,6 +2870,7 @@ form.topic-message {
         background: #EEE;
         padding: 15px;
         margin-bottom: 5px;
+        border-bottom: 1px solid #CCC;
 
         pre {
             margin: 0;
@@ -2880,6 +2881,14 @@ form.topic-message {
         }
     }
     .show-markdown-help + .open-markdown-help {
+        margin-top: -5px;
+        padding-top: 5px;
+        line-height: 35px;
+
+        &:after {
+            margin-top: 15px !important;
+        }
+
         .close-markdown-help-text {
             display: inline;
         }

--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -2844,6 +2844,7 @@ form.topic-message {
    ============== */
 .markdown-help {
     min-height: 50px;
+    overflow: hidden;
 
     .open-markdown-help {
         float: none !important;

--- a/assets/scss/_mobile.scss
+++ b/assets/scss/_mobile.scss
@@ -142,7 +142,6 @@
             .open-markdown-help {
                 position: relative;
                 width: 100%;
-                margin-top: -10px;
                 margin-left: -10px !important;
                 padding-left: 40px;
 

--- a/assets/scss/_mobile.scss
+++ b/assets/scss/_mobile.scss
@@ -107,8 +107,8 @@
         }
         .message-submit {
             display: block !important;
-            width: calc(100% - 16px);
-            margin: 0 8px !important;
+            width: 100%;
+            margin: 0;
 
             button {
                 float: right;
@@ -130,8 +130,30 @@
             left: 0;
             bottom: 0;
             float: none;
-            margin-bottom: 5px;
             margin-left: 0 !important;
+        }
+    }
+    .topic-message {
+        .markdown-help {
+            .markdown-help-more {
+                margin-bottom: 0;
+            }
+
+            .open-markdown-help {
+                position: relative;
+                width: 100%;
+                margin-top: -10px;
+                margin-left: -10px !important;
+                padding-left: 40px;
+
+                &:after {
+                    margin-left: 15px;
+                }
+            }
+
+            .show-markdown-help + .open-markdown-help {
+                margin-top: 0;
+            }
         }
     }
 }


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1557 |

**QA** : Vérifiez que le bouton "Afficher l'aide Markdown" s'affiche correctement et ne cache aucun bouton, sur mobile et sur ordinateur.
