### PR TITLE
Ajout de controle sur les champs d'imports

### DIFF
--- a/zds/tutorial/forms.py
+++ b/zds/tutorial/forms.py
@@ -301,7 +301,7 @@ class ImportForm(forms.Form):
     def clean(self):
         cleaned_data = super(ImportForm, self).clean()
 
-        # Check that the password and it's confirmation match
+        # Check that the files extensions are correct
         tuto = cleaned_data.get('file')
         images = cleaned_data.get('images')
 

--- a/zds/tutorial/forms.py
+++ b/zds/tutorial/forms.py
@@ -279,7 +279,7 @@ class ImportForm(forms.Form):
 
     file = forms.FileField(
         label='Sélectionnez le tutoriel à importer',
-        required=False
+        required=True
     )
     images = forms.FileField(
         label='Fichier zip contenant les images du tutoriel',
@@ -297,6 +297,27 @@ class ImportForm(forms.Form):
             Submit('import-tuto', 'Importer le .tuto'),
         )
         super(ImportForm, self).__init__(*args, **kwargs)
+
+    def clean(self):
+        cleaned_data = super(ImportForm, self).clean()
+
+        # Check that the password and it's confirmation match
+        tuto = cleaned_data.get('file')
+        images = cleaned_data.get('images')
+
+        if tuto is not None:
+            ext = tuto.name.split(".")[-1]
+            if ext != "tuto":
+                del cleaned_data['file']
+                msg = u'Le fichier doit être au format .tuto'
+                self._errors['file'] = self.error_class([msg])
+
+        if images is not None:
+            ext = images.name.split(".")[-1]
+            if ext != "zip":
+                del cleaned_data['images']
+                msg = u'Le fichier doit être au format .zip'
+                self._errors['images'] = self.error_class([msg])
 
 
 class ImportArchiveForm(forms.Form):

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2560,18 +2560,13 @@ def import_tuto(request):
         # for import tuto
         if "import-tuto" in request.POST:
             form = ImportForm(request.POST, request.FILES)
-            form_archive = ImportArchiveForm(user=request.user)
-            if "file" in request.FILES:
-                filename = str(request.FILES["file"])
-                ext = filename.split(".")[-1]
-                if ext == "tuto":
-                    import_content(request, request.FILES["file"],
-                                   request.FILES["images"], "")
-                else:
-                    raise Http404
-            return redirect(reverse("zds.member.views.tutorials"))
+            if form.is_valid():
+                import_content(request, request.FILES["file"], request.FILES["images"], "")
+                return redirect(reverse("zds.member.views.tutorials"))
+            else:
+                form_archive = ImportArchiveForm(user=request.user)
+
         elif "import-archive" in request.POST:
-            form = ImportForm()
             form_archive = ImportArchiveForm(request.user, request.POST, request.FILES)
             if form_archive.is_valid():
                 (check, reason) = import_archive(request)
@@ -2581,9 +2576,8 @@ def import_tuto(request):
                     messages.success(request, reason)
                     return redirect(reverse("zds.member.views.tutorials"))
             else:
-                return render_template("tutorial/tutorial/import.html",
-                                       {"form": form,
-                                        "form_archive": form_archive})
+                form = ImportForm()
+
     else:
         form = ImportForm()
         form_archive = ImportArchiveForm(user=request.user)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1249 |

Ce fix vient corriger un problème sur le formulaire d'import des archives .tuto . Il rajoute ainsi des controles sur le champ pour vérifier que l'on envoi bien un .tuto et un .zip (ce dernier est facultatif).
### QA
- Vérifier que l'on peut toujours bien importer des .tuto (deux sont présents dans les fixtures)
- Vérifier les cas d'échec (.tuto absent ou mauvais format dans un des champs)
- Confirmer qu'aucun impact n'a lien sur l'import d'archive (le formulaire du dessus)
