### PR TITLE
Rends anonyme et externe moins bavard

### DIFF
--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -193,6 +193,15 @@ def details(request, user_name):
     except SiteProfileNotAvailable:
         raise Http404
 
+    if usr.username == settings.ANONYMOUS_USER or \
+       usr.username == settings.EXTERNAL_USER:
+        form = OldTutoForm(profile)
+        return render_template("member/profile.html", {
+            "usr": usr,
+            "profile": profile,
+            "form": form,
+        })
+
     # refresh moderation chart
 
     dot_chart = pygal.Dot(x_label_rotation=30)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1541 |

Ce fix a pour but de rendre les bots "Auteur externe" et "Anonyme" moins bavard en enlevant leurs statistiques de profil.
### QA
- Vérifier que ces deux utilisateurs n'ont plus d'infos comme précisé dans le ticket GH
- Vérifier que les autres utilisateurs fonctionnent toujours correctement
