### PR TITLE
Karma d'un user

### DIFF
--- a/doc/sphinx/source/member/member.rst
+++ b/doc/sphinx/source/member/member.rst
@@ -117,3 +117,12 @@ Enfin, le dernier point concerne simplement l'activation du compte (normalement 
 
 Elle est géré par le formulaire `PromoteMemberForm` présent dans le fichier `zds/member/forms.py`.
 Elle est ensuite visible via le template `member/settings/promote.html` qui peut-être accédé en tant que super-utilisateur via le profil de n'importe quel membre.
+
+L'interface de karma
+--------------------
+
+Pour pouvoir communiquer entre modérateur, il est utile d'avoir un outil de suivi sur les membres. Ce dernier prend forme via la gestion du "karma" d'un membre. Le karma est une valeur numérique pouvant aller de -100 à +100. Cette valeur peut-être modifié via l'ajout de bonus/malus par les modérateurs. Chaque modification du karma doit s'accompagner d'un commentaire, mais un commentaire n'entraine pas forcément une modification du karma (0 point de bonus/malus).
+
+Cet outil à deux rôles. Permettre d'identifier les membres *perturbateurs* mais aussi les membres *moteurs* qui pourrait faire l'objet d'un article ou d'une mise en avant de leurs projets.
+
+Pour modifier le karma d'un membre, il faut donc être modérateur sur le site. Sur la fiche profil d'un membre apparait alors un formulaire pour ajouter un bonus/malus et une liste des modifications précédentes montrant l'impact (+/-), le message, l'auteur du bonus/malus et la date d'effet de ce dernier.

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -72,6 +72,22 @@
             {% endif %}
         </ul>
 
+        {% if perms.member.change_profile %}
+            <div>
+                Remarques sur cette utilisateur ({{ profile.karma }}) :
+                <ul>
+                {% if karmanotes.count > 0 %}
+                    {% for note in karmanotes %}
+                        <li><strong>{{ note.value }}</strong> {{ note.create_at|format_date:True }} par {{ note.staff.username }} : {{ note.comment }}</li>
+                    {% endfor %}
+                {% else %}
+                    <li>Cet utilisateur n'a reçu aucune remarque</li>
+                {% endif %}
+                </ul>
+                Ajouter une remarque :
+                {% crispy karmaform %}
+            </div>
+        {% endif %}
 
         {% if profile.sign %}
             <h2 id="signature">Signature</h2>

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -84,8 +84,10 @@
                     <li>Cet utilisateur n'a reçu aucune remarque</li>
                 {% endif %}
                 </ul>
-                Ajouter une remarque :
-                {% crispy karmaform %}
+                <a href="#karmatiser-modal" class="open-modal">Ajouter une remarque</a>
+                <div id="karmatiser-modal" class="modal modal-big">
+                    {% crispy karmaform %}
+                </div>
             </div>
         {% endif %}
 

--- a/templates/misc/message_user.html
+++ b/templates/misc/message_user.html
@@ -10,15 +10,18 @@
 
         {% include 'misc/badge.part.html' %}
 
-        {% if perms.forum.change_post %}
-            <div class="user-metadata">
-                {% if profile.karma < 0 %}
-                    <a href="{{ member.get_absolute_url }}" class="user-karma negative">{{ profile.karma }}</a>
-                {% else %}
-                    <a href="{{ member.get_absolute_url }}" class="user-karma">{{ profile.karma }}</a>
-                {% endif %}
-                <a href="{{ member.get_absolute_url }}">IPs</a>
-            </div>
-        {% endif %}
+        {% comment %}
+            {# TODO : properly display metadata (karma) #}
+            {% if perms.forum.change_post %}
+                <div class="user-metadata">
+                    {% if profile.karma < 0 %}
+                        <a href="{{ member.get_absolute_url }}" class="user-karma negative">{{ profile.karma }}</a>
+                    {% else %}
+                        <a href="{{ member.get_absolute_url }}" class="user-karma">{{ profile.karma }}</a>
+                    {% endif %}
+                    <a href="{{ member.get_absolute_url }}">IPs</a>
+                </div>
+            {% endif %}
+        {% endcomment %}
     {% endwith %}
 </div>

--- a/templates/misc/message_user.html
+++ b/templates/misc/message_user.html
@@ -7,17 +7,18 @@
         <a href="{{ member.get_absolute_url }}" class="avatar-link">
             <img src="{{ profile.get_avatar_url }}" alt="" class="avatar">
         </a>
-        
+
         {% include 'misc/badge.part.html' %}
 
-        {# TODO : ajouter les metadatas #}
-        {% comment %}
-            {% if not hide_metadata and perms.forum.change_post %}
-                <div class="user-metadata">
-                    <a href="#" class="user-karma negative">-X</a>
-                    <a href="#">IPs</a>
-                </div>
-            {% endif %}
-        {% endcomment %}
+        {% if perms.forum.change_post %}
+            <div class="user-metadata">
+                {% if profile.karma < 0 %}
+                    <a href="{{ member.get_absolute_url }}" class="user-karma negative">{{ profile.karma }}</a>
+                {% else %}
+                    <a href="{{ member.get_absolute_url }}" class="user-karma">{{ profile.karma }}</a>
+                {% endif %}
+                <a href="{{ member.get_absolute_url }}">IPs</a>
+            </div>
+        {% endif %}
     {% endwith %}
 </div>

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -603,12 +603,14 @@ class KarmaForm(forms.Form):
             attrs={
                 'placeholder': 'Commentaire sur le comportement de ce membre'
             }),
+        required=True,
     )
 
     points = forms.IntegerField(
         max_value=100,
         min_value=-100,
         initial=0,
+        required=False,
     )
 
     def __init__(self, profile, *args, **kwargs):

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -13,6 +13,7 @@ from crispy_forms.layout import HTML, Layout, \
     Submit, Field, ButtonHolder, Hidden
 from zds.member.models import Profile, listing, KarmaNote
 from zds.settings import SITE_ROOT
+from zds.utils.forms import CommonLayoutModalText
 
 # Max password length for the user.
 # Unlike other fields, this is not the length of DB field
@@ -618,9 +619,9 @@ class KarmaForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_action = reverse('zds.member.views.modify_karma')
         self.helper.form_method = 'post'
-        self.helper.form_class = 'content-wrapper'
 
         self.helper.layout = Layout(
+            CommonLayoutModalText(),
             Field('warning'),
             Field('points'),
             Hidden('profile_pk', '{{ profile.pk }}'),

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -11,7 +11,7 @@ from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Layout, \
     Submit, Field, ButtonHolder, Hidden
-from zds.member.models import Profile, listing
+from zds.member.models import Profile, listing, KarmaNote
 from zds.settings import SITE_ROOT
 
 # Max password length for the user.
@@ -593,4 +593,36 @@ class PromoteMemberForm(forms.Form):
             Field('superuser'),
             Field('activation'),
             StrictButton('Valider', type='submit'),
+        )
+
+
+class KarmaForm(forms.Form):
+    warning = forms.CharField(
+        max_length=KarmaNote._meta.get_field('comment').max_length,
+        widget=forms.TextInput(
+            attrs={
+                'placeholder': 'Commentaire sur le comportement de ce membre'
+            }),
+    )
+
+    points = forms.IntegerField(
+        max_value=100,
+        min_value=-100,
+        initial=0,
+    )
+
+    def __init__(self, profile, *args, **kwargs):
+        super(KarmaForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_action = reverse('zds.member.views.modify_karma')
+        self.helper.form_method = 'post'
+        self.helper.form_class = 'content-wrapper'
+
+        self.helper.layout = Layout(
+            Field('warning'),
+            Field('points'),
+            Hidden('profile_pk', '{{ profile.pk }}'),
+            ButtonHolder(
+                StrictButton('Valider', type='submit'),
+            ),
         )

--- a/zds/member/migrations/0009_auto__add_karmanote.py
+++ b/zds/member/migrations/0009_auto__add_karmanote.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'KarmaNote'
+        db.create_table(u'member_karmanote', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(related_name='karmanote_user', to=orm['auth.User'])),
+            ('staff', self.gf('django.db.models.fields.related.ForeignKey')(related_name='karmanote_staff', to=orm['auth.User'])),
+            ('comment', self.gf('django.db.models.fields.CharField')(max_length=150)),
+            ('value', self.gf('django.db.models.fields.IntegerField')()),
+            ('create_at', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+        ))
+        db.send_create_signal(u'member', ['KarmaNote'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'KarmaNote'
+        db.delete_table(u'member_karmanote')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'member.ban': {
+            'Meta': {'object_name': 'Ban'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'moderator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'bans'", 'to': u"orm['auth.User']"}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '80', 'db_index': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'member.karmanote': {
+            'Meta': {'object_name': 'KarmaNote'},
+            'comment': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
+            'create_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'staff': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'karmanote_staff'", 'to': u"orm['auth.User']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'karmanote_user'", 'to': u"orm['auth.User']"}),
+            'value': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'member.profile': {
+            'Meta': {'object_name': 'Profile'},
+            'avatar_url': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'biography': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'can_read': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'can_write': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'email_for_answer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'end_ban_read': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'end_ban_write': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'hover_or_click': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'karma': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'last_ip_address': ('django.db.models.fields.CharField', [], {'max_length': '39', 'null': 'True', 'blank': 'True'}),
+            'last_visit': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'sdz_tutorial': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'show_email': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_sign': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'sign': ('django.db.models.fields.TextField', [], {'max_length': '250', 'blank': 'True'}),
+            'site': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'profile'", 'unique': 'True', 'to': u"orm['auth.User']"})
+        },
+        u'member.tokenforgotpassword': {
+            'Meta': {'object_name': 'TokenForgotPassword'},
+            'date_end': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'member.tokenregister': {
+            'Meta': {'object_name': 'TokenRegister'},
+            'date_end': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['member']

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -285,6 +285,19 @@ class Ban(models.Model):
         null=True, db_index=True)
 
 
+class KarmaNote(models.Model):
+
+    class Meta:
+        verbose_name = 'Note de karma'
+        verbose_name_plural = 'Notes de karma'
+
+    user = models.ForeignKey(User, related_name='karmanote_user', db_index=True)
+    staff = models.ForeignKey(User, related_name='karmanote_staff', db_index=True)
+    comment = models.CharField('Commentaire', max_length=150)
+    value = models.IntegerField('Valeur')
+    create_at = models.DateTimeField('Date d\'ajout', auto_now_add=True)
+
+
 def logout_user(username):
     now = datetime.now()
     request = HttpRequest()

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -4,7 +4,8 @@ from django.test import TestCase
 from zds.member.factories import ProfileFactory
 from zds.member.forms import LoginForm, RegisterForm, \
     MiniProfileForm, ProfileForm, ChangeUserForm, \
-    ChangePasswordForm, ForgotPasswordForm, NewPasswordForm
+    ChangePasswordForm, ForgotPasswordForm, NewPasswordForm, \
+    KarmaForm
 
 stringof77chars = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789-----"
 stringof129chars = u'http://www.01234567890123456789123456789' \
@@ -497,3 +498,35 @@ class NewPasswordFormTest(TestCase):
         }
         form = NewPasswordForm(data=data, identifier=self.user1.user.username)
         self.assertFalse(form.is_valid())
+
+
+class KarmaFormTest(TestCase):
+    """ Check the form to impact the karma of a user """
+
+    def setUp(self):
+        self.user = ProfileFactory()
+
+    def test_valid_karma_form(self):
+        data = {
+            'warning': "bad user is bad !",
+            'points': "-50"
+        }
+        form = KarmaForm(data=data, profile=self.user)
+        self.assertTrue(form.is_valid())
+
+    def test_missing_warning_karma_form(self):
+        data = {
+            'warning': "",
+            'points': "-50"
+        }
+        form = KarmaForm(data=data, profile=self.user)
+        self.assertFalse(form.is_valid())
+
+    def test_missing_points_karma_form(self):
+        data = {
+            'warning': "bad user is bad !",
+            'points': ""
+        }
+        form = KarmaForm(data=data, profile=self.user)
+        # should be fine as points is not required=True
+        self.assertTrue(form.is_valid())

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -14,7 +14,7 @@ from zds.settings import SITE_ROOT
 from zds.forum.models import TopicFollowed
 from zds.member.factories import ProfileFactory, StaffProfileFactory, NonAsciiProfileFactory, UserFactory
 from zds.mp.factories import PrivateTopicFactory, PrivatePostFactory
-from zds.member.models import Profile
+from zds.member.models import Profile, KarmaNote
 from zds.mp.models import PrivatePost, PrivateTopic
 from zds.member.models import TokenRegister, Ban
 from zds.tutorial.factories import MiniTutorialFactory
@@ -671,6 +671,67 @@ class MemberTests(TestCase):
             {}, follow=False)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(len(result.context['members']), 2)
+
+    def test_modify_user_karma(self):
+        tester = ProfileFactory()
+        staff = StaffProfileFactory()
+
+        # login as user
+        result = self.client.post(
+            reverse('zds.member.views.login_view'),
+            {'username': tester.user.username,
+             'password': 'hostel77'},
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # check that user can't use this feature
+        result = self.client.post(reverse('zds.member.views.modify_karma'), follow=False)
+        self.assertEqual(result.status_code, 403)
+
+        # login as staff
+        result = self.client.post(
+            reverse('zds.member.views.login_view'),
+            {'username': staff.user.username,
+             'password': 'hostel77'},
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # try to give a few bad points to the tester
+        result = self.client.post(
+            reverse('zds.member.views.modify_karma'),
+            {'profile_pk': tester.pk,
+             'warning': 'Bad tester is bad !',
+             'points': '-50'},
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        tester = Profile.objects.get(pk=tester.pk)
+        self.assertEqual(tester.karma, -50)
+        self.assertEqual(KarmaNote.objects.filter(user=tester.user).count(), 1)
+
+        # Now give a few good points
+        result = self.client.post(
+            reverse('zds.member.views.modify_karma'),
+            {'profile_pk': tester.pk,
+             'warning': 'Good tester is good !',
+             'points': '10'},
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        tester = Profile.objects.get(pk=tester.pk)
+        self.assertEqual(tester.karma, -40)
+        self.assertEqual(KarmaNote.objects.filter(user=tester.user).count(), 2)
+
+        # Now access some unknow user
+        result = self.client.post(
+            reverse('zds.member.views.modify_karma'),
+            {'profile_pk': -1,
+             'warning': 'Good tester is good !',
+             'points': '10'},
+            follow=False)
+        self.assertEqual(result.status_code, 404)
+
+        # Now access without post
+        result = self.client.get(reverse('zds.member.views.modify_karma'), follow=False)
+        self.assertEqual(result.status_code, 404)
 
     def tearDown(self):
         Profile.objects.all().delete()

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -729,6 +729,29 @@ class MemberTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 404)
 
+        # Now give unknow point
+        result = self.client.post(
+            reverse('zds.member.views.modify_karma'),
+            {'profile_pk': tester.pk,
+             'warning': 'Good tester is good !',
+             'points': ''},
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        tester = Profile.objects.get(pk=tester.pk)
+        self.assertEqual(tester.karma, -40)
+        self.assertEqual(KarmaNote.objects.filter(user=tester.user).count(), 3)
+
+        # Now give no point at all
+        result = self.client.post(
+            reverse('zds.member.views.modify_karma'),
+            {'profile_pk': tester.pk,
+             'warning': 'Good tester is good !'},
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        tester = Profile.objects.get(pk=tester.pk)
+        self.assertEqual(tester.karma, -40)
+        self.assertEqual(KarmaNote.objects.filter(user=tester.user).count(), 4)
+
         # Now access without post
         result = self.client.get(reverse('zds.member.views.modify_karma'), follow=False)
         self.assertEqual(result.status_code, 404)

--- a/zds/member/urls.py
+++ b/zds/member/urls.py
@@ -17,6 +17,8 @@ urlpatterns = patterns('',
                            'zds.member.views.add_oldtuto'),
                        url(r'^profil/delier/$',
                            'zds.member.views.remove_oldtuto'),
+                       url(r'^profil/karmatiser/$',
+                           'zds.member.views.modify_karma'),
 
                        url(r'^tutoriels/$',
                            'zds.member.views.tutorials'),

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1106,7 +1106,10 @@ def modify_karma(request):
         note.user = profile.user
         note.staff = request.user
         note.comment = request.POST["warning"]
-        note.value = int(request.POST["points"])
+        try:
+            note.value = int(request.POST["points"])
+        except:
+            note.value = 0
 
         note.save()
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1095,6 +1095,9 @@ def member_from_ip(request, ip):
 def modify_karma(request):
     """ Add a Karma note to the user profile """
 
+    if not request.user.has_perm("member.change_profile"):
+        raise PermissionDenied
+
     if request.method == "POST":
         profile_pk = request.POST["profile_pk"]
         profile = get_object_or_404(Profile, pk=profile_pk)

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -241,7 +241,7 @@ def details(request, user_name):
         .order_by("-pubdate").all()[:5]
 
     karmaform = KarmaForm(profile)
-    karmanotes = KarmaNote.objects.filter(user=usr)
+    karmanotes = KarmaNote.objects.filter(user=usr).order_by('-create_at')
     form = OldTutoForm(profile)
     oldtutos = []
     if profile.sdz_tutorial:


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | **oui** |
| Tickets concernés | #1444, #1720 |

Cette PR permet l'ajout du karma pour les utilisateurs. Le staff peut ainsi mettre des avertissements discrets visible uniquement par ces derniers afin d'avoir un certain historique positif/négatif sur certains membres (troll, bons samaritain etc...).
### Voici ce qui est fait :
- Ajout d'un model "KarmaNote" permet de modéliser une remarque sur une personne.
  - une clé étrangère vers l'utilisateur
  - une clé étrangère vers le staff qui signale
  - la date de la remarque
  - le commentaire de la remarque
  - le nombre de points de karma impacté
- Dénormalisation de la variable "karma" du modèle "profile". A chaque ajout de remarque, cette variable se voit ajusté selon la valeur de la remarque (positif ou négatif)
- Ajout d'un formulaire pour ajouter des remarques à un user et influencer son karma
- Ajout d'une liste des remarques liées à cet utilisateur
- Ajout du karma dans le template

Voici une petite capture d'écran du résultat (moche je sais). Si vous voulez tester, n'oubliez pas de faire un `migrate` car le modèle utilisateur a évolué.

![capture du 2014-10-23 18 19 44](https://cloud.githubusercontent.com/assets/761168/4756819/83254aec-5ad0-11e4-8b95-79f82b26a5c0.png)

![capture du 2014-10-03 23 55 56](https://cloud.githubusercontent.com/assets/761168/4513151/3e6a12c0-4b49-11e4-8f7b-ad913bbdafc3.png)
### QA
- Via un admin amusez vous à bidouiller le karma d'un utilisateur
- Via un utilisateur normal assurez vous que le karma n'est pas visible
- Idem dans les sujets du forum
