### PR TITLE
Retire le mot "Licence" en trop

### DIFF
--- a/templates/tutorial/tutorial/view_online.html
+++ b/templates/tutorial/tutorial/view_online.html
@@ -51,7 +51,7 @@
 
     {% if tutorial.licence %}
         <span class="license" itemprop="license">
-            Licence {{ tutorial.licence }}
+            {{ tutorial.licence }}
         </span>
     {% endif %}
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1560 |

**QA** : Aller sur un tutoriel en ligne et vérifier que la licence est affichée proprement et non avec le mot "Licence" doublé ou encore "Licence Tous droits réservés".
