### PR TITLE
Masque la zone de téléchargement si l'archive n'est pas téléchargeable

### DIFF
--- a/templates/tutorial/base.html
+++ b/templates/tutorial/base.html
@@ -54,7 +54,7 @@
 
         {% block sidebar_blocks %}{% endblock %}
 
-        {% if tutorial %}
+        {% if tutorial.on_line or tutorial.in_beta and user in tutorial.authors.all or perms.tutorial.change_tutorial %}
             <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Télécharger">
                 <h3>Télécharger</h3>
                 <ul>
@@ -69,25 +69,25 @@
                             {% endif %}
                         {% endif %}
                         {% if tutorial.have_html %}
-                        <li>
-                            <a href="{% url "zds.tutorial.views.download_html" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
-                                HTML
-                            </a>
-                        </li>
+                            <li>
+                                <a href="{% url "zds.tutorial.views.download_html" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
+                                    HTML
+                                </a>
+                            </li>
                         {% endif %}
                         {% if tutorial.have_pdf %}
-                        <li>
-                            <a href="{% url "zds.tutorial.views.download_pdf" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
-                                PDF
-                            </a>
-                        </li>
+                            <li>
+                                <a href="{% url "zds.tutorial.views.download_pdf" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
+                                    PDF
+                                </a>
+                            </li>
                         {% endif %}
                         {% if tutorial.have_epub %}
-                        <li>
-                            <a href="{% url "zds.tutorial.views.download_epub" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
-                                EPUB
-                            </a>
-                        </li>
+                            <li>
+                                <a href="{% url "zds.tutorial.views.download_epub" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
+                                    EPUB
+                                </a>
+                            </li>
                         {% endif %}
                     {% endif %}
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1569 |
# QA
## Avec un membre A, _non staff_
- Créer un tutoriel
- Mettre ce tutoriel **en bêta**
- Vérifier que l'**on peut** télécharger l'archive du tutoriel dans la zone "Télécharger" de la sidebar
- Créer un autre tutoriel
- Le mettre **en ligne**
- Vérifier que l'**on peut** télécharger dans les différents formats, dont l'archive
## Avec un membre B, _non staff_
- Aller sur le tutoriel **en bêta**
- Vérifier que l'on _ne peut pas_ télécharger l'archive : il ne doit pas y avoir de la zone "Télécharger dans la sidebar
- Aller sur le tutoriel **en ligne**
- Vérifier que l'archive et autres formats **sont bien disponibles** (téléchargez pour tester et vérifier que ça renvoie bien un fichier et non une 403/404)
## Avec un membre C, _staff_
- Aller sur le tutoriel **en bêta**
- Vérifier que l'**on peut** télécharger l'archive
- Aller sur le tutoriel **en ligne**
- Vérifier que l'**on peut** télécharger les différents formats, dont "Markdown"
## En étant déconnecté, en tant qu'invité
- Aller sur le tutoriel **en ligne**
- Vérifier que les différents formats sont disponibles, dont archive
