### PR TITLE
On ne peut plus s'envoyer de MP

### DIFF
--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -78,7 +78,7 @@ class PrivateTopicForm(forms.Form):
                 if User.objects.filter(username__exact=receiver.strip()).count() == 0 and receiver.strip() != '':
                     self._errors['participants'] = self.error_class(
                         [u'Un des participants saisi est introuvable'])
-                elif User.objects.filter(username=receiver.strip()).count() > 0:
+                elif receiver.strip().lower() == self.username.lower():
                     self._errors['participants'] = self.error_class(
                         [u'Vous ne pouvez pas vous écrire à vous-même !'])
 

--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -78,7 +78,7 @@ class PrivateTopicForm(forms.Form):
                 if User.objects.filter(username__exact=receiver.strip()).count() == 0 and receiver.strip() != '':
                     self._errors['participants'] = self.error_class(
                         [u'Un des participants saisi est introuvable'])
-                elif receiver.strip() == self.username:
+                elif User.objects.filter(username=receiver.strip()).count() > 0:
                     self._errors['participants'] = self.error_class(
                         [u'Vous ne pouvez pas vous écrire à vous-même !'])
 

--- a/zds/mp/tests/tests_forms.py
+++ b/zds/mp/tests/tests_forms.py
@@ -15,6 +15,7 @@ class PrivateTopicFormTest(TestCase):
         self.staff1 = StaffFactory()
 
     def test_valid_topic_form(self):
+        """  Reference valid case """
         data = {
             'participants':
                 self.profile1.user.username
@@ -23,97 +24,103 @@ class PrivateTopicFormTest(TestCase):
             'subtitle': 'Test subtitle',
             'text': 'blabla'
         }
-
         form = PrivateTopicForm(self.profile2.user.username, data=data)
-
         self.assertTrue(form.is_valid())
 
     def test_invalid_topic_form_user_notexist(self):
-
+        """ Case when we write to non-existing member """
         data = {
-            'participants': self.profile1.user.username + ', toto, tata',
+            'participants': self.profile2.user.username + ', toto, tata',
             'title': 'Test title',
             'subtitle': 'Test subtitle',
             'text': 'blabla'
         }
-
         form = PrivateTopicForm(self.profile1.user.username, data=data)
-
         self.assertFalse(form.is_valid())
 
     def test_invalid_topic_form_no_participants(self):
-
+        """ Case when we write to no-one """
         data = {
             'title': 'Test title',
             'subtitle': 'Test subtitle',
             'text': 'blabla'
         }
-
-        form = PrivateTopicForm('', data=data)
-
+        form = PrivateTopicForm(self.profile1.user.username, data=data)
         self.assertFalse(form.is_valid())
 
     def test_invalid_topic_form_empty_participants(self):
-
+        """ Case when we write to an empty list (spaces) """
         data = {
             'participants': ' ',
             'title': 'Test title',
             'subtitle': 'Test subtitle',
             'text': 'blabla'
         }
-
-        form = PrivateTopicForm(' ', data=data)
-
+        form = PrivateTopicForm(self.profile1.user.username, data=data)
         self.assertFalse(form.is_valid())
 
     def test_invalid_topic_form_no_title(self):
-
+        """ Case when title is absent """
         data = {
-            'participants': self.profile1.user.username,
+            'participants': self.profile2.user.username,
             'subtitle': 'Test subtitle',
             'text': 'blabla'
         }
-
         form = PrivateTopicForm(self.profile1.user.username, data=data)
-
         self.assertFalse(form.is_valid())
 
     def test_invalid_topic_form_empty_title(self):
-
+        """ Case when title is spaces only """
         data = {
-            'participants': self.profile1.user.username,
+            'participants': self.profile2.user.username,
             'title': ' ',
             'subtitle': 'Test subtitle',
             'text': 'blabla'
         }
-
         form = PrivateTopicForm(self.profile1.user.username, data=data)
-
         self.assertFalse(form.is_valid())
 
     def test_invalid_topic_form_no_text(self):
-
+        """ Case when there is no text """
         data = {
-            'participants': self.profile1.user.username,
+            'participants': self.profile2.user.username,
             'title': 'Test title',
             'subtitle': 'Test subtitle',
         }
-
         form = PrivateTopicForm(self.profile1.user.username, data=data)
-
         self.assertFalse(form.is_valid())
 
     def test_invalid_topic_form_empty_text(self):
+        """ Case when there is no text (spaces) """
+        data = {
+            'participants': self.profile2.user.username,
+            'title': 'Test title',
+            'subtitle': 'Test subtitle',
+            'text': ' '
+        }
+        form = PrivateTopicForm(self.profile1.user.username, data=data)
+        self.assertFalse(form.is_valid())
 
+    def test_invalid_topic_form_self_message(self):
+        """ Case when the sender is in the receiver list """
         data = {
             'participants': self.profile1.user.username,
             'title': 'Test title',
             'subtitle': 'Test subtitle',
             'text': ' '
         }
-
         form = PrivateTopicForm(self.profile1.user.username, data=data)
+        self.assertFalse(form.is_valid())
 
+    def test_invalid_topic_form_self_message_2(self):
+        """ Same as above but with case difference"""
+        data = {
+            'participants': self.profile1.user.username.upper(),
+            'title': 'Test title',
+            'subtitle': 'Test subtitle',
+            'text': ' '
+        }
+        form = PrivateTopicForm(self.profile1.user.username, data=data)
         self.assertFalse(form.is_valid())
 
 
@@ -129,7 +136,6 @@ class PrivatePostFormTest(TestCase):
         }
 
         form = PrivatePostForm(self.topic, self.profile.user, data=data)
-
         self.assertTrue(form.is_valid())
 
     def test_invalid_form_post_empty_text(self):
@@ -138,10 +144,8 @@ class PrivatePostFormTest(TestCase):
         }
 
         form = PrivatePostForm(self.topic, self.profile.user, data=data)
-
         self.assertFalse(form.is_valid())
 
     def test_invalid_form_post_no_text(self):
         form = PrivatePostForm(self.topic, self.profile.user, data={})
-
         self.assertFalse(form.is_valid())


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1581 |

On ne peut plus s'envoyer de MP, quel que soit la casse de son pseudo ! La méthode de verification utilisée est la même que celle employé dans le formulaire de création de compte (vérification via la bdd).
### QA
- Il faut utiliser une base de donnée mysql impérativement.
- Vérifier qu'un utilisateur ne peut pas s'écrire à lui même, même en changeant la casse de son pseudo
