### PR TITLE
HotFix : correction de la balise spoiler trop prospective

### DIFF
--- a/assets/js/spoiler.js
+++ b/assets/js/spoiler.js
@@ -1,30 +1,19 @@
 /* ===== Zeste de Savoir ====================================================
    Toggle spoiler content
-   ---------------------------------
-   Author: Alex-D / Alexandre Demode
    ========================================================================== */
 
-(function(document, $, undefined){
+(function($){
     "use strict";
     
-    function buildSpoilers($elem){
-        $elem.each(function(){
-            $(this).before($("<a/>", {
-                text: "Afficher/Masquer le contenu masqué",
-                class: "spoiler-title ico-after view",
-                href: "#",
-                click: function(e){
-                    $(this).next(".spoiler").toggle();
-                    e.preventDefault();
-                }
-            }));
-        });
-    }
-
-    $(document).ready(function(){
-        buildSpoilers($("#content .spoiler"));
-        $("#content").on("DOMNodeInserted", ".spoiler", function(e){
-            buildSpoilers($(e.target));
-        });
+    $(".spoiler").each(function(){
+        $(this).before($("<a/>", {
+            "text": "Afficher/Masquer le contenu masqué",
+            "class": "spoiler-title ico-after view",
+            "href": "#",
+            "click": function(e){
+                $(this).next(".spoiler").toggle();
+                e.preventDefault();
+            }
+        }));
     });
-})(document, jQuery);
+})(jQuery);


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1587 |

Cette PR a pour objectif de corriger le bug qui s'évit depuis la MEP de la 1.1 qui fait planter n'importe quelle page si on insère une balise math dans une balise secrete.

**Note pour QA**
- Poster dans le forum le contenu suivant : 

```
Bonjour

[[secret]]
| Déroulez le secret ci-dessous pour voir le spoiler :
| [[secret]]
| | ... je me découvre une passion pour le nombre $\pi$ !
```

Et vérifier si la page est toujours accessible.
