### PR TITLE
Feature: Filtre des membres par IP

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -45,7 +45,7 @@
                 </li>
                 {% if perms.member.show_ip %}
                     <li>
-                        Dernière IP : {{ profile.last_ip_address }}
+                        Dernière IP : <a href="{% url "zds.member.views.member_from_ip" profile.last_ip_address %}">{{ profile.last_ip_address }}</a>
                     </li>
                     <li>
                         {{ profile.get_city }}
@@ -283,7 +283,7 @@
                             </a>
                         </li>
                     {% endif %}
-                    {% if profile.get_draft_tutos.count > 0 %}    
+                    {% if profile.get_draft_tutos.count > 0 %}
                         <li>
                             <a href="{% url "zds.member.views.tutorials" %}?type=draft">
                                 En rédaction

--- a/templates/member/settings/memberip.html
+++ b/templates/member/settings/memberip.html
@@ -1,0 +1,34 @@
+{% extends "member/base.html" %}
+
+
+
+{% block title %}
+    Membres par IP
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    <li>IP</li>
+{% endblock %}
+
+
+
+{% block headline %}
+    Membres par IP : <strong>{{ ip }}</strong>
+{% endblock %}
+
+
+
+{% block content %}
+    <p>
+        Liste des membres dont la dernière IP est {{ ip }}
+    </p>
+    <ul>
+        {% for member in members %}
+            <li>
+                {% include "misc/member_item.part.html" with avatar=True %}
+            </li>
+        {% endfor %}
+    </ul>
+{% endblock %}

--- a/templates/member/settings/memberip.html
+++ b/templates/member/settings/memberip.html
@@ -1,5 +1,5 @@
 {% extends "member/base.html" %}
-
+{% load date %}
 
 
 {% block title %}
@@ -27,7 +27,14 @@
     <ul>
         {% for member in members %}
             <li>
-                {% include "misc/member_item.part.html" with avatar=True %}
+                <a href="{{ member.get_absolute_url }}"
+                    class="member-item"
+                    itemscope
+                    itemtype="http://schema.org/Person"
+                >{% spaceless %}
+                <img src="{{ member.get_avatar_url }}" alt="" class="avatar" itemprop="image">
+                <span itemprop="name">{{ member.user.username }}</span>
+            {% endspaceless %}</a> <span class="info">le {{ member.last_visit|format_date:True }}</span>
             </li>
         {% endfor %}
     </ul>

--- a/zds/member/urls.py
+++ b/zds/member/urls.py
@@ -35,6 +35,8 @@ urlpatterns = patterns('',
                            'zds.member.views.settings_user'),
                        url(r'^profil/promouvoir/(?P<user_pk>\d+)/$',
                            'zds.member.views.settings_promote'),
+                       url(r'^profil/multi/(?P<ip>.+)/$',
+                           'zds.member.views.member_from_ip'),
 
                        url(r'^connexion/$',
                            'zds.member.views.login_view'),

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1077,7 +1077,7 @@ def settings_promote(request, user_pk):
 def member_from_ip(request, ip):
     """ Get list of user connected from a particular ip """
 
-    members = User.objects.filter(profile__last_ip_address=ip)
+    members = Profile.objects.filter(last_ip_address=ip).order_by('-last_visit')
     return render_template('member/settings/memberip.html', {
         "members": members,
         "ip": ip

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1071,3 +1071,14 @@ def settings_promote(request, user_pk):
         "profile": profile,
         "form": form
     })
+
+
+@login_required
+def member_from_ip(request, ip):
+    """ Get list of user connected from a particular ip """
+
+    members = User.objects.filter(profile__last_ip_address=ip)
+    return render_template('member/settings/memberip.html', {
+        "members": members,
+        "ip": ip
+    })

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1077,6 +1077,9 @@ def settings_promote(request, user_pk):
 def member_from_ip(request, ip):
     """ Get list of user connected from a particular ip """
 
+    if not request.user.has_perm("member.change_profile"):
+        raise PermissionDenied
+
     members = Profile.objects.filter(last_ip_address=ip).order_by('-last_visit')
     return render_template('member/settings/memberip.html', {
         "members": members,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1614 |

Cette PR est pour aider les modos. Elle propose un filtre par IP afin de repérer les multis facilement.
### QA
- Connectez vous avec differents comptes
- Puis connectez vous avec admin
- Dans le profil de n'importe qui, cliquez sur l'IP qui s'affiche (127.0.0.1 normalement)
- Constater que le filtre marche
