### PR TITLE
[ZEP 3]typo dans le nom d'une constante

### DIFF
--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3528,7 +3528,7 @@ def help_tutorial(request):
                                 .all()
 
     # Paginator
-    paginator = Paginator(tutos, settings.TOPICS_PER_PAGE)
+    paginator = Paginator(tutos, settings.ZDS_APP['forum']['topics_per_page'])
     page = request.GET.get('page')
 
     try:


### PR DESCRIPTION
L'échec de travis est dû à une constante mal nommée.
