### PR TITLE
Cohérence lors de la màj de la version locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Elles sont reportées essentiellement dans le [bugtraker](https://github.com/zes
 Après avoir mis à jour votre dépot, vous devez executer les commandes suivantes (depuis la racine de votre projet) pour mettre à jour les dépendances.
 
 ```
-python manage.py migrate
 pip install --upgrade -r requirements.txt
+python manage.py migrate
 ```
 
 ### Données de test


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | x |

C'est beaucoup plus cohérent d'installer en premier lieu les dépendances PUIS lancer les migrations. Si jamais une dépendance à des migrations elles ne seront pas faites.
## QA

Rien à faire ici.
