### PR TITLE
Corrige le chevauchement icône/titre

### DIFF
--- a/assets/scss/_mobile-tablet.scss
+++ b/assets/scss/_mobile-tablet.scss
@@ -601,7 +601,7 @@
         }
         .content-wrapper,
         .full-content-wrapper {
-            h1,
+            h1:not(.ico-after),
             h2,
             h3,
             .subtitle {


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1644 |

**QA** : Vérifier que le texte est bien à droite de l'icône et non par dessus (voir l'issue pour le détail du problème).
