### PR TITLE
Retire pip du cache Travis car invalide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ notifications:
 
 cache:
   - apt
-  - pip
 
 install:
   # APT Stuff


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #1652 |

Si Travis passe, c'est bon. [Validé par le checker de Travis](https://lint.travis-ci.org/) (copiez collez le fichier pour tester vous même si vous souhaitez vérifier).
