### PR TITLE
Hotfix réponse sur MP avec titre unicode

### DIFF
--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -582,6 +582,50 @@ class AnswerViewTest(TestCase):
         self.assertEqual(403, response.status_code)
         self.assertEqual(2, PrivatePost.objects.all().count())
 
+    def test_unicode_title_answer(self):
+        """To test unicode title."""
+
+        unicodeTopic = PrivateTopicFactory(author=self.profile1.user,
+                                           title=u'Title with accent àéè')
+        unicodeTopic.participants.add(self.profile2.user)
+        unicodePost = PrivatePostFactory(
+            privatetopic=unicodeTopic,
+            author=self.profile1.user,
+            position_in_topic=1)
+
+        response = self.client.post(
+            reverse('zds.mp.views.answer')
+            + '?sujet=' + str(unicodeTopic.pk),
+            {
+                'text': 'answer',
+                'last_post': unicodePost.pk
+            },
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_unicode_subtitle_answer(self):
+        """To test unicode subtitle."""
+
+        unicodeTopic = PrivateTopicFactory(author=self.profile1.user,
+                                           subtitle=u'Subtitle with accent àéè')
+        unicodeTopic.participants.add(self.profile2.user)
+        unicodePost = PrivatePostFactory(
+            privatetopic=unicodeTopic,
+            author=self.profile1.user,
+            position_in_topic=1)
+
+        response = self.client.post(
+            reverse('zds.mp.views.answer')
+            + '?sujet=' + str(unicodeTopic.pk),
+            {
+                'text': 'answer',
+                'last_post': unicodePost.pk
+            },
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+
 
 class EditPostViewTest(TestCase):
 

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -308,9 +308,9 @@ def answer(request):
                 g_topic.save()
 
                 # send email
-                subject = "{} - MP : {}".format(settings.ZDS_APP['site']['abbr'], g_topic.title)
-                from_email = "{} <{}>".format(settings.ZDS_APP['site']['litteral_name'],
-                                              settings.ZDS_APP['site']['email_noreply'])
+                subject = u"{} - MP : {}".format(settings.ZDS_APP['site']['abbr'], g_topic.title)
+                from_email = u"{} <{}>".format(settings.ZDS_APP['site']['litteral_name'],
+                                               settings.ZDS_APP['site']['email_noreply'])
                 parts = list(g_topic.participants.all())
                 parts.append(g_topic.author)
                 parts.remove(request.user)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1681 |

Règle un bug d'encodage avec les sujets de MP qui ont des accents. (+ TU)
### QA
- Créer un MP entre A et B (avec A comme auteur et B comme destinataire). **Le titre doit contenir un accent**.
- Répondre au MP avec B. Le MP doit être bien envoyé, plus d'erreur 500
