### PR TITLE
Hotfix resolution des alertes

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -1077,7 +1077,7 @@ def solve_alert(request):
     alert = get_object_or_404(Alert, pk=request.POST['alert_pk'])
     reaction = Reaction.objects.get(pk=alert.comment.id)
 
-    if request.POST["text"] != "":
+    if "text" in request.POST and request.POST["text"] != "":
         bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
         msg = (u'Bonjour {0},\n\nVous recevez ce message car vous avez '
                u'signalé le message de *{1}*, dans l\'article [{2}]({3}). '

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -307,8 +307,8 @@ def solve_alert(request):
     alert = get_object_or_404(Alert, pk=request.POST["alert_pk"])
     post = Post.objects.get(pk=alert.comment.id)
 
-    if request.POST["text"] != "":
-        bot = get_object_or_404(User, username=settings.BOT_ACCOUNT)
+    if "text" in request.POST and request.POST["text"] != "":
+        bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
         msg = \
             (u'Bonjour {0},'
              u'Vous recevez ce message car vous avez signalé le message de *{1}*, '

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3308,7 +3308,7 @@ def solve_alert(request):
     alert = get_object_or_404(Alert, pk=request.POST["alert_pk"])
     note = Note.objects.get(pk=alert.comment.id)
 
-    if request.POST["text"] != "":
+    if "text" in request.POST and request.POST["text"] != "":
         bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
         msg = \
             (u'Bonjour {0},'


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1677 |

Règle le souci de résolution des alertes du à un appel de mauvaise variable (+TU)
### QA
- Poster dans le fofo
- Signaler le message
- Résoudre le message (avec ET sans message de résolution)
- L'alerte doit disparaitre et un MP est envoyé si la résolution est faite avec message
- Idem pour tuto et articles (non couvert par TU car copier/coller de code)
