### PR TITLE
Rajout de « width: auto » pour corriger la bande blanche sur la home

### DIFF
--- a/assets/scss/_wide.scss
+++ b/assets/scss/_wide.scss
@@ -346,6 +346,7 @@
             
             blockquote {
                 margin: 0 0 0 300px;
+                width: auto;
             }
         }
 


### PR DESCRIPTION
|                Q | R |
| --- | --- |
| Nouvelle fonctionnalité ? | Non |
| Correctif de bug ? |  Oui      |
| Ticket(s) Concerné(s) ? | #1702 |

Cette PR corrige l'apparition du blanc sur le côté de la home.
## Pour la QA

Relancez un build du css avec `gulp build` et vérifier que le blanc n'apparaît pas/plus.
