### PR TITLE
 Fix #1724 : Versionner les fichiers statiques 

### DIFF
--- a/update.md
+++ b/update.md
@@ -40,3 +40,8 @@ THUMBNAIL_OPTIMIZE_COMMAND = {
 
 Actions à faire pour mettre en prod la version : v1.3
 =====================================================
+
+Issue #1341
+-----------
+
+Dans le `settings_prod.py` il vaut bien vérifier que `STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'` pour le versionnage des fichiers statiques. Plus d'informations sur la doc : https://docs.djangoproject.com/en/1.6/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.CachedStaticFilesStorage.

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -351,6 +351,10 @@ ZDS_APP = {
     }
 }
 
+# TODO : add this in the good way when #1707 w'll by merged
+
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
+
 # Load the production settings, overwrite the existing ones if needed
 try:
     from settings_prod import *

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -353,7 +353,8 @@ ZDS_APP = {
 
 # TODO : add this in the good way when #1707 w'll by merged
 
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
+if DEBUG:
+    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
 
 # Load the production settings, overwrite the existing ones if needed
 try:

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -353,7 +353,7 @@ ZDS_APP = {
 
 # TODO : add this in the good way when #1707 w'll by merged
 
-if DEBUG:
+if not DEBUG:
     STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
 
 # Load the production settings, overwrite the existing ones if needed


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1724 |
### QA

Mettre temporairement `DEBUG = False` (ça risque de casser temporairement 2-3 autres trucs) puis lancer un `python manage.py collectstatic`. Vérifier dans le code HTML d'une page si les fichiers sont bien générés.

Il faut mettre `DEBUG = False` car sinon le serveur de dev ne sert pas les fichiers de la même manière.
## NE PAS MERGER AVANT #1707 (MAIS LA QA PEUT ÊTRE FAITE)
