### PR TITLE
Fix #1638 : mauvaise redirection lors de certains téléchargements

### DIFF
--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -2295,6 +2295,14 @@ class BigTutorialTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 404)
 
+        # check if 404 when we add a char != '/' at the end of URL
+        result = self.client.get(
+            reverse('zds.tutorial.views.download') +
+            '?tutoriel={0}a'.format(
+                self.bigtuto.pk),
+            follow=False)
+        self.assertEqual(result.status_code, 404)
+
         # 2. online version :
         result = self.client.get(
             reverse('zds.tutorial.views.download') +

--- a/zds/tutorial/tests.py
+++ b/zds/tutorial/tests.py
@@ -2278,6 +2278,23 @@ class BigTutorialTests(TestCase):
         f = open(draft_zip_path, 'w')
         f.write(result.content)
         f.close()
+
+        # check if it's OK when we add a '/' at then end of URL
+        result = self.client.get(
+            reverse('zds.tutorial.views.download') +
+            '?tutoriel={0}/'.format(
+                self.bigtuto.pk),
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+
+        # check if 404 when we add a to many chars at then end of URL
+        result = self.client.get(
+            reverse('zds.tutorial.views.download') +
+            '?tutoriel={0}/foo'.format(
+                self.bigtuto.pk),
+            follow=False)
+        self.assertEqual(result.status_code, 404)
+
         # 2. online version :
         result = self.client.get(
             reverse('zds.tutorial.views.download') +

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2908,7 +2908,12 @@ def download(request):
     except ValueError:
         # if not, check if it's int + '/' (nginx bug ?)
         try:
-            tutorial = get_object_or_404(Tutorial, pk=request.GET['tutoriel'][:-1])
+            # chek if "tutoriel" is not empty
+            tuto = request.GET['tutoriel']
+            if tuto != '' and tuto[-1:] == '/':
+                tutorial = get_object_or_404(Tutorial, pk=request.GET['tutoriel'][:-1])
+            else:
+                raise Http404
         except ValueError:
             raise Http404
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1638 |
### QA
- Télécharger un tuto
- Télécharger un tuto en rajoutant un '/' à la fin de l'adresse et vérifier que le tuto est bien téléchargé
- Télécharger un tuto en rajoutant plusieurs caractères à la fin de l'adresse et vérifier qu'on a bien une 404
### Mergé par erreur, je ré-ouvre une PR
