### PR TITLE
Fix #1731: Ajout de la possibilité de trier ses articles/tutoriels

### DIFF
--- a/templates/article/member/index.html
+++ b/templates/article/member/index.html
@@ -37,6 +37,13 @@
     {% elif request.GET.type == "draft" %}
         / Brouillons
     {% endif %}
+    {% if sort == "abc" %}
+        / Par ordre alphabétique
+    {% elif sort == "creation" %}
+        / Par date de création
+    {% elif sort == "modification" %}
+        / Par date de dernière modification
+    {% endif %}
 {% endblock %}
 
 
@@ -49,6 +56,13 @@
         / En validation
     {% elif request.GET.type == "draft" %}
         / Brouillons
+    {% endif %}
+    {% if sort == "abc" %}
+        / Par ordre alphabétique
+    {% elif sort == "creation" %}
+        / Par date de création
+    {% elif sort == "modification" %}
+        / Par date de dernière modification
     {% endif %}
 {% endblock %}
 
@@ -64,27 +78,47 @@
             <h3>Filtres</h3>
             <ul>
                 <li>
-                    <a href="{% url "zds.member.views.articles" %}?type=public" class="ico-after tick green {% if request.GET.type == "public" %}unread{% endif %}">
+                    <a href="{% url "zds.member.views.articles" %}?{% if sort %}sort={{ sort }}&{% endif %}type=public" class="ico-after tick green {% if request.GET.type == "public" %}unread{% endif %}">
                         Publiés
                     </a>
                 </li>
                 <li>
-                    <a href="{% url "zds.member.views.articles" %}?type=validate" class="ico-after tick {% if request.GET.type == "validate" %}unread{% endif %}">
+                    <a href="{% url "zds.member.views.articles" %}?{% if sort %}sort={{ sort }}&{% endif %}type=validate" class="ico-after tick {% if request.GET.type == "validate" %}unread{% endif %}">
                         En validation
                     </a>
                 </li>
                 <li>
-                    <a href="{% url "zds.member.views.articles" %}?type=draft" class="ico-after edit {% if request.GET.type == "draft" %}unread{% endif %}">
+                    <a href="{% url "zds.member.views.articles" %}?{% if sort %}sort={{ sort }}&{% endif %}type=draft" class="ico-after edit {% if request.GET.type == "draft" %}unread{% endif %}">
                         Brouillons
                     </a>
                 </li>
                 {% if request.GET.type %}
                     <li>
-                        <a href="{% url "zds.member.views.articles" %}" class="ico-after cross">
+                        <a href="{% url "zds.member.views.articles" %}{% if sort %}?sort={{ sort }}{% endif %}" class="ico-after cross">
                             Annuler le filtre
                         </a>
                     </li>
                 {% endif %}
+            </ul>
+        </div>
+        <div class="mobile-menu-bloc mobile-all-links" data-title="Trier">
+            <h3>Trier</h3>
+            <ul>
+                <li>
+                    <a href="{% url "zds.member.views.articles" %}?sort=abc{% if type %}&type={{ type }}{% endif %}" class="ico-after gear {% if sort == "abc" %}unread{% endif %}">
+                        Par ordre alphabétique
+                    </a>
+                </li>
+                <li>
+                    <a href="{% url "zds.member.views.articles" %}?sort=creation{% if type %}&type={{ type }}{% endif %}" class="ico-after gear {% if sort == "creation" %}unread{% endif %}">
+                        Par date de création
+                    </a>
+                </li>
+                <li>
+                    <a href="{% url "zds.member.views.articles" %}?sort=modification{% if type %}&type={{ type }}{% endif %}" class="ico-after gear {% if sort == "modification" %}unread{% endif %}">
+                        Par date de dernière modification
+                    </a>
+                </li>
             </ul>
         </div>
     </aside>

--- a/templates/tutorial/member/index.html
+++ b/templates/tutorial/member/index.html
@@ -14,6 +14,13 @@
     {% elif request.GET.type == "draft" %}
         / Brouillons
     {% endif %}
+    {% if sort == "abc" %}
+        / Par ordre alphabétique
+    {% elif sort == "creation" %}
+        / Par date de création
+    {% elif sort == "modification" %}
+        / Par date de dernière modification
+    {% endif %}
 {% endblock %}
 
 
@@ -53,6 +60,13 @@
                     / En bêta
                 {% elif request.GET.type == "draft" %}
                     / Brouillons
+                {% endif %}
+                {% if sort == "abc" %}
+                    / Par ordre alphabétique
+                {% elif sort == "creation" %}
+                    / Par date de création
+                {% elif sort == "modification" %}
+                    / Par date de dernière modification
                 {% endif %}
             {% endblock %}
         </h2>
@@ -113,33 +127,53 @@
         <h3>Filtres</h3>
         <ul>
             <li>
-                <a href="{% url "zds.member.views.tutorials" %}?type=public" class="ico-after tick green {% if request.GET.type == "public" %}unread{% endif %}">
+                <a href="{% url "zds.member.views.tutorials" %}?type=public{% if sort %}&sort={{ sort }}{% endif %}" class="ico-after tick green {% if request.GET.type == "public" %}unread{% endif %}">
                     Publiés
                 </a>
             </li>
             <li>
-                <a href="{% url "zds.member.views.tutorials" %}?type=validate" class="ico-after tick {% if request.GET.type == "validate" %}unread{% endif %}">
+                <a href="{% url "zds.member.views.tutorials" %}?type=validate{% if sort %}&sort={{ sort }}{% endif %}" class="ico-after tick {% if request.GET.type == "validate" %}unread{% endif %}">
                     En validation
                 </a>
             </li>
             <li>
-                <a href="{% url "zds.member.views.tutorials" %}?type=beta" class="ico-after beta {% if request.GET.type == "beta" %}unread{% endif %}">
+                <a href="{% url "zds.member.views.tutorials" %}?type=beta{% if sort %}&sort={{ sort }}{% endif %}" class="ico-after beta {% if request.GET.type == "beta" %}unread{% endif %}">
                     En bêta
                 </a>
             </li>
             <li>
-                <a href="{% url "zds.member.views.tutorials" %}?type=draft" class="ico-after edit {% if request.GET.type == "draft" %}unread{% endif %}">
+                <a href="{% url "zds.member.views.tutorials" %}?type=draft{% if sort %}&sort={{ sort }}{% endif %}" class="ico-after edit {% if request.GET.type == "draft" %}unread{% endif %}">
                     Brouillons
                 </a>
             </li>
 
             {% if request.GET.type %}
                 <li>
-                    <a href="{% url "zds.member.views.tutorials" %}" class="ico-after cross">
+                    <a href="{% url "zds.member.views.tutorials" %}{% if sort %}?sort={{ sort }}{% endif %}" class="ico-after cross">
                         Annuler le filtre
                     </a>
                 </li>
             {% endif %}
         </ul>
+        <div class="mobile-menu-bloc mobile-all-links" data-title="Trier">
+            <h3>Trier</h3>
+            <ul>
+                <li>
+                    <a href="{% url "zds.member.views.tutorials" %}?sort=abc{% if type %}&type={{ type }}{% endif %}" class="ico-after gear {% if sort == "abc" %}unread{% endif %}">
+                        Par ordre alphabétique
+                    </a>
+                </li>
+                <li>
+                    <a href="{% url "zds.member.views.tutorials" %}?sort=creation{% if type %}&type={{ type }}{% endif %}" class="ico-after gear {% if sort == "creation" %}unread{% endif %}">
+                        Par date de création
+                    </a>
+                </li>
+                <li>
+                    <a href="{% url "zds.member.views.tutorials" %}?sort=modification{% if type %}&type={{ type }}{% endif %}" class="ico-after gear {% if sort == "modification" %}unread{% endif %}">
+                        Par date de dernière modification
+                    </a>
+                </li>
+            </ul>
+        </div>
     </div>
 {% endblock %}

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -427,7 +427,6 @@ def articles(request):
     except KeyError:
         sort_articles = 'abc'
 
-
     # Retrieves all articles of the current user.
 
     profile = request.user.profile

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -402,24 +402,27 @@ def articles(request):
     # public, draft or all user's articles.
 
     try:
-        type = request.GET["type"]
+        type = request.GET['type']
     except KeyError:
         type = None
 
     # Retrieves all articles of the current user.
 
     profile = request.user.profile
-    if type == "draft":
+    if type == 'draft':
         user_articles = profile.get_draft_articles()
-    if type == "validate":
+    if type == 'validate':
         user_articles = profile.get_validate_articles()
-    elif type == "public":
+    elif type == 'public':
         user_articles = profile.get_public_articles()
     else:
         user_articles = profile.get_articles()
 
-    return render_template("article/member/index.html",
-                           {"articles": user_articles, "type": type})
+    # Order by title
+
+    user_articles = user_articles.extra(select={'lower_title': 'lower(title)'}).order_by('lower_title')
+
+    return render_template('article/member/index.html', {'articles': user_articles, 'type': type})
 
 
 # settings for public profile

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -373,6 +373,13 @@ def tutorials(request):
     except KeyError:
         type = None
 
+    # The sort indicate the order of tutorials.
+
+    try:
+        sort_tuto = request.GET['sort']
+    except KeyError:
+        sort_tuto = 'abc'
+
     # Retrieves all tutorials of the current user.
 
     profile = request.user.profile
@@ -387,24 +394,39 @@ def tutorials(request):
     else:
         user_tutorials = profile.get_tutos()
 
-    # Order by title
+    # Order articles (abc by default)
 
-    user_tutorials = user_tutorials.extra(select={'lower_title': 'lower(title)'}).order_by('lower_title')
+    if sort_tuto == 'creation':
+        pass  # nothing to do. Tutorials are already sort by creation date
+    elif sort_tuto == 'modification':
+        user_tutorials = user_tutorials.order_by('-update')
+    else:
+        user_tutorials = user_tutorials.extra(select={'lower_title': 'lower(title)'}).order_by('lower_title')
 
-    return render_template('tutorial/member/index.html', {'tutorials': user_tutorials, 'type': type})
+    return render_template(
+        'tutorial/member/index.html',
+        {'tutorials': user_tutorials, 'type': type, 'sort': sort_tuto}
+    )
 
 
 @login_required
 def articles(request):
     """Returns all articles of the authenticated user."""
 
-    # The type indicate what the user would like to display. We can display
-    # public, draft or all user's articles.
+    # The type indicate what the user would like to display. We can display public, draft or all user's articles.
 
     try:
         type = request.GET['type']
     except KeyError:
         type = None
+
+    # The sort indicate the order of articles.
+
+    try:
+        sort_articles = request.GET['sort']
+    except KeyError:
+        sort_articles = 'abc'
+
 
     # Retrieves all articles of the current user.
 
@@ -418,11 +440,19 @@ def articles(request):
     else:
         user_articles = profile.get_articles()
 
-    # Order by title
+    # Order articles (abc by default)
 
-    user_articles = user_articles.extra(select={'lower_title': 'lower(title)'}).order_by('lower_title')
+    if sort_articles == 'creation':
+        pass  # nothing to do. Articles are already sort by creation date
+    elif sort_articles == 'modification':
+        user_articles = user_articles.order_by('-update')
+    else:
+        user_articles = user_articles.extra(select={'lower_title': 'lower(title)'}).order_by('lower_title')
 
-    return render_template('article/member/index.html', {'articles': user_articles, 'type': type})
+    return render_template(
+        'article/member/index.html',
+        {'articles': user_articles, 'type': type, 'sort': sort_articles}
+    )
 
 
 # settings for public profile

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -366,30 +366,32 @@ def modify_profile(request, user_pk):
 def tutorials(request):
     """Returns all tutorials of the authenticated user."""
 
-    # The type indicate what the user would like to display. We can display
-    # public, draft or all user's tutorials.
+    # The type indicate what the user would like to display. We can display public, draft or all user's tutorials.
 
     try:
-        type = request.GET["type"]
+        type = request.GET['type']
     except KeyError:
         type = None
 
     # Retrieves all tutorials of the current user.
 
     profile = request.user.profile
-    if type == "draft":
+    if type == 'draft':
         user_tutorials = profile.get_draft_tutos()
-    elif type == "beta":
+    elif type == 'beta':
         user_tutorials = profile.get_beta_tutos()
-    elif type == "validate":
+    elif type == 'validate':
         user_tutorials = profile.get_validate_tutos()
-    elif type == "public":
+    elif type == 'public':
         user_tutorials = profile.get_public_tutos()
     else:
         user_tutorials = profile.get_tutos()
 
-    return render_template("tutorial/member/index.html",
-                           {"tutorials": user_tutorials, "type": type})
+    # Order by title
+
+    user_tutorials = user_tutorials.extra(select={'lower_title': 'lower(title)'}).order_by('lower_title')
+
+    return render_template('tutorial/member/index.html', {'tutorials': user_tutorials, 'type': type})
 
 
 @login_required


### PR DESCRIPTION
**PR REPRISE DANS #1951**

| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1731 |
### QA

Dans « Mes articles » : 
- Créer plusieurs articles
- Les trier avec les filtres
- Faire la même chose avec les tutoriels
