### PR TITLE
Corrige le prefixage des liens des miniatures

### DIFF
--- a/templates/gallery/image/edit.html
+++ b/templates/gallery/image/edit.html
@@ -46,13 +46,13 @@
             Code markdown pour insérer cette image : <br>
 
             Taille normale :
-            <input type="text" value="![{{ image.legend }}]({{ image.physical.content.url }})" readonly onclick="this.select()"> <br>
+            <input type="text" value="![{{ image.legend }}]({{app.site.url}}{{ image.physical.content.url }})" readonly onclick="this.select()"> <br>
 
             Miniature :
-            <input type="text" value="![{{ image.legend }}]({{ image.physical.gallery.url }})" readonly onclick="this.select()"> <br>
+            <input type="text" value="![{{ image.legend }}]({{app.site.url}}{{ image.physical.gallery.url }})" readonly onclick="this.select()"> <br>
 
             Miniature + lien vers taille noramle :
-            <input type="text" value="[![{{ image.legend }}]({{ image.physical.gallery.url }})]({{ image.physical.content.url }})" readonly onclick="this.select()">
+            <input type="text" value="[![{{ image.legend }}]({{app.site.url}}{{ image.physical.gallery.url }})]({{app.site.url}}{{ image.physical.content.url }})" readonly onclick="this.select()">
         </p>
         
         {% crispy as_avatar_form %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1680 |

La PR corrige les problème de préfixage des liens des miniatures.

**Note pour QA**

Aller dans une gallerie, et selectionner une image.

Copier les 3 propositions markdown dans un message du forum et vérifier que les images s'affichent et qu'en cliquant sur la miniature vous avez bien l'image version big
