### PR TITLE
masque le telechargement si le tuto n'existe pas

### DIFF
--- a/templates/tutorial/base.html
+++ b/templates/tutorial/base.html
@@ -53,51 +53,52 @@
         {% endif %}
 
         {% block sidebar_blocks %}{% endblock %}
-
-        {% if tutorial.on_line or tutorial.in_beta and user in tutorial.authors.all or perms.tutorial.change_tutorial %}
-            <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Télécharger">
-                <h3>{% trans "Télécharger" %}</h3>
-                <ul>
-                    {% if tutorial.on_line %}
-                        {% if perms.tutorial.change_tutorial %}
-                            {% if tutorial.have_markdown %}
+        {% if tutorial %}
+            {% if tutorial.on_line or tutorial.in_beta and user in tutorial.authors.all or perms.tutorial.change_tutorial %}
+                <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Télécharger">
+                    <h3>{% trans "Télécharger" %}</h3>
+                    <ul>
+                        {% if tutorial.on_line %}
+                            {% if perms.tutorial.change_tutorial %}
+                                {% if tutorial.have_markdown %}
+                                    <li>
+                                        <a href="{% url "zds.tutorial.views.download_markdown" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
+                                            {% trans "Markdown" %}
+                                        </a>
+                                    </li>
+                                {% endif %}
+                            {% endif %}
+                            {% if tutorial.have_html %}
                                 <li>
-                                    <a href="{% url "zds.tutorial.views.download_markdown" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
-                                        {% trans "Markdown" %}
+                                    <a href="{% url "zds.tutorial.views.download_html" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
+                                        {% trans "HTML" %}
+                                    </a>
+                                </li>
+                            {% endif %}
+                            {% if tutorial.have_pdf %}
+                                <li>
+                                    <a href="{% url "zds.tutorial.views.download_pdf" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
+                                        {% trans "PDF" %}
+                                    </a>
+                                </li>
+                            {% endif %}
+                            {% if tutorial.have_epub %}
+                                <li>
+                                    <a href="{% url "zds.tutorial.views.download_epub" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
+                                        {% trans "EPUB" %}
                                     </a>
                                 </li>
                             {% endif %}
                         {% endif %}
-                        {% if tutorial.have_html %}
-                            <li>
-                                <a href="{% url "zds.tutorial.views.download_html" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
-                                    {% trans "HTML" %}
-                                </a>
-                            </li>
-                        {% endif %}
-                        {% if tutorial.have_pdf %}
-                            <li>
-                                <a href="{% url "zds.tutorial.views.download_pdf" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
-                                    {% trans "PDF" %}
-                                </a>
-                            </li>
-                        {% endif %}
-                        {% if tutorial.have_epub %}
-                            <li>
-                                <a href="{% url "zds.tutorial.views.download_epub" %}?tutoriel={{ tutorial.pk }}" class="ico-after download blue">
-                                    {% trans "EPUB" %}
-                                </a>
-                            </li>
-                        {% endif %}
-                    {% endif %}
-
-                    <li>
-                        <a href="{% url "zds.tutorial.views.download" %}?tutoriel={{ tutorial.pk }}{% if tutorial.is_on_line %}&online{% endif %}" class="ico-after download blue">
-                            {% trans "Archive" %}
-                        </a>
-                    </li>
-                </ul>
-            </div>
+    
+                        <li>
+                            <a href="{% url "zds.tutorial.views.download" %}?tutoriel={{ tutorial.pk }}{% if tutorial.is_on_line %}&online{% endif %}" class="ico-after download blue">
+                                {% trans "Archive" %}
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            {% endif %}
         {% endif %}
     </aside>
 {% endblock %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1694 |

Cette PR permet de masquer le lien de téléchargement de l'archive si le tutoriel n'existe pas.

**Note pour QA**

Avant si on allait sur l'url suivante `tutoriels/nouveau/tutoriel/` on avait le lien de téléchargement d'un tutoriel

Vérifier que maintenant on ne l'a plus.
