### PR TITLE
Les notifications uniquement pour le contenu en ligne

### DIFF
--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -78,7 +78,7 @@ def interventions_topics(user):
         .exclude(post=F('topic__last_message'))
 
     articlesfollowed = Reaction.objects\
-        .filter(author=user)\
+        .filter(author=user, article__sha_public__is_null=False)\
         .values('article')\
         .distinct().all()
 
@@ -89,7 +89,7 @@ def interventions_topics(user):
         .exclude(reaction=F('article__last_reaction'))
 
     tutorialsfollowed = Note.objects\
-        .filter(author=user)\
+        .filter(author=user, tutorial__sha_public__is_null=False)\
         .values('tutorial')\
         .distinct().all()
 

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -78,7 +78,7 @@ def interventions_topics(user):
         .exclude(post=F('topic__last_message'))
 
     articlesfollowed = Reaction.objects\
-        .filter(author=user, article__sha_public__is_null=False)\
+        .filter(author=user, article__sha_public__isnull=False)\
         .values('article')\
         .distinct().all()
 
@@ -89,7 +89,7 @@ def interventions_topics(user):
         .exclude(reaction=F('article__last_reaction'))
 
     tutorialsfollowed = Note.objects\
-        .filter(author=user, tutorial__sha_public__is_null=False)\
+        .filter(author=user, tutorial__sha_public__isnull=False)\
         .values('tutorial')\
         .distinct().all()
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1608 |

Cette PR permet de n'afficher les notifications que pour du contenu en ligne.

**Note pour QA**
- Créez un tuto et un article
- publiez les
- postez avec l'utilisateur user (dans les commentaires du tutos et de l'article)
- connectez vous en tant que admin
- poster ensuite avec l'utilisateur admin (dans les commentaires du tuto et de l'article)
- deplubiez le tuto et l'article

Si vous vous reconnectez avec l'utilisateur user, vous n'aurez normalement pas de notification sur le tuto et/ou l'article. Si vous republiez le tutoriel/article par contre, la notification apparait.
