### PR TITLE
Améliore le rendu des diffs

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -2268,14 +2268,26 @@ table {
         width: 100%;
     }
 
-    &.diff tbody tr {
-        border-bottom: none;
-        background: #FFF;
-        line-height: 1.1em;
-        .diff_next {
-            display: none;
+    &.diff {
+        tbody tr {
+            border-bottom: none;
+            font-family : $font-monospace;
+            background: #FFF;
+            line-height: 1em;
+            .diff_next {
+                display: none;
+            }
+            td.diff_header {
+                padding : 5px;
+            }
         }
     }
+}
+
+.diff_delta {
+    overflow: scroll;
+    width: 100%;
+    font-size : 0.9em;
 }
 
 

--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -2267,6 +2267,15 @@ table {
     &.fullwidth {
         width: 100%;
     }
+
+    &.diff tbody tr {
+        border-bottom: none;
+        background: #FFF;
+        line-height: 1.1em;
+        .diff_next {
+            display: none;
+        }
+    }
 }
 
 

--- a/templates/base_content_page.html
+++ b/templates/base_content_page.html
@@ -12,6 +12,7 @@
         </section>
         {% block content_after %}{% endblock %}
     </article>
+    {% block content_ext %}{% endblock %}
 {% endblock %}
 
 

--- a/templates/tutorial/tutorial/diff.html
+++ b/templates/tutorial/tutorial/diff.html
@@ -37,12 +37,14 @@
 
 
 
-{% block content_out %}
+{% block content_ext %}
     <h2>{% trans "Nouveaux Fichiers" %}</h2>
     {% for add in path_add %}
         {% with add_next=add.b_blob|repo_blob %}
             <h3>{{ add.a_blob.path }}</h3>
-            {{ ''|diff_text:add_next|safe }}
+            <div class="diff_delta">
+                {{ ''|diff_text:add_next|safe }}
+            </div>
         {% endwith %}
     {% endfor %}
 
@@ -51,7 +53,9 @@
         {% with maj_next=maj.b_blob|repo_blob %}
             {% with maj_prev=maj.a_blob|repo_blob %}
                 <h3>{{ maj.a_blob.path }}</h3>
-                {{ maj_prev|diff_text:maj_next|safe }}
+                <div class="diff_delta">
+                    {{ maj_prev|diff_text:maj_next|safe }}
+                </div>
             {% endwith %}
         {% endwith %} 
     {% endfor %}

--- a/templates/tutorial/tutorial/diff.html
+++ b/templates/tutorial/tutorial/diff.html
@@ -37,7 +37,7 @@
 
 
 
-{% block content %}
+{% block content_out %}
     <h2>{% trans "Nouveaux Fichiers" %}</h2>
     {% for add in path_add %}
         {% with add_next=add.b_blob|repo_blob %}

--- a/zds/utils/templatetags/repo_reader.py
+++ b/zds/utils/templatetags/repo_reader.py
@@ -19,7 +19,7 @@ def diff_text(text1, text2="", title1="", title2=""):
     txt1 = text1.splitlines(1)
     txt2 = text2.splitlines(1)
 
-    d = HtmlDiff()
+    d = HtmlDiff(tabsize=4, wrapcolumn=80)
     result = d.make_file(txt1, txt2, title1, title2, context=True)
 
     return result


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #766 |

Cette issue vient améliorer le rendu des diffs sur les tutoriels. On peut certainement faire mieux, mais le rendu actuel est tellement inutilisable que cette PR permet au moins de rendre utilisable les diffs.

Le screenshot rendu est le suivant : 

![](http://zestedesavoir.com/media/galleries/241/5ea5951e-fea8-41b9-a613-023b389f0386.png)

**Note pour QA.**
- Créer une tutoriel et faites des modifications
- aller sur la page d'historique et regarder le diff
