### PR TITLE
[bloquant] correction du bug des tuto innacessible en cas de rennomage

### DIFF
--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -175,8 +175,8 @@ class Tutorial(models.Model):
         else:
             return os.path.join(settings.ZDS_APP['tutorial']['repo_path'], self.get_phy_slug())
 
-    def get_prod_path(self):
-        data = self.load_json_for_public()
+    def get_prod_path(self, sha=None):
+        data = self.load_json_for_public(sha)
         return os.path.join(
             settings.ZDS_APP['tutorial']['repo_public_path'],
             str(self.pk) + '_' + slugify(data['title']))

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -19,6 +19,7 @@ import shutil
 import re
 import zipfile
 import os
+import glob
 import tempfile
 
 from PIL import Image as ImagePIL
@@ -3103,11 +3104,14 @@ def mep(tutorial, sha):
     repo = Repo(tutorial.get_path())
     manifest = get_blob(repo.commit(sha).tree, "manifest.json")
     tutorial_version = json_reader.loads(manifest)
-    if os.path.isdir(tutorial.get_prod_path()):
-        try:
-            shutil.rmtree(tutorial.get_prod_path())
-        except:
-            shutil.rmtree(u"\\\\?\{0}".format(tutorial.get_prod_path()))
+    del_paths = glob.glob(os.path.join(settings.ZDS_APP['tutorial']['repo_public_path'],
+                          str(tutorial.pk) + '_*'))
+    for del_path in del_paths:
+        if os.path.isdir(del_path):
+            try:
+                shutil.rmtree(del_path)
+            except:
+                shutil.rmtree(u"\\\\?\{0}".format(del_path))
     shutil.copytree(tutorial.get_path(), tutorial.get_prod_path())
     repo.head.reset(commit=sha, index=True, working_tree=True)
 
@@ -3200,11 +3204,14 @@ def mep(tutorial, sha):
 
 
 def un_mep(tutorial):
-    if os.path.isdir(tutorial.get_prod_path()):
-        try:
-            shutil.rmtree(tutorial.get_prod_path())
-        except:
-            shutil.rmtree(u"\\\\?\{0}".format(tutorial.get_prod_path()))
+    del_paths = glob.glob(os.path.join(settings.ZDS_APP['tutorial']['repo_public_path'],
+                          str(tutorial.pk) + '_*'))
+    for del_path in del_paths:
+        if os.path.isdir(del_path):
+            try:
+                shutil.rmtree(del_path)
+            except:
+                shutil.rmtree(u"\\\\?\{0}".format(del_path))
 
 
 @can_write_and_read_now

--- a/zds/utils/tutorials.py
+++ b/zds/utils/tutorials.py
@@ -112,7 +112,7 @@ def get_blob(tree, chemin):
         return None
 
 
-def export_tutorial_to_md(tutorial):
+def export_tutorial_to_md(tutorial, sha=None):
     # Two variables to handle two distinct cases (large/small tutorial)
     chapter = None
     parts = None
@@ -120,14 +120,14 @@ def export_tutorial_to_md(tutorial):
 
     i = open(
         os.path.join(
-            tutorial.get_prod_path(),
+            tutorial.get_prod_path(sha),
             tutorial.introduction),
         "r")
     i_contenu = i.read()
     i.close()
     tuto['intro'] = i_contenu
 
-    c = open(os.path.join(tutorial.get_prod_path(), tutorial.conclusion), "r")
+    c = open(os.path.join(tutorial.get_prod_path(sha), tutorial.conclusion), "r")
     c_contenu = c.read()
     c.close()
     tuto['conclu'] = c_contenu
@@ -143,24 +143,24 @@ def export_tutorial_to_md(tutorial):
     tuto['slug'] = tutorial.slug
 
     # find the good manifest file
-    mandata = tutorial.load_json(online=True)
+    mandata = tutorial.load_json_for_public(sha=sha)
 
     # If it's a small tutorial, fetch its chapter
     if tutorial.type == 'MINI':
         if 'chapter' in mandata:
             chapter = mandata['chapter']
-            chapter['path'] = tutorial.get_prod_path()
+            chapter['path'] = tutorial.get_prod_path(sha)
             chapter['type'] = 'MINI'
             intro = open(
                 os.path.join(
-                    tutorial.get_prod_path(),
+                    tutorial.get_prod_path(sha),
                     mandata['introduction']),
                 "r")
             chapter['intro'] = intro.read()
             intro.close()
             conclu = open(
                 os.path.join(
-                    tutorial.get_prod_path(),
+                    tutorial.get_prod_path(sha),
                     mandata['conclusion']),
                 "r")
             chapter['conclu'] = conclu.read()
@@ -168,10 +168,10 @@ def export_tutorial_to_md(tutorial):
             cpt = 1
             for ext in chapter['extracts']:
                 ext['position_in_chapter'] = cpt
-                ext['path'] = tutorial.get_prod_path()
+                ext['path'] = tutorial.get_prod_path(sha)
                 text = open(
                     os.path.join(
-                        tutorial.get_prod_path(),
+                        tutorial.get_prod_path(sha),
                         ext['text']),
                     "r")
                 ext['txt'] = text.read()
@@ -189,14 +189,14 @@ def export_tutorial_to_md(tutorial):
             part['position_in_tutorial'] = cpt_p
             intro = open(
                 os.path.join(
-                    tutorial.get_prod_path(),
+                    tutorial.get_prod_path(sha),
                     part['introduction']),
                 "r")
             part['intro'] = intro.read()
             intro.close()
             conclu = open(
                 os.path.join(
-                    tutorial.get_prod_path(),
+                    tutorial.get_prod_path(sha),
                     part['conclusion']),
                 "r")
             part['conclu'] = conclu.read()
@@ -212,14 +212,14 @@ def export_tutorial_to_md(tutorial):
                 chapter['position_in_tutorial'] = cpt_c * cpt_p
                 intro = open(
                     os.path.join(
-                        tutorial.get_prod_path(),
+                        tutorial.get_prod_path(sha),
                         chapter['introduction']),
                     "r")
                 chapter['intro'] = intro.read()
                 intro.close()
                 conclu = open(
                     os.path.join(
-                        tutorial.get_prod_path(),
+                        tutorial.get_prod_path(sha),
                         chapter['conclusion']),
                     "r")
                 chapter['conclu'] = conclu.read()
@@ -230,7 +230,7 @@ def export_tutorial_to_md(tutorial):
                     ext['path'] = tutorial.get_path()
                     text = open(
                         os.path.join(
-                            tutorial.get_prod_path(),
+                            tutorial.get_prod_path(sha),
                             ext['text']),
                         "r")
                     ext['txt'] = text.read()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1544 |

Cette PR corrige le bug des tutoriels qui deviennent innaccessible si on les renomme.

**Note pour QA.**
- Créer un tuto (big ou mini), et le publier
- Aller dans la version hors ligne et modifier le nom du tutoriel
- Republiez le tutoriel
- Vérifiez si le tutoriel est toujours accessible sur son url publique.
