### PR TITLE
Utilise l'engine `pngsmith` par défaut

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -95,7 +95,8 @@ gulp.task("sprite", function() {
         }
 
         return output;
-      }
+      },
+      engine: "pngsmith"
     }));
   sprite.img
     .pipe($.imagemin({ optimisationLevel: 3, progressive: true, interlaced: true }))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | [#1743 (comment)](https://github.com/zestedesavoir/zds-site/pull/1743#issuecomment-63127250) |

Utilise l'engine `pngsmith` par défaut pour la génération de sprite, qui ne demande aucune dépendances externe. Cela peut régler certains problèmes dans la génération de sprite, [comme chez Eskimon](https://github.com/zestedesavoir/zds-site/pull/1743#issuecomment-63127250). 

D'ailleurs, @Eskimon si tu pouvais essayer de faire le même fix (rajouter l'engine pngsmith au niveau des lignes 90-100), en te basant sur la  PR #1743, et me dire si ça règle le problème chez toi, ça confirmerais si ce fix fonctionne ou non :)
