### PR TITLE
Fix #1729 : Ajout d'un filtre « Sujets sans réponse » dans les forums

### DIFF
--- a/doc/sphinx/source/forum/forum.rst
+++ b/doc/sphinx/source/forum/forum.rst
@@ -13,8 +13,20 @@ La modération des forums
 
 La modération des sujets
 ------------------------
+
 La modération des messages
 --------------------------
 
 Les filtres sur les sujets
 ==========================
+
+Dans un forum
+-------------
+
+Il existe actuellement 3 filtres pour filtrer les sujets dans un forum :
+
+* Sujets résolus (`solve`)
+* Sujets non résolus (`unsolve`)
+* Sujets sans réponse (`noanswer`)
+
+Il suffit d'ajouter `?filter=<filtre>` à l'URL en remplaçant `<filtre>` par un des 3 filtre ci-dessus.

--- a/templates/forum/category/forum.html
+++ b/templates/forum/category/forum.html
@@ -8,6 +8,8 @@
         / {% trans "Sujets résolus" %}
     {% elif request.GET.filter == "unsolve" %}
         / {% trans "Sujets non-résolus" %}
+    {% elif request.GET.filter == "noanswer" %}
+        / {% trans "Sujets sans réponse" %}
     {% endif %}
 {% endblock %}
 
@@ -36,6 +38,8 @@
         <li>{% trans "Sujets résolus" %}</li>
     {% elif request.GET.filter == "unsolve" %}
         <li>{% trans "Sujets non-résolus" %}</li>
+    {% elif request.GET.filter == "noanswer" %}
+        <li>{% trans "Sujets sans réponse" %}</li>
     {% endif %}
 {% endblock %}
 
@@ -47,6 +51,8 @@
         / {% trans "Sujets résolus" %}
     {% elif request.GET.filter == "unsolve" %}
         / {% trans "Sujets non-résolus" %}
+    {% elif request.GET.filter == "noanswer" %}
+        / {% trans "Sujets sans réponse" %}
     {% endif %}
 {% endblock %}
 
@@ -102,7 +108,7 @@
         <ul>
             <li>
                 <a href="{% url "zds.forum.views.details" forum.category.slug forum.slug %}?filter=solve"
-                   class="ico-after tick blue {% if request.GET.filter == "unsolve" %}unread{% endif %}"
+                   class="ico-after tick green {% if request.GET.filter == "solve" %}unread{% endif %}"
                 >
                     {% trans "Sujets résolus" %}
                 </a>
@@ -112,6 +118,13 @@
                    class="ico-after tick blue {% if request.GET.filter == "unsolve" %}unread{% endif %}"
                 >
                     {% trans "Sujets non résolus" %}
+                </a>
+            </li>
+            <li>
+                <a href="{% url "zds.forum.views.details" forum.category.slug forum.slug %}?filter=noanswer"
+                   class="ico-after view {% if request.GET.filter == "noanswer" %}unread{% endif %}"
+                >
+                    {% trans "Sujets sans réponse" %}
                 </a>
             </li>
             {% if request.GET.filter %}

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -449,21 +449,16 @@ def get_last_topics(user):
     return tops
 
 
-def get_topics(forum_pk, is_sticky, is_solved=None):
-    """ Get topics according to parameters """
+def get_topics(forum_pk, is_sticky, filter=None):
+    """Get topics according to parameters."""
 
-    if is_solved is not None:
-        return Topic.objects.filter(
-            forum__pk=forum_pk,
-            is_sticky=is_sticky,
-            is_solved=is_solved).order_by("-last_message__pubdate").prefetch_related(
-            "author",
-            "last_message",
-            "tags").all()
+    if filter == 'solve':
+        topics = Topic.objects.filter(forum__pk=forum_pk, is_sticky=is_sticky, is_solved=True)
+    elif filter == 'unsolve':
+        topics = Topic.objects.filter(forum__pk=forum_pk, is_sticky=is_sticky, is_solved=False)
+    elif filter == 'noanswer':
+        topics = Topic.objects.filter(forum__pk=forum_pk, is_sticky=is_sticky, last_message__position=1)
     else:
-        return Topic.objects.filter(
-            forum__pk=forum_pk,
-            is_sticky=is_sticky).order_by("-last_message__pubdate").prefetch_related(
-            "author",
-            "last_message",
-            "tags").all()
+        topics = Topic.objects.filter(forum__pk=forum_pk, is_sticky=is_sticky)
+
+    return topics.order_by('-last_message__pubdate').prefetch_related('author', 'last_message', 'tags').all()

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -51,18 +51,12 @@ def details(request, cat_slug, forum_slug):
     forum = get_object_or_404(Forum, slug=forum_slug)
     if not forum.can_read(request.user):
         raise PermissionDenied
-    if "filter" in request.GET:
-        filter = request.GET["filter"]
-        if filter == "solve":
-            sticky_topics = get_topics(forum_pk=forum.pk, is_sticky=True, is_solved=True)
-            topics = get_topics(forum_pk=forum.pk, is_sticky=False, is_solved=True)
-        else:
-            sticky_topics = get_topics(forum_pk=forum.pk, is_sticky=True, is_solved=False)
-            topics = get_topics(forum_pk=forum.pk, is_sticky=False, is_solved=False)
+    if 'filter' in request.GET:
+        filter = request.GET['filter']
     else:
         filter = None
-        sticky_topics = get_topics(forum_pk=forum.pk, is_sticky=True)
-        topics = get_topics(forum_pk=forum.pk, is_sticky=False)
+    sticky_topics = get_topics(forum_pk=forum.pk, is_sticky=True, filter=filter)
+    topics = get_topics(forum_pk=forum.pk, is_sticky=False, filter=filter)
 
     # Paginator
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1729 |
### QA
- Créer plusieurs sujets dans un forum (avec réponses, sans, résolus et non résolus)
- Vérifier que les filtres fonctionnent comme il faut

_PS : l’icône ne me plait pas trop trop mais pour le moment il n'y a rien de mieux_
