### PR TITLE
Bride le rendu du svg de stats posts

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -137,6 +137,17 @@
         </section>
     {% endif %}
 
+    {% if stats_filename and perms.member.change_profile %}
+        <hr class="clearfix" />
+        <section class="full-content-wrapper without-margin">
+            <h2 id="activity">{% trans "Activité" %}</h2>
+            <figure>
+                {% autoescape off %}
+                    {{stats_filename}}
+                {% endautoescape %}
+            </figure>
+        </section>
+    {% endif %}
 
 
     {% if old_tutos and perms.member.change_profile %}

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -210,11 +210,10 @@ def details(request, user_name):
         dates = date_to_chart(profile.get_posts())
         for i in range(0, 24):
             dot_chart.add(str(i) + " h", dates[(i + 1) % 24])
-        img_path = os.path.join(settings.MEDIA_ROOT, "pygal")
-        if not os.path.isdir(img_path):
-            os.makedirs(img_path, mode=0o777)
-        fchart = os.path.join(img_path, "mod-{}.svg".format(str(usr.pk)))
-        dot_chart.render_to_file(fchart)
+        dot_chart.disable_xml_declaration = True
+        render_chart = dot_chart.render()
+    else:
+        render_chart = None
 
     my_articles = Article.objects.filter(sha_public__isnull=False).order_by(
         "-pubdate").filter(authors__in=[usr]).all()[:5]
@@ -263,7 +262,7 @@ def details(request, user_name):
         "old_tutos": oldtutos,
         "karmaform": karmaform,
         "karmanotes": karmanotes,
-        "stats_filename": fchart,
+        "stats_filename": render_chart,
     })
 
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
-import os
 import uuid
 
 from django.conf import settings


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1701 |

Cette PR sert à brider le rendu de svg de statistiques sur la frequence de post des utilisateurs.
### QA

Pour vérifier, vider le dossier `pygal` dans `media` s'il existe. Ensuite, aller sur un profil en tant qu'utilisateur. Rien ne doit apparaitre dans pygal. Si en revanche vous faites pareil avec admin, l'image est générée

(PS : j'émet un doute sur le fonctionnement de cette feature, l'image générée est toute noire)
