### PR TITLE
WIP - Add jsfiddle support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ factory-boy==2.4.1
 pygeoip==0.3.1
 pillow==2.6.1
 https://github.com/zestedesavoir/GitPython/archive/0.3.2-RC2.zip
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.4.1-zds.10.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.4.1-zds.11.zip
 easy-thumbnails==2.2
 
 # Development tools

--- a/templates/article/member/view.html
+++ b/templates/article/member/view.html
@@ -143,6 +143,6 @@
 
 {% block content %}
     <div>
-        {{ article.txt|emarkdown }}
+        {{ article.txt|emarkdown:is_js }}
     </div>
 {% endblock %}

--- a/templates/tutorial/includes/chapter.part.html
+++ b/templates/tutorial/includes/chapter.part.html
@@ -6,7 +6,7 @@
 {% with extracts=chapter.extracts %}
     {% if not chapter.type = 'MINI' %}
         {% if chapter.intro and chapter.intro != None %}
-            {{ chapter.intro|emarkdown }}
+            {{ chapter.intro|emarkdown:is_js }}
         {% elif not tutorial.is_beta %}
             <p class="ico-after warning">
                 Il n'y a pas d'introduction.
@@ -91,7 +91,7 @@
         {% endif %}
 
         {% if extract.txt %}
-            {{ extract.txt|emarkdown }}
+            {{ extract.txt|emarkdown:is_js }}
         {% else %}
             <p class="ico-after warning">
                 Cet extrait est vide.
@@ -103,7 +103,7 @@
 
     {% if not chapter.type = 'MINI' %}
         {% if chapter.conclu and chapter.conclu != None %}
-            {{ chapter.conclu|emarkdown }}
+            {{ chapter.conclu|emarkdown:is_js }}
         {% elif not tutorial.is_beta %}
             <p class="ico-after warning">
                 Il n'y a pas de conclusion.

--- a/templates/tutorial/part/view.html
+++ b/templates/tutorial/part/view.html
@@ -42,7 +42,7 @@
 
 {% block content %}
     {% if part.intro and part.intro != "None" %}
-        {{ part.intro|emarkdown }}
+        {{ part.intro|emarkdown:is_js }}
     {% elif not tutorial.is_beta %}
         <p class="ico-after warning">
             Il n'y a pas d'introduction.
@@ -89,7 +89,7 @@
     <hr />
 
     {% if part.conclu and part.conclu != "None" %}
-        {{ part.conclu|emarkdown }}
+        {{ part.conclu|emarkdown:is_js }}
     {% elif not tutorial.is_beta %}
         <p class="ico-after warning">
             Il n'y a pas de conclusion.

--- a/templates/tutorial/tutorial/view.html
+++ b/templates/tutorial/tutorial/view.html
@@ -99,7 +99,7 @@
 
 {% block content %}
     {% if tutorial.get_introduction and tutorial.get_introduction != "None" %}
-        {{ tutorial.get_introduction|emarkdown }}
+        {{ tutorial.get_introduction|emarkdown:is_js }}
     {% elif not tutorial.is_beta %}
         <p class="ico-after warning">
             Il n'y a pas d'introduction.
@@ -133,7 +133,7 @@
     {% endif %}
 
     {% if tutorial.get_conclusion and tutorial.get_conclusion != "None" %}
-        {{ tutorial.get_conclusion|emarkdown }}
+        {{ tutorial.get_conclusion|emarkdown:is_js }}
     {% elif not tutorial.is_beta %}
         <p class="ico-after warning">
             Il n'y a pas de conclusion.

--- a/zds/article/migrations/0004_auto__add_field_article_js_support.py
+++ b/zds/article/migrations/0004_auto__add_field_article_js_support.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Article.js_support'
+        db.add_column(u'article_article', 'js_support',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Article.js_support'
+        db.delete_column(u'article_article', 'js_support')
+
+
+    models = {
+        u'article.article': {
+            'Meta': {'object_name': 'Article'},
+            'authors': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'db_index': 'True', 'symmetrical': 'False'}),
+            'create_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'is_locked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'js_support': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_reaction': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'last_reaction'", 'null': 'True', 'to': u"orm['article.Reaction']"}),
+            'licence': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.Licence']", 'null': 'True', 'blank': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'sha_draft': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'sha_public': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'sha_validation': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'subcategory': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['utils.SubCategory']", 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'article.articleread': {
+            'Meta': {'object_name': 'ArticleRead'},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['article.Article']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'reaction': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['article.Reaction']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'reactions_read'", 'to': u"orm['auth.User']"})
+        },
+        u'article.reaction': {
+            'Meta': {'object_name': 'Reaction', '_ormbases': [u'utils.Comment']},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['article.Article']"}),
+            u'comment_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['utils.Comment']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'article.validation': {
+            'Meta': {'object_name': 'Validation'},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['article.Article']", 'null': 'True', 'blank': 'True'}),
+            'comment_authors': ('django.db.models.fields.TextField', [], {}),
+            'comment_validator': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'date_proposition': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'date_reserve': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_validation': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'PENDING'", 'max_length': '10'}),
+            'validator': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'articles_author_validations'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'version': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'utils.comment': {
+            'Meta': {'object_name': 'Comment'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': u"orm['auth.User']"}),
+            'dislike': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'comments-editor'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.CharField', [], {'max_length': '39'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'like': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'text_hidden': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '80'}),
+            'text_html': ('django.db.models.fields.TextField', [], {}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'utils.licence': {
+            'Meta': {'object_name': 'Licence'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'utils.subcategory': {
+            'Meta': {'object_name': 'SubCategory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        }
+    }
+
+    complete_apps = ['article']

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -84,6 +84,7 @@ class Article(models.Model):
                                       related_name='last_reaction',
                                       verbose_name='Derniere réaction')
     is_locked = models.BooleanField('Est verrouillé', default=False)
+    js_support = models.BooleanField('Support du Javascript', default=False)
 
     licence = models.ForeignKey(Licence,
                                 verbose_name='Licence',

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -117,12 +117,18 @@ def view(request, article_pk, article_slug):
         .order_by("-date_proposition")\
         .first()
 
+    if article.js_support:
+        is_js = "js"
+    else:
+        is_js = ""
+
     return render_template('article/member/view.html', {
         'article': article_version,
         'authors': article.authors,
         'tags': article.subcategory,
         'version': sha,
-        'validation': validation
+        'validation': validation,
+        'is_js': is_js
     })
 
 
@@ -957,7 +963,11 @@ def mep(article, sha):
             article_version['text'] +
             '.html'),
         "w")
-    html_file.write(emarkdown(md_file_contenu))
+    if article.js_support:
+        is_js = "js"
+    else:
+        is_js = ""
+    html_file.write(emarkdown(md_file_contenu, is_js))
     html_file.close()
 
 

--- a/zds/tutorial/migrations/0005_auto__add_field_tutorial_js_support.py
+++ b/zds/tutorial/migrations/0005_auto__add_field_tutorial_js_support.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Tutorial.js_support'
+        db.add_column(u'tutorial_tutorial', 'js_support',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Tutorial.js_support'
+        db.delete_column(u'tutorial_tutorial', 'js_support')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'gallery.gallery': {
+            'Meta': {'object_name': 'Gallery'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'gallery.image': {
+            'Meta': {'object_name': 'Image'},
+            'gallery': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gallery.Gallery']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'legend': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'physical': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'tutorial.chapter': {
+            'Meta': {'object_name': 'Chapter'},
+            'conclusion': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gallery.Image']", 'null': 'True', 'blank': 'True'}),
+            'introduction': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'part': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Part']", 'null': 'True', 'blank': 'True'}),
+            'position_in_part': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'position_in_tutorial': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'tutorial': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Tutorial']", 'null': 'True', 'blank': 'True'})
+        },
+        u'tutorial.extract': {
+            'Meta': {'object_name': 'Extract'},
+            'chapter': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Chapter']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position_in_chapter': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'tutorial.note': {
+            'Meta': {'object_name': 'Note', '_ormbases': [u'utils.Comment']},
+            u'comment_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['utils.Comment']", 'unique': 'True', 'primary_key': 'True'}),
+            'tutorial': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Tutorial']"})
+        },
+        u'tutorial.part': {
+            'Meta': {'object_name': 'Part'},
+            'conclusion': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'introduction': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'position_in_tutorial': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'tutorial': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Tutorial']"})
+        },
+        u'tutorial.tutorial': {
+            'Meta': {'object_name': 'Tutorial'},
+            'authors': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'db_index': 'True', 'symmetrical': 'False'}),
+            'conclusion': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'create_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'gallery': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gallery.Gallery']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gallery.Image']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'images': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'introduction': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'is_locked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'js_support': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_note': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'last_note'", 'null': 'True', 'to': u"orm['tutorial.Note']"}),
+            'licence': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.Licence']", 'null': 'True', 'blank': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'sha_beta': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'sha_draft': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'sha_public': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'sha_validation': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'subcategory': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['utils.SubCategory']", 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'tutorial.tutorialread': {
+            'Meta': {'object_name': 'TutorialRead'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'note': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Note']"}),
+            'tutorial': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Tutorial']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'tuto_notes_read'", 'to': u"orm['auth.User']"})
+        },
+        u'tutorial.validation': {
+            'Meta': {'object_name': 'Validation'},
+            'comment_authors': ('django.db.models.fields.TextField', [], {}),
+            'comment_validator': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'date_proposition': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'date_reserve': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_validation': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'PENDING'", 'max_length': '10'}),
+            'tutorial': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['tutorial.Tutorial']", 'null': 'True', 'blank': 'True'}),
+            'validator': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'author_validations'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'version': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'utils.comment': {
+            'Meta': {'object_name': 'Comment'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': u"orm['auth.User']"}),
+            'dislike': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'comments-editor'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.CharField', [], {'max_length': '39'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'like': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'text_hidden': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '80'}),
+            'text_html': ('django.db.models.fields.TextField', [], {}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'utils.licence': {
+            'Meta': {'object_name': 'Licence'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'utils.subcategory': {
+            'Meta': {'object_name': 'SubCategory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        }
+    }
+
+    complete_apps = ['tutorial']

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -109,6 +109,7 @@ class Tutorial(models.Model):
                                   related_name='last_note',
                                   verbose_name='Derniere note')
     is_locked = models.BooleanField('Est verrouillé', default=False)
+    js_support = models.BooleanField('Support du Javascript', default=False)
 
     def __unicode__(self):
         return self.title

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -892,6 +892,11 @@ def view_tutorial(request, tutorial_pk, tutorial_slug):
         form_ask_validation = AskValidationForm()
         form_valid = ValidForm()
     form_reject = RejectForm()
+
+    if tutorial.js_support:
+        is_js = "js"
+    else:
+        is_js = ""
     return render_template("tutorial/tutorial/view.html", {
         "tutorial": mandata,
         "chapter": chapter,
@@ -901,6 +906,7 @@ def view_tutorial(request, tutorial_pk, tutorial_slug):
         "formAskValidation": form_ask_validation,
         "formValid": form_valid,
         "formReject": form_reject,
+        "is_js": is_js
     })
 
 
@@ -1329,10 +1335,16 @@ def view_part(
     if not find:
         raise Http404
 
+    if tutorial.js_support:
+        is_js = "js"
+    else:
+        is_js = ""
+
     return render_template("tutorial/part/view.html",
                            {"tutorial": mandata,
                             "part": final_part,
-                            "version": sha})
+                            "version": sha,
+                            "is_js": is_js})
 
 
 def view_part_online(
@@ -1686,12 +1698,18 @@ def view_chapter(
     next_chapter = (chapter_tab[final_position + 1] if final_position + 1
                     < len(chapter_tab) else None)
 
+    if tutorial.js_support:
+        is_js = "js"
+    else:
+        is_js = ""
+
     return render_template("tutorial/chapter/view.html", {
         "tutorial": mandata,
         "chapter": final_chapter,
         "prev": prev_chapter,
         "next": next_chapter,
         "version": sha,
+        "is_js": is_js
     })
 
 
@@ -3157,8 +3175,12 @@ def mep(tutorial, sha):
 
             target = u"\\\\?\{0}".format(target)
             html_file = open(target, "w")
+        if tutorial.js_support:
+            is_js = "js"
+        else:
+            is_js = ""
         if md_file_contenu is not None:
-            html_file.write(emarkdown(md_file_contenu))
+            html_file.write(emarkdown(md_file_contenu, is_js))
         html_file.close()
 
     # load markdown out

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -66,7 +66,7 @@ def render_markdown(text, inline=False, js_support=False):
 
 
 @register.filter(needs_autoescape=False)
-def emarkdown(text):
+def emarkdown(text, js=""):
     """
     Filter markdown text and render it to html.
 
@@ -74,8 +74,9 @@ def emarkdown(text):
     :return: Equivalent html string.
     :rtype: str
     """
+    is_js = (js == "js")
     try:
-        return mark_safe(render_markdown(text, inline=False))
+        return mark_safe(render_markdown(text, inline=False, js_support=is_js))
     except:
         return mark_safe(u'<div class="error ico-after"><p>{}</p></div>'.format(__MD_ERROR_PARSING))
 
@@ -91,7 +92,7 @@ def emarkdown_inline(text):
     """
 
     try:
-        return mark_safe(render_markdown(text, inline=True, js_support=False))
+        return mark_safe(render_markdown(text, inline=True))
     except:
         return mark_safe(u'<p>{}</p>'.format(__MD_ERROR_PARSING))
 

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -20,14 +20,14 @@ __MD_ERROR_PARSING = u"Une erreur est survenue dans la génération de texte Mar
                      u"Veuillez rapporter le bug."
 
 
-def get_markdown_instance(inline=False):
+def get_markdown_instance(inline=False, js_support=False):
     """
     Provide a pre-configured markdown parser.
 
     :param bool inline: If `True`, configure parser to parse only inline content.
     :return: A ZMarkdown parser.
     """
-    zdsext = ZdsExtension({"inline": inline, "emoticons": smileys})
+    zdsext = ZdsExtension({"inline": inline, "emoticons": smileys, "js_support": js_support})
     # Generate parser
     md = markdown.Markdown(extensions=(zdsext,),
                            safe_mode = 'escape',
@@ -53,7 +53,7 @@ def get_markdown_instance(inline=False):
     return md
 
 
-def render_markdown(text, inline=False):
+def render_markdown(text, inline=False, js_support=False):
     """
     Render a markdown text to html.
 
@@ -62,7 +62,7 @@ def render_markdown(text, inline=False):
     :return: Equivalent html string.
     :rtype: str
     """
-    return get_markdown_instance(inline=inline).convert(text).encode('utf-8').strip()
+    return get_markdown_instance(inline=inline, js_support=js_support).convert(text).encode('utf-8').strip()
 
 
 @register.filter(needs_autoescape=False)
@@ -91,7 +91,7 @@ def emarkdown_inline(text):
     """
 
     try:
-        return mark_safe(render_markdown(text, inline=True))
+        return mark_safe(render_markdown(text, inline=True, js_support=False))
     except:
         return mark_safe(u'<p>{}</p>'.format(__MD_ERROR_PARSING))
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | [Sujet forum](http://zestedesavoir.com/forums/sujet/1714/ajout-de-html-et-js-dans-le-contenu) |

**WIP** : les tests ne passeront pas a court terme (il faut qu'on me redonne les droits GH sur le dépot Python-zMarkdown pour ça, pour créer le dépot).

Le but de ce code est de faire une v0 permetant d'autoriser le HTML/JS dans le contenu et voir l'impact et la reception par les membres.

**Note pour QA**
- Après avoir installé zds en local, faites un `python manage.py migrate` et `pip install --upgrade -r requirements.txt`
- Connectez vous en tant que admin (admin/admin)
- créez un article, un minituto, et un bigtuto
- renseigner ceci : `!(http://jsfiddle.net/f62vt94r/5/)` dans les introductions, conclusions et extraits
- publiez vos articles et tutoriels et **constatez que les chaines n'ont pas été transformées** (car le js n'est pas activé sur votre tuto) en hors-ligne comme et en ligne.
- allez ensuite dans l'adminstration django `127.0.0.1:8000/admin/` et dans tutoriels -> <le_tuto_crée>, cochez la case "Support du Javascript". Faites de même pour les articles
- Constatez que dans la version hors-ligne de vos contenus, on a un affichage javascript à la place des chaines.
- Redemandez une validation, et constatez aussi que la version online est bien comme ce qu'on veut.
