### PR TITLE
Corrige les tests qui ne passent pas.

### DIFF
--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -130,7 +130,7 @@ class Gallery(models.Model):
     def get_last_image(self):
         return Image.objects.all()\
             .filter(gallery=self)\
-            .order_by('-pubdate')[0]
+            .last()
 
 
 @receiver(models.signals.post_delete, sender=Gallery)

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -947,7 +947,7 @@ class LeaveViewTest(TestCase):
             reverse('zds.mp.views.leave'),
             {
                 'leave': '',
-                'topic_pk': '154'
+                'topic_pk': '9999'
             }
         )
 
@@ -955,7 +955,7 @@ class LeaveViewTest(TestCase):
 
     def test_success_leave_topic_as_author_no_participants(self):
 
-        self.topic1.participants.remove(self.profile2)
+        self.topic1.participants.clear()
         self.topic1.save()
 
         response = self.client.post(


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | Aucun |

Etant donné qu'on tourne maintenant sur mysql sur travis, certains tests sont cassés alors qu'il sont bien passés au moment du merge. La cause étant qu'on se base beaucoup sur les date pour faire nos opération et vu que travis est souvent très rapide, on a parfois des dates qui cassent.

Cette PR vise à corriger donc ces soucis.
