### PR TITLE
Date de dernière visite au lieu de date de login

### DIFF
--- a/conf/locale/en/LC_MESSAGES/django.po
+++ b/conf/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-25 20:25+0100\n"
+"POT-Creation-Date: 2014-11-29 13:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1531,7 +1531,7 @@ msgid "Inscrit"
 msgstr ""
 
 #: templates/member/profile.html:45
-msgid "Dernière connexion"
+msgid "Dernière visite sur le site"
 msgstr ""
 
 #: templates/member/profile.html:49

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -42,7 +42,7 @@
                     {% trans "Inscrit" %} {{ usr.date_joined|format_date:True }}
                 </li>
                 <li>
-                    {% trans "Dernière connexion" %} {{ usr.last_login|format_date:True }}
+                    {% trans "Dernière connexion" %} {{ profile.last_visit|format_date:True }}
                 </li>
                 {% if perms.member.show_ip %}
                     <li>

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -42,7 +42,7 @@
                     {% trans "Inscrit" %} {{ usr.date_joined|format_date:True }}
                 </li>
                 <li>
-                    {% trans "Dernière connexion" %} {{ profile.last_visit|format_date:True }}
+                    {% trans "Dernière visite sur le site" %} {{ profile.last_visit|format_date:True }}
                 </li>
                 {% if perms.member.show_ip %}
                     <li>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #472 |

Cette PR corrige la date de dernière connexion sur la page de profil d'un membre. Avant on affichait la date de dernière connexion à la place, ce qui rendait l'information ambigue.

**Note pour QA**

Une code review devrait suffire ici.
