### PR TITLE
Mail invisible sur la page profil d'un membre

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django==1.6.8
 coverage==3.7.1
 south==1.0.1
 django-crispy-forms==1.4.0
-django-email-obfuscator==0.1.3
+git+https://github.com/morninj/django-email-obfuscator.git#egg=email_obfuscator
 django-haystack==2.3.1
 django-model-utils==2.2
 django-munin==0.1.5


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1672 |

Une simple mise à jour de la dépendance _django_email_obfuscator_ en passant par le dépot git directement et non par pypi.
