### PR TITLE
Ajout d'une notification mail lorsqu'on est ajouté à un MP

### DIFF
--- a/templates/email/mp/add_participant.html
+++ b/templates/email/mp/add_participant.html
@@ -7,7 +7,7 @@
     {% trans "Bonjour" %} <strong>{{ username }}</strong>,
     <br />
     <br />
-    <strong>{{ author }}</strong> {% trans "vous a ajouté à une conversation privée sur" %} {{ app.site.litteral_name }}.
+    <strong>{{ author }}</strong> {% trans "vous a ajouté à une conversation privée sur" %} {{ site_name }}.
     <br />
     <br />
     {% trans "Pour y accéder" %}, <a href="{{ url }}">{% trans "cliquez ici" %}</a>.
@@ -16,5 +16,5 @@
     <br />
     {% trans "Cordialement" %},
     <br />
-    {% trans "L'équipe" %} {{ app.site.litteral_name }}
+    {% trans "L'équipe" %} {{ site_name }}
 </body>

--- a/templates/email/mp/add_participant.html
+++ b/templates/email/mp/add_participant.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+<html lang="fr">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body>
+    {% trans "Bonjour" %} <strong>{{ username }}</strong>,
+    <br />
+    <br />
+    <strong>{{ author }}</strong> {% trans "vous a ajouté à une conversation privée sur" %} {{ app.site.litteral_name }}.
+    <br />
+    <br />
+    {% trans "Pour y accéder" %}, <a href="{{ url }}">{% trans "cliquez ici" %}</a>.
+    <br />
+    <br />
+    <br />
+    {% trans "Cordialement" %},
+    <br />
+    {% trans "L'équipe" %} {{ app.site.litteral_name }}
+</body>

--- a/templates/email/mp/add_participant.txt
+++ b/templates/email/mp/add_participant.txt
@@ -1,0 +1,10 @@
+{% load i18n %}
+{% trans "Bonjour" %} {{ username }},
+
+{{ author }} {% trans "vous a ajouté à une conversation privée sur" %} {{ app.site.litteral_name }}
+
+{% trans "Pour y accéder, cliquez ou recopiez l'url suivante" %} : {{ url }}
+
+{% trans "Cordialement,
+
+L'équipe" %} {{ app.site.litteral_name }}

--- a/templates/email/mp/add_participant.txt
+++ b/templates/email/mp/add_participant.txt
@@ -5,6 +5,6 @@
 
 {% trans "Pour y accéder, cliquez ou recopiez l'url suivante" %} : {{ url }}
 
-{% trans "Cordialement,
+{% trans "Cordialement" %},
 
-L'équipe" %} {{ site_name }}
+{% trans "L'équipe" %} {{ site_name }}

--- a/templates/email/mp/add_participant.txt
+++ b/templates/email/mp/add_participant.txt
@@ -1,10 +1,10 @@
 {% load i18n %}
 {% trans "Bonjour" %} {{ username }},
 
-{{ author }} {% trans "vous a ajouté à une conversation privée sur" %} {{ app.site.litteral_name }}
+{{ author }} {% trans "vous a ajouté à une conversation privée sur" %} {{ site_name }}
 
 {% trans "Pour y accéder, cliquez ou recopiez l'url suivante" %} : {{ url }}
 
 {% trans "Cordialement,
 
-L'équipe" %} {{ app.site.litteral_name }}
+L'équipe" %} {{ site_name }}

--- a/templates/email/mp/new.html
+++ b/templates/email/mp/new.html
@@ -7,7 +7,7 @@
     {% trans "Bonjour" %} <strong>{{ username }}</strong>,
     <br />
     <br />
-    <strong>{{ author }}</strong> {% trans "vous a envoyé un message privé sur" %} {{app.site.litteral_name}}.
+    <strong>{{ author }}</strong> {% trans "vous a envoyé un message privé sur" %} {{ site_name }}.
     <br />
     <br />
     {% trans "Pour le lire" %}, <a href="{{ url }}">{% trans "cliquez ici" %}</a>.
@@ -16,5 +16,5 @@
     <br />
     {% trans "Cordialement" %},
     <br />
-    {% trans "L'équipe" %} {{app.site.litteral_name}}
+    {% trans "L'équipe" %} {{ site_name }}
 </body>

--- a/templates/email/mp/new.txt
+++ b/templates/email/mp/new.txt
@@ -5,6 +5,6 @@
 
 {% trans "Pour le lire, cliquez ou recopiez l'url suivante" %} : {{ url }}
 
-{% trans "Cordialement,
+{% trans "Cordialement" %},
 
-L'équipe" %} {{ site_name }}
+{% trans "L'équipe" %} {{ site_name }}

--- a/templates/email/mp/new.txt
+++ b/templates/email/mp/new.txt
@@ -1,10 +1,10 @@
 {% load i18n %}
 {% trans "Bonjour" %} {{ username }},
 
-{{ author }} {% trans "vous a envoyé un message privé sur" %} {{app.site.litteral_name}}
+{{ author }} {% trans "vous a envoyé un message privé sur" %} {{ site_name }}
 
 {% trans "Pour le lire, cliquez ou recopiez l'url suivante" %} : {{ url }}
 
 {% trans "Cordialement,
 
-L'équipe" %} {{app.site.litteral_name}}
+L'équipe" %} {{ site_name }}

--- a/update.md
+++ b/update.md
@@ -1,9 +1,9 @@
-Ce fichier liste les actions √† faire pour mettre en production les diff√©rentes
+Ce fichier liste les actions ‡ faire pour mettre en production les diffÈrentes
 versions de Zeste de Savoir.
 
-Ajoutez tout simplement vos instructions √† la suite de ce fichier.
+Ajoutez tout simplement vos instructions ‡ la suite de ce fichier.
 
-Actions √† faire pour mettre en prod la version : v1.2
+Actions ‡ faire pour mettre en prod la version : v1.2
 =====================================================
 
 Issue #1520
@@ -27,7 +27,7 @@ apt-get install optipng
 apt-get install jpegoptim
 ```
 
-Mettre √† jour le fichier `settings_prod.py` :
+Mettre ‡ jour le fichier `settings_prod.py` :
 
 ```python
 THUMBNAIL_OPTIMIZE_COMMAND = { 
@@ -38,10 +38,10 @@ THUMBNAIL_OPTIMIZE_COMMAND = {
 ```
 
 
-Actions √† faire pour mettre en prod la version : v1.3
+Actions ‡ faire pour mettre en prod la version : v1.3
 =====================================================
 
-Actions √† faire pour mettre en prod la version : v1.4
+Actions ‡ faire pour mettre en prod la version : v1.4
 =====================================================
 
 Issue #381
@@ -49,17 +49,22 @@ Issue #381
 
 1. Pour un compte **facebook** : 
   - allez sur https://developers.facebook.com/apps/?action=create et cliquer sur "Create New App" en vert
-  - Dans les param√®tre de l'application cr√©e cliquez sur ‚ÄúAdd Platform‚Äù. Dans les options fournies, choisissez Web, et remplissez l'url du site avec "http://zestedesavoir.com" (adaptez l'adresse en fonction de l'adresse sur laquelle vous d√©ployez)
-  - dans votre fichier `settings_prod.py` rajouter les variables `SOCIAL_AUTH_FACEBOOK_KEY = "cl√©"`
+  - Dans les paramËtre de l'application crÈe cliquez sur ´ Add Platform ª. Dans les options fournies, choisissez Web, et remplissez l'url du site avec "http://zestedesavoir.com" (adaptez l'adresse en fonction de l'adresse sur laquelle vous dÈployez)
+  - dans votre fichier `settings_prod.py` rajouter les variables `SOCIAL_AUTH_FACEBOOK_KEY = "clÈ"`
 et `SOCIAL_AUTH_FACEBOOK_SECRET = "secret"` obtenu via l'application facebook
 
 2. Pour un compte **twitter** : 
   - allez sur https://apps.twitter.com/app/new et creez une nouvelle application
-  - remplissez les informations, et dans votre url de callback pensez √† renseigner `http://zestedesavoir.com/complete/twitter/` (adaptez l'adresse en fonction de l'adresse sur laquelle vous d√©ployez)
-  - dans votre fichier `settings_prod.py` rajouter les variables `SOCIAL_AUTH_TWITTER_KEY = "cl√©"`
+  - remplissez les informations, et dans votre url de callback pensez ‡ renseigner `http://zestedesavoir.com/complete/twitter/` (adaptez l'adresse en fonction de l'adresse sur laquelle vous dÈployez)
+  - dans votre fichier `settings_prod.py` rajouter les variables `SOCIAL_AUTH_TWITTER_KEY = "clÈ"`
 et `SOCIAL_AUTH_TWITTER_SECRET = "secret"`  obtenu via l'application twitter
 
 3. Pour un compte **google plus** : 
   - allez sur https://console.developers.google.com/ et creez une nouvelle application
-  - remplissez les informations, et dans votre url de callback pensez √† renseigner `http://zestedesavoir.com/complete/google-oauth2/` (adaptez l'adrese en fonction de l'adresse sur laquelle vous testez d√©ployez)
-  - dans votre fichier `settings_prod.py` rajouter les variables `SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = "cl√©"` et `SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = "secret"`  obtenu via l'application google
+  - remplissez les informations, et dans votre url de callback pensez ‡ renseigner `http://zestedesavoir.com/complete/google-oauth2/` (adaptez l'adrese en fonction de l'adresse sur laquelle vous testez dÈployez)
+  - dans votre fichier `settings_prod.py` rajouter les variables `SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = "clÈ"` et `SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = "secret"`  obtenu via l'application google
+
+PR #1785
+--------
+
+VÈrifier que `EMAIL_BACKEND` est bien dÈfinit dans le `settings_prod.py` car il a maintenant une valeur par dÈfaut. La configuration par dÈfaut sur la prod devrait Ítre `EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'`.

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -2,6 +2,7 @@
 
 import urllib
 
+from django.core import mail
 from django.conf import settings
 from django.test import TestCase
 from django.core.urlresolvers import reverse
@@ -1149,3 +1150,39 @@ class AddParticipantViewTest(TestCase):
             profile3.user,
             PrivateTopic.objects.get(pk=self.topic1.pk).participants.all()
         )
+
+    def test_add_participant_email_notification(self):
+
+        profile3 = ProfileFactory()
+        profile3.email_for_answer = True
+        profile3.save()
+
+        response = self.client.post(
+            reverse('zds.mp.views.add_participant'),
+            {
+                'topic_pk': self.topic1.pk,
+                'user_pk': profile3.user.username
+            },
+            follow=True
+        )
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, len(response.context['messages']))
+        self.assertEquals(len(mail.outbox), 1)
+
+    def test_add_participant_email_no_notification(self):
+
+        profile3 = ProfileFactory()
+
+        response = self.client.post(
+            reverse('zds.mp.views.add_participant'),
+            {
+                'topic_pk': self.topic1.pk,
+                'user_pk': profile3.user.username
+            },
+            follow=True
+        )
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, len(response.context['messages']))
+        self.assertEquals(len(mail.outbox), 0)

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -332,16 +332,16 @@ def answer(request):
                                 .render(
                                     Context({
                                         'username': part.username,
-                                        'url': settings.ZDS_APP['site']['url']
-                                        + post.get_absolute_url(),
-                                        'author': request.user.username
+                                        'url': settings.ZDS_APP['site']['url'] + post.get_absolute_url(),
+                                        'author': request.user.username,
+                                        'site_name': settings.ZDS_APP['site']['litteral_name']
                                     }))
                             message_txt = get_template('email/mp/new.txt').render(
                                 Context({
                                     'username': part.username,
-                                    'url': settings.ZDS_APP['site']['url']
-                                    + post.get_absolute_url(),
-                                    'author': request.user.username
+                                    'url': settings.ZDS_APP['site']['url'] + post.get_absolute_url(),
+                                    'author': request.user.username,
+                                    'site_name': settings.ZDS_APP['site']['litteral_name']
                                 }))
 
                             msg = EmailMultiAlternatives(
@@ -519,14 +519,16 @@ def add_participant(request):
                         Context({
                             'username': part.username,
                             'url': settings.ZDS_APP['site']['url'] + ptopic.get_absolute_url(),
-                            'author': request.user.username
+                            'author': request.user.username,
+                            'site_name': settings.ZDS_APP['site']['litteral_name']
                         }))
 
                 message_txt = get_template('email/mp/add_participant.txt').render(
                     Context({
                         'username': part.username,
                         'url': settings.ZDS_APP['site']['url'] + ptopic.get_absolute_url(),
-                        'author': request.user.username
+                        'author': request.user.username,
+                        'site_name': settings.ZDS_APP['site']['litteral_name']
                     }))
 
                 msg = EmailMultiAlternatives(subject, message_txt, from_email, [part.email])

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -269,6 +269,9 @@ HAYSTACK_CONNECTIONS = {
 
 GEOIP_PATH = os.path.join(SITE_ROOT, 'geodata')
 
+# Fake mails (in console)
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 from django.contrib.messages import constants as message_constants
 MESSAGE_TAGS = {
     message_constants.DEBUG: 'debug',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1771, #1784 |

J'ai profité du fix de #1771 pour corriger en même temps #1784.

J'ai également apporté les modifications suivantes : 
- Ajout de `EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'` dans les settings comme ça par défaut (en local donc), les mails envoyés apparaissent dans la console ce qui est vraiment plus pratique pour débugger.
- Nettoyage du `views.py` des MP
### QA #1771 (Absence de notification lorsqu'on nous ajoute à une conversation via MP)
- Se connecter avec `user`
- Dans les paramètres vérifier que « Recevez un courriel lorsque vous recevez une réponse à un message privé » est bien coché
- Se déconnecter de `user`
- Se connecter avec `admin`
- Créer une conversation avec `staff`
- Ajouter `user` à la conversation
- **Vérifier si un mail est bien envoyé à `user`** (dans la console maintenant)
### QA #1784
- Se connecter avec `user`
- Dans les paramètres vérifier que « Recevez un courriel lorsque vous recevez une réponse à un message privé » est bien coché
- Se déconnecter de `user`
- Se connecter avec `admin`
- Créer une conversation avec `user`
- **Vérifier si dans le mail envoyé à `user` il y a bien « Zeste de Savoir » présent 2 fois (dans le corps du message et dans la signature)** (dans la console maintenant)
