### PR TITLE
Fix #1764 : Décalage sur la pages de tous les forums sur mobile

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -1797,7 +1797,7 @@
 
 .forum-list {
     .group-title {
-        width: 100%;
+        max-width: 100%;
         margin-top: 30px !important;
         clear: both;
         border-bottom: 1px solid #CCC;


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1764 |
### QA
- Aller sur mobile sur la liste des forums
- Essayer de faire défiler l'écran de droite à gauche
- Si c'est impossible c'est que c'est bon ! (Pour avoir une idée du mauvais comportement aller sur la prod : http://zestedesavoir.com/forums/ )
- Vérifier quand même que ça ne casse pas tout sur d'autres supports

_Bug testé avec un Nexus 4 sous Firefox Mobile_

PS : premier fix front ! Les avis de @Alex-D @Situphen @sandhose m'intéressent sur ma solution qui semble fonctionner et ne rien casser.
