### PR TITLE
Fix #1787 : Mauvais lien de citation lorsqu'on est déjà en train de citer quelqu'un

### DIFF
--- a/templates/tutorial/comment/new.html
+++ b/templates/tutorial/comment/new.html
@@ -52,7 +52,7 @@
             {% endcaptureas %}
 
             {% captureas cite_link %}
-                {% url "zds.tutorial.views.answer" %}?tutorial={{ topic.pk }}&amp;cite={{ message.pk }}
+                {% url "zds.tutorial.views.answer" %}?tutorial={{ tutorial.pk }}&amp;cite={{ message.pk }}
             {% endcaptureas %}
 
             {% captureas upvote_link %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1787 |
### QA
- Créer un tuto et le publier
- Commenter
- Se déconnecter et se connecter avec un autre utilisateur (pour ne pas avoir à attendre 15 minutes)
- Aller sur le tuto et citer le commentaire
- **Sur la page de citation vérifier si le lien « Citer » du précédent message est bon.**
