### PR TITLE
Ordre d'affichage des catégories des tutoriels

### DIFF
--- a/update.md
+++ b/update.md
@@ -63,3 +63,8 @@ et `SOCIAL_AUTH_TWITTER_SECRET = "secret"`  obtenu via l'application twitter
   - allez sur https://console.developers.google.com/ et creez une nouvelle application
   - remplissez les informations, et dans votre url de callback pensez à renseigner `http://zestedesavoir.com/complete/google-oauth2/` (adaptez l'adrese en fonction de l'adresse sur laquelle vous testez déployez)
   - dans votre fichier `settings_prod.py` rajouter les variables `SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = "clé"` et `SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = "secret"`  obtenu via l'application google
+
+Issue #1487
+-----------
+
+Définir des positions pour les catégories de tutoriels dans la partie admin du site (par défaut toutes à 0). L'odre d'affichage se fait par ordre croissant. Les sous-catégories sont triées automatiquement par ordre alphabétique.

--- a/zds/utils/migrations/0006_auto__add_field_category_position.py
+++ b/zds/utils/migrations/0006_auto__add_field_category_position.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Category.position'
+        db.add_column(u'utils_category', 'position',
+                      self.gf('django.db.models.fields.IntegerField')(default=0),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Category.position'
+        db.delete_column(u'utils_category', 'position')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'utils.alert': {
+            'Meta': {'object_name': 'Alert'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'alerts'", 'to': u"orm['auth.User']"}),
+            'comment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'alerts'", 'to': u"orm['utils.Comment']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'scope': ('django.db.models.fields.CharField', [], {'max_length': '1', 'db_index': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        },
+        u'utils.category': {
+            'Meta': {'object_name': 'Category'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'utils.categorysubcategory': {
+            'Meta': {'object_name': 'CategorySubCategory'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.Category']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_main': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'subcategory': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.SubCategory']"})
+        },
+        u'utils.comment': {
+            'Meta': {'object_name': 'Comment'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': u"orm['auth.User']"}),
+            'dislike': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'editor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'comments-editor'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.CharField', [], {'max_length': '39'}),
+            'is_visible': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'like': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'pubdate': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'text_hidden': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '80'}),
+            'text_html': ('django.db.models.fields.TextField', [], {}),
+            'update': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'utils.commentdislike': {
+            'Meta': {'object_name': 'CommentDislike'},
+            'comments': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.Comment']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'post_disliked'", 'to': u"orm['auth.User']"})
+        },
+        u'utils.commentlike': {
+            'Meta': {'object_name': 'CommentLike'},
+            'comments': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['utils.Comment']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'post_liked'", 'to': u"orm['auth.User']"})
+        },
+        u'utils.licence': {
+            'Meta': {'object_name': 'Licence'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'utils.subcategory': {
+            'Meta': {'object_name': 'SubCategory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '80'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'utils.tag': {
+            'Meta': {'object_name': 'Tag'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        }
+    }
+
+    complete_apps = ['utils']

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -30,6 +30,7 @@ class Category(models.Model):
 
     title = models.CharField('Titre', max_length=80)
     description = models.TextField('Description')
+    position = models.IntegerField('Position', default=0)
 
     slug = models.SlugField(max_length=80)
 

--- a/zds/utils/templatetags/topbar.py
+++ b/zds/utils/templatetags/topbar.py
@@ -62,7 +62,8 @@ def top_categories(user):
 
 @register.filter('top_categories_tuto')
 def top_categories_tuto(user):
-    """ get all the categories and their related subcategories
+    """
+        Get all the categories and their related subcategories
         associed with an existing tutorial. The result is sorted
         by alphabetic order.
     """
@@ -74,28 +75,18 @@ def top_categories_tuto(user):
     catsubcats = CategorySubCategory.objects \
         .filter(is_main=True)\
         .filter(subcategory__in=subcats_tutos)\
-        .order_by('category__title', 'subcategory__title')\
+        .order_by('category__position', 'subcategory__title')\
         .select_related('subcategory', 'category')\
-        .values('category__title','subcategory__title')\
+        .values('category__title', 'subcategory__title')\
         .all()
-
-    # special categorie 'other' goes to the end
-    other = []
 
     for csc in catsubcats:
         key = csc['category__title']
-
-        if key == 'Autres':
-            other.append(csc['subcategory__title'])
-            continue
 
         if key in cats:
             cats[key].append(csc['subcategory__title'])
         else:
             cats[key] = [csc['subcategory__title']]
-
-    if other != []:
-        cats['Autres'] = other
 
     return cats
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1487 |

Je tente un trie par ordre alphabétique des catégories et sous catégories de tutoriels. La catégorie "Autres" est mise en dernière position. J'ai juste modifié le template tags associé qui est utilisé. Les catégories sont triées directement avec la requete sql, et sont mises dans un _OrderedDict_ pour garder l'ordre d'ajout.

**QA** : 
- Vérifier les catégories sur la page d'accueil
- Vérifier les catégories sur la topbar
