### PR TITLE
Commande de regénération de pdf

### DIFF
--- a/doc/sphinx/source/utils/utils.rst
+++ b/doc/sphinx/source/utils/utils.rst
@@ -4,6 +4,15 @@ Autres outils
 
 Le package ``zds/utils`` contient un certains nombres d'outils transverses.
 
+pdf_generator
+-------------
+
+Il s'agit d'une commande qui a pour objectif de donner la possibilité via une ligne de commande de regénerer un ou plusieurs pdf de tutoriels déjà publiés.
+
+La commande à lancer est : ``python manage.py pdf_generator``.
+
+Pour préciser le tutoriel à regenerer, il suffit de rajouter l'argument ``id=125,142,56`` pour regenerer les pdfs des tutos dont l'id est ``125``, ``142``, et ``56``.
+
 .. toctree::
    :maxdepth: 2
 

--- a/zds/utils/management/commands/pdf_generator.py
+++ b/zds/utils/management/commands/pdf_generator.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+
+from django.core.management.base import BaseCommand
+from zds.tutorial.models import Tutorial
+from zds import settings
+import os
+
+
+class Command(BaseCommand):
+    args = 'id=1,2,3,4,5'
+    help = 'Generate tutorials pdfs'
+    # python manage.py pdf_generator id=3
+
+    def handle(self, *args, **options):
+        ids = []
+
+        for arg in args:
+            ps = arg.split("=")
+            if len(ps) < 2:
+                continue
+            else:
+                if ps[0] in ["id", "ids"]:
+                    ids = ps[1].split(",")
+
+        pandoc_debug_str = ""
+        if settings.PANDOC_LOG_STATE:
+            pandoc_debug_str = " 2>&1 | tee -a " + settings.PANDOC_LOG
+
+        if len(ids) > 0:
+            tutorials = Tutorial.objects.filter(pk__in=ids, sha_public__isnull=False).all()
+            self.stdout.write(u"Génération de PDFs pour les tutoriels dont l'id est dans la liste : {}".format(ids))
+        else:
+            tutorials = Tutorial.objects.filter(sha_public__isnull=False).all()
+            self.stdout.write(u"Génération de PDFs pour tous les tutoriels du site")
+
+        for tutorial in tutorials:
+            prod_path = tutorial.get_prod_path(tutorial.sha_public)
+            os.system("cd "+prod_path + " && " + settings.PANDOC_LOC + "pandoc " + "--latex-engine=xelatex "
+                      + "--template=../../assets/tex/template.tex " + "-s " + "-S "
+                      + "-N " + "--toc " + "-V documentclass=scrbook "
+                      + "-V lang=francais " + "-V mainfont=Merriweather "
+                      + "-V monofont=\"Andale Mono\" " + "-V fontsize=12pt "
+                      + "-V geometry:margin=1in "
+                      + os.path.join(prod_path, tutorial.slug) + ".md "
+                      + "-o " + os.path.join(prod_path, tutorial.slug)
+                      + ".pdf" + pandoc_debug_str)
+            self.stdout.write(u"----> {} : OK".format(tutorial.title))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | Aucun |

Cette PR a pour objectif de donner la possibilité via la ligne de commande de regénerer un ou plusieurs pdf de tutoriels déjà publiés.

La commande à lancer est : `python manage.py pdf_generator`.
Pour préciser le tuto à regenerer, il suffit de rajouter l'argument `id=125,142,56` pour regenerer les pdfs des tutos dont l'id est 125, 142, et 56.

**Note pour QA**

NB : Vous devez avoir [installé pandoc](http://zds-site.readthedocs.org/fr/latest/install/install-linux.html#aller-plus-loin) sur votre système.
- Créer ou importez des tutoriels et publiez les
- supprimez les version pdfs des tutoriels dans le dossiers de chaque tutoriel sous l'arborescence `tutoriels-public`
- lancer la commande qui regénère un seul pdf : `python manage.py pdf_generator id=1`
- consultez le tutoriel dont l'id est 1, et vérifiez que son pdf est bien téléchargeable
- consultez les autres tutoriels et vérifiez que le pdf n'est pas téléchargeable
- lancez la commande qui génère tous les pdfs : `python manage.py pdf_generator`
- consultez tous les tutoriels et vérifiez que les pdfs pour lesquels il n'y a ps eu d'erreur LaTex sont téléchargeables.
