### PR TITLE
Correction du logo sur la page a propros

### DIFF
--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -47,7 +47,7 @@
                     	    {{ logo_desc }}
                             </a>
                         {% endblocktrans %}
-                        <img alt="Logo de {{app.site.litteral_name}}" src="{{app.site.url}}/static/images/logo.png">
+                        <img alt="Logo de {{app.site.litteral_name}}" src="{{app.site.url}}/static/images/logo-background.png">
                     </p>
                 {% endif %}
             </div>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1650 |

Corige l'affichage du logo sur la page A propros.

**Note pour QA**

Rendez vous sur cette page `/pages/apropos/`

Et vérifiez que le logo affiché est bien visible.
