### PR TITLE
Correction des images pour facebook

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -46,7 +46,7 @@
 
 
     {% captureas meta_image %}
-        {{ request.META.HTTP_HOST }}{% block meta_image %}{% spaceless %}
+        {{ app.site.url }}{% block meta_image %}{% spaceless %}
             {% static "images/apple-touch-icon-144x144-precomposed.png" %}
         {% endspaceless %}{% endblock %}
     {% endcaptureas %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -46,7 +46,7 @@
 
 
     {% captureas meta_image %}
-        {{ app.site.url }}{% block meta_image %}{% spaceless %}
+        {{ app.site.dns }}{% block meta_image %}{% spaceless %}
             {% static "images/apple-touch-icon-144x144-precomposed.png" %}
         {% endspaceless %}{% endblock %}
     {% endcaptureas %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1804 |

Cette PR permet d'afficher la bonne url pour les images par défaut dans opengraph

**Note pour QA**

Vérifiez qu'on a bien la bonne url dans la balise meta `<meta property="og:image:url" content="la_bonne_url_image">`
