### PR TITLE
Variabilisation du nombre d'articles et de tutoriels sur la page d'accueil

### DIFF
--- a/doc/sphinx/source/introduction.rst
+++ b/doc/sphinx/source/introduction.rst
@@ -59,11 +59,13 @@ Il est possible de personnaliser ZdS pour n'importe quel site communautaire de p
         },
         'article': {
             'repo_path': os.path.join(SITE_ROOT, 'articles-data'),
+            'home_number': 5,
         },
         'tutorial': {
             'repo_path': os.path.join(SITE_ROOT, 'tutoriels-private'),
             'repo_public_path': os.path.join(SITE_ROOT, 'tutoriels-public'),
-            'default_license_pk': 7
+            'default_license_pk': 7,
+            'home_number': 5,
         },
         'forum': {
             'posts_per_page': 21,

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -298,10 +298,11 @@ def get_old_field_value(instance, field, manager):
 
 
 def get_last_articles():
+    n = settings.ZDS_APP['article']['home_number']
     return Article.objects.all()\
         .exclude(sha_public__isnull=True)\
         .exclude(sha_public__exact='')\
-        .order_by('-pubdate')[:5]
+        .order_by('-pubdate')[:n]
 
 
 def get_prev_article(g_article):

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -333,11 +333,13 @@ ZDS_APP = {
     },
     'article': {
         'repo_path': os.path.join(SITE_ROOT, 'articles-data'),
+        'home_number': 5,
     },
     'tutorial': {
         'repo_path': os.path.join(SITE_ROOT, 'tutoriels-private'),
         'repo_public_path': os.path.join(SITE_ROOT, 'tutoriels-public'),
-        'default_license_pk': 7
+        'default_license_pk': 7,
+        'home_number': 5,
     },
     'forum': {
         'posts_per_page': 21,

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -449,10 +449,11 @@ class Tutorial(models.Model):
 
 
 def get_last_tutorials():
+    n = settings.ZDS_APP['tutorial']['home_number']
     tutorials = Tutorial.objects.all()\
         .exclude(sha_public__isnull=True)\
         .exclude(sha_public__exact='')\
-        .order_by('-pubdate')[:5]
+        .order_by('-pubdate')[:n]
 
     return tutorials
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1812 |

Cette PR permet de variabiliser le nombre de tutos maximum affichés sur le home.

**Note pour QA**
- Publiez plusieurs tutoriels et articles grâce à la commande suivante : `python manage.py load_fixtures size=medium type=member,staff,tutorial,article,category_content,note racine=user`
- Modifier dans le fichier settings.py, dans le dictionnaire ZDS_APP les variables `home_number` des tutoriels et articles. Et constatez qu sur la home page, le nombre de tutos/articles publiés est toujours celui demandé dans les paramètres.
