### PR TITLE
Corrige le chevauchement entre les icônes et le texte des titres `<h2>`

### DIFF
--- a/assets/scss/_mobile-tablet.scss
+++ b/assets/scss/_mobile-tablet.scss
@@ -641,7 +641,7 @@
         .content-wrapper,
         .full-content-wrapper {
             h1:not(.ico-after),
-            h2,
+            h2:not(.ico-after),
             h3,
             .subtitle {
                 padding-left: 10px;


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1808 |

**QA :** Vérifier que les icônes et le texte ne se chevauchent plus sur les pages "Tous les articles" et "Mes tutoriels"
