### PR TITLE
Aligne le comportement des listes ordonnées sur mobile

### DIFF
--- a/assets/scss/_mobile-tablet.scss
+++ b/assets/scss/_mobile-tablet.scss
@@ -632,6 +632,7 @@
 
         .article-content {
             p,
+            ol,
             ul:not(.pagination) {
                 font-size: 15px;
                 font-size: 1.5rem;


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1774 |

**QA :** Vérifier en affichage mobile que les listes ordonnées sont bien à la même taille que les paragraphes dans les articles.
