### PR TITLE
On ne peut plus déformer les modals en étirant les textarea

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -3141,6 +3141,7 @@ form.topic-message {
     select,
     textarea {
         margin: 10px 15px;
+        resize: none;
 
         &:not([type=checkbox]):not([type=radio]) {
             width: calc(98% - 32px) !important;


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1727 |
### QA
- Commencer par regénérer le front (`gulp build`)
- Faire apparaitre un modal (créer un tuto et demander la validation)
- Vérifier qu'on ne puisse plus étirer le textarea et ainsi déformer le modal (comme ceci http://i.imgur.com/pgxB3I1.png )
