### PR TITLE
Correction de get_last_message() qui ne renvoyait pas le dernier message d'un forum

### DIFF
--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -102,8 +102,7 @@ class Forum(models.Model):
     def get_last_message(self):
         """Gets the last message on the forum, if there are any."""
         try:
-            return Post.objects.all().filter(
-                topic__forum__pk=self.pk).order_by('-position')[0]
+            return Post.objects.all().filter(topic__forum__pk=self.pk).order_by('-pubdate')[0]
         except IndexError:
             return None
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1823 |
### QA
- Créer un sujet avec n (n >2) réponses
- Créer un sujet avec moins de n réponses
- Vérifier si dans « Tous les forums » on a bien la dernière réponse d'indiquée

**À QA EN PRIORITÉ : HOTFIX 1.3**
