### PR TITLE
Titre par défaut sur les mp de collaboration

### DIFF
--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -338,6 +338,23 @@ class NewTopicViewTest(TestCase):
         self.assertEqual(
             self.profile2.user.username,
             response2.context['form'].initial['participants'])
+        
+    def test_success_get_with_and_without_title(self):
+
+        response = self.client.get(reverse('zds.mp.views.new'))
+
+        self.assertEqual(200, response.status_code)
+        self.assertIsNone(
+            response.context['form'].initial['title'])
+
+        response2 = self.client.get(
+            reverse('zds.mp.views.new')
+            + '?title=Test titre')
+
+        self.assertEqual(200, response2.status_code)
+        self.assertEqual(
+            'Test titre',
+            response2.context['form'].initial['title'])
 
     def test_fail_get_with_username_not_exist(self):
 
@@ -348,7 +365,7 @@ class NewTopicViewTest(TestCase):
         self.assertEqual(200, response2.status_code)
         self.assertIsNone(
             response2.context['form'].initial['participants'])
-
+        
     def test_success_preview(self):
 
         self.assertEqual(0, PrivateTopic.objects.all().count())

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -338,7 +338,7 @@ class NewTopicViewTest(TestCase):
         self.assertEqual(
             self.profile2.user.username,
             response2.context['form'].initial['participants'])
-        
+
     def test_success_get_with_and_without_title(self):
 
         response = self.client.get(reverse('zds.mp.views.new'))
@@ -365,7 +365,7 @@ class NewTopicViewTest(TestCase):
         self.assertEqual(200, response2.status_code)
         self.assertIsNone(
             response2.context['form'].initial['participants'])
-        
+
     def test_success_preview(self):
 
         self.assertEqual(0, PrivateTopic.objects.all().count())

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -217,9 +217,14 @@ def new(request):
             if len(dest_list) > 0:
                 dest = ', '.join(dest_list)
 
+        title = None
+        if 'title' in request.GET:
+            title = request.GET['title']
+
         form = PrivateTopicForm(username=request.user.username,
                                 initial={
                                     'participants': dest,
+                                    'title': title
                                 })
         return render_template('mp/topic/new.html', {
             'form': form,

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -142,10 +142,15 @@ class Tutorial(models.Model):
             return self.get_absolute_url()
 
     def get_absolute_contact_url(self):
+        """ Get url to send a new mp for collaboration """
         auths = self.authors.all()
+        mp_title = "&title=Collaboration - {}".format(self.title)
+
         get = u"?username={}".format(auths[0])
-        for author in auths[:1]:
-            "&username={}".format(author.username)
+        for author in auths[1:]:
+            get += "&username={}".format(author.username)
+        get += mp_title
+
         return reverse('zds.mp.views.new')+get
 
     def get_edit_url(self):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | zep-03 |

Petite pr qui corrige un bug, lors de la construction du lien *Contacter par MP", dans le cas ou il y a plusieurs destinataires ça foire. Et aussi ajout par défaut du titre du mp : "Collaboration - {Titre du tuto}".

**QA** (dans la page d'aide des tutoriels, concernant le lien _Contacter par MP_): 
- vérifer que le titre du mp est correct
- vérifier que la liste des destinataires est correct
