### PR TITLE
Exclure le forum beta des sitemaps

### DIFF
--- a/zds/urls.py
+++ b/zds/urls.py
@@ -60,7 +60,9 @@ sitemaps = {
         priority=0.7
     ),
     'topics': GenericSitemap(
-        {'queryset': Topic.objects.filter(is_locked=False, forum__group__isnull=True).exclude(pk=settings.ZDS_APP['forum']['beta_forum_id']), 'date_field': 'pubdate'},
+        {'queryset': Topic.objects.filter(is_locked=False,
+                                          forum__group__isnull=True).exclude(forum__pk=settings.ZDS_APP['forum']['beta_forum_id']),
+         'date_field': 'pubdate'},
         changefreq='hourly',
         priority=0.7
     ),

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -55,12 +55,12 @@ sitemaps = {
         priority=0.7
     ),
     'forums': GenericSitemap(
-        {'queryset': Forum.objects.filter(group__isnull=True)},
+        {'queryset': Forum.objects.filter(group__isnull=True).exclude(pk=settings.ZDS_APP['forum']['beta_forum_id'])},
         changefreq='yearly',
         priority=0.7
     ),
     'topics': GenericSitemap(
-        {'queryset': Topic.objects.filter(is_locked=False, forum__group__isnull=True), 'date_field': 'pubdate'},
+        {'queryset': Topic.objects.filter(is_locked=False, forum__group__isnull=True).exclude(pk=settings.ZDS_APP['forum']['beta_forum_id']), 'date_field': 'pubdate'},
         changefreq='hourly',
         priority=0.7
     ),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1796 |

Cette PR permet de dire aux moteurs de recherche de ne pas indexer les topics du forum beta.

**Note pour QA**
- Créez des topics dans le forum beta (par défaut il s'agit du forum dont l'id est 1)
- Aller sur `/sitemap.xml` et vérifiez que le forum beta ni les topics associés ne sont pas dans l'arbre xml
