### PR TITLE
[FAILED] dependances pour developement devrait etre sur un autre fichier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,3 @@ pillow==2.6.1
 https://github.com/zestedesavoir/GitPython/archive/0.3.2-RC2.zip
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.4.1-zds.11.zip
 easy-thumbnails==2.2
-
-# Development tools
-PyYAML==3.11
-django-debug-toolbar==1.2.2
-flake8==2.2.5
-autopep8==1.0.4
-sphinx==1.2.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,5 @@
+PyYAML==3.11
+django-debug-toolbar==1.2.2
+flake8==2.2.5
+autopep8==1.0.4
+sphinx==1.2.3


### PR DESCRIPTION
Les dépendances de developement sont maintenant dans un fichier test-requirements.txt.
