### PR TITLE
docs : git pre-hook et autres instructions sur OSX

### DIFF
--- a/doc/sphinx/source/install/backend-linux-install.rst
+++ b/doc/sphinx/source/install/backend-linux-install.rst
@@ -73,7 +73,9 @@ Une fois dans votre environnement python (``source ../bin/activate`` si vous uti
 Aller plus loin
 ===============
 
-Pour faire fonctionner ZdS dans son ensemble (ceci n'est pas obligatoire) vous pouvez installer les outils LateX, Pandoc et les polices Microsoft. Ce qui revient à lancer les commmandes suivantes :
+Pour faire fonctionner ZdS dans son ensemble (ceci n'est pas obligatoire) vous pouvez installer les outils LateX,
+Pandoc et les polices Microsoft.
+Ce qui revient à lancer les commmandes suivantes :
 
 .. sourcecode:: bash
 
@@ -86,34 +88,4 @@ Pour faire fonctionner ZdS dans son ensemble (ceci n'est pas obligatoire) vous p
 Ajouter un hook de pre-commit a git pour tester flake
 -----------------------------------------------------
 
-Afin de s'assurer qu'aucune erreur de mise en forme ne passe les commits,
-il peut être utile de rajouter un hook de pre-commit à git. Un hook est un petit
-programme qui sera exécuté avant une action particulière de git. En l'occurence nous
-allons rajouter un hook qui s'executera juste avant la validation d'un commit.
-
-Pour cela, commencer par créer et éditer le fichier `.git/hooks/pre-commit`
-
-Ensuite, il ne reste plus qu'à rajouter le contenu suivant dans ce fichier et dorénavant
-le controle flake (pour le respect PEP) sera exécuté avant la validation du message de commit.
-Ainsi, plus aucune erreur flake ne viendra vous embêter à posteriori et la base de code
-restera propre et lisible au cours du temps !
-
-.. sourcecode:: bash
-
-    #!/bin/sh
-    
-    tox -e flake8
-    
-    # Store tests result
-    RESULT=$?
-    
-    [ $RESULT -ne 0 ] && exit 1
-    exit 0
-
-
-Enfin n'oubliez pas de le rendre executable via chmod
-
-.. sourcecode:: bash
-
-    chmod +x .git/hooks/pre-commit
-
+.. include:: git_pre-hook.rst

--- a/doc/sphinx/source/install/backend-os-x-install.rst
+++ b/doc/sphinx/source/install/backend-os-x-install.rst
@@ -21,9 +21,8 @@ Installation de virtualenv
 
 .. sourcecode:: bash
 
-    pip install tox
-    pip install virtualenv
-    pip install virtualenvwrapper
+    sudo port install virtualenv_select py27-virtualenv py27-virtualenvwrapper py27-tox
+
     mkdir ~/.virtualenvs
     echo "export WORKON_HOME=$HOME/.virtualenvs" >> ~/.bash_profile && export WORKON_HOME=$HOME/.virtualenvs
     echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bash_profile && source /usr/local/bin/virtualenvwrapper.sh
@@ -78,4 +77,18 @@ Aller plus loin
 Pour faire fonctionner ZdS dans son ensemble vous devez installer les outils LateX et Pandoc.
 
 - Téléchagez et installez `BasicTex <http://www.tug.org/mactex/morepackages.html>`_
+
+.. sourcecode:: bash
+
+  sudo port install texlive-basic
+
 - Téléchargez et installez `Pandoc <https://github.com/jgm/pandoc/releases>`_
+
+.. sourcecode:: bash
+
+  sudo port install pandoc
+
+Ajouter un hook de pre-commit a git pour tester flake
+-----------------------------------------------------
+
+.. include:: git_pre-hook.rst

--- a/doc/sphinx/source/install/git_pre-hook.rst
+++ b/doc/sphinx/source/install/git_pre-hook.rst
@@ -1,0 +1,30 @@
+Afin de s'assurer qu'aucune erreur de mise en forme ne passe les commits,
+il peut être utile de rajouter un hook de pre-commit à git. Un hook est un petit
+programme qui sera exécuté avant une action particulière de git. En l'occurence nous
+allons rajouter un hook qui s'executera juste avant la validation d'un commit.
+
+Pour cela, commencer par créer et éditer le fichier `.git/hooks/pre-commit`
+
+Ensuite, il ne reste plus qu'à rajouter le contenu suivant dans ce fichier et dorénavant
+le controle flake (pour le respect PEP) sera exécuté avant la validation du message de commit.
+Ainsi, plus aucune erreur flake ne viendra vous embêter à posteriori et la base de code
+restera propre et lisible au cours du temps !
+
+.. sourcecode:: bash
+
+    #!/bin/sh
+
+    flake8 --exclude=migrations,urls.py,settings.py --max-line-length=120 zds
+
+    # Store tests result
+    RESULT=$?
+
+    [ $RESULT -ne 0 ] && exit 1
+    exit 0
+
+
+Enfin n'oubliez pas de le rendre executable via chmod
+
+.. sourcecode:: bash
+
+    chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | - |

---
1. instructions git pre-hook dans un nouveau fichier
2. instructions git pre-hook maintenant inclus sur OSX
3. changement d'installation de virtualenv et virtualenvwrapper : pip -> macports
4. instructions d'installation texlive-basic et pandoc avec macports sur OSX
