### PR TITLE
Centralisation des variables de génération de pdf

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -254,6 +254,7 @@ ABSOLUTE_URL_OVERRIDES = {
 SERVE = False
 
 PANDOC_LOC = ''
+PANDOC_PDF_PARAM = "--latex-engine=xelatex --template=../../assets/tex/template.tex -s -S -N --toc -V documentclass=scrbook -V lang=francais -V mainfont=Merriweather -V monofont=\"Andale Mono\" -V fontsize=12pt -V geometry:margin=1in "
 # LOG PATH FOR PANDOC LOGGING
 PANDOC_LOG = './pandoc.log'
 PANDOC_LOG_STATE = False

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3218,12 +3218,7 @@ def mep(tutorial, sha):
               + os.path.join(prod_path, tutorial.slug)
               + ".md -o " + os.path.join(prod_path,
                                          tutorial.slug) + ".html" + pandoc_debug_str)
-    os.system(settings.PANDOC_LOC + "pandoc " + "--latex-engine=xelatex "
-              + "--template=../../assets/tex/template.tex " + "-s " + "-S "
-              + "-N " + "--toc " + "-V documentclass=scrbook "
-              + "-V lang=francais " + "-V mainfont=Merriweather "
-              + "-V monofont=\"Andale Mono\" " + "-V fontsize=12pt "
-              + "-V geometry:margin=1in "
+    os.system(settings.PANDOC_LOC + "pandoc " + settings.PANDOC_PDF_PARAM + " "
               + os.path.join(prod_path, tutorial.slug) + ".md "
               + "-o " + os.path.join(prod_path, tutorial.slug)
               + ".pdf" + pandoc_debug_str)

--- a/zds/utils/management/commands/pdf_generator.py
+++ b/zds/utils/management/commands/pdf_generator.py
@@ -35,13 +35,8 @@ class Command(BaseCommand):
 
         for tutorial in tutorials:
             prod_path = tutorial.get_prod_path(tutorial.sha_public)
-            os.system("cd "+prod_path + " && " + settings.PANDOC_LOC + "pandoc " + "--latex-engine=xelatex "
-                      + "--template=../../assets/tex/template.tex " + "-s " + "-S "
-                      + "-N " + "--toc " + "-V documentclass=scrbook "
-                      + "-V lang=francais " + "-V mainfont=Merriweather "
-                      + "-V monofont=\"Andale Mono\" " + "-V fontsize=12pt "
-                      + "-V geometry:margin=1in "
+            os.system("cd "+prod_path + " && " + settings.PANDOC_LOC + "pandoc " + settings.PANDOC_PDF_PARAM + " "
                       + os.path.join(prod_path, tutorial.slug) + ".md "
                       + "-o " + os.path.join(prod_path, tutorial.slug)
                       + ".pdf" + pandoc_debug_str)
-            self.stdout.write(u"----> {} : OK".format(tutorial.title))
+            self.stdout.write(u"----> {}".format(tutorial.title))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1520 |

Cette PR a pour but de centraliser les variables d'export en pdf. Ce qui permet au gestionnaire du site qui va déployer l'application de choisir ce qu'il veut comme police dans les pdfs, la taille, la coverpage, etc.

Indirectement, ça permettra aussi d'installer sans toucher au code, une autre version de pandoc, sur le système et de l'utiliser à la place de la version disponible dans les dépots. Utile si on veut améliorer la qualité de nos pdfs avec [la version de pandoc](https://github.com/cgabard/pandoc/tree/zds_flavored_markdown) disponible sur le dépot de @cgabard 

**Note pour QA**

NB : Vous devez avoir pandoc installé sur votre système. La version requise minimun est `>= 1.10`

Sur une installation neuve, lancez la commande `python manage.py size=low type=member,staff,tutorial,category_content racine=user`

Vérifiez que les tutoriels qui ont été publiés possède une version PDF.
