### PR TITLE
Une mauvaise extension ne fait plus planter le code

### DIFF
--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+﻿#!/usr/bin/python
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
 from datetime import datetime
@@ -3040,7 +3040,9 @@ def get_url_images(md_text, pt):
                             im.save(os.path.join(pt, "images", filename.split(".")[0] + ".png"))
                         else:
                             im.save(os.path.join(pt, "images", filename))
-                except IOError:
+                except (IOError, KeyError):
+                    # if we can't save or if the image was entered without a proper extension
+
                     pass
             else:
                 # relative link


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | [Pas de ticket pour l'instant, on a juste remarqué ça en faisant des tests sur la preprod] |

L'idée est celle-ci : lorsqu'on envoie une image qui n'a pas la bonne extension (svg par exemple), le script qui télécharge les images pour les mettre dans les PDF plante et donne des erreurs 500.

Je ne sais pas si ce sont seulement les .svg qui font bugger mais ce patch empêche le script de planter et ignore juste l'image si elle est incorrecte.
