### PR TITLE
Ajout de la bibliothèque faker

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ django-debug-toolbar==1.2.2
 flake8==2.2.5
 autopep8==1.0.4
 sphinx==1.2.3
+faker==0.0.4


### PR DESCRIPTION
Impossible de charger les fixtures automatique sans cette lib.

Vu les modifs, j'avoue avoir un peu la flemme de faire la cartouche.
