### PR TITLE
Vire une traduction qui n'a rien a faire la !

### DIFF
--- a/templates/member/register/token_already_used.html
+++ b/templates/member/register/token_already_used.html
@@ -15,7 +15,7 @@
 
 
 {% block breadcrumb %}
-    <li><a href="{% url "{% trans "zds.member.views.register_view" %}" %}">{% trans "Inscription" %}</a></li>
+    <li><a href="{% url "zds.member.views.register_view" %}">{% trans "Inscription" %}</a></li>
     <li>{% trans "Déjà activé" %}</li>
 {% endblock %}
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | **hotfix** |

Base sur une alerte Sentry, ce problème vient d'une chaîne "url" qui ne devrait pas etre traduite.

Cet hotfix est a merger au plus tot, en l’état un membre ne peut plus renouveler son token d'activation s'il le premier échoue... C'est mal. Et c'est surtout un bon moyen de faire renoncer a des gens de venir sur le site...
