### PR TITLE
Ajout de la directive "static" pour les fichiers CSS (plus de souplesse)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -563,10 +563,10 @@
 
     {# Javascript stuff start #}
     {% if debug %}
-        <script src="/static/js/vendors.js"></script>
-        <script src="/static/js/main.js"></script>
+        <script src="{% static "js/vendors.js" %}"></script>
+        <script src="{% static "js/main.js" %}"></script>
     {% else %}
-        <script src="/static/js/all.min.js"></script>
+        <script src="{% static "js/all.min.js" %}"></script>
     {% endif %}
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,9 +77,9 @@
 
     {# Stylesheets #}
     {% if debug %}
-        <link rel="stylesheet" href="/static/css/main.css">
+        <link rel="stylesheet" href="{% static "css/main.css" %}">
     {% else %}
-        <link rel="stylesheet" href="/static/css/main.min.css">
+        <link rel="stylesheet" href="{% static "css/main.min.css" %}">
         {% block canonical %}{% endblock %}
     {% endif %}
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | Aucun |

Juste histoire d'être souple... Il faut considérer les ressources CSS comme statiques au sens des templates Django. Au cas où vous décideriez de changer le nom du dossier dans un futur plus ou moins proche ? Certes je doute que ça arrive, mais ça reste une éventualité...
