### PR TITLE
Fix #1891 : correction de balises « url » fausses

### DIFF
--- a/templates/member/new_password/failed.html
+++ b/templates/member/new_password/failed.html
@@ -25,6 +25,6 @@
         {% trans "Votre mot de passe n'a pas pu être modifié. A partir du moment où vous soumettez votre requête pour réinitialiser votre mot de passe, vous n'avez qu'une heure pour la confirmer" %}.
     </p>
     <p>
-        <a href="{% url "{% trans "zds.member.views.forgot_password" %}" %}">{% trans "Re-soumettre votre demande de réinitialisation" %}</a>.
+        <a href="{% url "zds.member.views.forgot_password" %}">{% trans "Re-soumettre votre demande de réinitialisation" %}</a>.
     </p>
 {% endblock %}

--- a/templates/member/new_password/success.html
+++ b/templates/member/new_password/success.html
@@ -22,6 +22,6 @@
 
 {% block content %}
     <p>
-        {% trans "Votre mot de passe a bien été modifié" %}. <a href="{% url "{% trans "zds.member.views.login_view" %}" %}">{% trans "Vous connectez" %}</a>.
+        {% trans "Votre mot de passe a bien été modifié" %}. <a href="{% url "zds.member.views.login_view" %}">{% trans "Vous connectez" %}</a>.
     </p>
 {% endblock %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1891 |
### QA

Changer son mot de passe via le formulaire de mot de passe oublié et vérifier qu'on a bien la page de succès et pas une 500.
