### PR TITLE
Fix le problème des licences en local (#1896)

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -377,7 +377,7 @@ def edit(request):
             return redirect(article.get_absolute_url())
     else:
         if "licence" in json:
-            licence = Licence.objects.filter(code=json["licence"]).all()[0]
+            licence = json['licence']
         else:
             licence = Licence.objects.get(
                 pk=settings.ZDS_APP['tutorial']['default_license_pk']

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1255,7 +1255,7 @@ def edit_tutorial(request):
     else:
         json = tutorial.load_json()
         if "licence" in json:
-            licence = Licence.objects.filter(code=json["licence"]).all()[0]
+            licence = json['licence']
         else:
             licence = Licence.objects.get(
                 pk=settings.ZDS_APP['tutorial']['default_license_pk']


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1896 |

Permet de changer de licence sans avoir d'erreur `index out of range`. Pour moi, on ne la détectait pas en prod parce que les licences ont le même `code` et `title`.
# Note de QA

**Il faut absolument avoir chargé les fixtures par défaut**
- Créer un article avec une licence autre que "Tout droits réservés" (soit "Licence GNU GPL", soit "Licence Beerware"). Faire ensuite une édition et vérifier que la page d'édition est accessible sans message d'erreur ;
- Faire de même pour un tutoriel (à priori, mini ou big, peu importe)
