### PR TITLE
Conserve le message de suivi en cas d'apercu

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -231,7 +231,8 @@ def new(request):
                 'text': request.POST['text'],
                 'image': image,
                 'subcategory': request.POST.getlist('subcategory'),
-                'licence': request.POST['licence']
+                'licence': request.POST['licence'],
+                'msg_commit': request.POST['msg_commit']
             })
             return render(request, 'article/member/new.html', {
                 'text': request.POST['text'],
@@ -327,7 +328,8 @@ def edit(request):
                 'text': request.POST['text'],
                 'image': image,
                 'subcategory': request.POST.getlist('subcategory'),
-                'licence': licence
+                'licence': licence,
+                'msg_commit': request.POST['msg_commit']
             })
             form_js = ActivJsForm(initial={"js_support": article.js_support})
             return render(request, 'article/member/edit.html', {

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2116,7 +2116,8 @@ def add_extract(request):
 
         if "preview" in data:
             form = ExtractForm(initial={"title": data["title"],
-                                        "text": data["text"]})
+                                        "text": data["text"],
+                                        'msg_commit': data['msg_commit']})
             return render(request, "tutorial/extract/new.html",
                                    {"chapter": chapter, "form": form})
         else:
@@ -2176,7 +2177,8 @@ def edit_extract(request):
         if "preview" in data:
             form = ExtractForm(initial={
                 "title": data["title"],
-                "text": data["text"]
+                "text": data["text"],
+                'msg_commit': data['msg_commit']
             })
             return render(request, "tutorial/extract/edit.html",
                                    {
@@ -2187,7 +2189,8 @@ def edit_extract(request):
             if content_has_changed([extract.get_path()], data["last_hash"]):
                 form = ExtractForm(initial={
                     "title": extract.title,
-                    "text": extract.get_text()})
+                    "text": extract.get_text(),
+                    'msg_commit': data['msg_commit']})
                 return render(request, "tutorial/extract/edit.html",
                                        {
                                            "extract": extract,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1874 |
# Note de QA
- Sur la page de création d'un article, mettre un message de suivi, prévisualiser le tout et vérifier que le message est bien conservé.
- Créer l'article et vérifier que c'est toujours le cas quand on édite celui-ci.
- Créer un tutoriel. Lui rajouter un extrait et vérifier que c'est le cas sur la page de création, puis l'éditer et vérifier que c'est le cas sur la page d'édition.
