### PR TITLE
résoud le bug de 404 sur le lien de unfollow (#1884)

### DIFF
--- a/doc/sphinx/source/forum/forum.rst
+++ b/doc/sphinx/source/forum/forum.rst
@@ -74,3 +74,28 @@ Il existe actuellement 3 filtres pour filtrer les sujets dans un forum :
 * Sujets sans réponse (`noanswer`)
 
 Il suffit d'ajouter `?filter=<filtre>` à l'URL en remplaçant `<filtre>` par un des 3 filtre ci-dessus.
+
+Suivre un sujet
+===============
+
+Être notifié sur le site lui même
+---------------------------------
+
+Nous permettons à nos membres de "suivre" un sujet directement sur le site. "Suivre un sujet", cela signifie que, lorsqu'un nouveau message est posté sur ce sujet, l'icône de notification nous en informe.
+
+Dès lors vous pourrez par un simple clic allé au dernier message non lu.
+
+Pour repérer qu'un message est lu ou pas, nous utilisons côté backend la classe `̀zds.forum.models.TopicRead`` qui retient la date de dernière lecture du topic.
+De la même manière nous utilisons la classe ``zds.forum.models.TopicFollowed`` pour retenir le fait que vous suivez ou non un sujet.
+
+Pour suivre un sujet, deux méthodes sont envisageables :
+
+- Y participer : dès que vous y inscrivez une réponse, vous suivez le sujet.
+- Cliquer sur "Suivre le sujet" dans la sidebar.
+
+Pour cesser de suivre un sujet, et ne plus être notifier de son activité, vous pouvez :
+
+- Vous rendre sur le topic et cliquer sur "Ne plus suivre" en haut de la sidebar.
+- Vous rendre sur n'importe quelle page du forum, survoler le titre du sujet et cliquer sur la croix qui apparaît alors.
+
+En effectuant ces actions vous cessez de suivre le sujet, l'instance de TopicFollowed qui était associée à votre suivi est supprimée définitivement. Cela a pour effet que vous pourrez à nouveau suivre le sujet dans le future si vous le désirez.

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -6,7 +6,6 @@
 {% load i18n %}
 
 
-
 {% block title_base %}
     &bull; {% trans "Forums" %}
 {% endblock %}
@@ -73,8 +72,8 @@
                                 <li>
                                     <form action="{% url "zds.forum.views.edit" %}" method="post">
                                         <input type="hidden" name="topic" value="{{ topic.pk }}">
-                                        <input type="hidden" name="nb" value="{{ nb }}">
-                                        <input type="hidden" name="page" value="{{ page }}">
+                                        <input type="hidden" name="nb" value="{% if nb %} {{ nb }} {% else %} {{ zds.settings.ZDS_APP.forum.posts_per_page }} {% endif %}">
+                                        <input type="hidden" name="page" value="{% if page %} {{ page }} {% else %} 1 {% endif %}">
                                         <input type="hidden" name="follow" value="1">
                                         {% csrf_token %}
 

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -74,7 +74,7 @@
                                     <form action="{% url "zds.forum.views.edit" %}" method="post">
                                         <input type="hidden" name="topic" value="{{ topic.pk }}">
                                         <input type="hidden" name="nb" value="{{ nb }}">
-                                        <input type="hidden" name="page" value="{{ nb }}">
+                                        <input type="hidden" name="page" value="{{ page }}">
                                         <input type="hidden" name="follow" value="1">
                                         {% csrf_token %}
 

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -78,6 +78,7 @@ def details(request, cat_slug, forum_slug):
         "forum": forum,
         "sticky_topics": sticky_topics,
         "topics": shown_topics,
+        "page": 1,
         "pages": paginator_range(page, paginator.num_pages),
         "nb": page,
         "filter": filter,
@@ -105,8 +106,8 @@ def cat_details(request, cat_slug):
 
     return render(request, "forum/category/index.html", {"category": category,
                                                          "forums": forums,
-                                                        "nb": settings.ZDS_APP['forum']['topics_per_page'],
-                                                        "page": 1})
+                                                         "nb": settings.ZDS_APP['forum']['topics_per_page'],
+                                                         "page": 1})
 
 
 def topic(request, topic_pk, topic_slug):
@@ -180,6 +181,7 @@ def topic(request, topic_pk, topic_slug):
         "topic": topic,
         "posts": res,
         "categories": categories,
+        "page": 1,
         "pages": paginator_range(page_nbr, paginator.num_pages),
         "nb": page_nbr,
         "last_post_pk": last_post_pk,

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -42,7 +42,9 @@ def index(request):
     categories = top_categories(request.user)
 
     return render(request, "forum/index.html", {"categories": categories,
-                                                "user": request.user})
+                                                "user": request.user,
+                                                "nb": settings.ZDS_APP['forum']['topics_per_page'],
+                                                "page": 1})
 
 
 def details(request, cat_slug, forum_slug):
@@ -102,7 +104,9 @@ def cat_details(request, cat_slug):
         forums = forums_pub
 
     return render(request, "forum/category/index.html", {"category": category,
-                                                         "forums": forums})
+                                                         "forums": forums,
+                                                        "nb": settings.ZDS_APP['forum']['topics_per_page'],
+                                                        "page": 1})
 
 
 def topic(request, topic_pk, topic_slug):
@@ -385,6 +389,8 @@ def edit(request):
         except (KeyError, ValueError):
             # problem in variable format
             raise Http404
+        except:
+            page = 1
     else:
         page = 1
 

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -391,8 +391,6 @@ def edit(request):
         except (KeyError, ValueError):
             # problem in variable format
             raise Http404
-        except:
-            page = 1
     else:
         page = 1
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1884 |

Cette PR permet de nettoyer la #1888 
# Pour la QA

Voici le scénario : 

Lancez le site avec les fixtures des forums, des catégories et des sujets incluses.

Ensuite, connectez-vous avec n'importe quel utilisateur et allez suivre un sujet.

La résolution du bug, c'est à dire vérifier que lorsque l'on clique sur "ne plus suivre" dans la side bar, tout fonctionne,  est à vérifier depuis plusieurs pages : 
- l'index du forum (/forums)
- un sujet tiers (/forums/sujet/id/slug/)
- l'index d'un sous forum (/forums/slug_cat/slug_forum/)
- l'index d'une catégorie (/forums/slug_cat/)
