### PR TITLE
Gulp ne recrée plus les images après un changement de dossier

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -107,7 +107,7 @@ gulp.task("sprite", function() {
 gulp.task("images", ["stylesheet"], function() {
   return gulp.src(paths.images)
     .pipe($.newer("dist/images"))
-    .pipe($.cache($.imagemin({ optimizationLevel: 3, progressive: true, interlaced: true })))
+    .pipe($.imagemin({ optimizationLevel: 3, progressive: true, interlaced: true }))
     .pipe($.size())
     .pipe(gulp.dest("dist/images"));
 });
@@ -115,7 +115,7 @@ gulp.task("images", ["stylesheet"], function() {
 gulp.task("smileys", function() {
   return gulp.src(paths.smileys)
     .pipe($.newer("dist/smileys"))
-    .pipe($.cache($.imagemin({ optimizationLevel: 3, progressive: true, interlaced: true })))
+    .pipe($.imagemin({ optimizationLevel: 3, progressive: true, interlaced: true }))
     .pipe($.size())
     .pipe(gulp.dest("dist/smileys"));
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "del": "^0.1.3",
     "gulp": "^3.7.0",
     "gulp-autoprefixer": "^2.0.0",
-    "gulp-cache": "^0.2.4",
     "gulp-concat": "^2.2.0",
     "gulp-filter": "^1.0.0",
     "gulp-flatten": "0.0.4",


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1907 |

**Instruction pour la QA :**

Faire ces commandes :

``` shell
git clone https://github.com/Situphen/zds-site.git nom_a
cd nom_a
git checkout fix_1907
npm install
npm run-script build
cd ..
rm -rI nom_a
git clone https://github.com/Situphen/zds-site.git nom_b
cd nom_b
git checkout fix_1907
npm install
npm run-script build
```

Faire ``ls ..` et vérifier qu'il n'y a pas "nom_a"
