### PR TITLE
[Hotfix 1.4] Support unicode sur titre du tuto

### DIFF
--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -140,7 +140,7 @@ class Tutorial(models.Model):
     def get_absolute_contact_url(self):
         """ Get url to send a new mp for collaboration """
         auths = self.authors.all()
-        mp_title = "&title=Collaboration - {}".format(self.title)
+        mp_title = u"&title=Collaboration - {}".format(self.title)
 
         get = u"?username={}".format(auths[0])
         for author in auths[1:]:


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1904 |

Permet d'avoir a nouveau accès à la page d'aide des tutos.

 **Note**: je pense que ma réparation tient de la rustine plus que de la réflexion de fond sur le sujet. Quelque part, le titre doit déjà être pensé comme étant une chaine unicode, donc ce genre de chose aurait dû arriver plus tôt, mais je ne sais pas pourquoi ça n'arrive que maintenant.
# Note de QA
- Créer, avec un user A, un tutoriel dont le titre possède des accents et qui demande de l'aide (peu importe pourquoi)
- Visiter, avec un user B, la page d'accès au tutoriels. Vérifier qu'on a plus de 500.
