### PR TITLE
[Hotfix v1.4] Rajout du support unicode sur la page d'aide des tutos

### DIFF
--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -16,6 +16,7 @@ import os
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from django.utils.http import urlencode
 from django.db import models
 from datetime import datetime
 from git.repo import Repo
@@ -139,13 +140,10 @@ class Tutorial(models.Model):
 
     def get_absolute_contact_url(self):
         """ Get url to send a new mp for collaboration """
-        auths = self.authors.all()
-        mp_title = "&title=Collaboration - {}".format(self.title)
+        get = '?'+urlencode({'title': u'Collaboration - {}'.format(self.title)})
 
-        get = u"?username={}".format(auths[0])
-        for author in auths[1:]:
-            get += "&username={}".format(author.username)
-        get += mp_title
+        for author in self.authors.all():
+            get += '&'+urlencode({'username': author.username})
 
         return reverse('zds.mp.views.new')+get
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1904 |

Reprise de #1910, basé sur la bonne branche.

Permet d'avoir a nouveau accès à la page d'aide des tutos, en ajoutant le support unicode sur le titre et sur les auteurs éventuels, s'ils sont plusieurs et qu'ils ont des accents dans leur login.

 **Note**: je pense que ma réparation tient de la rustine plus que de la réflexion de fond sur le sujet. Quelque part, le titre doit déjà être pensé comme étant une chaine unicode, donc ce genre de chose aurait dû arriver plus tôt, mais je ne sais pas pourquoi ça n'arrive que maintenant.
# Note de QA
- Créer, avec un user A, un tutoriel dont le titre possède des accents et qui demande de l'aide (peu importe pourquoi)
- Visiter, avec un user B, la page d'accès au tutoriels. Vérifier qu'on a plus de 500.
- Rajouter un utilisateur avec accent (typiquement, `ïtrema` des fixtures) aux auteurs du tuto. Vérifier que ça fonctionne toujours. ATTENTION, IL FAUT que l'user a accent soit au moins second auteur (une autre faute apparaissant quand un auteur à accent est plus que premier auteur).
- Pensez à tester avec des titres de tutoriels un peu extravagants, contenant des accents, des guillemets, des +, des &, bref tout des trucs qui pourraient rentrer dans une URL. Puis testez si le MP conserve bien le bon titre du tutoriel
