### PR TITLE
[Hotfix v1.4] Corrige les liens du dropdown des tutos

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -186,10 +186,10 @@
                                                         <li class="dropdown-title">
                                                             {{ title }}
                                                         </li>
-                                                        {% for subcat in subcats %}
+                                                        {% for subcat,slug in subcats %}
                                                             <li>
-                                                                <a href="{{ subcat.get_absolute_url_tutorial }}">
-                                                                    {{ subcat.title }}
+                                                                <a href="{% url "zds.tutorial.views.index" %}?tag={{ slug }}">
+                                                                    {{  subcat }}
                                                                 </a>
                                                             </li>
                                                         {% endfor %}

--- a/zds/utils/templatetags/topbar.py
+++ b/zds/utils/templatetags/topbar.py
@@ -77,16 +77,16 @@ def top_categories_tuto(user):
         .filter(subcategory__in=subcats_tutos)\
         .order_by('category__position', 'subcategory__title')\
         .select_related('subcategory', 'category')\
-        .values('category__title', 'subcategory__title')\
+        .values('category__title', 'subcategory__title', 'subcategory__slug')\
         .all()
 
     for csc in catsubcats:
         key = csc['category__title']
 
         if key in cats:
-            cats[key].append(csc['subcategory__title'])
+            cats[key].append((csc['subcategory__title'], csc['subcategory__slug']))
         else:
-            cats[key] = [csc['subcategory__title']]
+            cats[key] = [(csc['subcategory__title'], csc['subcategory__slug'])]
 
     return cats
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1916 |

Basiquement, renvoyer le `slug` de la catégorie à la template, qui s'attendait auparavant à recevoir un objet.
# Note de QA

Vérifier qu'on peut à nouveau cliquer sur les liens contenu dans la dropdown en question et que ça renvois bien au bon endroit.
