### PR TITLE
[Hotfix v1.4]Fix conflit entre mathjax et génération .tex

### DIFF
--- a/assets/tex/template.tex
+++ b/assets/tex/template.tex
@@ -134,6 +134,8 @@ $endif$
 
 \usepackage{titlesec} % Allows customization of titles
 \usepackage{graphicx} % Required for including pictures
+\newcommand{\gt}{>}
+\newcommand{\lt}{<}
 \begin{titlepage}
 $if(title)$
 \title{\color{white}{$title$}}


### PR DESCRIPTION
L'utilisation du tuto arduino comme tuto de test pour la publication a mis en évidence un bug de la génération du latex.

En effet, lorsque nous utilisons mathjax, les signes < et > sont forcément remplacés par \lt et \gt qui ne sont pas des commandes standards. Du coup il faut les créer.

Merci @pierre-24 pour le diagnostique et @SpaceFox pour le temps passé à valider/revalider.
# Pour la QA :
- il faut que vous ayiez pandoc d'installé
- créez un tuto
- dans un de ses extraits mettez `$ A_1 \lt B_2$ de même $ A_2 \gt B_1 $`
- demandez la validation, validez
- vérifiez que le PDF est bien généré. 
