### PR TITLE
[Hotfix v1.4] La redirection après la connexion refonctionne

### DIFF
--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -65,8 +65,26 @@ class MemberTests(TestCase):
              'password': 'hostel77',
              'remember': 'remember'},
             follow=False)
-        # good password then redirection
-        self.assertEqual(result.status_code, 302)
+        # good password then redirection to the homepage
+        self.assertRedirects(result, reverse('zds.pages.views.home'))
+
+        result = self.client.post(
+            reverse('zds.member.views.login_view')
+            + '?next=' + reverse('zds.gallery.views.gallery_list'),
+            {'username': user.user.username,
+             'password': 'hostel77',
+             'remember': 'remember'},
+            follow=False)
+        # good password and ?next= then redirection to the "next" page
+        self.assertRedirects(result, reverse('zds.gallery.views.gallery_list'))
+
+        self.client.logout()
+        result = self.client.get(reverse('zds.member.views.login_view')
+                                 + '?next=' + reverse('zds.gallery.views.gallery_list'))
+        # check if the login form will redirect if there is a ?next=
+        self.assertContains(result, reverse('zds.member.views.login_view')
+                            + '?next=' + reverse('zds.gallery.views.gallery_list'),
+                            count=1)
 
     def test_register(self):
         """To test user registration."""

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -641,21 +641,19 @@ def login_view(request):
         else:
             messages.error(request,
                            _(u"Les identifiants fournis ne sont pas valides."))
-    form = LoginForm()
-    form.helper.form_action = reverse("zds.member.views.login_view")
+
     if next_page is not None:
-        form = LoginForm(next=next_page)
+        form = LoginForm()
         form.helper.form_action += "?next=" + next_page
     else:
         form = LoginForm()
-    form.helper.form_action = reverse("zds.member.views.login_view")
+
     csrf_tk["error"] = error
     csrf_tk["form"] = form
     csrf_tk["next_page"] = next_page
     return render(request, "member/login.html",
                            {"form": form,
-                            "csrf_tk": csrf_tk,
-                            "next_page": next_page})
+                            "csrf_tk": csrf_tk})
 
 
 @login_required


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1923 |

**QA :**
- Se déconnecter
- Aller sur un article
- Comme vous n'êtes pas connectés, il y a aura le bouton connexion à la fin des commentaires
- Cela va vous rediriger vers /membres/connexion/?next=/articles/pk/nom-de-l-article
- Connectez-vous
- Vous êtes redirigés vers l'article et non vers la page d'accueil
