### PR TITLE
Met à jour les instructions du deploy.sh et de la doc concernant npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,12 +59,12 @@ install:
   - travis_retry pip install coveralls
   - travis_retry pip install MySQL-python
 
-  # NodeJS + NPM stuff
+  # Node.js + npm stuff
   - sudo apt-get -y install nodejs
   - travis_retry npm install
 
 script:
-  - npm run-script travis
+  - npm run travis
   - coverage run --source='.' manage.py test
   - flake8 --exclude=migrations,urls.py,settings.py,settings_prod.py,settings_test.py --max-line-length=120 zds
 

--- a/doc/gulp.md
+++ b/doc/gulp.md
@@ -39,7 +39,7 @@ sudo ln -s /usr/bin/nodejs /usr/bin/node
 Une version récente de Node.js se trouve dans les dépôts *wheezy-backport*, *jessie* et *sid*. Sur ces versions de Debian, l'installation peut se faire de cette manière :
 
 ````shell
-sudo apt-get install node
+sudo apt-get install nodejs
 ````
 
 #### Fedora / CentOS / RHEL
@@ -55,7 +55,7 @@ sudo yum install -y nodejs
 
 Il faut simplement lancer cette commande : 
 
-````
+````shell
 pacman -S nodejs
 ````
 
@@ -63,7 +63,7 @@ pacman -S nodejs
 
 Une installation via `pkg` devrait suffire :
 
-````
+````shell
 pkg install node
 ````
 
@@ -71,9 +71,9 @@ pkg install node
 
 *Les instructions pour installer Node.js sur les distributions CentOS, RHEL, FreeBSD et OpenBSD sont issues du lien juste en dessous et n'ont pas été testées.*
 
-Les instructions détaillées pour toutes les distributions se trouvent dans la [documentation officielle (en anglais)](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
+Les **instructions détaillées** pour toutes les distributions se trouvent dans la [**documentation officielle** (en anglais)](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
 
-Pour vérifier que Node.js est installé (et que vous avez la bonne version) :
+Pour vérifier que Node.js et npm sont installés (et que vous avez les bonnes versions) :
 
 ````shell
 node -v
@@ -88,7 +88,7 @@ Vous devez avoir une version de Node.js > 0.10.x et de npm > 2.x.x. Si votre ver
 
 Pour npm, il suffit de le mettre à jour avec cette commande :
 
-````
+````shell
 sudo npm install -g npm
 ````
 
@@ -172,14 +172,20 @@ dist/
 
 ## Utilisation de Gulp
 
-Gulp se lance avec `npm run-script gulp [tâche]` où `[tâche]` est la tâche à lancer. Les différentes tâches sont :
+Gulp se lance avec `npm run gulp -- [tâche]` où `[tâche]` est la tâche à lancer. Les différentes tâches sont :
 
  - `clean`: Nettoie le dossier `dist/`
  - `build`: Compile tout (CSS, JS, et images)
  - `test`: Lance les tests (JSHint, ...)
  - `watch`: Compile les différents fichiers dès qu'ils sont modifiés (utile pour le développement; `Ctrl+C` pour arrêter)
 
-Si vous voulez utiliser directement la commande `gulp [tâche]` au lieu de `npm run-script gulp [tâche]`, il vous faut lancer cette commande avec les droits administrateurs :
+Si vos modifications n'apparaissent pas dans votre navigateur et que ce n'est pas dû à Gulp, pensez à vider le cache de votre navigateur !
+
+-----
+
+Pour information, la commande `npm run` est un raccourci de la commande `npm run-script`, donc les deux commandes sont identiques !
+
+Si vous voulez utiliser directement la commande `gulp [tâche]` au lieu de `npm run gulp -- [tâche]`, il vous faut lancer cette commande avec les droits administrateurs :
 
 ````shell
 sudo npm install -g gulp bower
@@ -187,22 +193,19 @@ sudo npm install -g gulp bower
 
 # Nettoyage des outils
 
-## Nettoyage de npm
+## Nettoyage de npm et suppression des dépendances
 
-Pour nettoyer npm, il vous suffit de lancer ces commandes dans votre environnement :
+Pour nettoyer npm (et supprimer les dépendances), il vous suffit de lancer ces commandes dans votre environnement :
 
 ````shell
 sudo rm -rI ~/.npm
 rm -rI node_modules/
 ````
 
-## Nettoyage des fichiers CSS et Javascript
+## Suppression des fichiers CSS et Javascript
 
-Toujours dans votre environnement :
+Toujours dans votre environnement, vous pouver supprimer les fichiers générés par cette commande :
 
 ````shell
 rm -rI dist/
-rm -rI gulp-cache/
 ````
-
-Il vous faudra peut-être aussi vider le cache de votre navigateur pour être sûr de repartir à zéro.

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -45,17 +45,24 @@ git checkout $1
 # Create a branch with the same name - required to have version data in footer
 git checkout -b $1
 
-# Compute front stuff
+# Front commands
 source /usr/local/nvm/nvm.sh
-sudo npm -q update
-sudo npm -q update bower gulp -g
-gulp pack
+# Update packages
+npm update --production
+# Remove unused packages
+npm prune --production
+# Clean the front stuff
+npm run gulp -- clean
+# Build the front stuff
+npm run gulp -- build
 
 # Update application data
 source ../bin/activate
 pip install --upgrade --use-mirrors -r requirements.txt
 python manage.py migrate
 python manage.py compilemessages
+# Collect all static files from dist/ and python packages to static/
+python manage.py collectstatic
 deactivate
 
 # Restart zds

--- a/update.md
+++ b/update.md
@@ -98,6 +98,7 @@ Tout est déjà prêt dans les fixtures dédiées à cela :
 ```
 python load_factory_data.py fixtures/advanced/aide_tuto_media.yaml
 ```
+
 Actions à faire pour mettre en prod la version : v1.5
 =====================================================
 
@@ -111,3 +112,10 @@ Il faudra donc :
 1. créer le groupe "bot"
 2. vérifier que `settings.ZDS_APP['member']['bot_group']` vaut bien `"bot"`
 3. Aller dans l'interface d'administration pour ajouter les comptes auteur externe et anonyme au groupe bot
+
+npm
+---
+
+Lancer la commande `npm -v` et voir le résultat. Si le résultat est 1.x.x, lancer la commande `sudo npm install -g npm`.
+
+Faire pointer nginx sur `static/` au lieu de `dist/`.


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | Aucun |
# Attention, ça touche à la MEP !!!

**Cette PR doit être mergée avant la MEP de la v1.5 !!**

Suppression de `sudo npm -q update bower gulp -g` et remplacement de `gulp pack` par `npm run gulp -- build` car on est passé à npm v2 et la tâche "pack" n'existe plus.

Suppression du `sudo` de `sudo npm -q update` car il n'y a pas besoin normalement. Ainsi que suppression de l'option `-q` qui n'existe pas ([cf la doc](https://docs.npmjs.com/cli/update) ; j'ai aussi testé et il n'y a aucune différence avec et sans).

---

Il faut voir la version de npm en production actuellement et la mettre à jour si besoin (`sudo npm install -g npm`) !
