### PR TITLE
[Hotfix v1.4] Manque un formulaire lors d'un echec import archive

### DIFF
--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -320,6 +320,7 @@ class BigTutorialTests(TestCase):
                     'r'),
                 'tutorial': self.bigtuto.pk,
                 'import-archive': "importer"},
+            follow=False
         )
         self.assertEqual(result.status_code, 200)
 
@@ -2701,6 +2702,7 @@ class MiniTutorialTests(TestCase):
                     'r'),
                 'tutorial': self.minituto.pk,
                 'import-archive': "importer"},
+            follow=False
         )
         self.assertEqual(result.status_code, 200)
 

--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -295,6 +295,37 @@ class BigTutorialTests(TestCase):
         shutil.rmtree(temp)
         os.remove(zip_path)
 
+    def test_fail_import_archive(self):
+
+        login_check = self.client.login(
+            username=self.user_author.username,
+            password='hostel77')
+        self.assertEqual(login_check, True)
+
+        temp = os.path.join(tempfile.gettempdir(), "temp")
+        if not os.path.exists(temp):
+            os.makedirs(temp, mode=0777)
+
+        # test fail import
+        with open(os.path.join(temp, 'test.py'), 'a') as f:
+            f.write('something')
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.import_tuto'),
+            {
+                'file': open(
+                    os.path.join(
+                        temp,
+                        'test.py'),
+                    'r'),
+                'tutorial': self.bigtuto.pk,
+                'import-archive': "importer"},
+        )
+        self.assertEqual(result.status_code, 200)
+
+        # delete temporary data directory
+        shutil.rmtree(temp)
+
     def test_add_note(self):
         """To test add note for tutorial."""
         user1 = ProfileFactory().user
@@ -2644,6 +2675,37 @@ class MiniTutorialTests(TestCase):
         # delete temporary data directory
         shutil.rmtree(temp)
         os.remove(zip_path)
+
+    def test_fail_import_archive(self):
+
+        login_check = self.client.login(
+            username=self.user_author.username,
+            password='hostel77')
+        self.assertEqual(login_check, True)
+
+        temp = os.path.join(tempfile.gettempdir(), "temp")
+        if not os.path.exists(temp):
+            os.makedirs(temp, mode=0777)
+
+        # test fail import
+        with open(os.path.join(temp, 'test.py'), 'a') as f:
+            f.write('something')
+
+        result = self.client.post(
+            reverse('zds.tutorial.views.import_tuto'),
+            {
+                'file': open(
+                    os.path.join(
+                        temp,
+                        'test.py'),
+                    'r'),
+                'tutorial': self.minituto.pk,
+                'import-archive': "importer"},
+        )
+        self.assertEqual(result.status_code, 200)
+
+        # delete temporary data directory
+        shutil.rmtree(temp)
 
     def test_add_extract_named_introduction(self):
         """test the use of an extract named introduction"""

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2640,6 +2640,7 @@ def import_tuto(request):
             if form_archive.is_valid():
                 (check, reason) = import_archive(request)
                 if not check:
+                    form = ImportForm()
                     messages.error(request, reason)
                 else:
                     messages.success(request, reason)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1930 |

**QA** : Par le formulaire "Envoi d'une archive", envoyer un fichier quelconque et vérifier qu'on ne se mange pas une erreur 500.
