### PR TITLE
[Hotfix v1.4] Affichage des sous catégories de tuto sur la home

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -149,10 +149,10 @@
             {% for title, subcats in categories.items %}
                 <h4>{{ title }}</h4>
                 <ul>
-                    {% for subcat in subcats %}
+                    {% for subcat, slug in subcats %}
                         <li>
-                            <a href="{{ subcat.get_absolute_url_tutorial }}">
-                                {{ subcat.title }}
+			    <a href="{% url "zds.tutorial.views.index" %}?tag={{ slug }}">
+                                {{ subcat }}
                             </a>
                         </li>
                     {% endfor %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1934 |

C'est le même principe que #1917 mais pour la home.

**QA** : vérifier que les sous catégories fonctionne sur la page d'accueil
