### PR TITLE
[Hotfix v1.4] Ajoute la pagination sur ZEP-03 (#1929)

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -1310,6 +1310,10 @@
     }
 }
 
+.tutorial-list {
+  margin: 0 0 12px 0;
+}
+
 .tutorial-list article,
 .main .article-content .tutorial-list article {
     min-height: 60px;
@@ -1344,6 +1348,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        clear: none;
     }
     a {
         text-decoration: none;
@@ -1393,6 +1398,10 @@
         &.no-illu {
             margin-left: 0;
         }
+    }
+
+    .tutorial-help{
+      margin: 12px 0 0 0;
     }
 
     .tutorial-help img.light {

--- a/templates/tutorial/tutorial/help.html
+++ b/templates/tutorial/tutorial/help.html
@@ -18,96 +18,98 @@
 {% endblock %}
 
 
+{% block headline %}
+    <h2 class="ico-after ico-tutorials">{% trans "Aider les auteurs de tutoriels" %} ({{ tutorials|length }})</h2>
+{% endblock %}
 
-{% block content_out %}
-    <section class="full-content-wrapper">
-        <h1 class="ico-after ico-tutorials">
-            {% block headline %}
-                {% trans "Aider les auteurs de tutoriels" %} ({{ tutorials|length }})
-            {% endblock %}
-        </h1>
 
-        {% block content %}
-            {% if tutorials %}
-                <div class="tutorial-list">
-                {% for tutorial in tutorials %}
-                    <article class="extend">
-                            {% if tutorial.image.physical.tutorial_illu.url %}
-                                <img src="{{ tutorial.image.physical.tutorial_illu.url }}" alt="" class="tutorial-img avatar">
+{% block content %}
+    {% include "misc/pagination.part.html" with position="top" %}
+
+    {% if tutorials %}
+        <div class="tutorial-list">
+        {% for tutorial in tutorials %}
+            <article>
+                {% if tutorial.image.physical.tutorial_illu.url %}
+                    <img src="{{ tutorial.image.physical.tutorial_illu.url }}" alt="" class="tutorial-img avatar">
+                {% endif %}
+                <div class="tutorial-infos {% if not tutorial.image.physical.tutorial_illu.url %}no-illu{% endif %}">
+                    <h3 itemprop="itemListElement">{{ tutorial.title }}</h3>
+
+                    <span class="contact">
+                        {% trans "Par " %}
+                        {% for author in tutorial.authors.all %}
+                            {% if not forloop.first %}
+                                {% if forloop.last %}
+                                    {% trans "et" %}
+                                {% else %}
+                                    ,
+                                {% endif %}
                             {% endif %}
-                            <div class="tutorial-infos">
-                                <h3 >{{tutorial.title}}</h3>
-                                <span>{% trans "Par " %}
-                                    {% for author in tutorial.authors.all %}
-                                        {% if not forloop.first %}
-                                            {% if forloop.last %}
-                                                {% trans "et" %}
-                                            {% else %}
-                                                ,
-                                            {% endif %}
-                                        {% endif %}
-                                        {% if author == user %}
-                                            {% trans "vous" %}
-                                        {% else %}
-                                            <strong><a href="{{ author.get_absolute_url }}" title="{% trans "Profil de" %} {{ author.username }}">
-                                            {{author.username}}
-                                            </a></strong>
-                                        {% endif %}
-                                    {% endfor %}
-                                    {% if not user in tutorial.authors.all %}
-                                        - <a href="{{ tutorial.get_absolute_contact_url }}">{% trans "Contacter par MP" %}</a>
-                                    {% endif %}
-                                </span>
-                                <p class="article-metadata">
-                                    {% if tutorial.subcategory %}
-                                        {% for category in tutorial.subcategory.all %}
-                                            {{ category.title }}
-                                            {% if tutorial.subcategory.all.count > 1 and not forloop.last %}
-                                                -
-                                            {% endif %}
-                                        {% endfor %}
-                                    {% endif %}
-                                </p>
-                                <div class="tutorial-help">
-                                {% if tutorial.on_line %}
-                                    <a title="{% blocktrans %}Lire la version en ligne{% endblocktrans %}" href="{{ tutorial.get_absolute_url_online }}">
-                                        <img src="{% static "images/tutorials.png" %}" alt="{% blocktrans %}Tutoriel en ligne{% endblocktrans %}" />
-                                    </a>
-                                {% else %}
-                                    <img src="{% static "images/tutorials.png" %}" alt="{% blocktrans %}Tutoriel hors-ligne{% endblocktrans %}"
-                                    title="{% blocktrans %}Tutoriel jamais publié{% endblocktrans %}" class="light" />
+                            {% if author == user %}
+                                {% trans "vous" %}
+                            {% else %}
+                                <strong><a href="{{ author.get_absolute_url }}" title="{% trans "Profil de" %} {{ author.username }}">
+                                {{author.username}}
+                                </a></strong>
+                            {% endif %}
+                        {% endfor %}
+                        {% if not user in tutorial.authors.all %}
+                            - <a href="{{ tutorial.get_absolute_contact_url }}">{% trans "Contacter par MP" %}</a>
+                        {% endif %}
+                    </span> <br/>
+
+                    <span class="article-metadata">
+                        {% if tutorial.subcategory %}
+                            {% for category in tutorial.subcategory.all %}
+                                {{ category.title }}
+                                {% if tutorial.subcategory.all.count > 1 and not forloop.last %}
+                                    -
                                 {% endif %}
-                                {% if tutorial.in_beta %}
-                                    <a title="{% blocktrans %}Lire la version bêta{% endblocktrans %}" href="{{ tutorial.get_absolute_url_beta }}">
-                                        <img src="{% static "images/beta.png" %}" alt="{% blocktrans %}Bêta Active{% endblocktrans %}" />
-                                    </a>
-                                {% else %}
-                                    <img src="{% static "images/beta.png" %}" alt="{% blocktrans %}Bêta Inactive{% endblocktrans %}"
-                                    title="{% blocktrans %}Bêta non activée{% endblocktrans %}" class="light" />
-                                {% endif %}
-                                {% for help in helps %}
-                                    <span>
-                                        {% if help in tutorial.helps.all %}
-                                            <img src="{{ help.image.help_illu.url }}" alt="{{help.title}}"
-                                            title="{% blocktrans %}Cherche un {% endblocktrans %}{{help.title}}" />
-                                        {% else %}
-                                            <img src="{{ help.image.help_illu.url }}" alt="{{help.title}}"
-                                            title="{% blocktrans %}Ne cherche aucun {% endblocktrans %}{{help.title}}" class="light" />
-                                        {% endif %}
-                                    </span>
-                                {% endfor %}
-                                </div>
-                            </div>
-                    </article>
+                            {% endfor %}
+                        {% endif %}
+                    </span>
+                </div>
+
+                <div class="tutorial-help">
+                {% if tutorial.on_line %}
+                    <a title="{% blocktrans %}Lire la version en ligne{% endblocktrans %}" href="{{ tutorial.get_absolute_url_online }}">
+                        <img src="{% static "images/tutorials.png" %}" alt="{% blocktrans %}Tutoriel en ligne{% endblocktrans %}" />
+                    </a>
+                {% else %}
+                    <img src="{% static "images/tutorials.png" %}" alt="{% blocktrans %}Tutoriel hors-ligne{% endblocktrans %}"
+                    title="{% blocktrans %}Tutoriel jamais publié{% endblocktrans %}" class="light" />
+                {% endif %}
+                {% if tutorial.in_beta %}
+                    <a title="{% blocktrans %}Lire la version bêta{% endblocktrans %}" href="{{ tutorial.get_absolute_url_beta }}">
+                        <img src="{% static "images/beta.png" %}" alt="{% blocktrans %}Bêta Active{% endblocktrans %}" />
+                    </a>
+                {% else %}
+                    <img src="{% static "images/beta.png" %}" alt="{% blocktrans %}Bêta Inactive{% endblocktrans %}"
+                    title="{% blocktrans %}Bêta non activée{% endblocktrans %}" class="light" />
+                {% endif %}
+                {% for help in helps %}
+                    <span>
+                        {% if help in tutorial.helps.all %}
+                            <img src="{{ help.image.help_illu.url }}" alt="{{help.title}}"
+                            title="{% blocktrans %}Cherche un {% endblocktrans %}{{help.title}}" />
+                        {% else %}
+                            <img src="{{ help.image.help_illu.url }}" alt="{{help.title}}"
+                            title="{% blocktrans %}Ne cherche aucun {% endblocktrans %}{{help.title}}" class="light" />
+                        {% endif %}
+                    </span>
                 {% endfor %}
                 </div>
-            {% else %}
-            <p>
-                {% trans "Aucun auteur n'a besoin d'aide pour le moment." %}
-            </p>
-            {% endif %}
-        {% endblock %}
-    </section>
+            </article>
+        {% endfor %}
+        </div>
+    {% else %}
+    <p>
+        {% trans "Aucun auteur n'a besoin d'aide pour le moment." %}
+    </p>
+    {% endif %}
+
+    {% include "misc/pagination.part.html" with position="bottom" %}
 {% endblock %}
 
 

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -363,6 +363,7 @@ ZDS_APP = {
         'repo_public_path': os.path.join(SITE_ROOT, 'tutoriels-public'),
         'default_license_pk': 7,
         'home_number': 5,
+        'helps_per_page': 20
     },
     'forum': {
         'posts_per_page': 21,

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3621,7 +3621,7 @@ def help_tutorial(request):
                                 .all()
 
     # Paginator
-    paginator = Paginator(tutos, settings.ZDS_APP['forum']['topics_per_page'])
+    paginator = Paginator(tutos, settings.ZDS_APP['tutorial']['helps_per_page'])
     page = request.GET.get('page')
 
     try:


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1929 |
- Inclus la pagination ;
- Corrige le style et la template en conséquent ;
- ajoute une variable `helps_per_page` dans le `settings.py`
# Note de QA
- Ne pas oublier de faire un `gulp build` pour que ça fonctionne ;
- Créer un certain nombre de tutoriels qui ont besoin d'aide, par exemple 4 ;
- Vérifier que la page d'aide des tutoriels est accessible et contient ce qu'elle doit contenir (filtre, icônes correctes). 
- Vérifiez que la pagination fonctionne (voir truc ci-dessous).

**(petit truc pour éviter d'avoir à créer 21 tutoriels)** 

Éditez la ligne 366 du fichier `/zds/settings.py` et changez 

``` python
 'helps_per_page': 20
```

par

``` python
 'helps_per_page': 2
```

Ce qui aura pour but de modifier le nombre de tutos affichés sur la page d'aide (de 20 à 2). Normalement, après enregistrement puis rechargement de la page, la pagination devrait apparaître. À la fin, n'oubliez pas d'annuler vos modifications à l'aide de `git stash` puis `git stash drop`
