### PR TITLE
Fix #1946 : mauvais lien + uniformisation de la page « Contact »

### DIFF
--- a/templates/pages/contact.html
+++ b/templates/pages/contact.html
@@ -24,14 +24,14 @@
     <h3>{% trans "L'équipe de communication" %}</h3>
     <p>
         {% blocktrans with site_name=app.site.litteral_name email_contact=app.site.email_contact %}
-            Vous pouvez à tout moment joindre l'équipe de communication de {{site_name}} par courriel via <a href="{{email_contact}}?Subject=Contact communication" target="_top">{{email_contact}}</a>
+            Vous pouvez à tout moment joindre l'équipe de communication de {{site_name}} par courriel via <a href="mailto:{{ email_contact }}?Subject=Contact communication" target="_top">{{ email_contact }}</a>.
         {% endblocktrans %}
     </p>
     {% if app.site.association %}
         <h3>{% trans "L'association" %}</h3>
         <p>
             {% blocktrans with site_name=app.site.litteral_name email_association=app.site.association.email %}
-                Vous pouvez joindre l'association par courriel via <a href="mailto:{{email_association}}?Subject=Contact association" target="_top">{{email_association}}</a>
+                Vous pouvez joindre l'association par courriel via <a href="mailto:{{ email_association }}?Subject=Contact association" target="_top">{{ email_association }}</a>.
             {% endblocktrans %}
         </p>
     {% endif %}
@@ -39,7 +39,7 @@
     <h3>{% trans "Le staff" %}</h3>
     <p>
         {% blocktrans with site_name=app.site.litteral_name %}
-            Le staff est constitué de certains membres du site dont le but est de contrôler le contenu publié sur {{site_name}}. Ils sont en charge de la modération des messages sur les forums et commentaires, ainsi que de la validation et publication d'articles et/ou de tutoriels de {{site_name}}.
+            Le staff est constitué de certains membres du site dont le but est de contrôler le contenu publié sur {{ site_name }}. Ils sont en charge de la modération des messages sur les forums et commentaires, ainsi que de la validation et publication d'articles et/ou de tutoriels de {{ site_name }}.
             Les membres faisant partie du Staff sont les suivants :
         {% endblocktrans %}
     </p>
@@ -49,6 +49,8 @@
                 {% for member in staffs %}
                     <li>{% include "misc/member_item.part.html" with avatar=True %}</li>
                 {% endfor %}
+            {% else %}
+                {% trans "Il n'y a pas de membre dans ce groupe." %}
             {% endif %}
         </ul>
     </div>
@@ -56,8 +58,8 @@
     <h3>{% trans "L'équipe technique" %}</h3>
     <p>
         {% blocktrans with repository=app.site.repository %}
-            L'équipe technique est constituée de certains membres du site dont le but est d'une part de s'assurer que le site reste toujours disponible en ligne, et d'autre part de corriger les bogues rencontrés sur le site.
-            Des administrateurs systèmes, jusqu'aux designeurs, en passant par les développeurs back-end et intégrateurs front-end, ils s'occupent aussi de la maintenance du <a href="{{repository}}">dépôt officiel du projet</a>. Les membres faisant partie de l'équipe technique sont les suivants :
+            L'équipe technique est constituée de certains membres du site dont le but est d'une part de s'assurer que le site reste toujours disponible en ligne, et d'autre part de corriger les bogues rencontrés sur le site ainsi que d'ajouter de nouvelles fonctionnalités.
+            Des administrateurs systèmes, jusqu'aux designeurs, en passant par les développeurs back-end et intégrateurs front-end, ils s'occupent aussi de la maintenance du <a href="{{ repository }}">dépôt officiel du projet</a>. Les membres faisant partie de l'équipe technique sont les suivants :
         {% endblocktrans %}
     </p>
     <div class="authors">
@@ -66,6 +68,8 @@
                 {% for member in devs %}
                     <li>{% include "misc/member_item.part.html" with avatar=True %}</li>
                 {% endfor %}
+            {% else %}
+                {% trans "Il n'y a pas de membre dans ce groupe." %}
             {% endif %}
         </ul>
     </div>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | ~non |
| Tickets concernés | #1946 |

J'en ai profité pour mettre les tags comme il faut (une espace après `{{` et une avant `}}`).
### QA

Rien de spécial. Vérifier l'ortograff !
