### PR TITLE
Fix #1954 : Augmente légèrement la taille des modals

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -3264,8 +3264,8 @@ form.topic-message {
         }
     }
     &.modal-big {
-        height: 300px;
-        margin: -150px auto 0;
+        height: 320px;
+        margin: -160px auto 0;
     }
 }
 .enable-mobile-menu #modals-overlay {


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1954 |
### QA
- Créer un tuto, faire une demande de validation puis le réserver (en admin)
- Cliquer sur « Valider et publier » et vérifier que le modal est suffisamment grand pour le pas cacher une partie de l'infobox (Version majeure).

Penser à rebuild le front (`gulp build`).
