### PR TITLE
Permet la mise à jour de la date d'update d'un article

### DIFF
--- a/templates/article/member/view.html
+++ b/templates/article/member/view.html
@@ -72,11 +72,11 @@
         {% endfor %}
     </ul>
 
-    {% if article.sha_public %}
+    {% if article.update %}
         <span class="pubdate">
-            {% trans "Publié" %}
-            <time datetime="{{ article.pubdate|date:"c" }}" pubdate="pubdate" itemprop="datePublished">
-                {{ article.pubdate|format_date }}
+            {% trans "Dernière mise à jour" %} :
+            <time datetime="{{ article.update|date:"c" }}" pubdate="pubdate" itemprop="dateModified">
+                {{ article.update|format_date }}
             </time>
         </span>
     {% endif %}

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -171,6 +171,7 @@ class Article(models.Model):
                                                       args=[self.pk, self.slug])
         article_version['get_absolute_url_online'] = reverse('zds.article.views.view_online',
                                                              args=[self.pk, slugify(article_version['title'])])
+        article_version['update'] = self.update
 
         return article_version
 

--- a/zds/article/tests/tests.py
+++ b/zds/article/tests/tests.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import tempfile
 import zipfile
+import datetime
 
 try:
     import ujson as json_reader
@@ -650,6 +651,41 @@ class ArticleTests(TestCase):
         # finally, clean up things:
         os.remove(draft_zip_path)
         os.remove(online_zip_path)
+
+    def test_change_update(self):
+        """test the change of `article.update` if modified (ensure #1956)"""
+
+        # login with author
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        time_0 = datetime.datetime.fromtimestamp(0)  # way deep in the past
+        tutorial = Article.objects.get(pk=self.article.pk)
+        tutorial.update = time_0
+        tutorial.save()
+
+        # first check if this modification is performed :
+        self.assertEqual(Article.objects.get(pk=self.article.pk).update, time_0)
+
+        # modify article content and title (implicit call to `maj_repo_article()`)
+        article_title = u'Le titre, mais pas pareil'
+        article_content = u'Mais nous c\'est pas pareil ...'
+        result = self.client.post(
+            reverse('zds.article.views.edit') +
+            '?article={}'.format(self.article.pk),
+            {
+                'title': article_title,
+                'description': self.article.description,
+                'text': article_content,
+                'subcategory': self.article.subcategory.all(),
+                'licence': self.licence.pk
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        self.assertNotEqual(Article.objects.get(pk=self.article.pk).update, time_0)
 
     def tearDown(self):
         if os.path.isdir(settings.ZDS_APP['article']['repo_path']):

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -427,6 +427,8 @@ def maj_repo_article(
         action=None,
         msg=None,):
 
+    article.update = datetime.now()
+
     if action == 'del':
         shutil.rmtree(old_slug_path)
     else:


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1952 |
# Note de QA
- Créer un article. Attendre quelques minutes.
- Le modifier et vérifier que la date de dernière mise à jour est correcte : 

![screenshot from 2014-12-21 20 52 08](https://cloud.githubusercontent.com/assets/7889675/5519419/5b64c346-8953-11e4-9195-56a1c8643611.png)
