### PR TITLE
Conserve la lecture zen de page en page

### DIFF
--- a/assets/js/zen-mode.js
+++ b/assets/js/zen-mode.js
@@ -14,6 +14,17 @@
                 $(".open-zen-mode").attr("data-content-on-click", Text);
                 $(".open-zen-mode").text(TextToPut);
 
+                if(typeof sessionStorage !== "undefined"){
+                    if($(".content-container").hasClass("zen-mode")){
+                        if("zenMode" in sessionStorage){
+                            sessionStorage.setItem("zenMode", "false");
+                        }
+                    }
+                    else{
+                        sessionStorage.setItem("zenMode", "true");
+                    }
+                }
+
                 $(".content-container").toggleClass("zen-mode tab-modalize");
                 $(this).blur();
                 e.preventDefault();
@@ -29,10 +40,24 @@
                 $(".open-zen-mode").attr("data-content-on-click", Text);
                 $(".open-zen-mode").text(TextToPut);
 
+                if(typeof sessionStorage !== "undefined"){
+                    if("zenMode" in sessionStorage){
+                        sessionStorage.setItem("zenMode", "false");
+                    }
+                }
+
                 $(".content-container").toggleClass("zen-mode tab-modalize");
                 $(this).blur();
                 e.stopPropagation();
             }
         });
+
+        if(typeof sessionStorage !== "undefined"){
+            if("zenMode" in sessionStorage){
+                if(sessionStorage.getItem("zenMode") === "true"){
+                    $(".open-zen-mode").click();
+                }
+            }
+        }
     }
 })(jQuery);


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #1156 |

**QA :**
- Aller sur un big tutoriel
- Cliquer sur la lecture zen
- Cliquer sur un lien du tutoriel et vérifier que la lecture zen reste
- Cliquer sur le bouton pour retourner à un vue normale
- Cliquer sur un lien du tutoriel et vérifier que la vue normale reste
- Cliquer sur la lecture zen
- Cliquer sur un lien du tutoriel et vérifier que la lecture zen reste
- Cliquer sur [Echap] pour retourner à un vue normale
- Cliquer sur un lien du tutoriel et vérifier que la vue normale reste

Vérifier que quand on est en lecture zen sur un onglet, les autres onglets ne sont pas en lecture zen

Tester d'autre cas possible
