### PR TITLE
Mise a jour zMarkdown : fix bug vidéo https

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.6.1
 https://github.com/zestedesavoir/GitPython/archive/0.3.2-RC2.zip
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.4.1-zds.11.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.4.1-zds.12.zip
 easy-thumbnails==2.2


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | coté zMarkdown |

Cette mise a jours force l'utilisation du https pour les vidéo insérées.

Note pour QA: pas si évident. Mettez a jours les dépendance de pip et vérifiez qu'on peut toujours insérer des vidéos. Si possible vérifiez le html généré qui contient bien un liens vers les versions https des vidéos.

La vérification réelle ne pourra être faite qu'en préprod.
