### PR TITLE
[Hotfix v1.4] Répare l'aperçu lors d'un nouveau commentaire d'article et de tutoriel

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -1013,17 +1013,20 @@ def answer(request):
     # User would like preview his post or post a new reaction on the article.
     if request.method == 'POST':
         data = request.POST
-        newreaction = last_reaction_pk != int(data['last_reaction'])
+
+        if not request.is_ajax():
+            newreaction = last_reaction_pk != int(data['last_reaction'])
 
         # Using the « preview button », the « more » button or new reaction
         if 'preview' in data or newreaction:
-            form = ReactionForm(article, request.user, initial={
-                'text': data['text']
-            })
             if request.is_ajax():
                 return HttpResponse(json.dumps({"text": emarkdown(data["text"])}),
                                     content_type='application/json')
             else:
+                form = ReactionForm(article, request.user, initial={
+                    'text': data['text']
+                })
+
                 return render(request, 'article/reaction/new.html', {
                     'article': article,
                     'last_reaction_pk': last_reaction_pk,

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3313,7 +3313,9 @@ def answer(request):
 
     if request.method == "POST":
         data = request.POST
-        newnote = last_note_pk != int(data["last_note"])
+
+        if not request.is_ajax():
+            newnote = last_note_pk != int(data["last_note"])
 
         # Using the « preview button », the « more » button or new note
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1980 |

**QA :** Vérifier que l'aperçu lors de la création d'un nouveau commentaire sur un article et un tutoriel est de nouveau possible
