### PR TITLE
[Hotfix v1.4] Répare l'aperçu lors d'un nouveau commentaire d'article et de tutoriel

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -1011,17 +1011,20 @@ def answer(request):
     # User would like preview his post or post a new reaction on the article.
     if request.method == 'POST':
         data = request.POST
-        newreaction = last_reaction_pk != int(data['last_reaction'])
+
+        if not request.is_ajax():
+            newreaction = last_reaction_pk != int(data['last_reaction'])
 
         # Using the « preview button », the « more » button or new reaction
         if 'preview' in data or newreaction:
-            form = ReactionForm(article, request.user, initial={
-                'text': data['text']
-            })
             if request.is_ajax():
                 return HttpResponse(json.dumps({"text": emarkdown(data["text"])}),
                                     content_type='application/json')
             else:
+                form = ReactionForm(article, request.user, initial={
+                    'text': data['text']
+                })
+
                 return render(request, 'article/reaction/new.html', {
                     'article': article,
                     'last_reaction_pk': last_reaction_pk,

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -152,16 +152,20 @@ def new(request):
     if request.method == 'POST':
         # If the client is using the "preview" button
         if 'preview' in request.POST:
-            form = PrivateTopicForm(request.user.username,
-                                    initial={
-                                        'participants': request.POST['participants'],
-                                        'title': request.POST['title'],
-                                        'subtitle': request.POST['subtitle'],
-                                        'text': request.POST['text'],
-                                    })
-            return render(request, 'mp/topic/new.html', {
-                'form': form,
-            })
+            if request.is_ajax():
+                return HttpResponse(json.dumps({"text": emarkdown(request.POST["text"])}),
+                                    content_type='application/json')
+            else:
+                form = PrivateTopicForm(request.user.username,
+                                        initial={
+                                            'participants': request.POST['participants'],
+                                            'title': request.POST['title'],
+                                            'subtitle': request.POST['subtitle'],
+                                            'text': request.POST['text'],
+                                        })
+                return render(request, 'mp/topic/new.html', {
+                    'form': form,
+                })
 
         form = PrivateTopicForm(request.user.username, request.POST)
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3303,7 +3303,9 @@ def answer(request):
 
     if request.method == "POST":
         data = request.POST
-        newnote = last_note_pk != int(data["last_note"])
+
+        if not request.is_ajax():
+            newnote = last_note_pk != int(data["last_note"])
 
         # Using the « preview button », the « more » button or new note
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1980 |

**QA :** Vérifier l'aperçu lors de :
- la création d'un commentaire sur un tutoriel
- la création d'un commentaire sur un article
- la création d'un nouveau message privé
- la réponse à un message privé
- l'édition d'un message privé
