### PR TITLE
[Hotfix v1.4] Répare le bouton "citer" dans les articles, tutoriels et messages privés

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -1065,6 +1065,7 @@ def answer(request):
 
         # Using the quote button
         if 'cite' in request.GET:
+            resp = {}
             reaction_cite_pk = request.GET['cite']
             reaction_cite = Reaction.objects.get(pk=reaction_cite_pk)
             if not reaction_cite.is_visible:
@@ -1078,6 +1079,10 @@ def answer(request):
                 reaction_cite.author.username,
                 settings.ZDS_APP['site']['url'],
                 reaction_cite.get_absolute_url())
+
+            if request.is_ajax():
+                resp["text"] = text
+                return HttpResponse(json.dumps(resp), content_type='application/json')
 
         form = ReactionForm(article, request.user, initial={
             'text': text

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -13,7 +13,7 @@ from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.shortcuts import redirect, get_object_or_404, render
 from django.template import Context
 from django.template.loader import get_template

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from datetime import datetime
+import json
 
 from django.conf import settings
 from django.contrib import messages
@@ -370,6 +371,7 @@ def answer(request):
 
         # Using the quote button
         if 'cite' in request.GET:
+            resp = {}
             post_cite_pk = request.GET['cite']
             post_cite = get_object_or_404(PrivatePost, pk=post_cite_pk)
 
@@ -381,6 +383,10 @@ def answer(request):
                 post_cite.author.username,
                 settings.ZDS_APP['site']['url'],
                 post_cite.get_absolute_url())
+
+            if request.is_ajax():
+                resp["text"] = text
+                return HttpResponse(json.dumps(resp), content_type='application/json')
 
         form = PrivatePostForm(g_topic, request.user, initial={
             'text': text

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3356,6 +3356,7 @@ def answer(request):
         # Using the quote button
 
         if "cite" in request.GET:
+            resp = {}
             note_cite_pk = request.GET["cite"]
             note_cite = Note.objects.get(pk=note_cite_pk)
             if not note_cite.is_visible:
@@ -3369,6 +3370,10 @@ def answer(request):
                 note_cite.author.username,
                 settings.ZDS_APP['site']['url'],
                 note_cite.get_absolute_url())
+
+            if request.is_ajax():
+                resp["text"] = text
+                return HttpResponse(json.dumps(resp), content_type='application/json')
 
         form = NoteForm(tutorial, request.user, initial={"text": text})
         return render(request, "tutorial/comment/new.html", {


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1984 #1977 |

Afin qu'on puisse passer ça en prod, j'ai repris #1984 et j'ai corrigé la faute.
# Note de QA

Vérifier que le bouton "citer" fonctionne à nouveau dans les articles, les tutoriels et (surtout) les messages privés.
