### PR TITLE
Répare la superposition de la date et des boutons d'actions

### DIFF
--- a/assets/scss/_all-supports.scss
+++ b/assets/scss/_all-supports.scss
@@ -2494,6 +2494,10 @@ table {
             }
             .date {
                 line-height: 32px;
+
+                .long-date {
+                    display: none;
+                }
             }
         }
 

--- a/assets/scss/_extra-wide.scss
+++ b/assets/scss/_extra-wide.scss
@@ -22,4 +22,13 @@
     .full-content-wrapper .tutorial-list article {
         width: 29.3%;
     }
+
+    .main .content-container .topic-message .message .message-metadata .date {
+        .short-date {
+            display: none;
+        }
+        .long-date {
+            display: inline;
+        }
+    }
 }

--- a/assets/scss/_mobile-tablet.scss
+++ b/assets/scss/_mobile-tablet.scss
@@ -9,7 +9,7 @@
 @media only screen and (max-width: 959px) {
     body {
         background: #222;
-        
+
         &:not(.swipping) {
             .page-container,
             .mobile-menu {
@@ -212,7 +212,7 @@
         .mobile-menu-hide {
             display: none;
         }
-        
+
         .page-container {
             .mobile-menu-bloc,
             .mobile-menu-link,
@@ -234,7 +234,7 @@
 
                 &:after {
                     display: block;
-                    content: " ";   
+                    content: " ";
                     position: absolute;
                     top: 15px;
                     left: 13px;
@@ -473,7 +473,7 @@
             p {
                 margin: 0 !important;
             }
-            
+
             .topic-members {
                 .topic-members-long-date {
                     display: none;
@@ -566,10 +566,6 @@
 
                 .date {
                     float: right;
-
-                    .long-date {
-                        display: none;
-                    }
                 }
             }
 

--- a/assets/scss/_wide.scss
+++ b/assets/scss/_wide.scss
@@ -501,10 +501,6 @@
                 white-space: nowrap;
                 overflow: hidden;
             }
-
-            .message-metadata .date .short-date {
-                display: none;
-            }
         }
     }
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1987 |

**QA :**
- Aller sur son profil puis "Messages postés"
- Choisir un message avec une grande date (par exemple "mardi 23 décembre 2014 à 12h34")
- Cliquer sur le lien pour y aller
- Redimensionnez votre navigateur et vérifier que la date et les boutons d'actions ("citer", "signaler"...) ne se superposent pas comme https://zestedesavoir.com/media/galleries/972/877b29a8-2a9d-4179-bb33-3b203e7fe50a.png
