### PR TITLE
Répare la gestion des exceptions de la page d'aide aux auteurs

### DIFF
--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -4216,6 +4216,22 @@ class MiniTutorialTests(TestCase):
             tutos = response.context['tutorials']
             self.assertEqual(len(tutos), 1)
 
+        # test pagination page doesn't exist
+        response = self.client.post(
+            reverse('zds.tutorial.views.help_tutorial') +
+            u'?page=1534',
+            follow=False
+        )
+        self.assertEqual(404, response.status_code)
+
+        # test pagination page not an integer
+        response = self.client.post(
+            reverse('zds.tutorial.views.help_tutorial') +
+            u'?page=abcd',
+            follow=False
+        )
+        self.assertEqual(404, response.status_code)
+
     def test_change_update(self):
         """test the change of `tutorial.update` if extract is modified (ensure #1715)"""
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3632,17 +3632,16 @@ def help_tutorial(request):
 
     # Paginator
     paginator = Paginator(tutos, settings.ZDS_APP['tutorial']['helps_per_page'])
-    page = request.GET.get('page')
 
+    # Get the `page` argument (if empty `page = 1` by default)
+    page = request.GET.get('page', 1)
+
+    # Check if `page` is correct (integer and exists)
     try:
-        shown_tutos = paginator.page(page)
         page = int(page)
-    except PageNotAnInteger:
-        shown_tutos = paginator.page(1)
-        page = 1
-    except EmptyPage:
-        shown_tutos = paginator.page(paginator.num_pages)
-        page = paginator.num_pages
+        shown_tutos = paginator.page(page)
+    except (PageNotAnInteger, EmptyPage, KeyError, ValueError):
+        raise Http404
 
     aides = HelpWriting.objects.all()
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1974 |

**QA :** Vérifier que lorsque la valeur de `?page=` n'est pas bonne, il y a bien une erreur 404.
