### PR TITLE
Fix #1994 : Erreur 500 lors de consultation de l'historique d'un article

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -949,8 +949,10 @@ def history(request, article_pk, article_slug):
     logs = repo.head.reference.log()
     logs = sorted(logs, key=attrgetter('time'), reverse=True)
 
+    form_js = ActivJsForm(initial={"js_support": article.js_support})
+
     return render(request, 'article/member/history.html', {
-        'article': article, 'logs': logs
+        'article': article, 'logs': logs, 'formJs': form_js
     })
 
 # Reactions at an article.


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1994 |
### QA
- Aller sur l'historique d'un article et vérifier que la page s'affiche.
