### PR TITLE
Fix #1995 : utilisation d'un template lors de la prévisualisation

### DIFF
--- a/assets/js/action-ajax.js
+++ b/assets/js/action-ajax.js
@@ -134,18 +134,16 @@
         $.ajax({
             url: $form.attr("action"),
             type: "POST",
-            dataType: "json",
             data: {
                 "csrfmiddlewaretoken": csrfmiddlewaretoken,
                 "text": text,
                 "last_post": lastPost,
-                "preview": "Apercu"
+                "preview": "preview"
             },
             success: function(data){
                 $(".previsualisation").remove();
-                var $prev = $("<div class='previsualisation content-wrapper'> <h3 class='reactions-title'>Prévisualisation de votre message</h3><div class='message-content'>"+data.text+"</div></div>");
-                $prev.insertAfter($form);
-            }
+                $(data).insertAfter($form);
+            },
         });
         e.stopPropagation();
         e.preventDefault();

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -25,8 +25,8 @@ from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q
-from django.http import Http404, HttpResponse
-from django.shortcuts import get_object_or_404, redirect, render
+from django.http import Http404, HttpResponse, StreamingHttpResponse
+from django.shortcuts import get_object_or_404, redirect, render, render_to_response
 from django.utils.encoding import smart_str
 from django.views.decorators.http import require_POST
 from git import Repo, Actor
@@ -1020,8 +1020,8 @@ def answer(request):
         # Using the « preview button », the « more » button or new reaction
         if 'preview' in data or newreaction:
             if request.is_ajax():
-                return HttpResponse(json.dumps({"text": emarkdown(data["text"])}),
-                                    content_type='application/json')
+                content = render_to_response('misc/previsualization.part.html', {'text': data['text']})
+                return StreamingHttpResponse(content)
             else:
                 form = ReactionForm(article, request.user, initial={
                     'text': data['text']
@@ -1225,8 +1225,8 @@ def edit_reaction(request):
                 '?message=' + \
                 str(reaction_pk)
             if request.is_ajax():
-                return HttpResponse(json.dumps({"text": emarkdown(request.POST["text"])}),
-                                    content_type='application/json')
+                content = render_to_response('misc/previsualization.part.html', {'text': request.POST['text']})
+                return StreamingHttpResponse(content)
             else:
                 return render(request, 'article/reaction/edit.html', {
                     'reaction': reaction,

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -13,8 +13,8 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.core.urlresolvers import reverse
 from django.db import transaction
-from django.http import Http404, HttpResponse
-from django.shortcuts import redirect, get_object_or_404, render
+from django.http import Http404, HttpResponse, StreamingHttpResponse
+from django.shortcuts import redirect, get_object_or_404, render, render_to_response
 from django.template import Context
 from django.template.loader import get_template
 from django.views.decorators.http import require_POST
@@ -244,8 +244,8 @@ def new(request):
 
         if "preview" in request.POST:
             if request.is_ajax():
-                return HttpResponse(json.dumps({"text": emarkdown(request.POST["text"])}),
-                                    content_type='application/json')
+                content = render_to_response('misc/previsualization.part.html', {'text': request.POST['text']})
+                return StreamingHttpResponse(content)
             else:
                 form = TopicForm(initial={"title": request.POST["title"],
                                           "subtitle": request.POST["subtitle"],
@@ -485,8 +485,8 @@ def answer(request):
             form.helper.form_action = reverse("zds.forum.views.answer") \
                 + "?sujet=" + str(g_topic.pk)
             if request.is_ajax():
-                return HttpResponse(json.dumps({"text": emarkdown(request.POST["text"])}),
-                                    content_type='application/json')
+                content = render_to_response('misc/previsualization.part.html', {'text': data['text']})
+                return StreamingHttpResponse(content)
             else:
                 return render(request, "forum/post/new.html", {
                     "text": data["text"],
@@ -664,8 +664,8 @@ def edit_post(request):
 
         if "preview" in request.POST:
             if request.is_ajax():
-                return HttpResponse(json.dumps({"text": emarkdown(request.POST["text"])}),
-                                    content_type='application/json')
+                content = render_to_response('misc/previsualization.part.html', {'text': request.POST['text']})
+                return StreamingHttpResponse(content)
             else:
                 if g_topic:
                     form = TopicForm(initial={"title": request.POST["title"],

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -13,8 +13,8 @@ from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q
-from django.http import Http404, HttpResponse
-from django.shortcuts import redirect, get_object_or_404, render
+from django.http import Http404, HttpResponse, StreamingHttpResponse
+from django.shortcuts import redirect, get_object_or_404, render, render_to_response
 from django.template import Context
 from django.template.loader import get_template
 from django.views.decorators.http import require_POST
@@ -153,8 +153,8 @@ def new(request):
         # If the client is using the "preview" button
         if 'preview' in request.POST:
             if request.is_ajax():
-                return HttpResponse(json.dumps({"text": emarkdown(request.POST["text"])}),
-                                    content_type='application/json')
+                content = render_to_response('misc/previsualization.part.html', {'text': request.POST['text']})
+                return StreamingHttpResponse(content)
             else:
                 form = PrivateTopicForm(request.user.username,
                                         initial={
@@ -296,8 +296,8 @@ def answer(request):
         # Using the « preview button », the « more » button or new post
         if 'preview' in data or newpost:
             if request.is_ajax():
-                return HttpResponse(json.dumps({"text": emarkdown(data["text"])}),
-                                    content_type='application/json')
+                content = render_to_response('misc/previsualization.part.html', {'text': data['text']})
+                return StreamingHttpResponse(content)
             else:
                 form = PrivatePostForm(g_topic, request.user, initial={
                     'text': data['text']
@@ -452,8 +452,8 @@ def edit_post(request):
         # Using the preview button
         if 'preview' in data:
             if request.is_ajax():
-                return HttpResponse(json.dumps({"text": emarkdown(data["text"])}),
-                                    content_type='application/json')
+                content = render_to_response('misc/previsualization.part.html', {'text': data['text']})
+                return StreamingHttpResponse(content)
             else:
                 form = PrivatePostForm(g_topic, request.user, initial={
                     'text': data['text']

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -33,8 +33,8 @@ from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q, Count
-from django.http import Http404, HttpResponse
-from django.shortcuts import get_object_or_404, redirect, render
+from django.http import Http404, HttpResponse, StreamingHttpResponse
+from django.shortcuts import get_object_or_404, redirect, render, render_to_response
 from django.utils.encoding import smart_str
 from django.views.decorators.http import require_POST
 from git import Repo, Actor
@@ -3323,8 +3323,8 @@ def answer(request):
             form = NoteForm(tutorial, request.user,
                             initial={"text": data["text"]})
             if request.is_ajax():
-                return HttpResponse(json.dumps({"text": emarkdown(data["text"])}),
-                                    content_type='application/json')
+                content = render_to_response('misc/previsualization.part.html', {'text': data['text']})
+                return StreamingHttpResponse(content)
             else:
                 return render(request, "tutorial/comment/new.html", {
                     "tutorial": tutorial,
@@ -3510,8 +3510,8 @@ def edit_note(request):
             form.helper.form_action = reverse("zds.tutorial.views.edit_note") \
                 + "?message=" + str(note_pk)
             if request.is_ajax():
-                return HttpResponse(json.dumps({"text": emarkdown(request.POST["text"])}),
-                                    content_type='application/json')
+                content = render_to_response('misc/previsualization.part.html', {'text': request.POST['text']})
+                return StreamingHttpResponse(content)
             else:
                 return render(request,
                               "tutorial/comment/edit.html",


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1995 |
### QA

Vérifier que la prévisualisation d'un message vie Ajax fonctionne un peu partout (MP, forums, articles et tutoriels).
