### PR TITLE
Fix #2013 : pas de lien d'adhésion si pas d'association

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -550,9 +550,9 @@
                     <li><a href="{% url "zds.pages.views.about" %}">{% trans "À propos" %}</a></li>
                     {% if app.site.association %}
                         <li><a href="{% url "zds.pages.views.association" %}">{% trans "L'association" %}</a></li>
-                    {% endif %}
-                    {% if user.is_authenticated %}
-                        <li><a href="{% url "zds.pages.views.assoc_subscribe" %}">{% trans "Adhérer" %}</a></li>
+                        {% if user.is_authenticated %}
+                            <li><a href="{% url "zds.pages.views.assoc_subscribe" %}">{% trans "Adhérer" %}</a></li>
+                        {% endif %}
                     {% endif %}
                     <li><a href="{% url "zds.pages.views.contact" %}">{% trans "Contact" %}</a></li>
                 </ul>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2013 |
### QA
1. Supprimer l'association des settings
2. Se connecter et vérifier que le lien d'adhésion est bien absent
