### PR TITLE
Corrige les `@override_settings()`

### DIFF
--- a/zds/article/tests/tests.py
+++ b/zds/article/tests/tests.py
@@ -28,11 +28,12 @@ from zds.settings import SITE_ROOT
 from zds.utils.models import Alert
 
 
+overrided_zds_app = settings.ZDS_APP
+overrided_zds_app['article']['repo_path'] = os.path.join(SITE_ROOT, 'article-data-test')
+
+
 @override_settings(MEDIA_ROOT=os.path.join(SITE_ROOT, 'media-test'))
-@override_settings(
-    REPO_ARTICLE_PATH=os.path.join(
-        SITE_ROOT,
-        'articles-data-test'))
+@override_settings(ZDS_APP=overrided_zds_app)
 class ArticleTests(TestCase):
 
     def setUp(self):

--- a/zds/article/tests/tests_feeds.py
+++ b/zds/article/tests/tests_feeds.py
@@ -16,11 +16,12 @@ from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.settings import SITE_ROOT
 
 
+overrided_zds_app = settings.ZDS_APP
+overrided_zds_app['article']['repo_path'] = os.path.join(SITE_ROOT, 'article-data-test')
+
+
 @override_settings(MEDIA_ROOT=os.path.join(SITE_ROOT, 'media-test'))
-@override_settings(
-    REPO_ARTICLE_PATH=os.path.join(
-        SITE_ROOT,
-        'articles-data-test'))
+@override_settings(ZDS_APP=overrided_zds_app)
 class LastArticlesFeedRSSTest(TestCase):
 
     def setUp(self):

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -21,10 +21,14 @@ from zds.utils.models import Alert
 from zds.settings import SITE_ROOT
 
 
+overrided_zds_app = settings.ZDS_APP
+overrided_zds_app['tutorial']['repo_path'] = os.path.join(SITE_ROOT, 'tutoriels-private-test')
+overrided_zds_app['tutorial']['repo_public_path'] = os.path.join(SITE_ROOT, 'tutoriels-public-test')
+overrided_zds_app['article']['repo_path'] = os.path.join(SITE_ROOT, 'article-data-test')
+
+
 @override_settings(MEDIA_ROOT=os.path.join(SITE_ROOT, 'media-test'))
-@override_settings(REPO_PATH=os.path.join(SITE_ROOT, 'tutoriels-private-test'))
-@override_settings(REPO_PATH_PROD=os.path.join(SITE_ROOT, 'tutoriels-public-test'))
-@override_settings(REPO_ARTICLE_PATH=os.path.join(SITE_ROOT, 'articles-data-test'))
+@override_settings(ZDS_APP=overrided_zds_app)
 class TestProfile(TestCase):
 
     def setUp(self):

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -27,10 +27,14 @@ from zds.gallery.factories import GalleryFactory, UserGalleryFactory
 from zds.gallery.models import Gallery, UserGallery
 
 
+overrided_zds_app = settings.ZDS_APP
+overrided_zds_app['tutorial']['repo_path'] = os.path.join(SITE_ROOT, 'tutoriels-private-test')
+overrided_zds_app['tutorial']['repo_public_path'] = os.path.join(SITE_ROOT, 'tutoriels-public-test')
+overrided_zds_app['article']['repo_path'] = os.path.join(SITE_ROOT, 'article-data-test')
+
+
 @override_settings(MEDIA_ROOT=os.path.join(SITE_ROOT, 'media-test'))
-@override_settings(REPO_PATH=os.path.join(SITE_ROOT, 'tutoriels-private-test'))
-@override_settings(REPO_PATH_PROD=os.path.join(SITE_ROOT, 'tutoriels-public-test'))
-@override_settings(REPO_ARTICLE_PATH=os.path.join(SITE_ROOT, 'articles-data-test'))
+@override_settings(ZDS_APP=overrided_zds_app)
 class MemberTests(TestCase):
 
     def setUp(self):
@@ -665,12 +669,11 @@ class MemberTests(TestCase):
         self.assertEqual(result.status_code, 404)
 
     def tearDown(self):
-        Profile.objects.all().delete()
-        if os.path.isdir(settings.REPO_ARTICLE_PATH):
-            rmtree(settings.REPO_ARTICLE_PATH)
+        if os.path.isdir(settings.ZDS_APP['tutorial']['repo_path']):
+            rmtree(settings.ZDS_APP['tutorial']['repo_path'])
+        if os.path.isdir(settings.ZDS_APP['tutorial']['repo_public_path']):
+            rmtree(settings.ZDS_APP['tutorial']['repo_public_path'])
+        if os.path.isdir(settings.ZDS_APP['article']['repo_path']):
+            rmtree(settings.ZDS_APP['article']['repo_path'])
         if os.path.isdir(settings.MEDIA_ROOT):
             rmtree(settings.MEDIA_ROOT)
-        if os.path.isdir(settings.REPO_PATH):
-            rmtree(settings.REPO_PATH)
-        if os.path.isdir(settings.REPO_PATH_PROD):
-            rmtree(settings.REPO_PATH_PROD)

--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -35,10 +35,14 @@ from zds.utils.models import SubCategory, Licence, Alert, HelpWriting
 from zds.utils.misc import compute_hash
 
 
+overrided_zds_app = settings.ZDS_APP
+overrided_zds_app['tutorial']['repo_path'] = os.path.join(SITE_ROOT, 'tutoriels-private-test')
+overrided_zds_app['tutorial']['repo_public_path'] = os.path.join(SITE_ROOT, 'tutoriels-public-test')
+overrided_zds_app['article']['repo_path'] = os.path.join(SITE_ROOT, 'article-data-test')
+
+
 @override_settings(MEDIA_ROOT=os.path.join(SITE_ROOT, 'media-test'))
-@override_settings(REPO_PATH=os.path.join(SITE_ROOT, 'tutoriels-private-test'))
-@override_settings(REPO_PATH_PROD=os.path.join(SITE_ROOT, 'tutoriels-public-test'))
-@override_settings(REPO_ARTICLE_PATH=os.path.join(SITE_ROOT, 'articles-data-test'))
+@override_settings(ZDS_APP=overrided_zds_app)
 class BigTutorialTests(TestCase):
 
     def setUp(self):
@@ -2649,9 +2653,7 @@ class BigTutorialTests(TestCase):
 
 
 @override_settings(MEDIA_ROOT=os.path.join(SITE_ROOT, 'media-test'))
-@override_settings(REPO_PATH=os.path.join(SITE_ROOT, 'tutoriels-private-test'))
-@override_settings(REPO_PATH_PROD=os.path.join(SITE_ROOT, 'tutoriels-public-test'))
-@override_settings(REPO_ARTICLE_PATH=os.path.join(SITE_ROOT, 'articles-data-test'))
+@override_settings(ZDS_APP=overrided_zds_app)
 class MiniTutorialTests(TestCase):
 
     def setUp(self):

--- a/zds/tutorial/tests/tests_feeds.py
+++ b/zds/tutorial/tests/tests_feeds.py
@@ -18,9 +18,14 @@ from zds.tutorial.feeds import LastTutorialsFeedRSS, LastTutorialsFeedATOM
 from zds.tutorial.models import Tutorial, Validation
 
 
+overrided_zds_app = settings.ZDS_APP
+overrided_zds_app['tutorial']['repo_path'] = os.path.join(SITE_ROOT, 'tutoriels-private-test')
+overrided_zds_app['tutorial']['repo_public_path'] = os.path.join(SITE_ROOT, 'tutoriels-public-test')
+overrided_zds_app['article']['repo_path'] = os.path.join(SITE_ROOT, 'article-data-test')
+
+
 @override_settings(MEDIA_ROOT=os.path.join(SITE_ROOT, 'media-test'))
-@override_settings(REPO_PATH=os.path.join(SITE_ROOT, 'tutoriels-private-test'))
-@override_settings(REPO_PATH_PROD=os.path.join(SITE_ROOT, 'tutoriels-public-test'))
+@override_settings(ZDS_APP=overrided_zds_app)
 class LastTutorialsFeedRSSTest(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2002 |

Sous le nom un peu alambiqué de la PR se cache en fait un truc très simple : lorsqu'on réalisais les tests en local, le contenu déjà généré via le site était écrasé, parce que ce n'était plus les bonnes variables qui étaient modifiée.
# Note de QA

QA **très facile**, mais longue parce qu'il faut attendre la fin des tests.
- Attendre que Travis soit passé, c'est un test en soit.
- Générer au moins un tutoriel et au moins un article, puis les valider
- Faire la série de test des membres, tutoriels et articles. En une commande : `python manage.py test zds.member zds.article zds.tutorial`. Objectivement, lancez les et faite autre chose : c'est long. Buvez un café, regarder une série, étudiez vos examens, j'en sais rien, mais comptez une bonne vingtaine de minute.
- Vérifiez finalement que vos tutoriels et articles sont toujours accessibles sur le site.
