### PR TITLE
Mise à jour de la version de Pillow (màj de sécurité)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 pysolr==3.2.0
 pygments==2.0.1
 python-social-auth==0.1.26
+
 # Explicit dependencies (references in code)
 django==1.6.8
 coverage==3.7.1
@@ -16,7 +17,7 @@ lxml==3.4.0
 pygal==1.5.1
 factory-boy==2.4.1
 pygeoip==0.3.2
-pillow==2.6.1
+Pillow==2.7.0
 https://github.com/zestedesavoir/GitPython/archive/0.3.2-RC2.zip
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.4.1-zds.12.zip
 easy-thumbnails==2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pygments==2.0.1
 python-social-auth==0.1.26
 
 # Explicit dependencies (references in code)
-django==1.6.8
+django==1.6.9
 coverage==3.7.1
 south==1.0.1
 django-crispy-forms==1.4.0


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | x |
# À merger rapidement quand Travis est OK

https://www.djangoproject.com/weblog/2015/jan/02/pillow-security-release/

_Les serveurs de prod et de preprod ont été mis à jour en 2.7.0_

J'ai également mis à jour la version de Django (https://www.djangoproject.com/weblog/2015/jan/02/bugfix-releases-issued/) mais ça pourra attendre la MEP pour mettre à jour sur les serveurs.
