### PR TITLE
Fix #2028 : correction du message pour les sujets épinglés

### DIFF
--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -415,11 +415,13 @@ def edit(request):
             messages.success(request,
                              u"Le sujet {0} est désormais verrouillé."
                              .format(g_topic.title))
-        if "sticky" in data:
-            g_topic.is_sticky = data["sticky"] == "true"
-            messages.success(request,
-                             u"Le sujet {0} est désormais épinglé."
-                             .format(g_topic.title))
+        if 'sticky' in data:
+            if data['sticky'] == 'true':
+                g_topic.is_sticky = True
+                messages.success(request, _(u'Le sujet « {0} » est désormais épinglé.').format(g_topic.title))
+            else:
+                g_topic.is_sticky = False
+                messages.success(request, _(u'Le sujet « {0} » n\'est désormais plus épinglé.').format(g_topic.title))
         if "move" in data:
             try:
                 forum_pk = int(request.POST["move_target"])


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2028 |
### QA
- Mettre un sujet en post-it et vérifier que le message de succès est bon
- idem en l'enlevant des post-it
