### PR TITLE
Mise a jour du filtre d'affichage de la liste (ZEP-3)

### DIFF
--- a/doc/sphinx/source/tutorial/tutorial.rst
+++ b/doc/sphinx/source/tutorial/tutorial.rst
@@ -377,7 +377,13 @@ Afin d'aider les auteurs de tutoriels à rédiger ces derniers, des options lors
 
 L'ensemble des tutoriels à la recherche d'aide est visible via la page "help.html" (template dans le fichier ``templates/tutorial/tutorial/help.html``). Cette page génère un tableau récapitulatif de toutes les demandes d'aides pour les différents tutoriels et des filtres peuvent être appliqués. Toutes les données servant à peupler ce tableau sont renvoyées via la méthode ``help_tutorial()`` dans le fichier ``zds/tutorial/views.py``. Cette méthode peut prendre en compte un argument en GET nommé type désignant le filtre à appliquer. Cet argument représente le slug d'une des options de la liste précédentes.
 En cas d'absence du paramètre, tout les tutoriels ayant au moins une demande d'aide d'activées ou en bêta sont renvoyé au template.
-De nouveau type de demande d'aide peuvent-être rajouté via l'interface d'administration Django dans la classe ``Utils.HelpWriting``.
+De nouveaux types de demande d'aide peuvent-être rajouté via l'interface d'administration Django dans la classe ``Utils.HelpWriting``.
+
+Sur la page d'entraide, les tutoriels sont ordonnées de la manière suivante (par ordre d'impact/priorité) :
+
+- Les tutos déjà publiés passent à la fin de la liste ;
+- Puis on trie par le nombre d'aides différentes demandées ;
+- Puis on trie par la date de mise à jour.
 
 Quelques données de test sont présentes dans le fichier ``fixtures/aide_tuto_media.yaml``. En chargeant ces dernières, un tuto peut alors être modifié pour recevoir des demandes d'aides (en allant les sélectionner dans la liste à cet effet lors de l'édition du tuto).
 Pour chaque données de test, il faut aussi passer par l'interface d'administration Django pour ajouter les images relatives à ces aides (limites techniques du chargement automatique). Quatres illustrations sont présentes dans le dossier de fixtures correspondant aux quatres aides présentes dans les fixtures.

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3784,10 +3784,10 @@ def help_tutorial(request):
     """fetch all tutorials that needs help"""
 
     # Retrieve type of the help. Default value is any help
-    type = request.GET.get('type', None)
+    filterslug = request.GET.get('type', None)
 
-    if type is not None:
-        aide = get_object_or_404(HelpWriting, slug=type)
+    if filterslug is not None:
+        aide = get_object_or_404(HelpWriting, slug=filterslug)
         tutos = Tutorial.objects.filter(helps=aide) \
                                 .order_by('pubdate', '-update') \
                                 .all()

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3789,10 +3789,12 @@ def help_tutorial(request):
     if type is not None:
         aide = get_object_or_404(HelpWriting, slug=type)
         tutos = Tutorial.objects.filter(helps=aide) \
+                                .order_by('pubdate', '-update') \
                                 .all()
     else:
         tutos = Tutorial.objects.annotate(total=Count('helps'), shasize=Count('sha_beta')) \
                                 .filter((Q(sha_beta__isnull=False) & Q(shasize__gt=0)) | Q(total__gt=0)) \
+                                .order_by('pubdate', '-total', '-update') \
                                 .all()
 
     # Paginator


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #1944 |

Cette PR vise à améliorer légèrement le tri de la liste de la ZEP-3 pour la rendre plus cohérente...

Dorénavant :
- Les tutos déjà publiés passent à la fin de la liste
- Puis on trie par nombre d'aides différentes demandés
- Puis on trie par date de mise à jour.

Ainsi, plus un tuto à besoin d'aides et plus il sera en avant (je ne suis pas sur que ce soit le plus judicieux cependant).
Un tuto déjà publié en revanche sera forcément derrière les tutos qui n'ont pas encore vu la gloire de la version online afin de privilégier leur progression.

QA : Faite des tutos pour jouer avec l'ordre d'affichage
