### PR TITLE
Ajout des boutons de redac/aides dans le dropdown

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -203,6 +203,12 @@
                                                 </ul>
                                             {% endfor %}
                                         {% endwith %}
+                                        <li>
+                                            <a href="{% url "zds.tutorial.views.add_tutorial" %}" class="btn btn-grey">{% trans "Rédiger un tutoriel" %}</a>
+                                        </li>
+                                        <li>
+                                            <a href="{% url "zds.tutorial.views.help_tutorial" %}" class="btn btn-grey">{% trans "Aider les auteurs" %}</a>
+                                        </li>
                                     </ul>
                                 </div>
                             </li>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | ~oui |
| Tickets concernés | #1921 |

Ici, on ajoute deux boutons dans le dropdown des tutoriels. Ainsi, le rédacteur/helpers potentiel à un accès plus rapide (et donc on augmente la visibilité de ces fonctions).
# WIP
### Besoin d'aide du front

J'ai besoin d'aide du front pour finaliser le bouzin car je n'arrive pas à faire apparaître un bouton dans son aspect "naturel" (car on est dans le header etc...) donc ping @sandhose @Situphen :)

Pour la QA, il suffira de vérifier que les liens pointent aux bons endroits...

Question : Ces boutons doivent-ils apparaître si on est pas connecté ?
