### PR TITLE
Update git python version for python3 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ pygal==1.5.1
 factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.6.1
-https://github.com/zestedesavoir/GitPython/archive/0.3.2-RC2.zip
+https://github.com/zestedesavoir/GitPython/archive/0.4.zip
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.4.1-zds.12.zip
 easy-thumbnails==2.2


### PR DESCRIPTION
Update de l'upstream de gitpython et support de python 3.

Vérifier que tout marche toujours.
