### PR TITLE
fix #2031 : Problème de saisie d'un membre dans l'ajout d'un auteur

### DIFF
--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -573,8 +573,11 @@ def modify_tutorial(request):
             author_username = request.POST["author"]
             author = None
             try:
-                author = User.objects.get(username=author_username)
+                author = User.objects.get(username=author_username.strip())
             except User.DoesNotExist:
+                messages.error(request,
+                               _(u'L\'auteur {0} n\'a pas pu être ajouté à la rédaction '
+                                 u'du tutoriel car il n\'existe pas...').format(request.POST["author"]))
                 return redirect(redirect_url)
             tutorial.authors.add(author)
             tutorial.save()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | https://github.com/zestedesavoir/zds-site/issues/2031 |
## QA

Tester plusieurs cas d'ajout d'un auteur _sans utiliser l'autocomplétion_
- Orthographe du pseudo correcte
- Orthographe correcte mais espace inséré avant/après
- Orthographe incorrecte
