### PR TITLE
L'éditeur ne se duplique plus lors d'un copier-coller sur Chrome

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -107,8 +107,11 @@
 
             this.addEvent(document.getElementById("content"), "DOMNodeInserted", (function(_this){
                 return function(e) {
-                    if (/md.editor/.test(e.target.className)) {
-                        _this.setup(e.target.id);
+                    var element = e.target;
+                    if (/md.editor/.test(element.className)) {
+                        if(element.previousElementSibling.indexOf("zform-toolbar") > -1) {
+                            _this.setup(element.id);
+                        }
                     }
                 };
             }) (this));

--- a/assets/js/markdown-help.js
+++ b/assets/js/markdown-help.js
@@ -34,7 +34,10 @@
     $(document).ready(function(){
         addDocMD($(".md-editor"));
         $("#content").on("DOMNodeInserted", ".md-editor", function(e){
-            addDocMD($(e.target));
+            var $editor = $(e.target);
+            if($editor.next().hasClass("markdown-help") === false) {
+                addDocMD($editor);
+            }
         });
     });
 })(document, jQuery);


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | [Forum](https://zestedesavoir.com/forums/sujet/1406/modification-de-lediteur-avec-des-copiercoller/) |

La barre d'outil et l'aide markdown de l'éditeur de texte ne se dupliquent plus lors d'un copier-coller sur Chrome.

**QA :**
- Vérifier que le bug ne se produit plus sur Chrome
- Vérifier que la barre d'outil et l'aide markdown fonctionnent encore
