### PR TITLE
Hotfix du Gulpfile: all.min.js pas créé

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -112,6 +112,11 @@ gulp.task("stylesheet", ["sprite", "vendors"], function() {
       sass: sourceDir + sassDir,
       imagePath: sourceDir + imagesDir
     }))
+    .on("error", $.notify.onError({
+      title: "SASS Error",
+      message: "<%= error.message %>"
+    }))
+    .on("error", function() { this.emit("end"); })
     .pipe($.autoprefixer(autoprefixerConfig), { cascade: true })
     .pipe($.size({ title: "Stylesheet" }))
     .pipe(gulp.dest(destDir + "css/"))
@@ -196,6 +201,7 @@ gulp.task("merge-scripts", ["vendors", "scripts"], function() {
     .pipe($.concat("all.js"))
     .pipe($.size({ title: "Scripts (all)" }))
     .pipe(gulp.dest(destDir + scriptsDir))
+    .pipe($.rename({ suffix: ".min" }))
     .pipe($.uglify())
     .pipe($.size({ title: "Scripts (all, minified)" }))
     .pipe(gulp.dest(destDir + scriptsDir));


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | x |

Avec le nouveau Gulpfile, j'ai fait une erreur: le script contenant tous les scripts (`all.js`), lors de la minification sortait vers `all.js`, et non vers `all.min.js`... Etant donné que c'est le script délivré en production aux clients, il vaut mieux qu'il soit présent!

J'en ai profité pour fixer un autre bug moins important: lorsque l'on avait une erreur SASS, Gulp s'arrêtait. C'est particulièrement embêtant lorsque l'on utilise "watch", puisqu'il fallait le relancer à la moindre erreur de syntaxe... C'est fixé, et en prime, il affiche maintenant une notification de bureau si il y a une erreur.
