### PR TITLE
Correction des mails d'inscription et de réinitialisation du mot de passe

### DIFF
--- a/templates/email/forgot_password/confirm.html
+++ b/templates/email/forgot_password/confirm.html
@@ -7,7 +7,7 @@
     {% trans "Bonjour" %} <strong>{{ username }}</strong>,
     <br />
     <br />
-    {% trans "Vous recevez ce message parce qu'une réinitialisation du mot de passe de votre compte utilisateur a été demandée sur" %} <a href="{{app.site.url}}">{{app.site.litteral_name}}</a>.
+    {% trans "Vous recevez ce message parce qu'une réinitialisation du mot de passe de votre compte utilisateur a été demandée sur" %} <a href="{{ site_url }}">{{ site_name }}</a>.
     <br />
     <br />
     <hr>
@@ -16,11 +16,11 @@
     {% trans "Si vous n'avez pas demandé une réinitialisation du mot de passe, IGNOREZ et EFFACEZ ce courriel immédiatement ! Continuez uniquement si vous souhaitez que votre mot de passe soit réinitialisé !" %}
     <hr>
     <br />
-    {% trans "Cliquez ou recopiez simplement le lien et complétez le reste du formulaire" %} : <a href="{{ url }}">{{ url }}</a>.
+    {% trans "Cliquez ou recopiez simplement le lien et complétez le reste du formulaire : " %} : <a href="{{ url }}">{{ url }}</a>.
     <br />
     <br />
     <br />
     {% trans "Cordialement" %},
     <br />
-    {% trans "L'équipe" %} {{app.site.litteral_name}}
+    {% trans "L'équipe" %} {{ site_name }}
 </body>

--- a/templates/email/forgot_password/confirm.txt
+++ b/templates/email/forgot_password/confirm.txt
@@ -1,13 +1,13 @@
 {% load i18n %}
 {% trans "Bonjour" %} {{ username }},
 
-{% trans "Vous recevez ce message parce qu'une réinitialisation du mot de passe de votre compte utilisateur a été demandée sur" %} {{app.site.litteral_name}}.
+{% trans "Vous recevez ce message parce qu'une réinitialisation du mot de passe de votre compte utilisateur a été demandée sur" %} {{ site_name }}.
 
-{% trans "ATTENTION
-Si vous n'avez pas demandé une réinitialisation du mot de passe, IGNOREZ et EFFACEZ ce courriel immédiatement ! Continuez uniquement si vous souhaitez que votre mot de passe soit réinitialisé !
+{% trans "ATTENTION" %}
+{% trans "Si vous n'avez pas demandé une réinitialisation du mot de passe, IGNOREZ et EFFACEZ ce courriel immédiatement ! Continuez uniquement si vous souhaitez que votre mot de passe soit réinitialisé ! " %}
 
-Cliquez ou recopiez simplement le lien et complétez le reste du formulaire" %} : {{ url }}.
+{% trans "Cliquez ou recopiez simplement le lien et complétez le reste du formulaire : " %} {{ url }}.
 
 
-{% trans "Cordialement,
-L'équipe" %} {{app.site.litteral_name}}
+{% trans "Cordialement," %}
+{% trans "L'équipe" %} {{ site_name }}

--- a/templates/email/register/confirm.html
+++ b/templates/email/register/confirm.html
@@ -8,20 +8,21 @@
     <br />
     <br />
     <p>
-        {% blocktrans with site_name=app.site.litteral_name site_url=app.site.url %}
-        Vous vous &ecirc;tes inscrit sur <a href="{{site_url}}">{{site_name}}</a> et nous vous en remercions.
-        En &eacute;tant membre de notre communaut&eacute;, vous aurez la possibilit&eacute; de r&eacute;diger des tutoriels et des articles
+        {% blocktrans %}
+        Vous vous êtes inscrit sur <a href="{{ site_url }}">{{ site_name }}</a> et nous vous en remercions.
+        En étant membre de notre communauté, vous aurez la possibilité de rédiger des tutoriels et des articles
         que vous pourrez ensuite publier et ainsi de rendre vos connaissances accessibles au plus grand nombre.
-        Vous pourrez &eacute;galement &eacute;changer avec les autres membres sur nos forums !
+        Vous pourrez également échanger avec les autres membres sur nos forums !
         <br />
-        Il ne vous reste plus qu'&agrave; activer votre profil ! Pour ce faire, visitez le lien ci-dessous :
+        Il ne vous reste plus qu'à activer votre profil ! Pour ce faire, visitez le lien ci-dessous :
         <br />
         <a href="{{ url }}">{{ url }}</a>
         <br />
         <br />
-        A tr&egrave;s bient&ocirc;t !
+        A très bientôt !
         <br />
-        L'&eacute;quipe {{site_name}}
+        L'équipe {{ site_name }}
         {% endblocktrans %}
     </p>
 </body>
+</html>

--- a/templates/email/register/confirm.txt
+++ b/templates/email/register/confirm.txt
@@ -1,8 +1,11 @@
 {% load i18n %}
-{% trans "Bonjour" %} <strong>{{ username }}</strong>,
+{% trans "Bonjour" %} {{ username }},
 
-{% blocktrans with site_name=app.site.litteral_name %}
-Vous vous êtes inscrit sur {{site_name}} et nous vous en remercions. En étant membre de notre communauté, vous aurez la possibilité de rédiger des tutoriels et des articles que vous pourrez ensuite publier et ainsi rendre votre savoir accessible au plus grand nombre. Vous pourrez également échanger avec les autres membres sur nos forums !
+{% blocktrans %}
+Vous vous êtes inscrit sur {{site_name}} et nous vous en remercions.
+En étant membre de notre communauté, vous aurez la possibilité de rédiger des tutoriels et des articles
+que vous pourrez ensuite publier et ainsi rendre votre savoir accessible au plus grand nombre.
+Vous pourrez également échanger avec les autres membres sur nos forums !
 
 Il ne vous reste plus qu'à activer votre profil ! Pour ce faire, visitez le lien ci-dessous :
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -795,9 +795,14 @@ def forgot_password(request):
             from_email = "{} <{}>".format(settings.ZDS_APP['site']['litteral_name'],
                                           settings.ZDS_APP['site']['email_noreply'])
             message_html = get_template("email/forgot_password/confirm.html").render(Context(
-                {"username": usr.username, "url": settings.ZDS_APP['site']['url'] + token.get_absolute_url()}))
+                {"username": usr.username,
+                 "site_name": settings.ZDS_APP['site']['name'],
+                 "site_url": settings.ZDS_APP['site']['url'],
+                 "url": settings.ZDS_APP['site']['url'] + token.get_absolute_url()}))
             message_txt = get_template("email/forgot_password/confirm.txt") .render(Context(
-                {"username": usr.username, "url": settings.ZDS_APP['site']['url'] + token.get_absolute_url()}))
+                {"username": usr.username,
+                 "site_name": settings.ZDS_APP['site']['name'],
+                 "url": settings.ZDS_APP['site']['url'] + token.get_absolute_url()}))
             msg = EmailMultiAlternatives(subject, message_txt, from_email,
                                          [usr.email])
             msg.attach_alternative(message_html, "text/html")

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -754,9 +754,15 @@ def register_view(request):
             from_email = "{} <{}>".format(settings.ZDS_APP['site']['litteral_name'],
                                           settings.ZDS_APP['site']['email_noreply'])
             message_html = get_template("email/register/confirm.html").render(Context(
-                {"username": user.username, "url": settings.ZDS_APP['site']['url'] + token.get_absolute_url()}))
+                {"username": user.username,
+                 "url": settings.ZDS_APP['site']['url'] + token.get_absolute_url(),
+                 "site_name": settings.ZDS_APP['site']['name'],
+                 "site_url": settings.ZDS_APP['site']['url']}))
             message_txt = get_template("email/register/confirm.txt") .render(Context(
-                {"username": user.username, "url": settings.ZDS_APP['site']['url'] + token.get_absolute_url()}))
+                {"username": user.username,
+                 "url": settings.ZDS_APP['site']['url'] + token.get_absolute_url(),
+                 "site_name": settings.ZDS_APP['site']['name'],
+                 "site_url": settings.ZDS_APP['site']['url']}))
             msg = EmailMultiAlternatives(subject, message_txt, from_email,
                                          [user.email])
             msg.attach_alternative(message_html, "text/html")
@@ -940,10 +946,13 @@ def generate_token_account(request):
     message_html = get_template("email/register/confirm.html"
                                 ) \
         .render(Context({"username": token.user.username,
+                         "site_url": settings.ZDS_APP['site']['url'],
+                         "site_name": settings.ZDS_APP['site']['name'],
                          "url": settings.ZDS_APP['site']['url'] + token.get_absolute_url()}))
     message_txt = get_template("email/register/confirm.txt"
                                ) \
         .render(Context({"username": token.user.username,
+                         "site_name": settings.ZDS_APP['site']['name'],
                          "url": settings.ZDS_APP['site']['url'] + token.get_absolute_url()}))
     msg = EmailMultiAlternatives(subject, message_txt, from_email,
                                  [token.user.email])


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | https://github.com/zestedesavoir/zds-site/issues/2060 |

But: correction de diverses erreurs dans les mails d'inscription et dans les mails de réinitialisation de mot de passe.

*\* Penser à régénérer le fichier de traduction. python manage.py makemessages -l en **

QA:
1. Lancer un terminal avec la commande "python -m smtpd -n -c DebuggingServer localhost:1025"
2. Ajouter dans le fichier "zds/settings.py" les deux lignes suivantes, aprés les import :

``` python
 EMAIL_HOST = 'localhost'
EMAIL_PORT = 1025
```
1. Lancer un autre terminal avec une instance de « zeste de savoir »
2. Tenter de s'inscrire sur le site par la page d'inscription, le mail envoyé doit apparaître dans la console ou la commande « python -m smtpd -n -c DebuggingServer localhost:1025 » a été lancée.
3. Tenter de réinitialiser le mot de passe sur le site par la page « mot de passe oublié », le mail envoyé doit apparaître dans la console ou la commande « python -m smtpd -n -c DebuggingServer localhost:1025 » a été lancée.
