### PR TITLE
[Release 1.5] Évite des dizaines de requêtes sur toute page connectée.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -269,9 +269,10 @@
                                 <div>
                                     {% with topics=user|interventions_privatetopics %}
                                     {% with unread_topics=topics.unread %}
+                                    {% with total_topics=topics.total %}
                                         <a href="{% url "zds.mp.views.index" %}" class="ico-link">
-                                            {% if unread_topics|length > 0 %}
-                                                <span class="notif-count">{{ unread_topics|length }}</span>
+                                            {% if total_topics > 0 %}
+                                                <span class="notif-count">{{ total_topics }}</span>
                                             {% endif %}
                                             <span class="notif-text ico ico-messages">{% trans "Messagerie privée" %}</span>
                                         </a>
@@ -297,7 +298,7 @@
                                                     {% endwith %}
                                                 {% endfor %}
 
-                                                {% if unread_topics|length = 0 %}
+                                                {% if total_topics = 0 %}
                                                     <li class="dropdown-empty-message">
                                                         {% trans "Aucun nouveau message" %}
                                                     </li>
@@ -307,6 +308,7 @@
                                                 {% trans "Tous les messages" %}
                                             </a>
                                         </div>
+                                    {% endwith %}
                                     {% endwith %}
                                     {% endwith %}
                                 </div>

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -4,11 +4,11 @@ from datetime import datetime, timedelta
 import time
 
 from django import template
-from django.db.models import Q, F
+from django.db.models import F
 
 from zds.article.models import Reaction, ArticleRead
 from zds.forum.models import TopicFollowed, never_read as never_read_topic, Post, TopicRead
-from zds.mp.models import PrivateTopic, PrivateTopicRead
+from zds.mp.models import PrivateTopic
 from zds.tutorial.models import Note, TutorialRead
 from zds.utils.models import Alert
 

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -131,22 +131,21 @@ def interventions_topics(user):
 @register.filter('interventions_privatetopics')
 def interventions_privatetopics(user):
 
-    topics_never_read = list(PrivateTopicRead.objects
-                             .filter(user=user)
-                             .filter(privatepost=F('privatetopic__last_message')).all())
+    # Raw query because ORM doesn't seems to allow this kind of "left outer join" clauses.
+    # Parameters = list with 3x the same ID because SQLite backend doesn't allow map parameters.
+    privatetopics_unread = PrivateTopic.objects.raw(
+        '''
+        select distinct t.*
+        from mp_privatetopic t
+        inner join mp_privatetopic_participants p on p.privatetopic_id = t.id
+        left outer join mp_privatetopicread r on r.user_id = %s and r.privatepost_id = t.last_message_id
+        where (t.author_id = %s or p.user_id = %s)
+          and r.id is null
+        order by t.pubdate desc''',
+        [user.id, user.id, user.id])
 
-    tnrs = []
-    for tnr in topics_never_read:
-        tnrs.append(tnr.privatetopic.pk)
-
-    privatetopics_unread = PrivateTopic.objects\
-        .filter(Q(author=user) | Q(participants__in=[user]))\
-        .exclude(pk__in=tnrs)\
-        .select_related("privatetopic")\
-        .order_by("-pubdate")\
-        .distinct()
-
-    return {'unread': privatetopics_unread}
+    # "total" re-do the query, but there is no other way to get the length as __len__ is not available on raw queries.
+    return {'unread': privatetopics_unread, 'total': len(list(privatetopics_unread))}
 
 
 @register.filter(name='alerts_list')


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #2090, #2087 |

Aujourd'hui, en mode connecté, tout affichage de page provoque autant de requêtes en base qu'il y a de MP dans la boîte aux lettres. Autant dire que pour quelqu'un qui a pas mal de MP, ça suffit a ralentir salement la navigation...

Comme à priori il n'existe pas de moyen de faire des choses comme `left outer join <égalité 1> and <égalité 2>` avec l'ORM Django, je suis passé par une requête SQL brute.

C'est pas ce qu'il y a de plus propre, mais c'est infiniment mieux qu'avant.

À noter que par effet de bord, ça corrige aussi la #2087, qui était en fait due à l'ancienne ligne 144 de `interventions.py`.

**Notes de QA** :
1. Vérifier que le compteur de MP non lus se comporte correctement
2. Vérifier que le dropdown de MP se comporte correctement
3. Vérifier qu'on évite de faire une requête par MP pour les membres connectés.

Si quelqu'un sait remplacer la requête brute par une version ORM qui ne provoque pas les délires de la version actuelle, je suis preneur.
