### PR TITLE
[Patch 1.5]Enlève le mp sur les profiles privés

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -210,7 +210,7 @@
             <div class="mobile-menu-bloc mobile-all-links" data-title='{% trans "Actions" %}'>
                 <h3>{% trans "Actions" %}</h3>
                 <ul>
-                    {% if usr != user %}
+                    {% if usr != user and !profile.is_private %}
                         <li>
                             <a href="{% url "zds.mp.views.new" %}?username={{ usr.username }}" class="ico-after cite blue">
                                 {% trans "Envoyer un message privé" %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets concernés | [#1541] |

Le #1541 (accessibilité des bots) avait un problème sur la page d'affichage de anonymous. Il y avait encore le bouton pour envoyer un mp et ce même si envoyer un mp à ce membre est impossible.
