### PR TITLE
Corrige le update.md

### DIFF
--- a/update.md
+++ b/update.md
@@ -111,7 +111,7 @@ Il faudra donc :
 
 1. créer le groupe "bot"
 2. vérifier que `settings.ZDS_APP['member']['bot_group']` vaut bien `"bot"`
-3. Aller dans l'interface d'administration pour ajouter les comptes auteur externe et anonyme au groupe bot
+3. Aller dans l'interface de promotion des utilisateurs pour ajouter les comptes auteur externe et anonyme au groupe bot
 
 npm
 ---


### PR DESCRIPTION
L'interface d'administration est plus restreinte en prod pour plusieurs raisons et n'accepte pas forcément l'envoie des comptes dans les groupes. Il vaut mieux utiliser l'interface de promotion.

Ce correctif ne fait que décrire l'opération réalisée par Spacefox lors de la mise en préprod et donne une cohérence à la documentation.
