### PR TITLE
Ctrl + Enter n'a pas d'effet si les touches Alt, Shift, Meta sont pressées

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -579,7 +579,8 @@
     "use strict";
 
     $(".md-editor").on("keydown", function(e){
-        if(e.ctrlKey && e.which === 13){
+        // the message is submitted if the user is pressing Ctrl and Enter and isn't pressing Alt, Shift and Super
+        if(e.ctrlKey && e.which === 13 && !e.altKey && !e.shiftKey && !e.metaKey){
             $(".message-submit > button[name=answer]").click();
         }
     });


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2082 |

**QA :**
- Positionner vous dans le champ de texte (`<textarea>`) d'un formulaire du forum.
- Vérifier qu'il ne se passe rien quand vous appuyez sur Ctrl + Enter + [Alt ou Shift]

Voilà le résultat que j'ai sur Kubuntu avec un clavier de portable Azerty. Il se peut que votre résultat diffère du mien en fonction de votre disposition, de votre clavier, de votre distribution ou de votre OS ; surtout pour les touches comme Windows ou Fn !

| Touche pressée (Ctrl + Enter + Touche) | Effet sur Chrome | Effet sur Firefox |
| --- | --- | --- |
| Alt | Rien | Rien |
| Shift | Rien | Rien |
| Alt Gr | Envoi du formulaire | Envoi du formulaire |
| Windows | Rien | Envoi du formulaire |
| Fn | Envoi du formulaire | Envoi du formulaire |
