### PR TITLE
Correction de l'erreur 500 dans le téléchargement des articles

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -480,7 +480,11 @@ def insert_into_zip(zip_file, git_tree):
 
 def download(request):
     """Download an article."""
-    article = get_object_or_404(Article, pk=request.GET["article"])
+    try:
+        article_id = int(request.GET["article"])
+    except (KeyError, ValueError):
+        raise Http404
+    article = get_object_or_404(Article, pk=article_id)
     repo_path = os.path.join(settings.ZDS_APP['article']['repo_path'], article.get_phy_slug())
     repo = Repo(repo_path)
     sha = article.sha_draft


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | https://github.com/zestedesavoir/zds-site/issues/2112 |

QA:
1. Lancer une instance de ZesteDeSavoir
2. Publier un article
3. Tenter de télécharger l'article
4. Tenter de charger l'adresse « http://localhost:8000/articles/telecharger/?article=%C3%A9%C3%A9%C3%A9%C3%A9&online », comportement normal: une erreur 404
5. Tenter de charger l'adresse « http://localhost:8000/articles/telecharger/?article=1001&online », comportement normal: une erreur 404
