### PR TITLE
[Relase 1.5] Suppression d'une classe CSS inutile.

### DIFF
--- a/templates/forum/includes/forums.part.html
+++ b/templates/forum/includes/forums.part.html
@@ -6,7 +6,7 @@
 
 {% for forum in forums %}
     <div class="topic navigable-elem">
-        <div class="topic-description {% if user.is_authenticated and not forum.is_read %}unread{% endif %}">
+        <div class="topic-description">
             <a href="{{ forum.get_absolute_url }}" class="navigable-link">
                 <h4 class="topic-title" itemprop="itemListElement">
                     {{ forum.title }}

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -120,13 +120,6 @@ class Forum(models.Model):
             else:
                 return False
 
-    def is_read(self):
-        """Checks if there are topics never read in the forum."""
-        for current_topic in Topic.objects.filter(forum=self).all():
-            if never_read(current_topic):
-                return False
-        return True
-
 
 class Topic(models.Model):
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #2094 |

On avait, au niveau des forums, un indicateur qui disait "ce forum contient des messages non lus". Indicateur jamais utilisé à l'affichage.

Problème : pour positionner cet indicateur, on bouclait sur la liste des forums, et pour chacun des forums on parcourait la liste des topics jusqu'à en trouver un lu. Ce qui peut vite devenir _très_ long...

Comme l'indicateur ne servait pas, je l'ai purement et simplement dégagé, et j'ai supprimé la méthode impliquée dans `Forum` (normalement elle ne sert nulle part ailleurs).

À noter que ce problème [vient du code de Progdupeu.pl](https://bitbucket.org/MicroJoe/progdupeupl/src/6247a055acb5/pdp/forum/models.py#cl-82) qui lui utilise cet indicateur, et qui [a _légèrement_ amélioré son code depuis](https://bitbucket.org/MicroJoe/progdupeupl/src/62de1acc20f7673220deafa7464b2d8130a2841e/pdp/forum/models.py?at=master#cl-186).

**Notes de QA** : vérifier qu'il n'y a aucune modification visible sur le module de tutos (navigation connectée, déconnectée et avec un compte tout neuf).

PS : toute personne qui voudrait rétablir cet indicateur devra le faire en passant par une requête propre, et pas une grosse boucle. Bon courage...
