### PR TITLE
[Release 1.5] Affichage des utilisateurs d'une galerie

### DIFF
--- a/templates/gallery/gallery/details.html
+++ b/templates/gallery/gallery/details.html
@@ -34,7 +34,7 @@
     <div class="authors">
         <span class="authors-label">{% trans "Galerie partagée avec" %} : </span>
         <ul>
-            {% for u in gallery.get_users %}
+            {% for u in gallery.get_linked_users %}
                 {% captureas info %}
                     {% if u.mode == 'R' %}
                         {% trans "Lecture" %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2072 |

Remet en place l'affichage des utilisateurs sur le détail d'une galerie. La méthode `get_users` du modèle Gallery est devenue `get_linked_users` mais n'a pas été répercutée dans le template.
