### PR TITLE
Répare l'affichage des tags dans les pages d'historique

### DIFF
--- a/templates/article/member/history.html
+++ b/templates/article/member/history.html
@@ -35,18 +35,18 @@
 
 
 {% block headline %}
+    {% if article.licence %}
+        <span class="license" itemprop="license">
+            {{ article.licence }}
+        </span>
+    {% endif %}
+
     <h1 {% if article.image %}class="illu"{% endif %}>
         {% if article.image %}
             <img src="{{article.image.article_illu.url }}" alt="">
         {% endif %}
         {% trans "Historique de" %} "{{ article.title }}"
     </h1>
-    
-    {% if article.licence %}
-        <span class="license" itemprop="license">
-            {{ article.licence }}
-        </span>
-    {% endif %}
 
     {% if article.description %}
         <h2 class="subtitle">
@@ -70,7 +70,7 @@
             {{ article.pubdate|format_date }}
         </time>
     </span>
-    
+
     <div class="authors">
         <span class="authors-label">{% trans "Contributeur" %}{{ article.authors.all|pluralize }} : </span>
         <ul>

--- a/templates/tutorial/tutorial/history.html
+++ b/templates/tutorial/tutorial/history.html
@@ -19,18 +19,18 @@
 
 
 {% block headline %}
+    {% if tutorial.licence %}
+        <span class="license">
+            {{ tutorial.licence }}
+        </span>
+    {% endif %}
+
     <h1 {% if tutorial.image %}class="illu"{% endif %} itemprop="name">
         {% if tutorial.image %}
             <img src="{{ tutorial.image.physical.tutorial_illu.url }}" alt="" itemprop="thumbnailUrl">
         {% endif %}
         {% trans "Historique de" %} "{{ tutorial.title }}"
     </h1>
-
-    {% if tutorial.licence %}
-        <span class="license">
-            {{ tutorial.licence }}
-        </span>
-    {% endif %}
 
     <h2 class="subtitle">
         {{ tutorial.description }}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2122 |

**QA :** Vérifier que les tags sont bien au bon endroit sur les pages d'historique des tutoriels et articles.
