### PR TITLE
Parallelisation des traitements pour réduire le temps de build travis à l'aide de tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,6 @@ omit =
     */factories.py
     */wsgi.py
     */migrations/*
+    */.tox/*
+    setup.py
+    *settings_test*

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ htmlcov/
 #Mr Developer
 .mr.developer.cfg
 
+#tox
+.tox/
+
 
 #################
 ## Eclipse

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ install:
 
 script:
   - tox $TEST_APP
-  - tox -e flake8
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ language: python
 python:
   - 2.7
 
+env:
+  - TEST_APP="-e back_mysql zds.tutorial"
+  - TEST_APP="-e back_mysql zds.article zds.forum zds.member zds.utils zds.gallery zds.mp zds.pages"
+  - TEST_APP="-e front"
+
 notifications:
   irc:
     channels:
@@ -55,18 +60,15 @@ install:
   - sudo apt-get --reinstall install -qq language-pack-fr
 
   # Python dependencies
-  - travis_retry pip install -r requirements.txt -r requirements-dev.txt
   - travis_retry pip install coveralls
-  - travis_retry pip install MySQL-python
+  - travis_retry pip install tox
 
   # Node.js + npm stuff
   - sudo apt-get -y install nodejs
   - travis_retry npm install
 
 script:
-  - npm run travis
-  - coverage run --source='.' manage.py test
-  - flake8 --exclude=migrations,urls.py,settings.py,settings_prod.py,settings_test.py --max-line-length=120 zds
+  - tox $TEST_APP
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,10 @@ install:
 
   # Node.js + npm stuff
   - sudo apt-get -y install nodejs
-  - travis_retry npm install
 
 script:
   - tox $TEST_APP
+  - tox -e flake8
 
 after_success:
   - coveralls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,12 @@ Les contributions externes sont les bienvenues !
 1. Créez une branche pour contenir votre travail
 2. Faites vos modifications
 3. Ajoutez un test pour votre modification. Seules les modifications de documentation et les réusinages n'ont pas besoin de nouveaux tests
-4. Assurez-vous que l'intégralité des tests passent : `python manage.py test`
-5. Assurez-vous que le code suit la [PEP-8](http://legacy.python.org/dev/peps/pep-0008/) : `flake8 --exclude=migrations,urls.py,settings.py --max-line-length=120 zds`
-6. Si vous avez fait des modifications du _front_, jouez les tests associés : `npm test`
+4. Assurez-vous que l'intégralité des tests passent : `tox -e back`
+5. Assurez-vous que le code suit la [PEP-8](http://legacy.python.org/dev/peps/pep-0008/) : `tox -e flake8`
+6. Si vous avez fait des modifications du _front_, jouez les tests associés : `tox -e front`
 7. Si vous modifiez le modèle (les fichiers models.py), n'oubliez pas de créer les fichiers de migration : `python manage.py schemamigration app_name --auto`
-8. Si vous avez ajouté/modifié une chaine de caractère, pensez à génerer le fichier de traduction : `python manage.py makemessages -l en`
-9. Si votre travail nécessite des actions spécifiques lors du déploiement, précisez-les dans le fichier [update.md](update.md).
-10. Poussez votre travail et faites une _pull request_
+8. Si votre travail nécessite des actions spécifiques lors du déploiement, précisez-les dans le fichier [update.md](update.md).
+9. Poussez votre travail et faites une _pull request_
 
 # Quelques bonnes pratiques
 * Respectez [les conventions de code de Django](https://docs.djangoproject.com/en/1.6/internals/contributing/writing-code/coding-style/), ce qui inclut la [PEP 8 de Python](http://legacy.python.org/dev/peps/pep-0008/)

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Elles sont reportées essentiellement dans le [bugtraker](https://github.com/zes
 
 ### Installation d'une version locale de ZdS
 
-- [Intallation du backend sur Windows](http://zds-site.readthedocs.org/fr/latest/install/backend-windows-install.html)
-- [Intallation du backend sur Linux](http://zds-site.readthedocs.org/fr/latest/install/backend-linux-install.html)
-- [Intallation du backend sur OS X](http://zds-site.readthedocs.org/fr/latest/install/backend-os-x-install.html)
+- [Installation du backend sur Windows](http://zds-site.readthedocs.org/fr/latest/install/backend-windows-install.html)
+- [Installation du backend sur Linux](http://zds-site.readthedocs.org/fr/latest/install/backend-linux-install.html)
+- [Installation du backend sur OS X](http://zds-site.readthedocs.org/fr/latest/install/backend-os-x-install.html)
 - [Installation du frontend](http://zds-site.readthedocs.org/fr/latest/install/frontend-install.html)
 - [Installation de Solr](doc/install-solr.md) pour gérer la recherche
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Elles sont reportées essentiellement dans le [bugtraker](https://github.com/zes
 
 ### Installation d'une version locale de ZdS
 
-- [Intallation sur Windows](http://zds-site.readthedocs.org/fr/latest/install/install-windows.html)
-- [Intallation sur Linux](http://zds-site.readthedocs.org/fr/latest/install/install-linux.html)
-- [Intallation sur OS X](http://zds-site.readthedocs.org/fr/latest/install/install-os-x.html)
+- [Intallation du backend sur Windows](http://zds-site.readthedocs.org/fr/latest/install/backend-windows-install.html)
+- [Intallation du backend sur Linux](http://zds-site.readthedocs.org/fr/latest/install/backend-linux-install.html)
+- [Intallation du backend sur OS X](http://zds-site.readthedocs.org/fr/latest/install/backend-os-x-install.html)
+- [Installation du frontend](http://zds-site.readthedocs.org/fr/latest/install/frontend-install.html)
 - [Installation de Solr](doc/install-solr.md) pour gérer la recherche
 
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ Elles sont reportées essentiellement dans le [bugtraker](https://github.com/zes
 
 ### Installation d'une version locale de ZdS
 
-- [Intallation du backend sur Windows](doc/backend-windows-install.md)
-- [Intallation du backend sur Linux](doc/backend-linux-install.md)
-- [Intallation du backend sur OS X](doc/backend-os-x-install.md)
-- [Installation du frontend](doc/frontend-install.md)
+- [Intallation sur Windows](http://zds-site.readthedocs.org/fr/latest/install/install-windows.html)
+- [Intallation sur Linux](http://zds-site.readthedocs.org/fr/latest/install/install-linux.html)
+- [Intallation sur OS X](http://zds-site.readthedocs.org/fr/latest/install/install-os-x.html)
 - [Installation de Solr](doc/install-solr.md) pour gérer la recherche
 
 

--- a/doc/sphinx/source/install/backend-linux-install.rst
+++ b/doc/sphinx/source/install/backend-linux-install.rst
@@ -15,7 +15,7 @@ Assurez vous que les dépendances suivantes soient résolues :
 - python2.7
 - python-dev : ``apt-get install python-dev``
 - easy_install : ``apt-get install python-setuptools``
-- pip : ``easy_install pip``
+- pip : ``easy_install pip tox``
 - libxml2-dev : ``apt-get install libxml2-dev``
 - python-lxml : ``apt-get install python-lxml``
 - libxlst-dev (peut être appelée libxlst1-dev sur certains OS comme ubuntu
@@ -28,7 +28,7 @@ Ou, en une ligne,
 .. sourcecode:: bash
 
     apt-get install git python-dev python-setuptools libxml2-dev python-lxml libxslt-dev libz-dev python-sqlparse libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev
-    easy_install pip
+    easy_install pip tox
 
 Installation et configuration de `virtualenv`
 ============================================
@@ -102,7 +102,7 @@ restera propre et lisible au cours du temps !
 
     #!/bin/sh
     
-    flake8 --exclude=migrations,urls.py,settings.py --max-line-length=120 zds
+    tox -e flake8
     
     # Store tests result
     RESULT=$?

--- a/doc/sphinx/source/install/backend-os-x-install.rst
+++ b/doc/sphinx/source/install/backend-os-x-install.rst
@@ -21,6 +21,7 @@ Installation de virtualenv
 
 .. sourcecode:: bash
 
+    pip install tox
     pip install virtualenv
     pip install virtualenvwrapper
     mkdir ~/.virtualenvs

--- a/doc/sphinx/source/install/backend-windows-install.rst
+++ b/doc/sphinx/source/install/backend-windows-install.rst
@@ -15,7 +15,7 @@ Prérequis
 - `Téléchargez et installez Python 2.7 <https://www.python.org/download/releases/2.7/>`_
 - Installez setuptools : Démarrez `Powershell <http://fr.wikipedia.org/wiki/Windows_PowerShell>`_ **en mode administrateur** et lancez la commande suivante : ``(Invoke-WebRequest https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py).Content | python -``
 - Redémarrez Powershell
-- Installez pip : ``easy_install pip``
+- Installez pip : ``easy_install pip tox``
 - Désactivez la sécurité sur les script powershell ``Set-ExecutionPolicy RemoteSigned``
 - Installez Virtualenv avec les commandes suivante : 
     - ``pip install virtualenv``

--- a/doc/sphinx/source/introduction.rst
+++ b/doc/sphinx/source/introduction.rst
@@ -75,7 +75,8 @@ Si vous voulez installer et démarrer une instance locale de ZdS, vous devez cli
 .. toctree::
    :maxdepth: 2
 
-   install/backend-windows-install
-   install/backend-os-x-install
-   install/backend-linux-install
+   install/install-windows
+   install/install-os-x
+   install/install-linux
    install/frontend-install
+   install/fixtures

--- a/doc/sphinx/source/introduction.rst
+++ b/doc/sphinx/source/introduction.rst
@@ -75,8 +75,8 @@ Si vous voulez installer et démarrer une instance locale de ZdS, vous devez cli
 .. toctree::
    :maxdepth: 2
 
-   install/install-windows
-   install/install-os-x
-   install/install-linux
+   install/backend-windows-install
+   install/backend-os-x-install
+   install/backend-linux-install
    install/frontend-install
    install/fixtures

--- a/load_factory_data.py
+++ b/load_factory_data.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import yaml
-import zds
 import os
-from zds import settings
 
 parser = argparse.ArgumentParser(description='Give yaml fixture files.')
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 PyYAML==3.11
-django-debug-toolbar==1.2.2
 flake8==2.2.5
 autopep8==1.0.4
 sphinx==1.2.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ PyYAML==3.11
 flake8==2.2.5
 autopep8==1.0.4
 sphinx==1.2.3
-faker==0.0.4
+fake-factory==0.4.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 PyYAML==3.11
+django-debug-toolbar==1.2.2
 flake8==2.2.5
 autopep8==1.0.4
 sphinx==1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 pysolr==3.2.0
 pygments==2.0.1
 python-social-auth==0.1.26
-django-debug-toolbar==1.2.2
 
 # Explicit dependencies (references in code)
 django==1.6.10
@@ -19,6 +18,6 @@ pygal==1.5.1
 factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.7.0
-gitpython==0.3.5
+https://github.com/zestedesavoir/GitPython/archive/0.3.2-RC2.zip
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.4.1-zds.12.zip
 easy-thumbnails==2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,6 @@ pygal==1.5.1
 factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.7.0
-https://github.com/zestedesavoir/GitPython/archive/0.3.2-RC2.zip
+gitpython==0.3.5
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.4.1-zds.12.zip
 easy-thumbnails==2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 pysolr==3.2.0
 pygments==2.0.1
 python-social-auth==0.1.26
+django-debug-toolbar==1.2.2
 
 # Explicit dependencies (references in code)
 django==1.6.10

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='zds',
-    version='1.3',
+    version='1.6',
     packages=['zds'],
     include_package_data=True,
     license='GPLv3',
-    description='Site internet communautaire codé à l\'aide du framework Django 1.6 et de Python 2.7.',
+    description='Community Website implemented with Django framework and Python 2.',
     long_description=README,
     url='https://github.com/zestedesavoir/zds-site',
     classifiers=[
@@ -33,7 +33,6 @@ setup(
         'Programming Language :: Python',
         # Replace these appropriately if you are stuck on Python 2.
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# https://docs.djangoproject.com/en/dev/intro/reusable-apps/
+
+import os
+
+from pip.req import parse_requirements
+
+from setuptools import setup
+
+with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
+    README = readme.read()
+
+# allow setup.py to be run from any path
+os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+
+setup(
+    name='zds',
+    version='1.3',
+    packages=['zds'],
+    include_package_data=True,
+    license='GPLv3',
+    description='Site internet communautaire codé à l\'aide du framework Django 1.6 et de Python 2.7.',
+    long_description=README,
+    url='https://github.com/zestedesavoir/zds-site',
+    classifiers=[
+        'Environment :: Web Environment',
+        'Framework :: Django',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        # Replace these appropriately if you are stuck on Python 2.
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Internet :: WWW/HTTP',
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+    ],
+    install_requires=[str(pkg.req) for pkg in parse_requirements('requirements.txt')],
+    tests_require=[str(pkg.req) for pkg in parse_requirements('requirements-dev.txt')],
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,30 @@
 [tox]
 envlist = py27
-deps = -rrequirements.txt
 skipsdist = True
 
 
 [testenv]
-usedevelop = True
+setenv =
+       DJANGO_SETTINGS_MODULE=zds.settings
+       PYTHONPATH = {toxinidir}
+
+[testenv:back_mysql]
+setenv = DJANGO_SETTINGS_MODULE=zds.settings_test
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
+       MySQL-python
+commands = coverage run --source='.' {toxinidir}/manage.py test {posargs}
 
-commands = coverage run --source='.' manage.py test
+[testenv:back]
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/requirements-dev.txt
+commands = coverage run --source='.' {toxinidir}/manage.py test {posargs}
+
+[testenv:front]
+commands =
+    npm install npm -g
+    npm install
+    npm run travis
 
 [testenv:docs]
 # to call this use `tox -e docs -- html`

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ setenv =
        PYTHONPATH = {toxinidir}
 
 [testenv:back_mysql]
-setenv = DJANGO_SETTINGS_MODULE=zds.settings_test
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
        MySQL-python

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = py27
+deps = -rrequirements.txt
+skipsdist = True
+
+
+[testenv]
+usedevelop = True
+deps =
+    -rrequirements.txt
+
+commands =
+    coverage run --source='.' manage.py test
+    flake8 --exclude=migrations,urls.py,settings.py,settings_prod.py,settings_test.py --max-line-length=120 zds
+
+[testenv:docs]
+# to call this use `tox -e docs -- html`
+deps =
+    Sphinx
+
+changedir = doc/sphinx
+
+commands =
+    make {posargs}
+
+whitelist_external = make

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ setenv =
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
        MySQL-python
-commands = coverage run --source='.' {toxinidir}/manage.py test {posargs}
+commands =
+       coverage run --source='.' {toxinidir}/manage.py test {posargs}
+       flake8
 
 [testenv:back]
 deps = -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,10 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
-deps =
-    -rrequirements.txt
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/requirements-dev.txt
 
-commands =
-    coverage run --source='.' manage.py test
-    flake8 --exclude=migrations,urls.py,settings.py,settings_prod.py,settings_test.py --max-line-length=120 zds
+commands = coverage run --source='.' manage.py test
 
 [testenv:docs]
 # to call this use `tox -e docs -- html`
@@ -24,3 +22,11 @@ commands =
     make {posargs}
 
 whitelist_external = make
+
+[testenv:flake8]
+commands = flake8 {posargs}
+
+[flake8]
+#show-source = True
+max-line-length = 120
+exclude = .tox,.venv,build,dist,doc,migrations,urls.py,settings.py,settings_prod.py,settings_test.py


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #2135 ? |

Cette PR reprend les commits de @steenzout sur [cette PR](https://github.com/zestedesavoir/zds-site/pull/1848) afin d'utiliser tox pour gérer au mieux les environnement de tests.

On arrive donc ainsi à paralleliser les tests qui commençait à prendre énormément de temps. Le temps de build passe de **~25 mins** à **~10 mins**.

Maintenant on a les commandes suivantes pour lancer les tests : 
- `tox -e flake8` : tester la syntaxe pep8
- `tox -e back` : test du back end sur sqlite (la commande prend en compte flake)
- `tox -e back_mysql` : test du back end sur mysql (pour travis)
- `tox -e front` : tests du front
- `tox -e docs` : tester la génération de la docs
