### PR TITLE
Fix #2131 : affichage de la licence sur les parties des tutoriels

### DIFF
--- a/templates/tutorial/part/view_online.html
+++ b/templates/tutorial/part/view_online.html
@@ -36,9 +36,9 @@
 
 
 {% block headline %}
-    {% if tutorial.licence %}
+    {% if part.tutorial.licence %}
         <span class="license" itemprop="license">
-            {{ tutorial.licence }}
+            {{ part.tutorial.licence }}
         </span>
     {% endif %}
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2131 |
### QA
- Créer un tutoriel avec une licence
- Vérifier si elle apparait bien sur la pages avec les parties (http://domain.tld/tutoriels/tuto_pk/tuto_slug/part_pk/part_slug/)
