### PR TITLE
Fix #2130 : correction du nom du chapitre pour le signalement d'une faute

### DIFF
--- a/templates/tutorial/includes/warn_typo.part.html
+++ b/templates/tutorial/includes/warn_typo.part.html
@@ -24,13 +24,17 @@
         </p>
         <p>
             {% trans "Pas assez de place ?" %}
-            <a href="{% url "zds.mp.views.new" %}?title={% trans "Je voudrais signaler une faute dans le tutoriel" %} &quot;{{ tutorial.title }}&quot;{% for username in tutorial.authors.all %}&amp;username={{ username }}{% endfor %}" >
-                {% trans "Envoyez un MP" %}
-                {% if tutorial.authors.all|length > 1 %}
-                    {% trans "aux auteurs" %}
-                {% else %}
-                    {% trans "à l'auteur" %}
-                {% endif %}
+            {%  if obj_type == "tutorial" %}
+                <a href="{% url "zds.mp.views.new" %}?title={% trans "Je voudrais signaler une faute dans le tutoriel" %} &quot;{{ tutorial.title }}&quot;{% for username in tutorial.authors.all %}&amp;username={{ username }}{% endfor %}" >
+            {% elif obj_type = "chapter" %}
+                <a href="{% url "zds.mp.views.new" %}?title={% trans "Je voudrais signaler une faute dans le chapitre" %} &quot;{{ chapter.title }}&quot;{% for username in tutorial.authors.all %}&amp;username={{ username }}{% endfor %}" >
+            {%  endif %}
+            {% trans "Envoyez un MP" %}
+            {% if tutorial.authors.all|length > 1 %}
+                {% trans "aux auteurs" %}
+            {% else %}
+                {% trans "à l'auteur" %}
+             {% endif %}
             </a>
         </p>
         <button type="submit">{% trans "Envoyer" %}</button>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2130 |
### QA
- Aller sur un chapitre, cliquer sur « signaler une faute dans ce chapitre » et vérifier si le message pour le MP envoyé est correct
