### PR TITLE
Fix #2124 : Ajout de la version en ligne dans l'historique d'un tutoriel

### DIFF
--- a/assets/scss/base/_helpers.scss
+++ b/assets/scss/base/_helpers.scss
@@ -62,6 +62,11 @@ hr.clearfix {
     border: none;
 }
 
+.unstyled-list {
+  list-style: none;
+  padding-left: 0;
+}
+
 // Hidden on mobile
 .screen,
 .wide {

--- a/templates/tutorial/tutorial/history.html
+++ b/templates/tutorial/tutorial/history.html
@@ -57,14 +57,17 @@
             {% for log in logs %}
                 <tr>
                     <td>
-                        {% if tutorial.sha_validation = log.newhexsha %}
-                            {% trans "Validation" %}
+                        {% if tutorial.sha_public == log.newhexsha %}
+                            {% trans "En ligne" %}
                         {% endif %}
-                        {% if tutorial.sha_beta = log.newhexsha %}
-                            {% trans "Beta" %}
+                        {% if tutorial.sha_validation == log.newhexsha %}
+                            {% trans "En validation" %}
                         {% endif %}
-                        {% if tutorial.sha_draft = log.newhexsha %}
-                            {% trans "Draft" %}
+                        {% if tutorial.sha_beta == log.newhexsha %}
+                            {% trans "En bêta" %}
+                        {% endif %}
+                        {% if tutorial.sha_draft == log.newhexsha %}
+                            {% trans "Brouillon" %}
                         {% endif %}
                     </td>
                     <td>
@@ -90,7 +93,7 @@
                         {% endwith %}
                     </td>
                     <td>
-                        {% if not tutorial.sha_beta = log.newhexsha %}
+                        {% if not tutorial.sha_beta == log.newhexsha %}
                             <a href="#activ-beta-{{ log.newhexsha }}" class="open-modal">
                                 {% if not tutorial.sha_beta %}
                                     {% trans "Activer" %}

--- a/templates/tutorial/tutorial/history.html
+++ b/templates/tutorial/tutorial/history.html
@@ -45,7 +45,7 @@
     <table class="fullwidth">
         <thead>
             <tr>
-                <th width="10%">{% trans "Etat" %}</th>
+                <th width="10%">{% trans "État" %}</th>
                 <th width="18%">{% trans "Date" %}</th>
                 <th>{% trans "Version" %}</th>
                 <th width="10%">{% trans "Diff" %}.</th>
@@ -57,17 +57,29 @@
             {% for log in logs %}
                 <tr>
                     <td>
-                        {% if tutorial.sha_public == log.newhexsha %}
-                            {% trans "En ligne" %}
-                        {% endif %}
-                        {% if tutorial.sha_validation == log.newhexsha %}
-                            {% trans "En validation" %}
-                        {% endif %}
-                        {% if tutorial.sha_beta == log.newhexsha %}
-                            {% trans "En bêta" %}
-                        {% endif %}
-                        {% if tutorial.sha_draft == log.newhexsha %}
-                            {% trans "Brouillon" %}
+                        {% if tutorial.sha_public == log.newhexsha or tutorial.sha_validation == log.newhexsha or tutorial.sha_beta == log.newhexsha or tutorial.sha_draft == log.newhexsha %}
+                                <ul class="unstyled-list">
+                                {% if tutorial.sha_public == log.newhexsha %}
+                                    <li>
+                                        {% trans "En ligne" %}
+                                    </li>
+                                {% endif %}
+                                {% if tutorial.sha_validation == log.newhexsha %}
+                                    <li>
+                                        {% trans "En validation" %}
+                                    </li>
+                                {% endif %}
+                                {% if tutorial.sha_beta == log.newhexsha %}
+                                    <li>
+                                        {% trans "En bêta" %}
+                                    </li>
+                                {% endif %}
+                                {% if tutorial.sha_draft == log.newhexsha %}
+                                    <li>
+                                        {% trans "Brouillon" %}
+                                    </li>
+                                {% endif %}
+                            </ul>
                         {% endif %}
                     </td>
                     <td>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2124 |
### QA
- Vérifier que la version « En ligne » soit bien dans l'historique d'un tuto
