### PR TITLE
Fix #2123 : supression de la section « Téléchargements » sur la page de l'hitorique d'un tuto

### DIFF
--- a/templates/tutorial/tutorial/history.html
+++ b/templates/tutorial/tutorial/history.html
@@ -18,6 +18,13 @@
 
 
 
+{%  block sidebar %}
+    {# Remove "Download" part #}
+    <aside class="sidebar summary mobile-menu-hide"></aside>
+{% endblock %}
+
+
+
 {% block headline %}
     {% if tutorial.licence %}
         <span class="license">


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2123 |
### QA
- Vérifier si la partie « Téléchargements » de la sidebar est bien absente sur la page d'historique d'un tutoriel
