### PR TITLE
Remove useless secret SECRET_KEY value

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -94,7 +94,7 @@ STATICFILES_FINDERS = (
 FIXTURE_DIRS = (os.path.join(SITE_ROOT, 'fixtures'))
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = 'n!01nl+318#x75_%le8#s0=-*ysw&amp;y49uc#t=*wvi(9hnyii0z'
+SECRET_KEY = ''
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | Aucun |

Comme on nous l'a fait remarquer, on a une valeur `SECRET_KEY` renseignée dans les settings.

Cette valeur ne sert à rien (elle est surchargée sur tous les environnements) et comme elle a une "vraie" valeur, un utilisateur d'un fork pourrait oublier de la renseigner.

En vidant cette clé, il devient évident qu'elle doit être surchargée sur les environnements de run.
