### PR TITLE
[hotfix v1.5] Correction de l'erreur 500 sur un profil

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -210,7 +210,7 @@
             <div class="mobile-menu-bloc mobile-all-links" data-title='{% trans "Actions" %}'>
                 <h3>{% trans "Actions" %}</h3>
                 <ul>
-                    {% if usr != user and !profile.is_private %}
+                    {% if usr != user and not profile.is_private %}
                         <li>
                             <a href="{% url "zds.mp.views.new" %}?username={{ usr.username }}" class="ico-after cite blue">
                                 {% trans "Envoyer un message privé" %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2152 |
# Note de QA

Vérifier que les profils sont à nouveaux accessible, mais aussi que ce correctif ne casse pas la PR #2109, donc qu'il n'est toujours pas possible d'envoyer un MP à un bot (`anonymous` ou `external`, en local)
