### PR TITLE
Fix #2179 : Les adresses emails des pages de contacts ne sont plus capturables par les bots

### DIFF
--- a/doc/sphinx/source/utils/templatetags.rst
+++ b/doc/sphinx/source/utils/templatetags.rst
@@ -95,6 +95,46 @@ génération des fichiers PDF et EPUB des tutos :
 - ``decale_header_3`` : Décale les titres de 3 niveaux (un titre de niveau 1 devient un titre de niveau 4, etc.)
 
 
+email_obfuscator
+----------------
+
+Ces templatetags sont principalement fondés sur https://github.com/morninj/django-email-obfuscator.
+
+
+obfuscate
++++++++++
+
+L'email va être encodé avec des caractères ASCII pour le protéger des bots ::
+
+    {% load email_obfuscator %}
+    {{ 'your@email.com'|obfuscate }}
+
+
+obfuscate_mailto
+++++++++++++++++
+
+Ce templatetag ajoute en plus un `mailto`. Il prend un paramètre optionnel qui permet d'avoir un text personnalisé dans
+la balise <a> ::
+
+    {% load email_obfuscator %}
+    {{ 'your@email.com'|obfuscate_mailto:"my custom text" }}
+    #returns '<a href="mailto:your@email.com">my custom text</a>' as an encoded string like
+    #<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#121;&#111;&#117;&#114;&#64;&#101;&#109;&#97;&#105;&#108;&#46;&#99;&#111;&#109;">my custom text</a>
+
+
+obfuscate_mailto_top_subject
+++++++++++++++++++++++++++++
+
+Identique sur le fonctionnement à `obfuscate_mailto`, ce templatetag ajoute en plus un sujet (qui remplace le champ
+pouvant être inséré entre les balises <a> et </a>) ainsi que `target="_top"`.
+
+Il est utilisé sur la page « Contact ».
+
+Exemple ::
+
+    {% load email_obfuscator %}
+    {{ 'association@zestedesavoir.com'|obfuscate_mailto_top_subject:"Contact communication" }}
+
 
 autres
 ------

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ django==1.6.10
 coverage==3.7.1
 south==1.0.1
 django-crispy-forms==1.4.0
-git+https://github.com/morninj/django-email-obfuscator.git#egg=email_obfuscator
 django-haystack==2.3.1
 django-model-utils==2.2
 django-munin==0.1.5

--- a/templates/pages/contact.html
+++ b/templates/pages/contact.html
@@ -1,5 +1,8 @@
 {% extends "pages/base.html" %}
+
+{% load email_obfuscator %}
 {% load i18n %}
+
 
 
 {% block title %}
@@ -23,15 +26,15 @@
 {% block content %}
     <h3>{% trans "L'équipe de communication" %}</h3>
     <p>
-        {% blocktrans with site_name=app.site.litteral_name email_contact=app.site.email_contact %}
-            Vous pouvez à tout moment joindre l'équipe de communication de {{site_name}} par courriel via <a href="mailto:{{ email_contact }}?Subject=Contact communication" target="_top">{{ email_contact }}</a>.
+        {% blocktrans with site_name=app.site.litteral_name email_contact=app.site.email_contact|obfuscate_mailto_top_subject:"Contact communication" %}
+            Vous pouvez à tout moment joindre l'équipe de communication de {{site_name}} par courriel via {{ email_contact }}.
         {% endblocktrans %}
     </p>
     {% if app.site.association %}
         <h3>{% trans "L'association" %}</h3>
         <p>
-            {% blocktrans with site_name=app.site.litteral_name email_association=app.site.association.email %}
-                Vous pouvez joindre l'association par courriel via <a href="mailto:{{ email_association }}?Subject=Contact association" target="_top">{{ email_association }}</a>.
+            {% blocktrans with site_name=app.site.litteral_name email_association=app.site.association.email|obfuscate_mailto_top_subject:"Contact association" %}
+                Vous pouvez joindre l'association par courriel via {{ email_association }}.
             {% endblocktrans %}
         </p>
     {% endif %}

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -166,7 +166,6 @@ INSTALLED_APPS = (
     'easy_thumbnails.optimize',
     'south',
     'crispy_forms',
-    'email_obfuscator',
     'haystack',
     'munin',
     'social.apps.django_app.default',

--- a/zds/utils/templatetags/email_obfuscator.py
+++ b/zds/utils/templatetags/email_obfuscator.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# Mainly based on django-email-obfuscator (https://github.com/morninj/django-email-obfuscator - MIT Licence)
+# https://github.com/morninj/django-email-obfuscator/blob/master/email_obfuscator/templatetags/email_obfuscator.py
+
+from django import template
+from django.template.defaultfilters import stringfilter
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+def obfuscate_string(value):
+    return ''.join(['&#{0:s};'.format(str(ord(char))) for char in value])
+
+
+@register.filter
+@stringfilter
+def obfuscate(value):
+    return mark_safe(obfuscate_string(value))
+
+
+@register.filter
+@stringfilter
+def obfuscate_mailto(value, text=None):
+    mail = obfuscate_string(value)
+
+    if text:
+        link_text = text
+    else:
+        link_text = mail
+
+    return mark_safe('<a href="{0:s}{1:s}">{2:s}</a>'.format(
+        obfuscate_string('mailto:'), mail, link_text))
+
+
+@register.filter
+@stringfilter
+def obfuscate_mailto_top_subject(value, subject=None):
+    mail = obfuscate_string(value)
+
+    if subject:
+        txt = obfuscate_string('?Subject={0}'.format(subject))
+    else:
+        txt = ''
+
+    return mark_safe('<a href="{0}{1}{2}" target="_top">{3}</a>'.format(obfuscate_string('mailto:'), mail, txt, mail))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets concernés | #2179 |
### QA
- Vérifier que les adresses mails de la page « Contact » sont toujours utilisables et ne sont plus en clair dans le code de ma la page
- Vérifier la doc ajoutée
