### PR TITLE
Fixes #2160: Un MP peut ne pas avoir de participants

### DIFF
--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -137,7 +137,7 @@ def interventions_privatetopics(user):
         '''
         select distinct t.*
         from mp_privatetopic t
-        inner join mp_privatetopic_participants p on p.privatetopic_id = t.id
+        left outer join mp_privatetopic_participants p on p.privatetopic_id = t.id
         left outer join mp_privatetopicread r on r.user_id = %s and r.privatepost_id = t.last_message_id
         where (t.author_id = %s or p.user_id = %s)
           and r.id is null
@@ -145,7 +145,8 @@ def interventions_privatetopics(user):
         [user.id, user.id, user.id])
 
     # "total" re-do the query, but there is no other way to get the length as __len__ is not available on raw queries.
-    return {'unread': privatetopics_unread, 'total': len(list(privatetopics_unread))}
+    topics = list(privatetopics_unread)
+    return {'unread': topics, 'total': len(topics)}
 
 
 @register.filter(name='alerts_list')

--- a/zds/utils/templatetags/tests/tests_interventions.py
+++ b/zds/utils/templatetags/tests/tests_interventions.py
@@ -1,0 +1,38 @@
+# coding: utf-8
+
+from django.test import TestCase
+
+from zds.member.factories import ProfileFactory
+from zds.mp.factories import PrivateTopicFactory, PrivatePostFactory
+from zds.utils.templatetags.interventions import interventions_privatetopics
+
+
+class InterventionsTest(TestCase):
+
+    def setUp(self):
+        self.author = ProfileFactory()
+        self.user = ProfileFactory()
+        self.topic = PrivateTopicFactory(author=self.author.user)
+        self.topic.participants.add(self.user.user)
+        self.post = PrivatePostFactory(
+            privatetopic=self.topic,
+            author=self.author.user,
+            position_in_topic=1)
+
+    def test_interventions_privatetopics(self):
+        result = interventions_privatetopics(self.author)
+        self.assertEqual(result['total'], 1)
+
+        result = interventions_privatetopics(self.user)
+        self.assertEqual(result['total'], 1)
+
+    def test_interventions_privatetopics_author_leave(self):
+
+        # profile1 (author) leave topic
+        move = self.topic.participants.first()
+        self.topic.author = move
+        self.topic.participants.remove(move)
+        self.topic.save()
+
+        result = interventions_privatetopics(self.user)
+        self.assertEqual(result['total'], 1)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets concernés | #2160 |

Cas non prévu à la base : que l'on puisse être seul dans un MP et que ce MP puisse être non lu. La détection du nombre de message non lus doit donc détecter les messages pour lesquels il n'y a pas de participant (extérieur à l'auteur).

Bonus : astuce pour que la requête ne soit exécutée qu'une seule fois.

**Notes de QA** : vérifier que le nombre de MP non lus est bon, même dans les cas limites comme "on est tout seul dans un MP non lu".
