### PR TITLE
Fix #2196 : Correction du lien dans le fil d'Ariane lors de l'édition d'un article

### DIFF
--- a/templates/article/member/edit.html
+++ b/templates/article/member/edit.html
@@ -29,7 +29,7 @@
 
 
 {% block breadcrumb %}
-    <li><a href="{{ article.get_absolute_online_url }}">{{ article.title }}</a></li>
+    <li><a href="{{ article.get_absolute_url }}">{{ article.title }}</a></li>
     <li>{% trans "Éditer" %}</li>
 {% endblock %}
 

--- a/templates/article/reaction/new.html
+++ b/templates/article/reaction/new.html
@@ -11,7 +11,7 @@
 
 
 {% block breadcrumb %}
-    <li><a href="{{ article.get_absolute_online_url }}">{{ article.title }}</a></li>
+    <li><a href="{{ article.get_absolute_url_online }}">{{ article.title }}</a></li>
     <li>{% trans "Répondre à l'article" %}</li>
 {% endblock %}
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2196 |
### QA
- Éditer un article et vérifier que le lien dans le fil d'Ariane est bien celui de la version hors-ligne
