### PR TITLE
Ne demande pas de confirmation pour collecter les statics.

### DIFF
--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -62,7 +62,7 @@ pip install --upgrade --use-mirrors -r requirements.txt
 python manage.py migrate
 python manage.py compilemessages
 # Collect all static files from dist/ and python packages to static/
-python manage.py collectstatic
+python manage.py collectstatic --noinput
 deactivate
 
 # Restart zds


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | ~Oui |
| Tickets concernés | Aucun |

Le script de déploiement demande une confirmation pour collecter les statics, ce qui n'est pas ce qu'on demande à un tel script. Du coup, je le force à collecter les statics.

QA : à moins que quelqu'un se soit amusé à utiliser ce script en local, ça me paraît difficile à QA...
