### PR TITLE
Fixes #2202: Utilise une page complète pour tester les notifications de MPs

### DIFF
--- a/zds/utils/templatetags/tests/tests_interventions.py
+++ b/zds/utils/templatetags/tests/tests_interventions.py
@@ -1,13 +1,21 @@
 # coding: utf-8
+from django.core.urlresolvers import reverse
 
 from django.test import TestCase
 
 from zds.member.factories import ProfileFactory
 from zds.mp.factories import PrivateTopicFactory, PrivatePostFactory
-from zds.utils.templatetags.interventions import interventions_privatetopics
 
 
 class InterventionsTest(TestCase):
+    """
+    This test uses quite complicated paths to check number of notifications:
+    1. Create private topics and do stuff with them
+    2. Log the user
+    3. Render the home page
+    4. Check the number of unread private messages on home page source code
+    This because a correct test of this function requires a complete context (or it behave strangely)
+    """
 
     def setUp(self):
         self.author = ProfileFactory()
@@ -20,11 +28,28 @@ class InterventionsTest(TestCase):
             position_in_topic=1)
 
     def test_interventions_privatetopics(self):
-        result = interventions_privatetopics(self.author)
-        self.assertEqual(result['total'], 1)
 
-        result = interventions_privatetopics(self.user)
-        self.assertEqual(result['total'], 1)
+        self.assertTrue(
+            self.client.login(
+                username=self.author.user.username,
+                password='hostel77'
+            )
+        )
+        response = self.client.post(reverse('zds.pages.views.home'))
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, '<span class="notif-count">1</span>', html=True)
+
+        self.client.logout()
+
+        self.assertTrue(
+            self.client.login(
+                username=self.user.user.username,
+                password='hostel77'
+            )
+        )
+        response = self.client.post(reverse('zds.pages.views.home'))
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, '<span class="notif-count">1</span>', html=True)
 
     def test_interventions_privatetopics_author_leave(self):
 
@@ -34,5 +59,12 @@ class InterventionsTest(TestCase):
         self.topic.participants.remove(move)
         self.topic.save()
 
-        result = interventions_privatetopics(self.user)
-        self.assertEqual(result['total'], 1)
+        self.assertTrue(
+            self.client.login(
+                username=self.user.user.username,
+                password='hostel77'
+            )
+        )
+        response = self.client.post(reverse('zds.pages.views.home'))
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, '<span class="notif-count">1</span>', html=True)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #2202 |

Suppression de toute tentative de subtilité : puisque môssieur le test veut un contexte, on lui file un contexte. Complet. En fait, on calcule la page et on regarde ce qu'il y a dedans.

**QA** : si Travis est content, c'est à merger.

N'est pas géré en hotfix parce qu'on se fiche un peu de savoir si Travis va re-passer sur la branche de prod.
