### PR TITLE
Fix #2030: Répare le partage de contenu par mail

### DIFF
--- a/assets/js/action-ajax.js
+++ b/assets/js/action-ajax.js
@@ -41,7 +41,7 @@
         e.stopPropagation();
         e.preventDefault();
     });
-    $(".sidebar").on("click", ".email", function(e){
+    $(".sidebar").on("click", ".email-notification", function(e){
         var $act = $(this),
             $follow = $(this).parents("li:first").prev().find(".follow"),
             $form = $(this).parents("form:first");

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -179,7 +179,7 @@
             <input type="hidden" name="email" value="1">
             {% csrf_token %}
 
-            <button class="email ico-after email {% if not topic.is_email_followed %}blue{% endif %}" type="submit">
+            <button class="email ico-after email-notification {% if not topic.is_email_followed %}blue{% endif %}" type="submit">
                 {% if topic.is_email_followed %}
                     {% trans "Ne plus être notifié par courriel" %}
                 {% else %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2030 |

L'erreur 403 est due à un appel ajax sur la notification par email des sujets du forum, qui prend en compte tout les liens avec la classe `email`.

QA : 
- Vérifier que le bouton de partage par mail d'un article ou tutoriel fonctionne
- Vérifier que le bouton de notification par mail dans les forums fonctionne toujours
