### PR TITLE
Fix #2073: Empeche l'utilisateur de s'envoyer un mp

### DIFF
--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -76,7 +76,8 @@ class PrivateTopicForm(forms.Form):
         if participants is not None and participants.strip() != '':
             receivers = participants.strip().split(',')
             for receiver in receivers:
-                if User.objects.filter(username__exact=receiver.strip()).count() == 0 and receiver.strip() != '':
+                if User.objects.filter(username__exact=receiver.strip()).count() == 0 and receiver.strip() != '' \
+                        or receiver.strip() == '':
                     self._errors['participants'] = self.error_class(
                         [_(u'Un des participants saisi est introuvable')])
                 elif receiver.strip().lower() == self.username.lower():

--- a/zds/mp/tests/tests_forms.py
+++ b/zds/mp/tests/tests_forms.py
@@ -123,6 +123,17 @@ class PrivateTopicFormTest(TestCase):
         form = PrivateTopicForm(self.profile1.user.username, data=data)
         self.assertFalse(form.is_valid())
 
+    def test_invalid_topic_form_comma(self):
+        """ Cas when participants is only a comma """
+        data = {
+            'participants': ',',
+            'title': 'Test title',
+            'subtitle': 'Test subtitle',
+            'text': 'Test text'
+        }
+        form = PrivateTopicForm(self.profile1.user.username, data=data)
+        self.assertFalse(form.is_valid())
+
 
 class PrivatePostFormTest(TestCase):
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2073 |

Gère le cas ou un utilisateur est une chaine vide.

QA:
Tester l'envoi d'un mp avec pour participant : 
- `,`
- `user,`
- `,user`
- `user, , staff`
  et vérifier que le formulaire est bien invalide.
