### PR TITLE
Fixes #2089: Amélioration des perfs sur l'affichage de membres

### DIFF
--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -171,7 +171,7 @@ class Topic(models.Model):
 
     def get_last_post(self):
         """Gets the last post in the thread."""
-        return self.last_message
+        return Post.objects.select_related("author__profile").get(pk=self.last_message)
 
     def get_last_answer(self):
         """Gets the last answer in the thread, if any."""
@@ -454,4 +454,7 @@ def get_topics(forum_pk, is_sticky, filter=None):
     else:
         topics = Topic.objects.filter(forum__pk=forum_pk, is_sticky=is_sticky)
 
-    return topics.order_by('-last_message__pubdate').prefetch_related('author', 'last_message', 'tags').all()
+    return topics.order_by('-last_message__pubdate')\
+        .select_related('author__profile')\
+        .prefetch_related('last_message', 'tags')\
+        .all()

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -134,9 +134,8 @@ def topic(request, topic_pk, topic_slug):
 
     posts = \
         Post.objects.filter(topic__pk=topic.pk) \
-        .select_related() \
-        .order_by("position"
-                  ).all()
+        .select_related("author__profile") \
+        .order_by("position").all()
     last_post_pk = topic.last_message.pk
 
     # Handle pagination

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -48,7 +48,7 @@ class MemberList(ZdSPagingListView):
     paginate_by = settings.ZDS_APP['member']['members_per_page']
     # TODO When User will be no more used, you can make this request with
     # Profile.objects.all_members_ordered_by_date_joined()
-    queryset = User.objects.order_by('-date_joined').all()
+    queryset = User.objects.order_by('-date_joined').all().select_related("profile")
     template_name = 'member/index.html'
 
 

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -152,7 +152,7 @@ def interventions_privatetopics(user):
 @register.filter(name='alerts_list')
 def alerts_list(user):
     total = []
-    alerts = Alert.objects.select_related('author').all().order_by('-pubdate')[:10]
+    alerts = Alert.objects.select_related('author', 'comment').all().order_by('-pubdate')[:10]
     for alert in alerts:
         if alert.scope == Alert.FORUM:
             post = Post.objects.select_related('topic').get(pk=alert.comment.pk)

--- a/zds/utils/templatetags/profile.py
+++ b/zds/utils/templatetags/profile.py
@@ -5,7 +5,7 @@ from django import template
 from django.contrib.auth.models import User
 
 from zds.member.models import Profile
-from zds.utils.models import Comment, CommentLike, CommentDislike
+from zds.utils.models import CommentLike, CommentDislike
 
 
 register = template.Library()
@@ -50,13 +50,9 @@ def state(user):
 
 @register.filter('liked')
 def liked(user, comment_pk):
-    comment = Comment.objects.get(pk=comment_pk)
-    return CommentLike.objects.filter(comments=comment, user=user) \
-                              .count() > 0
+    return CommentLike.objects.filter(comments__pk=comment_pk, user=user).exists()
 
 
 @register.filter('disliked')
 def disliked(user, comment_pk):
-    comment = Comment.objects.get(pk=comment_pk)
-    return CommentDislike.objects.filter(comments=comment, user=user) \
-                                 .count() > 0
+    return CommentDislike.objects.filter(comments__pk=comment_pk, user=user).exists()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets concernés | #2089 |

Quelques `select_related` bien placés permettent d'éliminer la plupart des requêtes de récupération de "juste un profil" qui traînent dans le code.

J'en ai profité pour éliminer quelques requêtes en trop qui traînaient dans le même coin.

**QA :**
- Vérifier que les forums marchent encore (y compris les +1/-1)
- Vérifier que les alertes marchent encore
