### PR TITLE
Correction #2223 : Le nom du validateur dans la sidebar de validation des articles est present

### DIFF
--- a/templates/article/includes/sidebar_actions.part.html
+++ b/templates/article/includes/sidebar_actions.part.html
@@ -180,8 +180,8 @@
                     {% else %}
                         <li>
                             <a href="#unreservation" class="open-modal ico-after lock blue">
-                                {% blocktrans %}
-                                    Réservé par <strong>{{ validation.validator.username }}</strong>, le retirer
+                                {% blocktrans with valido=validation.validator.username %}
+                                    Réservé par <strong>{{ valido }}</strong>, le retirer
                                 {% endblocktrans %}
                             </a>
                             <form action="{% url "zds.article.views.reservation" validation.pk %}" method="post" class="modal modal-small" id="unreservation">


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | https://github.com/zestedesavoir/zds-site/issues/2223 |

QA: 
- Créé un arcticle
- Demmander la validation avec un compte
- Réserver l'article
- Se déconnecter et se connecter avec un autre compte admin
- Aller dans l'interface de validation des articles 

Vérifier que dans la sidebar, le nom du validateur est présent dans la phrase "Réservé par XXX, le retirer"
