### PR TITLE
Fix #2176: erreur d'affichage à cause d'une balise strong

### DIFF
--- a/templates/forum/post/new.html
+++ b/templates/forum/post/new.html
@@ -30,8 +30,10 @@
 {% block content %}
     {% if newpost %}
         <div class="alert-box alert">
-            <strong>{% trans "Au moins un nouveau message a été posté</strong> dans la discussion
-            pendant que vous rédigiez le votre" %}.
+            {% blocktrans %}
+                <strong>Au moins un nouveau message a été posté</strong> dans la discussion
+                pendant que vous rédigiez le votre.
+            {% endblocktrans %}
         </div>
     {% endif %}
 


### PR DESCRIPTION
À partir du [travail de @Torejy](https://github.com/zestedesavoir/zds-site/pull/2195) que j'ai cherry-pick.

| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | https://github.com/zestedesavoir/zds-site/issues/2176 |

QA:
- Tester que le message « Au moins un nouveau message a été posté dans la discussion pendant que vous rédigiez le votre » s'affiche bien.
