### PR TITLE
fix #2232, #2233, #2234 Edition du profil

### DIFF
--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -51,7 +51,7 @@ class ProfileUsernameValidator(Validator):
             elif User.objects.filter(username=value).count() > 0:
                 msg = _(u'Ce nom d\'utilisateur est déjà utilisé')
             if msg is not None:
-                self.throw_error("username", msg)
+                self.throw_error('username', msg)
         return value
 
 

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -294,7 +294,7 @@ class ProfileForm(MiniProfileForm):
 # to update email/username
 class ChangeUserForm(forms.Form, ProfileUsernameValidator, ProfileEmailValidator):
 
-    username_new = forms.CharField(
+    username = forms.CharField(
         label=_(u'Nouveau pseudo'),
         max_length=User._meta.get_field('username').max_length,
         min_length=1,
@@ -306,7 +306,7 @@ class ChangeUserForm(forms.Form, ProfileUsernameValidator, ProfileEmailValidator
         )
     )
 
-    email_new = forms.EmailField(
+    email = forms.EmailField(
         label=_(u'Nouvelle adresse courriel'),
         max_length=User._meta.get_field('email').max_length,
         required=False,
@@ -325,8 +325,8 @@ class ChangeUserForm(forms.Form, ProfileUsernameValidator, ProfileEmailValidator
         self.helper.form_method = 'post'
 
         self.helper.layout = Layout(
-            Field('username_new'),
-            Field('email_new'),
+            Field('username'),
+            Field('email'),
             ButtonHolder(
                 StrictButton(_(u'Enregistrer'), type='submit'),
             ),
@@ -335,12 +335,12 @@ class ChangeUserForm(forms.Form, ProfileUsernameValidator, ProfileEmailValidator
     def clean(self):
         cleaned_data = super(ChangeUserForm, self).clean()
 
-        username_new = cleaned_data.get('username_new')
-        if username_new is not None and not username_new.strip() == '':
+        username_new = cleaned_data.get('username')
+        if username_new is not None:
             self.validate_username(username_new)
 
-        email_new = cleaned_data.get('email_new')
-        if email_new is not None and not email_new.strip() == '':
+        email_new = cleaned_data.get('email')
+        if email_new is not None:
             self.validate_email(email_new)
 
         return cleaned_data

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -5,7 +5,6 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.models import User, Group
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
-
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Layout, \
@@ -15,6 +14,7 @@ from zds.member.commons import ProfileUsernameValidator, ProfileEmailValidator
 from zds.member.models import Profile, listing, KarmaNote
 from zds.utils.forms import CommonLayoutModalText
 
+
 # Max password length for the user.
 # Unlike other fields, this is not the length of DB field
 MAX_PASSWORD_LENGTH = 76
@@ -23,7 +23,6 @@ MIN_PASSWORD_LENGTH = 6
 
 
 class OldTutoForm(forms.Form):
-
     id = forms.ChoiceField(
         label=_(u'Ancien Tutoriel'),
         required=True,
@@ -248,7 +247,7 @@ class ProfileForm(MiniProfileForm):
             ('show_sign', _(u"Afficher les signatures")),
             ('hover_or_click', _(u"Cochez pour dérouler les menus au survol")),
             ('email_for_answer', _(u'Recevez un courriel lorsque vous '
-             u'recevez une réponse à un message privé')),
+                                   u'recevez une réponse à un message privé')),
         ),
         widget=forms.CheckboxSelectMultiple,
     )
@@ -293,7 +292,6 @@ class ProfileForm(MiniProfileForm):
 
 # to update email/username
 class ChangeUserForm(forms.Form, ProfileUsernameValidator, ProfileEmailValidator):
-
     username = forms.CharField(
         label=_(u'Nouveau pseudo'),
         max_length=User._meta.get_field('username').max_length,
@@ -355,21 +353,19 @@ class ChangePasswordForm(forms.Form):
         label=_(u'Nouveau mot de passe'),
         max_length=MAX_PASSWORD_LENGTH,
         min_length=MIN_PASSWORD_LENGTH,
-        widget=forms.PasswordInput
+        widget=forms.PasswordInput,
     )
 
     password_old = forms.CharField(
         label=_(u'Mot de passe actuel'),
-        max_length=MAX_PASSWORD_LENGTH,
-        min_length=MIN_PASSWORD_LENGTH,
-        widget=forms.PasswordInput
+        widget=forms.PasswordInput,
     )
 
     password_confirm = forms.CharField(
         label=_(u'Confirmer le nouveau mot de passe'),
         max_length=MAX_PASSWORD_LENGTH,
         min_length=MIN_PASSWORD_LENGTH,
-        widget=forms.PasswordInput
+        widget=forms.PasswordInput,
     )
 
     def __init__(self, user, *args, **kwargs):

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -266,76 +266,76 @@ class ChangeUserFormTest(TestCase):
 
     def test_valid_change_pseudo_user_form(self):
         data = {
-            'username_new': "MyNewPseudo",
-            'email_new': ''
+            'username': "MyNewPseudo",
+            'email': ''
         }
         form = ChangeUserForm(data=data)
         self.assertTrue(form.is_valid())
 
     def test_valid_change_email_user_form(self):
         data = {
-            'username_new': '',
-            'email_new': 'test@gmail.com'
+            'username': '',
+            'email': 'test@gmail.com'
         }
         form = ChangeUserForm(data=data)
         self.assertTrue(form.is_valid())
 
     def test_already_used_username_user_form(self):
         data = {
-            'username_new': self.user1.user.username,
-            'email_new': ''
+            'username': self.user1.user.username,
+            'email': ''
         }
         form = ChangeUserForm(data=data)
         self.assertFalse(form.is_valid())
 
     def test_already_used_email_user_form(self):
         data = {
-            'username_new': '',
-            'email_new': self.user1.user.email
+            'username': '',
+            'email': self.user1.user.email
         }
         form = ChangeUserForm(data=data)
         self.assertFalse(form.is_valid())
 
     def test_forbidden_email_provider_user_form(self):
         data = {
-            'username_new': '',
-            'email_new': 'test@yopmail.com'
+            'username': '',
+            'email': 'test@yopmail.com'
         }
         form = ChangeUserForm(data=data)
         self.assertFalse(form.is_valid())
 
     def test_wrong_email_user_form(self):
         data = {
-            'username_new': '',
-            'email_new': 'wrong@'
+            'username': '',
+            'email': 'wrong@'
         }
         form = ChangeUserForm(data=data)
         self.assertFalse(form.is_valid())
 
         data = {
-            'username_new': '',
-            'email_new': '@test.com'
+            'username': '',
+            'email': '@test.com'
         }
         form = ChangeUserForm(data=data)
         self.assertFalse(form.is_valid())
 
         data = {
-            'username_new': '',
-            'email_new': 'wrong@test'
+            'username': '',
+            'email': 'wrong@test'
         }
         form = ChangeUserForm(data=data)
         self.assertFalse(form.is_valid())
 
         data = {
-            'username_new': '',
-            'email_new': 'wrong@.com'
+            'username': '',
+            'email': 'wrong@.com'
         }
         form = ChangeUserForm(data=data)
         self.assertFalse(form.is_valid())
 
         data = {
-            'username_new': '',
-            'email_new': 'wrongtest.com'
+            'username': '',
+            'email': 'wrongtest.com'
         }
         form = ChangeUserForm(data=data)
         self.assertFalse(form.is_valid())
@@ -343,8 +343,8 @@ class ChangeUserFormTest(TestCase):
     def test_pseudo_espaces_register_form(self):
         ProfileFactory()
         data = {
-            'username_new': '  ZeTester  ',
-            'email_new': ''
+            'username': '  ZeTester  ',
+            'email': ''
         }
         form = ChangeUserForm(data=data)
         self.assertFalse(form.is_valid())
@@ -352,8 +352,8 @@ class ChangeUserFormTest(TestCase):
     def test_pseudo_coma_register_form(self):
         ProfileFactory()
         data = {
-            'username_new': 'Ze,Tester',
-            'email_new': ''
+            'username': 'Ze,Tester',
+            'email': ''
         }
         form = ChangeUserForm(data=data)
         self.assertFalse(form.is_valid())

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -124,7 +124,7 @@ class UpdateMember(UpdateView):
         self.update_profile(profile, form)
         self.save_profile(profile)
 
-        return super(UpdateMember, self).form_valid(form)
+        return redirect(self.get_success_url())
 
     def update_profile(self, profile, form):
         cleaned_data_options = form.cleaned_data.get('options')
@@ -206,11 +206,11 @@ class UpdateUsernameEmailMember(UpdateMember):
         return form_class(self.request.POST)
 
     def update_profile(self, profile, form):
-        if form.data['username_new']:
-            profile.user.username = form.data['username_new']
-        elif form.data['email_new']:
-            if form.data['email_new'].strip() != '':
-                profile.user.email = form.data['email_new']
+        if form.data['username']:
+            profile.user.username = form.data['username']
+        if form.data['email']:
+            if form.data['email'].strip() != '':
+                profile.user.email = form.data['email']
 
     def get_success_url(self):
         profile = self.get_object()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2232, #2233, #2234 |

Permettre de modifier le pseudo, l'e-mail et le mot de passe d'un utilisateur par ses paramètres.

QA :
- Vérifier que vous pouvez modifier votre pseudo et/ou votre e-mail et le mot de passe.
- Vérifier que les messages d'erreur s'affichent si vous rentrez des valeurs non conformes.
