### PR TITLE
Versionne les fichiers statiques en production

### DIFF
--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -61,8 +61,8 @@ source ../bin/activate
 pip install --upgrade --use-mirrors -r requirements.txt
 python manage.py migrate
 python manage.py compilemessages
-# Collect all static files from dist/ and python packages to static/
-python manage.py collectstatic --noinput
+# Collect all staticfiles from dist/ and python packages to static/
+python manage.py collectstatic --noinput --clear
 deactivate
 
 # Restart zds

--- a/update.md
+++ b/update.md
@@ -119,3 +119,16 @@ npm
 Lancer la commande `npm -v` et voir le résultat. Si le résultat est 1.x.x, lancer la commande `sudo npm install -g npm`.
 
 Faire pointer nginx sur `static/` au lieu de `dist/`.
+
+
+Actions à faire pour mettre en prod la version : v1.6
+=====================================================
+
+Issue #1724
+-----------
+
+Rajouter cette ligne dans le fichier `zds/settings_prod.py` pour versionner les fichier statiques :
+
+```python
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.CachedStaticFilesStorage"
+```


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #1724 |

Versionne les fichiers statiques. Plus précisément on passera de `/static/js/all.min.js` à `/static/js/all.min.ee2719b38d59.js` où "ee2719b38d59" est le hash MD5 du fichier. Pour plus d'informations, il y a [la documentation de Django](https://docs.djangoproject.com/en/1.6/ref/contrib/staticfiles/#cachedstaticfilesstorage).

**QA :**

Pour faire comme si on est en production, il faut créer le fichier `zds/settings_prod.py` contenant :

``` python
DEBUG = False
SERVE = True
ALLOWED_HOSTS = ['localhost']
STATICFILES_STORAGE = "django.contrib.staticfiles.storage.CachedStaticFilesStorage"
```

Il faut collecter les fichiers statiques avec la commande `python manage.py collectstatic`, lancer le serveur (`python manage.py runserver`) et aller sur http://localhost:8000. Regarder dans la console que vous avez bien des lignes semblables à :

``` shell
[07/Feb/2015 17:26:24] "GET /static/js/all.min.ee2719b38d59.js HTTP/1.1" 200 126834
```
