### PR TITLE
Change la librairie d'authentification pour django-oauth2-toolkit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ easy-thumbnails==2.2
 # Api dependencies
 djangorestframework==3.0.2
 django-filter==0.8
-django-oauth2-provider==0.2.6.1
+django-oauth-toolkit==0.7.2
 drf-extensions==0.2.6
 django-rest-swagger==0.2.8

--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
-from provider.oauth2.models import AccessToken, Client
+from oauth2_provider.models import Application, AccessToken
 from rest_framework import status
 from rest_framework.test import APITestCase
 from rest_framework.test import APIClient
@@ -846,16 +846,15 @@ class MemberDetailBanAPITest(APITestCase):
 
 
 def create_oauth2_client(user):
-    client = Client.objects.create(user=user,
-                                   name='zds',
-                                   url='zestedesavoir.com',
-                                   client_type=1)
+    client = Application.objects.create(user=user,
+                                        client_type=Application.CLIENT_CONFIDENTIAL,
+                                        authorization_grant_type=Application.GRANT_PASSWORD)
     client.save()
     return client
 
 
 def authenticate_client(client, clientAuth, username, password):
-    client.post('/oauth2/access_token', {
+    client.post('/oauth2/token/', {
         'client_id': clientAuth.client_id,
         'client_secret': clientAuth.client_secret,
         'username': username,

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -174,8 +174,7 @@ INSTALLED_APPS = (
     'social.apps.django_app.default',
     'rest_framework',
     'rest_framework_swagger',
-    'provider',
-    'provider.oauth2',
+    'oauth2_provider',
 
     # Apps DB tables are created in THIS order by default
     # --> Order is CRITICAL to properly handle foreign keys
@@ -218,7 +217,7 @@ REST_FRAMEWORK = {
     'MAX_PAGINATE_BY': 100,             # Maximum limit allowed when using `?page_size=xxx`.
     # Active OAuth2 authentication.
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.OAuth2Authentication',
+        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
     ),
     'DEFAULT_PARSER_CLASSES': (
         'rest_framework.parsers.JSONParser',

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -94,7 +94,7 @@ urlpatterns = patterns('',
 # API
 urlpatterns += patterns('',
                         url(r'^api/', include('rest_framework_swagger.urls')),
-                        url(r'^oauth2/', include('provider.oauth2.urls', namespace='oauth2')),
+                        url(r'^oauth2/', include('oauth2_provider.urls', namespace='oauth2_provider')),
                         url(r'^api/membres/', include('zds.member.api.urls')),
                         )
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2229 |

Change la librairie d'authentification pour django-oauth2-toolkit

QA : 
# Environnement
- Mettez à jour vos dépendances.
- Mettez à jour votre base.
- Créez une `Application` via l'espace administrateur (avec un grant password).
# Récupérer un token
- Prenez la console rest de votre choix.
- Lancez une requête POST, vers `localhost:8000/oauth2/token/` avec les paramètres suivants :
  - client_id
  - client_secret
  - username
  - password
  - grant_type : password
- Récupérer l'`access_token` token dans la réponse.
# Test du token

Testez là avec une route qui nécessite l'authentification.
