### PR TITLE
Mise a jour markdown

### DIFF
--- a/assets/scss/base/_tables.scss
+++ b/assets/scss/base/_tables.scss
@@ -1,3 +1,8 @@
+.table-wrapper {
+    max-width: 100%;
+    overflow: auto;
+}
+
 table {
     margin: 15px 0;
     border-top: 1px solid #DDD;

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -317,9 +317,14 @@
             padding: 0 5px;
         }
 
-        mathjax {
-            font-size: 16px;
-            font-size: 1.6rem;
+        .mathjax-wrapper {
+            max-width: 100%;
+            overflow: auto;
+
+            mathjax {
+                font-size: 16px;
+                font-size: 1.6rem;
+            }
         }
 
         .footnote {

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.7.0
 gitpython==0.3.5
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.3.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.4.zip
 easy-thumbnails==2.2
 
 # Api dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.7.0
 gitpython==0.3.5
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.4.1-zds.12.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.1.zip
 easy-thumbnails==2.2
 
 # Api dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.7.0
 gitpython==0.3.5
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.1.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.2.zip
 easy-thumbnails==2.2
 
 # Api dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.7.0
 gitpython==0.3.5
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.2.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.3.zip
 easy-thumbnails==2.2
 
 # Api dependencies

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -28,7 +28,7 @@ def get_markdown_instance(inline=False, js_support=False):
     :param bool inline: If `True`, configure parser to parse only inline content.
     :return: A ZMarkdown parser.
     """
-    zdsext = ZdsExtension({'inline': inline, 'emoticons': smileys, 'js_support': js_support})
+    zdsext = ZdsExtension(inline=inline, emoticons=smileys, js_support=js_support)
     # Generate parser
     md = Markdown(
         extensions=(zdsext,),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | voir en dessous |

Bonne mise a jour de markdown. Quelques infos pour guider la QA et lister les mises à jour : 
- Mise a jour avec l'upstream. Vu les conflits, surtout vérifier les blocs de codes et coloration syntaxique
- Normalement compatible Python 2 et 3 ensemble. A vérifier formellement au moment du passage à Python 3
- [Rajout de wrapper autour des formules et tableaux](https://github.com/zestedesavoir/Python-ZMarkdown/issues/61) ~~poke @Situphen qui doit me faire une PR pour les class CSS~~
- [On ne trim plus les espaces autours des codes inlines](https://github.com/zestedesavoir/Python-ZMarkdown/issues/59)
- [Permettre les urls relatives quand commençant par /](https://github.com/zestedesavoir/Python-ZMarkdown/issues/54)
- [Liens avec des `:` sont maintenant fonctionnels](https://github.com/zestedesavoir/Python-ZMarkdown/issues/50)
- [Normalement, les kbd dans une liste ne génère plus de tableaux](https://github.com/zestedesavoir/Python-ZMarkdown/issues/49)
- https forcé pour jsfiddle

Je n'ai pas eu le temps de faire des tests super poussés donc je ne garranti pas à 100%. ~~Je PR tout de même pour que Situphen puisse ajouter les CSS et pour commencer la QA car je n'aurais pas le net avant Lundi, si il y a des problèmes, je pourrais par contre peut etre les corriger dans le week end.~~
