### PR TITLE
[Betafix] Répare l'auto-complétion des membres (fix #2320)

### DIFF
--- a/assets/js/autocompletion.js
+++ b/assets/js/autocompletion.js
@@ -12,11 +12,6 @@
         this.$input = this.$wrapper.find(".autocomplete-input");
         this.$dropdown = this.$wrapper.find(".autocomplete-dropdown");
 
-        this.$dropdown.css({
-            "marginTop": "-" + this.$input.css("margin-bottom"),
-            "left": this.$input.css("margin-left")
-        });
-
 
         this.$input.on("keyup", this.handleInput.bind(this));
         this.$input.on("keydown", this.handleKeydown.bind(this));

--- a/assets/scss/components/_autocomplete.scss
+++ b/assets/scss/components/_autocomplete.scss
@@ -28,3 +28,8 @@
         }
     }
 }
+
+.modal .autocomplete-dropdown {
+    margin-top: -10px;
+    margin-left: 15px;
+}

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -104,7 +104,11 @@
                             {% trans "Vous allez rajouter un nouveau membre dans la conversation privée" %}.
                         </p>
                         <input type="hidden" name="topic_pk" value="{{ topic.pk }}">
-                        <input type="text" class="input" name="user_pk" placeholder="Pseudo du membre" autocomplete="{'type':'single'}">
+                        <input
+                            type="text" class="input" name="user_pk"
+                            placeholder="Pseudo du membre"
+                            data-autocomplete="{'type':'single'}"
+                        >
 
                         {% csrf_token %}
                         <button type="submit">{% trans "Ajouter" %}</button>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2320 |

**QA :** Générer le front (`npm run gulp -- build`) et vérifier que l’auto-complétion fonctionne quand on veut ajouter des membres à un message privé : pendant la création ou après.
