### PR TITLE
Nettoie et améliore l'affichage du karma des messages (fix #2303)

### DIFF
--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -30,7 +30,7 @@
     /**
      * Karma of the messages
      */
-    $(".topic-message").on("click", ".upvote, .downvote", function(e){
+    $(".topic-message").on("click", "button.upvote, button.downvote", function(e){
         var $thumb = $(this),
             $form = $(this).parents("form:first"),
             $karma = $thumb.parents(".message-karma:first"),
@@ -78,6 +78,8 @@
                 } else {
                     $downvote.removeClass("more-voted");
                 }
+
+                $thumb.blur();
             }
         });
 

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -288,31 +288,64 @@
                     border-bottom-color: transparent;
                     background: none !important;
                     height: 32px;
-
+                }
+                span {
                     &.upvote,
                     &.downvote {
                         &:not(.has-vote) {
-                            text-indent: -9999px;
-                            width: 0;
-                        }
-                    }
-                    &.disabled {
-                        &,
-                        &:hover,
-                        &:focus {
-                            border-bottom-color: transparent;
-
-                            &:after {
-                                opacity: .25 !important;
-                            }
+                            border-bottom: none;
+                            opacity: .5;
                         }
                     }
                 }
-                span.upvote,
-                span.downvote {
+                button {
+                    // Disable transition for text-indent
+                    transition-property: opacity, border;
+
+                    &.voted:hover {
+                        &:after {
+                            opacity: .5;
+                        }
+                    }
+                }
+
+                .upvote,
+                .downvote {
+                    &:after {
+                        left: 10px;
+                    }
+                    &.voted:after {
+                        opacity: 1;
+                    }
+
+                    &:hover,
+                    &:focus {
+                        &:not(.more-voted) {
+                            border-bottom-color: transparent;
+                        }
+                    }
+
                     &:not(.has-vote) {
-                        border-bottom: none;
-                        opacity: .5;
+                        text-indent: -9999px;
+                        width: 0;
+                    }
+
+                    &.more-voted {
+                        font-weight: bold;
+                    }
+                }
+                .upvote {
+                    color: $color-success;
+
+                    &.more-voted {
+                        border-bottom-color: $color-success;
+                    }
+                }
+                .downvote {
+                    color: $color-danger;
+
+                    &.more-voted {
+                        border-bottom-color: $color-danger;
                     }
                 }
 
@@ -321,57 +354,17 @@
                     text-overflow: ellipsis;
                     white-space: nowrap;
 
-                    &:hover:not(.disabled),
-                    &:focus:not(.disabled) {
+                    &:hover,
+                    &:focus {
                         color: #555;
                         border-bottom-color: $color-success;
                     }
-                    &.active:not(.disabled) {
+                    &.active {
                         color: #48a200;
 
                         &:after {
                             opacity: 1;
                         }
-                    }
-                }
-                .upvote,
-                .downvote {
-                    &:after {
-                        left: 10px;
-                    }
-                }
-                .upvote {
-                    color: $color-success;
-
-                    &:hover:not(.disabled),
-                    &:focus:not(.disabled),
-                    &.more-voted {
-                        border-bottom-color: $color-success;
-                    }
-                    &:not(.has-vote){
-                        text-indent: -9999px;
-                        width: 0;
-                    }
-                }
-                .downvote {
-                    color: $color-danger;
-
-                    &:hover:not(.disabled),
-                    &:focus:not(.disabled),
-                    &.more-voted {
-                        border-bottom-color: $color-danger;
-                    }
-                }
-                .voted:after {
-                    opacity: 1;
-                }
-                .more-voted {
-                    font-weight: bold;
-                }
-                button.more-voted {
-                    &:hover,
-                    &:focus {
-                        border-bottom-color: transparent !important;
                     }
                 }
             }
@@ -475,18 +468,6 @@ form.topic-message {
     margin-top: 50px;
 }
 
-@media only screen and #{$media-tablet} {
-    .topic-message .message .message-bottom .message-karma {
-        a,
-        span {
-            &.upvote.has-vote,
-            &.downvote.has-vote {
-                padding-left: 27px;
-            }
-        }
-    }
-}
-
 @media only screen and #{$media-mobile-tablet} {
     .topic-message {
         padding: 20px 0;
@@ -566,14 +547,6 @@ form.topic-message {
                     top: 35px;
                     left: 7px;
 
-                    a,
-                    span {
-                        &:not(.has-vote){
-                            border-bottom-width: 1px !important;
-                            border-bottom-color: #D2D5D6;
-                        }
-                    }
-
                     .tick {
                         text-indent: -9999px;
                         margin-right: 1px;
@@ -587,10 +560,6 @@ form.topic-message {
                     .downvote {
                         padding: 0 7px;
                         text-align: center;
-
-                        &.has-vote {
-                            min-width: 30px;
-                        }
                     }
                 }
             }
@@ -667,18 +636,9 @@ form.topic-message {
         .message-actions a {
             width: 0px;
             text-indent: -9999px;
-        }
-        .message-actions a,
-        .message-karma a {
+
             &:after {
                 left: 12px !important;
-            }
-        }
-        .message-karma {
-            a,
-            span {
-                margin-right: 1px;
-                margin-left: 0;
             }
         }
         .message-submit {

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -320,9 +320,7 @@
                                 </span>
                             </span>
                         {% endif %}
-                    {% if upvote_link %}
-                        </div>
-                    {% endif %}
+                    </div>
                 {% endif %}
             </div>
         {% endif %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2303 |

L'effet au survol n'a plus lieu sur la bordure du bas mais sur la transparence (et donc la couleur) du pouce, ça évite donc les confusions ! J'ai profité de cette PR pour nettoyer un peu le SCSS qui gère ce karma, ça commençait à devenir urgent !

**QA :** Avant tout, régénérer le front (`npm run gulp -- build`).

Vérifier que quand on clique sur un pouce et que l'on recharge la page, l'affichage reste le même (il ne faut pas avoir le même problème que #2303

Le reste est une question de goût, est-ce que mes modifications vous conviennent-elles ?
