### PR TITLE
Fix #2319: masque l'extrait si le message original est masqué

### DIFF
--- a/templates/forum/find/post.html
+++ b/templates/forum/find/post.html
@@ -46,7 +46,7 @@
                 <tr>
                     <td>
                         <div class="forum-entry-title {% if user.is_authenticated %} {% if topic.never_read %} unread {% endif %} {% endif %}">
-                            <a href="{{ post.get_absolute_url }}">{{ post.topic.title }} </a> 
+                            <a href="{{ post.get_absolute_url }}">{{ post.topic.title }} </a>
                             {% if post.topic.subtitle %} <p> {{ post.topic.subtitle }} </p> {% endif %}
                         </div>
                     </td>
@@ -54,7 +54,14 @@
                         {{ post.pubdate|format_date }}
                     </td>
                     <td>
-                        {{ post.text|truncatechars:200|emarkdown|striptags }}
+                        {% if post.is_visible %}
+                            {{ post.text|truncatechars:200|emarkdown|striptags }}
+                        {% else %}
+                            {% if post.text_hidden %}
+                                {% trans "Masqué par" %} {{ post.editor }}
+                                : {{ post.text_hidden }}
+                            {% endif %}
+                        {% endif %}
                     </td>
                 </tr>
                 {% endfor %}

--- a/templates/forum/find/topic.html
+++ b/templates/forum/find/topic.html
@@ -44,7 +44,7 @@
                 <tr>
                     <td>
                         <div class="forum-entry-title {% if user.is_authenticated %} {% if topic.never_read %} unread {% endif %} {% endif %}">
-                        <a href="{{ topic.get_absolute_url }}">{{ topic.title }} </a> 
+                        <a href="{{ topic.get_absolute_url }}">{{ topic.title }} </a>
                             {% if topic.subtitle %} <p> {{ topic.subtitle }} </p> {% endif %}
                         </div>
                     </td>
@@ -52,15 +52,13 @@
                         {{ topic.pubdate|format_date }}
                     </td>
                     <td>
-                        {% if topic.first_post.is_visible != False %}
+                        {% if topic.first_post.is_visible %}
                             {{ topic.first_post.text|truncatechars:200|emarkdown|striptags }}
                         {% else %}
-                            <p>
+                            {% if topic.first_post.text_hidden %}
                                 {% trans "Masqué par" %} {{ topic.first_post.editor }}
-                                {% if topic.first_post.text_hidden %}
-                                    : {{ topic.first_post.text_hidden }}
-                                {% endif %}
-                            </p>
+                                : {{ topic.first_post.text_hidden }}
+                            {% endif %}
                         {% endif %}
                     </td>
                 </tr>

--- a/templates/forum/find/topic.html
+++ b/templates/forum/find/topic.html
@@ -6,13 +6,13 @@
 
 
 {% block title %}
-    {% trans "Sujets crées par" %} {{ usr.username }}
+    {% trans "Sujets créés par" %} {{ usr.username }}
 {% endblock %}
 
 
 
 {% block headline %}
-    {% trans "Sujets crées par" %} "{{ usr.username }}"
+    {% trans "Sujets créés par" %} "{{ usr.username }}"
 {% endblock %}
 
 
@@ -21,7 +21,7 @@
     {% with profile=usr|profile %}
         <li><a href="{{ profile.get_absolute_url }}">{{ usr.username }}</a></li>
     {% endwith %}
-    <li><a href="{% url "zds.forum.views.find_topic" usr.pk %}">{% trans "Sujets crées" %}</a></li>
+    <li><a href="{% url "zds.forum.views.find_topic" usr.pk %}">{% trans "Sujets créés" %}</a></li>
     <li>{% trans "Recherche" %}</li>
 {% endblock %}
 
@@ -52,7 +52,16 @@
                         {{ topic.pubdate|format_date }}
                     </td>
                     <td>
-                        {{ topic.first_post.text|truncatechars:200|emarkdown|striptags }}
+                        {% if topic.first_post.is_visible != False %}
+                            {{ topic.first_post.text|truncatechars:200|emarkdown|striptags }}
+                        {% else %}
+                            <p>
+                                {% trans "Masqué par" %} {{ topic.first_post.editor }}
+                                {% if topic.first_post.text_hidden %}
+                                    : {{ topic.first_post.text_hidden }}
+                                {% endif %}
+                            </p>
+                        {% endif %}
                     </td>
                 </tr>
                 {% endfor %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2319 |

Si vous masquez le premier message d'un topic, l'extrait de ce message ne s'affiche pas sur la page _Sujets créés par [...]_.

J'en ai profité pour corriger la faute d'orthographe sur le titre de la page.
