### PR TITLE
Fix #2161: Précisions sur les galeries lors de la désinscription

### DIFF
--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -60,11 +60,21 @@
             <ul>
                 <li>
                     {% blocktrans %}
-                        si vous étiez seul à avoir des droits sur cette galerie, elle sera placée sous la gouvernance du compte "Auteur Externe", sauf demande contraire de votre part à un membre du staff <strong>avant</strong> votre désinscription ;
+                        Si la galerie était liée à un tutoriel, et que vous étiez seul à avoir des droits dessus, elle sera placée sous la gouvernance du compte "Auteur Externe", sauf demande contraire de votre part à un membre du staff <strong>avant</strong> votre désinscription ;
                     {% endblocktrans %}
                 </li>
                 <li>
-                    {% trans "si vous étiez plusieurs à avoir des droits sur cette galerie, vous quitterez le groupe des personnes ayant des droits dessus. Les autres continueront de jouir des mêmes droits qu'auparavant" %}.
+                    {% blocktrans %}
+                        Si la galerie était liée à un tutoriel, et que vous étiez plusieurs à avoir des droits dessus, vous quitterez le groupe des personnes ayant des droits dessus. Les autres continueront de jouir des mêmes droits qu'auparavant ;
+                    {% endblocktrans %}
+                </li>
+                <li>
+                    {% blocktrans %}
+                        Si la galerie n'était pas liée à un tutoriel, et que vous étiez seul à avoir des droits dessus, elle sera supprimée ;
+                    {% endblocktrans %}
+                </li>
+                <li>
+                    {% trans "Si la galerie n'était pas liée à un tutoriel, et que vous étiez plusieurs à avoir des droits dessus, vous quitterez le groupe des personnes ayant des droits dessus. Les autres continueront de jouir des mêmes droits qu'auparavant" %}.
                 </li>
             </ul>
         </li>

--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -55,6 +55,19 @@
                 </li>
             </ul>
         </li>
+        <li>
+            {% trans "Vos galeries d'image subiront les modifications suivantes" %} :
+            <ul>
+                <li>
+                    {% blocktrans %}
+                        si vous étiez seul à avoir des droits sur cette galerie, elle sera placée sous la gouvernance du compte "Auteur Externe", sauf demande contraire de votre part à un membre du staff <strong>avant</strong> votre désinscription ;
+                    {% endblocktrans %}
+                </li>
+                <li>
+                    {% trans "si vous étiez plusieurs à avoir des droits sur cette galerie, vous quitterez le groupe des personnes ayant des droits dessus. Les autres continueront de jouir des mêmes droits qu'auparavant" %}.
+                </li>
+            </ul>
+        </li>
     </ul>
 
     <p>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2161 |

J'ai ajouté quelques phrases expliquant ce qu'il advient aux galeries d'images de l'utilisateur lorsque celui-ci décide de supprimer son compte.
