### PR TITLE
Enlève le chargement de nvm dans deploy.sh

### DIFF
--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -46,7 +46,6 @@ git checkout $1
 git checkout -b $1
 
 # Front commands
-source /usr/local/nvm/nvm.sh
 # Update packages
 npm install --production
 # Remove unused packages
@@ -75,4 +74,4 @@ sudo service nginx reload
 
 # Display current branch and commit
 git status
-echo "Commit deployé : `git rev-parse HEAD`"
+echo "Commit deployÃ© : `git rev-parse HEAD`"


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Peut-être |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés |  |

Etant donné que node à été réinstallé sur la préprod (via un dépot APT), et bientôt sur la prod, mais sans nvm, il ne faut plus le charger lors des déploiement. Ca devrait stabiliser un petit peu plus l'install :+1: 
