### PR TITLE
Petite correction d'url dans la doc

### DIFF
--- a/doc/source/install/deploy-in-production.rst
+++ b/doc/source/install/deploy-in-production.rst
@@ -398,7 +398,7 @@ Il est possible de personnaliser ZdS pour n'importe quel site communautaire de p
                     'code': u"GPL v3",
                     'url_license': u"http://www.gnu.org/licenses/gpl-3.0.html",
                     'provider_name': u"Progdupeupl",
-                    'provider_url': u"http://progdupeu.pl",
+                    'provider_url': u"http://pdp.microjoe.org/",
                 },
                 'licence_info_title': u'http://zestedesavoir.com/tutoriels/281/le-droit-dauteur-creative-commons-et-les-licences-sur-zeste-de-savoir/',
                 'licence_info_link': u'Le droit d\'auteur, Creative Commons et les licences sur Zeste de Savoir'


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |

J'ai remaqué ce bug sur le site en production, la page [/pages/apropos](http://zestedesavoir.com/pages/apropos/) a un lien qui pointe vers http://progdupeu.pl/

Apparement le fichier settings à déjà été mis à jour donc la correction ici est mineure. Et le bug a déjà été remarqué je pense.

**QA** : Vérifier que les liens sur la page [/pages/apropos](http://zestedesavoir.com/pages/apropos/) sont corrects
