### PR TITLE
N'ajoute pas de saut de ligne après Ctrl + Enter

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -581,6 +581,8 @@
     $(".md-editor").on("keydown", function(e){
         // the message is submitted if the user is pressing Ctrl or Cmd with Enter and isn't pressing Alt or Shift
         if((e.ctrlKey || e.metaKey) && e.which === 13 && !e.altKey && !e.shiftKey){
+            e.preventDefault();
+
             $(".message-submit > button[name=answer]").click();
         }
     });


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2364 |

**QA :**
- Vérifier que le Ctrl + Enter fonctionne toujours
- Vérifier qu'il n'y a plus de saut de ligne après la soumission du message (voir ticket)
