### PR TITLE
Displays always same information about a member.

### DIFF
--- a/zds/member/api/serializers.py
+++ b/zds/member/api/serializers.py
@@ -57,9 +57,9 @@ class ProfileDetailSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Profile
-        fields = ('pk', 'username', 'show_email', 'email', 'is_active',
-                  'site', 'avatar_url', 'biography', 'sign', 'email_for_answer',
-                  'last_visit', 'date_joined')
+        fields = ('pk', 'username', 'email', 'is_active', 'date_joined',
+                  'site', 'avatar_url', 'biography', 'sign', 'show_email',
+                  'show_sign', 'hover_or_click', 'email_for_answer', 'last_visit')
 
     def __init__(self, *args, **kwargs):
         """
@@ -82,12 +82,15 @@ class ProfileValidatorSerializer(serializers.ModelSerializer, ProfileUsernameVal
 
     username = serializers.CharField(source='user.username', required=False, allow_blank=True)
     email = serializers.EmailField(source='user.email', required=False, allow_blank=True)
+    is_active = serializers.BooleanField(source='user.is_active', required=False)
+    date_joined = serializers.DateTimeField(source='user.date_joined', required=False)
 
     class Meta:
         model = Profile
-        fields = ('pk', 'username', 'email', 'site', 'avatar_url', 'biography',
-                  'sign', 'show_email', 'show_sign', 'hover_or_click',
-                  'email_for_answer')
+        fields = ('pk', 'username', 'email', 'is_active', 'date_joined',
+                  'site', 'avatar_url', 'biography', 'sign', 'show_email',
+                  'show_sign', 'hover_or_click', 'email_for_answer', 'last_visit')
+        read_only_fields = ('is_active', 'date_joined', 'last_visit',)
 
     def update(self, instance, validated_data):
         """

--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -335,15 +335,17 @@ class MemberMyDetailAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(profile.pk, response.data.get('pk'))
         self.assertEqual(profile.user.username, response.data.get('username'))
+        self.assertEqual(profile.user.email, response.data.get('email'))
         self.assertEqual(profile.user.is_active, response.data.get('is_active'))
+        self.assertIsNotNone(response.data.get('date_joined'))
         self.assertEqual(profile.site, response.data.get('site'))
         self.assertEqual(profile.avatar_url, response.data.get('avatar_url'))
         self.assertEqual(profile.biography, response.data.get('biography'))
         self.assertEqual(profile.sign, response.data.get('sign'))
-        self.assertEqual(profile.email_for_answer, response.data.get('email_for_answer'))
-        self.assertIsNotNone(response.data.get('date_joined'))
         self.assertFalse(response.data.get('show_email'))
-        self.assertEqual(profile.user.email, response.data.get('email'))
+        self.assertEqual(profile.show_sign, response.data.get('show_sign'))
+        self.assertEqual(profile.hover_or_click, response.data.get('hover_or_click'))
+        self.assertEqual(profile.email_for_answer, response.data.get('email_for_answer'))
 
     def test_detail_of_the_member_not_authenticated(self):
         """
@@ -372,15 +374,17 @@ class MemberDetailAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(self.profile.pk, response.data.get('pk'))
         self.assertEqual(self.profile.user.username, response.data.get('username'))
+        self.assertIsNone(response.data.get('email'))
         self.assertEqual(self.profile.user.is_active, response.data.get('is_active'))
+        self.assertIsNotNone(response.data.get('date_joined'))
         self.assertEqual(self.profile.site, response.data.get('site'))
         self.assertEqual(self.profile.avatar_url, response.data.get('avatar_url'))
         self.assertEqual(self.profile.biography, response.data.get('biography'))
         self.assertEqual(self.profile.sign, response.data.get('sign'))
-        self.assertEqual(self.profile.email_for_answer, response.data.get('email_for_answer'))
-        self.assertIsNotNone(response.data.get('date_joined'))
         self.assertFalse(response.data.get('show_email'))
-        self.assertIsNone(response.data.get('email'))
+        self.assertEqual(self.profile.show_sign, response.data.get('show_sign'))
+        self.assertEqual(self.profile.hover_or_click, response.data.get('hover_or_click'))
+        self.assertEqual(self.profile.email_for_answer, response.data.get('email_for_answer'))
 
     def test_detail_of_a_member_who_accepts_to_show_his_email(self):
         """
@@ -417,16 +421,21 @@ class MemberDetailAPITest(APITestCase):
         Updates a member but without any changes.
         """
         response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(self.profile.pk, response.data.get('pk'))
         self.assertEqual(self.profile.user.username, response.data.get('username'))
+        self.assertEqual(self.profile.user.email, response.data.get('email'))
+        self.assertEqual(self.profile.user.is_active, response.data.get('is_active'))
+        self.assertIsNotNone(response.data.get('date_joined'))
         self.assertEqual(self.profile.site, response.data.get('site'))
         self.assertEqual(self.profile.avatar_url, response.data.get('avatar_url'))
         self.assertEqual(self.profile.biography, response.data.get('biography'))
         self.assertEqual(self.profile.sign, response.data.get('sign'))
-        self.assertEqual(self.profile.email_for_answer, response.data.get('email_for_answer'))
         self.assertFalse(response.data.get('show_email'))
-        self.assertEqual(self.profile.user.email, response.data.get('email'))
+        self.assertEqual(self.profile.show_sign, response.data.get('show_sign'))
+        self.assertEqual(self.profile.hover_or_click, response.data.get('hover_or_click'))
+        self.assertEqual(self.profile.email_for_answer, response.data.get('email_for_answer'))
 
     def test_update_member_details_not_exist(self):
         """


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2375 |

QA : Vérifier que les même informations sont renvoyés pour les routes `/api/membres/mon_profil/` en GET et `/api/membre/{pk}/` en GET et PUT.
