### PR TITLE
Displays number of members in the list of members page.

### DIFF
--- a/templates/member/index.html
+++ b/templates/member/index.html
@@ -22,7 +22,7 @@
 
 {% block content %}
     <p>
-        {% trans "Sur cette page vous pourrez trouver la liste des membres inscrits au site (actuellement" %} {{ members.count }} {% trans "membres" %}).
+        {% trans "Sur cette page vous pourrez trouver la liste des membres inscrits au site (actuellement" %} {{ paginator.count }} {% trans "membres" %}).
     </p>
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2324 |

Affiche le nombre correct de membres sur la page qui liste les membres.

QA : Rendez-vous sur la liste des membres `localhost:8000/membres` et constatez que le nombre de membres est correct.

> **Attention :** Il faut que vous disposez d'un nombre de membres supérieur à la taille d'une page pour vérifier que le nombre de membres est supérieur à la taille de la page.
