### PR TITLE
Fix #1771: Envoie un email lorsqu'un utilisateur est invité à rejoindre un MP

### DIFF
--- a/templates/email/mp/new_participant.html
+++ b/templates/email/mp/new_participant.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+<html lang="fr">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body>
+    {% trans "Bonjour" %} <strong>{{ username_new_participant }}</strong>,
+    <br />
+    <br />
+    <strong>{{ author }}</strong> {% trans "vous a invité pour participer à une discussion privée sur" %} {{site_name}}.
+    <br />
+    <br />
+    {% trans "Pour le lire" %}, <a href="{{ url }}">{% trans "cliquez ici" %}</a>.
+    <br />
+    <br />
+    <br />
+    {% trans "Cordialement" %},
+    <br />
+    {% trans "L'équipe" %} {{app.site.litteral_name}}
+</body>

--- a/templates/email/mp/new_participant.txt
+++ b/templates/email/mp/new_participant.txt
@@ -1,0 +1,10 @@
+{% load i18n %}
+{% trans "Bonjour" %} {{ username }},
+
+{{ author }} {% trans "vous a invité pour participer à une discussion privée sur" %} {{site_name}}.
+
+{% trans "Pour le lire, cliquez ou recopiez l'url suivante" %} : {{ url }}
+
+{% trans "Cordialement" %},
+
+{% trans "L'équipe" %} {{app.site.litteral_name}}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #1771 |

_Je ne sais pas dans quelle mesure c'est un problème qu'il y ai plusieurs PR touchant les mêmes fichiers... cf. #2378_

Pour tester il faut avoir la ligne `EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'` dans votre `zds/settings.py`.

Pour QA : 
- Envoyer un MP à quelqu'un.
- Ajouter un participant (vérifier que le participant a bien accepté de recevoir des emails)
- Vérifier que le mail est envoyé (console)

**J'ai utilisé l'attribut `email_for_answer`**, mais c'est pas forcément très pertinent. En fait, je sais pas trop toucher aux modèles, donc j'ai fait une première PR, mais si vous pensez qu'il faut créer un nouvel attribut, je suis preneur d'explications sur les modèles (surtout au niveau de la migration en fait).
