### PR TITLE
Enlève Twitter des options d'inscription et de connexion

### DIFF
--- a/templates/member/login.html
+++ b/templates/member/login.html
@@ -47,9 +47,6 @@
                     <a href="{% url "social:begin" "facebook" %}" class="btn ico-after facebook light btn-facebook btn-holder">
                         {% trans "Connexion via Facebook" %}
                     </a>
-                    <a href="{% url "social:begin" "twitter" %}" class="btn ico-after twitter light btn-twitter btn-holder">
-                        {% trans "Connexion via Twitter" %}
-                    </a>
                     <a href="{% url "social:begin" "google-oauth2" %}" class="btn ico-after google-plus light btn-google-plus btn-holder">
                         {% trans "Connexion via Google+" %}
                     </a>

--- a/templates/member/register/index.html
+++ b/templates/member/register/index.html
@@ -51,9 +51,6 @@
                     <a href="{% url "social:begin" "facebook" %}" class="btn ico-after facebook light btn-facebook btn-holder">
                         Inscription via Facebook
                     </a>
-                    <a href="{% url "social:begin" "twitter" %}" class="btn ico-after twitter light btn-twitter btn-holder">
-                        Inscription via Twitter
-                    </a>
                     <a href="{% url "social:begin" "google-oauth2" %}" class="btn ico-after google-plus light btn-google-plus btn-holder">
                         Inscription via Google+
                     </a>

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -470,7 +470,6 @@ LOGIN_REDIRECT_URL = "/"
 
 AUTHENTICATION_BACKENDS = ('social.backends.facebook.FacebookOAuth2',
                            'social.backends.google.GoogleOAuth2',
-                           'social.backends.twitter.TwitterOAuth',
                            'django.contrib.auth.backends.ModelBackend')
 SOCIAL_AUTH_GOOGLE_OAUTH2_USE_DEPRECATED_API = True
 
@@ -490,8 +489,6 @@ SOCIAL_AUTH_PIPELINE = (
 # redefine for real key and secret code
 SOCIAL_AUTH_FACEBOOK_KEY = ""
 SOCIAL_AUTH_FACEBOOK_SECRET = ""
-SOCIAL_AUTH_TWITTER_KEY = "bVWLd2pDe6F12SXRa5FQyVTze"
-SOCIAL_AUTH_TWITTER_SECRET = "pwdQ3trdMdT7Y669aKRwVM6tivrYsx3psbFnRJ5Tq4Wy1VjBNk"
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = "696570367703-r6hc7mdd27t1sktdkivpnc5b25i0uip2.apps.googleusercontent.com"
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = "mApWNh3stCsYHwsGuWdbZWP8"
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets (_issues_) concernés | #2204 |

Enlève Twitter des options d'inscription et de connexion : Twitter ne permet pas de récupérer le mail, donc toutes les fonctionnalités qui l'utilisent sont HS.

QA : vérifier qu'on ne peut plus s'inscrire et se connecter via Twitter, mais que l'on peut toujours partager via Twitter.
