### PR TITLE
Suppression d'un lien en double dans un template

### DIFF
--- a/templates/member/register/token_success.html
+++ b/templates/member/register/token_success.html
@@ -28,7 +28,6 @@
         <p>
             {% trans "Vous pouvez maintenant vous connecter et partager avec tous les membres" %}.
             {% crispy form %}
-            <a href="{% url "zds.member.views.forgot_password" %}" class="form-sub-link">{% trans "Mot de passe déjà oublié" %} ?</a>
         </p>
     </section>
 {% endblock %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés |  |

Comment reproduire ?
- Création d'un compte
- Valider le compte
- Vérifier que dans la page il n'y a pas deux fois le lien comme montré dans la capture

![bug2liens](https://cloud.githubusercontent.com/assets/6099338/6598382/a4d4e26a-c803-11e4-821b-b55f8935d9e8.png)
