### PR TITLE
Les catégories d'articles renvoient vers les tutos

### DIFF
--- a/templates/article/index.html
+++ b/templates/article/index.html
@@ -80,7 +80,7 @@
                 <ul>
                     {% for subcat,slug in subcats %}
                         <li>
-                            <a href="{% url "zds.tutorial.views.index" %}?tag={{ slug }}" class="mobile-menu-link mobile-menu-sublink">
+                            <a href="{% url "zds.article.views.index" %}?tag={{ slug }}" class="mobile-menu-link mobile-menu-sublink">
                                 {{  subcat }}
                             </a>
                         </li>

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -52,7 +52,7 @@ def index(request):
     # The tag indicate what the category article the user would
     # like to display. We can display all subcategories for articles.
     try:
-        tag = get_object_or_404(SubCategory, title=request.GET['tag'])
+        tag = get_object_or_404(SubCategory, slug=request.GET['tag'])
     except (KeyError, Http404):
         tag = None
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2407 |

QA:
- Aller sur la page listant tous les articles (/articles/)
- Sur la gauche, dans la partie « catégories des articles », cliquer sur un lien des catégories doit vous renvoyer sur les catégories des articles et non des tutoriels 
