### PR TITLE
Corrige une erreur dans Gulpfile.js

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -165,7 +165,7 @@ gulp.task("sprite", function() {
     .pipe(sprite({
       name: "sprite",
       style: "_sprite.scss",
-      cssPath: "../images",
+      cssPath: "../" + imagesDir,
       retina: true,
       prefix: "sprite-icon",
       processor: "scss",


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | _néant_ |

Parce qu'il faut toujours que les erreurs de `gulp` me tombent dessus ...
# Note de QA

Attention, nécéssite les outils du front
- Aller sur la branche `upstream/dev`, et faire `npm run gulp -- build`, constater que certaines images ne fonctionnent plus (en fait `sprite.png` n'est plus chargé, vous pouvez vérifier ça dans la console de votre navigateur préféré).
- Aller sur ma branche et refaire de même. Constater que ça fonctionne.

Ping @Situphen sur celle là.
