### PR TITLE
Display a correct slug in urls.

### DIFF
--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -45,7 +45,7 @@ class PrivateTopic(models.Model):
         :return: PrivateTopic object URL
         :rtype: str
         """
-        return reverse('private-posts-list', args=[self.pk, self.slug])
+        return reverse('private-posts-list', args=[self.pk, self.slug()])
 
     def slug(self):
         """

--- a/zds/mp/tests/tests_models.py
+++ b/zds/mp/tests/tests_models.py
@@ -37,7 +37,7 @@ class PrivateTopicTest(TestCase):
         self.assertEqual(self.topic1.__unicode__(), self.topic1.title)
 
     def test_absolute_url(self):
-        url = reverse('private-posts-list', args=[self.topic1.pk, self.topic1.slug])
+        url = reverse('private-posts-list', args=[self.topic1.pk, self.topic1.slug()])
 
         self.assertEqual(self.topic1.get_absolute_url(), url)
 

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -437,7 +437,7 @@ class PrivatePostEdit(UpdateView):
         self.current_post = self.get_object()
         form = self.form_class(self.topic, initial={'text': self.current_post.text})
         form.helper.form_action = reverse('private-posts-edit',
-                                          args=[self.topic.pk, self.topic.slug, self.current_post.pk])
+                                          args=[self.topic.pk, self.topic.slug(), self.current_post.pk])
         return render(request, self.template_name, {
             'post': self.current_post,
             'topic': self.topic,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets (_issues_) concernés | #2423 |

Affiche des slugs corrects dans les URLs.

QA : Vérifier que les slugs sont correctement affichés dans les URLs des MPs.
