### PR TITLE
Distinction d'un membre n'ayant pas encore activé son compte

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -431,7 +431,7 @@
         {% endif %}
     </div>
 
-    {% if perms.member.change_profile %}
+    {% if perms.member.change_profile and profile.user.is_active %}
         <div class="mobile-menu-bloc mobile-all-links" data-title='{% trans "Modération" %}'>
             <h3>{% trans "Modération" %}</h3>
 

--- a/templates/misc/badge.part.html
+++ b/templates/misc/badge.part.html
@@ -3,11 +3,13 @@
 
 
 {% with status=member|state %}
-    {% if status == 'BAN'%}
+    {% if status == 'STAFF' %}
+        <span class="badge staff {% if push_badge %}push-badge{% endif %}">{% trans "Staff" %}</span>
+    {% elif status == 'DOWN'%}
+        <span class="badge banned {% if push_badge %}push-badge{% endif %}" title={% blocktrans %}"Compte Inactif"{% endblocktrans %}>{% trans "Dead" %}</span>
+    {% elif status == 'BAN'%}
         <span class="badge banned {% if push_badge %}push-badge{% endif %}">{% trans "Banni" %}</span>
     {% elif status == 'LS'%}
         <span class="badge readonly {% if push_badge %}push-badge{% endif %}" title={% blocktrans %}"Lecture Seule"{% endblocktrans %}>{% trans "LS" %}</span>
-    {% elif status == 'STAFF' %}
-        <span class="badge staff {% if push_badge %}push-badge{% endif %}">{% trans "Staff" %}</span>
     {% endif %}
 {% endwith %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2300 |

Cette PR permet d'afficher sur la page de profil d'un membre inactif le badge portant une indication comme quoi le compte est inactif.

**Note pour la QA:**

Créer 4 types de comptes (inactif, staff, banni et en lecture seule) et vérifier que sur les pages de profil de chacun on a la bonne mention.

Vérifier aussi que pour le membre inactif, il n'y a aucune mention de personne à bannir
