### PR TITLE
Ajoute la possibilité d'utiliser des images SVG dans un tutoriel

### DIFF
--- a/doc/source/install/backend-linux-install.rst
+++ b/doc/source/install/backend-linux-install.rst
@@ -22,13 +22,14 @@ Assurez vous que les dépendances suivantes soient résolues :
 - libxlst-dev (peut être appelée libxlst1-dev sur certains OS comme ubuntu
 - libz-dev (peut être libz1g-dev sur système 64bits)
 - python-sqlparse
+- libffi : ``apt-get install libffi-dev``
 - libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev : ``apt-get install libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev``
 
 Ou, en une ligne,
 
 .. sourcecode:: bash
 
-    apt-get install git python-dev python-setuptools libxml2-dev python-lxml libxslt-dev libz-dev python-sqlparse libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev
+    apt-get install git python-dev python-setuptools libxml2-dev python-lxml libxslt-dev libz-dev python-sqlparse libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev libffi-dev
     easy_install pip tox
 
 Installation et configuration de `virtualenv`

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pillow==2.7.0
 gitpython==0.3.5
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.4.zip
 easy-thumbnails==2.2
+CairoSVG==1.0.13
 
 # Api dependencies
 djangorestframework==3.0.2

--- a/update.md
+++ b/update.md
@@ -146,6 +146,13 @@ Rajouter ces lignes dans le `settings_prod.py` :
 ZDS_SITE['site']['googleAnalyticsID'] = 'UA-27730868-1'
 ZDS_SITE['site']['googleTagManagerID'] = 'GTM-WH7642'
 ```
+
+Issue #1634
+-----------
+
+Exécuter la commande suivante : `sudo apt-get install libffi-dev`
+
+
 Actions à faire pour mettre en prod la version : v1.6
 =====================================================
 

--- a/zds/tutorial/factories.py
+++ b/zds/tutorial/factories.py
@@ -18,6 +18,7 @@ content = (
     u'Ceci est un contenu de tutoriel utile et à tester un peu partout\n\n '
     u'Ce contenu ira aussi bien dans les introductions, que dans les conclusions et les extraits \n\n '
     u'le gros intéret étant qu\'il renferme des images pour tester l\'execution coté pandoc \n\n '
+    u'Un svg ![Gnome](http://upload.wikimedia.org/wikipedia/commons/6/68/Gnomelogo.svg) \n\n '
     u'Exemple d\'image ![Ma pepite souris](http://blog.science-infuse.fr/public/souris.jpg)\n\n '
     u'\nExemple d\'image ![Image inexistante](http://blog.science-infuse.fr/public/inv_souris.jpg)\n\n '
     u'\nExemple de gif ![](http://corigif.free.fr/oiseau/img/oiseau_004.gif)\n\n '

--- a/zds/tutorial/factories.py
+++ b/zds/tutorial/factories.py
@@ -19,6 +19,8 @@ content = (
     u'Ce contenu ira aussi bien dans les introductions, que dans les conclusions et les extraits \n\n '
     u'le gros intéret étant qu\'il renferme des images pour tester l\'execution coté pandoc \n\n '
     u'Un svg ![Gnome](http://upload.wikimedia.org/wikipedia/commons/6/68/Gnomelogo.svg) \n\n '
+    u'Un giant svg ![HTML5](http://www.html5rocks.com/static/demos/svgmobile_fundamentals'
+    u'/images/HTML5-logo-faded-gradient.svg) \n\n '
     u'Exemple d\'image ![Ma pepite souris](http://blog.science-infuse.fr/public/souris.jpg)\n\n '
     u'\nExemple d\'image ![Image inexistante](http://blog.science-infuse.fr/public/inv_souris.jpg)\n\n '
     u'\nExemple de gif ![](http://corigif.free.fr/oiseau/img/oiseau_004.gif)\n\n '

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3088,6 +3088,7 @@ def get_url_images(md_text, pt):
                     try:
                         ext = filename.split(".")[-1].lower()
                         if ext == "svg":
+                            resize_svg(down_path)
                             cairosvg.svg2png(url=down_path,
                                              write_to=os.path.join(pt, "images", filename.split(".")[0] + ".png"))
                         else:
@@ -3117,6 +3118,7 @@ def get_url_images(md_text, pt):
                     try:
                         ext = dstroot.split(".")[-1]
                         if ext == "svg":
+                            resize_svg(dstroot)
                             cairosvg.svg2png(url=dstroot,
                                              write_to=os.path.join(dstroot.split(".")[0] + ".png"))
                         else:
@@ -3131,6 +3133,26 @@ def get_url_images(md_text, pt):
                             im.save(os.path.join(dstroot.split(".")[0] + ".png"))
                         else:
                             im.save(os.path.join(dstroot))
+
+
+def resize_svg(source, max_size=800):
+
+    tree = etree.parse(source)
+    svg = tree.getroot()
+    width = float(svg.attrib["width"])
+    height = float(svg.attrib["height"])
+    end_height = height
+    end_width = width
+    if width > max_size or height > max_size:
+        if width > height:
+            end_height = (height/width) * max_size
+            end_width = max_size
+        else:
+            end_height = max_size
+            end_width = (width/height) * max_size
+    svg.attrib["width"] = str(end_width)
+    svg.attrib["height"] = str(end_height)
+    tree.write(source)
 
 
 def sub_urlimg(g):

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3140,8 +3140,12 @@ def resize_svg(source, max_size=960):
     max_size = int(settings.THUMBNAIL_ALIASES[""]["content"]["size"][0])
     tree = etree.parse(source)
     svg = tree.getroot()
-    width = float(svg.attrib["width"])
-    height = float(svg.attrib["height"])
+    try:
+        width = float(svg.attrib["width"])
+        height = float(svg.attrib["height"])
+    except KeyError:
+        width = max_size
+        height = max_size
     end_height = height
     end_width = width
     if width > max_size or height > max_size:

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3145,11 +3145,11 @@ def resize_svg(source, max_size=800):
     end_width = width
     if width > max_size or height > max_size:
         if width > height:
-            end_height = (height/width) * max_size
+            end_height = (height / width) * max_size
             end_width = max_size
         else:
             end_height = max_size
-            end_width = (width/height) * max_size
+            end_width = (width / height) * max_size
     svg.attrib["width"] = str(end_width)
     svg.attrib["height"] = str(end_height)
     tree.write(source)

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3092,17 +3092,17 @@ def get_url_images(md_text, pt):
                             cairosvg.svg2png(url=down_path,
                                              write_to=os.path.join(pt, "images", filename.split(".")[0] + ".png"))
                         else:
-                            im = ImagePIL.open(down_path)
+                            im_display = ImagePIL.open(down_path)
                             # if image is gif, convert to png
                             if ext == "gif":
-                                im.save(os.path.join(pt, "images", filename.split(".")[0] + ".png"))
+                                im_display.save(os.path.join(pt, "images", filename.split(".")[0] + ".png"))
                     except IOError:
                         ext = filename.split(".")[-1].lower()
-                        im = ImagePIL.open(unknow_path)
+                        im_display = ImagePIL.open(unknow_path)
                         if ext == "gif" or ext == "svg":
-                            im.save(os.path.join(pt, "images", filename.split(".")[0] + ".png"))
+                            im_display.save(os.path.join(pt, "images", filename.split(".")[0] + ".png"))
                         else:
-                            im.save(os.path.join(pt, "images", filename))
+                            im_display.save(os.path.join(pt, "images", filename))
                 except IOError:
                     pass
             else:
@@ -3122,21 +3122,22 @@ def get_url_images(md_text, pt):
                             cairosvg.svg2png(url=dstroot,
                                              write_to=os.path.join(dstroot.split(".")[0] + ".png"))
                         else:
-                            im = ImagePIL.open(dstroot)
+                            im_display = ImagePIL.open(dstroot)
                             # if image is gif or svg, convert to png
                             if ext == "gif":
-                                im.save(os.path.join(dstroot.split(".")[0] + ".png"))
+                                im_display.save(os.path.join(dstroot.split(".")[0] + ".png"))
                     except IOError:
                         ext = dstroot.split(".")[-1].lower()
-                        im = ImagePIL.open(unknow_path)
+                        im_display = ImagePIL.open(unknow_path)
                         if ext == "gif" or ext == "svg":
-                            im.save(os.path.join(dstroot.split(".")[0] + ".png"))
+                            im_display.save(os.path.join(dstroot.split(".")[0] + ".png"))
                         else:
-                            im.save(os.path.join(dstroot))
+                            im_display.save(os.path.join(dstroot))
 
 
-def resize_svg(source, max_size=800):
+def resize_svg(source, max_size=960):
 
+    max_size = int(settings.THUMBNAIL_ALIASES[""]["content"]["size"][0])
     tree = etree.parse(source)
     svg = tree.getroot()
     width = float(svg.attrib["width"])

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -20,6 +20,7 @@ import zipfile
 import os
 import glob
 import tempfile
+import cairosvg
 
 from PIL import Image as ImagePIL
 from django.conf import settings
@@ -3085,15 +3086,19 @@ def get_url_images(md_text, pt):
                 try:
                     urlretrieve(real_url, down_path)
                     try:
-                        ext = filename.split(".")[-1]
-                        im = ImagePIL.open(down_path)
-                        # if image is gif, convert to png
-                        if ext == "gif":
-                            im.save(os.path.join(pt, "images", filename.split(".")[0] + ".png"))
+                        ext = filename.split(".")[-1].lower()
+                        if ext == "svg":
+                            cairosvg.svg2png(url=down_path,
+                                             write_to=os.path.join(pt, "images", filename.split(".")[0] + ".png"))
+                        else:
+                            im = ImagePIL.open(down_path)
+                            # if image is gif, convert to png
+                            if ext == "gif":
+                                im.save(os.path.join(pt, "images", filename.split(".")[0] + ".png"))
                     except IOError:
-                        ext = filename.split(".")[-1]
+                        ext = filename.split(".")[-1].lower()
                         im = ImagePIL.open(unknow_path)
-                        if ext == "gif":
+                        if ext == "gif" or ext == "svg":
                             im.save(os.path.join(pt, "images", filename.split(".")[0] + ".png"))
                         else:
                             im.save(os.path.join(pt, "images", filename))
@@ -3111,14 +3116,18 @@ def get_url_images(md_text, pt):
 
                     try:
                         ext = dstroot.split(".")[-1]
-                        im = ImagePIL.open(dstroot)
-                        # if image is gif, convert to png
-                        if ext == "gif":
-                            im.save(os.path.join(dstroot.split(".")[0] + ".png"))
+                        if ext == "svg":
+                            cairosvg.svg2png(url=dstroot,
+                                             write_to=os.path.join(dstroot.split(".")[0] + ".png"))
+                        else:
+                            im = ImagePIL.open(dstroot)
+                            # if image is gif or svg, convert to png
+                            if ext == "gif":
+                                im.save(os.path.join(dstroot.split(".")[0] + ".png"))
                     except IOError:
-                        ext = dstroot.split(".")[-1]
+                        ext = dstroot.split(".")[-1].lower()
                         im = ImagePIL.open(unknow_path)
-                        if ext == "gif":
+                        if ext == "gif" or ext == "svg":
                             im.save(os.path.join(dstroot.split(".")[0] + ".png"))
                         else:
                             im.save(os.path.join(dstroot))
@@ -3134,8 +3143,8 @@ def sub_urlimg(g):
     (filepath, filename) = os.path.split(parse_object.path)
     if filename != '':
         mark = g.group("mark")
-        ext = filename.split(".")[-1]
-        if ext == "gif":
+        ext = filename.split(".")[-1].lower()
+        if ext == "gif" or ext == "svg":
             if parse_object.scheme in ("http", "https") or \
                     parse_object.netloc[:3] == "www" or \
                     parse_object.path[:3] == "www":


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #1634 |

Cette PR permet de donner la possibilité d'ajouter des images de types svg à un tutoriel. Des tests sont associés à la résolution du bug pour éviter les regressions.

**Note pour QA**
- Installer la dépendance os necessaire (elle est précisée dans le update.md) : `apt-get install libffi-dev` 
- Mettre à jour les dépendances python : `pip install --upgrade -r requirements.txt -r requirements-dev.txt`
- Créer un tutoriel et insérer un lien vers une image svg (dans l'introduction, conclusion et/ou extrait)
- Publier le tutoriel, et constatez que vous n'avez plus d'erreur 500.
