### PR TITLE
Demande la confirmation avant de fermer un sujet

### DIFF
--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -231,19 +231,34 @@
             <h3>{% trans "Modération" %}</h3>
             <ul>
                 <li>
-                    <form action="{% url "zds.forum.views.edit" %}" method="post">
+                    <a href="#lock-open-topic-{{ topic.pk }}" class="open-modal ico-after lock {% if not topic.is_locked %}blue{% endif %}">
+                        {% if topic.is_locked %}
+                            {% trans "Ouvrir le sujet" %}
+                        {% else %}
+                            {% trans "Fermer le sujet" %}
+                        {% endif %}
+                    </a>
+                    <form action="{% url "zds.forum.views.edit" %}" method="post" id="lock-open-topic-{{ topic.pk }}" class="modal modal-small">
                         <input type="hidden" name="topic" value="{{ topic.pk }}">
                         <input type="hidden" name="nb" value="{{ nb }}">
                         <input type="hidden" name="page" value="{{ nb }}">
                         <input type="hidden" name="lock" value="{% if topic.is_locked %}false{% else %}true{% endif %}">
             			{% csrf_token %}
 
-                        <button class="ico-after lock {% if not topic.is_locked %}blue{% endif %}" type="submit">
-                            {% if topic.is_locked %}
-                                {% trans "Ouvrir le sujet" %}
-                            {% else %}
-                                {% trans "Fermer le sujet" %}
-                            {% endif %}
+                        <p>
+                            {% trans "Voulez-vous confirmer" %}
+                                <em>
+                                    {% if topic.is_locked %}
+                                        {% trans "la réouverture" %}
+                                    {% else %}
+                                        {% trans "la fermeture" %}
+                                    {% endif %}
+                                </em>
+                            {% trans "du sujet ?" %}
+                        </p>
+
+                        <button type="submit" name="lock-open-topic-{{ topic.pk }}">
+                            {% trans "Confirmer" %}
                         </button>
                     </form>
                 </li>

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -410,9 +410,13 @@ def edit(request):
 
         if "lock" in data:
             g_topic.is_locked = data["lock"] == "true"
-            messages.success(request,
-                             u"Le sujet {0} est désormais verrouillé."
-                             .format(g_topic.title))
+
+            if g_topic.is_locked:
+                success_message = u"Le sujet {0} est désormais verrouillé.".format(g_topic.title)
+            else:
+                success_message = u"Le sujet {0} est désormais déverrouillé.".format(g_topic.title)
+
+            messages.success(request, success_message)
         if 'sticky' in data:
             if data['sticky'] == 'true':
                 g_topic.is_sticky = True


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2048 |

QA:

Vérifier qu'il y'a bien une confirmation avant la fermeture du topic et l'ouverture du topic 
