### PR TITLE
Gestion des membres contactables

### DIFF
--- a/zds/member/managers.py
+++ b/zds/member/managers.py
@@ -1,12 +1,30 @@
 # -*- coding: utf-8 -*-
 
 from django.db import models
+from django.conf import settings
+from datetime import datetime
+from django.contrib.auth.models import Group
+from django.db.models import Q
 
 
 class ProfileManager(models.Manager):
     """
     Custom profile manager.
     """
+
+    def contactable_members(self):
+        """
+        Gets all members to whom you can send a private message and can respond.
+
+        :return: All members contactable
+        :rtype: QuerySet
+        """
+        excluded_groups = [Group.objects.get(name=settings.ZDS_APP['member']['bot_group'])]
+        now = datetime.now()
+        return super(ProfileManager, self).get_queryset()\
+            .exclude(user__groups__in=excluded_groups)\
+            .exclude(user__is_active=False)\
+            .filter(Q(can_read=True) | Q(end_ban_read__lte=now))
 
     def all_members_ordered_by_date_joined(self):
         """

--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -15,6 +15,7 @@ except:
     except:
         import json as json_reader
 from django.db.models import Q
+from django.contrib.auth.models import Group
 from django.conf import settings
 from django.core import mail
 from django.core.urlresolvers import reverse
@@ -2652,6 +2653,9 @@ class BigTutorialTests(TestCase):
         Add a non-regression test about warning the author(s) of a typo in tutorial
         """
 
+        bot = Group(name=settings.ZDS_APP["member"]["bot_group"])
+        bot.save()
+
         typo_text = u'T\'as fait une faute, t\'es nul'
 
         # login with author
@@ -4460,6 +4464,9 @@ class MiniTutorialTests(TestCase):
         """
         Add a non-regression test about warning the author(s) of a typo in tutorial
         """
+
+        bot = Group(name=settings.ZDS_APP["member"]["bot_group"])
+        bot.save()
 
         typo_text = u'T\'as fait une faute, t\'es nul'
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2305 |

Cette PR empeche de contacter un auteur qui n'est pas joignable (bot, ban, etc.).

J'en ai profité pour rajouter un manager qui récupère les membres joingables, et rajouté un test qui valide ce manager.

**Note pour QA**
- Prendre un tutoriel publié ou en beta associé a un bot, ou a un membre banni
- Essayer de signaler une faute via le bouton dédié.
- Constatez que : 
  - s'il y'a un seul auteur (injoignable) un message d'erreur est renvoyé
  - s'il y'a plusieurs auteurs (dont un injoignable) le mp est envoyé uniquement aux auteurs joignables

N'hésitez pas à vérifier les _corners cases_
