### PR TITLE
Correction de l'erreur 500 lors de la modification d'un profil

### DIFF
--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -109,6 +109,26 @@ class MemberTests(TestCase):
         )
         self.assertEqual(result.status_code, 404)
 
+    def test_modify_member(self):
+
+        # we need staff right for update other profile
+        self.client.logout()
+        self.client.login(username=self.staff.username, password="hostel77")
+
+        # an inexistant member return 404
+        result = self.client.get(
+            reverse('zds.member.views.settings_mini_profile', args=["xkcd"]),
+            follow=False
+        )
+        self.assertEqual(result.status_code, 404)
+
+        # an existant member return 200
+        result = self.client.get(
+            reverse('zds.member.views.settings_mini_profile', args=[self.mas.user.username]),
+            follow=False
+        )
+        self.assertEqual(result.status_code, 200)
+
     def test_login(self):
         """
         To test user login.

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -501,8 +501,7 @@ def settings_mini_profile(request, user_name):
     """Minimal settings of users for staff."""
 
     # extra information about the current user
-
-    profile = Profile.objects.get(user__username=user_name)
+    profile = get_object_or_404(Profile, user__username=user_name)
     if request.method == "POST":
         form = MiniProfileForm(request.POST)
         c = {"form": form, "profile": profile}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2321 |

Cette PR corrige l'issue associée, et rajoute un test pour éviter la regression plus tard.

**Note pour QA**:

Vérifier que ce que décrit l'issue n'est plus reproductible.
