### PR TITLE
Correction de l'erreur 500 sur l'adresse email d'un membre

### DIFF
--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -129,7 +129,7 @@ class Profile(models.Model):
             return self.avatar_url
         else:
             return 'https://secure.gravatar.com/avatar/{0}?d=identicon'.format(
-                md5(self.user.email.lower()).hexdigest())
+                md5(self.user.email.lower().encode("utf-8")).hexdigest())
 
     def get_post_count(self):
         """Number of messages posted."""

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -60,6 +60,12 @@ class MemberTests(TestCase):
         To test the listing of the members with and without page parameter.
         """
 
+        # create strange member
+        weird = ProfileFactory()
+        weird.user.username = u"ïtrema718"
+        weird.user.email = u"foo@\xfbgmail.com"
+        weird.user.save()
+
         # list of members.
         result = self.client.get(
             reverse('member-list'),

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -2705,7 +2705,7 @@ def maj_repo_tuto(
             conclu.close()
             index.add(["conclusion.md"])
         aut_user = str(request.user.pk)
-        aut_email = str(request.user.email)
+        aut_email = request.user.email
         if aut_email is None or aut_email.strip() == "":
             aut_email = "inconnu@{}".format(settings.ZDS_APP['site']['dns'])
         com = index.commit(
@@ -2766,7 +2766,7 @@ def maj_repo_part(
             index.add([os.path.join(part.get_path(relative=True), "conclusion.md"
                                     )])
     aut_user = str(request.user.pk)
-    aut_email = str(request.user.email)
+    aut_email = request.user.email
     if aut_email is None or aut_email.strip() == "":
         aut_email = "inconnu@{}".format(settings.ZDS_APP['site']['litteral_name'])
     com_part = index.commit(
@@ -2844,7 +2844,7 @@ def maj_repo_chapter(
         chapter.part.tutorial.dump_json(path=man_path)
     index.add(["manifest.json"])
     aut_user = str(request.user.pk)
-    aut_email = str(request.user.email)
+    aut_email = request.user.email
     if aut_email is None or aut_email.strip() == "":
         aut_email = "inconnu@{}".format(settings.ZDS_APP['site']['dns'])
     com_ch = index.commit(
@@ -2918,7 +2918,7 @@ def maj_repo_extract(
 
     index.add(["manifest.json"])
     aut_user = str(request.user.pk)
-    aut_email = str(request.user.email)
+    aut_email = request.user.email
     if aut_email is None or aut_email.strip() == "":
         aut_email = "inconnu@{}".format(settings.ZDS_APP['site']['dns'])
     com_ex = index.commit(


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #1640 |

Cette PR corrige le bug de l'erreur 500 lorsque l'on consulte la liste des membres dont l'un à une addresse étrange.

**Note pour QA**
- Créer un utilisateur et donner lui un email du genre `foo@\xfbgmail.com`
- Allez sur la page `/membres/` pour voir la liste des membres
- Constatez qu'il n y'a plus d'erreur 500 sur cette page.
