### PR TITLE
La même licence affichée pour tous le monde

### DIFF
--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -223,6 +223,9 @@ class Tutorial(models.Model):
             and self.sha_validation == sha
         mandata['is_on_line'] = self.on_line() and self.sha_public == sha
 
+        if 'licence' in mandata:
+            mandata['licence'] = Licence.objects.filter(code=mandata['licence']).first()
+
         # url:
         mandata['get_absolute_url'] = reverse(
             'zds.tutorial.views.view_tutorial',
@@ -264,8 +267,6 @@ class Tutorial(models.Model):
         repo = Repo(self.get_path())
         mantuto = get_blob(repo.commit(sha).tree, 'manifest.json')
         data = json_reader.loads(mantuto)
-        if 'licence' in data:
-            data['licence'] = Licence.objects.filter(code=data['licence']).first()
         return data
 
     def load_json(self, path=None, online=False):
@@ -282,8 +283,6 @@ class Tutorial(models.Model):
             json_data = open(man_path)
             data = json_reader.load(json_data)
             json_data.close()
-            if 'licence' in data:
-                data['licence'] = Licence.objects.filter(code=data['licence']).first()
             return data
 
     def dump_json(self, path=None):

--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -2265,7 +2265,7 @@ class BigTutorialTests(TestCase):
 
         # test change in JSON :
         json = tuto.load_json()
-        self.assertEquals(json['licence'].code, new_licence.code)
+        self.assertEquals(json['licence'], new_licence.code)
 
         # then logout ...
         self.client.logout()
@@ -2299,7 +2299,7 @@ class BigTutorialTests(TestCase):
 
         # test change in JSON :
         json = tuto.load_json()
-        self.assertEquals(json['licence'].code, self.licence.code)
+        self.assertEquals(json['licence'], self.licence.code)
 
         # then logout ...
         self.client.logout()
@@ -2356,7 +2356,7 @@ class BigTutorialTests(TestCase):
 
         # test change in JSON (normaly, nothing has) :
         json = tuto.load_json()
-        self.assertEquals(json['licence'].code, self.licence.code)
+        self.assertEquals(json['licence'], self.licence.code)
 
     def test_workflow_archive_tuto(self):
         """ensure the behavior of archive with a big tutorial"""
@@ -4066,7 +4066,7 @@ class MiniTutorialTests(TestCase):
 
         # test change in JSON :
         json = tuto.load_json()
-        self.assertEquals(json['licence'].code, new_licence.code)
+        self.assertEquals(json['licence'], new_licence.code)
 
         # then logout ...
         self.client.logout()
@@ -4100,7 +4100,7 @@ class MiniTutorialTests(TestCase):
 
         # test change in JSON :
         json = tuto.load_json()
-        self.assertEquals(json['licence'].code, self.licence.code)
+        self.assertEquals(json['licence'], self.licence.code)
 
         # then logout ...
         self.client.logout()
@@ -4157,7 +4157,7 @@ class MiniTutorialTests(TestCase):
 
         # test change in JSON (normaly, nothing has) :
         json = tuto.load_json()
-        self.assertEquals(json['licence'].code, self.licence.code)
+        self.assertEquals(json['licence'], self.licence.code)
 
     def test_workflow_archive_tuto(self):
         """ensure the behavior of archive with a mini tutorial"""


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2052 |

Cette PR permet d'afficher la même licence d'un tutoriel en mode hors ligne comme en mode online.

**Note pour QA**
- Créer et publiez un tutoriel
- Vérifier que le libellé de la licence dans sa version online est le même que le libellé dans sa version offline.

Voir l'issue liée, pour plus de détail.
