### PR TITLE
Correction d'un debordement de page

### DIFF
--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -959,8 +959,7 @@ def find_topic_by_tag(request, tag_pk, tag_slug):
         shown_topics = paginator.page(1)
         page = 1
     except EmptyPage:
-        shown_topics = paginator.page(paginator.num_pages)
-        page = paginator.num_pages
+        raise Http404
     return render(request, "forum/find/topic_by_tag.html", {
         "topics": shown_topics,
         "tag": tag,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2049 |

Cette PR permet de corriger le débordement de page dans la navigation par tag.

**Note pour QA**

Vérifier que lorsque je navigue par tag et que je vais sur une page qui n'existe pas (n'a aucun topic), je me prend une 404
