### PR TITLE
Suppression des beta topic si suppression de tuto

### DIFF
--- a/zds/forum/managers.py
+++ b/zds/forum/managers.py
@@ -16,3 +16,6 @@ class TopicManager(models.Manager):
                    .prefetch_related("author") \
                    .order_by("-pubdate") \
                    .all()[:settings.ZDS_APP['forum']['home_number']]
+
+    def get_beta_topic_of(self, tutorial):
+        return self.filter(key=tutorial.pk, key__isnull=False).first()

--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -238,7 +238,7 @@ class BigTutorialTests(TestCase):
         # then active the beta on tutorial
         self.assertIsNone(Topic.objects.get_beta_topic_of(future_tutorial))
         sha_draft = Tutorial.objects.get(pk=future_tutorial_pk).sha_draft
-        response = self.client.post(
+        self.client.post(
             reverse('zds.tutorial.views.modify_tutorial'),
             {
                 'tutorial': future_tutorial_pk,
@@ -271,7 +271,7 @@ class BigTutorialTests(TestCase):
         # then active the beta on tutorial
         self.assertIsNone(Topic.objects.get_beta_topic_of(future_tutorial))
         sha_draft = Tutorial.objects.get(pk=future_tutorial_pk).sha_draft
-        response = self.client.post(
+        self.client.post(
             reverse('zds.tutorial.views.modify_tutorial'),
             {
                 'tutorial': future_tutorial_pk,
@@ -286,7 +286,7 @@ class BigTutorialTests(TestCase):
         # then desactive the beta on tutorial
         self.assertIsNone(Topic.objects.filter(pk=topic_pk, is_locked=True).first())
         sha_draft = Tutorial.objects.get(pk=future_tutorial_pk).sha_draft
-        response = self.client.post(
+        self.client.post(
             reverse('zds.tutorial.views.modify_tutorial'),
             {
                 'tutorial': future_tutorial_pk,

--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -226,6 +226,24 @@ class BigTutorialTests(TestCase):
         self.assertEqual(pub.status_code, 302)
         self.assertEquals(len(mail.outbox), 1)
 
+    def test_delete_tutorial_never_beta(self):
+        future_tutorial = self.create_basic_big_tutorial()
+        future_tutorial_pk = future_tutorial.pk
+
+        login_check = self.client.login(
+            username=self.user_author.username,
+            password='hostel77')
+        self.assertEqual(login_check, True)
+
+        # delete tutorial
+        response = self.client.post(
+            reverse('zds.tutorial.views.delete_tutorial', args=[future_tutorial_pk]),
+            {},
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(Tutorial.objects.filter(pk=future_tutorial_pk).first())
+
     def test_delete_tutorial_on_beta(self):
         future_tutorial = self.create_basic_big_tutorial()
         future_tutorial_pk = future_tutorial.pk

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -536,6 +536,7 @@ def delete_tutorial(request, tutorial_pk):
         messages.success(request,
                          _(u'Le tutoriel {0} a bien '
                            u'été supprimé.').format(tutorial.title))
+        Topic.objects.get_beta_topic_of(tutorial).delete()
         tutorial.delete()
     else:
         tutorial.authors.remove(request.user)

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -536,7 +536,9 @@ def delete_tutorial(request, tutorial_pk):
         messages.success(request,
                          _(u'Le tutoriel {0} a bien '
                            u'été supprimé.').format(tutorial.title))
-        Topic.objects.get_beta_topic_of(tutorial).delete()
+        beta_topic = Topic.objects.get_beta_topic_of(tutorial)
+        if beta_topic is not None:
+            beta_topic.delete()
         tutorial.delete()
     else:
         tutorial.authors.remove(request.user)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2079 |

Cette PR permet de supprimer un topic de beta lorsque le tutoriel en question est supprimé.

**Note pour QA**

Créer un tutoriel, le mettre en beta, et supprimer le tutoriel et vérifier que le topic de beta n'existe plus

Refaire l'expérience en créant le tuto, mettre en beta, désactiver la beta, et supprimer le tutoriel. Le topic aussi devrait avoir disparu.
