### PR TITLE
Compile les code C sans optimisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ python:
 
 env:
   - TEST_APP="-e back_mysql zds.tutorial"
+    CFLAGS="-O0"
   - TEST_APP="-e back_mysql zds.article zds.forum zds.member zds.utils zds.gallery zds.mp zds.pages"
+    CFLAGS="-O0" 
   - TEST_APP="-e front"
 
 notifications:


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | Aucun |

Comme recommandé dans [la doc d'installation](http://lxml.de/installation.html) de lxml, afin de pouvoir accelerer le build de lxml, la variable d'environnement `CFLAGS` est valorisée.

> To speed up the build in test environments, e.g. on a continuous integration server, disable the C compiler optimisations by setting the CFLAGS environment variable:

**Note pour QA**

Travis se suffit à lui même ici.
