### PR TITLE
Elimine les doublons sur les forums

### DIFF
--- a/zds/utils/templatetags/topbar.py
+++ b/zds/utils/templatetags/topbar.py
@@ -24,7 +24,7 @@ def top_categories(user):
         forums_prv = Forum\
             .objects\
             .filter(group__isnull=False, group__in=user.groups.all())\
-            .select_related("category").all()
+            .select_related("category").distinct().all()
         forums = list(forums_pub | forums_prv)
     else:
         forums = list(forums_pub)

--- a/zds/utils/templatetags/topbar.py
+++ b/zds/utils/templatetags/topbar.py
@@ -19,7 +19,7 @@ register = template.Library()
 def top_categories(user):
     cats = {}
 
-    forums_pub = Forum.objects.filter(group__isnull=True).select_related("category").all()
+    forums_pub = Forum.objects.filter(group__isnull=True).select_related("category").distinct().all()
     if user and user.is_authenticated():
         forums_prv = Forum\
             .objects\


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #1913 |

Cette PR permet de corriger le bug des forums en double dans le topbar. Pour les membres qui possèdent des groupes.

**Note pour QA**
- Allez dans la zone d'admin et créez 2 groupes A et B
- Allez dans la zone d'admin encore et associez le forum "Discussion Générales" aux 2 groupes A et B
- Connectez vous en tant que admin, et dans votre profil cliquez sur le lien "promouvoir", puis associez votre compte aux 2 groupes A et B et validez
- Déroulez la topbar et constatez que vous n'avez pas le forum "Discussions Générale" en double dans votre topbar.
