### PR TITLE
Retour du sommaire pour les tutoriels en hors ligne

### DIFF
--- a/templates/tutorial/chapter/view.html
+++ b/templates/tutorial/chapter/view.html
@@ -148,7 +148,7 @@
 
 
 {% block sidebar_blocks %}
-    {% include "tutorial/includes/summary.part.html" with tutorial=tutorial chapter_current=chapter %}
+    {% include "tutorial/includes/summary.part.html" with tutorial=chapter.part.tutorial chapter_current=chapter %}
 
     {% if chapter.part %}
         {% if user in tutorial.authors.all or perms.tutorial.change_tutorial %}

--- a/templates/tutorial/includes/summary.part.html
+++ b/templates/tutorial/includes/summary.part.html
@@ -32,14 +32,14 @@
         {% endif %}
     {% else %}
         {# Large tutorial #}
-        {% if tutorial.get_parts %}
-            {% for part in tutorial.get_parts %}
+        {% if tutorial.parts %}
+            {% for part in tutorial.parts %}
                 <h4 data-num="{{ part.position_in_tutorial|roman }}">
                     <a class="mobile-menu-link"
                         {% if online %}
                             href="{% url "view-part-url-online" tutorial.pk tutorial.slug part.pk part.slug %}"
                         {% else %}
-                            href="{% url "view-part-url" tutorial.pk tutorial.slug part.pk part.slug %}"{% if version %}?version={{ version }}{% endif %}
+                            href="{% url "view-part-url" tutorial.pk tutorial.slug part.pk part.slug %}{% if version %}?version={{ version }}{% endif %}"
                         {% endif %}
                     >
                         {{ part.title }}
@@ -47,13 +47,13 @@
                 </h4>
                 
                 <ol>
-                    {% for chapter in part.get_chapters %}
+                    {% for chapter in part.chapters %}
                         <li {% if chapter_current.pk == chapter.pk %}class="current"{% endif %}>
                             <a data-num="{{ chapter.position_in_part }}"
                                 {% if online %}
                                     href="{% url "view-chapter-url-online" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}"
                                 {% else %}
-                                    href="{% url "view-chapter-url" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}"{% if version %}?version={{ version }}{% endif %}
+                                    href="{% url "view-chapter-url" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}{% if version %}?version={{ version }}{% endif %}"
                                 {% endif %}
                                 class="mobile-menu-link mobile-menu-sublink"
                             >
@@ -68,7 +68,7 @@
                                                 {% if online %}
                                                     href="{% url "view-chapter-url-online" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}#{{ extract.position_in_chapter }}-{{  extract.title|slugify }}"
                                                 {% else %}
-                                                    href="{% url "view-chapter-url" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}#{{ extract.position_in_chapter }}-{{ extract.title|slugify }}"{% if version %}?version={{ version }}{% endif %}
+                                                    href="{% url "view-chapter-url" tutorial.pk tutorial.slug part.pk part.slug chapter.pk chapter.slug %}#{{ extract.position_in_chapter }}-{{ extract.title|slugify }}{% if version %}?version={{ version }}{% endif %}"
                                                 {% endif %}
                                             >
                                                 {{ extract.title }}

--- a/templates/tutorial/part/view.html
+++ b/templates/tutorial/part/view.html
@@ -204,5 +204,5 @@
 
 
 {% block sidebar_blocks %}
-    {% include "tutorial/includes/summary.part.html" with tutorial=part.tutorial parts=part.tutorial.get_parts %}
+    {% include "tutorial/includes/summary.part.html" with parts=tutorial.parts %}
 {% endblock %}

--- a/templates/tutorial/part/view_online.html
+++ b/templates/tutorial/part/view_online.html
@@ -74,7 +74,7 @@
         </div>
     {% endif %}
 
-    {% include "tutorial/includes/summary.part.html" with online=True tutorial=part.tutorial parts=part.tutorial.get_parts %}
+    {% include "tutorial/includes/summary.part.html" with online=True parts=tutorial.parts %}
 
     {% include "misc/social_buttons.part.html" with link=part.tutorial.get_absolute_url_online text=part.tutorial.title %}
 {% endblock %}

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1314,31 +1314,31 @@ def view_part(
     find = False
     cpt_p = 1
     for part in parts:
+        part["tutorial"] = tutorial
+        part["path"] = tutorial.get_path()
+        part["slug"] = slugify(part["title"])
+        part["position_in_tutorial"] = cpt_p
+
+        cpt_c = 1
+        for chapter in part["chapters"]:
+            chapter["part"] = part
+            chapter["path"] = tutorial.get_path()
+            chapter["slug"] = slugify(chapter["title"])
+            chapter["type"] = "BIG"
+            chapter["position_in_part"] = cpt_c
+            chapter["position_in_tutorial"] = cpt_c * cpt_p
+            cpt_e = 1
+            for ext in chapter["extracts"]:
+                ext["chapter"] = chapter
+                ext["position_in_chapter"] = cpt_e
+                ext["path"] = tutorial.get_path()
+                cpt_e += 1
+            cpt_c += 1
         if part_pk == str(part["pk"]):
             find = True
-            part["tutorial"] = tutorial
-            part["path"] = tutorial.get_path()
-            part["slug"] = slugify(part["title"])
-            part["position_in_tutorial"] = cpt_p
             part["intro"] = get_blob(repo.commit(sha).tree, part["introduction"])
             part["conclu"] = get_blob(repo.commit(sha).tree, part["conclusion"])
-            cpt_c = 1
-            for chapter in part["chapters"]:
-                chapter["part"] = part
-                chapter["path"] = tutorial.get_path()
-                chapter["slug"] = slugify(chapter["title"])
-                chapter["type"] = "BIG"
-                chapter["position_in_part"] = cpt_c
-                chapter["position_in_tutorial"] = cpt_c * cpt_p
-                cpt_e = 1
-                for ext in chapter["extracts"]:
-                    ext["chapter"] = chapter
-                    ext["position_in_chapter"] = cpt_e
-                    ext["path"] = tutorial.get_path()
-                    cpt_e += 1
-                cpt_c += 1
             final_part = part
-            break
         cpt_p += 1
 
     # if part can't find
@@ -1420,7 +1420,7 @@ def view_part_online(
     if not find:
         raise Http404
 
-    return render(request, "tutorial/part/view_online.html", {"part": final_part})
+    return render(request, "tutorial/part/view_online.html", {"tutorial": mandata, "part": final_part})
 
 
 @can_write_and_read_now
@@ -1653,13 +1653,12 @@ def view_chapter(
     mandata = json_reader.loads(manifest)
     tutorial.load_dic(mandata, sha=sha)
 
-    parts = mandata["parts"]
     cpt_p = 1
     final_chapter = None
     chapter_tab = []
     final_position = 0
     find = False
-    for part in parts:
+    for part in mandata["parts"]:
         cpt_c = 1
         part["slug"] = slugify(part["title"])
         part["get_absolute_url"] = reverse(
@@ -1669,7 +1668,9 @@ def view_chapter(
                 tutorial.slug,
                 part["pk"],
                 part["slug"]])
-        part["tutorial"] = tutorial
+        part["tutorial"] = mandata
+        part["position_in_tutorial"] = cpt_p
+        part["get_chapters"] = part["chapters"]
         for chapter in part["chapters"]:
             chapter["part"] = part
             chapter["path"] = tutorial.get_path()
@@ -1704,10 +1705,11 @@ def view_chapter(
     if not find:
         raise Http404
 
-    prev_chapter = (chapter_tab[final_position - 1] if final_position >
-                    0 else None)
-    next_chapter = (chapter_tab[final_position + 1] if final_position + 1 >
-                    len(chapter_tab) else None)
+    prev_chapter = (chapter_tab[final_position - 1] if final_position > 0 else None)
+    next_chapter = (chapter_tab[final_position + 1] if final_position + 1 < len(chapter_tab) else None)
+    print "-------------> {}".format(next_chapter)
+    print "-------------> {}".format(final_position)
+    print "-------------> {}".format(len(chapter_tab))
 
     if tutorial.js_support:
         is_js = "js"

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1707,9 +1707,6 @@ def view_chapter(
 
     prev_chapter = (chapter_tab[final_position - 1] if final_position > 0 else None)
     next_chapter = (chapter_tab[final_position + 1] if final_position + 1 < len(chapter_tab) else None)
-    print "-------------> {}".format(next_chapter)
-    print "-------------> {}".format(final_position)
-    print "-------------> {}".format(len(chapter_tab))
 
     if tutorial.js_support:
         is_js = "js"


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #1528 |

Cette PR permet de rétablir l'affichage du sommaire pour les tutoriels hors lignes.

**Note pour QA**
- Vérifiez que le sommaire est toujours disponible en ligne
- Vérifiez que le sommaire est disponible pour les tutoriel en beta, en validation, et en rédaction
