### PR TITLE
Mise à disposition de l'envoie d'image depuis une galérie

### DIFF
--- a/templates/gallery/gallery/details.html
+++ b/templates/gallery/gallery/details.html
@@ -117,22 +117,22 @@
 
 
 
-{% block sidebar_actions %}
+{% block sidebar %}
     {% if gallery_mode.is_write %}
-        <div class="mobile-menu-bloc" data-title="Actions">
-            <h3>{% trans "Actions" %}</h3>
-            <ul>
-                <li>
-                    <a href="{% url "zds.gallery.views.new_image" gallery.pk %}" class="ico-after more blue">
-                        {% trans "Ajouter une image" %}
-                    </a>
-                </li>
-                <li>
-                    <a href="{% url "zds.gallery.views.import_image" gallery.pk %}" class="ico-after import blue">
-                        {% trans "Importer une archive" %}
-                    </a>
-                </li>
-            </ul>
-        </div>
+        <aside class="sidebar mobile-menu-hide">
+            <a href="{% url "zds.gallery.views.new_image" gallery.pk %}" class="new-btn ico-after more blue">
+                {% trans "Ajouter une image" %}
+            </a>
+            <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Actions">
+                <h3>{% trans "Actions" %}</h3>
+                <ul>
+                    <li>
+                        <a href="{% url "zds.gallery.views.import_image" gallery.pk %}" class="ico-after import blue">
+                            {% trans "Importer une archive" %}
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </aside>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #1706 |

Cette PR permet de mettre à disposition un bouton d'envoi d'image lorsqu'on est sur une gallerie. Et dans la sidebar mobile un bouton d'import d'archive (car c'est une opération moins courante sur mobile).

**Note pour QA** : à tester surtout sur mobile
- Builder le front : `npm run gulp --build`
- Créez une galérie et rendez vous y
- Vérifiez que vous avez bien le bouton "Ajouter une image" visible directement après le header
- Vérifiez que le bouton "Importer une archive" est dans la sidebar.
