### PR TITLE
Correction de l'alignement sur le bouton connexion

### DIFF
--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -9,7 +9,7 @@
 {% elif not user.is_authenticated %}
     <div class="alert-box info alert-box-not-closable">
         {% trans "Vous devez être connecté pour pouvoir poster un message" %}. <br>
-        <a href="{% url "zds.member.views.login_view" %}?next={{ request.path }}" class="btn alert-box-btn alert-box-btn-right">Connexion</a>
+        <a href="{% url "zds.member.views.login_view" %}?next={{ request.path }}" class="alert-box-btn alert-box-btn-right">Connexion</a>
     </div>
     <div class="alert-box not-member alert-box-not-closable">
         <h4 class="alert-box-title">Pas encore inscrit ?</h4>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #2287 |

Cette PR permet d'avoir un alignement correct du bouton de connexion en tant qu'invité

**Note pour QA**
- Builder le front : `npm run gulp --build`
- Allez sur le site sans être connecté
- Regardez un message de forum, et constatez que le bouton "connexion" s'affiche correctement. (pas comme dans l'issue reportée)
