### PR TITLE
Efface le texte suivant/précédent sur mobile dans la pagination

### DIFF
--- a/assets/scss/components/_pagination.scss
+++ b/assets/scss/components/_pagination.scss
@@ -99,3 +99,16 @@
         border: 1px solid #d2d5d6;
     }
 }
+
+@media only screen and #{$media-mobile} {
+    .pagination {
+        li {
+            &.next a {
+                min-width: 0px;
+                span {
+                    display: none;
+                }
+            }
+        }
+    }
+}

--- a/assets/scss/components/_pagination.scss
+++ b/assets/scss/components/_pagination.scss
@@ -103,6 +103,7 @@
 @media only screen and #{$media-mobile} {
     .pagination {
         li {
+            &.prev a,
             &.next a {
                 min-width: 0px;
                 span {

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -15,7 +15,9 @@
             <li class="prev">
                 {% with prev=nb|add:-1 %}
                     <a href="{% append_to_get page=prev %}{{ full_anchor }}" class="ico-after arrow-left blue">
+                    <span>
                         {% trans "Précédente" %}
+                    </span>
                     </a>
                 {% endwith %}
             </li>
@@ -61,7 +63,9 @@
             <li class="next">
                 {% with next=nb|add:1 %}
                     <a href="{% append_to_get page=next %}{{ full_anchor }}" class="ico-after arrow-right blue">
+                        <span>
                         {% trans "Suivante" %}
+                        </span>
                     </a>
                 {% endwith %}
             </li>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2289 |

**Note pour QA**
- Builder le front : `npm run gulp --build`
- Allez sur pc/tablette, et vérifiez que vous avez bien le texte suivant/précédent avec les flèche
- Allez sur mobile et vérifiez que le texte à disparu, et il ne reste que les flèches
