### PR TITLE
Editer une image en gardant la meme url

### DIFF
--- a/templates/gallery/image/edit.html
+++ b/templates/gallery/image/edit.html
@@ -26,6 +26,9 @@
 
 
 {% block content %}
+    <div class="alert-box ico-after tick light">
+        {% trans "En éditant cette image, vous écraserez l'ancienne, mais l'url sera conservée" %}
+    </div>
     <div class="gallery-col-image">
         <p>
             {% trans "Image" %} :

--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -18,9 +18,15 @@ GALLERY_READ = 'R'
 
 def image_path(instance, filename):
     """Return path to an image."""
-    ext = filename.split('.')[-1]
-    filename = u'{}.{}'.format(str(uuid.uuid4()), string.lower(ext))
-    return os.path.join('galleries', str(instance.gallery.pk), filename)
+    try:
+        img = Image.objects.get(pk=instance.pk)
+        file = "{}".format(img.physical)
+        os.remove(os.path.join(settings.MEDIA_ROOT, file))
+        return file
+    except:
+        ext = filename.split('.')[-1]
+        filename = u'{}.{}'.format(str(uuid.uuid4()), string.lower(ext))
+        return os.path.join('galleries', str(instance.gallery.pk), filename)
 
 
 class UserGallery(models.Model):

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -361,6 +361,8 @@ class EditImageViewTest(TestCase):
     def test_success_member_edit_image(self):
         login_check = self.client.login(username=self.profile1.user.username, password='hostel77')
         self.assertTrue(login_check)
+        filename = os.path.join(settings.MEDIA_ROOT, "{}".format(self.image.physical))
+        size_old = os.stat(filename).st_size
 
         with open(os.path.join(settings.SITE_ROOT, 'fixtures', 'logo.png'), 'r') as fp:
 
@@ -378,8 +380,11 @@ class EditImageViewTest(TestCase):
                 follow=True
             )
         self.assertEqual(200, response.status_code)
+        size = os.stat(filename).st_size
         image_test = Image.objects.get(pk=self.image.pk)
         self.assertEqual('edit title', image_test.title)
+        self.assertTrue(os.path.exists(filename))
+        self.assertNotEqual(size_old, size)
         image_test.delete()
 
     def test_access_permission(self):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2452 |

Cette PR permet d'éditer une image dans la gallérie en conservant la meme url. Un message d'avertissement permet de prévénir l'utilisateur que son ancienne image sera perdue.

**Note pour QA**
- Créez une gallerie et inserez une image : notez l'url de l'image ne question
- Editez l'image, et vérifiez que l'ancienne url est bien la meme que la nouvelle, mais l'image a changée.
