### PR TITLE
Correction de la liste des pages

### DIFF
--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -26,8 +26,10 @@
         <li><a href="{% url "zds.pages.views.about" %}">{% trans "À propos" %}</a></li>
         {% if app.site.association %}
             <li><a href="{% url "zds.pages.views.association" %}">{% trans "L'association" %}</a></li>
+            {% if user.is_authenticated %}
+                <li><a href="{% url "zds.pages.views.assoc_subscribe" %}">{% trans "Adhérer" %}</a></li>
+            {% endif %}
         {% endif %}
-        <li><a href="{% url "zds.pages.views.assoc_subscribe" %}">{% trans "Adhérer" %}</a></li>
         <li><a href="{% url "zds.pages.views.contact" %}">{% trans "Contact" %}</a></li>
         <li><a href="{% url "zds.pages.views.cookies" %}">{% trans "Les cookies" %}</a></li>
     </ul>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2013 |

Cette PR répare la page `/pages/` pour ne pas afficher les liens d'adhesions ni d'associations, si ceux-ci ne sont pas renseignés dans le settings. On reste donc cohérent avec le footer.

**Note pour QA**
### cas 1
- Allez sur l'url `/pages/` sans être connecté et vérifiez que vous ne voyez pas le lien "Adhérer"
- Allez sur l'url `/pages/` en etant connecté et vérifiez que vous voyez bien le lien "Adhérer"
### cas 2
- Créez un fichier settings_prod.py dans `zds-site/zds/` et ajouter le morceau de code suivant pour surcharger le dictionnaire : 

``` python
from settings import ZDS_APP
ZDS_APP['site'].pop("association")
```
- Lancer votre serveur python `python manage.py runserver`
- Allez sur la page `/pages/` et vérifier que les liens "L'association" et "Adhérer" ne sont plus présent
