### PR TITLE
Prise en compte des positions des catégories/forums

### DIFF
--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -37,6 +37,7 @@ class Category(models.Model):
     class Meta:
         verbose_name = 'Catégorie'
         verbose_name_plural = 'Catégories'
+        ordering = ['position', 'title']
 
     title = models.CharField('Titre', max_length=80)
     position = models.IntegerField('Position', null=True, blank=True)
@@ -66,6 +67,7 @@ class Forum(models.Model):
     class Meta:
         verbose_name = 'Forum'
         verbose_name_plural = 'Forums'
+        ordering = ['position_in_category', 'title']
 
     title = models.CharField('Titre', max_length=80)
     subtitle = models.CharField('Sous-titre', max_length=200)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #1822 |

Cette PR permet de positionner les forums et les catégories de forum en suivant la position marquée dans le back-end. Petite note tout de même, les forums privés sont mis après les forums publics pour éviter un double tri qui pourrait alterer les performances.

**Note pour QA**
- Chargez les fixtures `python manage.py loaddata fixtures/*.yaml`
- Allez dans la zone d'administration `/admin/` et connectez vous avec le login/password : admin/admin 
- Attribuer des positions à chaques forums et catégories de forum
- Vérifiez que : 
  - les forums et catégories sont triés par position
  - si jamais deux forums/catégories ont la même position, ils sont triés par titre du forum
