### PR TITLE
Mathjax ne s'exécute que dans le contenu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -627,6 +627,8 @@
                 inlineMath: [['$', '$']],
                 displayMath: [['$$','$$']],
                 processEscapes: true,
+                processClass: "message-content|article-content",
+                ignoreClass: "page-container"
             },
             TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js", "mhchem.js"] },
             messageStyle: "none",

--- a/templates/base_content_page.html
+++ b/templates/base_content_page.html
@@ -7,9 +7,11 @@
         <header>
             {% block headline %}{% endblock %}
         </header>
-        <section class="article-content" {% block article_centent_schema %}{% endblock %}>
-            {% block content %}{% endblock %}
-        </section>
+        {% block content_page %}
+            <section class="article-content" {% block article_centent_schema %}{% endblock %}>
+                {% block content %}{% endblock %}
+            </section>
+        {% endblock %}
         {% block content_after %}{% endblock %}
     </article>
     {% block content_ext %}{% endblock %}

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -138,7 +138,7 @@
 
     {% if profile.biography %}
         <hr class="clearfix" />
-        <section class="full-content-wrapper without-margin">
+        <section class="full-content-wrapper without-margin article-content">
             <h2 id="biographie">{% trans "Biographie" %}</h2>
             {{ profile.biography|emarkdown }}
         </section>

--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -22,7 +22,7 @@
 
 
 
-{% block content %}
+{% block content_page %}
     <table class="fullwidth">
         <thead>
             <th>{% trans "Type" %}</th>

--- a/templates/tutorial/tutorial/help.html
+++ b/templates/tutorial/tutorial/help.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 
-{% block content %}
+{% block content_page %}
     {% include "misc/pagination.part.html" with position="top" %}
 
     {% if tutorials %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2394 , #1817 |

Cette PR permet de n'appliquer l'interprétation de Mathjax que dans le contenu. Le contenu c'est un message dans le forum, une prévisualisation de texte, un texte d'article, un texte de tutoriel.

**Note pour QA**
- Faites tous les tests possible dans le but de faire interpreter une formule ailleurs que dans un contenu. Si vous n'y arrivez pas, c'est que la QA est positive.
