### PR TITLE
Empêche de créer du contenu vide sur les forums avec les balises Mathjax

### DIFF
--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -5,6 +5,7 @@ import re
 from django import forms
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.utils.html import strip_tags
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Layout, Field, Hidden
@@ -12,6 +13,7 @@ from crispy_forms.bootstrap import StrictButton
 from zds.forum.models import Forum, Topic, sub_tag, Tag
 from zds.utils.forms import CommonLayoutEditor
 from django.utils.translation import ugettext_lazy as _
+from zds.utils.templatetags.emarkdown import emarkdown
 
 
 class TopicForm(forms.Form):
@@ -139,7 +141,7 @@ class PostForm(forms.Form):
 
         text = cleaned_data.get('text')
 
-        if text is None or text.strip() == '':
+        if text is None or text.strip() == '' or strip_tags(emarkdown(text)).strip() == '':
             self._errors['text'] = self.error_class(
                 [_(u'Vous devez écrire une réponse !')])
             if 'text' in cleaned_data:

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -290,6 +290,18 @@ class ForumMemberTests(TestCase):
 
         self.assertEqual(result.status_code, 404)
 
+        # mathjax backdoor don't work
+        result = self.client.post(
+            reverse('zds.forum.views.answer') + '?sujet=' + str(topic1.pk),
+            {
+                'last_post': topic1.last_message.pk,
+                'text': u'C\'est tout simplement l\'histoire de la ville de Paris que je voudrais vous conter '
+            },
+            follow=False)
+
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.request["PATH_INFO"], reverse('zds.forum.views.answer'))
+
     def test_edit_main_post(self):
         """To test all aspects of the edition of main post by member."""
         topic1 = TopicFactory(forum=self.forum11, author=self.user)

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -299,7 +299,7 @@ class ForumMemberTests(TestCase):
             },
             follow=False)
 
-        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.status_code, 302)
         self.assertEqual(result.request["PATH_INFO"], reverse('zds.forum.views.answer'))
 
     def test_edit_main_post(self):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui |
| Nouvelle Fonctionnalité ? | [oui |
| Tickets (_issues_) concernés | #2245 |

Cette PR permet de corriger le bug qui fait qu'en saisissant du vide dans une balise mathjax on arrivait à créer du contenu vide à l'affichage.

**Note pour QA**
- Allez sur un topic et essayez de répondre à un message en saisissant la valeur `$    $`.
- Constatez le refus du système.
