### PR TITLE
Correction des parametres dans la doc de l'API

### DIFF
--- a/zds/member/api/views.py
+++ b/zds/member/api/views.py
@@ -276,11 +276,11 @@ class MemberDetailBan(CreateDestroyMemberSanctionAPIView):
               description: Bearer token to make a authenticated request.
               required: true
               paramType: header
-            - name: ls-jrs
+            - name: ban-jrs
               description: Number of days for the sanction.
               required: false
               paramType: form
-            - name: ls-text
+            - name: ban-text
               description: Description of the sanction.
               required: false
               paramType: form


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2294 |

Cette PR permet d'afficher les bons paramètres dans la doc de l'API visible depuis le site.

**Note pour QA**
- Allez sur le l'url `/api/#!/membres/Member_Detail_Ban` 
- Vérifiez que vous visualisez bien parmi les paramètres `ban-jrs` et `ban-text` au lieu de `ls-jrs` et de `ls-text`
