### PR TITLE
Correction des membres joignables par MP

### DIFF
--- a/zds/mp/commons.py
+++ b/zds/mp/commons.py
@@ -34,7 +34,7 @@ class ParticipantsValidator(Validator):
                         msg = _(u'Vous ne pouvez pas vous écrire à vous-même !')
                     try:
                         current = get_object_or_404(Profile, user__username=participant)
-                        if current.is_private():
+                        if not Profile.objects.contactable_members().filter(pk=current.pk).exists():
                             msg = _(u'Vous avez tenté d\'ajouter un utilisateur injoignable.')
                     except Http404:
                         msg = _(u'Un des participants saisi est introuvable')

--- a/zds/mp/tests/tests_forms.py
+++ b/zds/mp/tests/tests_forms.py
@@ -5,6 +5,8 @@ from django.test import TestCase
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.mp.forms import PrivateTopicForm, PrivatePostForm
 from zds.mp.factories import PrivateTopicFactory
+from zds.settings import ZDS_APP
+from django.contrib.auth.models import Group
 
 
 class PrivateTopicFormTest(TestCase):
@@ -13,6 +15,8 @@ class PrivateTopicFormTest(TestCase):
         self.profile1 = ProfileFactory()
         self.profile2 = ProfileFactory()
         self.staff1 = StaffProfileFactory()
+        bot = Group(name=ZDS_APP["member"]["bot_group"])
+        bot.save()
 
     def test_valid_topic_form(self):
         """  Reference valid case """

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -248,6 +248,8 @@ class NewTopicViewTest(TestCase):
     def setUp(self):
         self.profile1 = ProfileFactory()
         self.profile2 = ProfileFactory()
+        bot = Group(name=settings.ZDS_APP["member"]["bot_group"])
+        bot.save()
 
         login_check = self.client.login(
             username=self.profile1.user.username,
@@ -333,6 +335,26 @@ class NewTopicViewTest(TestCase):
             reverse('mp-new'),
             {
                 'participants': 'wronguser',
+                'title': 'title',
+                'subtitle': 'subtitle',
+                'text': 'text'
+            }
+        )
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(0, PrivateTopic.objects.all().count())
+
+    def test_fail_new_topic_user_no_active(self):
+
+        profile_inactive = ProfileFactory()
+        profile_inactive.user.is_active = False
+        profile_inactive.user.save()
+
+        self.assertEqual(0, PrivateTopic.objects.all().count())
+        response = self.client.post(
+            reverse('mp-new'),
+            {
+                'participants': u"{}".format(profile_inactive.user.username),
                 'title': 'title',
                 'subtitle': 'subtitle',
                 'text': 'text'


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2299 |

Cette PR permet d'éviter d'envoyer un MP à n'importe quel membre injoignable. Un membre injoignable est soit un membre banni, ou un bot.

**Note pour QA**
- Chargez les fixtures : `python manage.py loaddata fixtures/*.yaml`
- Faire une tentative d'inscriptions, sans toutefois valider le compte nouvellement crée.
- Essayez d'envoyer un MP au compte nouvellement crée (a lui seul ou avec d'autres participants)
- Constatez que le système refuse de vous laisser envoyer un MP a ce compte inactif
