### PR TITLE
Correction du design du sommaire des partie hors-ligne

### DIFF
--- a/templates/tutorial/part/view.html
+++ b/templates/tutorial/part/view.html
@@ -54,7 +54,7 @@
     <hr />
 
     {% if part.chapters %}
-        <ul>
+        <ol class="summary-part">
             {% for chapter in part.chapters %}
                 <li>
                     <h3>
@@ -62,7 +62,7 @@
                             {{ chapter.title }}
                         </a>
                     </h3>
-                    <ul>
+                    <ol class="summary-part">
                         {% for extract in chapter.extracts %}
                             <li>
                                 <h4>
@@ -78,16 +78,17 @@
                                 </h4>
                             </li>
                         {% endfor %}
-                    </ul>
+                    </ol>
                 </li>
             {% empty %}
                 <p class="ico-after warning">
                     {% trans "Il n'y a actuellement aucune partie dans ce tutoriel" %}.
                 </p>
             {% endfor %}
-        </ul>
+        </ol>
     {% endif %}
     
+    <hr class="clearfix" />
     <hr />
 
     {% if part.conclu and part.conclu != "None" %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2132 |

Cette PR permet de corriger l'incohérence dans l'affichage d'une partie entre la version hors ligne et la version online.

**Note pour QA**
- Créer ou importez (Irrlicht dans les fixtures) un big tuto 
- Publiez le tutoriel
- Constatez que l'affichage d'une partie du tutoriel en mode hors ligne est le même que l'affichage d'une partie du tutoriel en mode online.
