### PR TITLE
Possibilité d'ajouter un auteur pendant l'édition d'un article

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -394,7 +394,7 @@ def edit(request):
 
     form_js = ActivJsForm(initial={"js_support": article.js_support})
     return render(request, 'article/member/edit.html', {
-        'article': article, 'form': form, 'formJs': form_js
+        'article': article, 'form': form, 'formJs': form_js, 'authors': article.authors,
     })
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2106 |

Cette PR permet d'ajouter un auteur pendant l'édition d'un article.

**Note pour QA**
- Chargez les fixtures `python manage.py loaddata fixtures/*.yaml`
- Créez un article
- Cliquez dans la sidebar sur editer
- Cliquez dans la sidebar sur "Gérer les auteurs" et vérifiez que vous êtes bien seul
- Cliquez sur "ajouter un auteur" dans la sidebar et ajouter un utilisateur.

Si tout se passe bien, c'est que la PR fait le job.
