### PR TITLE
Encodage du pseudo des membres

### DIFF
--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db import models
 from hashlib import md5
 from django.http import HttpRequest
+from django.utils.http import urlquote
 from django.contrib.sessions.models import Session
 from django.contrib.auth import logout
 import os
@@ -103,8 +104,7 @@ class Profile(models.Model):
 
     def get_absolute_url(self):
         """Absolute URL to the profile page."""
-        return reverse('member-detail',
-                       kwargs={'user_name': self.user.username})
+        return reverse('member-detail', kwargs={'user_name': urlquote(self.user.username)})
 
     def get_city(self):
         """return physical adress by geolocalisation."""

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -115,6 +115,36 @@ class MemberTests(TestCase):
         )
         self.assertEqual(result.status_code, 404)
 
+    def test_profile_page_of_weird_member_username(self):
+
+        # create some user with weird username
+        user_1 = ProfileFactory()
+        user_2 = ProfileFactory()
+        user_3 = ProfileFactory()
+        user_1.user.username = u"ïtrema"
+        user_1.user.save()
+        user_2.user.username = u"&#34;a"
+        user_2.user.save()
+        user_3.user.username = u"_`_`_`_"
+        user_3.user.save()
+
+        # profile pages of weird users.
+        result = self.client.get(
+            reverse('member-detail', args=[user_1.user.username]),
+            follow=True
+        )
+        self.assertEqual(result.status_code, 200)
+        result = self.client.get(
+            reverse('member-detail', args=[user_2.user.username]),
+            follow=True
+        )
+        self.assertEqual(result.status_code, 200)
+        result = self.client.get(
+            reverse('member-detail', args=[user_3.user.username]),
+            follow=True
+        )
+        self.assertEqual(result.status_code, 200)
+
     def test_modify_member(self):
 
         # we need staff right for update other profile


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2301 |

Cette PR permet de corriger un problème d'encodage afin de visualiser la page profile des membres dont le pseudo contient le caractère "?" ou le caractère "#".

**Note pour QA**
- Créez un utilisateur dont le pseudo contient le cacractère "?" et un autre utilisateur dont le pseudo contient le caractère "&".
- Consultez la page profile de ces membres : `/membres/voir/<pseudo>`

Si vous n'avez pas de 404 là dessus, c'est que la PR fait le job.

PS : il faudra que je squash avant le merge, mais la QA peut travailler.
