### PR TITLE
La mise à jour d'un tutoriel en beta n'efface plus le premier post

### DIFF
--- a/doc/source/back-end/tutorial.rst
+++ b/doc/source/back-end/tutorial.rst
@@ -231,7 +231,7 @@ en bêta, en postant le lien vers la version bêta du tutoriel.
 
 .. attention::
 
-    Le lien de la bêta, peut être trouvé via votre profil utilisateur, vous devez recopier tout le lien avec la partie ``?version=blablabla``. Et pensez bien à modifier ce lien lorsque vous mettez à jour votre version bêta.
+    Le lien de la bêta, peut être trouvé via votre profil utilisateur, et est sous la forme ``/tutoriels/beta/<id>/<slug>``. Le lien est aussi disponible via ``/tutoriel/off/<id>/<slug>/?version=sha``. Seule la première forme doit etre donnée au public.
 
 En fait lorsqu'un tutoriel est en mode bêta, il s'agit d'une version précise qui est mise
 dans ce mode. On peut continuer à mettre à jour la version brouillon pour rajouter de nouveaux chapitres

--- a/robots.txt
+++ b/robots.txt
@@ -5,4 +5,5 @@ Sitemap: http://zestedesavoir.com/sitemap.xml
 User-agent: *
 Disallow: /mp/
 Disallow: /tutoriels/off/
+Disallow: /tutoriels/beta/
 Disallow: /articles/off/

--- a/templates/tutorial/part/view.html
+++ b/templates/tutorial/part/view.html
@@ -205,5 +205,5 @@
 
 
 {% block sidebar_blocks %}
-    {% include "tutorial/includes/summary.part.html" with parts=tutorial.parts %}
+    {% include "tutorial/includes/summary.part.html" with tutorial=tutorial parts=tutorial.parts %}
 {% endblock %}

--- a/templates/tutorial/part/view_online.html
+++ b/templates/tutorial/part/view_online.html
@@ -74,7 +74,7 @@
         </div>
     {% endif %}
 
-    {% include "tutorial/includes/summary.part.html" with online=True parts=tutorial.parts %}
+    {% include "tutorial/includes/summary.part.html" with online=True tutorial=tutorial parts=tutorial.parts %}
 
     {% include "misc/social_buttons.part.html" with link=part.tutorial.get_absolute_url_online text=part.tutorial.title %}
 {% endblock %}

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -135,9 +135,9 @@ class Tutorial(models.Model):
 
     def get_absolute_url_beta(self):
         if self.sha_beta is not None:
-            return reverse('zds.tutorial.views.view_tutorial', args=[
+            return reverse('zds.tutorial.views.view_tutorial_beta', args=[
                 self.pk, slugify(self.title)
-            ]) + '?version=' + self.sha_beta
+            ])
         else:
             return self.get_absolute_url()
 
@@ -234,9 +234,8 @@ class Tutorial(models.Model):
 
         if self.in_beta():
             mandata['get_absolute_url_beta'] = reverse(
-                'zds.tutorial.views.view_tutorial',
-                args=[self.pk, mandata['slug']]
-            ) + '?version=' + self.sha_beta
+                'zds.tutorial.views.view_tutorial_beta',
+                args=[self.pk, mandata['slug']])
 
         else:
             mandata['get_absolute_url_beta'] = reverse(
@@ -591,6 +590,14 @@ class Part(models.Model):
             self.slug,
         ])
 
+    def get_absolute_url_beta(self):
+        return reverse('zds.tutorial.views.view_part_beta', args=[
+            self.tutorial.pk,
+            self.tutorial.slug,
+            self.pk,
+            self.slug,
+        ])
+
     def get_absolute_url_online(self):
         return reverse('zds.tutorial.views.view_part_online', args=[
             self.tutorial.pk,
@@ -756,6 +763,12 @@ class Chapter(models.Model):
 
         else:
             return reverse('zds.tutorial.views.index')
+
+    def get_absolute_url_beta(self):
+        if self.tutorial:
+            return self.tutorial.get_absolute_url_beta()
+        elif self.part:
+            return self.part.get_absolute_url_beta() + '{0}/{1}/'.format(self.pk, self.slug)
 
     def get_absolute_url_online(self):
         if self.tutorial:
@@ -964,6 +977,13 @@ class Extract(models.Model):
     def get_absolute_url(self):
         return '{0}#{1}-{2}'.format(
             self.chapter.get_absolute_url(),
+            self.position_in_chapter,
+            slugify(self.title)
+        )
+
+    def get_absolute_url_beta(self):
+        return '{0}#{1}-{2}'.format(
+            self.chapter.get_absolute_url_beta(),
             self.position_in_chapter,
             slugify(self.title)
         )

--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -2208,11 +2208,10 @@ class BigTutorialTests(TestCase):
             follow=False
         )
         self.assertEqual(302, response.status_code)
-        old_url = url
         url = Tutorial.objects.get(pk=self.bigtuto.pk).get_absolute_url_beta()
         # test access to new beta url (get 200) :
         self.assertEqual(
-            self.client.get(old_url).status_code,
+            self.client.get(url).status_code,
             200)
         # test access for random user to new url (get 200) and old (get 403)
         self.assertEqual(
@@ -2223,9 +2222,6 @@ class BigTutorialTests(TestCase):
         self.assertEqual(
             self.client.get(url).status_code,
             200)
-        self.assertEqual(
-            self.client.get(old_url).status_code,
-            403)
 
         # then desactive beta :
         self.assertEqual(
@@ -2919,7 +2915,7 @@ class BigTutorialTests(TestCase):
         sent_pm = PrivateTopic.objects.filter(author=self.user.pk).last()
         self.assertIn(self.user_author, sent_pm.participants.all())  # author is in participants
         self.assertIn(typo_text, sent_pm.last_message.text)  # typo is in message
-        self.assertIn(Chapter.objects.get(pk=self.chapter1_1.pk).get_absolute_url() + '?version=' + sha_beta,
+        self.assertIn(Chapter.objects.get(pk=self.chapter1_1.pk).get_absolute_url_beta(),
                       sent_pm.last_message.text)  # public url is in message
 
     def tearDown(self):
@@ -3900,11 +3896,10 @@ class MiniTutorialTests(TestCase):
             follow=False
         )
         self.assertEqual(302, response.status_code)
-        old_url = url
         url = Tutorial.objects.get(pk=self.minituto.pk).get_absolute_url_beta()
         # test access to new beta url (get 200) :
         self.assertEqual(
-            self.client.get(old_url).status_code,
+            self.client.get(url).status_code,
             200)
         # test access for random user to new url (get 200) and old (get 403)
         self.assertEqual(
@@ -3915,9 +3910,6 @@ class MiniTutorialTests(TestCase):
         self.assertEqual(
             self.client.get(url).status_code,
             200)
-        self.assertEqual(
-            self.client.get(old_url).status_code,
-            403)
 
         # then desactive beta :
         self.assertEqual(

--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -1456,25 +1456,25 @@ class BigTutorialTests(TestCase):
         # deleted part and section HAVE TO be accessible on beta (get 200)
         result = self.client.get(
             reverse(
-                'zds.tutorial.views.view_part',
+                'zds.tutorial.views.view_part_beta',
                 args=[
                     tuto.pk,
                     tuto.slug,
                     p1.pk,
-                    p1.slug]) + '?version={}'.format(sha_beta),
+                    p1.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
 
         result = self.client.get(
             reverse(
-                'zds.tutorial.views.view_chapter',
+                'zds.tutorial.views.view_chapter_beta',
                 args=[
                     tuto.pk,
                     tuto.slug,
                     p2.pk,
                     p2.slug,
                     c3.pk,
-                    c3.slug]) + '?version={}'.format(sha_beta),
+                    c3.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
 
@@ -1587,25 +1587,25 @@ class BigTutorialTests(TestCase):
         # deleted part and section still accessible on beta (get 200)
         result = self.client.get(
             reverse(
-                'zds.tutorial.views.view_part',
+                'zds.tutorial.views.view_part_beta',
                 args=[
                     tuto.pk,
                     tuto.slug,
                     p1.pk,
-                    p1.slug]) + '?version={}'.format(sha_beta),
+                    p1.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
 
         result = self.client.get(
             reverse(
-                'zds.tutorial.views.view_chapter',
+                'zds.tutorial.views.view_chapter_beta',
                 args=[
                     tuto.pk,
                     tuto.slug,
                     p2.pk,
                     p2.slug,
                     c3.pk,
-                    c3.slug]) + '?version={}'.format(sha_beta),
+                    c3.slug]),
             follow=True)
         self.assertEqual(result.status_code, 200)
 

--- a/zds/tutorial/urls.py
+++ b/zds/tutorial/urls.py
@@ -25,6 +25,18 @@ urlpatterns = patterns('',
                        url(r'^off/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/$',
                            'zds.tutorial.views.view_tutorial'),
 
+                       # Beta URLs
+                       url(r'^beta/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/(?P<part_pk>\d+)/(?P<part_slug>.+)/(?P<chapter_pk>\d+)/(?P<chapter_slug>.+)/$',
+                           'zds.tutorial.views.view_chapter_beta',
+                           name="view-chapter-url-beta"),
+
+                       url(r'^beta/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/(?P<part_pk>\d+)/(?P<part_slug>.+)/$',
+                           'zds.tutorial.views.view_part_beta',
+                           name="view-part-url-beta"),
+
+                       url(r'^beta/(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/$',
+                           'zds.tutorial.views.view_tutorial_beta'),
+
                        # View online
                        url(r'^(?P<tutorial_pk>\d+)/(?P<tutorial_slug>.+)/(?P<part_pk>\d+)/(?P<part_slug>.+)/(?P<chapter_pk>\d+)/(?P<chapter_slug>.+)/$',
                            'zds.tutorial.views.view_chapter_online',

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -669,7 +669,7 @@ def modify_tutorial(request):
             )
 
             return redirect(redirect_url)
-        elif "activ_beta" in request.POST:
+        elif ("activ_beta" in request.POST) or ("update_beta" in request.POST):
             if "version" in request.POST:
                 tutorial.sha_beta = request.POST['version']
                 tutorial.save()
@@ -688,7 +688,6 @@ def modify_tutorial(request):
                            settings.ZDS_APP['site']['url'] + tutorial.get_absolute_url_beta()))
                 if topic is None:
                     forum = get_object_or_404(Forum, pk=settings.ZDS_APP['forum']['beta_forum_id'])
-
                     create_topic(author=request.user,
                                  forum=forum,
                                  title=_(u"[beta][tutoriel]{0}").format(tutorial.title),
@@ -696,81 +695,50 @@ def modify_tutorial(request):
                                  text=msg,
                                  key=tutorial.pk
                                  )
-                    tp = Topic.objects.get(key=tutorial.pk)
-                    bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
-                    private_mp = \
-                        (_(u'Bonjour {},\n\n'
-                           u'Vous venez de mettre votre tutoriel **{}** en beta. La communauté '
-                           u'pourra le consulter afin de vous faire des retours '
-                           u'constructifs avant sa soumission en validation.\n\n'
-                           u'Un sujet dédié pour la beta de votre tutoriel a été '
-                           u'crée dans le forum et est accessible [ici]({})').format(
-                               request.user.username,
-                               tutorial.title,
-                               settings.ZDS_APP['site']['url'] + tp.get_absolute_url()))
-                    send_mp(
-                        bot,
-                        [request.user],
-                        _(u"Tutoriel en beta : {0}").format(tutorial.title),
-                        "",
-                        private_mp,
-                        False,
-                    )
+                    if "activ_beta" in request.POST:
+                        tp = Topic.objects.get(key=tutorial.pk)
+                        bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
+                        private_mp = \
+                            (_(u'Bonjour {},\n\n'
+                               u'Vous venez de mettre votre tutoriel **{}** en beta. La communauté '
+                               u'pourra le consulter afin de vous faire des retours '
+                               u'constructifs avant sa soumission en validation.\n\n'
+                               u'Un sujet dédié pour la beta de votre tutoriel a été '
+                               u'crée dans le forum et est accessible [ici]({})').format(
+                                   request.user.username,
+                                   tutorial.title,
+                                   settings.ZDS_APP['site']['url'] + tp.get_absolute_url()))
+                        send_mp(
+                            bot,
+                            [request.user],
+                            _(u"Tutoriel en beta : {0}").format(tutorial.title),
+                            "",
+                            private_mp,
+                            False,
+                        )
                 else:
-                    msg_up = \
-                        (_(u'Bonjour,\n\n'
-                           u'La beta du tutoriel est de nouveau active.'
-                           u'\n\n-> [Lien de la beta du tutoriel : {0}]({1}) <-\n\n'
-                           u'\n\nMerci pour vos relectures').format(tutorial.title,
-                                                                    settings.ZDS_APP['site']['url'] +
-                                                                    tutorial.get_absolute_url_beta()))
-                    unlock_topic(topic, msg)
+                    if "activ_beta" in request.POST:
+                        msg_up = \
+                            (_(u'Bonjour,\n\n'
+                               u'La beta du tutoriel est de nouveau active.'
+                               u'\n\n-> [Lien de la beta du tutoriel : {0}]({1}) <-\n\n'
+                               u'\n\nMerci pour vos relectures').format(tutorial.title,
+                                                                        settings.ZDS_APP['site']['url'] +
+                                                                        tutorial.get_absolute_url_beta()))
+                        messages.success(request, _(u"La BETA sur ce tutoriel est bien activée."))
+                    elif "update_beta" in request.POST:
+                        msg_up = \
+                            (_(u'Bonjour à tous !\n\n'
+                               u'La beta du tutoriel a été mise à jour.'
+                               u'\n\n-> [Lien de la beta du tutoriel : {0}]({1}) <-\n\n'
+                               u'\n\nMerci pour vos relectures').format(tutorial.title,
+                                                                        settings.ZDS_APP['site']['url'] +
+                                                                        tutorial.get_absolute_url_beta()))
+                        messages.success(request, _(u"La BETA sur ce tutoriel a bien été mise à jour."))
+                    unlock_topic(topic)
                     send_post(topic, msg_up)
-
-                messages.success(request, _(u"La BETA sur ce tutoriel est bien activée."))
             else:
                 messages.error(request, _(u"La BETA sur ce tutoriel n'a malheureusement pas pu être activée."))
-            return redirect(tutorial.get_absolute_url_beta())
-        elif "update_beta" in request.POST:
-            if "version" in request.POST:
-                tutorial.sha_beta = request.POST['version']
-                tutorial.save()
-                topic = Topic.objects.filter(key=tutorial.pk,
-                                             forum__pk=settings.ZDS_APP['forum']['beta_forum_id']).first()
-                msg = \
-                    (_(u'Bonjour à tous,\n\n'
-                       u'J\'ai commencé ({0}) la rédaction d\'un tutoriel dont l\'intitulé est **{1}**.\n\n'
-                       u'J\'aimerai obtenir un maximum de retour sur celui-ci, sur le fond ainsi que '
-                       u'sur la forme, afin de proposer en validation un texte de qualité.'
-                       u'\n\nSi vous êtes intéressé, cliquez ci-dessous '
-                       u'\n\n-> [Lien de la beta du tutoriel : {1}]({2}) <-\n\n'
-                       u'\n\nMerci d\'avance pour votre aide').format(
-                           naturaltime(tutorial.create_at),
-                           tutorial.title,
-                           settings.ZDS_APP['site']['url'] + tutorial.get_absolute_url_beta()))
-                if topic is None:
-                    forum = get_object_or_404(Forum, pk=settings.ZDS_APP['forum']['beta_forum_id'])
-
-                    create_topic(author=request.user,
-                                 forum=forum,
-                                 title=u"[beta][tutoriel]{0}".format(tutorial.title),
-                                 subtitle=u"{}".format(tutorial.description),
-                                 text=msg,
-                                 key=tutorial.pk
-                                 )
-                else:
-                    msg_up = \
-                        (_(u'Bonjour à tous !\n\n'
-                           u'La beta du tutoriel a été mise à jour.'
-                           u'\n\n-> [Lien de la beta du tutoriel : {0}]({1}) <-\n\n'
-                           u'\n\nMerci pour vos relectures').format(tutorial.title,
-                                                                    settings.ZDS_APP['site']['url'] +
-                                                                    tutorial.get_absolute_url_beta()))
-                    unlock_topic(topic, msg)
-                    send_post(topic, msg_up)
-                messages.success(request, _(u"La BETA sur ce tutoriel a bien été mise à jour."))
-            else:
-                messages.error(request, _(u"La BETA sur ce tutoriel n'a malheureusement pas pu être mise à jour."))
             return redirect(tutorial.get_absolute_url_beta())
         elif "desactiv_beta" in request.POST:
             tutorial.sha_beta = None
@@ -787,15 +755,11 @@ def modify_tutorial(request):
             return redirect(tutorial.get_absolute_url())
 
     # No action performed, raise 403
-
     raise PermissionDenied
 
 
-# Tutorials.
-
-
 @login_required
-def view_tutorial(request, tutorial_pk, tutorial_slug):
+def view_tutorial(request, tutorial_pk, tutorial_slug, sha=None):
     """Show the given offline tutorial if exists."""
 
     tutorial = get_object_or_404(Tutorial, pk=tutorial_pk)
@@ -809,6 +773,9 @@ def view_tutorial(request, tutorial_pk, tutorial_slug):
         sha = tutorial.sha_draft
 
     is_beta = sha == tutorial.sha_beta and tutorial.in_beta()
+
+    if request.path.startswith("/tutoriels/off") and is_beta:
+        return redirect(tutorial.get_absolute_url_beta())
 
     # Only authors of the tutorial and staff can view tutorial in offline.
 
@@ -909,6 +876,12 @@ def view_tutorial(request, tutorial_pk, tutorial_slug):
         "formReject": form_reject,
         "is_js": is_js
     })
+
+
+@login_required
+def view_tutorial_beta(request, tutorial_pk, tutorial_slug):
+    tutorial = get_object_or_404(Tutorial, pk=tutorial_pk)
+    return view_tutorial(request, tutorial_pk, tutorial_slug, sha=tutorial.sha_beta)
 
 
 def view_tutorial_online(request, tutorial_pk, tutorial_slug):
@@ -1287,6 +1260,7 @@ def view_part(
     tutorial_slug,
     part_pk,
     part_slug,
+    sha=None,
 ):
     """Display a part."""
 
@@ -1297,6 +1271,10 @@ def view_part(
         sha = tutorial.sha_draft
 
     is_beta = sha == tutorial.sha_beta and tutorial.in_beta()
+
+    if request.path.startswith("/tutoriels/off") and is_beta:
+        part = get_object_or_404(Part, pk=part_pk)
+        return redirect(part.get_absolute_url_beta())
 
     # Only authors of the tutorial and staff can view tutorial in offline.
 
@@ -1358,6 +1336,18 @@ def view_part(
                             "part": final_part,
                             "version": sha,
                             "is_js": is_js})
+
+
+@login_required
+def view_part_beta(
+    request,
+    tutorial_pk,
+    tutorial_slug,
+    part_pk,
+    part_slug,
+):
+    tutorial = get_object_or_404(Tutorial, pk=tutorial_pk)
+    return view_part(request, tutorial_pk, tutorial_slug, part_pk, part_slug, sha=tutorial.sha_beta)
 
 
 def view_part_online(
@@ -1631,6 +1621,7 @@ def view_chapter(
     part_slug,
     chapter_pk,
     chapter_slug,
+    sha=None,
 ):
     """View chapter."""
 
@@ -1642,6 +1633,10 @@ def view_chapter(
         sha = tutorial.sha_draft
 
     is_beta = sha == tutorial.sha_beta and tutorial.in_beta()
+
+    if request.path.startswith("/tutoriels/off") and is_beta:
+        chapter = get_object_or_404(Chapter, pk=chapter_pk)
+        return redirect(chapter.get_absolute_url_beta())
 
     # Only authors of the tutorial and staff can view tutorial in offline.
 
@@ -1724,6 +1719,27 @@ def view_chapter(
         "version": sha,
         "is_js": is_js
     })
+
+
+@login_required
+def view_chapter_beta(
+    request,
+    tutorial_pk,
+    tutorial_slug,
+    part_pk,
+    part_slug,
+    chapter_pk,
+    chapter_slug,
+):
+    tutorial = get_object_or_404(Tutorial, pk=tutorial_pk)
+    return view_chapter(request,
+                        tutorial_pk,
+                        tutorial_slug,
+                        part_pk,
+                        part_slug,
+                        chapter_pk,
+                        chapter_slug,
+                        sha=tutorial.sha_beta)
 
 
 def view_chapter_online(
@@ -3726,12 +3742,10 @@ def warn_typo(request, obj_type, obj_pk):
                         msg += _(u'La correction concerne le chapitre [{}]({}) de la partie [{}]({}).\n\n').format(
                             chapter.title,
                             settings.ZDS_APP['site']['url'] +
-                            chapter.get_absolute_url() +
-                            '?version=' + tutorial.sha_beta,
+                            chapter.get_absolute_url_beta(),
                             chapter.part.title,
                             settings.ZDS_APP['site']['url'] +
-                            chapter.part.get_absolute_url() +
-                            '?version=' + tutorial.sha_beta
+                            chapter.part.get_absolute_url_beta()
                         )
 
                 msg += _(u'Voici son message :\n\n{}').format(explanation)
@@ -3755,7 +3769,7 @@ def warn_typo(request, obj_type, obj_pk):
         if is_on_line:
             return redirect(chapter.get_absolute_url_online())
         elif is_beta:
-            return redirect(chapter.get_absolute_url() + '?version=' + tutorial.sha_beta)
+            return redirect(chapter.get_absolute_url_beta())
 
 
 def help_tutorial(request):

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -767,10 +767,11 @@ def view_tutorial(request, tutorial_pk, tutorial_slug, sha=None):
     # Retrieve sha given by the user. This sha must to be exist. If it doesn't
     # exist, we take draft version of the article.
 
-    try:
-        sha = request.GET["version"]
-    except KeyError:
-        sha = tutorial.sha_draft
+    if sha is None:
+        try:
+            sha = request.GET["version"]
+        except KeyError:
+            sha = tutorial.sha_draft
 
     is_beta = sha == tutorial.sha_beta and tutorial.in_beta()
 
@@ -1265,16 +1266,13 @@ def view_part(
     """Display a part."""
 
     tutorial = get_object_or_404(Tutorial, pk=tutorial_pk)
-    try:
-        sha = request.GET["version"]
-    except KeyError:
-        sha = tutorial.sha_draft
+    if sha is None:
+        try:
+            sha = request.GET["version"]
+        except KeyError:
+            sha = tutorial.sha_draft
 
     is_beta = sha == tutorial.sha_beta and tutorial.in_beta()
-
-    if request.path.startswith("/tutoriels/off") and is_beta:
-        part = get_object_or_404(Part, pk=part_pk)
-        return redirect(part.get_absolute_url_beta())
 
     # Only authors of the tutorial and staff can view tutorial in offline.
 
@@ -1320,6 +1318,12 @@ def view_part(
             part["intro"] = get_blob(repo.commit(sha).tree, part["introduction"])
             part["conclu"] = get_blob(repo.commit(sha).tree, part["conclusion"])
             final_part = part
+            if request.path.startswith("/tutoriels/off") and is_beta:
+                return redirect(reverse('zds.tutorial.views.view_part_beta', args=[
+                    tutorial_pk,
+                    tutorial_slug,
+                    part_pk,
+                    part_slug]))
         cpt_p += 1
 
     # if part can't find
@@ -1627,16 +1631,13 @@ def view_chapter(
 
     tutorial = get_object_or_404(Tutorial, pk=tutorial_pk)
 
-    try:
-        sha = request.GET["version"]
-    except KeyError:
-        sha = tutorial.sha_draft
+    if sha is None:
+        try:
+            sha = request.GET["version"]
+        except KeyError:
+            sha = tutorial.sha_draft
 
     is_beta = sha == tutorial.sha_beta and tutorial.in_beta()
-
-    if request.path.startswith("/tutoriels/off") and is_beta:
-        chapter = get_object_or_404(Chapter, pk=chapter_pk)
-        return redirect(chapter.get_absolute_url_beta())
 
     # Only authors of the tutorial and staff can view tutorial in offline.
 
@@ -1696,6 +1697,15 @@ def view_chapter(
             if chapter_pk == str(chapter["pk"]):
                 final_chapter = chapter
                 final_position = len(chapter_tab) - 1
+
+                if request.path.startswith("/tutoriels/off") and is_beta:
+                    return redirect(reverse('zds.tutorial.views.view_chapter_beta', args=[
+                        tutorial_pk,
+                        tutorial_slug,
+                        part_pk,
+                        part_slug,
+                        chapter_pk,
+                        chapter_slug]))
             cpt_c += 1
         cpt_p += 1
 

--- a/zds/utils/forums.py
+++ b/zds/utils/forums.py
@@ -67,12 +67,6 @@ def lock_topic(topic):
     topic.save()
 
 
-def unlock_topic(topic, msg):
+def unlock_topic(topic):
     topic.is_locked = False
-    main = Post.objects.filter(topic__pk=topic.pk, position=1).first()
-    main.text = msg
-    main.text_html = emarkdown(msg)
-    main.editor = topic.author
-    main.update = datetime.now()
-    main.save()
     topic.save()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | ~presque |
| Tickets (_issues_) concernés | #1607 |

Cette PR corrige un bug certes, mais pour cela, elle introduit un principe qui s'apparente à une nouvelle fonctionnalité. Donc, à voir si la façon de faire vous va.
La PR corrige le problème qui fait qu'à chaque mise à jour de la beta d'un tutoriel le premier post du topic de beta est écrasé. Jusqu'ici le premier post était écrasé pour mettre à jour le nouveau lien de beta qui changeait à chaque nouvelle version. La PR corrige donc ce problème en mettant à disposition une url unique pour un tutoriel en beta.
Le lien de la beta d'un tutoriel est désormais unique et sous la forme `/tutoriels/beta/<id>/<slug>`.

Voila un résumé de la PR.

**Note pour QA**
- Créez ou importez un tutoriel
- Activez la beta du tutoriel, vérifiez que tout est en place (le topic de beta crée, lien de beta accessible pour tous les membres)
- Désactivez la beta du tutoriel, vérifiez que tout est en place (tuto toujours accessible à l'auteur, lien de la beta posté sur le topic redirigeant vers une 403)
- Réactivez la beta du tutoriel, et vérifiez aussi.

Faites ces manipulations aussi avec un tutoriel publié, et en postant sur le topic de beta entre deux activation/désactivation ... bref, testez les _corners cases_.

Si vous ne voyez rien de choquant, c'est positif.

**PS** : avant de merger, assurez vous que j'ai fais un squash avant.
