### PR TITLE
Intediction de sanction des bots

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -80,7 +80,7 @@
             {% endif %}
         </ul>
 
-        {% if perms.member.change_profile %}
+        {% if perms.member.change_profile and not profile.is_private %}
             <div>
                 {% trans "Remarques sur cet utilisateur" %} ({{ profile.karma }}) :
                 <ul>
@@ -451,6 +451,7 @@
                 </li>
             </ul>
 
+            {% if not profile.is_private %}
             <h4>{% trans "Sanctions" %}</h4>
             <ul>
                 {% if profile.can_write_now %}
@@ -559,6 +560,7 @@
                     </li>
                 {% endif %}
             </ul>
+            {% endif %}
         </div>
     {% endif %}
 {% endblock %}

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -366,6 +366,8 @@ def modify_profile(request, user_pk):
     """Modifies sanction of a user if there is a POST request."""
 
     profile = get_object_or_404(Profile, user__pk=user_pk)
+    if profile.is_private():
+        raise PermissionDenied
 
     if 'ls' in request.POST:
         state = ReadingOnlySanction(request.POST)
@@ -1005,30 +1007,34 @@ def member_from_ip(request, ip):
 
 
 @login_required
+@require_POST
 def modify_karma(request):
     """ Add a Karma note to the user profile """
 
     if not request.user.has_perm("member.change_profile"):
         raise PermissionDenied
 
-    if request.method == "POST":
+    try:
         profile_pk = request.POST["profile_pk"]
-        profile = get_object_or_404(Profile, pk=profile_pk)
-
-        note = KarmaNote()
-        note.user = profile.user
-        note.staff = request.user
-        note.comment = request.POST["warning"]
-        try:
-            note.value = int(request.POST["points"])
-        except (KeyError, ValueError):
-            note.value = 0
-
-        note.save()
-
-        profile.karma += note.value
-        profile.save()
-
-        return redirect(reverse("member-detail", args=[profile.user.username]))
-    else:
+    except (KeyError, ValueError):
         raise Http404
+
+    profile = get_object_or_404(Profile, pk=profile_pk)
+    if profile.is_private():
+        raise PermissionDenied
+
+    note = KarmaNote()
+    note.user = profile.user
+    note.staff = request.user
+    note.comment = request.POST["warning"]
+    try:
+        note.value = int(request.POST["points"])
+    except (KeyError, ValueError):
+        note.value = 0
+
+    note.save()
+
+    profile.karma += note.value
+    profile.save()
+
+    return redirect(reverse("member-detail", args=[profile.user.username]))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2074 |

Cette PR permet d'interdire de sanctionner un bot (anonyme, externe, etc.)

**Note pour QA**
- Créez un compte appartenant au groupe bot
- Allez sur sa page de profil
- Essayez de sanctionner ce dernier (ls, ban, etc.)
- Si vous n'arrivez pas, c'est que la PR fait le job.

**PS** : un squash sera necessaire avant le merge.
