### PR TITLE
Fix mathjax in markdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.7.0
 gitpython==0.3.5
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.4.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.5.zip
 easy-thumbnails==2.2
 
 # Api dependencies


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2419 |

Devrait fixer le bug avec tous les mathjax inline passés en non-inline. En fait c'est drôle qu'on ai pas eu le bug avant :-°

QA : vérifier que des codes types `Avec $U$ le potentiel, défini par $\sum_i K\,(\theta-\theta_i)$` sont bien rendu inline.
