### PR TITLE
Force l'HTTPS pour les utilisateurs connectés et la page de connexion

### DIFF
--- a/update.md
+++ b/update.md
@@ -265,8 +265,8 @@ Issues #2718, #2658 et #2615
 
 Si le fichier `zds-maintenance` n'est pas dans la doc, c'est que vous n'êtes pas sur la bonne version.
 
-Actions à faire pour mettre en prod la prochaine version
-========================================================
+Actions à faire pour mettre en prod la version : v15.7
+======================================================
 
 Issue #2401
 -----------
@@ -280,6 +280,8 @@ La recherche est maintenant en français:
   - Redémarrer Solr : `supervisorctl start solr`
   - Lancer l'indexation : `python manage.py rebuild_index`
 
+Actions à faire pour mettre en prod la version : v15.9
+======================================================
 
 ZEP-12 aka Apocalypse
 ---------------------
@@ -332,3 +334,16 @@ et de les écarter temporairement (en les déplacant dans un autre dossier), afi
     - `tutorialv2 | Contenu | Can change Contenu` (`tutorialv2.change_publishablecontent`) pour le droit au staff d'accéder et de modifier les contenus
     - `tutorialv2 | Validation | Can change Validation` (`tutorialv2.change_validation`) pour le droit au staff de valider des contenus
     - `tutorialv2 | note sur un contenu | Can change note sur un contenu` (`tutorialv2.change_contentreaction`) pour le droit au staff de modérer les commentaires sur les contenus
+
+Actions à faire pour mettre en prod la prochaine version
+========================================================
+
+#1376 - Forcer l'HTTPS pour les membres connectés
+-------------------------------------------------
+
+Dans le `settings_prod.py`, rajouter deux lignes :
+
+```py
+FORCE_HTTPS_FOR_MEMBERS = True
+ENABLE_HTTPS_DECORATOR = True
+```

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -38,6 +38,7 @@ from zds.member.decorator import can_write_and_read_now
 from zds.member.commons import ProfileCreate, TemporaryReadingOnlySanction, ReadingOnlySanction, \
     DeleteReadingOnlySanction, TemporaryBanSanction, BanSanction, DeleteBanSanction, TokenGenerator
 from zds.mp.models import PrivatePost, PrivateTopic
+from zds.utils.decorators import https_required
 from zds.utils.mps import send_mp
 from zds.utils.paginator import ZdSPagingListView
 from zds.utils.tokens import generate_token
@@ -230,6 +231,10 @@ class RegisterView(CreateView, ProfileCreate, TokenGenerator):
 
     form_class = RegisterForm
     template_name = 'member/register/index.html'
+
+    @method_decorator(https_required)
+    def dispatch(self, *args, **kwargs):
+        return super(RegisterView, self).dispatch(*args, **kwargs)
 
     def get_object(self, queryset=None):
         return get_object_or_404(Profile, user=self.request.user)
@@ -603,6 +608,7 @@ def settings_mini_profile(request, user_name):
         return render(request, "member/settings/profile.html", data)
 
 
+@https_required
 def login_view(request):
     """Log in user."""
 
@@ -675,6 +681,7 @@ def logout_view(request):
     return redirect(reverse("zds.pages.views.home"))
 
 
+@https_required
 def forgot_password(request):
     """If the user forgot his password, he can have a new one."""
 
@@ -727,6 +734,7 @@ def forgot_password(request):
     return render(request, "member/forgot_password/index.html", {"form": form})
 
 
+@https_required
 def new_password(request):
     """Create a new password for a user."""
 
@@ -754,6 +762,7 @@ def new_password(request):
     return render(request, "member/new_password/index.html", {"form": form})
 
 
+@https_required
 def active_account(request):
     """Active token for a user."""
 
@@ -828,6 +837,7 @@ def active_account(request):
     return render(request, "member/register/token_success.html", {"usr": usr, "form": form})
 
 
+@https_required
 def generate_token_account(request):
     """Generate token for account."""
 

--- a/zds/middlewares/ForceHttpsMembersMiddleware.py
+++ b/zds/middlewares/ForceHttpsMembersMiddleware.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.http import HttpResponseRedirect
+
+
+class ForceHttpsMembersMiddleware(object):
+    """
+    Check if the middleware is enabled, the request is unsecured, the user is authenticated and redirect the user
+    in HTTPS.
+    """
+
+    def process_request(self, request):
+        if getattr(settings, 'FORCE_HTTPS_FOR_MEMBERS', False) and not request.is_secure():
+            if request.user.is_authenticated():
+                # Code from http://www.redrobotstudios.com/blog/2009/02/18/securing-django-with-ssl/
+                request_url = request.build_absolute_uri(request.get_full_path())
+                secure_url = request_url.replace('http://', 'https://')
+                return HttpResponseRedirect(secure_url)

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -114,6 +114,7 @@ MIDDLEWARE_CLASSES = (
     'zds.utils.ThreadLocals',
     'zds.middlewares.SetLastVisitMiddleware.SetLastVisitMiddleware',
     'zds.middlewares.profile.ProfileMiddleware',
+    'zds.middlewares.ForceHttpsMembersMiddleware.ForceHttpsMembersMiddleware',
 )
 
 ROOT_URLCONF = 'zds.urls'
@@ -319,6 +320,12 @@ CACHES = {
 }
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+
+# Change to True to force HTTPS for members
+FORCE_HTTPS_FOR_MEMBERS = False
+# Change to True to force HTTPS on views with `@https_required`
+ENABLE_HTTPS_DECORATOR = False
+
 
 LOGIN_URL = '/membres/connexion'
 

--- a/zds/utils/decorators.py
+++ b/zds/utils/decorators.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.http import HttpResponseRedirect
+
+
+def https_required(func):
+    """
+    Check if the decorator is enabled, the request is unsecured and redirect the visitor in HTTPS.
+    """
+    def _https_required(request, *args, **kwargs):
+        if getattr(settings, 'ENABLE_HTTPS_DECORATOR', False) and not request.is_secure():
+            # Code from http://www.redrobotstudios.com/blog/2009/02/18/securing-django-with-ssl/
+            request_url = request.build_absolute_uri(request.get_full_path())
+            secure_url = request_url.replace('http://', 'https://')
+            return HttpResponseRedirect(secure_url)
+
+        return func(request, *args, **kwargs)
+    return _https_required


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #1376 |

Suite de #2040 : Force la navigation en HTTPS pour les utilisateurs connectés ainsi que sur la page de connexion et d'inscription.

**Ne pas merger avant #2757 !**

**QA :**
- Mettre `FORCE_HTTPS_FOR_MEMBERS` et `ENABLE_HTTPS_DECORATOR` à `True` dans le `settings.py`
- Vérifier que l'on est bien redirigé en HTTPS sur les pages :
  - http://127.0.0.1:8000/membres/connexion/`
  - http://127.0.0.1:8000/membres/inscription/`
  - http://127.0.0.1:8000/membres/reinitialisation/`
  - http://127.0.0.1:8000/membres/new_password/`
  - http://127.0.0.1:8000/membres/activation/`
  - http://127.0.0.1:8000/membres/envoi_jeton/`
- (En local supprimer la ligne 554 de `zds/member/views.py`)
- Une fois connecté, aller sur http://127.0.0.1/ et vérifier que l'on est bien redirigé en HTTPS
- Remettre `FORCE_HTTPS_FOR_MEMBERS` et `ENABLE_HTTPS_DECORATOR` à `False` dans le `settings.py`
- Vérifier que le site fonctionne normalement, sans rediriger en HTTPS
