### PR TITLE
[Betafix] fix #2486 #2492 - Répare le clic sur un pseudo dans le forum

### DIFF
--- a/assets/js/forgot-password.js
+++ b/assets/js/forgot-password.js
@@ -8,7 +8,7 @@
     else
         $("#form-email").removeClass("hidden");
 
-    $(".email").on("click", function(e) {
+    $("[data-forgot-password-button=email]").on("click", function(e) {
         $("#form-email").toggleClass("hidden");
         $("#form-username").addClass("hidden");
 
@@ -22,7 +22,7 @@
     else
         $("#form-username").removeClass("hidden");
 
-    $(".username").on("click", function(e) {
+    $("[data-forgot-password-button=username]").on("click", function(e) {
         $("#form-username").toggleClass("hidden");
         $("#form-email").addClass("hidden");
 

--- a/templates/member/forgot_password/index.html
+++ b/templates/member/forgot_password/index.html
@@ -42,8 +42,8 @@
 
             <p>Comment souhaitez vous retrouvez votre mot de passe ?
                 <ul>
-                    <li><a href="#" class="email">En saisissant votre adresse de courriel</a></li>
-                    <li><a href="#" class="username">En saisissant votre nom d'utilisateur</a></li>
+                    <li><a href="#" data-forgot-password-button="email">En saisissant votre adresse de courriel</a></li>
+                    <li><a href="#" data-forgot-password-button="username">En saisissant votre nom d'utilisateur</a></li>
                 </ul>
             </p>
         {% endblocktrans %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2486 #2492 |

**QA :**
- Générer le front
- Vérifier que l'on peut cliquer sur les pseudos dans le forum et dans les messages privés
- Vérifier que la page de réinitialisation du mot de passe fonctionne toujours bien (le champ qui s'affiche correspond bien à ce que vous avez choisi, courriel ou nom d'utilisateur)
