### PR TITLE
Django 1.8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Tous les détails sur le workflow se trouvent [sur la page dédiée](http://zds-
     | Nouvelle Fonctionnalité ?     | [oui|non]
     | Tickets (_issues_) concernés  | [Liste de tickets séparés par des virgules]
     ```
-* Ajoutez des notes de QA (Quality Assurance). Ces notes doivent permettent à un testeur de comprendre ce que vous avez modifié, ce qu'il faut tester en priorité et les pièges auxquels il doit s'attendre et donc sur lesquels porter une attention particulière. Précisez tout particulièrement s'il est nécessaire d'effectuer une action de gestion préalable, comme `python manage.py migrate`, `python manage.py loaddata fixture/*.yaml` ou `npm run gulp -- build`.
+* Ajoutez des notes de QA (Quality Assurance). Ces notes doivent permettent à un testeur de comprendre ce que vous avez modifié, ce qu'il faut tester en priorité et les pièges auxquels il doit s'attendre et donc sur lesquels porter une attention particulière. Précisez tout particulièrement s'il est nécessaire d'effectuer une action de gestion préalable, comme `python manage.py migrate --fake-initial`, `python manage.py loaddata fixture/*.yaml` ou `npm run gulp -- build`.
 
 ## Les commits
 * Pour les commits, nous suivons le même ordre d'idée des standards Git, à savoir :

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Après avoir mis à jour votre dépôt, vous devez exécuter les commandes suiva
 
 ```console
 pip install --upgrade -r requirements.txt -r requirements-dev.txt
-python manage.py migrate
+python manage.py migrate --fake-initial
 ```
 
 

--- a/doc/source/back-end-code/arborescence-back.rst
+++ b/doc/source/back-end-code/arborescence-back.rst
@@ -104,7 +104,7 @@ Cela permettra aux autres développeurs de répercuter les modifications en util
 
 .. sourcecode:: bash
 
-    python manage.py migrate
+    python manage.py migrate --fake-initial
 
 
 API

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 PyYAML==3.11
-django-debug-toolbar==1.2.2
+django-debug-toolbar==1.3
 flake8==2.3.0
 autopep8==1.1.1
 sphinx==1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ pygments==2.0.2
 python-social-auth==0.2.2
 
 # Explicit dependencies (references in code)
-django==1.7.7
+django==1.8
+
 coverage==3.7.1
 django-crispy-forms==1.4.0
 django-haystack==2.3.1

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -59,7 +59,7 @@ npm run build
 # Update application data
 source ../bin/activate
 pip install --upgrade --use-mirrors -r requirements.txt
-python manage.py migrate
+python manage.py migrate --fake-initial
 python manage.py compilemessages
 # Collect all staticfiles from dist/ and python packages to static/
 python manage.py collectstatic --noinput --clear

--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -65,7 +65,7 @@
             <h4>{% trans "Site" %}</h4>
             <ul>
                 <li><a href="http://www.python.org/">Python 2.7</a></li>
-                <li><a href="https://www.djangoproject.com/">Django 1.7</a></li>
+                <li><a href="https://www.djangoproject.com/">Django 1.8</a></li>
             </ul>
 
             <h4>HTTP(S) + WSGI</h4>

--- a/zds/article/migrations/0002_auto_20150407_2258.py
+++ b/zds/article/migrations/0002_auto_20150407_2258.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('article', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='article',
+            name='subcategory',
+            field=models.ManyToManyField(to='utils.SubCategory', db_index=True, verbose_name=b'Sous-Cat\xc3\xa9gorie', blank=True),
+        ),
+    ]

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -62,7 +62,7 @@ class Article(models.Model):
 
     subcategory = models.ManyToManyField(SubCategory,
                                          verbose_name='Sous-Catégorie',
-                                         blank=True, null=True, db_index=True)
+                                         blank=True, db_index=True)
 
     image = ThumbnailerImageField(upload_to=image_path, blank=True, null=True)
 

--- a/zds/forum/migrations/0002_auto_20150407_2258.py
+++ b/zds/forum/migrations/0002_auto_20150407_2258.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forum', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='forum',
+            name='group',
+            field=models.ManyToManyField(to='auth.Group', verbose_name=b'Groupe autoris\xc3\xa9s (Aucun = public)', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='tags',
+            field=models.ManyToManyField(to='utils.Tag', db_index=True, verbose_name=b'Tags du forum', blank=True),
+        ),
+    ]

--- a/zds/forum/migrations/0003_auto_20150412_2005.py
+++ b/zds/forum/migrations/0003_auto_20150412_2005.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forum', '0002_auto_20150407_2258'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='category',
+            options={'ordering': ['position', 'title'], 'verbose_name': 'Cat\xe9gorie', 'verbose_name_plural': 'Cat\xe9gories'},
+        ),
+        migrations.AlterModelOptions(
+            name='forum',
+            options={'ordering': ['position_in_category', 'title'], 'verbose_name': 'Forum', 'verbose_name_plural': 'Forums'},
+        ),
+    ]

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -91,7 +91,6 @@ class Forum(models.Model):
     group = models.ManyToManyField(
         Group,
         verbose_name='Groupe autorisés (Aucun = public)',
-        null=True,
         blank=True)
     # TODO: A forum defines an image, but it doesn't seems to be used...
     image = models.ImageField(upload_to=image_path_forum)
@@ -185,7 +184,6 @@ class Topic(models.Model):
     tags = models.ManyToManyField(
         Tag,
         verbose_name='Tags du forum',
-        null=True,
         blank=True,
         db_index=True)
 

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -131,6 +131,7 @@ class PrivateTopicLeaveDetail(SingleObjectMixin, RedirectView):
     """
     Leaves a MP.
     """
+    permanent = True
     queryset = PrivateTopic.objects.all()
 
     @method_decorator(login_required)
@@ -158,6 +159,7 @@ class PrivateTopicLeaveDetail(SingleObjectMixin, RedirectView):
 
 
 class PrivateTopicAddParticipant(SingleObjectMixin, RedirectView):
+    permanent = True
     object = None
     queryset = PrivateTopic.objects.all()
 
@@ -216,6 +218,7 @@ class PrivateTopicLeaveList(MultipleObjectMixin, RedirectView):
     """
     Leaves a list of MP.
     """
+    permanent = True
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -47,7 +47,7 @@ class PrivateTopicList(ZdSPagingListView):
     def get_queryset(self):
         return PrivateTopic.objects \
             .filter(Q(participants__in=[self.request.user.id]) | Q(author=self.request.user.id)) \
-            .select_related("author", "participants") \
+            .select_related("author") \
             .distinct().order_by('-last_message__pubdate').all()
 
 

--- a/zds/search/forms.py
+++ b/zds/search/forms.py
@@ -26,10 +26,10 @@ class CustomSearchForm(ModelSearchForm):
         choices = [
             ("%s.%s" %
              (m._meta.app_label,
-              m._meta.module_name),
+              m._meta.model_name),
                 self.get_model_name(
                  m._meta.app_label,
-                 m._meta.module_name,
+                 m._meta.model_name,
                  True)) for m in connections[using].get_unified_index().get_indexed_models()]
         return sorted(choices, key=lambda x: x[1])
 

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -83,8 +83,6 @@ STATICFILES_FINDERS = (
     #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
-FIXTURE_DIRS = (os.path.join(BASE_DIR, 'fixtures'))
-
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'n!01nl+318#x75_%le8#s0=-*ysw&amp;y49uc#t=*wvi(9hnyii0z'
 

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -143,7 +143,6 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sitemaps',

--- a/zds/tutorial/migrations/0002_auto_20150407_2258.py
+++ b/zds/tutorial/migrations/0002_auto_20150407_2258.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tutorial', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='tutorial',
+            name='subcategory',
+            field=models.ManyToManyField(to='utils.SubCategory', db_index=True, verbose_name=b'Sous-Cat\xc3\xa9gorie', blank=True),
+        ),
+    ]

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -55,7 +55,7 @@ class Tutorial(models.Model):
 
     subcategory = models.ManyToManyField(SubCategory,
                                          verbose_name='Sous-Catégorie',
-                                         blank=True, null=True, db_index=True)
+                                         blank=True, db_index=True)
 
     slug = models.SlugField(max_length=80)
 

--- a/zds/utils/migrations/0002_auto_20150407_2222.py
+++ b/zds/utils/migrations/0002_auto_20150407_2222.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('utils', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='comment',
+            name='editor',
+            field=models.ForeignKey(related_name='comments_editor', verbose_name=b'Editeur', blank=True, to=settings.AUTH_USER_MODEL, null=True),
+        ),
+    ]

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -176,7 +176,7 @@ class Comment(models.Model):
     author = models.ForeignKey(User, verbose_name='Auteur',
                                related_name='comments', db_index=True)
     editor = models.ForeignKey(User, verbose_name='Editeur',
-                               related_name='comments-editor',
+                               related_name='comments_editor',
                                null=True, blank=True)
     ip_address = models.CharField('Adresse IP de l\'auteur ', max_length=39)
 

--- a/zds/utils/templatetags/profile.py
+++ b/zds/utils/templatetags/profile.py
@@ -49,10 +49,10 @@ def state(user):
 
 
 @register.filter('liked')
-def liked(user, comment_pk):
-    return CommentLike.objects.filter(comments__pk=comment_pk, user=user).exists()
+def liked(profile, comment_pk):
+    return CommentLike.objects.filter(comments__pk=comment_pk, user=profile.user).exists()
 
 
 @register.filter('disliked')
-def disliked(user, comment_pk):
-    return CommentDislike.objects.filter(comments__pk=comment_pk, user=user).exists()
+def disliked(profile, comment_pk):
+    return CommentDislike.objects.filter(comments__pk=comment_pk, user=profile.user).exists()

--- a/zds/utils/templatetags/tests/tests_append_to_get.py
+++ b/zds/utils/templatetags/tests/tests_append_to_get.py
@@ -2,7 +2,7 @@
 
 
 from django.test import TestCase, RequestFactory
-from django.template import TemplateSyntaxError, Token, TOKEN_TEXT, Context, VariableDoesNotExist, Template
+from django.template.base import TemplateSyntaxError, Token, TOKEN_TEXT, Context, VariableDoesNotExist, Template
 
 from zds.utils.templatetags.append_to_get import easy_tag, AppendGetNode
 


### PR DESCRIPTION
Vous savez quoi ? Le passage à Django 1.8, sans tenir compte des warnings, nécessite 37 additions et 19 délétions.

| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets (_issues_) concernés | #2507 |

Comme d'hab, y'a plein de tout petits commits pour retrouver pourquoi j'ai fait telle ou telle particularité.

Je crée déjà la PR, je rajoute des commits pour corriger les warnings ensuite.

**Notes de QA** : Si vous voulez, mais à votre place j'attendrais qu'il n'y ait plus de warnings. À noter que la migration d'une BDD MySQL (dump de prod de ce WE) a été testé et passe crème. En fait je crée surtout la PR pour profiter de Travis au plus tôt.

Voici les warnings qui restent, comme vous le voyez, Django est assez sympa pour indiquer ce qu'il faut faire pour corriger !

```
(zdsenv)spacefox@azathoth:~/Dev/Django/zds-site$ python manage.py runserver
/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/haystack/utils/__init__.py:12: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
  from django.utils import importlib

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/social/apps/django_app/default/models.py:29: RemovedInDjango19Warning: Model class social.apps.django_app.default.models.UserSocialAuth doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class UserSocialAuth(models.Model, DjangoUserMixin):

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/social/apps/django_app/default/models.py:67: RemovedInDjango19Warning: Model class social.apps.django_app.default.models.Nonce doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Nonce(models.Model, DjangoNonceMixin):

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/social/apps/django_app/default/models.py:78: RemovedInDjango19Warning: Model class social.apps.django_app.default.models.Association doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Association(models.Model, DjangoAssociationMixin):

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/social/apps/django_app/default/models.py:91: RemovedInDjango19Warning: Model class social.apps.django_app.default.models.Code doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Code(models.Model, DjangoCodeMixin):

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/corsheaders/middleware.py:10: RemovedInDjango19Warning: The utilities in django.db.models.loading are deprecated in favor of the new application loading system.
  from django.db.models.loading import get_model

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/crispy_forms/utils.py:25: RemovedInDjango19Warning: memoize wrapper is deprecated and will be removed in Django 1.9. Use django.utils.lru_cache instead.
  default_field_template = memoize(default_field_template, {}, 1)

/home/spacefox/Dev/Django/zds-site/zds/mp/urls.py:13: RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
  url(r'^quitter/$', PrivateTopicLeaveList.as_view(), name='mp-list-delete'),

/home/spacefox/Dev/Django/zds-site/zds/mp/urls.py:16: RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
  url(r'^(?P<pk>\d+)/(?P<topic_slug>.+)/quitter/$', PrivateTopicLeaveDetail.as_view(),

/home/spacefox/Dev/Django/zds-site/zds/mp/urls.py:19: RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
  PrivateTopicAddParticipant.as_view(), name='mp-edit-participant'),

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/haystack/utils/__init__.py:12: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
  from django.utils import importlib

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/social/apps/django_app/default/models.py:29: RemovedInDjango19Warning: Model class social.apps.django_app.default.models.UserSocialAuth doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class UserSocialAuth(models.Model, DjangoUserMixin):

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/social/apps/django_app/default/models.py:67: RemovedInDjango19Warning: Model class social.apps.django_app.default.models.Nonce doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Nonce(models.Model, DjangoNonceMixin):

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/social/apps/django_app/default/models.py:78: RemovedInDjango19Warning: Model class social.apps.django_app.default.models.Association doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Association(models.Model, DjangoAssociationMixin):

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/social/apps/django_app/default/models.py:91: RemovedInDjango19Warning: Model class social.apps.django_app.default.models.Code doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Code(models.Model, DjangoCodeMixin):

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/corsheaders/middleware.py:10: RemovedInDjango19Warning: The utilities in django.db.models.loading are deprecated in favor of the new application loading system.
  from django.db.models.loading import get_model

/home/spacefox/Dev/virtualenvs/zdsenv/local/lib/python2.7/site-packages/crispy_forms/utils.py:25: RemovedInDjango19Warning: memoize wrapper is deprecated and will be removed in Django 1.9. Use django.utils.lru_cache instead.
  default_field_template = memoize(default_field_template, {}, 1)

/home/spacefox/Dev/Django/zds-site/zds/mp/urls.py:13: RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
  url(r'^quitter/$', PrivateTopicLeaveList.as_view(), name='mp-list-delete'),

/home/spacefox/Dev/Django/zds-site/zds/mp/urls.py:16: RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
  url(r'^(?P<pk>\d+)/(?P<topic_slug>.+)/quitter/$', PrivateTopicLeaveDetail.as_view(),

/home/spacefox/Dev/Django/zds-site/zds/mp/urls.py:19: RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
  PrivateTopicAddParticipant.as_view(), name='mp-edit-participant'),

Performing system checks...

System check identified some issues:

WARNINGS:
article.Article.subcategory: (fields.W340) null has no effect on ManyToManyField.
forum.Forum.group: (fields.W340) null has no effect on ManyToManyField.
forum.Topic.tags: (fields.W340) null has no effect on ManyToManyField.
tutorial.Tutorial.subcategory: (fields.W340) null has no effect on ManyToManyField.

System check identified 4 issues (0 silenced).
```

Comme on peut le voir, certains viennent des dépendances qu'on devra mettre à jour.
