### PR TITLE
Interdiction aux membres bannis et inscrit via les reseaux sociaux de se connecter

### DIFF
--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1004,6 +1004,26 @@ def member_from_ip(request, ip):
     })
 
 
+def save_profile(request, backend, user, response, *args, **kwargs):
+    profile = Profile.objects.filter(user=user).first()
+    if profile is None:
+        profile = Profile(user=user,
+                          show_email=False,
+                          show_sign=True,
+                          hover_or_click=True,
+                          email_for_answer=False)
+        profile.last_ip_address = get_client_ip(request)
+        profile.save()
+
+
+def ban_control(request, backend, user, response, *args, **kwargs):
+    profile = Profile.objects.filter(user=user).first()
+    if not profile.can_read_now():
+        messages.error(request,
+                       _("Votre compte a été banni, vous ne pouvez plus vous connecter"))
+        return redirect(reverse('zds.member.views.login_view'))
+
+
 @login_required
 @require_POST
 def modify_karma(request):

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -461,6 +461,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social.pipeline.user.get_username',
     'social.pipeline.user.create_user',
     'zds.member.models.save_profile',
+    'zds.member.models.ban_control',
     'social.pipeline.social_auth.associate_user',
     'social.pipeline.social_auth.load_extra_data',
     'social.pipeline.user.user_details'


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2328 |

Cette PR interdit aux membres qui se sont inscrit via les réseaux sociaux, de se connecter s'ils ont été ban. 

**Note pour QA**
- Inscrivez vous via les résaux sociaux (google)
- Connectez vous ensuite avec le comtpe admin
- Bannissez (temporairement ou définitivement le nouveau membre)
- Essayez de vous connecter à nouveau avec votre compte banni
- Constatez que vous n'y arrrivez pas.
