### PR TITLE
Ajout d'un fichier de migration manquant

### DIFF
--- a/zds/forum/migrations/0002_auto_20150410_1505.py
+++ b/zds/forum/migrations/0002_auto_20150410_1505.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forum', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='category',
+            options={'ordering': ['position', 'title'], 'verbose_name': 'Cat\xe9gorie', 'verbose_name_plural': 'Cat\xe9gories'},
+        ),
+        migrations.AlterModelOptions(
+            name='forum',
+            options={'ordering': ['position_in_category', 'title'], 'verbose_name': 'Forum', 'verbose_name_plural': 'Forums'},
+        ),
+    ]


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | _néant_ |

En testant la nouvelle commande de migration de Django 1.7 (`python manage.py makemigrations`) sur _upstream/dev_, je me suis rendu compte qu'il y avait le module forum qui n'avait pas été migré à un moment. Pour éviter les problèmes, le voici.
# Note de QA

... Y'en a pas ? Je pense que si Travis est content (et c'est pas gagné, par les temps qui courent), ben c'est bon. Si vous y tenez absolument, un `python manage.py migrate` et Django est heureux :)
