### PR TITLE
MP hotfix - on peut mp une liste de participants via GET

### DIFF
--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -284,6 +284,21 @@ class NewTopicViewTest(TestCase):
             self.profile2.user.username,
             response2.context['form'].initial['participants'])
 
+    def test_success_get_with_multi_username(self):
+
+        profile3 = ProfileFactory()
+
+        response = self.client.get(
+            reverse('mp-new') +
+            '?username=' + self.profile2.user.username +
+            '&username=' + profile3.user.username)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(2, len(response.context['form'].initial['participants'].split(', ')))
+        self.assertTrue(self.profile1.user.username not in response.context['form'].initial['participants'])
+        self.assertTrue(self.profile2.user.username in response.context['form'].initial['participants'])
+        self.assertTrue(profile3.user.username in response.context['form'].initial['participants'])
+
     def test_success_get_with_and_without_title(self):
 
         response = self.client.get(reverse('mp-new'))

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -65,11 +65,18 @@ class PrivateTopicNew(CreateView):
 
     def get(self, request, *args, **kwargs):
         title = request.GET.get('title') if 'title' in request.GET else None
-        try:
-            participants = User.objects.get(username=request.GET.get('username')).username \
-                if 'username' in request.GET else None
-        except:
-            participants = None
+
+        participants = None
+        if 'username' in request.GET:
+            dest_list = []
+            # check that usernames in url is in the database
+            for username in request.GET.getlist('username'):
+                try:
+                    dest_list.append(User.objects.get(username=username).username)
+                except:
+                    pass
+            if len(dest_list) > 0:
+                participants = ', '.join(dest_list)
 
         form = self.form_class(username=request.user.username,
                                initial={

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -73,7 +73,7 @@ class PrivateTopicNew(CreateView):
             for username in request.GET.getlist('username'):
                 try:
                     dest_list.append(User.objects.get(username=username).username)
-                except:
+                except ObjectDoesNotExist:
                     pass
             if len(dest_list) > 0:
                 participants = ', '.join(dest_list)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2501 |

Depuis le refactor du module des mp (v1.7)on ne pouvait plus préparer un mp vers plusieurs participants via les paramètres de l'url. Ce fix répare cela.
### QA
- Avec le compte user
- Essayezrd'accéder à l'URL `/mp/creer/?&username=staff`
  - Un MP avec `staff` se prépare
- Essayer d'accéder à l'URL `/mp/creer/?&username=staff&username=admin`
  - Un MP avec `staff` **et** `admin` se prépare

(sur la branche de dev le mp multiple n'aurait pas marché)

PS : J'ai codé un peu à l'aveugle sans tester, j'ai des soucis avec ma version locale à force de jongler entre les versions de Django. Cependant le code provient de [ce commit](https://github.com/zestedesavoir/zds-site/commit/ef9c7a555db7df9cddc84c74b418629ef930559c) qui introduit le problème
