### PR TITLE
hotfix - ZEP-3 remet le nombre de tutos

### DIFF
--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -3792,7 +3792,7 @@ def help_tutorial(request):
 
     return render(request, "tutorial/tutorial/help.html", {
         "tutorials": shown_tutos,
-        "nb_tuto": paginator.count,
+        "nb_tutos": paginator.count,
         "helps": aides,
         "pages": paginator_range(page, paginator.num_pages),
         "nb": page


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets concernés | #2488 |

Le nombre de tutos qui ont besoin d'aide(s) n'était plus affiché. Ce fix doit le remettre.
### QA

Alors c'est chiant à QA car il faut générer plusieurs tutos...
- Faites plusieurs tutos, avec ou sans aides, en beta ou non etc
- Aller dans la page de demande d'aide
- Vérifier que le nombre de tutos s'affiches en haut
- En jouant avec les filtres, verifier que le nombre affiche bien la quantité de tuto filtrée.

PS : J'ai codé un peu à l'aveugle sans tester, j'ai des soucis avec ma version locale à force de jongler entre les versions de Django. Désolé
