### PR TITLE
Hotfix release 1.7 : réparation de l'encodage des URLs de membre

### DIFF
--- a/templates/misc/member_item.part.html
+++ b/templates/misc/member_item.part.html
@@ -4,7 +4,7 @@
 
 {% with profile=member|profile %}
     <a
-        href="{{ member.get_absolute_url }}"
+        href="{{ profile.get_absolute_url }}"
         class="member-item"
         itemscope
         itemtype="http://schema.org/Person"

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -15,7 +15,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q
-from django.utils.http import urlquote
+from django.utils.http import urlunquote
 from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import redirect, render, get_object_or_404
 from django.template.loader import render_to_string

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -15,6 +15,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q
+from django.utils.http import urlquote
 from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import redirect, render, get_object_or_404
 from django.template.loader import render_to_string
@@ -60,7 +61,7 @@ class MemberDetail(DetailView):
     template_name = 'member/profile.html'
 
     def get_object(self, queryset=None):
-        return get_object_or_404(User, username=self.kwargs['user_name'])
+        return get_object_or_404(User, username=urlunquote(self.kwargs['user_name']))
 
     def get_context_data(self, **kwargs):
         context = super(MemberDetail, self).get_context_data(**kwargs)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui ... and so hot |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2301 |

Cette PR hotfix la release (Voir l'issue pour plus d'information)

**Note pour QA**:
- Créez un utilisateur au pseudo un peu tordu : `&#34;b` par exemple
- Allez dans la liste des membres `/membres/`
- Cliquez sur le lien correspondant au profil de ce dernier
- Constatez que vous atterissez bien sur sa page de profil.
