### PR TITLE
Correction du filtre de validation des articles

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -902,7 +902,7 @@ def list_validation(request):
 
     # Get subcategory to filter validations.
     try:
-        subcategory = get_object_or_404(Category, pk=int(request.GET['subcategory']))
+        subcategory = get_object_or_404(SubCategory, pk=int(request.GET['subcategory']))
     except (KeyError, ValueError, Http404):
         subcategory = None
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2067 |

Cette PR permet de corriger le bug du filtre dans l'interface de validation des articles, qui faisait que malgré qu'on cliquait sur une sous-catégorie, le contenu n'était pas toujours filtré.

**Note pour la QA**:
- Créez au moins deux articles dans 2 catégories différentes
- Mettez ces articles en validation
- Allez dans l'interface de validation de article et cliquez sur une catégorie pour fitrer
- Constatez que seuls les articles de la catégorie demandée sont afficher.

N'hésitez pas a tester avec des tutoriels qui contiennent plusieurs catégories.
