### PR TITLE
Titre du mp pour signaler des fautes dans un tuto/chapitre

### DIFF
--- a/templates/tutorial/includes/warn_typo.part.html
+++ b/templates/tutorial/includes/warn_typo.part.html
@@ -24,7 +24,13 @@
         </p>
         <p>
             {% trans "Pas assez de place ?" %}
-            <a href="{% url 'mp-new' %}?title={% trans "Je voudrais signaler une faute dans le tutoriel" %} &quot;{{ tutorial.title }}&quot;{% for username in tutorial.authors.all %}&amp;username={{ username }}{% endfor %}" >
+
+            {% if obj_type == "tutorial" %}
+                <a href="{% url 'mp-new' %}?title={% trans "Je voudrais signaler une faute dans le tutoriel" %} &quot;{{ tutorial.title }}&quot;{% for username in tutorial.authors.all %}&amp;username={{ username }}{% endfor %}" >
+            {%  elif obj_type == "chapter" %}
+                <a href="{% url 'mp-new' %}?title={% trans "Je voudrais signaler une faute dans le chapitre" %} &quot;{{ chapter.title }}&quot;{% for username in tutorial.authors.all %}&amp;username={{ username }}{% endfor %}" >
+            {% endif %}
+
                 {% trans "Envoyez un MP" %}
                 {% if tutorial.authors.all|length > 1 %}
                     {% trans "aux auteurs" %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2130 |

Corrige le titre du mp dans le lien de signalement de faute `Pas assez de place ? Envoyez un MP à l'auteur` en fonction du type de l'objet, tutorial ou chapitre.

QA : Vérifier que le titre du mp dans le lien est correct.
