### PR TITLE
fix(paginator): #2556 Fixes paging page with previous item in list.

### DIFF
--- a/templates/misc/paginator.html
+++ b/templates/misc/paginator.html
@@ -2,8 +2,7 @@
 {% load append_to_get %}
 {% load i18n %}
 
-
-{% if page_obj|length > 1 %}
+{% if paginator.num_pages > 1 %}
     {% captureas full_anchor %}
         {% if anchor %}
             #{{ anchor }}

--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -81,7 +81,7 @@
         {% endfor %}
     </div>
 
-    {% include "misc/pagination.part.html" with position='bottom' %}
+    {% include "misc/paginator.html" with position="bottom" %}
 {% endblock %}
 
 

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -263,7 +263,7 @@ class PrivatePostList(SingleObjectMixin, ZdSPagingListView):
         context['topic'] = self.object
         context['last_post_pk'] = self.object.last_message.pk
         context['form'] = PrivatePostForm(self.object)
-        context['posts'] = self.build_list()
+        context['posts'] = self.build_list_with_previous_item(context['object_list'])
         if never_privateread(self.object):
             mark_read(self.object)
         return context

--- a/zds/utils/paginator.py
+++ b/zds/utils/paginator.py
@@ -40,11 +40,12 @@ class ZdSPagingListView(ListView):
         context.update(kwargs)
         return super(MultipleObjectMixin, self).get_context_data(**context)
 
-    def build_list(self):
+    def build_list_with_previous_item(self, queryset):
         """
         For some list paginated, we would like to display the last item of the previous page.
         This function returns the list paginated with this previous item.
         """
+        original_list = queryset.all()
         list = []
         # If necessary, add the last item in the previous page.
         if self.page.number != 1:
@@ -52,7 +53,7 @@ class ZdSPagingListView(ListView):
             last_item = (last_page)[len(last_page) - 1]
             list.append(last_item)
         # Adds all items of the list paginated.
-        for item in self.object_list:
+        for item in original_list:
             list.append(item)
         return list
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets (_issues_) concernés | #2556 #2557 |

Corrige la pagination avec l'item précédent dans la liste. Cette correction est visible dans la liste des MPs (sans item précédent) et dans la liste des messages d'un MP (avec un item précédent).

Corrige #2556 et #2557 par effet de bord (positif).

QA : 
- Vérifier que la pagination s'affiche que lorsqu'une 2ème page est nécessaire.
- Vérifier que la pagination affiche les bons messages sur chaque page.
