### PR TITLE
Incohérence entre les +1/-1 en mode invité et en mode connecté

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -306,8 +306,7 @@
                                 class="upvote
                                        ico-after
                                        {% if message.like > message.dislike %}more-voted{% endif %}
-                                       {% if message.like > 0 %}has-vote{% endif %}
-                                       {% if not user.is_authenticated and message.like > message.dislike %}voted{% endif %}"
+                                       {% if message.like > 0 %}has-vote{% endif %}"
                                 {% if message.like > 0 %}
                                     title="{{ message.like }} personne{{ message.like|pluralize }} {% if message.like > 1 %}ont{% else %}a{% endif %} trouvé ce message utile"
                                 {% endif %}
@@ -320,8 +319,7 @@
                                 class="downvote
                                        ico-after
                                        {% if message.like < message.dislike %}more-voted{% endif %} 
-                                       {% if message.dislike > 0 %}has-vote{% endif %}
-                                       {% if not user.is_authenticated and message.like < message.dislike %}voted{% endif %}"
+                                       {% if message.dislike > 0 %}has-vote{% endif %}"
                                 {% if message.dislike > 0 %}
                                     title="{{ message.dislike }} personne{{ message.dislike|pluralize }} n'{% if message.dislike > 1 %}ont{% else %}a{% endif %} pas trouvé ce message utile"
                                 {% endif %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2403 |

QA : 
- Les pouces ne doivent pas s'afficher en couleur en mode invité (signe que l'on a voté en connecté)
- En mode connecté vérifier que l'affichage fonctionne normalement
