### PR TITLE
Edition d'un mp

### DIFF
--- a/templates/mp/topic/edit.html
+++ b/templates/mp/topic/edit.html
@@ -1,0 +1,32 @@
+{% extends "mp/base.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+
+
+{% block title %}
+    {{ topic.title }}
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    <li><a href="{{ topic.get_absolute_url }}">{{ topic.title }}</a></li>
+    <li> {% trans "Éditer" %}</li>
+{% endblock %}
+
+
+
+{% block headline %}
+    {{ topic.title }}
+{% endblock %}
+
+
+{% block headline_sub %}
+    {{ topic.subtitle }}
+{% endblock %}
+
+
+{% block content %}
+    {% crispy form %}
+{% endblock %}

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -116,6 +116,12 @@
             {% endif %}
 
             <li>
+                <a href="{% url "mp-edit" topic.pk topic.slug %}" class="ico-after edit blue">
+                    {% trans "Éditer la conversation" %}
+                </a>
+            </li>
+
+            <li>
                 <a href="#leave-conversation" class="open-modal ico-after cross blue">
                     {% trans "Quitter la conversation" %}
                 </a>

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -113,13 +113,13 @@
                         <button type="submit">{% trans "Ajouter" %}</button>
                     </form>
                 </li>
-            {% endif %}
 
-            <li>
-                <a href="{% url "mp-edit" topic.pk topic.slug %}" class="ico-after edit blue">
-                    {% trans "Éditer la conversation" %}
-                </a>
-            </li>
+                <li>
+                    <a href="{% url "mp-edit-topic" topic.pk topic.slug %}" class="ico-after edit blue">
+                        {% trans "Éditer la conversation" %}
+                    </a>
+                </li>
+            {% endif %}
 
             <li>
                 <a href="#leave-conversation" class="open-modal ico-after cross blue">

--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -1,14 +1,16 @@
 # coding: utf-8
 
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout, Field, Hidden
+from crispy_forms.layout import Layout, Field, Hidden, ButtonHolder
+from crispy_forms.bootstrap import StrictButton
+
 from django import forms
 from django.core.urlresolvers import reverse
-from zds.mp.commons import ParticipantsValidator, TitleValidator, TextValidator
+from django.utils.translation import ugettext_lazy as _
 
+from zds.mp.commons import ParticipantsValidator, TitleValidator, TextValidator
 from zds.mp.models import PrivateTopic
 from zds.utils.forms import CommonLayoutEditor
-from django.utils.translation import ugettext_lazy as _
 
 
 class PrivateTopicForm(forms.Form, ParticipantsValidator, TitleValidator, TextValidator):
@@ -68,6 +70,35 @@ class PrivateTopicForm(forms.Form, ParticipantsValidator, TitleValidator, TextVa
         self.validate_title(cleaned_data.get('title'))
         self.validate_text(cleaned_data.get('text'))
 
+        return cleaned_data
+
+    def throw_error(self, key=None, message=None):
+        self._errors[key] = self.error_class([message])
+
+
+class PrivateTopicEditForm(forms.ModelForm, TitleValidator):
+
+    class Meta:
+        model = PrivateTopic
+        fields = ['title', 'subtitle']
+
+    def __init__(self, *args, **kwargs):
+        super(PrivateTopicEditForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_class = 'content-wrapper'
+        self.helper.form_method = 'post'
+
+        self.helper.layout = Layout(
+            Field('title'),
+            Field('subtitle'),
+            ButtonHolder(
+                StrictButton(_(u'Mettre à jour'), type='submit'),
+            ),
+        )
+
+    def clean(self):
+        cleaned_data = super(PrivateTopicEditForm, self).clean()
+        self.validate_title(cleaned_data.get('title'))
         return cleaned_data
 
     def throw_error(self, key=None, message=None):

--- a/zds/mp/migrations/0002_auto_20150416_1750.py
+++ b/zds/mp/migrations/0002_auto_20150416_1750.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mp', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='privatetopic',
+            name='subtitle',
+            field=models.CharField(max_length=200, verbose_name='Sous-titre', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -21,7 +21,7 @@ class PrivateTopic(models.Model):
         verbose_name_plural = u'Messages privés'
 
     title = models.CharField(u'Titre', max_length=130)
-    subtitle = models.CharField(u'Sous-titre', max_length=200)
+    subtitle = models.CharField(u'Sous-titre', max_length=200, blank=True)
     author = models.ForeignKey(User, verbose_name=u'Auteur', related_name='author', db_index=True)
     participants = models.ManyToManyField(User, verbose_name=u'Participants', related_name='participants',
                                           db_index=True)

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -938,3 +938,135 @@ class AddParticipantViewTest(TestCase):
             profile3.user,
             PrivateTopic.objects.get(pk=self.topic1.pk).participants.all()
         )
+
+
+class PrivateTopicEditTest(TestCase):
+
+    def setUp(self):
+        self.profile1 = ProfileFactory()
+        self.profile2 = ProfileFactory()
+        self.topic1 = PrivateTopicFactory(author=self.profile1.user)
+        self.topic1.participants.add(self.profile2.user)
+        self.post1 = PrivatePostFactory(
+            privatetopic=self.topic1,
+            author=self.profile1.user,
+            position_in_topic=1)
+
+        self.post2 = PrivatePostFactory(
+            privatetopic=self.topic1,
+            author=self.profile2.user,
+            position_in_topic=2)
+
+    def test_denies_anonymous(self):
+
+        self.client.logout()
+
+        # get
+        response = self.client.get(reverse('mp-edit-topic', args=[self.topic1.pk, 'private-topic']), follow=True)
+
+        self.assertRedirects(
+            response,
+            reverse('zds.member.views.login_view') +
+            '?next=' + urllib.quote(reverse('mp-edit-topic', args=[self.topic1.pk, 'private-topic']), ''))
+
+        # post
+        response = self.client.post(reverse('mp-edit-topic', args=[self.topic1.pk, 'private-topic']), {
+            'title': 'test',
+            'subtitle': 'subtest'
+        }, follow=True)
+
+        self.assertRedirects(
+            response,
+            reverse('zds.member.views.login_view') +
+            '?next=' + urllib.quote(reverse('mp-edit-topic', args=[self.topic1.pk, 'private-topic']), ''))
+
+        topic = PrivateTopic.objects.get(pk=self.topic1.pk)
+        self.assertEqual('Mon Sujet No1', topic.title)
+        self.assertEqual('Sous Titre du sujet No1', topic.subtitle)
+
+    def test_success_edit_topic(self):
+        self.assertTrue(
+            self.client.login(
+                username=self.profile1.user.username,
+                password='hostel77'
+            )
+        )
+
+        response = self.client.post(reverse('mp-edit-topic', args=[self.topic1.pk, 'private-topic']), {
+            'title': 'test',
+            'subtitle': 'subtest'
+        }, follow=True)
+
+        self.assertEqual(200, response.status_code)
+
+        topic = PrivateTopic.objects.get(pk=self.topic1.pk)
+        self.assertEqual('test', topic.title)
+        self.assertEqual('subtest', topic.subtitle)
+
+    def test_fail_user_is_not_author(self):
+
+        self.topic1.title = 'super title'
+        self.topic1.subtitle = 'super subtitle'
+        self.topic1.save()
+
+        self.assertTrue(
+            self.client.login(
+                username=self.profile2.user.username,
+                password='hostel77'
+            )
+        )
+
+        response = self.client.get(reverse('mp-edit-topic', args=[self.topic1.pk, 'private-topic']), follow=True)
+        self.assertEqual(403, response.status_code)
+
+        response = self.client.post(reverse('mp-edit-topic', args=[self.topic1.pk, 'private-topic']), {
+            'title': 'test',
+            'subtitle': 'subtest'
+        }, follow=True)
+
+        self.assertEqual(403, response.status_code)
+
+        topic = PrivateTopic.objects.get(pk=self.topic1.pk)
+        self.assertEqual('super title', topic.title)
+        self.assertEqual('super subtitle', topic.subtitle)
+
+    def test_fail_topic_doesnt_exist(self):
+        self.assertTrue(
+            self.client.login(
+                username=self.profile1.user.username,
+                password='hostel77'
+            )
+        )
+
+        response = self.client.get(reverse('mp-edit-topic', args=[91, 'private-topic']), follow=True)
+        self.assertEqual(404, response.status_code)
+
+        response = self.client.post(reverse('mp-edit-topic', args=[91, 'private-topic']), {
+            'title': 'test',
+            'subtitle': 'subtest'
+        }, follow=True)
+        self.assertEqual(404, response.status_code)
+
+    def test_fail_blank_title(self):
+
+        self.topic1.title = 'super title'
+        self.topic1.subtitle = 'super subtitle'
+        self.topic1.save()
+
+        self.assertTrue(
+            self.client.login(
+                username=self.profile1.user.username,
+                password='hostel77'
+            )
+        )
+
+        response = self.client.post(reverse('mp-edit-topic', args=[self.topic1.pk, 'private-topic']), {
+            'title': '',
+            'subtitle': 'subtest'
+        }, follow=True)
+
+        self.assertEqual(200, response.status_code)
+
+        topic = PrivateTopic.objects.get(pk=self.topic1.pk)
+        self.assertEqual('super title', topic.title)
+        self.assertEqual('super subtitle', topic.subtitle)

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -960,6 +960,9 @@ class PrivateTopicEditTest(TestCase):
     def test_denies_anonymous(self):
 
         self.client.logout()
+        self.topic1.title = 'super title'
+        self.topic1.subtitle = 'super subtitle'
+        self.topic1.save()
 
         # get
         response = self.client.get(reverse('mp-edit-topic', args=[self.topic1.pk, 'private-topic']), follow=True)
@@ -981,8 +984,8 @@ class PrivateTopicEditTest(TestCase):
             '?next=' + urllib.quote(reverse('mp-edit-topic', args=[self.topic1.pk, 'private-topic']), ''))
 
         topic = PrivateTopic.objects.get(pk=self.topic1.pk)
-        self.assertEqual('Mon Sujet No1', topic.title)
-        self.assertEqual('Sous Titre du sujet No1', topic.subtitle)
+        self.assertEqual('super title', topic.title)
+        self.assertEqual('super subtitle', topic.subtitle)
 
     def test_success_edit_topic(self):
         self.assertTrue(

--- a/zds/mp/urls.py
+++ b/zds/mp/urls.py
@@ -15,8 +15,8 @@ urlpatterns = patterns('',
 
                        url(r'^(?P<pk>\d+)/(?P<topic_slug>.+)/quitter/$', PrivateTopicLeaveDetail.as_view(),
                            name='mp-delete'),
-                       url(r'^(?P<pk>\d+)/(?P<topic_slug>.+)/editer/$', PrivateTopicEdit.as_view(),
-                           name='mp-edit'),
+                       url(r'^(?P<pk>\d+)/(?P<topic_slug>.+)/editer/topic/$', PrivateTopicEdit.as_view(),
+                           name='mp-edit-topic'),
                        url(r'^(?P<pk>\d+)/(?P<topic_slug>.+)/editer/participants/$',
                            PrivateTopicAddParticipant.as_view(), name='mp-edit-participant'),
 

--- a/zds/mp/urls.py
+++ b/zds/mp/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls import patterns, url
 
 from zds.mp.views import PrivateTopicList, PrivatePostList, PrivateTopicNew, PrivateTopicAddParticipant, \
     PrivateTopicLeaveDetail, PrivateTopicLeaveList, \
-    PrivatePostAnswer, PrivatePostEdit
+    PrivatePostAnswer, PrivatePostEdit, PrivateTopicEdit
 
 
 urlpatterns = patterns('',
@@ -15,6 +15,8 @@ urlpatterns = patterns('',
 
                        url(r'^(?P<pk>\d+)/(?P<topic_slug>.+)/quitter/$', PrivateTopicLeaveDetail.as_view(),
                            name='mp-delete'),
+                       url(r'^(?P<pk>\d+)/(?P<topic_slug>.+)/editer/$', PrivateTopicEdit.as_view(),
+                           name='mp-edit'),
                        url(r'^(?P<pk>\d+)/(?P<topic_slug>.+)/editer/participants/$',
                            PrivateTopicAddParticipant.as_view(), name='mp-edit-participant'),
 

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -26,7 +26,7 @@ from zds.member.models import Profile
 from zds.utils.mps import send_mp
 from zds.utils.paginator import ZdSPagingListView
 from zds.utils.templatetags.emarkdown import emarkdown
-from .forms import PrivateTopicForm, PrivatePostForm
+from .forms import PrivateTopicForm, PrivatePostForm, PrivateTopicEditForm
 from .models import PrivateTopic, PrivatePost, \
     never_privateread, mark_read, PrivateTopicRead
 
@@ -125,6 +125,26 @@ class PrivateTopicNew(CreateView):
                           False)
 
         return redirect(p_topic.get_absolute_url())
+
+
+class PrivateTopicEdit(UpdateView):
+    """ Update mp informations """
+
+    model = PrivateTopic
+    template_name = "mp/topic/edit.html"
+    form_class = PrivateTopicEditForm
+    pk_url_kwarg = "pk"
+    context_object_name = "topic"
+
+    @method_decorator(login_required)
+    def dispatch(self, *args, **kwargs):
+        return super(PrivateTopicEdit, self).dispatch(*args, **kwargs)
+
+    def get_object(self, queryset=None):
+        topic = super(PrivateTopicEdit, self).get_object(queryset)
+        if topic is not None and not topic.author == self.request.user:
+            raise PermissionDenied
+        return topic
 
 
 class PrivateTopicLeaveDetail(SingleObjectMixin, RedirectView):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #2393 |

Permet à l'auteur d'un mp de modifier le titre et sous titre. Quelques pistes pour qa : 
- Vérifier l'affichage dans la sidebar seulement pour l'auteur.
- Tester en tant que participant, simple membre ou déconnecté.
- Tester le formulaire d'édition
