### PR TITLE
Classement des tags du forum

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -441,6 +441,7 @@ ZDS_APP = {
         'beta_forum_id': 1,
         'max_post_length': 1000000,
         'top_tag_max': 5,
+        'top_tag_exclu': {},
         'home_number': 5,
     },
     'paginator': {

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -442,6 +442,7 @@ ZDS_APP = {
         'max_post_length': 1000000,
         'top_tag_max': 5,
         'top_tag_exclu': {},
+        'top_tag_cache': 60*60*24,# cache for top tag in second
         'home_number': 5,
     },
     'paginator': {

--- a/zds/utils/templatetags/tests/test_top_tags.py
+++ b/zds/utils/templatetags/tests/test_top_tags.py
@@ -2,6 +2,7 @@
 from django.contrib.auth.models import Group
 
 from django.test import TestCase
+from zds import settings
 
 from zds.forum.factories import CategoryFactory, ForumFactory, TopicFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory
@@ -67,3 +68,10 @@ class TopBarTests(TestCase):
         top_tags_for_staff = top_categories(self.staff1.user).get('tags')
         self.assertEqual(top_tags_for_staff[2].title, 'stafftag')
 
+        # Now we want to exclude a tag
+        settings.ZDS_APP['forum']['top_tag_exclu'] = {'php'}
+        top_tags = top_categories(user).get('tags')
+
+        # Assert
+        self.assertEqual(top_tags[0].title, 'c#')
+        self.assertEqual(len(top_tags), 1)

--- a/zds/utils/templatetags/tests/test_top_tags.py
+++ b/zds/utils/templatetags/tests/test_top_tags.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+from django.contrib.auth.models import Group
+
+from django.test import TestCase
+
+from zds.forum.factories import CategoryFactory, ForumFactory, TopicFactory
+from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.utils.templatetags.topbar import top_categories
+
+
+class TopBarTests(TestCase):
+
+    def setUp(self):
+
+        # Create some forum's category
+        self.category1 = CategoryFactory(position=1)
+        self.category2 = CategoryFactory(position=2)
+
+        # Create forum
+        self.forum11 = ForumFactory(
+            category=self.category1,
+            position_in_category=1)
+
+        # Only for staff
+        self.staff1 = StaffProfileFactory()
+
+        self.forum12 = ForumFactory(
+            category=self.category2,
+            position_in_category=2)
+
+        self.forum12.group.add(Group.objects.filter(name="staff").first())
+        self.forum12.save()
+
+    def test_top_tags(self):
+        """Test if we make a list of most use tags"""
+
+        user = ProfileFactory().user
+
+        # Create some topics
+        topic = TopicFactory(forum=self.forum11, author=user)
+        topic.add_tags({'C#'})
+
+        topic1 = TopicFactory(forum=self.forum11, author=user)
+        topic1.add_tags({'C#'})
+
+        topic2 = TopicFactory(forum=self.forum11, author=user)
+        topic2.add_tags({'C#'})
+
+        topic3 = TopicFactory(forum=self.forum11, author=user)
+        topic3.add_tags({'PHP'})
+
+        topic4 = TopicFactory(forum=self.forum11, author=user)
+        topic4.add_tags({'PHP'})
+
+        topic5 = TopicFactory(forum=self.forum12, author=user)
+        topic5.add_tags({'stafftag'})
+
+        # Now call the function, should be "C#", "PHP", "LoveZesteDeSavoir"
+        top_tags = top_categories(user).get('tags')
+
+        # Assert
+        self.assertEqual(top_tags[0].title, 'c#')
+        self.assertEqual(top_tags[1].title, 'php')
+        self.assertEqual(len(top_tags), 2)
+
+        # Admin should see theirs specifics tags
+        top_tags_for_staff = top_categories(self.staff1.user).get('tags')
+        self.assertEqual(top_tags_for_staff[2].title, 'stafftag')
+

--- a/zds/utils/templatetags/topbar.py
+++ b/zds/utils/templatetags/topbar.py
@@ -39,6 +39,7 @@ def top_categories(user):
         Tag.objects.annotate(num_topic=Count('topic'))
                    .order_by('-num_topic')
                    .filter(topic__not_in=Topic.objects.filter(forum__in=forums).all())
+                   .exclude(title__in=settings.ZDS_APP['forum']['top_tag_exclu'])
         [:settings.ZDS_APP['forum']['top_tag_max']]
     )
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | ~oui |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2572 |

La nouvelle fonctionnalités permet de supprimer des top tags par la configuration. On peut éviter ainsi d'avoir des top tags qui sont bug et suggestion (Par défaut, il y'en a pas). 
Ajout d'un cache pour cette requête.
Résolution du bug qui ne trie pas les top tags correctement.

**QA:**
- Passer les tests
- Créé des topics avec des tags
- Vérifier que les top tags sont dans le bon ordre
- Ajouter un tag exclu dans la config du fichier settings.py (Par exemple: changer 'top_tag_exclu': {} de 'top_tag_exclu': {'bug'}) et vérifier que le top tag n’apparaît plus
- Installer memcache sur votre machine et lancer le ou changer la variable cache dans le settings.py pour 
  `
  'default': {
      'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
      'LOCATION': '/var/tmp/django_cache',
  }
  `
  Cela permet de cacher les données dans un fichier.
- Rafraîchir deux fois et vérifier que la requette sql qui permet de récupérer le cache n'est pas exécute dans la toolbar django.
