### PR TITLE
Uniformisation de l'objet du mail de création d'un MP et de réponse

### DIFF
--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -376,7 +376,7 @@ class PrivatePostAnswer(CreateView):
         self.topic.save()
 
         # send email
-        subject = u"{} - {} : {}".format(settings.ZDS_APP['site']['abbr'],
+        subject = u"{} - {} : {}".format(settings.ZDS_APP['site']['litteral_name'],
                                          _(u'Message Privé'),
                                          self.topic.title)
         from_email = u"{} <{}>".format(settings.ZDS_APP['site']['litteral_name'],


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2586 |

> Lorsqu'on reçoit le mail de création d'un MP, l'objet du mail s'intitule "Zeste de savoir - blabla" alors que 
> les objets des réponses s'intitulent "ZdS - blabla" ce qui crée deux fils de discussion inutiles dans les 
> boites mails.

**QA**:
- Se connecter avec un compte 'user', envoyer un MP à 'admin'
- Vérifier que l'option « Recevez un courriel lorsque vous recevez une réponse à un message privé » est activé dans le profil du membre
- Se connecter avec le compte admin et envoyer une réponse à ce message personnel
- Vérifier que l'objet du mail d'une réponse de MP est bien conforme au pattern ci-dessous Zeste de Savoir Message Privé : titre du mail
