### PR TITLE
[hotfix] Correction du bug unicode dans le markdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.7.0
 gitpython==0.3.5
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.6.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.7.zip
 easy-thumbnails==2.2
 
 # Api dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ factory-boy==2.4.1
 pygeoip==0.3.2
 pillow==2.7.0
 gitpython==0.3.5
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.5.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.6.zip
 easy-thumbnails==2.2
 
 # Api dependencies


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | [forum](https://zestedesavoir.com/forums/sujet/2868/les-urls-ne-peuvent-plus-contenir-de-caracteres-accentues/) |

Cette PR corrige le bug unicode qui fait qu'on ne pouvait plus mettre de lien avec caractère accentué dans l'url.

**Note pour QA**
- Créez un topic et dans le corps du message, renseignez la chaine `[article](http://fr.wikipedia.org/wiki/Liste_en_compréhension)`
- Constatez que le topic est bien crée sans message d'erreur
