### PR TITLE
Revert de GeoIP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ install:
   - sudo apt-get install texlive-xetex
   - sudo apt-get install texlive-lang-french
   - sudo apt-get install texlive-latex-extra
-  - sudo apt-get install libgeoip-dev
 
   # Add fonts
   - sudo wget -P /usr/share/fonts/truetype https://www.dropbox.com/s/ema28tjn52960mq/Merriweather.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-munin==0.1.5
 python-memcached==1.53
 lxml==3.4.2
 factory-boy==2.4.1
-geoip==1.3.2
+pygeoip==0.3.2
 pillow==2.7.0
 gitpython==0.3.6
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.4.zip

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 import os
+import pygeoip
 
 from hashlib import md5
 from importlib import import_module
@@ -9,7 +10,6 @@ from importlib import import_module
 from django.conf import settings
 from django.contrib.auth import logout
 from django.contrib.auth.models import User
-from django.contrib.gis.geoip import GeoIP
 from django.contrib.sessions.models import Session
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -117,11 +117,12 @@ class Profile(models.Model):
         providers.
         :return: The city and the country name of this profile.
         """
-        g = GeoIP()
-        geo = g.city(self.last_ip_address)
-        if geo is not None:
-            return u'{0}, {1}'.format(geo['city'], geo['country_name'])
-        return ''
+        if len(self.last_ip_address) <= 16:
+            gic = pygeoip.GeoIP(os.path.join(settings.GEOIP_PATH, 'GeoLiteCity.dat'))
+        else:
+            gic = pygeoip.GeoIP(os.path.join(settings.GEOIP_PATH, 'GeoLiteCityv6.dat'))
+        geo = gic.record_by_addr(self.last_ip_address)
+        return u'{0}, {1}'.format(geo['city'], geo['country_name'])
 
     def get_avatar_url(self):
         """


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2600 , #2483 |

Cette PR,  permet de revenir à l'état d'avant, c'est à dire utiliser pygeoip à la place de geoip (introduit récemment dans le code). Les raisons du rollback sont évoqués dans la [discussion sur le forum](http://zestedesavoir.com/forums/sujet/2962/geoip-vs-pygeoip/?page=1#p53292).

La PR règle donc par conséquent les régressions introduites avec ce changement de lib.

**Note pour QA** : 
- Connectez vous si le site depuis une adresse IP en ipv6 et vérifiez dans votre page de profil que la localisation est bien faite. Vous devez au moins voir votre pays
