### PR TITLE
[Beta 1.8] Fixes #2590 #2591 : SITE_ID supprimé mais pas l'app --> plantages

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -176,6 +176,8 @@ INSTALLED_APPS = (
     # 'django.contrib.admindocs',
 )
 
+SITE_ID = 1
+
 THUMBNAIL_ALIASES = {
     '': {
         'avatar': {'size': (60, 60), 'crop': True},


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets (_issues_) concernés | #2590, #2591 |

En fait, la migration vers Django 1.7 supprimait le SITE_ID (plus obligatoire) mais pas l'application dans la liste des applications installées, ce qui provoquait des plantages.

J'ai remis le SITE_ID et ça semble suffire.

**QA** : Vérifier que les `sitemap.xml`  fonctionnent (le principal et les différents sous-sitemaps). Vérifier que les flux RSS et Atom fonctionnent.
