### PR TITLE
[bêta v1.8] Fixe erreurs unicodes

### DIFF
--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -680,13 +680,20 @@ def modify(request):
         # A validatir would like to valid an article in validation. We
         # must update sha_public with the current sha of the validation.
         elif 'valid-article' in request.POST:
-            mep(article, article.sha_validation)
+
             validation = Validation.objects\
                 .filter(article__pk=article.pk,
                         version=article.sha_validation)\
                 .latest('date_proposition')
 
             if request.user == validation.validator:
+
+                try:
+                    mep(article, article.sha_validation)
+                except UnicodeErrorInArticle as e:
+                    messages.error(request, e)
+                    return redirect(article.get_absolute_url() + '?version=' + validation.version)
+
                 validation.comment_validator = request.POST['comment-v']
                 validation.status = 'PUBLISHED'
                 validation.date_validation = datetime.now()
@@ -1036,7 +1043,12 @@ def history(request, article_pk, article_slug):
         'article': article, 'logs': logs, 'formJs': form_js
     })
 
+
 # Reactions at an article.
+class UnicodeErrorInArticle(Exception):
+
+    def __init__(self, *args, **kwargs):
+        super(UnicodeErrorInArticle, self).__init__(*args, **kwargs)
 
 
 def mep(article, sha):
@@ -1057,7 +1069,12 @@ def mep(article, sha):
         is_js = "js"
     else:
         is_js = ""
-    html_file.write(emarkdown(md_file_contenu, is_js))
+    try:
+        html_file.write(emarkdown(md_file_contenu, is_js))
+    except (UnicodeError, UnicodeEncodeError):
+        raise UnicodeErrorInArticle(
+            u'Une erreur est survenue lors de la génération du HTML, vérifiez que le code markdown ne contient '
+            u'pas d\'erreurs')
     html_file.close()
 
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -348,9 +348,12 @@ def valid_tutorial(request):
         version=tutorial.sha_validation).latest("date_proposition")
 
     if request.user == validation.validator:
-        (output, err) = mep(tutorial, tutorial.sha_validation)
-        messages.info(request, output)
-        messages.error(request, err)
+        try:
+            mep(tutorial, tutorial.sha_validation)
+        except UnicodeErrorInTutorial as e:
+            messages.error(request, e)
+            return redirect(tutorial.get_absolute_url() + "?version=" + validation.version)
+
         validation.comment_validator = request.POST["text"]
         validation.status = "ACCEPT"
         validation.date_validation = datetime.now()
@@ -408,7 +411,7 @@ def valid_tutorial(request):
 def invalid_tutorial(request, tutorial_pk):
     """Staff invalid tutorial of an author."""
 
-    # Retrieve current tutorial
+    # Retrieve current tutorials
 
     tutorial = get_object_or_404(Tutorial, pk=tutorial_pk)
     un_mep(tutorial)
@@ -3109,6 +3112,7 @@ def get_url_images(md_text, pt):
                     os.makedirs(os.path.join(pt, "images"))
 
                 # download image
+                filename = filename.decode('utf-8')
                 down_path = os.path.abspath(os.path.join(pt, "images", filename))
                 try:
                     urlretrieve(real_url, down_path)
@@ -3188,8 +3192,13 @@ def markdown_to_out(md_text):
                   md_text)
 
 
+class UnicodeErrorInTutorial(Exception):
+
+    def __init__(self, *args, **kwargs):
+        super(UnicodeErrorInTutorial, self).__init__(*args, **kwargs)
+
+
 def mep(tutorial, sha):
-    (output, err) = (None, None)
     repo = Repo(tutorial.get_path())
     manifest = get_blob(repo.commit(sha).tree, "manifest.json")
     tutorial_version = json_reader.loads(manifest)
@@ -3237,7 +3246,7 @@ def mep(tutorial, sha):
 
         # download images
 
-        get_url_images(md_file_contenu, prod_path)
+        get_url_images(md_file_contenu.encode('utf-8'), prod_path)
 
         # convert to out format
         out_file = open(os.path.join(prod_path, fichier), "w")
@@ -3259,7 +3268,12 @@ def mep(tutorial, sha):
         else:
             is_js = ""
         if md_file_contenu is not None:
-            html_file.write(emarkdown(md_file_contenu, is_js))
+            try:
+                html_file.write(emarkdown(md_file_contenu, is_js))
+            except (UnicodeEncodeError, UnicodeError):
+                raise UnicodeErrorInTutorial(_(u'Une erreur est survenue lors de la génération du HTML à partir '
+                                               u'du fichier « {} », vérifiez que le code markdown correspondant ne '
+                                               u'contient pas d\'erreurs'.format(fichier)))
         html_file.close()
 
     # load markdown out
@@ -3292,7 +3306,6 @@ def mep(tutorial, sha):
               ".md -o " + os.path.join(prod_path,
                                        tutorial.slug) + ".epub" + pandoc_debug_str)
     os.chdir(settings.BASE_DIR)
-    return (output, err)
 
 
 def un_mep(tutorial):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2584 #2606 #2585 |
# Pourquoi, comment ?

Parce que la PR #2585 fait exactement la même chose, mais sur la version de prod'. Sauf que sur la version de _prod'_, c'est toujours django 1.6 et que [je tombe sur une erreur mystique](https://github.com/zestedesavoir/zds-site/pull/2585#issuecomment-97585579) (du genre que j'ai passé deux heure a essayer de la fixer). D'autant que #2588 règle #2585 ... De la mauvaise manière (en faisant disparaître le bug dans le markdown, donc à la source). Donc je fixe les problèmes convenablement sur la bêta (avec Django 1.7).

**Pourquoi il n'y a pas de T.U.**: parce que tant que #2588 est pas mergée, le moindre test que je pourrait mettre en place plantera lamentablement, puisque _markdown_ nous lâche sur les liens avec accents, et que c'est justement ce que cette PR corrige.

**Est ce que c'est du bugfix ?** je pense, oui. C'était déjà du _hotfix_ à la base, donc bon.
# Note de QA

**je préviens, c'est pas une QA drôle**
- Commencez avec la version de markdown actuelement en bêta (`pip install --upgrade https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.5.zip`). C'est le seul moyen d'avoir un bug markdown et que cette PR soit testable, donc faites le.
- Créez un article et, pour texte, écrivez :

```
Cette image va planter: ![](http://upload.wikimedia.org/wikipedia/commons/thumb/c/c6/Latin_alphabet_Ćć.svg/langfr-260px-Latin_alphabet_Ćć.svg.png)

Puis ce lien va planter, aussi : [ce lien va rater](http://fr.wikipedia.org/wiki/Clémentine) 
```
- Tentez quand même de valider l'article et vérifiez que vous êtes bien arrêté avant la fin par un message d'erreur qui vous dit que quelque chose ne va pas dans le code markdown.
- Faites de même avec un tutoriel, mais cette fois, vérifiez que vous êtes également empêché de publier si l'erreur se trouve dans une introduction/conclusion

**PUIS !**
- Mettez à jour votre version de markdown (`pip install --upgrade https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.7.zip`, ça vient de #2588)
- Vérifiez que cette fois, tuto et article passent la validation **ET** que l'image est bien affichée.

Merci à @GerardPaligot pour son acharnement sur la première PR, injustement remercié par mon comportement d'il y a quelques heures.
