### PR TITLE
Bloque les telechargements pour les crawler

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -7,3 +7,10 @@ Disallow: /mp/
 Disallow: /tutoriels/off/
 Disallow: /tutoriels/beta/
 Disallow: /articles/off/
+
+# Prevent indexing robots to go on downloading pages (except pdf and epub of tutorials)
+# Articles don't have any pdf and epub
+Allow: /tutoriels/telecharger/epub/
+Allow: /tutoriels/telecharger/pdf/
+Disallow: /tutoriels/telecharger/
+Disallow: /articles/telecharger/


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | ~oui |
| Tickets (_issues_) concernés | #1999 |

Empeche les robots d'indexation d'aller indexer les pages de téléchargements.
Pourquoi ? car ce n'est pas super convivial alors qu'on propose déjà le contenu dans un format web (le lecteur ayant ensuite le choix de télécharger dans le format qu'il veut)
