### PR TITLE
Force la deco d'un banni

### DIFF
--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -409,10 +409,11 @@ def logout_user(username):
     request = HttpRequest()
 
     sessions = Session.objects.filter(expire_date__gt=now)
+    user = User.objects.get(username=username)
 
     for session in sessions:
         user_id = session.get_decoded().get('_auth_user_id')
-        if username == user_id:
+        if user.id == user_id:
             engine = import_module(settings.SESSION_ENGINE)
             request.session = engine.SessionStore(session.session_key)
             logout(request)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2396 |

Lorsqu'un membre est banni, sa session doit-être détruite pour éviter qu'il ne continue a faire du bazar entre temps (MP par exemple). ce commit règle ca (on faisait une comparaison entre un username et un id, ca pouvait pas marcher).
Je ne sais pas comment le TU, si qqun a une idée qu'il me PR sinon tant pis...
### QA
- Faire un utilisateur bidon actif
- Se connecter avec dans un navigateur
- Dans un autre navigateur, bannissez le bidon (temporaire ou definitif)
- Verifier que bidon est bien déconnecté ET que les autres sessions n'ont pas bougée
