### PR TITLE
Corrige la valeur par défaut pour le champ licence

### DIFF
--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1233,11 +1233,9 @@ def edit_tutorial(request):
     else:
         json = tutorial.load_json()
         if "licence" in json:
-            licence = json['licence']
+            licence = Licence.objects.get(code=json['licence'])
         else:
-            licence = Licence.objects.get(
-                pk=settings.ZDS_APP['tutorial']['default_license_pk']
-            )
+            licence = Licence.objects.get(pk=settings.ZDS_APP['tutorial']['default_license_pk'])
         form = TutorialForm(initial={
             "title": json["title"],
             "type": json["type"],


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2613 |

**QA**:
- Créé un tutoriel
- Vérifier que le champs licence par défaut est bien sur "Tous droits réservé"
- Changer la licence en "GNU GPL" et valider le formulaire
- Cliquer sur le bouton éditer le tutoriel et vérifier que la licence proposé par défaut est bien « GNU GPL».
