### PR TITLE
Fixe les probleme de documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,6 +30,9 @@ if not on_rtd:
 sys.path.insert(0, os.path.abspath('../../'))  # add modules to python search path
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'zds.settings')   # Django should use OUR settings also with SPHINX
 
+import django
+django.setup()
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -42,7 +42,7 @@ from zds.utils.models import SubCategory, Category, CommentLike, \
 from zds.utils.paginator import paginator_range
 from zds.utils.tutorials import get_sep, get_text_is_empty
 from zds.utils.templatetags.emarkdown import emarkdown
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from .forms import ArticleForm, ReactionForm, ActivJsForm
 from .models import Article, get_prev_article, get_next_article, Validation, \

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -17,7 +17,7 @@ from django.http import Http404, HttpResponse, StreamingHttpResponse
 from django.shortcuts import redirect, get_object_or_404, render, render_to_response
 from django.template.loader import render_to_string
 from django.views.decorators.http import require_POST
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from haystack.inputs import AutoQuery
 from haystack.query import SearchQuerySet

--- a/zds/gallery/forms.py
+++ b/zds/gallery/forms.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
@@ -11,7 +12,6 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 
 from zds.gallery.models import Gallery, Image
-from django.utils.translation import ugettext_lazy as _
 
 
 class GalleryForm(forms.ModelForm):

--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -12,7 +12,7 @@ from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.db import models
 from django.dispatch import receiver
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from zds.settings import MEDIA_ROOT, MEDIA_URL
 

--- a/zds/gallery/tests/tests_models.py
+++ b/zds/gallery/tests/tests_models.py
@@ -4,7 +4,7 @@ import os
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from zds.gallery.factories import GalleryFactory, UserGalleryFactory, ImageFactory
 from zds.member.factories import ProfileFactory

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -28,7 +28,7 @@ from zds.tutorial.models import Tutorial
 import zipfile
 import shutil
 import os
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from django.views.generic import ListView, DetailView, CreateView, UpdateView, DeleteView, FormView
 from django.utils.decorators import method_decorator

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -5,7 +5,7 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.models import User, Group
 from django.core.urlresolvers import reverse
 from django.db.models import Q
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -20,6 +20,7 @@ from django.shortcuts import redirect, render, get_object_or_404
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import string_concat
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, UpdateView, CreateView
 from forms import LoginForm, MiniProfileForm, ProfileForm, RegisterForm, \
@@ -960,15 +961,15 @@ def settings_promote(request, user_pk):
                 u'Un administrateur vient de modifier les groupes '
                 u'auxquels vous appartenez.  \n').format(user.username)
         if len(usergroups) > 0:
-            msg += _(u'Voici la liste des groupes dont vous faites dorénavant partie :\n\n')
+            msg = string_concat(msg, _(u'Voici la liste des groupes dont vous faites dorénavant partie :\n\n'))
             for group in usergroups:
                 msg += u'* {0}\n'.format(group.name)
         else:
-            msg += _(u'* Vous ne faites partie d\'aucun groupe')
+            msg = string_concat(msg, _(u'* Vous ne faites partie d\'aucun groupe'))
         msg += u'\n\n'
         if user.is_superuser:
-            msg += _(u'Vous avez aussi rejoint le rang des super utilisateurs. '
-                     u'N\'oubliez pas, un grand pouvoir entraine de grandes responsabiltiés !')
+            msg = string_concat(msg, _(u'Vous avez aussi rejoint le rang des super utilisateurs. '
+                                       u'N\'oubliez pas, un grand pouvoir entraine de grandes responsabiltiés !'))
         send_mp(
             bot,
             [user],

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -19,7 +19,7 @@ from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import redirect, render, get_object_or_404
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, UpdateView, CreateView
 from forms import LoginForm, MiniProfileForm, ProfileForm, RegisterForm, \

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -20,7 +20,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.views.generic import CreateView, RedirectView, UpdateView
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.list import MultipleObjectMixin
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from zds.member.models import Profile
 from zds.utils.mps import send_mp

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -19,7 +19,7 @@ from zds.pages.forms import AssocSubscribeForm
 from zds.settings import BASE_DIR
 from zds.tutorial.models import get_last_tutorials
 from zds.utils.models import Alert
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 
 def home(request):

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -58,7 +58,7 @@ from zds.utils.paginator import paginator_range
 from zds.utils.templatetags.emarkdown import emarkdown
 from zds.utils.tutorials import get_blob, export_tutorial_to_md, move, get_sep, get_text_is_empty, import_archive
 from zds.utils.misc import compute_hash, content_has_changed
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 
 def render_chapter_form(chapter):

--- a/zds/utils/mps.py
+++ b/zds/utils/mps.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from zds.mp.models import PrivateTopic, PrivatePost
 from zds.utils.templatetags.emarkdown import emarkdown

--- a/zds/utils/tutorials.py
+++ b/zds/utils/tutorials.py
@@ -9,7 +9,7 @@ from git import Repo, Actor
 from django.conf import settings
 from django.template import Context
 from django.template.loader import get_template
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from zds.utils import slugify
 from zds.utils.models import Licence


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | ~non |
| Tickets (_issues_) concernés | #2616 |

Comme reporté sur #2616, on évite les `ugettext` à l'avenir et on emploi `ugettext_lazy` :)
# Note de QA

EDIT: on est repassé à l'ancienne version de `geoip`, donc si jamais c'est mergé dans `dev`, n'hésitez pas à tester (voir #2600)
- Vérifiez que vous avez bien installé GeoIP convenablement, sinon la compilation de la doc plantera lamentablement ~~(j'attend patiemment qu'on repasse à l'ancien `geoip`, mais c'est une autre histoire)~~
- Exécutez `cd doc/; make clean; make html` et vérifiez que Sphinx ne vous lache pas l'erreur reportée sur #2616
- Visitez la doc, partie "documentation technique du back-end" et vérifiez que `autodoc` a bien fait son travail et que les modules sont documentés. Par exemple, pour les articles, vous devriez obtenir ceci:

![screenshot from 2015-05-03 12 27 10](https://cloud.githubusercontent.com/assets/7889675/7445793/bb1e546a-f18f-11e4-84fb-b99500bd8c89.png)

Profitez en pour reporter toute erreur que vous pourriez avoir avec l'installation de sphinx et la génération de la documentation. C'est _hors-scope_, mais tant qu'on est dedans, on va s'attaquer à ça. Je pense en particulier à @GerardPaligot qui a eu des problèmes par le passé :)
