### PR TITLE
Remplacement d'un lien mort dans la doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Vous trouverez tout sur [la page dédiée de la documentation](CONTRIBUTING.md)
 
 ## En savoir plus
 
-- [Comment déployer ZDS sur un serveur de production ?](http://zds-site.readthedocs.org/fr/latest/install/deploiement-production.html)
+- [Comment déployer ZDS sur un serveur de production ?](http://zds-site.readthedocs.org/fr/latest/install/deploy-in-production.html)
 - [Comment contribuer et conseils de développement](CONTRIBUTING.md)
 - [Comment contribuer : comprendre comment suivre le workflow (sur zds)](http://zestedesavoir.com/forums/sujet/324/comment-contribuer-comprendre-comment-suivre-le-workflow/)
 - [Les détails du workflow utilisé sur Zeste de Savoir](http://zds-site.readthedocs.org/fr/latest/workflow.html)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2624 |

Remplace du lien mort dans le readme sur "Comment déployer ZDS sur un serveur de production ?"

=> Merge direct possible.
