### PR TITLE
Corrige deux petites erreur 500

### DIFF
--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -419,6 +419,16 @@ class ForumMemberTests(TestCase):
         # check edit data
         self.assertEqual(Post.objects.get(pk=post2.pk).editor, self.user)
 
+        # if the post pk is altered
+        result = self.client.post(
+            reverse('zds.forum.views.edit_post') + '?message=abcd',
+            {
+                'text': u'C\'est tout simplement l\'histoire de la ville de Paris que je voudrais vous conter '
+            },
+            follow=False)
+
+        self.assertEqual(result.status_code, 404)
+
     def test_edit_post_with_blank(self):
 
         topic1 = TopicFactory(forum=self.forum11, author=self.user)
@@ -461,6 +471,12 @@ class ForumMemberTests(TestCase):
             topic1.pk, post2.pk), follow=True)
 
         self.assertEqual(result.status_code, 200)
+
+        # if the quote pk is altered
+        result = self.client.get(reverse('zds.forum.views.answer') + '?sujet={0}&cite=abcd'.format(
+            topic1.pk), follow=True)
+
+        self.assertEqual(result.status_code, 404)
 
     def test_signal_post(self):
         """To test when a member signal a post."""
@@ -954,7 +970,7 @@ class ForumMemberTests(TestCase):
         self.assertEqual(topic_with_conflict_tags.tags.all().count(), 1)
         topic_with_conflict_tags = TopicFactory(
             forum=self.forum11, author=self.user)
-        topic_with_conflict_tags.title = u"[][ ][	]name"
+        topic_with_conflict_tags.title = u"[][ ][   ]name"
         (tags, title) = get_tag_by_title(topic_with_conflict_tags.title)
         topic_with_conflict_tags.add_tags(tags)
         self.assertEqual(topic_with_conflict_tags.tags.all().count(), 0)

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -622,7 +622,7 @@ def answer(request):
         if "cite" in request.GET:
             resp = {}
             try:
-                post_cite_pk = request.GET["cite"]
+                post_cite_pk = int(request.GET["cite"])
             except ValueError:
                 raise Http404
             post_cite = Post.objects.get(pk=post_cite_pk)
@@ -662,8 +662,8 @@ def edit_post(request):
     """
 
     try:
-        post_pk = request.GET["message"]
-    except KeyError:
+        post_pk = int(request.GET["message"])
+    except (KeyError, ValueError):
         # problem in variable format
         raise Http404
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2633 |

Corrige deux petites erreur 500 inoffensives...
### QA
- Faites un sujet de fofo avec deux utilisateurs et quelques messages
1. Editer un message
   - Sur la page d'edition, alterer l'url pour y mettre des lettres
   - Valider l'URL et constater une 404 au lieu d'une 500
2. Essayer de citer en ouvrant le lien de citation (donc copier le lien du bouton et ouvrez un nouvel onglet)
   - Sur la page de message, alterer l'url pour y mettre des lettres dans le paramètre `cite=`
   - Valider l'URL et constater une 404 au lieu d'une 500
