### PR TITLE
Fix 2632: Impossible de remettre un champ de son profil à `False`

### DIFF
--- a/zds/member/api/serializers.py
+++ b/zds/member/api/serializers.py
@@ -104,12 +104,15 @@ class ProfileValidatorSerializer(serializers.ModelSerializer, ProfileUsernameVal
         instance.avatar_url = validated_data.get('avatar_url', instance.avatar_url) or instance.avatar_url
         instance.biography = validated_data.get('biography', instance.biography) or instance.biography
         instance.sign = validated_data.get('sign', instance.sign) or instance.sign
-        instance.show_email = validated_data.get('show_email', instance.show_email) or instance.show_email
-        instance.show_sign = validated_data.get('show_sign', instance.show_sign) or instance.show_sign
-        instance.hover_or_click = validated_data.get('hover_or_click',
-                                                     instance.hover_or_click) or instance.hover_or_click
-        instance.email_for_answer = validated_data.get('email_for_answer',
-                                                       instance.email_for_answer) or instance.email_for_answer
+
+        if validated_data.get('show_email', instance.show_email) != instance.show_email:
+            instance.show_email = validated_data.get('show_email', instance.show_email)
+        if validated_data.get('show_sign', instance.show_sign) != instance.show_sign:
+            instance.show_sign = validated_data.get('show_sign', instance.show_sign)
+        if validated_data.get('hover_or_click', instance.hover_or_click) != instance.hover_or_click:
+            instance.hover_or_click = validated_data.get('hover_or_click', instance.hover_or_click)
+        if validated_data.get('email_for_answer', instance.email_for_answer) != instance.email_for_answer:
+            instance.email_for_answer = validated_data.get('email_for_answer', instance.email_for_answer)
         instance.user.save()
         instance.save()
         return instance

--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -539,12 +539,26 @@ class MemberDetailAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('show_email'), data.get('show_email'))
 
+        data = {
+            'show_email': False
+        }
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('show_email'), data.get('show_email'))
+
     def test_update_member_details_show_sign(self):
         """
         Updates show sign of a member given.
         """
         data = {
             'show_sign': True
+        }
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('show_sign'), data.get('show_sign'))
+
+        data = {
+            'show_sign': False
         }
         response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -561,12 +575,26 @@ class MemberDetailAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('hover_or_click'), data.get('hover_or_click'))
 
+        data = {
+            'hover_or_click': False
+        }
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('hover_or_click'), data.get('hover_or_click'))
+
     def test_update_member_details_email_for_answer(self):
         """
         Updates email for answer of a member given.
         """
         data = {
             'email_for_answer': True
+        }
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('email_for_answer'), data.get('email_for_answer'))
+
+        data = {
+            'email_for_answer': False
         }
         response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2632 |

**QA**
- Faire un PUT /api/membres/{pk} et tenter de changer de valeurs les champs suivants: shown_sign, shown_email, hover_or_click, email_for_answer.
- Faire des requêtes vide et vérifier que le champ à toujours la même valeur
- Vérifier avec des 0 et des 1
