### PR TITLE
Change "/api/membres/mon_profil/" en "/api/membres/mon-profil/"

### DIFF
--- a/zds/member/api/urls.py
+++ b/zds/member/api/urls.py
@@ -7,7 +7,7 @@ from zds.member.api.views import MemberListAPI, MemberDetailAPI, \
 
 urlpatterns = patterns('',
                        url(r'^$', MemberListAPI.as_view(), name='api-member-list'),
-                       url(r'^mon_profil/$', MemberMyDetailAPI.as_view(), name='api-member-profile'),
+                       url(r'^mon-profil/$', MemberMyDetailAPI.as_view(), name='api-member-profile'),
                        url(r'^(?P<pk>[0-9]+)/$', MemberDetailAPI.as_view(), name='api-member-detail'),
                        url(r'^(?P<pk>[0-9]+)/lecture-seule/$', MemberDetailReadingOnly.as_view(),
                            name='api-member-read-only'),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | _néant_ |

Parce que c'est pas logique, alors que toutes nos URLs sont avec des tirets, d'avoir une URLs avec un "_".
# Rapport de QA

Vérifier que l'API fonctionne toujours et que la page de Swagger à bien pris en compte le changement.

PS: j'ai été un peu trop vite et j'ai fait des choses que j'avais pas le droit de faire, donc j'ai effacé mes changements et je fais une PR normale, et toutes mes excuses à @Eskimon et @SpaceFox (la fonction "éditer" de GH est dangereuse !).
