### PR TITLE
Fix un souci de variable nulle dans un cas precis

### DIFF
--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -128,10 +128,12 @@ class Profile(models.Model):
                 os.path.join(
                     settings.GEOIP_PATH,
                     'GeoLiteCityv6.dat'))
+
         geo = gic.record_by_addr(self.last_ip_address)
 
-        return u'{0}, {1}'.format(
-            geo['city'], geo['country_name'])
+        if geo is not None:
+            return u'{0}, {1}'.format(geo['city'], geo['country_name'])
+        return ''
 
     def get_avatar_url(self):
         """

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -262,6 +262,18 @@ class MemberModelsTest(TestCase):
         self.assertEqual(len(topicsfollowed), 1)
         self.assertEqual(self.forumtopic, topicsfollowed[0])
 
+    def test_get_city_with_wrong_ip(self):
+        # Set a local IP to the user
+        self.user1.last_ip_address = '127.0.0.1'
+        # Then the get_city is not found and return empty string
+        self.assertEqual('', self.user1.get_city())
+
+        # Same goes for IPV6
+        # Set a local IP to the user
+        self.user1.last_ip_address = '0000:0000:0000:0000:0000:0000:0000:0001'
+        # Then the get_city is not found and return empty string
+        self.assertEqual('', self.user1.get_city())
+
     def test_reachable_manager(self):
         # profile types
         profile_normal = ProfileFactory()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2631 |

Pour une raison dont je ne suis pas sur, un test "None" manquait suite au revert de geoip. Je l'ai remis et en ai profité pour rajouter un TU
### QA

Vérifier que la page user marche. Si vous pouvez tester aussi de feinter l'ip pour vérifier que geoip marche bien.
