### PR TITLE
Nettoyage du code de la bannière de cookie

### DIFF
--- a/assets/scss/components/_cookies-banner.scss
+++ b/assets/scss/components/_cookies-banner.scss
@@ -1,39 +1,20 @@
 #cookies-eu-banner {
-    padding: 0 2.5%;
+    padding: 0 3%;
     background: #062E41;
     display: none;
 
-    span {
+    div,
+    #cookies-eu-reject {
         display: inline-block;
         margin: 0;
         padding: 7px 0;
         color: #EEE;
         line-height: 23px;
     }
-
-    #cookies-eu-more {
-        display: inline-block;
-        color: #EEE;
-        padding: 4px 13px;
-        margin-left: 15px;
-        background: $color-primary;
-        text-decoration: none;
-
-        &:hover,
-        &:focus {
-            background: #EEE;
-            color: $color-primary;
-        }
-    }
-
     #cookies-eu-reject {
-        display: inline-block;
         background: none;
         border: none;
         text-decoration: underline;
-        margin: 0;
-        padding: 0;
-        color: #EEE;
 
         &:hover,
         &:focus {
@@ -41,27 +22,34 @@
         }
     }
 
+    #cookies-eu-more,
     #cookies-eu-accept {
-        text-decoration: none;
-        background: #EEE;
-        color: $color-primary;
-        padding: 4px 15px;
-        border: none;
-        transition: background $transition-duration, color $transition-duration;
+        display: inline-block;
         margin-top: 3px;
+        padding: 4px 15px;
+        text-decoration: none;
+        transition: background $transition-duration, color $transition-duration;
+    }
+    #cookies-eu-more {
+        margin-left: 15px;
+        color: #EEE;
+        background: $color-primary;
 
         &:hover,
         &:focus {
-            background: $color-primary;
-            color: #EEE;
+            color: $color-primary;
+            background: #EEE;
         }
     }
-}
+    #cookies-eu-accept {
+        border: none;
+        color: $color-primary;
+        background: #EEE;
 
-@media only screen and #{$media-mega-wide} {
-    #cookies-eu-banner {
-        #cookies-eu-accept {
-            float: right;
+        &:hover,
+        &:focus {
+            color: #EEE;
+            background: $color-primary;
         }
     }
 }
@@ -75,12 +63,13 @@
         left: 0;
         z-index: 10;
 
-        span {
+        div {
             margin-top: 40px;
-            padding: 0 20px;
+            padding: 0 5px;
         }
 
-        #cookies-eu-more, #cookies-eu-accept {
+        #cookies-eu-more,
+        #cookies-eu-accept {
             display: block;
             width: 100%;
             height: 40px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -140,10 +140,10 @@
         </ul>
 
         <div id="cookies-eu-banner">
-            <span>
+            <div>
                 {% trans "Ce site utilise Google Analytics. En poursuivant votre navigation sur ce site, vous nous autorisez à déposer des cookies à des fins de mesure d'audience. Pour s'opposer à ce dépôt vous pouvez cliquer" %}
-            </span>
-            <button id="cookies-eu-reject">{% trans "ici" %}</button>.
+                <button id="cookies-eu-reject">{% trans "ici" %}</button>.
+            </div>
             <a href="/pages/cookies" id="cookies-eu-more">{% trans "En savoir plus" %}</a>
             <button id="cookies-eu-accept">{% trans "OK" %}</button>
         </div>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2544 |

Nettoie le code de la bannière de cookie et résout #2544 

**Instructions de QA :**
- Rajouter `ZDS_APP['site']['googleAnalyticsID'] = 'UA-27730868-1'` et `ZDS_APP['site']['googleTagManagerID'] = 'GTM-WH7642'` dans le `settings.py` ;
- Générer le _front-end_ (`npm run gulp -- build`) ;
- Vérifier que la bannière fonctionne toujours correctement.
