### PR TITLE
Met un avertissement anti-déterrage sur les vieux sujets

### DIFF
--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -27,6 +27,16 @@
         {% trans "Vous êtes seul dans cette conversation" %}.
     </div>
 {% else %}
+    {% if topic.old_post_warning %}
+        <div class="alert-box warning">
+            <p>
+                {% blocktrans with old_post_limit_days=app.forum.old_post_limit_days %}
+                    Ce sujet est sans activité depuis plus de {{ old_post_limit_days }} jours. Êtes-vous certain de vouloir y contribuer ?
+                {% endblocktrans %}
+            </p>
+        </div>
+    {% endif %}
+
     <section class="topic-message">
         <form action="{{ form_action }}" method="post">
             {% include "misc/message_user.html" with hide_metadata=True %}

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -9,7 +9,7 @@ import string
 import uuid
 
 from django.contrib.auth.models import Group, User
-from datetime import datetime
+from datetime import datetime, timedelta
 from django.core.urlresolvers import reverse
 from django.utils.encoding import smart_text
 
@@ -347,6 +347,22 @@ class Topic(models.Model):
         if last_user_post and last_user_post == self.get_last_post():
             t = datetime.now() - last_user_post.pubdate
             if t.total_seconds() < settings.ZDS_APP['forum']['spam_limit_seconds']:
+                return True
+
+        return False
+
+    def old_post_warning(self):
+        """
+        Check if the last message was written a long time ago according to `ZDS_APP['forum']['old_post_limit_days']`
+        value.
+
+        :return: `True` if the post is old (users are warned), `False` otherwise.
+        """
+        last_post = self.last_message
+
+        if last_post is not None:
+            t = last_post.pubdate + timedelta(days=settings.ZDS_APP['forum']['old_post_limit_days'])
+            if t < datetime.today():
                 return True
 
         return False

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -453,6 +453,7 @@ ZDS_APP = {
         'max_post_length': 1000000,
         'top_tag_max': 5,
         'home_number': 5,
+        'old_post_limit_days': 90
     },
     'topic': {
         'home_number': 6,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #2509 |

Met un avertissement de déterrage au dessus de l'éditeur quand le dernier message du sujet date de plus de 3 mois (durée paramétrable en mois dans `settings.py`)

Je suis ouvert aux commentaires concernant le texte d'avertissement !

_Je ne pouvais pas laisser OpenClassrooms mettre en place une telle feature sans que nous l'ayons aussi ! :D (En réalité, c'est surtout parce que ça me fait toucher au back-end)_

**Instructions de QA :**
- Charger les _fixtures_ (`python loaddata fixtures/*.yaml`) ;
- Aller sur un message du forum ;
- Vérifier qu'il y a bien l'avertissement (les _fixtures_ ont été mises en place il y a plus de trois mois donc les messages ont une date de plus de 3 mois) ;
- Répondre au sujet ;
- Vérifier que le message ne s'affiche plus.

---

![Petit aperçu](http://i.gyazo.com/169a6049cb1105e6cf076c508a0d566c.png)
