### PR TITLE
Regle un souci de 500 sur citation de MP

### DIFF
--- a/zds/mp/decorator.py
+++ b/zds/mp/decorator.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from django.core.exceptions import PermissionDenied
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from zds.mp.models import PrivateTopic, PrivatePost
 
@@ -17,7 +18,12 @@ def is_participant(func):
         if not request.user == private_topic.author and request.user not in list(private_topic.participants.all()):
             raise PermissionDenied
         if 'cite' in request.GET:
-            if PrivatePost.objects.filter(privatetopic=private_topic).filter(pk=request.GET.get('cite')).count() != 1:
-                raise PermissionDenied
+            try:
+                if PrivatePost.objects.filter(privatetopic=private_topic) \
+                                      .filter(pk=int(request.GET.get('cite'))) \
+                                      .count() != 1:
+                    raise PermissionDenied
+            except ValueError:
+                raise Http404
         return func(request, *args, **kwargs)
     return _is_participant

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -504,6 +504,13 @@ class AnswerViewTest(TestCase):
 
         self.assertEqual(403, response.status_code)
 
+    def test_fail_cite_weird_pk(self):
+
+        response = self.client.get(reverse('private-posts-new', args=[self.topic1.pk, self.topic1.slug()]) +
+                                   '?cite=abcd')
+
+        self.assertEqual(404, response.status_code)
+
     def test_success_cite_post(self):
 
         response = self.client.get(reverse('private-posts-new', args=[self.topic1.pk, self.topic1.slug()]) +

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -301,7 +301,10 @@ class PrivatePostAnswer(CreateView):
 
         # Using the quote button
         if 'cite' in request.GET:
-            post_cite = get_object_or_404(PrivatePost, pk=(request.GET.get('cite')))
+            try:
+                post_cite = get_object_or_404(PrivatePost, pk=int(request.GET.get('cite')))
+            except ValueError:
+                raise Http404
 
             for line in post_cite.text.splitlines():
                 text = text + '> ' + line + '\n'


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2642 |

Corrige une erreur 500 de citation et vient avec son TU
### QA

Dans un MP cliquer sur le bouton de citation pour ouvrir un nouvel onglet. Sur la nouvelle page, changer le parametre `cite` pour y mettre un truc funky (comme `abcd`), valider et contempler une 404 plutôt qu'une 500.
