### PR TITLE
[Beta 15.5.1] MAJ des dépendances

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 PyYAML==3.11
-django-debug-toolbar==1.2.2
-flake8==2.3.0
+django-debug-toolbar==1.3.0
+flake8==2.4.0
 autopep8==1.1.1
-sphinx==1.2.3
-sphinx_rtd_theme==0.1.6
+sphinx==1.3.1
+sphinx_rtd_theme==0.1.8
 fake-factory==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,21 @@
 # Implicit dependencies (optional dependencies of dependencies)
-pysolr==3.3.0
+pysolr==3.3.1
 pygments==2.0.2
-python-social-auth==0.2.2
+python-social-auth==0.2.9
 
 # Explicit dependencies (references in code)
-django==1.7.7
+django==1.7.8
 coverage==3.7.1
 django-crispy-forms==1.4.0
 django-haystack==2.3.1
 django-model-utils==2.2
-django-munin==0.1.5
-python-memcached==1.53
-lxml==3.4.2
+django-munin==0.2.0
+python-memcached==1.54
+lxml==3.4.4
 factory-boy==2.4.1
 pygeoip==0.3.2
-pillow==2.7.0
-gitpython==0.3.6
+pillow==2.8.1
+gitpython==1.0.1
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.7.zip
 easy-thumbnails==2.2
 CairoSVG==1.0.13
@@ -24,7 +24,7 @@ CairoSVG==1.0.13
 djangorestframework==3.1.1
 djangorestframework-xml==1.0.1
 django-filter==0.9.2
-django-oauth-toolkit==0.7.2
+django-oauth-toolkit==0.8.1
 drf-extensions==0.2.7
 django-rest-swagger==0.2.9
 django-cors-headers==1.0.0


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets (_issues_) concernés | #2640 |

MAJ des dépendances. Celle de Django comme demandé dans le ticket #2640, et puis du coup toutes les autres qu'il était possible de mettre à jour sans toucher une ligne de code.

Ce qui n'inclus donc pas le passage de `factory-boy` en version 2.5+, puisque ceci nécessite visiblement de modifier _toutes_ nos factories...

**QA** : Si Travis passe, je suppose que c'est OK. On peut refaire une passe rapide pour vérifier.
