### PR TITLE
Regle le souci de filtre sur slug

### DIFF
--- a/templates/article/includes/article_item.part.html
+++ b/templates/article/includes/article_item.part.html
@@ -73,7 +73,7 @@
         <ul class="content-tags" itemprop="keywords">
             {% for tag in article.tags.all|slice:":3" %}
                 <li>
-                  <a href="{% url "zds.article.views.index" %}?tag={{ tag.title }}">
+                  <a href="{% url "zds.article.views.index" %}?tag={{ tag.slug }}">
                     {{ tag.title }}
                   </a>
                 </li>

--- a/templates/article/member/history.html
+++ b/templates/article/member/history.html
@@ -57,7 +57,7 @@
     <ul class="taglist" itemprop="keywords">
         {% for tag in tags.all %}
             <li>
-                <a href="{% url "zds.article.views.index" %}?tag={{ tag.title }}">
+                <a href="{% url "zds.article.views.index" %}?tag={{ tag.slug }}">
                     {{ tag.title }}
                 </a>
             </li>
@@ -65,7 +65,7 @@
     </ul>
 
     <span class="pubdate">
-        {% trans "Publié" %} 
+        {% trans "Publié" %}
         <time datetime="{{ article.pubdate|date:"c" }}" pubdate="pubdate" itemprop="datePublished">
             {{ article.pubdate|format_date }}
         </time>

--- a/templates/article/member/view.html
+++ b/templates/article/member/view.html
@@ -65,7 +65,7 @@
     <ul class="taglist">
         {% for tag in tags.all %}
             <li>
-                <a href="{% url "zds.article.views.index" %}?tag={{ tag.title }}">
+                <a href="{% url "zds.article.views.index" %}?tag={{ tag.slug }}">
                     {{ tag.title }}
                 </a>
             </li>

--- a/templates/article/validation/history.html
+++ b/templates/article/validation/history.html
@@ -35,7 +35,7 @@
     <ul class="taglist">
         {% for tag in tags.all %}
             <li>
-                <a href="{% url "zds.article.views.index" %}?tag={{ tag.title }}">
+                <a href="{% url "zds.article.views.index" %}?tag={{ tag.slug }}">
                     {{ tag.title }}
                 </a>
             </li>

--- a/templates/article/view.html
+++ b/templates/article/view.html
@@ -74,7 +74,7 @@
     <ul class="taglist" itemprop="keywords">
         {% for tag in tags.all %}
             <li>
-                <a href="{% url "zds.article.views.index" %}?tag={{ tag.title }}">
+                <a href="{% url "zds.article.views.index" %}?tag={{ tag.slug }}">
                     {{ tag.title }}
                 </a>
             </li>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2674 |

Ce commit regle les differents problemes de filtrage des tags pour les articles. En effet, jusque la on utilisait le titre du tag plutot que son slug, ce qui ne marchait pas !
### QA
- Via l'admin creer un tag avec des accents et des espaces
- Puis publier un article avec ce tag et un autre sans
- Maintenant essayer de filtrer aux différents endroits (home page, listes d'articles, article lui-même) pour bien afficher les articles concerne uniquement

_(PS: pas de TU car la ZEP-12 s'en occupe déjà)_
