### PR TITLE
Ajoute un espace manquant

### DIFF
--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -18,7 +18,7 @@
 
 {# Categories (in X, Y and Z) #}
 {% captureas categories_text %}
-    {% for category in tutorial.subcategory.all %}{% if forloop.first %}{% trans "dans" %}{% elif forloop.last %}{% trans "et" %}{% else %},{% endif %} {{ category.title }}{% endfor %}
+    {% for category in tutorial.subcategory.all %}{% if forloop.first %}{% trans "dans" %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %} {{ category.title }}{% endfor %}
 {% endcaptureas %}
 
 <article class="content-item expand-description tutorial-item{{ item_class }}">


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2676 |

Il manquait un espace dans la liste des categories d'un tuto.
### QA
- Ajouter une sous categories de tutos via l'interface d'admin
- Creer un tuto faisant partie des 3 categories (2 par defaut + la nouvelle)
- Retourner dans "mes tutos" et verifier que l'affichage est correct
