### PR TITLE
Change l'approche des auteurs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,29 +1,4 @@
 Original code base (Progdupeupl / fork on 11-02-2013) : Romain Porte (MicroJoe) <microjoe@mailoo.org>
 
 
-"Zeste de Savoir" code base : 
-
-- Alex-D (https://github.com/Alex-D)
-- AlexandreBroudin (https://github.com/AlexandreBroudin)
-- artragis (https://github.com/artragis)
-- cgabard (https://github.com/cgabard)
-- coma94 (https://github.com/coma94)
-- Coy0te (https://github.com/Coy0te)
-- delphiki (https://github.com/delphiki)
-- Eskimon (https://github.com/Eskimon)
-- firm1 (https://github.com/firm1)
-- Florian BOUX (https://github.com/Florianboux)
-- Ge0 (https://github.com/Ge0)
-- geoffreyc (https://github.com/geoffreyc)
-- GerardPaligot (https://github.com/GerardPaligot)
-- gustavi / Augustin Laville (https://github.com/gustavi)
-- pierre-24 (https://github.com/pierre-24)
-- poulp (https://github.com/poulp)
-- sandhose (https://github.com/sandhose)
-- ShigeruM (https://github.com/ShigeruM)
-- Situphen (https://github.com/Situphen)
-- SpaceFox (https://github.com/SpaceFox)
-- Taluu (https://github.com/Taluu)
-- Thunderseb (https://github.com/Thunderseb)
-- vhf / victor felder (https://github.com/vhf)
-- Vulser (https://github.com/Vulser)
+"Zeste de Savoir" developers : https://github.com/zestedesavoir/zds-site/graphs/contributors


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | pas vraiment |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2659 |

J'ai change l'approche pour le fichier AUTHORS. Plutôt que de fournir une liste a maintenir, je fournis un lien vers la liste des gens faisant parti de l’équipe dans le dépôt. Ca me semble aussi juste et plus besoin de maintenance.
