### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,18 +45,19 @@ before_script:
   - mv zds/settings_test.py zds/settings_prod.py
 
 install:
-  # TexLive
-  - sed -i 's@\$HOME@'"$HOME"'@' texlive.profile
-  - wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
-  - tar -zxf install-tl*
-  - ./install-tl*/install-tl -profile texlive.profile
-  - export PATH=~/texlive/bin/x86_64-linux:$PATH
-
+  - |
+    if [[ "$TEST_APP" == *"back"* ]]
+    then
+      ./scripts/install_texlive.sh
+      export PATH=~/.texlive/bin/x86_64-linux:$PATH
+    fi
   # Add fonts
   - mkdir -p ~/.fonts/truetype
+  - wget -P ~/.fonts/truetype https://www.dropbox.com/s/4vzkldw55iag546/Andale-Mono.ttf
   - wget -P ~/.fonts/truetype https://www.dropbox.com/s/ema28tjn52960mq/Merriweather.zip
   - unzip ~/.fonts/truetype/Merriweather.zip -d ~/.fonts/truetype/Merriweather/
   - chmod a+r ~/.fonts/truetype/Merriweather/*.ttf
+  - chmod a+r ~/.fonts/truetype/Andale-Mono.ttf
   - fc-cache -f -v
 
   # Cabal + Pandoc stuff

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,11 @@ install:
       ./scripts/install_texlive.sh
       export PATH=~/.texlive/bin/x86_64-linux:$PATH
     fi
+  - export RESOURCES_URL="http://www.googledrive.com/host/0BzabS14KitJgfmV2ekdWSktmVEpieU93TG11RFNkWlZqS0JwZk93ZGhMR1lCWVg5NzFVc00"
   # Add fonts
   - mkdir -p ~/.fonts/truetype
-  - wget -P ~/.fonts/truetype https://www.dropbox.com/s/4vzkldw55iag546/Andale-Mono.ttf
-  - wget -P ~/.fonts/truetype https://www.dropbox.com/s/ema28tjn52960mq/Merriweather.zip
+  - wget -P ~/.fonts/truetype $RESOURCES_URL/Andale-Mono.ttf
+  - wget -P ~/.fonts/truetype $RESOURCES_URL/Merriweather.zip
   - unzip ~/.fonts/truetype/Merriweather.zip -d ~/.fonts/truetype/Merriweather/
   - chmod a+r ~/.fonts/truetype/Merriweather/*.ttf
   - chmod a+r ~/.fonts/truetype/Andale-Mono.ttf
@@ -63,9 +64,9 @@ install:
   # Cabal + Pandoc stuff
   - mkdir -p ~/cabal/bin
   - mkdir -p ~/.pandoc
-  - wget -P ~/cabal/bin https://dl.dropboxusercontent.com/u/18967337/pandoc
-  - wget -P ~/.pandoc/templates https://dl.dropboxusercontent.com/u/14517385/dev/default.epub
-  - wget -P ~/.pandoc/templates https://dl.dropboxusercontent.com/u/14517385/dev/default.html
+  - wget -P ~/cabal/bin $RESOURCES_URL/pandoc
+  - wget -P ~/.pandoc/templates $RESOURCES_URL/default.epub
+  - wget -P ~/.pandoc/templates $RESOURCES_URL/default.html
   - touch ~/.pandoc/epub.css
   - touch ~/.pandoc/templates/epub.css
   - chmod u+x,g+x,o+x ~/cabal/bin/pandoc
@@ -74,7 +75,7 @@ install:
 
   # Python dependencies
   - travis_retry pip install coveralls
-  - travis_retry pip install tox
+  - travis_retry pip install tox==2.0.1
 
 script:
   - tox $TEST_APP

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,16 @@ notifications:
 
 services: mysql
 
-cache:
-  - apt
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libmysqlclient-dev
+      - ttf-mscorefonts-installer
+      - language-pack-fr
+      - unzip
+
 
 before_script:
   # configure mysql
@@ -34,46 +42,38 @@ before_script:
   - mysql -e "SHOW VARIABLES LIKE 'wait_timeout';"
   # database services
   - mysql -e 'create database zds_test;'
-  - sudo mv zds/settings_test.py zds/settings_prod.py
-  - sudo apt-get -y install python-mysqldb
-  - sudo apt-get -y install libmysqlclient-dev
+  - mv zds/settings_test.py zds/settings_prod.py
 
 install:
-  # APT Stuff
-  - sudo apt-get update
-  - sudo echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-  - sudo apt-get install ttf-mscorefonts-installer
-  - sudo apt-get install unzip
-  - sudo apt-get install texlive
-  - sudo apt-get install texlive-xetex
-  - sudo apt-get install texlive-lang-french
-  - sudo apt-get install texlive-latex-extra
+  # TexLive
+  - sed -i 's@\$HOME@'"$HOME"'@' texlive.profile
+  - wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+  - tar -zxf install-tl*
+  - ./install-tl*/install-tl -profile texlive.profile
+  - export PATH=~/texlive/bin/x86_64-linux:$PATH
 
   # Add fonts
-  - sudo wget -P /usr/share/fonts/truetype https://www.dropbox.com/s/ema28tjn52960mq/Merriweather.zip
-  - sudo unzip /usr/share/fonts/truetype/Merriweather.zip -d /usr/share/fonts/truetype/Merriweather/
-  - sudo chmod a+r /usr/share/fonts/truetype/Merriweather/*.ttf
-  - sudo fc-cache -f -v
+  - mkdir -p ~/.fonts/truetype
+  - wget -P ~/.fonts/truetype https://www.dropbox.com/s/ema28tjn52960mq/Merriweather.zip
+  - unzip ~/.fonts/truetype/Merriweather.zip -d ~/.fonts/truetype/Merriweather/
+  - chmod a+r ~/.fonts/truetype/Merriweather/*.ttf
+  - fc-cache -f -v
 
   # Cabal + Pandoc stuff
-  - sudo mkdir -p ~/cabal/bin
-  - sudo mkdir -p ~/.pandoc
-  - sudo wget -P ~/cabal/bin https://dl.dropboxusercontent.com/u/18967337/pandoc
-  - sudo wget -P ~/.pandoc/templates https://dl.dropboxusercontent.com/u/14517385/dev/default.epub
-  - sudo wget -P ~/.pandoc/templates https://dl.dropboxusercontent.com/u/14517385/dev/default.html
-  - sudo touch ~/.pandoc/epub.css
-  - sudo touch ~/.pandoc/templates/epub.css
-  - sudo chmod u+x,g+x,o+x ~/cabal/bin/pandoc
+  - mkdir -p ~/cabal/bin
+  - mkdir -p ~/.pandoc
+  - wget -P ~/cabal/bin https://dl.dropboxusercontent.com/u/18967337/pandoc
+  - wget -P ~/.pandoc/templates https://dl.dropboxusercontent.com/u/14517385/dev/default.epub
+  - wget -P ~/.pandoc/templates https://dl.dropboxusercontent.com/u/14517385/dev/default.html
+  - touch ~/.pandoc/epub.css
+  - touch ~/.pandoc/templates/epub.css
+  - chmod u+x,g+x,o+x ~/cabal/bin/pandoc
   - export PATH=$PATH:~/cabal/bin
-  - sudo ~/cabal/bin/pandoc --version
-  - sudo apt-get --reinstall install -qq language-pack-fr
+  - ~/cabal/bin/pandoc --version
 
   # Python dependencies
   - travis_retry pip install coveralls
   - travis_retry pip install tox
-
-  # Node.js + npm stuff
-  - sudo apt-get -y install nodejs
 
 script:
   - tox $TEST_APP

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Install texlive to $HOME/.texlive
+
+TEXLIVE_PROFILE=${BASH_SOURCE[0]/%install_texlive.sh/texlive.profile}
+
+# Creating install dir
+mkdir -p ~/.texlive/
+cp $TEXLIVE_PROFILE ~/.texlive/
+cd ~/.texlive/
+
+# Replace correct paths in profile (needs absolute paths)
+sed -i 's@\$HOME@'"$HOME"'@' texlive.profile
+
+# Download and run installer
+wget -O ./install-tl.tar.gz http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+tar -zxf ./install-tl.tar.gz
+./install-tl*/install-tl -profile texlive.profile
+
+# Install extra latex packages
+./bin/x86_64-linux/tlmgr install wallpaper titlesec
+
+echo "Installation complete ! Don't forget to add ~/.texlive/bin/x86_64-linux to PATH"

--- a/scripts/texlive.profile
+++ b/scripts/texlive.profile
@@ -3,17 +3,16 @@
 # installation profile at installation time.
 selected_scheme scheme-small
 TEXMFCONFIG $TEXMFSYSCONFIG
-TEXDIR $HOME/texlive
-TEXMFLOCAL $HOME/texlive/texmf-local
-TEXMFSYSCONFIG $HOME/texlive/texmf-config
-TEXMFSYSVAR $HOME/texlive/texmf-var
+TEXDIR $HOME/.texlive
+TEXMFLOCAL $HOME/.texlive/texmf-local
+TEXMFSYSCONFIG $HOME/.texlive/texmf-config
+TEXMFSYSVAR $HOME/.texlive/texmf-var
 TEXMFHOME $TEXMFLOCAL
 TEXMFVAR $TEXMFSYSVAR
 binary_x86_64-linux 1
 collection-basic 1
 collection-latex 1
 collection-latexrecommended 1
-collection-metapost 1
 collection-xetex 1
 in_place 0
 option_adjustrepo 1

--- a/texlive.profile
+++ b/texlive.profile
@@ -1,0 +1,36 @@
+# texlive.profile written on Tue May 12 14:54:48 2015 UTC
+# It will NOT be updated and reflects only the
+# installation profile at installation time.
+selected_scheme scheme-small
+TEXMFCONFIG $TEXMFSYSCONFIG
+TEXDIR $HOME/texlive
+TEXMFLOCAL $HOME/texlive/texmf-local
+TEXMFSYSCONFIG $HOME/texlive/texmf-config
+TEXMFSYSVAR $HOME/texlive/texmf-var
+TEXMFHOME $TEXMFLOCAL
+TEXMFVAR $TEXMFSYSVAR
+binary_x86_64-linux 1
+collection-basic 1
+collection-latex 1
+collection-latexrecommended 1
+collection-metapost 1
+collection-xetex 1
+in_place 0
+option_adjustrepo 1
+option_autobackup 1
+option_backupdir tlpkg/backups
+option_desktop_integration
+option_doc 1
+option_file_assocs
+option_fmt 1
+option_letter 0
+option_menu_integration
+option_path
+option_post_code 1
+option_src 1
+option_sys_bin /usr/local/bin
+option_sys_info /usr/local/share/info
+option_sys_man /usr/local/share/man
+option_w32_multi_user 1
+option_write18_restricted 1
+portable 1

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 
 
 [testenv]
+passenv = HOME
 setenv =
        DJANGO_SETTINGS_MODULE=zds.settings
        PYTHONPATH = {toxinidir}
@@ -23,7 +24,6 @@ deps = -r{toxinidir}/requirements.txt
 commands = coverage run --source='.' {toxinidir}/manage.py test {posargs}
 
 [testenv:front]
-passenv = HOME
 commands =
     npm install
     npm run travis

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,6 @@ commands = coverage run --source='.' {toxinidir}/manage.py test {posargs}
 
 [testenv:front]
 commands =
-    npm install npm -g
     npm install
     npm run travis
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps = -r{toxinidir}/requirements.txt
 commands = coverage run --source='.' {toxinidir}/manage.py test {posargs}
 
 [testenv:front]
+passenv = HOME
 commands =
     npm install
     npm run travis


### PR DESCRIPTION
**Cette PR est une copie de [celle de sandhose](https://github.com/zestedesavoir/zds-site/pull/2672) pour avoir les corrections de Travis sur la branche de release. Si Travis passe c'est que tout va bien normalement.** @SpaceFox ca te conviens ?

| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #2664 |

Travis a actuellement deux infrastructures de build: une, qui virtualise un ubuntu complet, et l'autre qui utilise des container, à base de Docker.

Cette PR passe le build travis vers cette nouvelle infra, qui est bien plus rapide, autant à démarrer (le build démarre au bout d'une minute, contre 5min voir plus auparavant), qu'a lancer les tests.

Exemple de build avec container: https://travis-ci.org/sandhose/zds-site/builds/62295015

Le gain de temps est assez impressionnant, puisqu'on passe d'environ 30-35min à 15-20min pour le back, et de 10-12min à 5min pour le front.

Une des restrictions de cette infra est de tout lancer sans root, pour des raisons de sécurité. J'ai du donc installer texlive, qui n'est pas dans la liste des paquets autorisés par travis manuellement (d'où le `scripts/install_texlive.sh`, qui installe texlive avec les paquets qu'il faut dans `~/.texlive`).
