### PR TITLE
[Beta 15.5.1] Correction du wording de la page d'accueil

### DIFF
--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -48,6 +48,15 @@ $content-width: 1145px;
             text-align: justify;
         }
 
+        a:not(.home-description-button) {
+            color: white;
+
+            &:hover, &:focus {
+                color: #90ABB6;
+                text-decoration: none;
+            }
+        }
+
         .column {
             flex: 1;
             padding: 0 10px;

--- a/templates/home.html
+++ b/templates/home.html
@@ -57,7 +57,13 @@
                         {% trans "La connaissance pour tous" %}
                     </h2>
                     <p>
-                        {% trans "Zeste de Savoir est un site de partage de connaissances sur lequel vous trouverez des tutoriels de tous niveaux, des articles et des forums d'entraide annimés par et pour les communautés." %}
+                    {% blocktrans with site_name=app.site.litteral_name %}
+                        {{site_name}} est un site de <strong>partage de connaissances</strong> sur lequel vous trouverez
+                        des <a href="{{url_tutorials}}">tutoriels de tous niveaux</a>, des
+                        <a href='{{url_articles}}'>articles</a> et des <a href='{{url_forums}}'>forums d'entraide</a>
+                        animés par et pour la communauté. Les sujets abordés sont, pour l'instant, l'informatique et les
+                        sciences, mais nous n'attendons que vous pour élargir les domaines présentés !
+                    {% endblocktrans %}
                     </p>
                 </div>
                 <div class="column">
@@ -65,7 +71,11 @@
                         {% trans "Partagez vos connaissances" %}
                     </h2>
                     <p>
-                        {% trans "Tout les membres peuvent écrire et publier des tutoriels et des articles sur le site. Pour assurer la qualité et la pédagogie du contenu, l'équipe du site valide chaque cours avant publication." %}
+                    {% blocktrans %}
+                        Tous les membres peuvent écrire et <strong>publier des tutoriels et articles sur le site</strong>.
+                        Pour assurer la qualité et la pédagogie du contenu, l'équipe du site valide chaque cours avant
+                        publication.
+                    {% endblocktrans %}
                     </p>
                 </div>
                 <div class="column">
@@ -73,7 +83,10 @@
                         {% trans "Gratuit et sans publicité" %}
                     </h2>
                     <p>
-                        {% trans "Tout cela est entièrement gratuit et garanti sans publicité, le site est géré et financé par une association à but non lucratif." %}
+                    {% blocktrans %}
+                        Tout cela est <strong>entièrement gratuit et garanti sans publicité</strong>, le site est géré
+                        et financé par une <a href="{{url_association}}">association</a> à but non lucratif.
+                    {% endblocktrans %}
                     </p>
                     {% if app.site.contribute_link %}
                     <p>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets (_issues_) concernés | #2673 |

J'ai remis le wording actuel de la page d'accueil, avec les liens et tout. Et une mise en forme de la source pour éviter les lignes de 15 km.

**Par contre**, les liens sont en bleu sur bleu... et je n'ai pas la moindre idée de comment corriger ça ! Donc ping @sandhose @Situphen :)
