### PR TITLE
[Beta 15.5.1] Fixe quelques régressions dues à la nouvelle home

### DIFF
--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -31,7 +31,7 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
             white-space: nowrap;
             text-overflow: ellipsis;
 
-            & > * {
+            &:not(.inline) > * {
                 display: inline;
             }
         }
@@ -156,6 +156,10 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+
+        .short {
+            display: none;
+        }
     }
 
     .content-meta {
@@ -164,7 +168,7 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
         font-size: 1.3rem;
         line-height: 15px;
 
-        & > * {
+        &:not(.inline) > * {
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -350,7 +354,7 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
             display: none;
         }
 
-        .content-meta {
+        .content-meta, .content-description {
             .short {
                 display: inline;
             }

--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -164,6 +164,13 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
         font-size: 1.3rem;
         line-height: 15px;
 
+        & > * {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            display: block;
+        }
+
         .short {
             display: none;
         }
@@ -318,9 +325,6 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
 
                 & > * {
                     display: block;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
                 }
             }
         }

--- a/templates/forum/includes/topic_item.part.html
+++ b/templates/forum/includes/topic_item.part.html
@@ -14,16 +14,20 @@
         <p class="content-description">
             {{ topic.forum.title }},
             {% trans "par" %}{% include "misc/member_item.part.html" with member=topic.author %}
-            - {{ topic.pubdate|format_date|capfirst }}
+            -
+            <time pubdate="{{ topic.pubdate|date:"c" }}">
+                <span class="long">{{ topic.pubdate|format_date|capfirst }}</span>
+                <span class="short">{{ topic.pubdate|format_date:True|capfirst }}</span>
+            </time>
         </p>
 
-        <p class="content-meta">
+        <p class="content-meta inline">
             {% with answer=topic.get_last_answer last_read=topic.last_read_post %}
                 {% if answer %}
                     {% spaceless %}
                     <a href="{{ last_read.get_absolute_url }}" class="last-read-link">
                         {% trans "Dernière réponse :" %}
-                        <time class="content-pubdate" pubdate="{{ anwser.pubdate|date:"c" }}">
+                        <time class="content-pubdate" pubdate="{{ answer.pubdate|date:"c" }}">
                             <span class="long">{{ answer.pubdate|format_date|capfirst }}</span>
                             <span class="short">{{ answer.pubdate|format_date:True|capfirst }}</span>
                         </time>

--- a/templates/home.html
+++ b/templates/home.html
@@ -43,7 +43,7 @@
             </section>
         {% else %}
             <section class="home-description short" id="description">
-                <blockquote><span>{% trans "Zeste de Savoir, le site de partage" %}</span> <span>{% trans "de connaissances, sans pépins !" %}</span></blockquote>
+                <blockquote><span>{% trans "Zeste de Savoir, la connaissance" %}</span> <span>{% trans "pour tous et sans pépins" %}</span></blockquote>
                 <a class="home-description-button" href="#description">
                     {% trans "En savoir plus" %}
                 </a>

--- a/templates/tutorial/member/index.html
+++ b/templates/tutorial/member/index.html
@@ -74,7 +74,7 @@
         {% if tutorials %}
             <div class="content-item-list">
                 {% for tutorial in tutorials %}
-                    {% include 'tutorial/includes/tutorial_item.part.html' with show_description=True %}
+                    {% include 'tutorial/includes/tutorial_item.part.html' with show_description=True beta=True %}
                 {% endfor %}
                 <div class="fill"></div>
                 <div class="fill"></div>

--- a/zds/featured/forms.py
+++ b/zds/featured/forms.py
@@ -52,7 +52,7 @@ class FeaturedResourceForm(forms.ModelForm):
         max_length=FeaturedResource._meta.get_field('image_url').max_length,
         widget=forms.TextInput(
             attrs={
-                'placeholder': _(u'Lien vers l\'url de l\'image de la une.')
+                'placeholder': _(u'Lien vers l\'url de l\'image de la une (dimensions: 228x228).')
             }
         )
     )


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2670, #2675, #2692, #2694, #2695 |

Cette PR fixe quelques petites régressions de la 15.5.1
## Instructions QA
- Générer le front (`npm run build`)
- Vérifier que la dimensions des images est indiquée lors de la création des mises en avant (placeholder)
- Vérifier que le "texte orange" ne va pas à la ligne sur mobile dans la liste des articles sur la home (voir #2694)
- Vérifier que la punchline est la bonne sur mobile quand on est pas connecté (#2675)
- Vérifier que dans "Mes tutoriels", les liens vers les tutos mènent bien vers la version bêta
- Vérifier que la date courte est utilisée dans les topics de forum sur la home sur mobile
