### PR TITLE
[Beta 15.5.1] Remet puis cache le subheader sur la home

### DIFF
--- a/assets/js/mobile-menu.js
+++ b/assets/js/mobile-menu.js
@@ -72,9 +72,7 @@
                  * Build sidebar menu from page
                  */
 
-                var search = $('<div class="search header-right"><div class="search header-right mobile-menu-imported"> <form action="/rechercher/"> <input type="text" name="q" placeholder="Rechercher"> <button type="submit" class="ico-after search-submit" title="Lancer la recherche">OK</button> </form> <a href="/rechercher/" title="Recherche avancée" class="search-more"></a> </div></div>');
-
-                appendToSidebar($(search), true);
+                appendToSidebar($("#search"), true);
                 appendToSidebar($(".logbox .my-account"), true);
                 appendToSidebar($(".header-menu"));
 

--- a/assets/js/mobile-menu.js
+++ b/assets/js/mobile-menu.js
@@ -71,7 +71,10 @@
                 /**
                  * Build sidebar menu from page
                  */
-                appendToSidebar($("#search"), true);
+
+                var search = $('<div class="search header-right"><div class="search header-right mobile-menu-imported"> <form action="/rechercher/"> <input type="text" name="q" placeholder="Rechercher"> <button type="submit" class="ico-after search-submit" title="Lancer la recherche">OK</button> </form> <a href="/rechercher/" title="Recherche avancée" class="search-more"></a> </div></div>');
+
+                appendToSidebar($(search), true);
                 appendToSidebar($(".logbox .my-account"), true);
                 appendToSidebar($(".header-menu"));
 
@@ -104,7 +107,7 @@
                     if(swipping || parseInt(e.originalEvent.touches[0].pageX, 10) - $(this).offset().left < borderWidth){
                         e.preventDefault();
                         $("body:not(.swipping)").addClass("swipping");
-                        
+
                         swipping   = true;
 
                         var toMove = parseInt(e.originalEvent.touches[0].pageX, 10) - beginTouchDown;
@@ -137,7 +140,7 @@
                     }
                 });
 
-                
+
                 $(".page-container").on("click", function(e){
                     if($("html").hasClass("show-mobile-menu")){
                         toggleMobileMenu(false);

--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -14,6 +14,10 @@ $content-width: 1145px;
         margin: 0;
         padding: 0;
     }
+
+    .sub-header{
+        display: none;
+    }
 }
 
 .home {

--- a/templates/base.html
+++ b/templates/base.html
@@ -486,29 +486,28 @@
                 </div>
             </header>
 
-
-                <div class="clearfix sub-header">
-                    <div class="wrapper">
-                        <div class="breadcrumb" itemprop="breadcrumb">
-                            <ol>
-                                <li>
-                                    <a href="{% url "zds.pages.views.home" %}" rel="home" itemprop="url">
-                                        <span itemprop="title">{% trans "Accueil" %}</span>
-                                    </a>
-                                </li>
-                                {% block breadcrumb_base %}{% endblock %}
-                                {% block breadcrumb %}{% endblock %}
-                            </ol>
-                        </div>
-                        <div class="search header-right" id="search">
-                            <form action="{% url "haystack_search" %}">
-                                <input type="text" name="q" placeholder="{% trans "Rechercher" %}">
-                                <button type="submit" class="ico-after search-submit" title="{% trans "Lancer la recherche" %}">{% trans "OK" %}</button>
-                            </form>
-                            <a href="{% url "haystack_search" %}" title="{% trans "Recherche avancée" %}" class="search-more"></a>
-                        </div>
+            <div class="clearfix sub-header">
+                <div class="wrapper">
+                    <div class="breadcrumb" itemprop="breadcrumb">
+                        <ol>
+                            <li>
+                                <a href="{% url "zds.pages.views.home" %}" rel="home" itemprop="url">
+                                    <span itemprop="title">{% trans "Accueil" %}</span>
+                                </a>
+                            </li>
+                            {% block breadcrumb_base %}{% endblock %}
+                            {% block breadcrumb %}{% endblock %}
+                        </ol>
+                    </div>
+                    <div class="search header-right" id="search">
+                        <form action="{% url "haystack_search" %}">
+                            <input type="text" name="q" placeholder="{% trans "Rechercher" %}">
+                            <button type="submit" class="ico-after search-submit" title="{% trans "Lancer la recherche" %}">{% trans "OK" %}</button>
+                        </form>
+                        <a href="{% url "haystack_search" %}" title="{% trans "Recherche avancée" %}" class="search-more"></a>
                     </div>
                 </div>
+            </div>
         </div>
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -487,7 +487,6 @@
             </header>
 
 
-            {% block subheader %}
                 <div class="clearfix sub-header">
                     <div class="wrapper">
                         <div class="breadcrumb" itemprop="breadcrumb">
@@ -510,7 +509,6 @@
                         </div>
                     </div>
                 </div>
-            {% endblock %}
         </div>
 
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -13,13 +13,6 @@
 
 {% block body_class %}home{% endblock %}
 
-
-
-{# Don't show the subheader on the home page #}
-{% block subheader %}{% endblock %}
-
-
-
 {% block content_out %}
     {% url 'zds.tutorial.views.index' as url_tutorials %}
     {% url 'zds.article.views.index' as url_articles %}
@@ -91,7 +84,7 @@
                     <label for="search">
                         {% trans "Recherche" %}
                     </label>
-                    <input type="text" name="q" id="search" placeholder='{% trans "Mathématiques, UDK, HTML, Java, PHP, ..." %}' >
+                    <input type="text" name="q" placeholder='{% trans "Mathématiques, UDK, HTML, Java, PHP, ..." %}' >
                     <button type="submit" class="ico-after ico-search" title='{% trans "Lancer la recherche" %}'></button>
                 </form>
             </section>

--- a/templates/home.html
+++ b/templates/home.html
@@ -13,13 +13,6 @@
 
 {% block body_class %}home{% endblock %}
 
-
-
-{# Don't show the subheader on the home page #}
-{% block subheader %}{% endblock %}
-
-
-
 {% block content_out %}
     {% url 'zds.tutorial.views.index' as url_tutorials %}
     {% url 'zds.article.views.index' as url_articles %}
@@ -104,7 +97,7 @@
                     <label for="search">
                         {% trans "Recherche" %}
                     </label>
-                    <input type="text" name="q" id="search" placeholder='{% trans "Mathématiques, UDK, HTML, Java, PHP, ..." %}' >
+                    <input type="text" name="q" placeholder='{% trans "Mathématiques, UDK, HTML, Java, PHP, ..." %}' >
                     <button type="submit" class="ico-after ico-search" title='{% trans "Lancer la recherche" %}'></button>
                 </form>
             </section>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2679 |

La barre de recherche du menu mobile était mal ajoutée sur la page d'accueil

Comme vu ici : #2696  , on remet le subheader sur la page d'accueil puis on le cache en CSS pour permettre au menu mobile de se générer correctement.
### QA
- Il faut au préalable avoir builder le front : `npm run gulp -- build`
- Ouvrez la page d'accueil ainsi qu'une autre page (tutoriel, forum...)
- Diminuez la taille de la fenêtre jusqu'à ce que l'ouverture du menu mobile soit disponible.
- Vérifiez que la barre de recherche en haut du menu mobile soit identique sur les 2 pages.
