### PR TITLE
Importe la bonne version de gettext

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -5,7 +5,7 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.models import User, Group
 from django.core.urlresolvers import reverse
 from django.db.models import Q
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | nop |

Lors d'un mini refacto pour la doc (passage des `ugettext` en `ugettext_lazy` coucou @pierre-24 :) ) une typo s'est faufilée et du coup on importait plus le bon module (a un caractère près c'est balot).
### QA
- Sur votre branche de dev, aller sur la page de login ou register et constatez que les labels des champs on disparu.
- Switchez sur ma branche de fix et constatez qu'ils sont revenus !
