### PR TITLE
[Beta 15.5.1] Rends les dernières réponses cliquables sur la home, et uniformise le texte avec le forum

### DIFF
--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -167,6 +167,14 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
         .short {
             display: none;
         }
+
+        & > a {
+            color: darken($color-secondary, 10%);
+
+            &:hover, &:focus {
+                text-decoration: underline;
+            }
+        }
     }
 
     .content-tags {

--- a/templates/forum/includes/topic_item.part.html
+++ b/templates/forum/includes/topic_item.part.html
@@ -18,14 +18,19 @@
         </p>
 
         <p class="content-meta">
-            {% with answer=topic.get_last_answer %}
+            {% with answer=topic.get_last_answer last_read=topic.last_read_post %}
                 {% if answer %}
-                    {% trans "Dernière réponse :" %}
-                    {% include "misc/member_item.part.html" with member=answer.author %} -
-                    <time class="content-pubdate" pubdate="{{ anwser.pubdate|date:"c" }}">
-                        <span class="long">{{ answer.pubdate|format_date|capfirst }}</span>
-                        <span class="short">{{ answer.pubdate|format_date:True|capfirst }}</span>
-                    </time>
+                    {% spaceless %}
+                    <a href="{{ last_read.get_absolute_url }}" class="last-read-link">
+                        {% trans "Dernière réponse :" %}
+                        <time class="content-pubdate" pubdate="{{ anwser.pubdate|date:"c" }}">
+                            <span class="long">{{ answer.pubdate|format_date|capfirst }}</span>
+                            <span class="short">{{ answer.pubdate|format_date:True|capfirst }}</span>
+                        </time>
+                    </a>
+                    {% endspaceless %}
+                    {% trans "par" %}
+                    {% include "misc/member_item.part.html" with member=answer.author %}
                 {% else %}
                     {% trans "Aucune réponse" %}
                 {% endif %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #2710 |

Rends les dernières réponses cliquables sur les topics de la home (mène sur la première réponse non-lue, comme sur le forum), et uniformise le texte avec celui des dernières réponses sur l'index des sous-forums (avant: `Dernière réponse: {auteur} - {date}` ; après: `Dernière réponse: {date} par {auteur}`)

![image](https://cloud.githubusercontent.com/assets/1549952/7665681/f7967358-fbc3-11e4-98d4-b8ab1a5be25c.png)
