### PR TITLE
[Beta 15.5.1] Remets en place le style de la page d'aide aux auteurs

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -79,6 +79,7 @@
 @import "pages/home";
 @import "pages/gallery";
 @import "pages/api";
+@import "pages/tutorial-help";
 
 /*-------------------------
 10. High pixel ratio (retina)

--- a/assets/scss/pages/_tutorial-help.scss
+++ b/assets/scss/pages/_tutorial-help.scss
@@ -1,0 +1,82 @@
+/* Temp fix to #2667 ; see: https://github.com/zestedesavoir/zds-site/issues/2667 */
+
+.tutorial-help-item {
+    min-height: 60px;
+    padding: 20px 2%;
+    border-bottom: 1px solid #e0e4e5;
+
+    &:nth-child(2n+1) {
+        background-color: rgba(255, 255, 255, .8);
+    }
+
+    p {
+        margin: 0;
+    }
+
+    color: #424242;
+    font-weight: normal;
+
+    .tutorial-title {
+        margin: 0;
+        padding: 0;
+        font-size: 20px;
+        font-size: 2.0rem;
+        height: 27px;
+        width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        clear: none;
+        font-weight: normal;
+        color: #424242;
+    }
+
+    a {
+        text-decoration: none;
+        &:hover,
+        &:focus {
+            text-decoration: underline;
+        }
+    }
+
+    .tutorial-categories {
+        margin: 0 0 5px;
+        padding: 0;
+        color: #ee8709;
+
+        a {
+            color: #ee8709;
+
+            &:hover,
+            &:focus {
+                text-decoration: underline;
+            }
+        }
+    }
+
+    .tutorial-illu {
+        display: block;
+        overflow: hidden;
+        float: left;
+    }
+
+    .tutorial-infos {
+        margin: 7px 0 0 70px;
+
+        &.no-illu {
+            margin-left: 0;
+        }
+    }
+
+    .tutorial-help {
+      margin: 12px 0 0 0;
+    }
+
+    .tutorial-help img.light {
+        opacity: 0.2;
+        &:hover,
+        &:focus {
+            opacity: 0.5;
+        }
+    }
+}

--- a/templates/tutorial/tutorial/help.html
+++ b/templates/tutorial/tutorial/help.html
@@ -30,53 +30,52 @@
         <meta itemprop="itemListOrder" content="Unordered">
 
         {% for tutorial in tutorials %}
-            <article class="tutorial-item">
+            <article class="tutorial-help-item">
                 {% if tutorial.image.physical.tutorial_illu.url %}
-                    <img src="{{ tutorial.image.physical.tutorial_illu.url }}" alt="" class="tutorial-illu">
+                    <img src="{{ tutorial.image.physical.tutorial_illu.url }}" alt="" class="tutorial-illu avatar">
                 {% endif %}
 
-                <h3 class="tutorial-title" itemprop="itemListElement" title="{{ tutorial.title }}">
-                    {{ tutorial.title }}
-                </h3>
+                <div class="tutorial-infos{% if not tutorial.image.physical.tutorial_illu.url %} no-illu{% endif %}">
+                    <h3 class="tutorial-title" itemprop="itemListElement" title="{{ tutorial.title }}">
+                        {{ tutorial.title }}
+                    </h3>
 
-                <p class="tutorial-authors">
-                    {% for author in tutorial.authors.all %}
-                        {% if forloop.first %}
-                            {% trans "par" %}
-                        {% elif forloop.last %}
-                            {% trans "et" %}
-                        {% else %}
-                            ,
-                        {% endif %}
-
-                        {% if author == user %}
-                            {% trans "vous" %}
-                        {% else %}
-                            <strong><a href="{{ author.get_absolute_url }}" title="{% trans "Profil de" %} {{ author.username }}">
-                            {{author.username}}
-                            </a></strong>
-                        {% endif %}
-                    {% endfor %}
-                    {% if not user in tutorial.authors.all %}
-                        - <a href="{{ tutorial.get_absolute_contact_url }}">{% trans "Contacter par MP" %}</a>
-                    {% endif %}
-                </p>
-
-                <p class="tutorial-categories">
-                    {% if tutorial.subcategory %}
-                        {% for category in tutorial.subcategory.all %}
+                    <p class="tutorial-authors">
+                        {% for author in tutorial.authors.all %}
                             {% if forloop.first %}
-                                {% trans "dans" %}
+                                {% trans "Par" %}
                             {% elif forloop.last %}
                                 {% trans "et" %}
                             {% else %}
                                 ,
                             {% endif %}
 
-                            {{ category.title }}
+                            {% if author == user %}
+                                {% trans "vous" %}
+                            {% else %}
+                                <strong><a href="{{ author.get_absolute_url }}" title="{% trans "Profil de" %} {{ author.username }}">
+                                {{author.username}}
+                                </a></strong>
+                            {% endif %}
                         {% endfor %}
-                    {% endif %}
-                </p>
+                        {% if not user in tutorial.authors.all %}
+                            - <a href="{{ tutorial.get_absolute_contact_url }}">{% trans "Contacter par MP" %}</a>
+                        {% endif %}
+                    </p>
+
+                    <p class="tutorial-categories">
+                        {% if tutorial.subcategory %}
+                            {% for category in tutorial.subcategory.all %}
+                                {% if forloop.first %}
+                                {% else %}
+                                    -
+                                {% endif %}
+
+                                {{ category.title }}
+                            {% endfor %}
+                        {% endif %}
+                    </p>
+                </div>
 
                 <div class="tutorial-help">
                     {% if tutorial.on_line %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2667 |

Il s'agit d'un fix temporaire, en attendant de refaire cette page, qui remet en place l'ancien style. J'aime pas trop cette solution, puisque ça réintroduit une grande partie de l'ancien code pour les listes de tutoriels...
## Instructions QA
- Build le front (`npm run build`)
- Demander de l'aide sur un ou plusieurs tutos
- Vérifier que le style est correct sur `/tutoriels/aides/`
