### PR TITLE
Corrige la recherche sur mobile et le menu d'accessibilité (home)

### DIFF
--- a/assets/js/mobile-menu.js
+++ b/assets/js/mobile-menu.js
@@ -71,6 +71,7 @@
                 /**
                  * Build sidebar menu from page
                  */
+
                 appendToSidebar($("#search"), true);
                 appendToSidebar($(".logbox .my-account"), true);
                 appendToSidebar($(".header-menu"));
@@ -104,7 +105,7 @@
                     if(swipping || parseInt(e.originalEvent.touches[0].pageX, 10) - $(this).offset().left < borderWidth){
                         e.preventDefault();
                         $("body:not(.swipping)").addClass("swipping");
-                        
+
                         swipping   = true;
 
                         var toMove = parseInt(e.originalEvent.touches[0].pageX, 10) - beginTouchDown;
@@ -137,7 +138,7 @@
                     }
                 });
 
-                
+
                 $(".page-container").on("click", function(e){
                     if($("html").hasClass("show-mobile-menu")){
                         toggleMobileMenu(false);

--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -14,6 +14,10 @@ $content-width: 1145px;
         margin: 0;
         padding: 0;
     }
+
+    .sub-header{
+        display: none;
+    }
 }
 
 .home {

--- a/templates/base.html
+++ b/templates/base.html
@@ -135,7 +135,7 @@
                 <a href="#content" accesskey="s">{% trans "Aller au contenu" %}</a>
             </li>
             <li>
-                <a href="#search" accesskey="4">{% trans "Aller à la recherche" %}</a>
+                <a href="#{% block searchbox_id %}search{% endblock %}" accesskey="4">{% trans "Aller à la recherche" %}</a>
             </li>
         </ul>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -486,31 +486,28 @@
                 </div>
             </header>
 
-
-            {% block subheader %}
-                <div class="clearfix sub-header">
-                    <div class="wrapper">
-                        <div class="breadcrumb" itemprop="breadcrumb">
-                            <ol>
-                                <li>
-                                    <a href="{% url "zds.pages.views.home" %}" rel="home" itemprop="url">
-                                        <span itemprop="title">{% trans "Accueil" %}</span>
-                                    </a>
-                                </li>
-                                {% block breadcrumb_base %}{% endblock %}
-                                {% block breadcrumb %}{% endblock %}
-                            </ol>
-                        </div>
-                        <div class="search header-right" id="search">
-                            <form action="{% url "haystack_search" %}">
-                                <input type="text" name="q" placeholder="{% trans "Rechercher" %}">
-                                <button type="submit" class="ico-after search-submit" title="{% trans "Lancer la recherche" %}">{% trans "OK" %}</button>
-                            </form>
-                            <a href="{% url "haystack_search" %}" title="{% trans "Recherche avancée" %}" class="search-more"></a>
-                        </div>
+            <div class="clearfix sub-header">
+                <div class="wrapper">
+                    <div class="breadcrumb" itemprop="breadcrumb">
+                        <ol>
+                            <li>
+                                <a href="{% url "zds.pages.views.home" %}" rel="home" itemprop="url">
+                                    <span itemprop="title">{% trans "Accueil" %}</span>
+                                </a>
+                            </li>
+                            {% block breadcrumb_base %}{% endblock %}
+                            {% block breadcrumb %}{% endblock %}
+                        </ol>
+                    </div>
+                    <div class="search header-right" id="search">
+                        <form action="{% url "haystack_search" %}">
+                            <input type="text" name="q" placeholder="{% trans "Rechercher" %}">
+                            <button type="submit" class="ico-after search-submit" title="{% trans "Lancer la recherche" %}">{% trans "OK" %}</button>
+                        </form>
+                        <a href="{% url "haystack_search" %}" title="{% trans "Recherche avancée" %}" class="search-more"></a>
                     </div>
                 </div>
-            {% endblock %}
+            </div>
         </div>
 
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -13,6 +13,8 @@
 
 {% block body_class %}home{% endblock %}
 
+{% block searchbox_id %}search-home{% endblock %}
+
 {% block content_out %}
     {% url 'zds.tutorial.views.index' as url_tutorials %}
     {% url 'zds.article.views.index' as url_articles %}
@@ -93,11 +95,11 @@
         {% endif %}
 
              <section class="home-search-box">
-                <form action='{% url "haystack_search" %}'>
-                    <label for="search">
+                <form action='{% url "haystack_search" %}' id="search-home">
+                    <label for="search-home-input">
                         {% trans "Recherche" %}
                     </label>
-                    <input type="text" name="q" placeholder='{% trans "Mathématiques, UDK, HTML, Java, PHP, ..." %}' >
+                    <input type="text" id="search-home-input" name="q" placeholder='{% trans "Mathématiques, UDK, HTML, Java, PHP, ..." %}' >
                     <button type="submit" class="ico-after ico-search" title='{% trans "Lancer la recherche" %}'></button>
                 </form>
             </section>

--- a/templates/home.html
+++ b/templates/home.html
@@ -13,13 +13,6 @@
 
 {% block body_class %}home{% endblock %}
 
-
-
-{# Don't show the subheader on the home page #}
-{% block subheader %}{% endblock %}
-
-
-
 {% block content_out %}
     {% url 'zds.tutorial.views.index' as url_tutorials %}
     {% url 'zds.article.views.index' as url_articles %}
@@ -104,7 +97,7 @@
                     <label for="search">
                         {% trans "Recherche" %}
                     </label>
-                    <input type="text" name="q" id="search" placeholder='{% trans "Mathématiques, UDK, HTML, Java, PHP, ..." %}' >
+                    <input type="text" name="q" placeholder='{% trans "Mathématiques, UDK, HTML, Java, PHP, ..." %}' >
                     <button type="submit" class="ico-after ico-search" title='{% trans "Lancer la recherche" %}'></button>
                 </form>
             </section>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2693, #2679, #2706 |

J'ai repris la PR de @Luuka #2706 en rebasant + squash les commits, et j'ai rajouté le fix par rapport à la #2693. La recherche sur la home est donc accessible via ce menu comme sur les autres pages ; par contre, il semblerait que c'est quelque chose qui ne marche pas sur chrome (suffit de tester en prod)
## Instructions QA
- build le front (`npm run build`)
- vérifier que le champ de recherche est présent dans le menu sur mobile
- vérifier que le lien "Aller à la recherche" renvoie bien sur le champ de recherche (lien accessible via "tab") sur la home
