### PR TITLE
[Beta 15.5.1] Amélioration des performances des pages liste des article, liste des tutos, home

### DIFF
--- a/doc/source/cache.rst
+++ b/doc/source/cache.rst
@@ -1,0 +1,105 @@
+========
+Le cache
+========
+
+Cette page détaille tout ce qui a trait au cache dans Zeste de Savoir. Comme le cache impacte à la fois le *front-end* et le *back-end*, il a droit à sa page dédiée.
+
+Règles d'implémentation
+=======================
+
+Les systèmes de cache peuvent être très puissants et gérer beaucoup de cas différents ; hélas il est très facile d'en faire une soupe imbuvable et de provoquer des bugs mystiques et impossibles à reproduire.
+
+Pour éviter les prises de tête et conserver une application propre, tout cache sur Zeste de Savoir doit respecter les règles suivantes :
+
+1. Le cache est **facultatif**. Le site conserve des **performances acceptables sans cache** :
+    - Ça garanti les performances en cas d'échec de cache (*cache miss*)
+    - Si le cache est désactivé (problème serveur, développement...) l'application fonctionne
+2. Le cache est **inoffensif** :
+   - Aucune donnée sensible ne peut se retrouver dans le cache. Jamais. Dans aucun cas.
+   - Si jamais un bug provoque une fuite de cache (*donnée de cache servie à la mauvaise personne*), les conséquences sont sans importance.
+3. Le cache est **efficace**. Si c'est pour gagner 1 ms, ce n'est pas la peine.
+4. Le cache est **invalidé** autant que faire se peut. Parce que c'est toujours mieux d'avoir un cache long et correctement invalidé plutôt que de devoir le rendre presque inefficace à cause de *timeouts* très courts imposés pour garder une cohérence dans les données.
+
+Implémentation technique
+========================
+
+1. Définir un **identifiant**. Caractères autorisés : ``a-z0-9_``
+    - C'est le nom de fragment de cache
+    - C'est la clé de *timeout* dans les paramètres
+2. Définir la **clé de cache**
+3. Vérifier les **cas d'invalidation**
+4. Vérifier que toutes les règles d'implémentation vont bien être respectées
+5. Définir la durée de cache dans le fichier ``settings.py``, paramètre ``CACHE_TIMEOUTS``.
+6. Implémenter le cache ! (définition des blocs, vues, ... à cacher ; invalidations ...).
+7. Mise à jour de cette documentation.
+
+Les caches implémentés
+======================
+
+*Type* dans les tableaux correspond au `type de cache Django <https://docs.djangoproject.com/en/1.7/topics/cache/>`.
+
+*Usage* dans les tableaux correspond à l'endroit où est défini le bloc caché.
+
+Blocs des articles
+-------------------
+
+Il s'agit des blocs visuels de présentation des articles que l'on trouve par exemple sur la page d'accueil ou sur la liste des articles.
+
+==================  =====================================================================
+Identifiant         article_item
+Type                Template fragment caching
+Clé de cache        identifiant + clé primaire de l'article + "link" + "show_description"
+Usage               templates/article/includes/article_item.part.html
+Temps de cache      1 heure
+Cas d'invalidation  La sauvegarde d'un article invalide l'entrée correspondante
+==================  =====================================================================
+
+``link`` et ``show_description`` dans la clé de cache sont les deux paramètres de même nom passés au *template* ``article/includes/article_item.part.html``.
+
+Comme l'ajout de commentaires sauvegarde l'article lui-même (lien vers le dernier commentaire), ce cas est automatiquement géré.
+
+Blocs des tutoriels
+-------------------
+
+Il s'agit des blocs visuels de présentation des tutoriels que l'on trouve par exemple sur la page d'accueil ou sur la liste des tutoriels.
+
+==================  ============================================================
+Identifiant         tutorial_item
+Type                Template fragment caching
+Clé de cache        identifiant + clé primaire du tutoriel +  "show_description"
+Usage               templates/tutorial/includes/tutorial_item.part.html
+Temps de cache      1 heure
+Cas d'invalidation  La sauvegarde d'un tutoriel invalide l'entrée correspondante
+==================  ============================================================
+
+``show_description`` dans la clé de cache est le paramètre de même nom passé au *template* ``tutorial/includes/tutorial_item.part.html``.
+
+Blocs "À la une"
+----------------
+
+Il s'agit du bloc des éléments à la une sur la page d'accueil
+
+==================  =================================================================
+Identifiant         home_featured_resources
+Type                Template fragment caching
+Clé de cache        identifiant (une seule clé de cache, donc)
+Usage               templates/home.html
+Temps de cache      1 heure
+Cas d'invalidation  La sauvegarde d'un une quelconque invalide cette entrée de cache.
+==================  =================================================================
+
+Menu principal "Tutoriels / Articles / Forums"
+----------------------------------------------
+
+Il s'agit du bloc "Tutoriels / Articles / Forums" du menu principal.
+
+==================  ===========================================================
+Identifiant         header_menu
+Type                Template fragment caching
+Clé de cache        identifiant + clé primaire de l'utilisateur (User) connecté
+Usage               templates/base.html
+Temps de cache      1 heure
+Cas d'invalidation  Aucun
+==================  ===========================================================
+
+Le menu "Tutoriels / Articles / Forum" est toujours le même pour un utilisateur donné (ou presque, ça doit bouger 2 fois dans les semaines très riches en nouvelles catégories). Par contre, l'invalidation serait très casse-pieds à faire, puisque la plupart du temps modifier l'utilisateur ne change pas son menu. Comme le menu ne contient aucune donné sensible, on peut avoir donc un élément faux dans le menu pendant 1h max.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,6 +18,7 @@ Sommaire
    workflow
    back-end
    back-end-code
+   cache
    front-end
    api
    utils

--- a/templates/article/includes/article_item.part.html
+++ b/templates/article/includes/article_item.part.html
@@ -4,14 +4,14 @@
 {% load date %}
 {% load cache %}
 
-{% cache cache_timeouts.article_item article_item article.pk link show_description %}
-
 {# Public link by default #}
 {% if not link %}
     {% captureas link %}
         {{ article.get_absolute_url_online }}
     {% endcaptureas %}
 {% endif %}
+
+{% cache cache_timeouts.article_item article_item article.pk link show_description %}
 
 {# Authors (by X, Y and Z) ; can't have multiple whitespaces because of the title ! #}
 {% captureas authors_text %}

--- a/templates/article/includes/article_item.part.html
+++ b/templates/article/includes/article_item.part.html
@@ -15,7 +15,7 @@
 
 {# Authors (by X, Y and Z) ; can't have multiple whitespaces because of the title ! #}
 {% captureas authors_text %}
-    {% for author in article.authors.all %}{% if forloop.first %}{% trans "par" %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %} {% if author == user %}{% trans "vous" %}{% else %}{{ author.username }}{% endif %}{% endfor %}
+    {% for author in article.authors.all %}{% if forloop.first %}{% trans "par" %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %} {{ author.username }}{% endfor %}
 {% endcaptureas %}
 
 <article class="content-item article-item has-reactions">

--- a/templates/article/includes/article_item.part.html
+++ b/templates/article/includes/article_item.part.html
@@ -4,7 +4,7 @@
 {% load date %}
 {% load cache %}
 
-{% cache 3600 article_item article.pk link show_description %}
+{% cache cache_timeouts.article_item article_item article.pk link show_description %}
 
 {# Public link by default #}
 {% if not link %}

--- a/templates/article/includes/article_item.part.html
+++ b/templates/article/includes/article_item.part.html
@@ -2,6 +2,9 @@
 {% load thumbnail %}
 {% load i18n %}
 {% load date %}
+{% load cache %}
+
+{% cache 3600 article_item article.pk link show_description %}
 
 {# Public link by default #}
 {% if not link %}
@@ -81,3 +84,4 @@
         </ul>
     {% endif %}
 </article>
+{% endcache %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
 {% load captureas %}
 {% load thumbnail %}
 {% load i18n %}
+{% load cache %}
 
 
 
@@ -171,6 +172,7 @@
 
 
                     {# Menu #}
+                    {% cache 3600 header_menu user.pk %}
                     <nav class="header-menu mobile-menu-bloc" id="menu" data-title="Menu"
                         {% if user.is_authenticated %}
                             {% with profile=user.profile %}
@@ -268,6 +270,7 @@
                             </li>
                         </ul>
                     </nav>
+                    {% endcache %}
 
 
                     {# Logbox #}

--- a/templates/base.html
+++ b/templates/base.html
@@ -172,7 +172,7 @@
 
 
                     {# Menu #}
-                    {% cache 3600 header_menu user.pk %}
+                    {% cache cache_timeouts.header_menu header_menu user.pk %}
                     <nav class="header-menu mobile-menu-bloc" id="menu" data-title="Menu"
                         {% if user.is_authenticated %}
                             {% with profile=user.profile %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -117,7 +117,7 @@
                 {% endif %}
             </h2>
 
-            {% cache 3600 home_featured_resources %}
+            {% cache cache_timeouts.home_featured_resources home_featured_resources %}
             <div class="featured-resource-row">
                 {% for featured_resource in last_featured_resources %}
                     {% include "featured/includes/featured_resource_item.part.html" %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,6 +8,7 @@
 {% load thumbnail %}
 {% load i18n %}
 {% load captureas %}
+{% load cache %}
 
 
 
@@ -116,6 +117,7 @@
                 {% endif %}
             </h2>
 
+            {% cache 3600 home_featured_resources %}
             <div class="featured-resource-row">
                 {% for featured_resource in last_featured_resources %}
                     {% include "featured/includes/featured_resource_item.part.html" %}
@@ -123,6 +125,7 @@
                     <p class="no-featured-resource">{% trans "Aucun élément &quot;À la une&quot; disponible" %}</p>
                 {% endfor %}
             </div>
+            {% endcache %}
         </section>
         <div class="home-row">
            <section itemscope itemtype="http://schema.org/ItemList">

--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -15,7 +15,7 @@
 
 {# Authors (by X, Y and Z) ; can't have multiple whitespaces because of the title ! #}
 {% captureas authors_text %}
-    {% for author in tutorial.authors.all %}{% if forloop.first %}{% trans "par" %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %} {% if author == user %}{% trans "vous" %}{% else %}{{ author.username }}{% endif %}{% endfor %}
+    {% for author in tutorial.authors.all %}{% if forloop.first %}{% trans "par" %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %} {{ author.username }}{% endfor %}
 {% endcaptureas %}
 
 {# Categories (in X, Y and Z) #}

--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -2,7 +2,9 @@
 {% load thumbnail %}
 {% load i18n %}
 {% load date %}
+{% load cache %}
 
+{% cache 3600 tutorial_item tutorial.pk show_description %}
 {% captureas link %}
     {% if beta %}
         {{ tutorial.get_absolute_url_beta }}
@@ -64,3 +66,4 @@
         </div>
     </a>
 </article>
+{% endcache %}

--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -4,7 +4,7 @@
 {% load date %}
 {% load cache %}
 
-{% cache 3600 tutorial_item tutorial.pk show_description %}
+{% cache cache_timeouts.tutorial_item tutorial_item tutorial.pk show_description %}
 {% captureas link %}
     {% if beta %}
         {{ tutorial.get_absolute_url_beta }}

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 
 from django.conf import settings
+from django.core.cache import cache
+from django.core.cache.utils import make_template_fragment_key
 from django.db import models
 from math import ceil
 from git import Repo
@@ -95,6 +97,12 @@ class Article(models.Model):
 
     def __unicode__(self):
         return self.title
+
+    def save(self):
+        super(Article, self).save()
+        # Delete associated cache keys
+        cache.delete(make_template_fragment_key('article_item', [self.pk, self.get_absolute_url_online(), True]))
+        cache.delete(make_template_fragment_key('article_item', [self.pk, self.get_absolute_url_online(), False]))
 
     def delete_entity_and_tree(self):
         """deletes the entity and its filesystem counterpart"""

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -218,6 +218,8 @@ class Article(models.Model):
         # Delete associated cache keys
         cache.delete(make_template_fragment_key('article_item', [self.pk, self.get_absolute_url_online(), True]))
         cache.delete(make_template_fragment_key('article_item', [self.pk, self.get_absolute_url_online(), False]))
+        cache.delete(make_template_fragment_key('article_item', [self.pk, self.get_absolute_url(), True]))
+        cache.delete(make_template_fragment_key('article_item', [self.pk, self.get_absolute_url(), False]))
 
     def get_reaction_count(self):
         """Return the number of reactions in the article."""

--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -98,12 +98,6 @@ class Article(models.Model):
     def __unicode__(self):
         return self.title
 
-    def save(self):
-        super(Article, self).save()
-        # Delete associated cache keys
-        cache.delete(make_template_fragment_key('article_item', [self.pk, self.get_absolute_url_online(), True]))
-        cache.delete(make_template_fragment_key('article_item', [self.pk, self.get_absolute_url_online(), False]))
-
     def delete_entity_and_tree(self):
         """deletes the entity and its filesystem counterpart"""
         shutil.rmtree(self.get_path(), 0)
@@ -220,6 +214,10 @@ class Article(models.Model):
                 os.remove(name)
 
         super(Article, self).save(*args, **kwargs)
+
+        # Delete associated cache keys
+        cache.delete(make_template_fragment_key('article_item', [self.pk, self.get_absolute_url_online(), True]))
+        cache.delete(make_template_fragment_key('article_item', [self.pk, self.get_absolute_url_online(), False]))
 
     def get_reaction_count(self):
         """Return the number of reactions in the article."""

--- a/zds/featured/models.py
+++ b/zds/featured/models.py
@@ -31,8 +31,8 @@ class FeaturedResource(models.Model):
         """Textual form of a featured resource."""
         return self.title
 
-    def save(self):
-        super(FeaturedResource, self).save()
+    def save(self, *args, **kwargs):
+        super(FeaturedResource, self).save(*args, **kwargs)
         # Clear associated cache keys
         cache.delete(make_template_fragment_key('home_featured_resources'))
 

--- a/zds/featured/models.py
+++ b/zds/featured/models.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+from django.core.cache import cache
+from django.core.cache.utils import make_template_fragment_key
 
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -28,6 +30,11 @@ class FeaturedResource(models.Model):
     def __unicode__(self):
         """Textual form of a featured resource."""
         return self.title
+
+    def save(self):
+        super(FeaturedResource, self).save()
+        # Clear associated cache keys
+        cache.delete(make_template_fragment_key('home_featured_resources'))
 
 
 class FeaturedMessage(models.Model):

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -141,6 +141,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     # ZDS context processors
     'zds.utils.context_processor.app_settings',
     'zds.utils.context_processor.git_version',
+    'zds.utils.context_processor.cache_timeouts',
 )
 
 CRISPY_TEMPLATE_PACK = 'bootstrap'
@@ -310,6 +311,13 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
         'LOCATION': '127.0.0.1:11211',
     }
+}
+
+CACHE_TIMEOUTS = {
+    'article_item': 3600,
+    'header_menu': 3600,
+    'home_featured_resources': 3600,
+    'tutorial_item': 3600,
 }
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -123,12 +123,6 @@ class Tutorial(models.Model):
     def __unicode__(self):
         return self.title
 
-    def save(self):
-        super(Tutorial, self).save()
-        # Clear associated cache keys
-        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, True]))
-        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, False]))
-
     def get_phy_slug(self):
         return str(self.pk) + "_" + self.slug
 
@@ -374,6 +368,10 @@ class Tutorial(models.Model):
         self.slug = slugify(self.title)
 
         super(Tutorial, self).save(*args, **kwargs)
+
+        # Clear associated cache keys
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, True]))
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, False]))
 
     def get_note_count(self):
         """Return the number of notes in the tutorial."""

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -2,6 +2,9 @@
 
 from math import ceil
 import shutil
+from django.core.cache import cache
+from django.core.cache.utils import make_template_fragment_key
+
 try:
     import ujson as json_reader
 except ImportError:
@@ -119,6 +122,12 @@ class Tutorial(models.Model):
 
     def __unicode__(self):
         return self.title
+
+    def save(self):
+        super(Tutorial, self).save()
+        # Clear associated cache keys
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, True]))
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, False]))
 
     def get_phy_slug(self):
         return str(self.pk) + "_" + self.slug

--- a/zds/utils/context_processor.py
+++ b/zds/utils/context_processor.py
@@ -31,3 +31,10 @@ def app_settings(request):
     A context processor with all APP settings.
     """
     return {'app': settings.ZDS_APP}
+
+
+def cache_timeouts(request):
+    """
+    A context processor to access CACHE_TIMEOUTS on templates
+    """
+    return {'cache_timeouts': settings.CACHE_TIMEOUTS}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~Oui |
| Nouvelle Fonctionnalité ? | ~Oui aussi (mais c'est pour corriger le bug) |
| Tickets (_issues_) concernés | #2669, #2671 |

Les nouvelles pages "Liste des tutos", "Liste des articles" et la home sont beaucoup plus lourdes que les actuelles, ce qui est problématique parce que ce sont des pages _très_ vues.

Or, ces pages sont constituées d'éléments qui bougent très peu :
- Les blocs d'affichage des tutos : ne changent qu'à la mise à jour du tuto
- Les blocs d'affichage des articles : changent à la mise à jour de l'article ou au post d'un nouveau commentaire... ce qui met à jour l'article (pointeur sur le dernier commentaire)
- Le bloc des unes ne change que lors de la sauvegarde d'une une
- Le menu "Tutoriels / Articles / Forum" est toujours le même pour un utilisateur donné (ou presque, ça doit bouger 2 fois dans les semaines très riches en nouvelles catégories)

Les blocs des forums (en pied de home), par contre, sont très souvent mis à jour.

Donc, j'ai mis du cache sur les 4 premiers types de blocs listés, avec les règles suivantes :
1. Les blocs des tutos sont cachés séparément.
   - Clé de cache : (ID du tuto + est-ce qu'on doit afficher la description).
   - Temps de cache : 1 heure
   - Cache du bloc invalidé quand on sauvegarde le tuto correspondant
2. Les blocs des articles sont cachés séparément.
   - Clé de cache : (ID de l'article + URL (bizarrement passé à la procédure d'affichage) + est-ce qu'on doit afficher la description).
   - Temps de cache : 1 heure
   - Cache du bloc invalidé quand on sauvegarde l'article correspondant
3. La série d'éléments "à la une" est cachée en entier
   - Clé de cache : une seule entrée de cache
   - Temps de cache : 1 heure
   - Cache du bloc invalidé quand on sauvegarde une "une" quelconque
4. Le menu "Tuto / articles / forums" est caché par utilisateur
   - Clé de cache : (ID de l'utilisateur).
   - Temps de cache : 1 heure
   - Cache du bloc invalidé uniquement sur timeout (on peut avoir donc un élément faux dans le menu pendant 1h max)

Tout ceci réduit très massivement le poids de ces pages pour un risque d'erreur de cache minime. Caches remplis :
- La page d'accueil en mode déconnecté descend à 22 requêtes, au lieu de 107 au début de la release et 57 suite à la PR #270, et j'espère la servir en moins de 150 ms en prod.
- La page des forums en mode admin descend à 79000 function calls
# Comment QA tout ceci ?
1. **Activez un système de cache quelconque autre que le DummyCache**
2. [Chargez des tutos, articles et forums](http://zds-site.readthedocs.org/fr/latest/utils/fixture_loaders.html) sinon vous n'allez rien voir.
3. Vérifiez que, sur les pages suivantes, en mode connecté ou non, la page est plus rapide et fait moins de requêtes au rechargement qu'au premier chargement : 
   - Accueil
   - Liste des tutos
   - Liste des articles
4. Vérifiez que si vous mettez à jour un tuto (titre, auteur) la home et la liste des tutos sont bien MAJ sans avoir à attendre 1h
5. Vérifiez que si vous mettez à jour un article (titre, auteur) la home et la liste des articles sont bien MAJ sans avoir à attendre 1h
6. Vérifiez que commenter un article met bien à jour le compteur sur la home et la liste des articles sans avoir à attendre 1h
7. Vérifiez que le bloc des "Unes" est bien mis à jour si vous en modifiez ou ajoutez une
8. Connectez vous avec un utilisateur qui a le droit de voir des forums masqués. Vérifiez :
   - Qu'il voit bien ces forums dans son menu
   - Que les membres normaux et déconnecté ne voient pas ces forums

PS : Ce message est bien plus long que la PR...
