### PR TITLE
Corrections typos, indentation et traductions

### DIFF
--- a/assets/js/markdown-help.js
+++ b/assets/js/markdown-help.js
@@ -14,7 +14,7 @@
                 "class": "markdown-help",
                 "html": "<div class=\"markdown-help-more\">" +
                         "<p>Les simples retours à la ligne ne sont pas pris en compte. Pour créer un nouveau paragraphe, pensez à <em>sauter une ligne</em> !</p>" +
-                        "<pre><code>**gras** \n*italique* \n[texte de lien](url du lien) \n> citation \n+ liste a puces </code></pre>" +
+                        "<pre><code>**gras** \n*italique* \n[texte de lien](url du lien) \n> citation \n+ liste à puces </code></pre>" +
                         "<a href=\"//zestedesavoir.com/tutoriels/221/rediger-sur-zds/\">Voir la documentation complète</a></div>" +
                         "<a href=\"#open-markdown-help\" class=\"open-markdown-help btn btn-grey ico-after help\">"+
                             "<span class=\"close-markdown-help-text\">Masquer</span>" +

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -132,7 +132,7 @@
 
 
         {% if articles %}
-            <h2 class="ico-after ico-articles" id="derniers-artilces">{% trans "Derniers articles" %}</h2>
+            <h2 class="ico-after ico-articles" id="derniers-articles">{% trans "Derniers articles" %}</h2>
             <div class="content-item-list">
                 {% for article in articles %}
                     {% include 'article/includes/article_item.part.html' with show_description=True %}

--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -1,7 +1,7 @@
 {% extends "pages/base.html" %}
-
 {% load i18n %}
 {% load staticfiles %}
+{% load set %}
 
 
 
@@ -24,6 +24,7 @@
 
 
 {% block content %}
+    {% set app.site.litteral_name as site_name %}
     <p>
         {% blocktrans with repository=app.site.repository %}
             Si vous vous intéressez à tout cela, vous devriez songer à <a href="{{ repository }}">contribuer au développement du site</a> !
@@ -36,21 +37,21 @@
                 <h3>{% trans "Droits" %}</h3>
                 {% if app.site.licenses.source %}
                     <p>
-                        {% blocktrans with site_name=app.site.litteral_name src_url_license=app.site.licenses.source.url_license src_code=app.site.licenses.source.code provider_url=app.site.licenses.source.provider_url provider_name=app.site.licenses.source.provider_name %}
+                        {% blocktrans with src_url_license=app.site.licenses.source.url_license src_code=app.site.licenses.source.code provider_url=app.site.licenses.source.provider_url provider_name=app.site.licenses.source.provider_name %}
                             {{ site_name }} est un site dont le code source est sous licence <a href="{{ src_url_license }}">{{ src_code }}</a>, et provient en partie de <a href="{{ provider_url }}">{{ provider_name }}</a>.
                         {% endblocktrans %}
                     </p>
                 {% endif %}
                 {% if app.site.licenses.logo %}
                     <p>
-                        {% blocktrans with site_name=app.site.litteral_name author_logo=app.site.licenses.logo.author url_license=app.site.licenses.logo.url_license url_image=app.site.licenses.logo.url_image logo_title=app.site.licenses.logo.title logo_desc=app.site.licenses.logo.description %}
+                        {% blocktrans with author_logo=app.site.licenses.logo.author url_license=app.site.licenses.logo.url_license url_image=app.site.licenses.logo.url_image logo_title=app.site.licenses.logo.title logo_desc=app.site.licenses.logo.description %}
                             Le logo de {{ site_name }} a été créé par {{ author_logo }} et est sous
                             <a rel="license" href="{{ url_license }}">
                             <img alt="{{ logo_title }}" src="{{ url_image }}">
                             {{ logo_desc }}
                             </a>
                         {% endblocktrans %}
-                        <img alt="Logo de {{ app.site.litteral_name }}" src="{% static 'images/logo-background.png' %}">
+                        <img alt="{% blocktrans %}Logo de {{ site_name }}{% endblocktrans %}" src="{% static 'images/logo-background.png' %}">
                     </p>
                 {% endif %}
             </div>
@@ -59,7 +60,7 @@
         <div class="content-col-3">
             <h3>{% trans "Système / Back-end" %}</h3>
             <p>
-                {% trans "Le Back-end est propulsé par les outils suivants" %} :
+                {% trans "Le Back-end est propulsé par les outils suivants :" %}
             </p>
 
             <h4>{% trans "Site" %}</h4>
@@ -81,7 +82,7 @@
 
             <h4>{% trans "Géolocalisation des adresses IP" %}</h4>
             <p>
-                {% trans "Données GeoLite créées par MaxMind, disponibles sous licence CC-BY-SA 3.0 unported" %}.
+                {% trans "Données GeoLite créées par MaxMind, disponibles sous licence CC-BY-SA 3.0 unported." %}
             </p>
             <ul>
                 <li><a href="http://www.maxmind.com">http://www.maxmind.com</a></li>
@@ -91,7 +92,7 @@
         <div class="content-col-3">
             <h3>{% trans "Front-end" %}</h3>
             <p>
-                {% trans "Le front-end utilise les outils suivants" %} :
+                {% trans "Le front-end utilise les outils suivants :" %}
             </p>
 
             <h4>{% trans "Feuilles de style" %}</h4>

--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -24,7 +24,7 @@
 
 
 {% block content %}
-	<p>
+    <p>
         {% blocktrans with repository=app.site.repository %}
             Si vous vous intéressez à tout cela, vous devriez songer à <a href="{{ repository }}">contribuer au développement du site</a> !
         {% endblocktrans %}
@@ -37,17 +37,17 @@
                 {% if app.site.licenses.source %}
                     <p>
                         {% blocktrans with site_name=app.site.litteral_name src_url_license=app.site.licenses.source.url_license src_code=app.site.licenses.source.code provider_url=app.site.licenses.source.provider_url provider_name=app.site.licenses.source.provider_name %}
-                            {{site_name}} est un site donc le code source est sous licence <a href="{{ src_url_license }}">{{ src_code }}</a>, et provient en partie de <a href="{{ provider_url }}">{{ provider_name }}</a>.
+                            {{ site_name }} est un site dont le code source est sous licence <a href="{{ src_url_license }}">{{ src_code }}</a>, et provient en partie de <a href="{{ provider_url }}">{{ provider_name }}</a>.
                         {% endblocktrans %}
                     </p>
                 {% endif %}
                 {% if app.site.licenses.logo %}
                     <p>
                         {% blocktrans with site_name=app.site.litteral_name author_logo=app.site.licenses.logo.author url_license=app.site.licenses.logo.url_license url_image=app.site.licenses.logo.url_image logo_title=app.site.licenses.logo.title logo_desc=app.site.licenses.logo.description %}
-                            <a href="#">Le logo de {{ site_name }}</a> a été créé par {{ author_logo }} et est sous
+                            Le logo de {{ site_name }} a été créé par {{ author_logo }} et est sous
                             <a rel="license" href="{{ url_license }}">
                             <img alt="{{ logo_title }}" src="{{ url_image }}">
-                    	    {{ logo_desc }}
+                            {{ logo_desc }}
                             </a>
                         {% endblocktrans %}
                         <img alt="Logo de {{ app.site.litteral_name }}" src="{% static 'images/logo-background.png' %}">
@@ -97,7 +97,8 @@
             <h4>{% trans "Feuilles de style" %}</h4>
             <ul>
                 <li><a href="http://necolas.github.io/normalize.css/">Normalize.css</a></li>
-                <li><a href="http://sass-lang.com/">SCSS</a></li></ul>
+                <li><a href="http://sass-lang.com/">SCSS</a></li>
+            </ul>
 
             <h4>Javascript</h4>
             <ul>

--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -29,7 +29,7 @@
             <th>{% trans "Auteur" %}</th>
             <th class="wide">{% trans "Date" %}</th>
             <th class="wide">{% trans "Message" %}</th>
-            <th>{% trans "Sur un message de" %}...</th>
+            <th>{% trans "Sur un message de..." %}</th>
         </thead>
         <tbody>
             {% for alert in alerts %}
@@ -38,7 +38,12 @@
                     <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
                     <td class="wide">{{ alert.pubdate|format_date|capfirst }}</td>
                     <td class="wide"><a href="{{ alert.get_comment_subclass.get_absolute_url }}">{{ alert.text }}</a></td>
-                    <td><a href="{% url "member-detail" alert.comment.author.username %}">{{ alert.comment.author.username }}</a>, {% blocktrans with timing=alert.comment.pubdate|format_date%} posté le {{ timing }} {% endblocktrans %}</td>
+                    <td>
+                        {% url "member-detail" alert.comment.author.username as url_member_detail %}
+                        {% blocktrans with author_username=alert.comment.author.username timing=alert.comment.pubdate|format_date %}
+                            <a href="{{ url_member_detail }}">{{ author_username }}</a>, posté le {{ timing }}
+                        {% endblocktrans %}
+                    </td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/templates/pages/assoc_subscribe.html
+++ b/templates/pages/assoc_subscribe.html
@@ -3,26 +3,27 @@
 {% load i18n %}
 
 
+
 {% block title %}
-    {% trans "Adhérer à l'association" %} {{ app.site.association.name }}
+    {% blocktrans with asso_name=app.site.association.name %}Adhérer à l'association {{ asso_name }}{% endblocktrans %}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li>{% trans "Adhérer à l'association" %} {{ app.site.association.name }}</li>
+    <li>{% blocktrans with asso_name=app.site.association.name %}Adhérer à l'association {{ asso_name }}{% endblocktrans %}</li>
 {% endblock %}
 
 
 
 {% block headline %}
-    <h1>{% trans "Adhérer à l'association" %} {{ app.site.association.name }}</h1>
+    <h1>{% blocktrans with asso_name=app.site.association.name %}Adhérer à l'association {{ asso_name }}{% endblocktrans %}</h1>
 {% endblock %}
 
 
 
 {% block content %}
-    <h3>{% trans "Pourquoi adhérer" %} ?</h3>
+    <h3>{% trans "Pourquoi adhérer ?" %}</h3>
     <p>
         {% blocktrans with asso_name=app.site.association.name %}
             Adhérer à l'association {{ asso_name }} permet de nous soutenir de manière concrète et d'officialiser votre engagement.
@@ -37,10 +38,10 @@
         {% endblocktrans %}
     </p>
     <p>
-        {% trans "Notez que l'adhésion est subordonnée au paiement de cette cotisation" %}.
+        {% trans "Notez que l'adhésion est subordonnée au paiement de cette cotisation." %}
     </p>
     <p>
-        {% trans "Adhérer permet bien entendu de participer à l'Assemblée Générale annuelle de l'association, qui élit le Conseil d'Administration. Si vous avez des idées pour faire avancer l'association et donc le site, c'est le moment" %} !
+        {% trans "Adhérer permet bien entendu de participer à l'Assemblée Générale annuelle de l'association, qui élit le Conseil d'Administration. Si vous avez des idées pour faire avancer l'association et donc le site, c'est le moment !" %}
     </p>
     <p>
         {% blocktrans %}
@@ -50,7 +51,7 @@
         {% endblocktrans %}
     </p>
     <p>
-        {% trans "Enfin, toutes les fonctionnalités du site sont disponibles à tous : aucune n'est conditionnée à l'adhésion à l'association" %}.
+        {% trans "Enfin, toutes les fonctionnalités du site sont disponibles à tous : aucune n'est conditionnée à l'adhésion à l'association." %}
     </p>
 
     <h3>{% trans "Formulaire d'adhésion" %}</h3>

--- a/templates/pages/assoc_subscribe.html
+++ b/templates/pages/assoc_subscribe.html
@@ -4,19 +4,19 @@
 
 
 {% block title %}
-    {% trans "Adhérer à l'association" %} {{app.site.association.name}}
+    {% trans "Adhérer à l'association" %} {{ app.site.association.name }}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-  	<li>{% trans "Adhérer à l'association" %} {{app.site.association.name}}</li>
+    <li>{% trans "Adhérer à l'association" %} {{ app.site.association.name }}</li>
 {% endblock %}
 
 
 
 {% block headline %}
-    <h1>{% trans "Adhérer à l'association" %} {{app.site.association.name}}</h1>
+    <h1>{% trans "Adhérer à l'association" %} {{ app.site.association.name }}</h1>
 {% endblock %}
 
 
@@ -25,14 +25,14 @@
     <h3>{% trans "Pourquoi adhérer" %} ?</h3>
     <p>
         {% blocktrans with asso_name=app.site.association.name %}
-            Adhérer à l'association {{asso_name}} permet de nous soutenir de manière concrète et d'officialiser votre engagement.
+            Adhérer à l'association {{ asso_name }} permet de nous soutenir de manière concrète et d'officialiser votre engagement.
         {% endblocktrans %}
     </p>
     <p>
         {% blocktrans with asso_fee=app.site.association.fee %}
             D'autre part, le financement des activités de l'association, dont bien sûr le site, est intégralement assuré par
             les cotisations des membres : adhérer vous permet ainsi d'assurer la pérennité du site.
-            La cotisation est de <strong>{{asso_fee}}</strong> (le montant est révisé tous les ans durant les assemblées générales).
+            La cotisation est de <strong>{{ asso_fee }}</strong> (le montant est révisé tous les ans durant les assemblées générales).
             Si pour une raison quelconque vous ne pouvez pas payer cette cotisation, faites-en nous part, nous pouvons accorder des dérogations exceptionnelles.
         {% endblocktrans %}
     </p>

--- a/templates/pages/association.html
+++ b/templates/pages/association.html
@@ -1,29 +1,32 @@
 {% extends "pages/base.html" %}
 {% load i18n %}
+{% load set %}
+
 
 
 {% block title %}
-    {% trans "L'association" %} {{ app.site.association.name }}
+    {% blocktrans with asso_name=app.site.association.name %}L'association {{ asso_name }}{% endblocktrans %}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li>{% trans "L'association" %} {{ app.site.association.name }}</li>
+    <li>{% blocktrans with asso_name=app.site.association.name %}L'association {{ asso_name }}{% endblocktrans %}</li>
 {% endblock %}
 
 
 
 {% block headline %}
-    <h1>{% trans "L'association" %} {{ app.site.association.name }}</h1>
+    <h1>{% blocktrans with asso_name=app.site.association.name %}L'association {{ asso_name }}{% endblocktrans %}</h1>
 {% endblock %}
 
 
 
 {% block content %}
+    {% set app.site.association.name as asso_name %}
     <h3>{% trans "Présentation de l'association" %}</h3>
     <p>
-        {% blocktrans with asso_name=app.site.association.name site_url=app.site.url %}
+        {% blocktrans with site_url=app.site.url %}
             {{ asso_name }} est une association loi 1901 (association à but non lucratif) et joue le rôle de structure
             légale du site {{ site_url }}, dont le but est de promouvoir le partage de connaissances à travers des
             ressources pédagogiques gratuites et de préférence sous licence libre.
@@ -33,10 +36,10 @@
         {% endblocktrans %}
     </p>
     <p>
-        {% trans "Ces membres fondateurs sont tous des anciens membres très actifs du feu siteduzero, un site de diffusion de connaissances et d'entraide. À la suite du changement de politique de ce dernier, ils ont décidé de recréer une plateforme sur laquelle ils pourraient à nouveau s'entraider et partager convenablement leurs connaissances et surtout retrouver l'esprit communautaire qu'ils aimaient tant" %}.
+        {% trans "Ces membres fondateurs sont tous des anciens membres très actifs du feu siteduzero, un site de diffusion de connaissances et d'entraide. À la suite du changement de politique de ce dernier, ils ont décidé de recréer une plateforme sur laquelle ils pourraient à nouveau s'entraider et partager convenablement leurs connaissances et surtout retrouver l'esprit communautaire qu'ils aimaient tant." %}
     </p>
     <p>
-        {% blocktrans with asso_name=app.site.association.name %}
+        {% blocktrans %}
             Voilà l'histoire de {{ asso_name }}.
         {% endblocktrans %}
     </p>
@@ -50,9 +53,9 @@
         {% endblocktrans %}
     </p>
     <p>
-        {% trans "De même, toutes les fonctionnalités du site sont disponibles à tous : aucune n'est conditionnée à l'adhésion à l'association" %}.
+        {% trans "De même, toutes les fonctionnalités du site sont disponibles à tous : aucune n'est conditionnée à l'adhésion à l'association." %}
     </p>
     <p>
-        {% trans "Notez que vous devez être inscrit pour pouvoir adhérer" %}.
+        {% trans "Notez que vous devez être inscrit pour pouvoir adhérer." %}
     </p>
 {% endblock %}

--- a/templates/pages/association.html
+++ b/templates/pages/association.html
@@ -3,19 +3,19 @@
 
 
 {% block title %}
-    {% trans "L'association" %} {{app.site.association.name}}
+    {% trans "L'association" %} {{ app.site.association.name }}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li>{% trans "L'association" %} {{app.site.association.name}}</li>
+    <li>{% trans "L'association" %} {{ app.site.association.name }}</li>
 {% endblock %}
 
 
 
 {% block headline %}
-    <h1>{% trans "L'association" %} {{app.site.association.name}}</h1>
+    <h1>{% trans "L'association" %} {{ app.site.association.name }}</h1>
 {% endblock %}
 
 
@@ -24,8 +24,8 @@
     <h3>{% trans "Présentation de l'association" %}</h3>
     <p>
         {% blocktrans with asso_name=app.site.association.name site_url=app.site.url %}
-            {{asso_name}} est une association loi 1901 (association à but non lucratif) et joue le rôle de structure
-            légale du site {{site_url}}, dont le but est de promouvoir le partage de connaissances à travers des
+            {{ asso_name }} est une association loi 1901 (association à but non lucratif) et joue le rôle de structure
+            légale du site {{ site_url }}, dont le but est de promouvoir le partage de connaissances à travers des
             ressources pédagogiques gratuites et de préférence sous licence libre.
             <a href="http://www.journal-officiel.gouv.fr/publications/assoc/pdf/2014/0016/JOAFE_PDF_Unitaire_20140016_01712.pdf">
                 Parue au Journal officiel le 19 avril 2014</a>, l'association a tenu sa première assemblée générale le 15 mars
@@ -37,8 +37,8 @@
     </p>
     <p>
         {% blocktrans with asso_name=app.site.association.name %}
-            Voilà l'histoire de {{asso_name}}.
-        {% endblocktrans %}    
+            Voilà l'histoire de {{ asso_name }}.
+        {% endblocktrans %}
     </p>
 
     <h3>{% trans "L'association et le site" %}</h3>

--- a/templates/pages/base.html
+++ b/templates/pages/base.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 
+
 {% block breadcrumb_base %}
     <li><a href="{% url "zds.pages.views.index" %}">{% trans "Pages" %}</a></li>
 {% endblock %}

--- a/templates/pages/contact.html
+++ b/templates/pages/contact.html
@@ -27,7 +27,7 @@
     <h3>{% trans "L'équipe de communication" %}</h3>
     <p>
         {% blocktrans with site_name=app.site.litteral_name email_contact=app.site.email_contact|obfuscate_mailto_top_subject:"Contact communication" %}
-            Vous pouvez à tout moment joindre l'équipe de communication de {{site_name}} par courriel via {{ email_contact }}.
+            Vous pouvez à tout moment joindre l'équipe de communication de {{ site_name }} par courriel via {{ email_contact }}.
         {% endblocktrans %}
     </p>
     {% if app.site.association %}

--- a/templates/pages/contact.html
+++ b/templates/pages/contact.html
@@ -1,7 +1,7 @@
 {% extends "pages/base.html" %}
-
 {% load email_obfuscator %}
 {% load i18n %}
+{% load set %}
 
 
 
@@ -24,16 +24,17 @@
 
 
 {% block content %}
+    {% set app.site.litteral_name as site_name %}
     <h3>{% trans "L'équipe de communication" %}</h3>
     <p>
-        {% blocktrans with site_name=app.site.litteral_name email_contact=app.site.email_contact|obfuscate_mailto_top_subject:"Contact communication" %}
+        {% blocktrans with email_contact=app.site.email_contact|obfuscate_mailto_top_subject:"Contact communication" %}
             Vous pouvez à tout moment joindre l'équipe de communication de {{ site_name }} par courriel via {{ email_contact }}.
         {% endblocktrans %}
     </p>
     {% if app.site.association %}
         <h3>{% trans "L'association" %}</h3>
         <p>
-            {% blocktrans with site_name=app.site.litteral_name email_association=app.site.association.email|obfuscate_mailto_top_subject:"Contact association" %}
+            {% blocktrans with email_association=app.site.association.email|obfuscate_mailto_top_subject:"Contact association" %}
                 Vous pouvez joindre l'association par courriel via {{ email_association }}.
             {% endblocktrans %}
         </p>
@@ -41,7 +42,7 @@
 
     <h3>{% trans "Le staff" %}</h3>
     <p>
-        {% blocktrans with site_name=app.site.litteral_name %}
+        {% blocktrans %}
             Le staff est constitué de certains membres du site dont le but est de contrôler le contenu publié sur {{ site_name }}. Ils sont en charge de la modération des messages sur les forums et commentaires, ainsi que de la validation et publication d'articles et/ou de tutoriels de {{ site_name }}.
             Les membres faisant partie du Staff sont les suivants :
         {% endblocktrans %}

--- a/templates/pages/cookies.html
+++ b/templates/pages/cookies.html
@@ -44,7 +44,7 @@
     <p>{% blocktrans with site_name=app.site.litteral_name %}Ces cookies, purement techniques, <strong>sont indispensables au fonctionnement de {{site_name}}</strong>. Si vous les refusez, les éléments qui en dépendent ne fonctionneront tout simplement pas !{% endblocktrans %}</p>
 
     <h4>{% trans "Cookies d'analyse d'audience" %}</h4>
-    <p>{% blocktrans with site_name=app.site.litteral_name %} {{site_name}} analyse son audience. Que signifie ce terme barbare ? Tout simplement que nous étudions la manière dont le site est utilisé :{% endblocktrans %}</p>
+    <p>{% blocktrans with site_name=app.site.litteral_name %}{{ site_name }} analyse son audience. Que signifie ce terme barbare ? Tout simplement que nous étudions la manière dont le site est utilisé :{% endblocktrans %}</p>
     <ul>
         <li>{% trans "Quelles fonctionnalités sont utilisées" %} ?</li>
         <li>À {% trans "quelle fréquence" %} ?</li>
@@ -55,15 +55,15 @@
     <p><em>À {% trans "quoi cela peut-il bien servir" %}</em>, {% trans "allez-vous me demander avec sagacit" %}é.</p>
     <p>{% blocktrans %}Tout simplement à <strong>améliorer l'expérience utilisateur du site</strong>. Les développeurs, aussi ingénieux soient-ils, ne peuvent <em>jamais</em> deviner l'utilisation <em>réelle</em> qui sera faite du site. Telle ou telle fonctionnalité qui leur paraîtra mineure sera en fait utilisée par une grande majorité, ou telle autre qui leur paraissait cruciale sera ignorée. {% endblocktrans%}</p>
     <p>{% blocktrans %}Le seul moyen <em>fiable</em> de savoir ce qui est réellement utilisé - et donc ce qu'il faut travailler - est d'analyser l'audience réelle. {% endblocktrans %}</p>
-    <p>{% trans "Ceci implique de suivre les utilisateurs à travers le site, ce qui se fait grâce à un cookie dédié;" %}</p>
+    <p>{% trans "Ceci implique de suivre les utilisateurs à travers le site, ce qui se fait grâce à un cookie dédié." %}</p>
     <p>{% trans "C'est cette analyse qui peut être désactivée, puisqu'elle n'est pas strictement indispensable au bon fonctionnement du site" %}.</p>
 
     <h3>{% trans "Les cookies sur ce site" %}</h3>
-    <p>{% blocktrans with site_name=app.site.litteral_name %} Pour être tout à fait précis, {{site_name}} utilise les cookies suivants :{% endblocktrans %}</p>
+    <p>{% blocktrans with site_name=app.site.litteral_name %} Pour être tout à fait précis, {{ site_name }} utilise les cookies suivants :{% endblocktrans %}</p>
     <h4>{% trans "Cookies techniques" %}</h4>
     <dl>
         <dt><tt>sessionid</tt></dt>
-        <dd>{% blocktrans with site_name=app.site.litteral_name %} Ce cookie est un identifiant unique qui permet de faire le lien entre votre session de navigation et les différentes pages que vous visitez. Il permet en particulier de vous connecter à {{site_name}}. Il ne contient qu'une chaîne de caractères aléatoires.{% endblocktrans %}</dd>
+        <dd>{% blocktrans with site_name=app.site.litteral_name %} Ce cookie est un identifiant unique qui permet de faire le lien entre votre session de navigation et les différentes pages que vous visitez. Il permet en particulier de vous connecter à {{ site_name }}. Il ne contient qu'une chaîne de caractères aléatoires.{% endblocktrans %}</dd>
         <dt><tt>csrftoken</tt></dt>
         <dd>{% blocktrans %}Ce cookie contient une chaîne de caractères aléatoires qui permet de se prémunir des attaques <a href="http://fr.wikipedia.org/wiki/Cross-Site_Request_Forgery">CSRF</a>. Composant indispensable de la sécurité du site, vous ne pourrez rien poster sans ce cookie. {% endblocktrans %}</dd>
         <dt><tt>hasconsent</tt></dt>
@@ -79,10 +79,10 @@
     <h3>{% trans "Comment refuser les cookies tiers" %}</h3>
     <h4>{% trans "Refus pur et simple des cookies tiers dans le navigateur" %}</h4>
     <p>{% blocktrans %} Vous pouvez bloquer purement et simplement les cookies <strong>tiers</strong> dans votre navigateur, en suivant la procédure décrite <a href="http://www.cnil.fr/vos-droits/vos-traces/les-cookies/conseils-aux-internautes">sur le site de la CNIL dans le Conseil 1</a>.{% endblocktrans %}</p>
-    <p>{% blocktrans with site_name=app.site.litteral_name %}Cette man&oelig;uvre n'empêchera pas {{site_name}} de fonctionner, puisque les cookies techniques ne sont pas des cookies tiers.{% endblocktrans %}</p>
+    <p>{% blocktrans with site_name=app.site.litteral_name %}Cette man&oelig;uvre n'empêchera pas {{ site_name }} de fonctionner, puisque les cookies techniques ne sont pas des cookies tiers.{% endblocktrans %}</p>
     <p>{% trans "Toutefois, devant le manque de finesse de contrôle d'une telle solution, vous pourriez préférer utiliser une solution présentée au paragraphe suivant" %}.</p>
 
-    <h4>{% trans "Utilisation d'un logiciel 'anti-espions' "%}</h4>
+    <h4>{% trans "Utilisation d'un logiciel 'anti-espions'" %}</h4>
     <p>{% blocktrans %}Il existe différents logiciels <em>"anti-espions"</em>, qui empêchent l'installation des cookies d'analyse d'audience, et bien d'autres encore.{% endblocktrans %}</p>
     <p>{% blocktrans %}La CNIL <a href="http://www.cnil.fr/vos-droits/vos-traces/les-cookies/conseils-aux-internautes">indique quelles solutions sont disponibles avec votre navigateur</a>, dans son Conseil 2.{% endblocktrans %}</p>
 
@@ -92,14 +92,14 @@
         <p>
             {% blocktrans with site_name=app.site.litteral_name url_license=app.site.licenses.cookies.url_license cook_descr=app.site.licenses.cookies.description cook_title=app.site.licenses.cookies.title cook_img=app.site.licenses.cookies.url_image %}
             <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="{{ cook_title }}" style="border-width:0" src="{{ cook_img }}" /></a>
-            <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">À propos des cookies</span> de <a href="{{cook_url}}">{{site_name}}</a> est mis à disposition selon les termes de la <a rel="license" href="{{ url_license }}">{{ cook_descr }}</a>.
+            <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">À propos des cookies</span> de <a href="{{ cook_url }}">{{ site_name }}</a> est mis à disposition selon les termes de la <a rel="license" href="{{ url_license }}">{{ cook_descr }}</a>.
             {% endblocktrans %}
         </p>
     {% else %}
         <p>
             {% blocktrans %}
             <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Licence Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a>
-            <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">À propos des cookies</span> de <a xmlns:cc="http://creativecommons.org/ns#" href="{{cook_url}}" property="cc:attributionName" rel="cc:attributionURL">Zeste de Savoir</a> est mis à disposition selon les termes de la <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">licence Creative Commons Attribution 4.0 International</a>.
+            <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">À propos des cookies</span> de <a xmlns:cc="http://creativecommons.org/ns#" href="{{ cook_url }}" property="cc:attributionName" rel="cc:attributionURL">Zeste de Savoir</a> est mis à disposition selon les termes de la <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">licence Creative Commons Attribution 4.0 International</a>.
             {% endblocktrans %}
         </p>
     {% endif %}
@@ -133,8 +133,8 @@
     <p>{% trans "Façonnez des cookies pas trop épais par petite cuillerées sur une plaque de cuisson recouverte de papier sulfurisé. Espacez-les parce qu'ils s'étalent à la cuisson." %}</p>
     <p>{% trans "Enfournez-les environ 10 minutes, ils sont cuits lorsqu'ils prennent une belle couleur dorée" %} !</p>
     <h4>{% trans "Conseils divers" %}</h4>
-    <p>{% trans "Si vous avez la flemme de découper le chocolat, vous pouvez utiliser des pépites de chocolat mais en général c'est moins bon. Surtout pas de chocolat à déguster : ces chocolats manquent de sucre pour la patisserie" %} !</p>
+    <p>{% trans "Si vous avez la flemme de découper le chocolat, vous pouvez utiliser des pépites de chocolat mais en général c'est moins bon. Surtout pas de chocolat à déguster : ces chocolats manquent de sucre pour la pâtisserie" %} !</p>
     <p>{% trans "Pour découper le chocolat, vous aurez besoin d'un grand couteau solide (donc pas un couteau céramique) et très bien aiguisé. Non, le vôtre n'est pas assez aiguisé. Attaquez la plaque de chocolat côté lisse (carrés sur le dessous), c'est plus simple." %}</p>
-    <p>{% trans "La cuisson parfaite se joue à quelques secondes près (sérieusement), alors surveillez-les bien ! Un SMS de trop, et vous obtenez des cookies en béton. Ce qui serait dommage. Les cookies sont assez mous en sortie de four, c'est normal : ils durcissent en refroidissant." %} !</p>
+    <p>{% trans "La cuisson parfaite se joue à quelques secondes près (sérieusement), alors surveillez-les bien ! Un SMS de trop, et vous obtenez des cookies en béton. Ce qui serait dommage. Les cookies sont assez mous en sortie de four, c'est normal : ils durcissent en refroidissant." %}</p>
     <p>{% blocktrans %} On peut faire des cookies à beaucoup de parfums, mais le <em>must</em> reste le cookie au chocolat{% endblocktrans %}.</p>
 {% endblock %}

--- a/templates/pages/cookies.html
+++ b/templates/pages/cookies.html
@@ -1,5 +1,7 @@
 {% extends "pages/base.html" %}
 {% load i18n %}
+{% load set %}
+
 
 
 {% block title %}
@@ -21,51 +23,52 @@
 
 
 {% block content %}
-    <h3>{% trans "Qu'est-ce qu'un cookie" %} ?</h3>
+    {% set app.site.litteral_name as site_name %}
+    <h3>{% trans "Qu'est-ce qu'un cookie ?" %}</h3>
     <p>
         {% blocktrans %}
             Un <strong>cookie</strong> (aussi appelé <strong>témoin de connexion</strong> ou <strong>témoin</strong> au Québec) est un petit bout de texte envoyé par le serveur web au navigateur, et renvoyé à l'identique par le navigateur au serveur.
         {% endblocktrans %}
     </p>
-    <p>{% trans "Les cookies ne sont ni des logiciels espions ni des virus, puisqu'ils ne sont en réalité que de simples fichiers textes et ne peuvent en aucun cas être exécutés" %}.</p>
+    <p>{% trans "Les cookies ne sont ni des logiciels espions ni des virus, puisqu'ils ne sont en réalité que de simples fichiers textes et ne peuvent en aucun cas être exécutés." %}</p>
     <p>
         {% blocktrans %}
             Pour plus de détails sur ce qu'est un cookie, voyez <a href="http://www.cnil.fr/vos-droits/vos-traces/les-cookies/">le site de la CNIL</a> ou <a href="http://fr.wikipedia.org/wiki/Cookie_%28informatique%29">Wikipédia</a>.
         {% endblocktrans %}
     </p>
 
-    <h3>{% trans "À quoi servent les cookies" %} ?</h3>
-    <p>{% trans "Les cookies se répartissent en deux grands types : les impératifs techniques et la mesure d'audience" %}.</p>
+    <h3>{% trans "À quoi servent les cookies ?" %}</h3>
+    <p>{% trans "Les cookies se répartissent en deux grands types : les impératifs techniques et la mesure d'audience." %}</p>
     <p>{% blocktrans %}<strong>En aucun cas</strong> les cookies servent à recueillir des renseignements personnels, transmettre des données sensibles ou transmettre des données personnelles à des tiers.{% endblocktrans %}</p>
 
     <h4>{% trans "Cookies techniques" %}</h4>
-    <p>{% trans "Certaines fonctionnalités du site nécessitent des cookies pour pouvoir être opérationnelles. L'exemple typique est la connexion aux parties privées de" %} {{app.site.litteral_name}}.</p>
-    <p>{% trans "La liste complète des cookies techniques utilisés sur" %} {{app.site.litteral_name}} {% trans "et leur utilité est détaillée un peu plus bas" %}.</p>
-    <p>{% blocktrans with site_name=app.site.litteral_name %}Ces cookies, purement techniques, <strong>sont indispensables au fonctionnement de {{site_name}}</strong>. Si vous les refusez, les éléments qui en dépendent ne fonctionneront tout simplement pas !{% endblocktrans %}</p>
+    <p>{% blocktrans %}Certaines fonctionnalités du site nécessitent des cookies pour pouvoir être opérationnelles. L'exemple typique est la connexion aux parties privées de {{ site_name }}.{% endblocktrans %}</p>
+    <p>{% blocktrans %}La liste complète des cookies techniques utilisés sur {{ site_name }} et leur utilité est détaillée un peu plus bas.{% endblocktrans %}</p>
+    <p>{% blocktrans %}Ces cookies, purement techniques, <strong>sont indispensables au fonctionnement de {{ site_name }}</strong>. Si vous les refusez, les éléments qui en dépendent ne fonctionneront tout simplement pas !{% endblocktrans %}</p>
 
     <h4>{% trans "Cookies d'analyse d'audience" %}</h4>
-    <p>{% blocktrans with site_name=app.site.litteral_name %}{{ site_name }} analyse son audience. Que signifie ce terme barbare ? Tout simplement que nous étudions la manière dont le site est utilisé :{% endblocktrans %}</p>
+    <p>{% blocktrans %}{{ site_name }} analyse son audience. Que signifie ce terme barbare ? Tout simplement que nous étudions la manière dont le site est utilisé :{% endblocktrans %}</p>
     <ul>
-        <li>{% trans "Quelles fonctionnalités sont utilisées" %} ?</li>
-        <li>À {% trans "quelle fréquence" %} ?</li>
-        <li>{% trans "D'où viennent nos utilisateurs ? (oui, c'est de vous dont je parle" %} !)</li>
-        <li>{% trans "Comment naviguent-ils dans le site" %} ?</li>
-        <li>{% trans "Etc" %}.</li>
+        <li>{% trans "Quelles fonctionnalités sont utilisées ?" %}</li>
+        <li>{% trans "À quelle fréquence ?" %}</li>
+        <li>{% trans "D'où viennent nos utilisateurs ? (oui, c'est de vous dont je parle !)" %}</li>
+        <li>{% trans "Comment naviguent-ils dans le site ?" %}</li>
+        <li>{% trans "Etc." %}</li>
     </ul>
-    <p><em>À {% trans "quoi cela peut-il bien servir" %}</em>, {% trans "allez-vous me demander avec sagacit" %}é.</p>
-    <p>{% blocktrans %}Tout simplement à <strong>améliorer l'expérience utilisateur du site</strong>. Les développeurs, aussi ingénieux soient-ils, ne peuvent <em>jamais</em> deviner l'utilisation <em>réelle</em> qui sera faite du site. Telle ou telle fonctionnalité qui leur paraîtra mineure sera en fait utilisée par une grande majorité, ou telle autre qui leur paraissait cruciale sera ignorée. {% endblocktrans%}</p>
-    <p>{% blocktrans %}Le seul moyen <em>fiable</em> de savoir ce qui est réellement utilisé - et donc ce qu'il faut travailler - est d'analyser l'audience réelle. {% endblocktrans %}</p>
+    <p>{% trans "<em>À quoi cela peut-il bien servir</em>, allez-vous me demander avec sagacité." %}</p>
+    <p>{% blocktrans %}Tout simplement à <strong>améliorer l'expérience utilisateur du site</strong>. Les développeurs, aussi ingénieux soient-ils, ne peuvent <em>jamais</em> deviner l'utilisation <em>réelle</em> qui sera faite du site. Telle ou telle fonctionnalité qui leur paraîtra mineure sera en fait utilisée par une grande majorité, ou telle autre qui leur paraissait cruciale sera ignorée.{% endblocktrans %}</p>
+    <p>{% blocktrans %}Le seul moyen <em>fiable</em> de savoir ce qui est réellement utilisé - et donc ce qu'il faut travailler - est d'analyser l'audience réelle.{% endblocktrans %}</p>
     <p>{% trans "Ceci implique de suivre les utilisateurs à travers le site, ce qui se fait grâce à un cookie dédié." %}</p>
-    <p>{% trans "C'est cette analyse qui peut être désactivée, puisqu'elle n'est pas strictement indispensable au bon fonctionnement du site" %}.</p>
+    <p>{% trans "C'est cette analyse qui peut être désactivée, puisqu'elle n'est pas strictement indispensable au bon fonctionnement du site." %}</p>
 
     <h3>{% trans "Les cookies sur ce site" %}</h3>
-    <p>{% blocktrans with site_name=app.site.litteral_name %} Pour être tout à fait précis, {{ site_name }} utilise les cookies suivants :{% endblocktrans %}</p>
+    <p>{% blocktrans %}Pour être tout à fait précis, {{ site_name }} utilise les cookies suivants :{% endblocktrans %}</p>
     <h4>{% trans "Cookies techniques" %}</h4>
     <dl>
         <dt><tt>sessionid</tt></dt>
-        <dd>{% blocktrans with site_name=app.site.litteral_name %} Ce cookie est un identifiant unique qui permet de faire le lien entre votre session de navigation et les différentes pages que vous visitez. Il permet en particulier de vous connecter à {{ site_name }}. Il ne contient qu'une chaîne de caractères aléatoires.{% endblocktrans %}</dd>
+        <dd>{% blocktrans %}Ce cookie est un identifiant unique qui permet de faire le lien entre votre session de navigation et les différentes pages que vous visitez. Il permet en particulier de vous connecter à {{ site_name }}. Il ne contient qu'une chaîne de caractères aléatoires.{% endblocktrans %}</dd>
         <dt><tt>csrftoken</tt></dt>
-        <dd>{% blocktrans %}Ce cookie contient une chaîne de caractères aléatoires qui permet de se prémunir des attaques <a href="http://fr.wikipedia.org/wiki/Cross-Site_Request_Forgery">CSRF</a>. Composant indispensable de la sécurité du site, vous ne pourrez rien poster sans ce cookie. {% endblocktrans %}</dd>
+        <dd>{% blocktrans %}Ce cookie contient une chaîne de caractères aléatoires qui permet de se prémunir des attaques <a href="http://fr.wikipedia.org/wiki/Cross-Site_Request_Forgery">CSRF</a>. Composant indispensable de la sécurité du site, vous ne pourrez rien poster sans ce cookie.{% endblocktrans %}</dd>
         <dt><tt>hasconsent</tt></dt>
         <dd>{% blocktrans %}Ce cookie indique si vous acceptez l'analyse d'audience. Il peut prendre les valeurs <tt>true</tt> (analyse acceptée) ou <tt>false</tt> (analyse refusée).{% endblocktrans %}</dd>
     </dl>
@@ -78,9 +81,9 @@
 
     <h3>{% trans "Comment refuser les cookies tiers" %}</h3>
     <h4>{% trans "Refus pur et simple des cookies tiers dans le navigateur" %}</h4>
-    <p>{% blocktrans %} Vous pouvez bloquer purement et simplement les cookies <strong>tiers</strong> dans votre navigateur, en suivant la procédure décrite <a href="http://www.cnil.fr/vos-droits/vos-traces/les-cookies/conseils-aux-internautes">sur le site de la CNIL dans le Conseil 1</a>.{% endblocktrans %}</p>
-    <p>{% blocktrans with site_name=app.site.litteral_name %}Cette man&oelig;uvre n'empêchera pas {{ site_name }} de fonctionner, puisque les cookies techniques ne sont pas des cookies tiers.{% endblocktrans %}</p>
-    <p>{% trans "Toutefois, devant le manque de finesse de contrôle d'une telle solution, vous pourriez préférer utiliser une solution présentée au paragraphe suivant" %}.</p>
+    <p>{% blocktrans %}Vous pouvez bloquer purement et simplement les cookies <strong>tiers</strong> dans votre navigateur, en suivant la procédure décrite <a href="http://www.cnil.fr/vos-droits/vos-traces/les-cookies/conseils-aux-internautes">sur le site de la CNIL dans le Conseil 1</a>.{% endblocktrans %}</p>
+    <p>{% blocktrans %}Cette man&oelig;uvre n'empêchera pas {{ site_name }} de fonctionner, puisque les cookies techniques ne sont pas des cookies tiers.{% endblocktrans %}</p>
+    <p>{% trans "Toutefois, devant le manque de finesse de contrôle d'une telle solution, vous pourriez préférer utiliser une solution présentée au paragraphe suivant." %}</p>
 
     <h4>{% trans "Utilisation d'un logiciel 'anti-espions'" %}</h4>
     <p>{% blocktrans %}Il existe différents logiciels <em>"anti-espions"</em>, qui empêchent l'installation des cookies d'analyse d'audience, et bien d'autres encore.{% endblocktrans %}</p>
@@ -90,7 +93,7 @@
     {% url "zds.pages.views.cookies" as cook_url %}
     {% if app.site.licenses.cookies %}
         <p>
-            {% blocktrans with site_name=app.site.litteral_name url_license=app.site.licenses.cookies.url_license cook_descr=app.site.licenses.cookies.description cook_title=app.site.licenses.cookies.title cook_img=app.site.licenses.cookies.url_image %}
+            {% blocktrans with url_license=app.site.licenses.cookies.url_license cook_descr=app.site.licenses.cookies.description cook_title=app.site.licenses.cookies.title cook_img=app.site.licenses.cookies.url_image %}
             <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="{{ cook_title }}" style="border-width:0" src="{{ cook_img }}" /></a>
             <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">À propos des cookies</span> de <a href="{{ cook_url }}">{{ site_name }}</a> est mis à disposition selon les termes de la <a rel="license" href="{{ url_license }}">{{ cook_descr }}</a>.
             {% endblocktrans %}
@@ -103,12 +106,12 @@
             {% endblocktrans %}
         </p>
     {% endif %}
-    <p>{% trans "N'oubliez pas d'adapter les cookies réellement utilisés à votre cas si vous reprenez cette page" %} !</p>
+    <p>{% trans "N'oubliez pas d'adapter les cookies réellement utilisés à votre cas si vous reprenez cette page !" %}</p>
 
     <hr>
 
     <h3>{% trans "Une recette de cookies" %}</h3>
-    <p>{% trans "Puisque vous avez réussi à trouver cette page et que vous avez eu le courage de lire jusqu'ici, vous avez bien droit à une récompense : une recette de cookies" %} !</p>
+    <p>{% trans "Puisque vous avez réussi à trouver cette page et que vous avez eu le courage de lire jusqu'ici, vous avez bien droit à une récompense : une recette de cookies !" %}</p>
     <h4>{% trans "Ingrédients" %}</h4>
     <p>{% trans "Pour beaucoup de cookies (parce que le nombre dépend de leur taille) :" %}</p>
     <ul>
@@ -124,17 +127,17 @@
     <p>{% trans "Préparation : 10 minutes + 15 minutes pour couper le chocolat" %}</p>
     <p>{% blocktrans %}Cuisson : 10 minutes <strong>par fournée</strong>{% endblocktrans %}</p>
     <h4>{% trans "Préparation" %}</h4>
-    <p>{% trans "Avec un grand couteau solide et bien aiguisé, découpez le chocolat en petits morceaux" %}.</p>
+    <p>{% trans "Avec un grand couteau solide et bien aiguisé, découpez le chocolat en petits morceaux." %}</p>
     <p>{% trans "Mélangez en crème le beurre ramolli et le sucre. Incorporez les &oelig;ufs et la vanille liquide (ou le sucre vanillé)." %}</p>
     <p>{% trans "Ajoutez la farine et la levure. Mélangez bien." %}</p>
-    <p>{% trans "Ajoutez les morceaux de chocolat et mélangez avec soin" %}.</p>
+    <p>{% trans "Ajoutez les morceaux de chocolat et mélangez avec soin." %}</p>
     <h4>{% trans "Cuisson" %}</h4>
-    <p>{% trans "Préchauffez votre four à 200°C / thermostat 6-7 (un peu moins si vous utilisez la chaleur tournante), grille en position basse" %}.</p>
+    <p>{% trans "Préchauffez votre four à 200°C / thermostat 6-7 (un peu moins si vous utilisez la chaleur tournante), grille en position basse." %}</p>
     <p>{% trans "Façonnez des cookies pas trop épais par petite cuillerées sur une plaque de cuisson recouverte de papier sulfurisé. Espacez-les parce qu'ils s'étalent à la cuisson." %}</p>
-    <p>{% trans "Enfournez-les environ 10 minutes, ils sont cuits lorsqu'ils prennent une belle couleur dorée" %} !</p>
+    <p>{% trans "Enfournez-les environ 10 minutes, ils sont cuits lorsqu'ils prennent une belle couleur dorée !" %}</p>
     <h4>{% trans "Conseils divers" %}</h4>
-    <p>{% trans "Si vous avez la flemme de découper le chocolat, vous pouvez utiliser des pépites de chocolat mais en général c'est moins bon. Surtout pas de chocolat à déguster : ces chocolats manquent de sucre pour la pâtisserie" %} !</p>
+    <p>{% trans "Si vous avez la flemme de découper le chocolat, vous pouvez utiliser des pépites de chocolat mais en général c'est moins bon. Surtout pas de chocolat à déguster : ces chocolats manquent de sucre pour la pâtisserie !" %}</p>
     <p>{% trans "Pour découper le chocolat, vous aurez besoin d'un grand couteau solide (donc pas un couteau céramique) et très bien aiguisé. Non, le vôtre n'est pas assez aiguisé. Attaquez la plaque de chocolat côté lisse (carrés sur le dessous), c'est plus simple." %}</p>
     <p>{% trans "La cuisson parfaite se joue à quelques secondes près (sérieusement), alors surveillez-les bien ! Un SMS de trop, et vous obtenez des cookies en béton. Ce qui serait dommage. Les cookies sont assez mous en sortie de four, c'est normal : ils durcissent en refroidissant." %}</p>
-    <p>{% blocktrans %} On peut faire des cookies à beaucoup de parfums, mais le <em>must</em> reste le cookie au chocolat{% endblocktrans %}.</p>
+    <p>{% blocktrans %} On peut faire des cookies à beaucoup de parfums, mais le <em>must</em> reste le cookie au chocolat.{% endblocktrans %}</p>
 {% endblock %}

--- a/templates/pages/eula.html
+++ b/templates/pages/eula.html
@@ -42,7 +42,7 @@
             L'édition du site {{ app.site.dns }} est assurée par l'association française de loi 1901 {{ app.site.litteral_name }}, déclarée à la préfecture de Vendée et parue au Journal Officiel le 19 avril 2014.
         </p>
         <p>
-            Vous pouvez joindre l’association via l’adresse e-mail : <a href="{{ app.site.association.email }}">{{ app.site.association.email }}</a>.
+            Vous pouvez joindre l’association via l’adresse e-mail : <a href="mailto:{{ app.site.association.email }}">{{ app.site.association.email }}</a>.
         </p>
     {% endif %}
     {% if app.site.hosting %}
@@ -202,7 +202,7 @@
         L'éditeur du site utilise la technologie des marqueurs (cookies) afin d'améliorer la qualité du site  et mieux répondre aux attentes des utilisateurs. Le membre prend acte que le site procède à l'installation de cookies sur le disque dur de son ordinateur en vue d'identifier chacune de ses connexion.
     </p>
     <p>
-        De manière générale, les cookies sont sans dommage pour l'ordinateur du membre. Ce dernier est libre d'accepter ou refuser les cookies en configurant son navigateur internet à cet effet. Pour ce faire, le membre peut se rendre sur le site de la Commission Nationale de l'Informatique et des Libertés (CNIL) à l'adresse : <a href="http://www.google.com/url?q=http%3A%2F%2Fwww.cnil.fr%2Fvos-libertes%2Fvos-traces%2Fles-cookies%2F&amp;sa=D&amp;sntz=1&amp;usg=AFQjCNGTMYq5pUcHrTYYP4OpVsSYp3G73Q">http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/</a> donnant toutes les informations relatives à une telle configuration. Les cookies sont anonymes et ne sont en aucun cas utilisés pour collecter des données à caractère personnel, mais uniquement à des fins de connexion et statistiques.
+        De manière générale, les cookies sont sans dommage pour l'ordinateur du membre. Ce dernier est libre d'accepter ou refuser les cookies en configurant son navigateur internet à cet effet. Pour ce faire, le membre peut se rendre sur le site de la Commission Nationale de l'Informatique et des Libertés (CNIL) à l'adresse : <a href="http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/">http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/</a> donnant toutes les informations relatives à une telle configuration. Les cookies sont anonymes et ne sont en aucun cas utilisés pour collecter des données à caractère personnel, mais uniquement à des fins de connexion et statistiques.
     </p>
     <p>
         Pour plus de détails, voir <a href="{% url "zds.pages.views.cookies" %}">la page d'explications sur les cookies</a>.
@@ -245,7 +245,7 @@
     <h4>7.2 Code source du site</h4>
     {% if app.site.licenses.source %}
         <p>
-            {{ app.site.litteral_name }} est un site dont le code source est sous licence <a href="{{ app.site.licenses.source.url_license }}">{{ app.site.licenses.source.code }}</a>, et provient en partie de <a href="{{ app.site.licenses.source.provider_name }}">{{ app.site.licenses.source.provider_url }}</a>.
+            {{ app.site.litteral_name }} est un site dont le code source est sous licence <a href="{{ app.site.licenses.source.url_license }}">{{ app.site.licenses.source.code }}</a>, et provient en partie de <a href="{{ app.site.licenses.source.provider_url }}">{{ app.site.licenses.source.provider_name }}</a>.
         </p>
     {% else %}
         <p>

--- a/templates/pages/eula.html
+++ b/templates/pages/eula.html
@@ -199,7 +199,7 @@
 
     <h4>6.4 Politique relative à l'installation de cookies</h4>
     <p>
-        L'éditeur du site utilise la technologie des marqueurs (cookies) afin d'améliorer la qualité du site  et mieux répondre aux attentes des utilisateurs. Le membre prend acte que le site procède à l'installation de cookies sur le disque dur de son ordinateur en vue d'identifier chacune de ses connexion.
+        L'éditeur du site utilise la technologie des marqueurs (cookies) afin d'améliorer la qualité du site et mieux répondre aux attentes des utilisateurs. Le membre prend acte que le site procède à l'installation de cookies sur le disque dur de son ordinateur en vue d'identifier chacune de ses connexions.
     </p>
     <p>
         De manière générale, les cookies sont sans dommage pour l'ordinateur du membre. Ce dernier est libre d'accepter ou refuser les cookies en configurant son navigateur internet à cet effet. Pour ce faire, le membre peut se rendre sur le site de la Commission Nationale de l'Informatique et des Libertés (CNIL) à l'adresse : <a href="http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/">http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/</a> donnant toutes les informations relatives à une telle configuration. Les cookies sont anonymes et ne sont en aucun cas utilisés pour collecter des données à caractère personnel, mais uniquement à des fins de connexion et statistiques.
@@ -236,7 +236,7 @@
         Tout recours en justice engagé par un tiers lésé sera de la responsabilité du membre et ce dernier s'engage en particulier à prendre en charge le paiement de toutes sommes, quelles qu'elles soient, qui résulteraient d'une action légale d'un tiers, y compris les honoraires d'avocat et frais de justice.
     </p>
     <p>
-        Le membre reste titulaire de l'intégralité de ses droits de propriété intellectuelle. Il concède cependant des droits à l'éditeur du site (voir titre 5. &ldquo;Contenu de l'utilisateur&rdquo;).  Selon la licence choisie, le membre peut également autoriser d'autres utilisations de son oeuvre.
+        Le membre reste titulaire de l'intégralité de ses droits de propriété intellectuelle. Il concède cependant des droits à l'éditeur du site (voir titre 5. &ldquo;Contenu de l'utilisateur&rdquo;). Selon la licence choisie, le membre peut également autoriser d'autres utilisations de son &oelig;uvre.
     </p>
     <p>
         Le contenu d'un membre peut être à tout moment et pour n'importe quelle raison supprimé ou modifié par le site. Le membre peut ne recevoir aucune justification et notification préalable à la suppression ou à la modification du contenu.

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 
+
 {% block title %}
     {% trans "Pages" %}
 {% endblock %}

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -22,7 +22,7 @@
 
 {% block content %}
     <ul>
-        <li><a href="{% url "zds.pages.views.eula" %}"><abbr title='{% trans "Conditions générales d utilisation" %}'>{% trans "CGU" %}</abbr></a></li>
+        <li><a href="{% url "zds.pages.views.eula" %}"><abbr title="{% trans "Conditions générales d'utilisation" %}">{% trans "CGU" %}</abbr></a></li>
         <li><a href="{% url "zds.pages.views.about" %}">{% trans "À propos" %}</a></li>
         {% if app.site.association %}
             <li><a href="{% url "zds.pages.views.association" %}">{% trans "L'association" %}</a></li>

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -621,9 +621,9 @@ def modify(request):
                     u'Désolé, le zeste **{0}** '
                     u'n\'a malheureusement pas passé l’étape de validation. '
                     u'Mais ne désespère pas, certaines corrections peuvent '
-                    u'surement être faite pour l’améliorer et repasser la '
+                    u'sûrement être faites pour l’améliorer et repasser la '
                     u'validation plus tard. Voici le message que [{1}]({2}), '
-                    u'ton validateur t\'a laissé:\n\n`{3}`\n\nN\'hésite pas a '
+                    u'ton validateur t\'a laissé:\n\n`{3}`\n\nN\'hésite pas à '
                     u'lui envoyer un petit message pour discuter de la décision '
                     u'ou demander plus de détail si tout cela te semble '
                     u'injuste ou manque de clarté.'.format(
@@ -712,9 +712,9 @@ def modify(request):
                 msg = (
                     u'Félicitations ! Le zeste [{0}]({1}) '
                     u'est maintenant publié ! Les lecteurs du monde entier '
-                    u'peuvent venir le lire et réagir a son sujet. Je te conseille '
-                    u'de rester a leur écoute afin d\'apporter des '
-                    u'corrections/compléments. Un Article vivant et a jour '
+                    u'peuvent venir le lire et réagir à son sujet. Je te conseille '
+                    u'de rester à leur écoute afin d\'apporter des '
+                    u'corrections/compléments. Un article vivant et à jour '
                     u'est bien plus lu qu\'un sujet abandonné !'.format(
                         article.title,
                         settings.ZDS_APP['site']['url'] + article.get_absolute_url_online()))
@@ -780,9 +780,9 @@ def modify(request):
                 bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
                 msg = \
                     (u'Bonjour {0},\n\n'
-                     u'L\'article *{1}* que tu as réservé a été mis à jour en zone de validation,  '
-                     u'pour retrouver les modifications qui ont été faites, je t\'invite à'
-                     u'consulter l\'historique des versions'
+                     u'L\'article *{1}* que tu as réservé a été mis à jour en zone de validation, '
+                     u'pour retrouver les modifications qui ont été faites, je t\'invite à '
+                     u'consulter l\'historique des versions.'
                      u'\n\nMerci'.format(old_validator.username, article.title))
                 send_mp(
                     bot,

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -937,7 +937,7 @@ def settings_promote(request, user_pk):
                                  .format(user.username))
         else:
             if user == request.user:
-                messages.error(request, _(u'Un super-utilisateur ne peux pas se retirer des super-utilisateurs.'))
+                messages.error(request, _(u'Un super-utilisateur ne peut pas se retirer des super-utilisateurs.'))
             else:
                 if user.is_superuser:
                     user.is_superuser = False
@@ -968,8 +968,8 @@ def settings_promote(request, user_pk):
             msg = string_concat(msg, _(u'* Vous ne faites partie d\'aucun groupe'))
         msg += u'\n\n'
         if user.is_superuser:
-            msg = string_concat(msg, _(u'Vous avez aussi rejoint le rang des super utilisateurs. '
-                                       u'N\'oubliez pas, un grand pouvoir entraine de grandes responsabiltiés !'))
+            msg = string_concat(msg, _(u'Vous avez aussi rejoint le rang des super-utilisateurs. '
+                                       u'N\'oubliez pas, un grand pouvoir entraîne de grandes responsabilités !'))
         send_mp(
             bot,
             [user],

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -139,7 +139,7 @@ def eula(request):
 
 
 def cookies(request):
-    """Cookies explaination page."""
+    """Cookies explanation page."""
     return render(request, 'pages/cookies.html')
 
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -300,10 +300,10 @@ def reject_tutorial(request):
         msg = (
             _(u'Désolé, le zeste **{0}** n\'a malheureusement '
               u'pas passé l’étape de validation. Mais ne désespère pas, '
-              u'certaines corrections peuvent surement être faite pour '
+              u'certaines corrections peuvent sûrement être faites pour '
               u'l’améliorer et repasser la validation plus tard. '
               u'Voici le message que [{1}]({2}), ton validateur t\'a laissé:\n\n`{3}`\n\n'
-              u'N\'hésite pas a lui envoyer un petit message pour discuter '
+              u'N\'hésite pas à lui envoyer un petit message pour discuter '
               u'de la décision ou demander plus de détail si tout cela te '
               u'semble injuste ou manque de clarté.')
             .format(tutorial.title,
@@ -376,10 +376,10 @@ def valid_tutorial(request):
         msg = (
             _(u'Félicitations ! Le zeste [{0}]({1}) '
               u'a été publié par [{2}]({3}) ! Les lecteurs du monde entier '
-              u'peuvent venir l\'éplucher et réagir a son sujet. '
-              u'Je te conseille de rester a leur écoute afin '
+              u'peuvent venir l\'éplucher et réagir à son sujet. '
+              u'Je te conseille de rester à leur écoute afin '
               u'd\'apporter des corrections/compléments.'
-              u'Un Tutoriel vivant et a jour est bien plus lu '
+              u'Un tutoriel vivant et à jour est bien plus lu '
               u'qu\'un sujet abandonné !')
             .format(tutorial.title,
                     settings.ZDS_APP['site']['url'] + tutorial.get_absolute_url_online(),
@@ -481,7 +481,7 @@ def ask_validation(request):
         bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
         msg = \
             (_(u'Bonjour {0},'
-               u'Le tutoriel *{1}* que tu as réservé a été mis à jour en zone de validation, '
+               u'Le tutoriel *{1}* que tu as réservé a été mis à jour en zone de validation. '
                u'Pour retrouver les modifications qui ont été faites, je t\'invite à '
                u'consulter l\'historique des versions'
                u'\n\n> Merci').format(old_validator.username, tutorial.title))
@@ -656,7 +656,7 @@ def modify_tutorial(request):
             msg = (
                 _(u'Bonjour **{0}**,\n\n'
                   u'Tu as été supprimé des auteurs du tutoriel [{1}]({2}). Tant qu\'il ne sera pas publié, tu ne '
-                  u'pourra plus y accéder.\n').format(
+                  u'pourras plus y accéder.\n').format(
                       author.username,
                       tutorial.title,
                       settings.ZDS_APP['site']['url'] + tutorial.get_absolute_url())
@@ -708,7 +708,7 @@ def modify_tutorial(request):
                                u'pourra le consulter afin de vous faire des retours '
                                u'constructifs avant sa soumission en validation.\n\n'
                                u'Un sujet dédié pour la beta de votre tutoriel a été '
-                               u'crée dans le forum et est accessible [ici]({})').format(
+                               u'créé dans le forum et est accessible [ici]({})').format(
                                    request.user.username,
                                    tutorial.title,
                                    settings.ZDS_APP['site']['url'] + tp.get_absolute_url()))
@@ -751,7 +751,7 @@ def modify_tutorial(request):
             if topic is not None:
                 msg = \
                     (_(u'Désactivation de la beta du tutoriel  **{}**'
-                       u'\n\nPour plus d\'informations envoyez moi un message privé.').format(tutorial.title))
+                       u'\n\nPour plus d\'informations envoyez-moi un message privé.').format(tutorial.title))
                 lock_topic(topic)
                 send_post(topic, msg)
             messages.info(request, _(u"La BETA sur ce tutoriel a bien été désactivée."))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | N/A |

Les CGU contiennent actuellement trois liens incorrects.
1. Oubli mailto pour l'adresse mail communication@zestedesavoir.com (dans _2. Mentions légales_)
2. Lien vers les résultats de Google au lieu de la page pour le lien vers la CNIL (dans _6.4 Politique relative à l'installation de cookies_)
3. Inversion entre le texte du lien et l'URL pour Progdupeupl (dans _7.2 Code source du site_)

La page de profil contient une typo dans l'ancre, en effet le lien "Derniers articles" ne fonctionne pas.
De plus il y a plusieurs typos et fautes d'orthographe qui ont été répéré et corrigé par ce commit.

Est-il nécessaire que je créé une issue pour cette PR (correction de typos) ?
# QA
- Vérifier que les pages (/pages/*) s'affichent correctement.
- Vérifier que le lien (ancre) vers "Derniers articles" fonctionne correctement sur la page de profil d'un membre
