### PR TITLE
Ajout de $ manquants dans les URL de certaines pages (fix #2728)

### DIFF
--- a/zds/pages/urls.py
+++ b/zds/pages/urls.py
@@ -2,17 +2,15 @@
 
 from django.conf.urls import patterns, url
 
-from . import views
-
 
 urlpatterns = patterns('',
 
                        url(r'^apropos/$', 'zds.pages.views.about'),
                        url(r'^association/$', 'zds.pages.views.association'),
-                       url(r'^contact/', 'zds.pages.views.contact'),
-                       url(r'^cgu/', 'zds.pages.views.eula'),
-                       url(r'^alertes/', 'zds.pages.views.alerts'),
-                       url(r'^cookies/', 'zds.pages.views.cookies'),
+                       url(r'^contact/$', 'zds.pages.views.contact'),
+                       url(r'^cgu/$', 'zds.pages.views.eula'),
+                       url(r'^alertes/$', 'zds.pages.views.alerts'),
+                       url(r'^cookies/$', 'zds.pages.views.cookies'),
                        url(r'^association/inscription/$', 'zds.pages.views.assoc_subscribe'),
 
                        url(r'^$', 'zds.pages.views.index'),

--- a/zds/search/urls.py
+++ b/zds/search/urls.py
@@ -2,7 +2,6 @@
 
 from django.conf.urls import patterns, url
 
-from . import views
 from haystack.views import search_view_factory
 from zds.search.views import CustomSearchView
 from zds.search.forms import CustomSearchForm
@@ -15,5 +14,5 @@ urlpatterns = patterns('haystack.views',
                        ), name='haystack_search'))
 
 urlpatterns += patterns('',
-                        url(r'^opensearch.xml', 'zds.search.views.opensearch')
+                        url(r'^opensearch\.xml$', 'zds.search.views.opensearch')
                         )


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2728 |

Cette PR modifie le fichier zds/pages/urls.py, ajoute les $ manquants et supprime un import inutile.
# QA

Vérifier que l'on obtient bien une erreur 404 (truc peut être remplacer par n'importe quoi)
- /pages/cgu/truc
- /pages/contact/truc
- /pages/alertes/truc
- /pages/cookies/truc
- /rechercher/opensearchxml
- /rechercher/opensearch.xmltruc

EDIT: Oubli tableau + QA
