### PR TITLE
[Beta 15.5.1] Les sujets non-public sont bien caché sur la home page

### DIFF
--- a/zds/forum/managers.py
+++ b/zds/forum/managers.py
@@ -29,6 +29,7 @@ class TopicManager(models.Manager):
 
     def get_last_topics(self):
         return self.order_by('-pubdate') \
+                   .exclude(Q(forum__group__isnull=False)) \
                    .all() \
                    .select_related('forum', 'author', 'last_message') \
                    .prefetch_related('tags')[:settings.ZDS_APP['topic']['home_number']]

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -1486,7 +1486,6 @@ class ManagerTests(TestCase):
             self.forum1 = ForumFactory(category=self.cat1)
             self.forum2 = ForumFactory(category=self.cat1)
 
-            self.tester = ProfileFactory()
             self.staff = StaffProfileFactory()
             staff_group = Group.objects.filter(name="staff").first()
 
@@ -1500,5 +1499,5 @@ class ManagerTests(TestCase):
 
         def test_get_last_topics(self):
 
-            fofos = Topic.objects.get_last_topics()
-            self.assertEqual(2, len(fofos))
+            topics = Topic.objects.get_last_topics()
+            self.assertEqual(2, len(topics))

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -3,6 +3,7 @@
 from django.conf import settings
 from django.test import TestCase
 
+from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
 from zds.utils import slugify
 
@@ -1475,3 +1476,29 @@ class ForumGuestTests(TestCase):
             topic_solved_sticky,
             get_topics(forum_pk=self.forum11.pk, is_sticky=True, filter='noanswer'),
         )
+
+
+class ManagerTests(TestCase):
+
+        def setUp(self):
+
+            self.cat1 = CategoryFactory()
+            self.forum1 = ForumFactory(category=self.cat1)
+            self.forum2 = ForumFactory(category=self.cat1)
+
+            self.tester = ProfileFactory()
+            self.staff = StaffProfileFactory()
+            staff_group = Group.objects.filter(name="staff").first()
+
+            self.forum3 = ForumFactory(category=self.cat1)
+            self.forum3.group = [staff_group]
+            self.forum3.save()
+
+            TopicFactory(forum=self.forum1, author=self.staff.user)
+            TopicFactory(forum=self.forum2, author=self.staff.user)
+            TopicFactory(forum=self.forum3, author=self.staff.user)
+
+        def test_get_last_topics(self):
+
+            fofos = Topic.objects.get_last_topics()
+            self.assertEqual(2, len(fofos))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2731 |

Les sujets non-public sont bien cache sur la home page
### QA
- Via l'interface d'admin mettez un des fofos dans le groupe staff
- Via l'utilisateur admin aller creer un sujet dans ce fofo
- Constater que vous le voyez sur la home page
- Deconnectez vous, constater qu'il n'est plus visible
- Connectez vous en tant que user et constater qu'il n'est toujours pas visible
