### PR TITLE
[Beta 15.5.1] Fixes #2745 : manque d'un bout de clé de cache

### DIFF
--- a/doc/source/cache.rst
+++ b/doc/source/cache.rst
@@ -66,13 +66,13 @@ Il s'agit des blocs visuels de présentation des tutoriels que l'on trouve par e
 ==================  ============================================================
 Identifiant         tutorial_item
 Type                Template fragment caching
-Clé de cache        identifiant + clé primaire du tutoriel +  "show_description"
+Clé de cache        identifiant + clé primaire du tutoriel + "beta" + "show_description"
 Usage               templates/tutorial/includes/tutorial_item.part.html
 Temps de cache      1 heure
 Cas d'invalidation  La sauvegarde d'un tutoriel invalide l'entrée correspondante
 ==================  ============================================================
 
-``show_description`` dans la clé de cache est le paramètre de même nom passé au *template* ``tutorial/includes/tutorial_item.part.html``.
+``beta`` et ``show_description``  dans la clé de cache sont les deux paramètres de même nom passés au *template*``tutorial/includes/tutorial_item.part.html``.
 
 Blocs "À la une"
 ----------------

--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -4,7 +4,9 @@
 {% load date %}
 {% load cache %}
 
-{% cache cache_timeouts.tutorial_item tutorial_item tutorial.pk show_description %}
+<article class="content-item expand-description tutorial-item{{ item_class }}">
+
+{% cache cache_timeouts.tutorial_item tutorial_item tutorial.pk beta show_description %}
 {% captureas link %}
     {% if beta %}
         {{ tutorial.get_absolute_url_beta }}
@@ -22,8 +24,6 @@
 {% captureas categories_text %}
     {% for category in tutorial.subcategory.all %}{% if forloop.first %}{% trans "dans" %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %} {{ category.title }}{% endfor %}
 {% endcaptureas %}
-
-<article class="content-item expand-description tutorial-item{{ item_class }}">
     <a href="{{ link }}" title="{{ tutorial.title }}{% if tutorial.description and show_description %} − {{ tutorial.description }}{% endif %}">
         <div class="content-illu">
             {% if tutorial.image %}

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -370,8 +370,10 @@ class Tutorial(models.Model):
         super(Tutorial, self).save(*args, **kwargs)
 
         # Clear associated cache keys
-        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, True]))
-        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, False]))
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, True, True]))
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, True, False]))
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, False, True]))
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, False, False]))
 
     def get_note_count(self):
         """Return the number of notes in the tutorial."""


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets (_issues_) concernés | #2745 |

Il manquait un bout de la clé de cache des blocs de tutos. Merci les paramètres facultatifs !

**QA** :

Avec un système de cache autre que "DummyCache" activé, vérifier :
- Que la home se comporte correctement
- Qu'il n'y a plus de demi-blocs dans la liste des tutos
- Que sur la page de ses propres tutos quand on est connectés, on est bien renvoyés vers des tutos en offline
