### PR TITLE
Corrige les liens des tutoriels

### DIFF
--- a/doc/source/cache.rst
+++ b/doc/source/cache.rst
@@ -36,7 +36,7 @@ Implémentation technique
 Les caches implémentés
 ======================
 
-*Type* dans les tableaux correspond au `type de cache Django <https://docs.djangoproject.com/en/1.7/topics/cache/>`.
+*Type* dans les tableaux correspond au `type de cache Django <https://docs.djangoproject.com/en/1.7/topics/cache/>`__.
 
 *Usage* dans les tableaux correspond à l'endroit où est défini le bloc caché.
 
@@ -48,13 +48,13 @@ Il s'agit des blocs visuels de présentation des articles que l'on trouve par ex
 ==================  =====================================================================
 Identifiant         article_item
 Type                Template fragment caching
-Clé de cache        identifiant + clé primaire de l'article + "link" + "show_description"
+Clé de cache        identifiant + clé primaire de l'article + "type_link" + "show_description"
 Usage               templates/article/includes/article_item.part.html
 Temps de cache      1 heure
 Cas d'invalidation  La sauvegarde d'un article invalide l'entrée correspondante
 ==================  =====================================================================
 
-``link`` et ``show_description`` dans la clé de cache sont les deux paramètres de même nom passés au *template* ``article/includes/article_item.part.html``.
+``type_link`` et ``show_description`` dans la clé de cache sont les deux paramètres de même nom passés au *template* ``article/includes/article_item.part.html``.
 
 Comme l'ajout de commentaires sauvegarde l'article lui-même (lien vers le dernier commentaire), ce cas est automatiquement géré.
 
@@ -66,13 +66,13 @@ Il s'agit des blocs visuels de présentation des tutoriels que l'on trouve par e
 ==================  ============================================================
 Identifiant         tutorial_item
 Type                Template fragment caching
-Clé de cache        identifiant + clé primaire du tutoriel + "beta" + "show_description"
+Clé de cache        identifiant + clé primaire du tutoriel + "type" + "show_description"
 Usage               templates/tutorial/includes/tutorial_item.part.html
 Temps de cache      1 heure
 Cas d'invalidation  La sauvegarde d'un tutoriel invalide l'entrée correspondante
 ==================  ============================================================
 
-``beta`` et ``show_description``  dans la clé de cache sont les deux paramètres de même nom passés au *template*``tutorial/includes/tutorial_item.part.html``.
+``type`` et ``show_description``  dans la clé de cache sont les deux paramètres de même nom passés au *template* ``tutorial/includes/tutorial_item.part.html``.
 
 Blocs "À la une"
 ----------------

--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -6,10 +6,13 @@
 
 <article class="content-item expand-description tutorial-item{{ item_class }}">
 
-{% cache cache_timeouts.tutorial_item tutorial_item tutorial.pk beta show_description %}
+{% cache cache_timeouts.tutorial_item tutorial_item tutorial.pk type_link show_description %}
+
 {% captureas link %}
-    {% if beta %}
+    {% if type_link == 'beta'%}
         {{ tutorial.get_absolute_url_beta }}
+    {% elif type_link == 'draft' %}
+        {{ tutorial.get_absolute_url }}
     {% else %}
         {{ tutorial.get_absolute_url_online }}
     {% endif %}

--- a/templates/tutorial/member/beta.html
+++ b/templates/tutorial/member/beta.html
@@ -31,7 +31,7 @@
         {% if tutorials %}
             <div class="tutorial-list">
                 {% for tutorial in tutorials %}
-                    {% include 'tutorial/includes/tutorial_item.part.html' with beta=True show_description=True %}
+                    {% include 'tutorial/includes/tutorial_item.part.html' with type_link="beta" show_description=True %}
                 {% endfor %}
                 <div class="fill"></div>
                 <div class="fill"></div>

--- a/templates/tutorial/member/index.html
+++ b/templates/tutorial/member/index.html
@@ -74,7 +74,7 @@
         {% if tutorials %}
             <div class="content-item-list">
                 {% for tutorial in tutorials %}
-                    {% include 'tutorial/includes/tutorial_item.part.html' with show_description=True beta=True %}
+                    {% include 'tutorial/includes/tutorial_item.part.html' with show_description=True type_link="draft" %}
                 {% endfor %}
                 <div class="fill"></div>
                 <div class="fill"></div>

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -370,8 +370,10 @@ class Tutorial(models.Model):
         super(Tutorial, self).save(*args, **kwargs)
 
         # Clear associated cache keys
-        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, True, True]))
-        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, True, False]))
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, 'draft', True]))
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, 'draft', False]))
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, 'beta', True]))
+        cache.delete(make_template_fragment_key('tutorial_item', [self.pk, 'beta', False]))
         cache.delete(make_template_fragment_key('tutorial_item', [self.pk, False, True]))
         cache.delete(make_template_fragment_key('tutorial_item', [self.pk, False, False]))
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2747 |

J'espère pas avoir pêté tout le cache au passage
# Note de QA
- Vérifiez que vous avez le cache activé
- Créez un tutoriel nommé "A", passez le en bêta
- Éditer ensuite "A" (peu importe pour quoi, changer la description, par exemple), puis rendez vous sur la page "mes tutoriels", et vérifiez qu'en cliquant sur le lien correspondant à "A", vous êtes renvoyé sur la version brouillon et pas bêta

Puis (et c'est important, puisqu'on touche au cache),
- Vérifiez que sur la page d'accueil, vous êtes toujours bien renvoyé vers des version publiées
- Que sur la page des tutoriels en bêta de votre utilisateur actuel (`/tutoriels/recherche/{pk}/?type=beta`), le lien renvoi bien sur la version bêta de "A"
- Vérifiez que sur la page des tutos en public de l'utilisateur (`/tutoriels/recherche/{pk}/`), vous êtes bien renvoyé sur la version publique des tutos.
- Publiez "A" et refaites les mêmes vérifications (pour vérifier que le cache correspondant à cet _item_ a bien été détruit corps et âmes).
