### PR TITLE
Indexe qu'une seule fois le premier post

### DIFF
--- a/zds/forum/search_indexes.py
+++ b/zds/forum/search_indexes.py
@@ -32,4 +32,4 @@ class PostIndex(indexes.SearchIndex, indexes.Indexable):
         return Post
 
     def index_queryset(self, using=None):
-        return self.get_model().objects.filter(is_visible=True)
+        return self.get_model().objects.filter(is_visible=True, position__gt=1)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | J'ai pas trouvé |

Le premier post est indexé deux fois, une fois comme Topic, une fois comme Post. Cette PR corrige cela.

QA:
- Avant de cloner la branche: Réinitialiser votre index (pas besoin de changer votre schema.xml). Taper comme mot clés: "Rédiger sur ZesteDeSavoir". A droite, cocher la case, "Sujets du forum" et vérifier que le sujet apparaisse. Décocher cette case et cocher la case "Messages du forum". Vérifier que le message apparaisse
- Aller sur la branche et réinitialiser votre index (pas besoin de changer votre schema.xml). Taper comme mot clés: "Rédiger sur ZesteDeSavoir". A droite, cocher la case, "Sujets du forum" et vérifier que le sujet apparaisse. Décocher cette case et cocher la case "Messages du forum". Vérifier que le message n’apparaît plus.
