### PR TITLE
Indexe les tags

### DIFF
--- a/templates/search/indexes/forum/topic_text.txt
+++ b/templates/search/indexes/forum/topic_text.txt
@@ -3,3 +3,7 @@
 {{ object.author.username }}
 {{ object.first_post.text }}
 {{ object.forum }}
+
+{% for tag in object.tags.all %}
+ {{ tag.title }}
+{% endfor %}

--- a/zds/forum/search_indexes.py
+++ b/zds/forum/search_indexes.py
@@ -17,8 +17,13 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
     author = indexes.CharField(model_attr='author')
     pubdate = indexes.DateTimeField(model_attr='pubdate')
 
+    tags = indexes.MultiValueField()
+
     def get_model(self):
         return Topic
+
+    def prepare_tags(self, obj):
+        return obj.tags.values_list('title', flat=True).all()
 
 
 class PostIndex(indexes.SearchIndex, indexes.Indexable):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés |  |

Edit SpaceFox : WIP, ne pas merger - Cf [ce message](https://github.com/zestedesavoir/zds-site/pull/2765#issuecomment-107223107)

Ajoute la possibilité d'indexer les tags, on ne peut pas encore rechercher dessus.

QA:
- Stopper toute instance de Solr qui tourne (vraiment obligatoire)
- python manage.py build_solr_schema > schema.xml
- Supprimer le fichier solr-4.9.0/example/solr/collection1/conf/schema.xml
- Déplacer le  schema.xml vers solr-4.9.0/example/solr/collection1/conf
- Créé un sujets avec des tags
- Lancer Solr
- Réindexer le contenu: python manage.py rebuild_index
- http://localhost:8983/solr/select?q=_:_
- Vérifier que les tags apparaisse.
