### PR TITLE
Indexe uniquement les champs utiles dans les post

### DIFF
--- a/templates/search/indexes/forum/post_text.txt
+++ b/templates/search/indexes/forum/post_text.txt
@@ -1,8 +1,3 @@
-{{ object.topic.forum }}
-{{ object.topic.title }}
-{{ object.topic.subtitle }}
-{{ object.topic.author.username }}
 {{ object.author.username }}
+
 {{ object.text }}
-{{ object.pubdate }}
-{{ object.update }}

--- a/update.md
+++ b/update.md
@@ -220,8 +220,8 @@ Exécuter la commande suivante : `sudo apt-get install libffi-dev`
 Actions à faire pour mettre en prod la version : v15.6
 ======================================================
 
-Issue #1511
------------
+Issue #1511 et Pull Request #2766
+---------------------------------
 
 Fix sur la recherche d'article avec Solr :
 

--- a/zds/forum/search_indexes.py
+++ b/zds/forum/search_indexes.py
@@ -26,10 +26,23 @@ class PostIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
     txt = indexes.CharField(model_attr='text')
     author = indexes.CharField(model_attr='author')
-    pubdate = indexes.DateTimeField(model_attr='pubdate')
+
+    pubdate = indexes.DateTimeField(model_attr='pubdate', stored=True, indexed=False)
+    topic_title = indexes.CharField(stored=True, indexed=False)
+    topic_author = indexes.CharField(stored=True, indexed=False)
+    topic_forum = indexes.CharField(stored=True, indexed=False)
 
     def get_model(self):
         return Post
 
     def index_queryset(self, using=None):
         return self.get_model().objects.filter(is_visible=True, position__gt=1)
+
+    def prepare_topic_title(self, obj):
+        return obj.topic.title
+
+    def prepare_topic_author(self, obj):
+        return obj.topic.author
+
+    def prepare_topic_forum(self, obj):
+        return obj.topic.forum


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | ~oui |
| Tickets (_issues_) concernés |  |

Les posts indexe plein de truc inutile comme le titre du topic, le titre du forum, le sous-titre du topic, et l'auteur du topic. Toutes ces infos, sont déjà dans les post. Mais bien sur on les stocke pour ne pas faire de requête supplémentaire.

QA:
- Lancer une recherche avec un titre de sujet, voir que tous les messages apparaissent.
- Stopper toute instance de Solr qui tourne (vraiment obligatoire)
- python manage.py build_solr_schema > schema.xml
- Supprimer le fichier solr-4.9.0/example/solr/collection1/conf/schema.xml
- Déplacer le schema.xml vers solr-4.9.0/example/solr/collection1/conf
- Lancer Solr
- Réindexer le contenu: python manage.py rebuild_index
- Lancer une recherche avec un titre de sujet, voir que seul celui du sujet apparait.
- Aller sur http://localhost:8983/solr/select?q=_:_ et vérifier que les balises topic_forum, topic_author, topic_title apparaissent.

Penser à modifier le UPDATE.md.
