### PR TITLE
Index les droits des posts et des forums

### DIFF
--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -62,91 +62,87 @@
             <div class="topic-list navigable-list">
                 {% for result in page.object_list %}
                     {% if result and result.object %}
-                        {% if result.object.forum and not result.object.forum|auth_forum:user %}
-                        {% elif result.object.topic.forum and not result.object.topic.forum|auth_forum:user %}
-                        {% else %}
-                            <div class="topic navigable-elem">
-                                <div class="topic-infos">
-                                </div>
-                                <div class="topic-description">
-                                    {% if result.object.first_post %}
-                                        <a href="{{ result.object.get_absolute_url }}" class="topic-title-link navigable-link">
-                                            <div class="topic-title">
-                                                {% highlight result.object.title with query html_tag "mark" %}
-                                            </div>
-                                    {% elif result.object.get_text_online %}
-                                        <a href="{{ result.object.get_absolute_url_online }}" class="topic-title-link navigable-link">
-                                            <div class="topic-title">
-                                                {% highlight result.object.title with query html_tag "mark" %}
-                                            </div>
-                                    {% elif result.object.topic %}
-                                        <a href="{{ result.object.get_absolute_url }}" class="topic-title-link navigable-link">
-                                            <div class="topic-title">
-                                                {% highlight result.object.topic.title with query html_tag "mark" %}
-                                            </div>
-                                    {% else %}
-                                        <a href="{{ result.object.get_absolute_url_online }}" class="topic-title-link navigable-link">
-                                            <div class="topic-title">
-                                                {% highlight result.object.title with query html_tag "mark" %}
-                                            </div>
-                                    {% endif %}
-                                            <div class="topic-subtitle">
-                                                {% if result.object.first_post %}
-                                                    {% with text=result.object.first_post.text|emarkdown|striptags|safe %}
-                                                        {% highlight text with query html_tag "mark" %}
-                                                    {% endwith %}
-                                                {% elif result.object.get_text_online %}
-                                                    {% with text=result.object.get_text_online|striptags|safe %}
-                                                        {% highlight text with query html_tag "mark" %}
-                                                    {% endwith %}
-						{% elif result.object.get_text %}
-                                                    {% with text=result.object.get_text|striptags|safe %}
-                                                        {% highlight text with query html_tag "mark" %}
-                                                    {% endwith %}
-                                                {% elif result.object.topic %}
-                                                    {% with text=result.object.text|emarkdown|striptags|safe %}
-                                                        {% highlight text with query html_tag "mark" %}
-                                                    {% endwith %}
-                                                {% else %}
-                                                    {% with text=result.object.get_introduction_online|striptags|safe %}
-                                                        {% highlight text with query html_tag "mark" %}
-                                                    {% endwith %}
-                                                {% endif %}
-                                            </div>
-                                        </a>
-                                        <div class="topic-members">
-                                            {% model_name result.app_label result.model_name False %}
-                                        </div>
-                                </div>
-                                <div class="topic-last-answer">
-                                    {% if result.object.pubdate %}
-                                        <a href="
-                                            {% if result.object.first_post %}
-                                                {{ result.object.get_absolute_url }}
-                                            {% elif result.object.get_introduction_online %}
-                                                {{ result.object.get_absolute_url_online }}
-                                            {% else %}
-                                                {{ result.object.get_absolute_url }}
-                                            {% endif %}
-                                        ">
-                                            {{ result.object.pubdate|format_date|capfirst }}
-                                        </a>
-                                    {% elif result.object.tutorial.pubdate %}
-                                        <a href="{{ result.object.get_absolute_url_online }}">
-                                            {{ result.object.tutorial.pubdate|format_date|capfirst }}
-                                        </a>
-                                    {% elif result.object.part.tutorial.pubdate %}
-                                        <a href="{{ result.object.get_absolute_url_online }}">
-                                            {{ result.object.part.tutorial.pubdate|format_date|capfirst }}
-                                        </a>
-                                    {% elif result.object.chapter.tutorial.pubdate %}
-                                        <a href="{{ result.object.get_absolute_url_online }}">
-                                            {{ result.object.chapter.tutorial.pubdate|format_date|capfirst }}
-                                        </a>
-                                    {% endif %}
-                                </div>
+                        <div class="topic navigable-elem">
+                            <div class="topic-infos">
                             </div>
-                        {% endif %}
+                            <div class="topic-description">
+                                {% if result.object.first_post %}
+                                    <a href="{{ result.object.get_absolute_url }}" class="topic-title-link navigable-link">
+                                        <div class="topic-title">
+                                            {% highlight result.object.title with query html_tag "mark" %}
+                                        </div>
+                                {% elif result.object.get_text_online %}
+                                    <a href="{{ result.object.get_absolute_url_online }}" class="topic-title-link navigable-link">
+                                        <div class="topic-title">
+                                            {% highlight result.object.title with query html_tag "mark" %}
+                                        </div>
+                                {% elif result.object.topic %}
+                                    <a href="{{ result.object.get_absolute_url }}" class="topic-title-link navigable-link">
+                                        <div class="topic-title">
+                                            {% highlight result.object.topic.title with query html_tag "mark" %}
+                                        </div>
+                                {% else %}
+                                    <a href="{{ result.object.get_absolute_url_online }}" class="topic-title-link navigable-link">
+                                        <div class="topic-title">
+                                            {% highlight result.object.title with query html_tag "mark" %}
+                                        </div>
+                                {% endif %}
+                                        <div class="topic-subtitle">
+                                            {% if result.object.first_post %}
+                                                {% with text=result.object.first_post.text|emarkdown|striptags|safe %}
+                                                    {% highlight text with query html_tag "mark" %}
+                                                {% endwith %}
+                                            {% elif result.object.get_text_online %}
+                                                {% with text=result.object.get_text_online|striptags|safe %}
+                                                    {% highlight text with query html_tag "mark" %}
+                                                {% endwith %}
+                                            {% elif result.object.get_text %}
+                                                {% with text=result.object.get_text|striptags|safe %}
+                                                    {% highlight text with query html_tag "mark" %}
+                                                {% endwith %}
+                                            {% elif result.object.topic %}
+                                                {% with text=result.object.text|emarkdown|striptags|safe %}
+                                                    {% highlight text with query html_tag "mark" %}
+                                                {% endwith %}
+                                            {% else %}
+                                                {% with text=result.object.get_introduction_online|striptags|safe %}
+                                                    {% highlight text with query html_tag "mark" %}
+                                                {% endwith %}
+                                            {% endif %}
+                                        </div>
+                                    </a>
+                                    <div class="topic-members">
+                                        {% model_name result.app_label result.model_name False %}
+                                    </div>
+                            </div>
+                            <div class="topic-last-answer">
+                                {% if result.object.pubdate %}
+                                    <a href="
+                                        {% if result.object.first_post %}
+                                            {{ result.object.get_absolute_url }}
+                                        {% elif result.object.get_introduction_online %}
+                                            {{ result.object.get_absolute_url_online }}
+                                        {% else %}
+                                            {{ result.object.get_absolute_url }}
+                                        {% endif %}
+                                    ">
+                                        {{ result.object.pubdate|format_date|capfirst }}
+                                    </a>
+                                {% elif result.object.tutorial.pubdate %}
+                                    <a href="{{ result.object.get_absolute_url_online }}">
+                                        {{ result.object.tutorial.pubdate|format_date|capfirst }}
+                                    </a>
+                                {% elif result.object.part.tutorial.pubdate %}
+                                    <a href="{{ result.object.get_absolute_url_online }}">
+                                        {{ result.object.part.tutorial.pubdate|format_date|capfirst }}
+                                    </a>
+                                {% elif result.object.chapter.tutorial.pubdate %}
+                                    <a href="{{ result.object.get_absolute_url_online }}">
+                                        {{ result.object.chapter.tutorial.pubdate|format_date|capfirst }}
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
                     {% endif %}
                 {% endfor %}
             </div>

--- a/update.md
+++ b/update.md
@@ -220,8 +220,8 @@ Exécuter la commande suivante : `sudo apt-get install libffi-dev`
 Actions à faire pour mettre en prod la version : v15.6
 ======================================================
 
-Issue #1511 et Pull Request #2766
----------------------------------
+Issue #1511, Issue #983 et Pull Request #2766
+---------------------------------------------
 
 Fix sur la recherche d'article avec Solr :
 
@@ -230,3 +230,4 @@ Fix sur la recherche d'article avec Solr :
   - Regénérer le schema.xml : `python manage.py build_solr_schema > /votre/path/vers/solr-4.9.1/example/solr/collection1/conf/schema.xml`
   - Redémarrer Solr : `supervisorctl start solr`
   - Lancer l'indexation : `python manage.py rebuild_index`
+

--- a/zds/forum/search_indexes.py
+++ b/zds/forum/search_indexes.py
@@ -17,8 +17,14 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
     author = indexes.CharField(model_attr='author')
     pubdate = indexes.DateTimeField(model_attr='pubdate')
 
+    # Groups authorized to read this topic. If no group is defined, the forum is public (and anyone can read it).
+    permissions = indexes.MultiValueField()
+
     def get_model(self):
         return Topic
+
+    def prepare_permissions(self, obj):
+        return obj.forum.group.values_list('name', flat=True).all() or None
 
 
 class PostIndex(indexes.SearchIndex, indexes.Indexable):
@@ -31,6 +37,9 @@ class PostIndex(indexes.SearchIndex, indexes.Indexable):
     topic_title = indexes.CharField(stored=True, indexed=False)
     topic_author = indexes.CharField(stored=True, indexed=False)
     topic_forum = indexes.CharField(stored=True, indexed=False)
+
+    # Groups authorized to read this post. If no group is defined, the forum is public (and anyone can read it).
+    permissions = indexes.MultiValueField()
 
     def get_model(self):
         return Post
@@ -46,3 +55,6 @@ class PostIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_topic_forum(self, obj):
         return obj.topic.forum
+
+    def prepare_permissions(self, obj):
+        return obj.topic.forum.group.values_list('name', flat=True).all() or None

--- a/zds/search/views.py
+++ b/zds/search/views.py
@@ -34,6 +34,21 @@ class CustomSearchView(SearchView):
         context.update(self.extra_context())
         return render(self.request, self.template, context)
 
+    def get_results(self):
+        queryset = super(CustomSearchView, self).get_results()
+
+        # We want to search only on authorized post and topic
+        if self.request.user.is_authenticated():
+            groups = self.request.user.groups
+
+            if groups.count() > 0:
+                return queryset.filter_or(permissions=None, permissions__in=groups.all())
+            else:
+                return queryset.filter(permissions=None)
+
+        else:
+            return queryset.filter(permissions=None)
+
 
 def opensearch(request):
     """Generate OpenSearch Description file"""


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/983#issuecomment-107143373 |

Je laisse SpaceFox expliquer 

> Solr sait si un topic est public ou non
> Le back lui passe l'info quand il fait la requête (en fonction du profil de l'utilisateur, renvoyer ou 
> non les topics privés)
> Les résultats sont automatiquement bons
> 
> Conséquences :
> 
> Il faut indexer l'information "topic public ou non"
> Les appels à Solr doivent être modifiés en conséquence
> 
> Avantages :
> 
> Tout marche nickel : aucun problème de filtrage, de pagination, etc.
> On ne pourra jamais faire plus plus performant par un autre moyen

QA:
- Créé un topic dans un forum avec des droits spéciaux
- Couper Solr
- Remplacer votre schema.xml
- Relancer Solr
- Indexer le contenu 
- Vérifier avec un membre simple et en mode non connecté qu'on ne puisse pas voir le topic
- Vérifier qu'on puisse voir d'autre topic en mode non connecté et membre simple
- Vérifier en tant qu'admin qu'on puisse voir le post.
