### PR TITLE
Agrandit les champs d'url

### DIFF
--- a/zds/featured/models.py
+++ b/zds/featured/models.py
@@ -16,10 +16,10 @@ class FeaturedResource(models.Model):
     type = models.CharField(_(u'Type'), max_length=80)
     authors = models.ManyToManyField(Profile, verbose_name=_(u'Auteurs'), db_index=True)
     image_url = models.CharField(
-        _(u'URL de l\'image à la une'), max_length=128, null=False, blank=False
+        _(u'URL de l\'image à la une'), max_length=2000, null=False, blank=False
     )
     url = models.CharField(
-        _(u'URL de la une'), max_length=128, null=False, blank=False
+        _(u'URL de la une'), max_length=2000, null=False, blank=False
     )
     pubdate = models.DateTimeField(_(u'Date de publication'), blank=True, null=False, db_index=True)
 
@@ -36,7 +36,7 @@ class FeaturedMessage(models.Model):
         verbose_name_plural = _(u'Messages')
 
     message = models.CharField(_(u'Message'), max_length=255)
-    url = models.CharField(_(u'URL du message'), max_length=128, null=False, blank=False)
+    url = models.CharField(_(u'URL du message'), max_length=2000, null=False, blank=False)
     objects = FeaturedMessageManager()
 
     def __unicode__(self):

--- a/zds/featured/tests.py
+++ b/zds/featured/tests.py
@@ -8,6 +8,12 @@ from zds.featured.factories import FeaturedResourceFactory
 from zds.featured.models import FeaturedResource, FeaturedMessage
 
 
+stringof2001chars = 'http://url.com/'
+for i in range(198):
+    stringof2001chars += "0123456789"
+stringof2001chars += "12.jpg"
+
+
 class FeaturedResourceListViewTest(TestCase):
     def test_success_list_of_featured(self):
         staff = StaffProfileFactory()
@@ -80,6 +86,45 @@ class FeaturedResourceCreateViewTest(TestCase):
         response = self.client.get(reverse('featured-resource-create'))
 
         self.assertEqual(403, response.status_code)
+
+    def test_failure_too_long_url(self):
+        staff = StaffProfileFactory()
+        login_check = self.client.login(
+            username=staff.user.username,
+            password='hostel77'
+        )
+        self.assertTrue(login_check)
+
+        self.assertEqual(0, FeaturedResource.objects.all().count())
+        response = self.client.post(
+            reverse('featured-resource-create'),
+            {
+                'title': 'title',
+                'type': 'type',
+                'image_url': stringof2001chars,
+                'url': 'url',
+                'authors': staff.user.username
+            },
+            follow=True
+        )
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(0, FeaturedResource.objects.all().count())
+
+        response = self.client.post(
+            reverse('featured-resource-create'),
+            {
+                'title': 'title',
+                'type': 'type',
+                'image_url': 'url',
+                'url': stringof2001chars,
+                'authors': staff.user.username
+            },
+            follow=True
+        )
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(0, FeaturedResource.objects.all().count())
 
 
 class FeaturedResourceUpdateViewTest(TestCase):

--- a/zds/member/migrations/0002_auto_20150601_1144.py
+++ b/zds/member/migrations/0002_auto_20150601_1144.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('member', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='profile',
+            name='avatar_url',
+            field=models.CharField(max_length=2000, null=True, verbose_name=b"URL de l'avatar", blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='profile',
+            name='site',
+            field=models.CharField(max_length=2000, verbose_name=b'Site internet', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -49,12 +49,12 @@ class Profile(models.Model):
         blank=True,
         null=True)
 
-    site = models.CharField('Site internet', max_length=128, blank=True)
+    site = models.CharField('Site internet', max_length=2000, blank=True)
     show_email = models.BooleanField('Afficher adresse mail publiquement',
                                      default=False)
 
     avatar_url = models.CharField(
-        'URL de l\'avatar', max_length=128, null=True, blank=True
+        'URL de l\'avatar', max_length=2000, null=True, blank=True
     )
 
     biography = models.TextField('Biographie', blank=True)

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -8,16 +8,15 @@ from zds.member.forms import LoginForm, RegisterForm, \
     KarmaForm
 
 stringof77chars = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789-----"
-stringof129chars = u'http://www.01234567890123456789123456789' \
-                   u'0123456789012345678901234567890123456789' \
-                   u'0123456789012345678901234567890123456789' \
-                   u'012345678'
 stringof251chars = u'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy' \
                    u'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy' \
                    u'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy' \
                    u'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy' \
                    u'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy0'
-
+stringof2001chars = 'http://url.com/'
+for i in range(198):
+    stringof2001chars += "0123456789"
+stringof2001chars += "12.jpg"
 
 # This form is tricky to test as it needs a tuto to be done
 # class OldTutoFormTest(TestCase):
@@ -215,9 +214,11 @@ class MiniProfileFormTest(TestCase):
         self.assertTrue(form.is_valid())
 
     def test_too_long_site_url_miniprofile_form(self):
+
+        # url is one char too long
         data = {
             'biography': '',
-            'site': stringof129chars,
+            'site': stringof2001chars,
             'avatar_url': '',
             'sign': ''
         }
@@ -228,7 +229,7 @@ class MiniProfileFormTest(TestCase):
         data = {
             'biography': '',
             'site': '',
-            'avatar_url': stringof129chars,
+            'avatar_url': stringof2001chars,
             'sign': ''
         }
         form = MiniProfileForm(data=data)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2755 |

Un consensus semble exister autour d'une longueur d'url de 2000 caracteres. Cette PR allonge donc les champs de 128 car actuellement a 2000.
### QA
- Vérifier que l'on peut créer des unes avec des urls très longues (mais pas plus que 2000)
- Idem pour les champs du profil

Question bonus : Pourquoi le modèle `featured` ne déclenche pas de migrations mais que ca semble marcher quand même ?
