### PR TITLE
Améliore l'affichage des signatures

### DIFF
--- a/assets/js/message-signature.js
+++ b/assets/js/message-signature.js
@@ -1,0 +1,11 @@
+/* ===== Zeste de Savoir ====================================================
+   Single line/Multi lines signatures
+   ========================================================================== */
+
+(function($, undefined){
+    "use strict";
+
+    $(".message-bottom .signature").on("click", function(){
+        $(this).toggleClass("full");
+    });
+})(jQuery);

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -253,7 +253,7 @@
 
             .signature {
                 border-top: 1px solid #D2D5D6;
-                padding: 3px 0 0 10px;
+                padding: 3px 0 3px 10px;
                 margin: 0 10px 0 0;
                 font-size: 12px;
                 font-size: 1.2rem;
@@ -623,9 +623,18 @@ form.topic-message {
                     margin-top: 10px;
                 }
             }
-            .message-bottom .signature p {
-                white-space: nowrap;
-                overflow: hidden;
+            .message-bottom .signature {
+                cursor: pointer;
+
+                p {
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+
+                &.full p {
+                    white-space: normal;
+                }
             }
         }
     }

--- a/zds/member/migrations/0003_auto_20151019_2333.py
+++ b/zds/member/migrations/0003_auto_20151019_2333.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('member', '0002_auto_20150601_1144'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='profile',
+            name='sign',
+            field=models.TextField(max_length=500, verbose_name=b'Signature', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -59,7 +59,7 @@ class Profile(models.Model):
 
     karma = models.IntegerField('Karma', default=0)
 
-    sign = models.TextField('Signature', max_length=250, blank=True)
+    sign = models.TextField('Signature', max_length=500, blank=True)
 
     show_sign = models.BooleanField('Voir les signatures', default=True)
 

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -13,6 +13,7 @@ stringof251chars = u'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy' \
                    u'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy' \
                    u'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy' \
                    u'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy0'
+stringof501chars = ['1' for n in range(501)]
 stringof2001chars = 'http://url.com/'
 for i in range(198):
     stringof2001chars += "0123456789"
@@ -240,7 +241,7 @@ class MiniProfileFormTest(TestCase):
             'biography': '',
             'site': '',
             'avatar_url': '',
-            'sign': stringof251chars
+            'sign': stringof501chars
         }
         form = MiniProfileForm(data=data)
         self.assertFalse(form.is_valid())


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | [Forum](https://zestedesavoir.com/forums/sujet/3298/signature-trop-longue-tronquee/) , #1393 |

Augmente la longueur autorisée des signatures (pour que les utilisateurs puissent mettre des liens avec des longues URLs)
Affiche la signature complète lorsque l'on clique dessus (et la réduit si l'on re-clique dessus)

Voici [une petite vidéo de démonstration](https://drive.google.com/file/d/0ByCc7U2bgTkbb243Wk5nVHoxeVU/view?usp=sharing) !

**QA :**
- Appliquer la migration `python manage.py migrate` ;
- Générer le front `npm run gulp -- build` ;
- Créer une signature de plus de 2000 caractères et vérifier que ça s'affiche bien ;
- Tester le bon fonctionnement de la signature (et des liens qui sont dedans) et des +1/-1.
