### PR TITLE
Personnalise le highlighter de la recherche

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -351,6 +351,7 @@ HAYSTACK_CONNECTIONS = {
         # 'URL': 'http://127.0.0.1:8983/solr/mysite',
     },
 }
+HAYSTACK_CUSTOM_HIGHLIGHTER = 'zds.utils.highlighter.SearchHighlighter'
 
 GEOIP_PATH = os.path.join(BASE_DIR, 'geodata')
 

--- a/zds/utils/highlighter.py
+++ b/zds/utils/highlighter.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+from haystack.utils import Highlighter
+
+
+MAX_WRAP_TEXT = 50
+
+
+class SearchHighlighter(Highlighter):
+
+    def render_html(self, highlight_locations=None, start_offset=None, end_offset=None):
+
+        if start_offset is not None:
+            start_offset = max([0, start_offset - MAX_WRAP_TEXT])
+        if end_offset is not None:
+            end_offset = min([len(self.text_block), end_offset + MAX_WRAP_TEXT])
+
+        return super(SearchHighlighter, self).render_html(highlight_locations=highlight_locations,
+                                                          start_offset=start_offset,
+                                                          end_offset=end_offset)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [non] |
| Nouvelle Fonctionnalité ? | [oui] |
| Tickets (_issues_) concernés | #2129 |

Cette petite amélioration est finalement un assez grand pas dans l'utilisation de la recherche. En effet, au lieu d'avoir un bout de texte sans contexte (inutilisable ou presque) dorénavant ce dernier se voit assorti d'un contexte de 50 caractères\* avant/après.

Pour réaliser ce tour de passe-passe je donne un Highlighter redéfini a Haystack. Ce highlighter est en fait le même que [l'original](https://github.com/django-haystack/django-haystack/blob/master/haystack/utils/highlighting.py#L113) a la différence près que j'agrandit la fenêtre de texte (donc le fonctionnement fondamental ne change pas).

*cette limite est empirique (et changeable via une constante), j'ai regardé ce que faisait les autres et une taille de 50 caractères semblait ressortir.

Voila un exemple de rendu (à comparer avec celui que j'ai posté dans le ticket d'origine)

![screenshot from 2015-06-03 11 36 29](https://cloud.githubusercontent.com/assets/761168/7957140/7a48dbb8-09e5-11e5-91a9-ba682d1b8215.png)
### QA
- Jouer avec la recherche et constater que le texte possède maintenant un contexte. Essayer de faire des cas rigolos comme avec plusieurs mots-clés dans une seule recherche.
