### PR TITLE
Affiche les alertes sur les articles

### DIFF
--- a/templates/tutorial/part/view_online.html
+++ b/templates/tutorial/part/view_online.html
@@ -61,7 +61,7 @@
 
 
 {% block sidebar_blocks %}
-    {% if perms.tutorial.change_tutorial %}
+    {% if is_staff %}
         <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Administration">
             <h3>{% blocktrans %}Admin<span class="wide">istration</span>{% endblocktrans %}</h3>
             <ul>

--- a/zds/article/tests/tests.py
+++ b/zds/article/tests/tests.py
@@ -179,6 +179,9 @@ class ArticleTests(TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Alert.objects.all().count(), 1)
 
+        self.client.login(username="staff", password="hostel77")
+        result = self.client.get(reverse('zds.article.view_online', [self.article.pk]))
+        self.assertContains(result, 'Troll')
         # connect with staff
         login_check = self.client.login(
             username=self.staff.username,

--- a/zds/article/tests/tests.py
+++ b/zds/article/tests/tests.py
@@ -180,7 +180,8 @@ class ArticleTests(TestCase):
         self.assertEqual(Alert.objects.all().count(), 1)
 
         self.client.login(username="staff", password="hostel77")
-        result = self.client.get(reverse('zds.article.view_online', [self.article.pk]))
+        result = self.client.get(reverse('zds.article.views.view_online',
+                                         args=[self.article.pk, self.article.slug]))
         self.assertContains(result, 'Troll')
         # connect with staff
         login_check = self.client.login(

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -243,7 +243,7 @@ def view_online(request, article_pk, article_slug):
         'form': form,
         'on_line': True,
         'authors_reachable': authors_reachable,
-        'is_staff': request.user.has_perm('tutorial.change_article'),
+        'is_staff': request.user.has_perm('article.change_article'),
         'user_like': user_like,
         'user_dislike': user_dislike
     })


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [#2787] |

corrige le bug #2787 qui empêche d'afficher les alertes sur les articles. La faute à une typo dans le nom de la permission.
# Pour la QA
- Publiez un article (ou chargez les articles des fixtures)
- avec staff postez un commentaire
- avec user mettez une alerte sur ce commentaire
- avec staff et admin vérifiez que le message d'alerte apparait.
