### PR TITLE
Retablit le comportement des alertes (compteur et limite)

### DIFF
--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -272,13 +272,19 @@ Récupère la liste des alertes (si l'utilisateur possède les droits pour le fa
 .. sourcecode:: html
 
     {% load interventions %}
-    {% with alerts=user|alerts_list %}
-        {% for alert in alerts %}
+    {% with alerts_list=user|alerts_list %}
+        {% for alert in alerts_list.alerts %}
         ...
         {% endfor %}
     {% endwith %}
 
-où ``alert`` est un dictionnaire contenant 4 champs:
+``alert_list`` est un dictionnaire contenant 2 champs:
+
+- ``alerts`` : Les 10 alertes les plus récentes (détail ci-dessous) ;
+- ``nb_alerts`` : Le nombre total d'alertes existantes.
+
+
+``alerts`` énuméré souvent en ``alert`` est aussi un dictionnaire contenant 4 champs:
 
 - ``alert.url`` donne l'URL du *post* ayant généré l'alerte ;
 - ``alert.username`` contient le nom de l'auteur de l'alerte ;

--- a/templates/base.html
+++ b/templates/base.html
@@ -368,39 +368,37 @@
 
                                 {# ALERTES MODERATION #}
                                 {% if perms.forum.change_post %}
-                                    {% with alerts=user|alerts_list %}
-                                        {%  with nb_alerts=alerts|length %}
-                                            <div>
-                                                <a href="{% url "zds.pages.views.alerts" %}" class="ico-link">
-                                                    <span class="notif-text ico ico-alerts">{% trans "Alertes" %}</span>
-                                                    {% if nb_alerts > 0 %}
-                                                        <span class="notif-count">{{ nb_alerts }}</span>
-                                                    {% endif %}
-                                                </a>
+                                    {% with alerts_list=user|alerts_list %}
+                                        <div>
+                                            <a href="{% url "zds.pages.views.alerts" %}" class="ico-link">
+                                                <span class="notif-text ico ico-alerts">{% trans "Alertes" %}</span>
+                                                {% if alerts_list.nb_alerts > 0 %}
+                                                    <span class="notif-count">{{ alerts_list.nb_alerts }}</span>
+                                                {% endif %}
+                                            </a>
 
-                                                <div class="dropdown">
-                                                    <span class="dropdown-title">{% trans "Alertes Modération" %}</span>
-                                                    <ul class="dropdown-list">
-                                                        {% for alert in alerts %}
-                                                            <li>
-                                                                <a href="{{ alert.url }}">
-                                                                    <span class="username">{{ alert.title }}</span>
-                                                                    <span class="date">{{ alert.pubdate|format_date:True|capfirst }}</span>
-                                                                    <span class="topic">{{ alert.text }}</span>
-                                                                </a>
-                                                            </li>
-                                                        {% empty %}
-                                                            <li class="dropdown-empty-message">
-                                                                {% trans "Aucune alerte" %}
-                                                            </li>
-                                                        {% endfor %}
-                                                    </ul>
-                                                    <a href="{% url "zds.pages.views.alerts" %}" class="dropdown-link-all">
-                                                        {% trans "Toutes les alertes" %}
-                                                    </a>
-                                                </div>
+                                            <div class="dropdown">
+                                                <span class="dropdown-title">{% trans "Alertes Modération" %}</span>
+                                                <ul class="dropdown-list">
+                                                    {% for alert in alerts_list.alerts %}
+                                                        <li>
+                                                            <a href="{{ alert.url }}">
+                                                                <span class="username">{{ alert.title }}</span>
+                                                                <span class="date">{{ alert.pubdate|format_date:True|capfirst }}</span>
+                                                                <span class="topic">{{ alert.text }}</span>
+                                                            </a>
+                                                        </li>
+                                                    {% empty %}
+                                                        <li class="dropdown-empty-message">
+                                                            {% trans "Aucune alerte" %}
+                                                        </li>
+                                                    {% endfor %}
+                                                </ul>
+                                                <a href="{% url "zds.pages.views.alerts" %}" class="dropdown-link-all">
+                                                    {% trans "Toutes les alertes" %}
+                                                </a>
                                             </div>
-                                        {%  endwith %}
+                                        </div>
                                     {% endwith %}
                                 {% else %}
                                     <a href="{% url "member-detail" user.username %}"

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -154,6 +154,7 @@ def interventions_privatetopics(user):
 def alerts_list(user):
     total = []
     alerts = Alert.objects.select_related('author', 'comment').all().order_by('-pubdate')[:10]
+    nb_alerts = Alert.objects.select_related('author', 'comment').all().count()
     for alert in alerts:
         if alert.scope == Alert.FORUM:
             post = Post.objects.select_related('topic').get(pk=alert.comment.pk)
@@ -177,4 +178,4 @@ def alerts_list(user):
                           'author': alert.author,
                           'text': alert.text})
 
-    return total
+    return {'alerts': total, 'nb_alerts': nb_alerts}

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -154,7 +154,7 @@ def interventions_privatetopics(user):
 def alerts_list(user):
     total = []
     alerts = Alert.objects.select_related('author', 'comment').all().order_by('-pubdate')[:10]
-    nb_alerts = Alert.objects.select_related('author', 'comment').all().count()
+    nb_alerts = Alert.objects.count()
     for alert in alerts:
         if alert.scope == Alert.FORUM:
             post = Post.objects.select_related('topic').get(pk=alert.comment.pk)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | #2793 |

Rétablit le comportement des alertes en gardant les mêmes perfs
- Seul les 10 alertes les plus récentes sont récupérées/affichées dans la top bar (pour afficher les plus vieilles il faut aller sur la page "toutes les alertes")
- Le compteur affiche cependant le nombre **total** d'alertes (et c'est la qu’était le bug !)
### QA
- Vérifier le bon comportement de la top bar pour les alertes (affichage du nombre cohérent, des alertes dans le bon ordre etc)
- Bonus, vérifier que le nombre de requêtes n'a pas vraiment bouge (une seule requête simple supplémentaires normalement)
