### PR TITLE
Corrige l'indexation des catégories des tutos

### DIFF
--- a/templates/search/indexes/tutorial/tutorial_text.txt
+++ b/templates/search/indexes/tutorial/tutorial_text.txt
@@ -1,7 +1,10 @@
 {{ object.get_conclusion_online }}
 {{ object.get_introduction_online }}
-{{ object.category.title }}
-{{ object.category.description }}
+
+{% for subcategory in object.subcategory.all %}
+ {{ subcategory.title }}
+{% endfor %}
+
 {{ object.text }}
 {{ object.description }}
 {{ object.title }}

--- a/zds/tutorial/search_indexes.py
+++ b/zds/tutorial/search_indexes.py
@@ -11,7 +11,7 @@ class TutorialIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
     title = indexes.CharField(model_attr='title')
     description = indexes.CharField(model_attr='description')
-    category = indexes.CharField(model_attr='subcategory')
+    subcategory = indexes.MultiValueField()
     sha_public = indexes.CharField(model_attr='sha_public')
 
     def get_model(self):
@@ -20,6 +20,9 @@ class TutorialIndex(indexes.SearchIndex, indexes.Indexable):
     def index_queryset(self, using=None):
         """Only tutorials online."""
         return self.get_model().objects.filter(sha_public__isnull=False)
+
+    def prepare_subcategory(self, obj):
+        return obj.subcategory.values_list('title', flat=True).all() or None
 
 
 class PartIndex(indexes.SearchIndex, indexes.Indexable):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2792 |

Cette PR s’occupe uniquement de résoudre un problème liés à l'indexation des catégories de tutoriels. 

Il y'a surement un deuxième bug en prod, qui empêché certains contenu de s'indexer.

**QA:**

Avant de checkout la branche:
- `python manage.py load_fixtures` 
- Lancer Solr
- Vérifier que l'on ne peut pas indexer les tutoriels.

Checkout la branche:
- Couper Solr
- Mettre à jours le schema.xml  
- Relancer Solr
- Relancer l'indexation, l'erreur devrait avoir disparu.
