### PR TITLE
Utilisation de urlquote pour la page de profil d'un membre

### DIFF
--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.db import models
 from hashlib import md5
 from django.http import HttpRequest
-from django.utils.http import urlquote
 from django.contrib.sessions.models import Session
 from django.contrib.auth import logout
 import os
@@ -107,7 +106,7 @@ class Profile(models.Model):
 
     def get_absolute_url(self):
         """Absolute URL to the profile page."""
-        return reverse('member-detail', kwargs={'user_name': urlquote(self.user.username)})
+        return reverse('member-detail', kwargs={'user_name': self.user.username})
 
     def get_city(self):
         """

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -64,6 +64,8 @@ class MemberDetail(DetailView):
     template_name = 'member/profile.html'
 
     def get_object(self, queryset=None):
+        # Use urlunquote to accept quoted twice URLs (for instance in MPs send
+        # through emarkdown parser)
         return get_object_or_404(User, username=urlunquote(self.kwargs['user_name']))
 
     def get_context_data(self, **kwargs):

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 from django.contrib.messages import constants as message_constants
+from django.utils.http import urlquote
 from django.utils.translation import gettext_lazy as _
 
 # Changes the default encoding of python to UTF-8.
@@ -326,7 +327,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 LOGIN_URL = '/membres/connexion'
 
 ABSOLUTE_URL_OVERRIDES = {
-    'auth.user': lambda u: '/membres/voir/{0}/'.format(u.username.encode('utf-8'))
+    'auth.user': lambda u: '/membres/voir/{0}/'.format(urlquote(u.username.encode('utf-8')))
 }
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2788, #2301 |

Cette PR supprime un urlquote inutile (car déjà fait par Django) et ajoute un urlquote dans settings.py pour corriger un lien erroné si nom d'utilisateur "complexe".
# QA
- Utiliser un nom d'utilisateur avec des caractères spéciaux comme &, espace, # et unicode (genre `ïtréma & #h@ck`)
- Publier un article avec un autre auteur (par exemple admin)
- Signaler une typo depuis l'utilisateur au nom complexe sur l'article publié par admin
- Vérifier que TOUS les liens fonctionnent: liens dans la liste des participants, avatar et dans le message

Remarques:
- Le lien dans le message est différent des autres, il est quoté deux fois, c'est normal (à cause du parseur markdown)
- Il est possible de faire bugger le lien en choisissant un pseudo qui casse la syntaxe markdown (genre avec un `$`, `]` ou `)` dedans) mais cela est hors du scop de cette PR.
