### PR TITLE
Met a jour les infos de deploiement

### DIFF
--- a/update.md
+++ b/update.md
@@ -155,7 +155,7 @@ Actions à faire pour mettre en prod la version : v1.8
 Issue #1455 Django 1.7
 ----------------------
 
-**Avant** de lancer la migration de la base, prévenir Django que `easy_thumbnail` est déjà OK : 
+**Avant** de lancer la migration de la base, prévenir Django que `easy_thumbnail` est déjà OK :
 
 
 ```
@@ -208,7 +208,7 @@ stderr_logfile = /opt/zdsenv/logs/supervisor_stderr.log
 
 ```
 
-4. Redémarrer Supervisor pour prendre en compte les modifications : `sudo service supervisor restart` 
+4. Redémarrer Supervisor pour prendre en compte les modifications : `sudo service supervisor restart`
 
 
 Issue #1634
@@ -231,3 +231,16 @@ Fix sur la recherche d'article avec Solr :
   - Redémarrer Solr : `supervisorctl start solr`
   - Lancer l'indexation : `python manage.py rebuild_index`
 
+Issue #2753 et #2751
+--------------------
+
+Règle le souci de migration de oauth2_provider.
+La mise à jour de oauth2_provider met la table oauth2_provider dans un état bancale à cause d'une migration non appliquée par South (vu que non utilisé par Django 1.7).
+Pour régler ça, il faut faire les modifications de la migration nous-même.
+
+  - Se connecter sur mysql : `mysql -u <user> -D <base> -p` (puis entrer le mot de passe au prompt)
+  - Ajouter une colonne à la table oauth2_provider_application : `ALTER TABLE oauth2_provider_application ADD COLUMN skip_authorization TINYINT NOT NULL DEFAULT 0;`
+  - Ajouter une clé étrangère à la table oauth2_provider_accesstoken : `ALTER TABLE oauth2_provider_accesstoken ADD CONSTRAINT fk_user_oauth2_provider_accesstoken FOREIGN KEY(user_id) REFERENCES auth_user(id);`
+  - Les deux commandes doivent passer sans souci
+  - Quitter mysql
+  - Puis feinter la migration de oauth2_provider : `python manage.py migrate oauth2_provider --fake`


### PR DESCRIPTION
Un commit con en apparence mais important :D

| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | #2753 , #2751 |

Ce commit indique juste comment réussir a remettre sur pied la table de oauth2_provider qui est bancale suite a un tres mauvais concours de circonstances.

Si vous voulez QA il faut (sans certitude et probablement sur une base MySQL serait mieux) :
- Se lancer sur prod' avec les requirements de l’époque et une base de données propre a ce moment
- Switcher sur dev'
- Mettre a jour ses requirements et faire un migrate
- Constater que l'api ou la désinscription ne marche plus car la BDD est pas d’équerre
- Faire les choses indiques dans le `update.md`
- Retester l'API ou la désinscription et tout devrait marcher...
- A cote de ca le "social authentification" devrait toujours marcher...

Bref... une plaie... Toutes les opérations (et uniquement elles) du commit ont ete faite sur la preprod' pour la remettre en état de marche. Je sais que ca vaux pas une vraie QA mais comme j'ai peur que personne n'en fasse une ici j'aime autant prévenir...
