### PR TITLE
Enleve le champ d'image pour les chapitres pour le moment

### DIFF
--- a/zds/tutorial/forms.py
+++ b/zds/tutorial/forms.py
@@ -261,7 +261,7 @@ class ChapterForm(FormWithTitle):
 
         self.helper.layout = Layout(
             Field('title'),
-            Field('image'),
+            # Field('image'),  # disable because not used yet
             Field('introduction', css_class='md-editor'),
             Field('conclusion', css_class='md-editor'),
             Field('msg_commit'),

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -719,7 +719,8 @@ class Chapter(models.Model):
 
     image = models.ForeignKey(Image,
                               verbose_name='Image du chapitre',
-                              blank=True, null=True)
+                              blank=True, null=True,
+                              on_delete=models.SET_NULL)
     # This field is required in order to use pagination in chapters, see the
     # update_position_in_tutorial() method.
     position_in_tutorial = models.IntegerField('Position dans le tutoriel',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | #2812 |

Enleve le champ d'image pour les chapitres pour le moment afin d'eviter un bug genant (qui se reproduit dans des conditions particulieres)
### QA
- Verifier l'absence du champ pour charger une image dans la creation/edition de chapitre
- Verifier que ca ne perturbe pas le workflow de creation d'un tuto (jusqu'a publication)
- Confirmer la resolution du bug
