### PR TITLE
Vire les informations non pertinentes pour les membres robots

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -39,18 +39,23 @@
             </div>
 
             <ul class="member-infos">
-                <li>
-                    {% trans "Inscrit" %} {{ usr.date_joined|format_date:True }}
-                </li>
-                <li>
-                    {% trans "Dernière visite sur le site" %} :
-                        {% if profile.last_visit %}
-                            {{ profile.last_visit|format_date:True }}
-                        {% else %}
-                            {% trans "ne s'est jamais connecté(e)" %}
-                        {% endif %}
-                </li>
-
+                {% if not profile.is_private %}
+                    <li>
+                        {% trans "Inscrit" %} {{ usr.date_joined|format_date:True }}
+                    </li>
+                    <li>
+                        {% trans "Dernière visite sur le site" %} :
+                            {% if profile.last_visit %}
+                                {{ profile.last_visit|format_date:True }}
+                            {% else %}
+                                {% trans "ne s'est jamais connecté(e)" %}
+                            {% endif %}
+                    </li>
+                {% else %}
+                    <li>
+                        Ce membre est un compte d'administration
+                    </li>
+                {% endif %}
                 {% if perms.member.show_ip %}
                     <li>
                         {% trans "Dernière IP" %} : <a href="{% url "zds.member.views.member_from_ip" profile.last_ip_address %}">{{ profile.last_ip_address }}</a>

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -53,7 +53,7 @@
                     </li>
                 {% else %}
                     <li>
-                        Ce membre est un compte d'administration
+                        {% trans "Ce membre est un compte d'administration" %}
                     </li>
                 {% endif %}
                 {% if perms.member.show_ip %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | #2814 |

Ce commit supprime les informations non pertinentes (date inscription et dernière visite) pour un compte robot et les remplace par un message informant sur le but de ce compte (**besoin d'avis sur ce message**...). J'ai pris le plis de laisser l'IP "au cas ou" quelqu'un arriverait a s'y connecter et faire n'importe quoi avec... (même si ca serait toujours visible en BDD de toute façon)
### QA

Vérifier le comportement des infos de profils pour différents membres (staff, admin, user, robot...) et dans différents modes (connecte en tant que staff, admin, user, hors-ligne...)
