### PR TITLE
Facebook enregistre maintenant les emails

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -486,6 +486,7 @@ AUTHENTICATION_BACKENDS = ('social.backends.facebook.FacebookOAuth2',
                            'social.backends.google.GoogleOAuth2',
                            'django.contrib.auth.backends.ModelBackend')
 SOCIAL_AUTH_GOOGLE_OAUTH2_USE_DEPRECATED_API = True
+SOCIAL_AUTH_FACEBOOK_SCOPE = ['email']
 
 SOCIAL_AUTH_PIPELINE = (
     'social.pipeline.social_auth.social_details',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2217 |

QA (Elle prend pas plus de 3 minutes ^^):
- Aller dans le settings.py dans le dossier zds
- Remplacer les deux lignes: 

```
# redefine for real key and secret code
SOCIAL_AUTH_FACEBOOK_KEY = ""
SOCIAL_AUTH_FACEBOOK_SECRET = ""
```

par 

```
SOCIAL_AUTH_FACEBOOK_KEY = "1602384896675944"
SOCIAL_AUTH_FACEBOOK_SECRET = "edb3b86854c3378d64497974cb7d4791"
```
- Aller sur la page d'inscription ou de connexion. Cliquer sur le bouton 'Facebook'
- Aller dans les paramètre de votre compte et cocher la case 'afficher votre email publiquement'
- Aller sur la page de votre profil, vérifier qu'une adresse email s'affiche.
