### PR TITLE
Répare les fixtures des forums

### DIFF
--- a/zds/forum/factories.py
+++ b/zds/forum/factories.py
@@ -39,6 +39,7 @@ class PostFactory(factory.DjangoModelFactory):
 
     ip_address = '192.168.3.1'
     text = 'Bonjour, je me présente, je m\'appelle l\'homme au texte bidonné'
+    text_html = text
 
     @classmethod
     def _prepare(cls, create, **kwargs):

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -232,6 +232,7 @@ def load_topics(cli, size, fake):
                     topic.title = fake.text(max_nb_chars=80)
                     topic.subtitle = fake.text(max_nb_chars=200)
                     topic.save()
+                    PostFactory(topic=topic, author=topic.author, position=1)
                     sys.stdout.write(" Topic {}/{}  \r".format(i + 1, nb_topics))
                     sys.stdout.flush()
                 tps2 = time.time()
@@ -258,12 +259,9 @@ def load_posts(cli, size, fake):
         else:
             profiles = list(Profile.objects.all())
             for i in range(0, nb_topics):
-                nb_posts = randint(0, nb_avg_posts_in_topic * 2)
-                for j in range(0, nb_posts):
-                    if j == 0:
-                        post = PostFactory(topic=topics[i], author=topics[i].author, position=1)
-                    else:
-                        post = PostFactory(topic=topics[i], author=profiles[j % nb_users].user, position=j + 1)
+                nb_posts = randint(0, nb_avg_posts_in_topic * 2) + 1
+                for j in range(1, nb_posts):
+                    post = PostFactory(topic=topics[i], author=profiles[j % nb_users].user, position=j + 1)
                     post.text = fake.paragraph(nb_sentences=5, variable_nb_sentences=True)
                     post.text_html = emarkdown(post.text)
                     if int(nb_posts * 0.3) > 0:


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2774 |

A la création d'un topic, un premier post par l'auteur du topic est automatiquement crée (comme ce serait le cas dans la vraie vie) évitant ainsi de se retrouver avec des topics inaccessibles car mal-construit.
### QA

En testant la commande de création de fixtures (en low ca suffit), créer uniquement des topics (type=topic) et constater qu'ils sont bien accessibles. Ensuite créer des posts (type=post) et vérifier que ça marche toujours. Enfin, reset de la bdd et faire les deux en même temps (type=topic,post) et vérifier que tout marche toujours.
