### PR TITLE
Regle des soucis de throttling

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -210,6 +210,7 @@ REST_FRAMEWORK = {
     # Active OAuth2 authentication.
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'oauth2_provider.ext.rest_framework.OAuth2Authentication',
+        'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_PARSER_CLASSES': (
         'rest_framework.parsers.JSONParser',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2386 |

Étend le throttling pour les utilisateurs connecte. Ainsi, un utilisateur connecte ne se mange plus des limites sur l'autocompletion au bout des 60 essais par heure.

La **QA** est bien tricky car il faut avoir un serveur avec throttling de configuré... Si vous avez ca, ramenez le fix et constatez que vous ne vous prenez plus des 429 au bout de 60 essais d'autocompletion lorsque vous êtes connecte sur le site. Par contre si vous vous déconnecter et essayer l'API vous devez vous faire jeter rapidement...
