### PR TITLE
N'indexe plus les contenus non publiés (sur la bonne branche)

### DIFF
--- a/zds/tutorial/search_indexes.py
+++ b/zds/tutorial/search_indexes.py
@@ -5,6 +5,7 @@ from django.db.models import Q
 from haystack import indexes
 
 from zds.tutorial.models import Tutorial, Part, Chapter, Extract
+from zds.utils.tutorials import GetPublished
 
 
 class TutorialIndex(indexes.SearchIndex, indexes.Indexable):
@@ -34,9 +35,10 @@ class PartIndex(indexes.SearchIndex, indexes.Indexable):
         return Part
 
     def index_queryset(self, using=None):
-        """Only parts online."""
-        return self.get_model().objects.filter(
-            tutorial__sha_public__isnull=False)
+
+        published_content = GetPublished().get_published_content()
+
+        return self.get_model().objects.filter(tutorial__sha_public__isnull=False, id__in=published_content["parts"])
 
 
 class ChapterIndex(indexes.SearchIndex, indexes.Indexable):
@@ -51,9 +53,11 @@ class ChapterIndex(indexes.SearchIndex, indexes.Indexable):
 
     def index_queryset(self, using=None):
         """Only chapters online."""
-        return self.get_model()\
-            .objects.filter(Q(tutorial__sha_public__isnull=False) |
-                            Q(part__tutorial__sha_public__isnull=False))
+        published_content = GetPublished().get_published_content()
+
+        return self.get_model().objects.filter(Q(tutorial__sha_public__isnull=False) |
+                                               Q(part__tutorial__sha_public__isnull=False),
+                                               id__in=published_content["chapters"])
 
 
 class ExtractIndex(indexes.SearchIndex, indexes.Indexable):
@@ -67,5 +71,9 @@ class ExtractIndex(indexes.SearchIndex, indexes.Indexable):
 
     def index_queryset(self, using=None):
         """Only extracts online."""
+
+        published_content = GetPublished().get_published_content()
+
         return self.get_model() .objects.filter(Q(chapter__tutorial__sha_public__isnull=False) |
-                                                Q(chapter__part__tutorial__sha_public__isnull=False))
+                                                Q(chapter__part__tutorial__sha_public__isnull=False),
+                                                id__in=published_content["extracts"])

--- a/zds/utils/tutorials.py
+++ b/zds/utils/tutorials.py
@@ -15,9 +15,73 @@ from zds.utils import slugify
 from zds.utils.models import Licence
 
 
+# Used for indexing tutorials, we need to parse each manifest to know which content have been published
+class GetPublished:
+
+    published_part = []
+    published_chapter = []
+    published_extract = []
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def get_published_content(cls):
+        # If all array are empty load_it
+        if not len(GetPublished.published_part) and \
+           not len(GetPublished.published_chapter) and \
+           not len(GetPublished.published_extract):
+
+            # Get all published tutorials
+            from zds.tutorial.models import Tutorial
+            tutorials_database = Tutorial.objects.filter(sha_public__isnull=False).all()
+
+            for tutorial in tutorials_database:
+                # Load Manifest
+                json = tutorial.load_json_for_public()
+
+                # Parse it
+                GetPublished.load_tutorial(json)
+
+        return {"parts": GetPublished.published_part,
+                "chapters": GetPublished.published_chapter,
+                "extracts": GetPublished.published_extract}
+
+    @classmethod
+    def load_tutorial(cls, json):
+        # Load parts, chapter and extract
+        if 'parts' in json:
+            for part_json in json['parts']:
+
+                # If inside of parts we have chapters, load it
+                GetPublished.load_chapters(part_json)
+                GetPublished.load_extracts(part_json)
+
+                GetPublished.published_part.append(part_json['pk'])
+
+        GetPublished.load_chapters(json)
+        GetPublished.load_extracts(json)
+
+    @classmethod
+    def load_chapters(cls, json):
+        if 'chapters' in json:
+            for chapters_json in json['chapters']:
+
+                GetPublished.published_chapter.append(chapters_json['pk'])
+                GetPublished.load_extracts(chapters_json)
+
+        return GetPublished.published_chapter
+
+    @classmethod
+    def load_extracts(cls, json):
+        if 'extracts' in json:
+            for extract_json in json['extracts']:
+                GetPublished.published_extract.append(extract_json['pk'])
+
+        return GetPublished.published_extract
+
+
 # Export-to-dict functions
-
-
 def export_chapter(chapter, export_all=True):
     from zds.tutorial.models import Extract
     """


### PR DESCRIPTION
La même que https://github.com/zestedesavoir/zds-site/pull/2834 mais sur la bonne branche.

| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2819 |

QA: 
- Créé un tutoriel avec tous ce que voulez à l’intérieur: partie, chapitres, extraits et publier le.
- Ajouter une partie, ou/et un chapitre ou/et un extrait
- Indexer
