### PR TITLE
Revert "N'indexe plus les contenus non publiés" (branche dev)

### DIFF
--- a/zds/tutorial/search_indexes.py
+++ b/zds/tutorial/search_indexes.py
@@ -5,7 +5,6 @@ from django.db.models import Q
 from haystack import indexes
 
 from zds.tutorial.models import Tutorial, Part, Chapter, Extract
-from zds.utils.tutorials import GetPublished
 
 
 class TutorialIndex(indexes.SearchIndex, indexes.Indexable):
@@ -35,10 +34,9 @@ class PartIndex(indexes.SearchIndex, indexes.Indexable):
         return Part
 
     def index_queryset(self, using=None):
-
-        published_content = GetPublished().get_published_content()
-
-        return self.get_model().objects.filter(tutorial__sha_public__isnull=False, id__in=published_content["parts"])
+        """Only parts online."""
+        return self.get_model().objects.filter(
+            tutorial__sha_public__isnull=False)
 
 
 class ChapterIndex(indexes.SearchIndex, indexes.Indexable):
@@ -53,11 +51,9 @@ class ChapterIndex(indexes.SearchIndex, indexes.Indexable):
 
     def index_queryset(self, using=None):
         """Only chapters online."""
-        published_content = GetPublished().get_published_content()
-
-        return self.get_model().objects.filter(Q(tutorial__sha_public__isnull=False) |
-                                               Q(part__tutorial__sha_public__isnull=False),
-                                               id__in=published_content["chapters"])
+        return self.get_model()\
+            .objects.filter(Q(tutorial__sha_public__isnull=False) |
+                            Q(part__tutorial__sha_public__isnull=False))
 
 
 class ExtractIndex(indexes.SearchIndex, indexes.Indexable):
@@ -71,9 +67,5 @@ class ExtractIndex(indexes.SearchIndex, indexes.Indexable):
 
     def index_queryset(self, using=None):
         """Only extracts online."""
-
-        published_content = GetPublished().get_published_content()
-
         return self.get_model() .objects.filter(Q(chapter__tutorial__sha_public__isnull=False) |
-                                                Q(chapter__part__tutorial__sha_public__isnull=False),
-                                                id__in=published_content["extracts"])
+                                                Q(chapter__part__tutorial__sha_public__isnull=False))

--- a/zds/tutorial/tests/tests.py
+++ b/zds/tutorial/tests/tests.py
@@ -7,8 +7,6 @@ import zipfile
 import datetime
 
 from git import Repo
-from zds.utils.tutorials import GetPublished
-
 try:
     import ujson as json_reader
 except:
@@ -31,8 +29,8 @@ from zds.gallery.factories import UserGalleryFactory, ImageFactory
 from zds.mp.models import PrivateTopic
 from zds.forum.models import Topic
 from zds.settings import BASE_DIR
-from zds.tutorial.factories import BigTutorialFactory, MiniTutorialFactory, PartFactory, ChapterFactory, \
-    NoteFactory, SubCategoryFactory, LicenceFactory, ExtractFactory
+from zds.tutorial.factories import BigTutorialFactory, MiniTutorialFactory, PartFactory, \
+    ChapterFactory, NoteFactory, SubCategoryFactory, LicenceFactory
 from zds.gallery.factories import GalleryFactory
 from zds.tutorial.models import Note, Tutorial, Validation, Extract, Part, Chapter
 from zds.tutorial.views import insert_into_zip
@@ -2919,105 +2917,6 @@ class BigTutorialTests(TestCase):
         self.assertIn(typo_text, sent_pm.last_message.text)  # typo is in message
         self.assertIn(Chapter.objects.get(pk=self.chapter1_1.pk).get_absolute_url_beta(),
                       sent_pm.last_message.text)  # public url is in message
-
-    def test_get_published_content(self):
-        """
-        Add a non-regression test for not indexing content that have not been published.
-        """
-
-        count_parts = len(self.bigtuto.get_parts())
-        count_chapter = Chapter.objects.count()
-
-        # Non published Chapter and Extracts
-        non_published_chapter_link_tuto = ChapterFactory(tutorial=self.bigtuto)
-        ExtractFactory(chapter=non_published_chapter_link_tuto, position_in_chapter=1)
-
-        # Non published parts, chapters and extracts
-        self.part4 = PartFactory(tutorial=self.bigtuto, position_in_tutorial=4)
-        non_published_chapter = ChapterFactory(part=self.part4)
-        ExtractFactory(chapter=non_published_chapter, position_in_chapter=1)
-
-        # Create a non published parts and chapters
-        self.part5 = PartFactory(tutorial=self.bigtuto, position_in_tutorial=5)
-        ChapterFactory(part=self.part5)
-
-        # Empty non published parts
-        PartFactory(tutorial=self.bigtuto, position_in_tutorial=6)
-
-        # Empty non published chapters
-        ChapterFactory(tutorial=self.bigtuto)
-
-        published_content = GetPublished().get_published_content()
-        self.assertEqual(len(published_content["parts"]), count_parts)
-        self.assertEqual(len(published_content["chapters"]), count_chapter)
-
-        # Clear all the lists
-        GetPublished.published_part = []
-        GetPublished.published_chapter = []
-        GetPublished.published_extract = []
-
-        # Manifest for tutorial with parts only
-        m = '{"title": "Ceci est un test", "parts": [{"pk": 1}] }'
-        json = json_reader.loads(m)
-
-        GetPublished.load_tutorial(json)
-        self.assertEqual(GetPublished.published_part[0], 1)
-
-        GetPublished.published_part = []
-
-        # Manifest for tutorial with chapters only
-        m = '{"title": "Ceci est un test", "chapters": [{"pk": 1}] }'
-        json = json_reader.loads(m)
-
-        GetPublished.load_tutorial(json)
-        self.assertEqual(GetPublished.published_chapter[0], 1)
-
-        GetPublished.published_chapter = []
-
-        # Manifest for tutorial with extracts only
-        m = '{"title": "Ceci est un test", "extracts": [{"pk": 1}] }'
-        json = json_reader.loads(m)
-
-        GetPublished.load_tutorial(json)
-        self.assertEqual(GetPublished.published_extract[0], 1)
-
-        GetPublished.published_extract = []
-
-        # Manifest for tutorial with parts, chapters and extracts
-        m = '{"title": "Ceci est un test", "parts": [{"pk": 1, "chapters":[{"pk": 2, "extracts":[{"pk": 3}] }] }] }'
-        json = json_reader.loads(m)
-
-        GetPublished.load_tutorial(json)
-        self.assertEqual(GetPublished.published_part[0], 1)
-        self.assertEqual(GetPublished.published_chapter[0], 2)
-        self.assertEqual(GetPublished.published_extract[0], 3)
-
-        # Manifest for tutorial with chapters and extracts
-        GetPublished.published_part = []
-        GetPublished.published_chapter = []
-        GetPublished.published_extract = []
-
-        m = '{"title": "Ceci est un test", "chapters": [{"pk": 1, "extracts":[{"pk": 2}] }] }'
-        json = json_reader.loads(m)
-
-        GetPublished.load_tutorial(json)
-        self.assertEqual(GetPublished.published_chapter[0], 1)
-        self.assertEqual(GetPublished.published_extract[0], 2)
-
-        GetPublished.published_chapter = []
-        GetPublished.published_extract = []
-
-        # Manifest for tutorial with parts and chapters
-
-        m = '{"title": "Ceci est un test", "parts": [{"pk": 1, "chapters":[{"pk": 2}] }] }'
-        json = json_reader.loads(m)
-
-        GetPublished.load_tutorial(json)
-        self.assertEqual(GetPublished.published_part[0], 1)
-        self.assertEqual(GetPublished.published_chapter[0], 2)
-
-        GetPublished.published_part = []
-        GetPublished.published_chapter = []
 
     def tearDown(self):
         if os.path.isdir(settings.ZDS_APP['tutorial']['repo_path']):

--- a/zds/utils/tutorials.py
+++ b/zds/utils/tutorials.py
@@ -15,73 +15,9 @@ from zds.utils import slugify
 from zds.utils.models import Licence
 
 
-# Used for indexing tutorials, we need to parse each manifest to know which content have been published
-class GetPublished:
-
-    published_part = []
-    published_chapter = []
-    published_extract = []
-
-    def __init__(self):
-        pass
-
-    @classmethod
-    def get_published_content(cls):
-        # If all array are empty load_it
-        if not len(GetPublished.published_part) and \
-           not len(GetPublished.published_chapter) and \
-           not len(GetPublished.published_extract):
-
-            # Get all published tutorials
-            from zds.tutorial.models import Tutorial
-            tutorials_database = Tutorial.objects.filter(sha_public__isnull=False).all()
-
-            for tutorial in tutorials_database:
-                # Load Manifest
-                json = tutorial.load_json_for_public()
-
-                # Parse it
-                GetPublished.load_tutorial(json)
-
-        return {"parts": GetPublished.published_part,
-                "chapters": GetPublished.published_chapter,
-                "extracts": GetPublished.published_extract}
-
-    @classmethod
-    def load_tutorial(cls, json):
-        # Load parts, chapter and extract
-        if 'parts' in json:
-            for part_json in json['parts']:
-
-                # If inside of parts we have chapters, load it
-                GetPublished.load_chapters(part_json)
-                GetPublished.load_extracts(part_json)
-
-                GetPublished.published_part.append(part_json['pk'])
-
-        GetPublished.load_chapters(json)
-        GetPublished.load_extracts(json)
-
-    @classmethod
-    def load_chapters(cls, json):
-        if 'chapters' in json:
-            for chapters_json in json['chapters']:
-
-                GetPublished.published_chapter.append(chapters_json['pk'])
-                GetPublished.load_extracts(chapters_json)
-
-        return GetPublished.published_chapter
-
-    @classmethod
-    def load_extracts(cls, json):
-        if 'extracts' in json:
-            for extract_json in json['extracts']:
-                GetPublished.published_extract.append(extract_json['pk'])
-
-        return GetPublished.published_extract
-
-
 # Export-to-dict functions
+
+
 def export_chapter(chapter, export_all=True):
     from zds.tutorial.models import Extract
     """


### PR DESCRIPTION
Reverts zestedesavoir/zds-site#2834 du à un merge dans la mauvaise branche (dev au lieu de release). Ce revert à lieu pour éviter de poser de quelconque souci lors du merge de release dans dev plus tard.
