### PR TITLE
[15.6] L'indexation des droits fait planter la recherche

### DIFF
--- a/zds/search/views.py
+++ b/zds/search/views.py
@@ -38,16 +38,21 @@ class CustomSearchView(SearchView):
     def get_results(self):
         queryset = super(CustomSearchView, self).get_results()
 
+        # Due to a bug in Haystack library (https://github.com/django-haystack/django-haystack/issues/163)
+        # We can do field = None or use __isnull. We are obliged to use a raw solr query.
+        # Obviously, it is solr dependant
+        is_empty = Raw("[* TO *]")
+
         # We want to search only on authorized post and topic
         if self.request.user.is_authenticated():
             groups = self.request.user.groups
 
             if groups.count() > 0:
-                return queryset.filter_or(permissions=Raw("[* TO *]"), permissions__in=groups.all())
+                return queryset.filter_or(permissions=is_empty, permissions__in=groups.all())
             else:
-                return queryset.exclude(permissions=Raw("[* TO *]"))
+                return queryset.exclude(permissions=is_empty)
         else:
-            return queryset.exclude(permissions=Raw("[* TO *]"))
+            return queryset.exclude(permissions=is_empty)
 
 
 def opensearch(request):

--- a/zds/search/views.py
+++ b/zds/search/views.py
@@ -2,6 +2,7 @@
 
 from django.shortcuts import render
 from django.core.urlresolvers import reverse
+from haystack.inputs import Raw
 
 from haystack.views import SearchView
 
@@ -42,12 +43,11 @@ class CustomSearchView(SearchView):
             groups = self.request.user.groups
 
             if groups.count() > 0:
-                return queryset.filter_or(permissions=None, permissions__in=groups.all())
+                return queryset.filter_or(permissions=Raw("[* TO *]"), permissions__in=groups.all())
             else:
-                return queryset.filter(permissions=None)
-
+                return queryset.exclude(permissions=Raw("[* TO *]"))
         else:
-            return queryset.filter(permissions=None)
+            return queryset.exclude(permissions=Raw("[* TO *]"))
 
 
 def opensearch(request):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/pull/2767 |

Dans certains cas, bien précis, on tombait sur un [bug upstream dans la librairie haystack](https://github.com/django-haystack/django-haystack/issues/163) qui empêchait de retourner les résultats de la recherche.

Le = None, contrairement à Django, ne marche pas. 

QA:
- Mettre des droits sur un forum
- Avec un membre non inscrit, vérifier que vous ne pouvez pas rechercher les topics qui sont dans le forum privé. Vérifier aussi que vous pouvez rechercher des topics qui sont dans les autres forums.
- Avec un membre inscrit sans droit, vérifier que vous ne pouvez pas rechercher les topics qui sont dans le forum privé. Vérifier aussi que vous pouvez rechercher des topics qui sont dans les autres forums.
- Avec le profil admin, vérifier que vous pouvez rechercher les topics qui sont dans le forum privé. Vérifier aussi que vous pouvez rechercher des topics qui sont dans les autres forums.
