### PR TITLE
Posibilité de recherche en français

### DIFF
--- a/doc/source/install/install-solr.rst
+++ b/doc/source/install/install-solr.rst
@@ -31,7 +31,7 @@ Ouvrez le terminal ou powershell
 
 .. code:: bash
 
-    python manage.py build_solr_schema > %solr_home%/example/solr/collection1/conf/schema.xml
+    python manage.py build_solr_schema_fr > %solr_home%/example/solr/collection1/conf/schema.xml
 
 où ``%solr_home%`` est le dossier dans lequel vous avez installé Solr.
 

--- a/update.md
+++ b/update.md
@@ -244,3 +244,13 @@ Pour régler ça, il faut faire les modifications de la migration nous-même.
   - Les deux commandes doivent passer sans souci
   - Quitter mysql
   - Puis feinter la migration de oauth2_provider : `python manage.py migrate oauth2_provider --fake`
+  
+Actions à faire pour mettre en prod la prochaine version
+========================================================
+
+La recherche est maintenant en français:
+
+  - Arrêter Solr : `supervisorctl stop solr`
+  - Utiliser la nouvelle commande pour regénérer le schema.xml : `python manage.py build_solr_schema_fr > /votre/path/vers/solr-4.9.1/example/solr/collection1/conf/schema.xml`
+  - Redémarrer Solr : `supervisorctl start solr`
+  - Lancer l'indexation : `python manage.py rebuild_index`

--- a/zds/utils/management/commands/build_solr_schema_fr.py
+++ b/zds/utils/management/commands/build_solr_schema_fr.py
@@ -1,0 +1,96 @@
+from io import StringIO
+import xml.etree.ElementTree as libxml
+from optparse import make_option
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from haystack import constants
+
+import sys
+
+
+class Command(BaseCommand):
+    help = 'Generates a Solr schema with french filter that reflects the indexes.'
+    base_options = (
+        make_option("-f", "--filename", action="store", type="string", dest="filename",
+                    help='If provided, directs output to a file instead of stdout.'),
+        make_option("-u", "--using", action="store", type="string", dest="using", default=constants.DEFAULT_ALIAS,
+                    help='If provided, chooses a connection to work with.'),
+    )
+    option_list = BaseCommand.option_list + base_options
+
+    def handle(self, *args, **options):
+        using = options.get('using')
+        filename = options.get('filename')
+
+        command = 'build_solr_schema'
+
+        if using and using != 'default':
+            command + ' --using ' + using
+
+        # We need to save the build_solr_schema
+        orig_stdout = sys.stdout
+        sys.stdout = contentio = StringIO()
+
+        # Call the command
+        call_command(command, stdout=contentio)
+
+        # Save the result
+        sys.stdout = orig_stdout
+        contentio.seek(0)
+        content = contentio.getvalue()
+        contentio.close()
+
+        # Load the XML
+        root = libxml.fromstring(content)
+
+        field_type_french = '    <fieldType name="text_french" class="solr.TextField" positionIncrementGap="100">\n' \
+                            '      <analyzer>\n' \
+                            '        <tokenizer class="solr.StandardTokenizerFactory" />\n' \
+                            '        <filter class="solr.ElisionFilterFactory" ignoreCase="true" ' \
+                            '        articles="lang/contractions_fr.txt"/>\n' \
+                            '        <filter class="solr.LowerCaseFilterFactory"/>\n' \
+                            '        <filter class="solr.StopFilterFactory" ignoreCase="true" ' \
+                            '        words="lang/stopwords_fr.txt" format="snowball" />\n' \
+                            '        <filter class="solr.FrenchLightStemFilterFactory"/>\n' \
+                            '      </analyzer>\n' \
+                            '    </fieldType>\n' \
+
+        xml_field_type_french = libxml.fromstring(field_type_french)
+
+        root.find('types').append(xml_field_type_french)
+
+        # Replace all text_en to text_french
+        for field in root.find('fields').findall('field'):
+            if field.get('type') == 'text_en':
+                field.set('type', 'text_french')
+
+        licence = '<?xml version="1.0" ?>\n' \
+                  '<!--\n' \
+                  '  Licensed to the Apache Software Foundation (ASF) under one or more\n' \
+                  '  contributor license agreements.  See the NOTICE file distributed with\n' \
+                  '  this work for additional information regarding copyright ownership.\n' \
+                  '  The ASF licenses this file to You under the Apache License, Version 2.0\n' \
+                  '  (the "License"); you may not use this file except in compliance with\n' \
+                  '  the License. You may obtain a copy of the License at\n' \
+                  '\n' \
+                  '      http://www.apache.org/licenses/LICENSE-2.0\n' \
+                  '\n' \
+                  '  Unless required by applicable law or agreed to in writing, software\n' \
+                  '  distributed under the License is distributed on an "AS IS" BASIS,\n' \
+                  '  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n' \
+                  '  See the License for the specific language governing permissions and\n' \
+                  '  limitations under the License.\n' \
+                  '-->\n'
+
+        xml = licence + libxml.tostring(root)
+
+        if filename:
+            self.write_file(options.get('filename'), xml)
+        else:
+            self.stdout.write(xml)
+
+    def write_file(self, filename, schema_xml):
+        schema_file = open(filename, 'w')
+        schema_file.write(schema_xml)
+        schema_file.close()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | ~oui |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2401 |

Donne la possibilité aux utilisateurs de pouvoir rechercher en français.

Pour cela, j'ai du créé une nouvelle commande `build_solr_schema_fr` qui est basé sur `build_solr_schema` de Haystack. La commande modifie un peu le schema.xml pour rajouter une balise. Celle-ci définit, les différents filtres et le tokeniser à appliquer.

```
<fieldType name="text_french" class="solr.TextField" positionIncrementGap="100">
  <analyzer>
    <tokenizer class="solr.StandardTokenizerFactory" /> # Decoupe les mots
    <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/> # Decoupe les mots contracté style j'aime et ignore la partie non intéréssent 
    <filter class="solr.LowerCaseFilterFactory"/> # On met tout en minuscule
    <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" /># On supprime les mots pas intéressent
    <filter class="solr.FrenchLightStemFilterFactory"/> #  racinisation ou désuffixation. On peut aussi utiliser la version Minimal.
  </analyzer>
</fieldType>
```

Le script permet de remplacer les text_en en text_french pour appliquer les filtres. 

La doc sur le sujet arrive dans un prochain commit 

QA:
- Généré le nouveau schema.xml grâce à la commande `python manage.py build_solr_schema_fr` 
- Remplacer le nouveau schema.xml par l'ancien dans dossier d'installation solr/example/solr/collection1/conf/schema.xml
- Redémarrer votre instance Solr (trés important)
- Aller dans l'administration http://127.0.0.1:8983/solr/#, dans la liste déroulante sur votre gauche, choisissez "collection1". Puis juste en-dessous, cliquer sur le bouton 'Analysis'. Une nouvelle page s'ouvre, 
  ![solr-recherche-fr](https://cloud.githubusercontent.com/assets/6099338/8272934/ec3e2d2e-1857-11e5-8cca-101dc1307ea2.png). 

Cette interface permet de savoir quels filtres sont appliqués et comment. Le champ à gauche, c'est pour l'indexation et à droite pour la recherche.

Taper une phrase d'exemple en français dans le champ à gauche comme dans la capture. Choisissez le champ, par-exemple: "text". Cliquer maintenant sur le bouton "Analyse Values" en bleu à droite. Vous avez un tableau avec chaque mot en colonne et sur les lignes c'est les résultats après chaque filtre, dans la première colonne vous avez le nom des filtres, si vous passez votre curseur dessus. Vérifier que le nom des filtres correspondent bien à StandardTokenizerFactory, ElisionFilterFactory, LowerCaseFilterFactory, StopFilterFactory, FrenchLightStemFilterFactory.
