### PR TITLE
Configuration de la recherche en francais

### DIFF
--- a/templates/search_configuration/solr.xml
+++ b/templates/search_configuration/solr.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" ?>
+<!--
+ build_solr_schema uses a template to generate schema.xml.
+ Haystack provides a default template using some sensible defaults. This template override Haystack default template.
+
+ We add a new fieldType, called 'text_french' with some filters and tokenisers to provide indexation and search in french.
+ We applied it, in the field loop.
+-->
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<schema name="default" version="1.5">
+    <types>
+        <fieldtype name="string"  class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+        <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
+        <fieldtype name="binary" class="solr.BinaryField"/>
+
+        <!-- Numeric field types that manipulate the value into
+             a string value that isn't human-readable in its internal form,
+             but with a lexicographic ordering the same as the numeric ordering,
+             so that range queries work correctly. -->
+        <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="true" sortMissingLast="true" positionIncrementGap="0"/>
+        <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="true" sortMissingLast="true" positionIncrementGap="0"/>
+        <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" sortMissingLast="true" positionIncrementGap="0"/>
+        <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true" sortMissingLast="true" positionIncrementGap="0"/>
+        <fieldType name="sint" class="solr.SortableIntField" sortMissingLast="true" omitNorms="true"/>
+        <fieldType name="slong" class="solr.SortableLongField" sortMissingLast="true" omitNorms="true"/>
+        <fieldType name="sfloat" class="solr.SortableFloatField" sortMissingLast="true" omitNorms="true"/>
+        <fieldType name="sdouble" class="solr.SortableDoubleField" sortMissingLast="true" omitNorms="true"/>
+
+        <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+        <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+        <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+        <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+
+        <fieldType name="date" class="solr.TrieDateField" omitNorms="true" precisionStep="0" positionIncrementGap="0"/>
+        <!-- A Trie based date field for faster date range queries and date faceting. -->
+        <fieldType name="tdate" class="solr.TrieDateField" omitNorms="true" precisionStep="6" positionIncrementGap="0"/>
+
+        <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+        <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+        <fieldtype name="geohash" class="solr.GeoHashField"/>
+
+        <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
+            <analyzer type="index">
+                <tokenizer class="solr.StandardTokenizerFactory"/>
+                <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+                <!-- in this example, we will only use synonyms at query time
+                <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+                -->
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+            <analyzer type="query">
+                <tokenizer class="solr.StandardTokenizerFactory"/>
+                <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+                <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+        </fieldType>
+
+        <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
+            <analyzer type="index">
+                <tokenizer class="solr.StandardTokenizerFactory"/>
+                <filter class="solr.StopFilterFactory"
+                        ignoreCase="true"
+                        words="lang/stopwords_en.txt"
+                        enablePositionIncrements="true"
+                        />
+                <filter class="solr.LowerCaseFilterFactory"/>
+                <filter class="solr.EnglishPossessiveFilterFactory"/>
+                <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+                <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
+                  <filter class="solr.EnglishMinimalStemFilterFactory"/>
+                -->
+                <filter class="solr.PorterStemFilterFactory"/>
+            </analyzer>
+            <analyzer type="query">
+                <tokenizer class="solr.StandardTokenizerFactory"/>
+                <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+                <filter class="solr.StopFilterFactory"
+                        ignoreCase="true"
+                        words="lang/stopwords_en.txt"
+                        enablePositionIncrements="true"
+                        />
+                <filter class="solr.LowerCaseFilterFactory"/>
+                <filter class="solr.EnglishPossessiveFilterFactory"/>
+                <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+                <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
+                  <filter class="solr.EnglishMinimalStemFilterFactory"/>
+                -->
+                <filter class="solr.PorterStemFilterFactory"/>
+            </analyzer>
+        </fieldType>
+
+        <fieldType name="text_french" class="solr.TextField" positionIncrementGap="100">
+            <analyzer>
+                <tokenizer class="solr.StandardTokenizerFactory" />
+                <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
+                <filter class="solr.LowerCaseFilterFactory"/>
+                <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" />
+                <filter class="solr.FrenchLightStemFilterFactory"/>
+            </analyzer>
+        </fieldType>
+
+        <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
+            <analyzer>
+                <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            </analyzer>
+        </fieldType>
+
+        <fieldType name="ngram" class="solr.TextField" >
+            <analyzer type="index">
+                <tokenizer class="solr.KeywordTokenizerFactory"/>
+                <filter class="solr.LowerCaseFilterFactory"/>
+                <filter class="solr.NGramFilterFactory" minGramSize="3" maxGramSize="15" />
+            </analyzer>
+            <analyzer type="query">
+                <tokenizer class="solr.KeywordTokenizerFactory"/>
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+        </fieldType>
+
+        <fieldType name="edge_ngram" class="solr.TextField" positionIncrementGap="1">
+            <analyzer type="index">
+                <tokenizer class="solr.WhitespaceTokenizerFactory" />
+                <filter class="solr.LowerCaseFilterFactory" />
+                <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+                <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="15" side="front" />
+            </analyzer>
+            <analyzer type="query">
+                <tokenizer class="solr.WhitespaceTokenizerFactory" />
+                <filter class="solr.LowerCaseFilterFactory" />
+                <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            </analyzer>
+        </fieldType>
+    </types>
+
+    <fields>
+        <!-- general -->
+        <field name="{{ ID }}" type="string" indexed="true" stored="true" multiValued="false" required="true"/>
+        <field name="{{ DJANGO_CT }}" type="string" indexed="true" stored="true" multiValued="false"/>
+        <field name="{{ DJANGO_ID }}" type="string" indexed="true" stored="true" multiValued="false"/>
+        <field name="_version_" type="long" indexed="true" stored ="true"/>
+
+        <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>
+        <dynamicField name="*_s"  type="string"  indexed="true"  stored="true"/>
+        <dynamicField name="*_l"  type="long"   indexed="true"  stored="true"/>
+        <dynamicField name="*_t"  type="text_en"    indexed="true"  stored="true"/>
+        <dynamicField name="*_b"  type="boolean" indexed="true"  stored="true"/>
+        <dynamicField name="*_f"  type="float"  indexed="true"  stored="true"/>
+        <dynamicField name="*_d"  type="double" indexed="true"  stored="true"/>
+        <dynamicField name="*_dt" type="date" indexed="true" stored="true"/>
+        <dynamicField name="*_p" type="location" indexed="true" stored="true"/>
+        <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false"/>
+
+        {% for field in fields %}
+            <field name="{{ field.field_name }}" type="{% if field.type == 'text_en' %}text_french{% else %}{{ field.type }}{% endif %}" indexed="{{ field.indexed }}" stored="{{ field.stored }}" multiValued="{{ field.multi_valued }}" />
+        {% endfor %}
+    </fields>
+
+    <!-- field to use to determine and enforce document uniqueness. -->
+    <uniqueKey>{{ ID }}</uniqueKey>
+
+    <!-- field for the QueryParser to use when an explicit fieldname is absent -->
+    <defaultSearchField>{{ content_field_name }}</defaultSearchField>
+
+    <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
+    <solrQueryParser defaultOperator="{{ default_operator }}"/>
+</schema>

--- a/templates/search_configuration/solr.xml
+++ b/templates/search_configuration/solr.xml
@@ -112,6 +112,9 @@
                 <filter class="solr.LowerCaseFilterFactory"/>
                 <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" />
                 <filter class="solr.FrenchLightStemFilterFactory"/>
+                <!-- Optionally you may want to use this less aggressive stemmer instead of FrenchLightStemFilterFactory:
+                   <filter class="solr.FrenchMinimalStemFilterFactory"/>
+                 -->
             </analyzer>
         </fieldType>
 

--- a/update.md
+++ b/update.md
@@ -253,5 +253,9 @@ La recherche est maintenant en français:
 
   - Arrêter Solr : `supervisorctl stop solr`
   - Regénérer le schema.xml : `python manage.py build_solr_schema > /votre/path/vers/solr-4.9.1/example/solr/collection1/conf/schema.xml`
+  - Vérifier que les fichiers contractions_fr.txt et stopwords_fr.txt dans le dossier d'installation de Solr/example/solr/collection1/conf/lang/ sont pertinent.
+  - Si les fichiers contractions_fr.txt et stopwords_fr.txt ne sont pas pertinent. Télécharger et remplacer les fichiers par ceux contenu dans [ce drive](https:// drive.google.com/folderview?id=0B5ux7uNoD6owfklUNnpOVWhuaTFkVjltSzR0UER2bWcwT1VQdUQ1WW5telU5TWFGLXFqM0U&usp=sharing). 
   - Redémarrer Solr : `supervisorctl start solr`
   - Lancer l'indexation : `python manage.py rebuild_index`
+
+

--- a/update.md
+++ b/update.md
@@ -244,3 +244,14 @@ Pour régler ça, il faut faire les modifications de la migration nous-même.
   - Les deux commandes doivent passer sans souci
   - Quitter mysql
   - Puis feinter la migration de oauth2_provider : `python manage.py migrate oauth2_provider --fake`
+
+
+Actions à faire pour mettre en prod la prochaine version
+========================================================
+
+La recherche est maintenant en français:
+
+  - Arrêter Solr : `supervisorctl stop solr`
+  - Regénérer le schema.xml : `python manage.py build_solr_schema > /votre/path/vers/solr-4.9.1/example/solr/collection1/conf/schema.xml`
+  - Redémarrer Solr : `supervisorctl start solr`
+  - Lancer l'indexation : `python manage.py rebuild_index`


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | ~oui |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2401 |

Donne la possibilité aux utilisateurs de pouvoir rechercher en français. **Reprise de [2840](https://github.com/zestedesavoir/zds-site/pull/2840) avec un moyen beaucoup plus simple.**

Haystack nous permet de configurer un template pour généré le schema.xml.

Pour cela, j'ai repris le template de base et ajouté une partie pour configurer les filters et les tokeniser en français. J'ai ajouté:

```
<fieldType name="text_french" class="solr.TextField" positionIncrementGap="100">
  <analyzer>
    <tokenizer class="solr.StandardTokenizerFactory" /> # Decoupe les mots
    <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/> # Decoupe les mots contracté style j'aime et ignore la partie non intéréssent 
    <filter class="solr.LowerCaseFilterFactory"/> # On met tout en minuscule
    <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" /># On supprime les mots pas intéressent
    <filter class="solr.FrenchLightStemFilterFactory"/> #  racinisation ou désuffixation. On peut aussi utiliser la version Minimal.
  </analyzer>
</fieldType>
```

Le template permet de remplacer les text_en en text_french pour appliquer les filtres. C'est dans la boucle des fields

La doc sur le sujet arrive dans un prochain commit 

QA:

Etape 1:
- Généré le nouveau schema.xml grâce à la commande `python manage.py build_solr_schema` 
- Remplacer le nouveau schema.xml par l'ancien dans dossier d'installation solr/example/solr/collection1/conf/schema.xml
- Redémarrer votre instance Solr (trés important)
- Aller dans l'administration http://127.0.0.1:8983/solr/#, dans la liste déroulante sur votre gauche, choisissez "collection1". Puis juste en-dessous, cliquer sur le bouton 'Analysis'. Une nouvelle page s'ouvre, 
  ![solr-recherche-fr](https://cloud.githubusercontent.com/assets/6099338/8272934/ec3e2d2e-1857-11e5-8cca-101dc1307ea2.png). 

Cette interface permet de savoir quels filtres sont appliqués et comment. Le champ à gauche, c'est pour l'indexation et à droite pour la recherche.

Taper une phrase d'exemple en français dans le champ à gauche comme dans la capture. Choisissez le champ, par-exemple: "text". Cliquer maintenant sur le bouton "Analyse Values" en bleu à droite. Vous avez un tableau avec chaque mot en colonne et sur les lignes c'est les résultats après chaque filtre, dans la première colonne vous avez le nom des filtres, si vous passez votre curseur dessus. Vérifier que le nom des filtres correspondent bien à StandardTokenizerFactory, ElisionFilterFactory, LowerCaseFilterFactory, StopFilterFactory, FrenchLightStemFilterFactory.

Etape 2:
- Changer la ligne  < filter class="solr.FrenchLightStemFilterFactory" /> en  < filter class="solr.FrenchMinimalStemFilterFactory " /> dans le fichier templates/search_configuration/solr.xml
  - Refaite l'étape 1 et vérifier si le filtre moins agressif correspond mieux.
