### PR TITLE
Empeche un staff de se sanctionner lui-meme

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -486,7 +486,7 @@
                 </li>
             </ul>
 
-            {% if not profile.is_private %}
+            {% if not profile.is_private and usr != user %}
             <h4>{% trans "Sanctions" %}</h4>
             <ul>
                 {% if profile.can_write_now %}

--- a/zds/member/api/generics.py
+++ b/zds/member/api/generics.py
@@ -35,6 +35,11 @@ class CreateDestroyMemberSanctionAPIView(CreateAPIView, DestroyAPIView):
         state = self.get_state_instance(request)
 
         ban = state.get_sanction(request.user, instance.user)
+
+        if ban.user == ban.moderator:
+            return Response({u'detail': u'Sanction can not be applied to yourself.'},
+                            status=status.HTTP_403_FORBIDDEN)
+
         try:
             state.apply_sanction(instance, ban)
         except ValueError:

--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -779,6 +779,16 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         response = client_authenticated.delete(reverse('api-member-read-only', args=[self.profile.pk]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_staff_apply_read_only_on_self(self):
+        """
+        A staff user can not put LS on himself
+        """
+        data = {
+            'ls-text': 'I am a bad staff!'
+        }
+        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.staff.pk]), data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
 
 class MemberDetailBanAPITest(APITestCase):
     def setUp(self):
@@ -926,6 +936,16 @@ class MemberDetailBanAPITest(APITestCase):
         authenticate_client(client_authenticated, client_oauth2, self.profile.user.username, 'hostel77')
 
         response = client_authenticated.delete(reverse('api-member-ban', args=[self.profile.pk]))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_apply_ban_on_self(self):
+        """
+        A staff user can not put a ban on himself
+        """
+        data = {
+            'ban-text': 'I am a bad staff!'
+        }
+        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.staff.pk]), data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -428,6 +428,9 @@ def modify_profile(request, user_pk):
     profile = get_object_or_404(Profile, user__pk=user_pk)
     if profile.is_private():
         raise PermissionDenied
+    if request.user.profile == profile:
+        messages.error(request, _(u"Vous ne pouvez pas vous sanctionner vous-même !"))
+        raise PermissionDenied
 
     if 'ls' in request.POST:
         state = ReadingOnlySanction(request.POST)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2794 |

Un staff ne peut plus se sanctionner lui-meme par accident.
### QA

Verifier qu'un staff peut bien sanctionner tout le monde (ban, LS) (sauf les robots) mais pas lui-meme.
Verifier via l'API serait bien aussi...
