### PR TITLE
Focus le premier élément au clic des liens d'accessibilité

### DIFF
--- a/assets/js/accessibility-links.js
+++ b/assets/js/accessibility-links.js
@@ -6,12 +6,16 @@
 
 (function($, undefined){
     "use strict";
-    
-    $("#accessibility a").on("focus", function(){
+
+    $("#accessibility a").on("focus", function() {
         $(".dropdown:visible").parent().find(".active").removeClass("active");
         $("#accessibility").addClass("focused");
-    });
-    $("#accessibility a").on("blur", function(){
+    }).on("blur", function() {
         $("#accessibility").removeClass("focused");
+    }).on("click", function() {
+        var link = $(this).attr("href");
+        setTimeout(function() { // Forces the focus on next tick
+            $(link).find(":tabbable").first().focus(); // Focus the first focusable element
+        });
     });
 })(jQuery);


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | ~non |
| Tickets (_issues_) concernés | #2693 |

Petit bout de JS qui permet de prendre le focus du premier élément ciblé par un lien d'accessibilité.
### Note sur le code:

Pour bien que le navigateur gère tout l'événement, et engage le scroll, j'ai fait un setTimeout pour forcer à aller au _tick_ suivant (et donc attendre que l'événement soit fini)
### Note QA:

_Tabber_ sur le menu d'accessibilité, et vérifier que l'on gagne bien le focus sur la recherche lorsque l'on clique sur "aller la recherche", et sur le menu lorsqu'on clique sur "aller au menu". Le bouton "Aller au contenu" devrait également focus le premier élément focusable du menu
