### PR TITLE
[Betafix] Répare les marges de la phrase choc de la page d'accueil

### DIFF
--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -276,6 +276,10 @@ $content-width: 1145px;
         .home-description.short {
             display: block;
 
+            // Rules to don't be hidden by the .home-search-box::before background-image
+            width: auto;
+            padding: 0 20px;
+
             &:target {
                 .home-description-button {
                     display: none;
@@ -290,6 +294,10 @@ $content-width: 1145px;
                     margin-top: 20px;
                 }
             }
+        }
+        .home-description.connected {
+            // Rules to don't be hidden by the .home-search-box::before background-image
+            padding: 0 20px !important;
         }
 
         .home-description .featured-message {


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2827 |

Reprise de #2833 sur la branche de _release_.

**QA :**
- `npm run gulp -- build`
- Vérifier que la phrase choc prend tout l'espace disponible (sans chevaucher Clem) sur mobile (en étant connecté)

En mode déconnecté, la phrase choc est statique (en dur dans la gabarit) donc @sandhose l'a coupée en deux pour que ce soit plus joli. Donc c'est normal s'il y a cette situation http://i.gyazo.com/2829f853123dd0e3b8e89dfb8069c8fc.png !
