### PR TITLE
[15.6] Met à jour les dépendances front et règle les soucis de front Travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,27 +22,27 @@
   },
   "homepage": "https://github.com/zestedesavoir/zds-site",
   "dependencies": {
-    "cookies-eu-banner": "1.2.6",
+    "cookies-eu-banner": "1.2.7",
     "css-sprite": "0.9.8",
-    "del": "1.1.1",
-    "gulp": "3.8.11",
-    "gulp-autoprefixer": "2.1.0",
+    "del": "1.2.0",
+    "gulp": "3.9.0",
+    "gulp-autoprefixer": "2.3.1",
     "gulp-concat": "2.5.2",
     "gulp-if": "1.2.5",
-    "gulp-imagemin": "2.2.1",
+    "gulp-imagemin": "2.3.0",
     "gulp-load-plugins": "0.10.0",
-    "gulp-minify-css": "1.1.0",
+    "gulp-minify-css": "1.1.6",
     "gulp-notify": "2.2.0",
     "gulp-rename": "1.2.2",
-    "gulp-sass": "1.3.3",
-    "gulp-size": "1.2.1",
+    "gulp-sass": "2.0.1",
+    "gulp-size": "1.2.2",
     "gulp-uglify": "1.2.0",
-    "jquery": "2.1.3",
+    "jquery": "2.1.4",
     "normalize.css": "3.0.3"
   },
   "devDependencies": {
-    "gulp-jshint": "1.10.0",
+    "gulp-jshint": "1.11.0",
     "gulp-livereload": "3.8.0",
-    "jshint-stylish": "1.0.1"
+    "jshint-stylish": "2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-minify-css": "1.1.6",
     "gulp-notify": "2.2.0",
     "gulp-rename": "1.2.2",
-    "gulp-sass": "2.0.1",
+    "gulp-sass": "2.0.2",
     "gulp-size": "1.2.2",
     "gulp-uglify": "1.2.0",
     "jquery": "2.1.4",


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | Aucun |

**QA :** Laisser Travis faire son job et regarder en local vite fait si tout est bien généré

**Tout ceci a déjà été vérifié sur `dev`, mais il faut mettre à jour ses dépendances aussi sur release car le front ne peut plus build à cause de npm qui a décidé de virer des packages "trop vieux". Ca arrive, c'est la vie.
