### PR TITLE
[15.6] betafix #2849: Corrige la couleur des boutons

### DIFF
--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -139,8 +139,8 @@
             float: right;
         }
     }
-    [type=submit],
-    .btn-submit {
+    [type=submit]:not(.link),
+    .btn-submit:not(.link) {
         color: #FFF;
         background: $color-success;
 
@@ -159,7 +159,7 @@
             }
         }
     }
-    .btn-cancel {
+    .btn-cancel:not(.link) {
         background: $color-danger;
 
         &:not([disabled]):hover,
@@ -177,7 +177,7 @@
             }
         }
     }
-    .btn-grey {
+    .btn-grey:not(.link) {
         background: #EEE;
         color: #555;
 
@@ -207,7 +207,7 @@
         }
     }
 
-    .btn-facebook {
+    .btn-facebook:not(.link) {
         background: #3b5998;
 
         &:hover,
@@ -215,7 +215,7 @@
             background: darken(#3b5998, 10%);
         }
     }
-    .btn-twitter {
+    .btn-twitter:not(.link) {
         background: #4099FF;
 
         &:hover,
@@ -223,7 +223,7 @@
             background: darken(#4099FF, 10%);
         }
     }
-    .btn-google-plus {
+    .btn-google-plus:not(.link) {
         background: #d34836;
 
         &:hover,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2849 |

Remet la priorité sur les boutons "spéciaux" (=non-gris), en rajoutant le selecteur `:not(.link)`, introduit dans 61235dd
### Notes QA

Build le front, et vérifier que les boutons vert, rouge, gris, et les boutons de connexions aux réseaux sociaux ont la bonne couleur (= la même qu'en prod)

---

ping @Situphen, du coup :)
