### PR TITLE
Amélioration du script de déploiement

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,13 +8,23 @@
 # - This script must be run by zds user
 # - This script has exactly 1 parameter: the tag name to deploy
 
-: ${ZDS_USER:="zds"}
-: ${VIRTUALENV_PATH:=/opt/zdsenv}
-: ${APP_PATH:=/opt/zdsenv/ZesteDeSavoir}
-: ${NGINX_CONFIG_ROOT:=/etc/nginx}
-: ${NGINX_MAINTENANCE_SITE:=zds-maintenance}
-: ${NGINX_APP_SITE:=zestedesavoir}
-: ${ENABLE_MAINTENANCE:=true}
+# Defaults:
+_D_ZDS_USER="zds"
+_D_VIRTUALENV_PATH=/opt/zdsenv
+_D_APP_PATH=/opt/zdsenv/ZesteDeSavoir
+_D_NGINX_CONFIG_ROOT=/etc/nginx
+_D_NGINX_MAINTENANCE_SITE=zds-maintenance
+_D_NGINX_APP_SITE=zestedesavoir
+_D_ENABLE_MAINTENANCE=true
+
+# Setting variables using env & defaults
+: ${ZDS_USER:=$_D_ZDS_USER}
+: ${VIRTUALENV_PATH:=$_D_VIRTUALENV_PATH}
+: ${APP_PATH:=$_D_APP_PATH}
+: ${NGINX_CONFIG_ROOT:=$_D_NGINX_CONFIG_ROOT}
+: ${NGINX_MAINTENANCE_SITE:=$_D_NGINX_MAINTENANCE_SITE}
+: ${NGINX_APP_SITE:=$_D_NGINX_APP_SITE}
+: ${ENABLE_MAINTENANCE:=$_D_ENABLE_MAINTENANCE}
 
 if [ "$(whoami)" != $ZDS_USER ]; then
 	echo "This script must be run by zds user" >&2
@@ -34,13 +44,19 @@ then
 	exit 1
 fi
 
+# Diaplay config
 echo "Here is the config:"
-echo "  VIRTUALENV_PATH = $VIRTUALENV_PATH"
-echo "  APP_PATH = $APP_PATH"
-echo "  NGINX_CONFIG_ROOT = $NGINX_CONFIG_ROOT"
-echo "  NGINX_MAINTENANCE_SITE = $NGINX_MAINTENANCE_SITE"
-echo "  NGINX_APP_SITE = $NGINX_APP_SITE"
-echo "  ENABLE_MAINTENANCE = $ENABLE_MAINTENANCE"
+for varname in "ZDS_USER" "VIRTUALENV_PATH" "APP_PATH" "NGINX_CONFIG_ROOT" "NGINX_MAINTENANCE_SITE" "NGINX_APP_SITE" "ENABLE_MAINTENANCE"
+do
+	default_varname=_D_$varname
+	if [[ x${!default_varname} == x${!varname} ]]
+	then
+		echo $varname = ${!varname}
+	else
+		echo -e "$varname = \e[0;32m${!varname}\e[0m (default: ${!default_varname})"
+	fi
+done
+
 read -p "Is this OK ? [y/N] " -r
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #2842 |

Cette PR rends le script de déploiement beaucoup plus flexible (et plus organisé dans le code), sans pour autant modifier la manière dont il est lancé normalement (c'est toujours `scripts/deploy.sh <tag>`)

Alors, y'a un certain nombre de variables d'environnement qui sont prises en compte pour les différents chemins.
- `ZDS_USER` (par défaut: `zds`): Si jamais dans certaines configurations, le script doit être lancé sous un autre utilisateur que `zds`. Ca peut servir pour tester le script, si on veut pas créer un utilisateur `zds` sur sa machine.
- `VIRTUALENV_PATH` (par défaut: `/opt/zdsenv`): Chemin vers le virtualenv
- `APP_PATH` (par défaut: `/opt/zdsenv/ZesteDeSavoir`): Chemin vers la racine du répo
- `NGINX_CONFIG_ROOT` (par défaut: `/etc/nginx`): Chemin vers la config nginx (si jamais on est dans un environnement un peu exotique, ou alors qu'on veut juste tester le script sans que ca touche à la vraie config nginx)
- `NGINX_APP_SITE` (par défaut: `zestedesavoir`): Nom du fichier de config correspondant au site (`/etc/nginx/sites-available/zestedesavoir`)
- `NGINX_MAINTENANCE_SITE` (par défaut: `zds-maintenance`): Nom du fichier de config correspondant au site de maintenance
- `ENABLE_MAINTENANCE` (par défaut: `true`): Si le mode maintenance doit être activé ou non par le script.
- `MANUAL_BUILD_FRONT` (par défaut: `false`)
  - `true`: Build manuellement le front (voir la fonction `update_frontend`)
  - `false`: Checkout le tag `$1-build` avec le front _déjà_ buildé

Alors, cette config est affichée par le script, avec une mise en évidence des valeurs qui sont pas "par défaut":

![image](https://cloud.githubusercontent.com/assets/1549952/8397331/4dd697d6-1dc8-11e5-86a9-c85d6bb30531.png)

---

Aussi, le script check si le tag `*-build` existe avant de faire quoi que ce soit, et affiche chaque commande qu'il exécute (hors commandes de statuts, qui touchent à rien)

Avec le `MANUAL_BUILD_FRONT` à true, il est aussi maintenant possible de checkout autre chose qu'un tag. Si par exemple on veut mettre en place sur la bêta une branche spécifique, eh bah on peut en utilisant le script, sans forcément créer un tag :)

Voila, un petit ping @SpaceFox au passage, parce que je veux son avis sur le script ; sache que ça ne change rien à la procédure de MEP (enfin si, juste un "y" à taper en plus pour valider la config avant de faire quoi que ce soit :) )
