### PR TITLE
[15.6] Remets les content-meta des tutos "mini" sur deux lignes

### DIFF
--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -327,7 +327,7 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
                     display: none;
                 }
 
-                & > * {
+                &:not(.inline) > * {
                     display: block;
                 }
             }


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2861 |

Fix #2861 
### Instructions QA:

Build le front, et vérifier que les tutoriels sur la home (la partie sur deux colonnes) ont bien un "texte orange" sur deux lignes sur grand écran (sur petit écran, y'a pas de petites colonnes, donc ca devrait être sur une ligne)
