### PR TITLE
[15.6] L'indexation des droits permet aux membres avec un groupe autre de voir tous les posts

### DIFF
--- a/zds/forum/search_indexes.py
+++ b/zds/forum/search_indexes.py
@@ -24,7 +24,7 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
         return Topic
 
     def prepare_permissions(self, obj):
-        return obj.forum.group.values_list('name', flat=True).all() or None
+        return [group.name for group in obj.forum.group.all()] or "public"
 
 
 class PostIndex(indexes.SearchIndex, indexes.Indexable):
@@ -57,4 +57,4 @@ class PostIndex(indexes.SearchIndex, indexes.Indexable):
         return obj.topic.forum
 
     def prepare_permissions(self, obj):
-        return obj.topic.forum.group.values_list('name', flat=True).all() or None
+        return [group.name for group in obj.topic.forum.group.all()] or "public"

--- a/zds/search/views.py
+++ b/zds/search/views.py
@@ -1,8 +1,8 @@
 # coding: utf-8
+from django.db.models import Q
 
 from django.shortcuts import render
 from django.core.urlresolvers import reverse
-from haystack.inputs import Raw
 
 from haystack.views import SearchView
 
@@ -38,21 +38,17 @@ class CustomSearchView(SearchView):
     def get_results(self):
         queryset = super(CustomSearchView, self).get_results()
 
-        # Due to a bug in Haystack library (https://github.com/django-haystack/django-haystack/issues/163)
-        # We can do field = None or use __isnull. We are obliged to use a raw solr query.
-        # Obviously, it is solr dependant
-        is_empty = Raw("[* TO *]")
-
         # We want to search only on authorized post and topic
         if self.request.user.is_authenticated():
             groups = self.request.user.groups
 
             if groups.count() > 0:
-                return queryset.filter_or(permissions=is_empty, permissions__in=groups.all())
+                return queryset.filter(Q(permissions="public") |
+                                       Q(permissions__in=[group.name for group in groups.all()]))
             else:
-                return queryset.exclude(permissions=is_empty)
+                return queryset.filter(permissions="public")
         else:
-            return queryset.exclude(permissions=is_empty)
+            return queryset.filter(permissions="public")
 
 
 def opensearch(request):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2874 |

3éme édition, j’espère que ça sera la bonne.

QA:
- Mettre des droits sur un forum
- Avec un membre non inscrit, vérifier que vous ne pouvez pas rechercher les topics qui sont dans le forum privé. Vérifier aussi que vous pouvez rechercher des topics qui sont dans les autres forums.
- Avec un membre inscrit sans droit, vérifier que vous ne pouvez pas rechercher les topics qui sont dans le forum privé. Vérifier aussi que vous pouvez rechercher des topics qui sont dans les autres forums.
- Avec le profil admin, vérifier que vous pouvez rechercher les topics qui sont dans le forum privé. Vérifier aussi que vous pouvez rechercher des topics qui sont dans les autres forums.
- Créé un autre groupe dev, mettez un autre utilisateur dans ce groupe dev. Le forum ne doit pas lui être autorisé. Utiliser la recherche pour un message dans le forum privé que cet utilisateur n’aurait pas le droit de voir. Vérifier qu'il a pas accés. Vérifié qu'il accès au autre.
