### PR TITLE
[hotfix v15.6] Indexe les tutos et articles comme du contenu public

### DIFF
--- a/zds/article/search_indexes.py
+++ b/zds/article/search_indexes.py
@@ -12,6 +12,10 @@ class ArticleIndex(indexes.SearchIndex, indexes.Indexable):
     pubdate = indexes.DateTimeField(model_attr='pubdate')
     txt = indexes.CharField(model_attr='text')
 
+    # Groups authorized to read this topic.
+    # If a group "public" is defined, the forum is public (and anyone can read it).
+    permissions = indexes.MultiValueField()
+
     def get_model(self):
         return Article
 
@@ -19,3 +23,6 @@ class ArticleIndex(indexes.SearchIndex, indexes.Indexable):
         """Used when the entire index for model is updated."""
         return self.get_model().objects\
             .filter(sha_public__isnull=False)
+
+    def prepare_permissions(self, obj):
+        return "public"

--- a/zds/forum/search_indexes.py
+++ b/zds/forum/search_indexes.py
@@ -17,7 +17,8 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
     author = indexes.CharField(model_attr='author')
     pubdate = indexes.DateTimeField(model_attr='pubdate')
 
-    # Groups authorized to read this topic. If no group is defined, the forum is public (and anyone can read it).
+    # Groups authorized to read this topic.
+    # If a group "public" is defined, the forum is public (and anyone can read it).
     permissions = indexes.MultiValueField()
 
     def get_model(self):
@@ -38,7 +39,8 @@ class PostIndex(indexes.SearchIndex, indexes.Indexable):
     topic_author = indexes.CharField(stored=True, indexed=False)
     topic_forum = indexes.CharField(stored=True, indexed=False)
 
-    # Groups authorized to read this post. If no group is defined, the forum is public (and anyone can read it).
+    # Groups authorized to read this topic.
+    # If a group "public" is defined, the forum is public (and anyone can read it).
     permissions = indexes.MultiValueField()
 
     def get_model(self):

--- a/zds/tutorial/search_indexes.py
+++ b/zds/tutorial/search_indexes.py
@@ -15,6 +15,10 @@ class TutorialIndex(indexes.SearchIndex, indexes.Indexable):
     subcategory = indexes.MultiValueField()
     sha_public = indexes.CharField(model_attr='sha_public')
 
+    # Groups authorized to read this topic.
+    # If a group "public" is defined, the forum is public (and anyone can read it).
+    permissions = indexes.MultiValueField()
+
     def get_model(self):
         return Tutorial
 
@@ -25,11 +29,18 @@ class TutorialIndex(indexes.SearchIndex, indexes.Indexable):
     def prepare_subcategory(self, obj):
         return obj.subcategory.values_list('title', flat=True).all() or None
 
+    def prepare_permissions(self, obj):
+        return "public"
+
 
 class PartIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
     title = indexes.CharField(model_attr='title')
     tutorial = indexes.CharField(model_attr='tutorial')
+
+    # Groups authorized to read this topic.
+    # If a group "public" is defined, the forum is public (and anyone can read it).
+    permissions = indexes.MultiValueField()
 
     def get_model(self):
         return Part
@@ -40,6 +51,9 @@ class PartIndex(indexes.SearchIndex, indexes.Indexable):
 
         return self.get_model().objects.filter(tutorial__sha_public__isnull=False, id__in=published_content["parts"])
 
+    def prepare_permissions(self, obj):
+        return "public"
+
 
 class ChapterIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
@@ -47,6 +61,10 @@ class ChapterIndex(indexes.SearchIndex, indexes.Indexable):
     # A Chapter belongs to a Part (big-tuto) **or** a Tutorial (mini-tuto)
     part = indexes.CharField(model_attr='part', null=True)
     tutorial = indexes.CharField(model_attr='tutorial', null=True)
+
+    # Groups authorized to read this topic.
+    # If a group "public" is defined, the forum is public (and anyone can read it).
+    permissions = indexes.MultiValueField()
 
     def get_model(self):
         return Chapter
@@ -59,12 +77,19 @@ class ChapterIndex(indexes.SearchIndex, indexes.Indexable):
                                                Q(part__tutorial__sha_public__isnull=False),
                                                id__in=published_content["chapters"])
 
+    def prepare_permissions(self, obj):
+        return "public"
+
 
 class ExtractIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
     title = indexes.CharField(model_attr='title')
     chapter = indexes.CharField(model_attr='chapter')
     txt = indexes.CharField(model_attr='text')
+
+    # Groups authorized to read this topic.
+    # If a group "public" is defined, the forum is public (and anyone can read it).
+    permissions = indexes.MultiValueField()
 
     def get_model(self):
         return Extract
@@ -77,3 +102,6 @@ class ExtractIndex(indexes.SearchIndex, indexes.Indexable):
         return self.get_model() .objects.filter(Q(chapter__tutorial__sha_public__isnull=False) |
                                                 Q(chapter__part__tutorial__sha_public__isnull=False),
                                                 id__in=published_content["extracts"])
+
+    def prepare_permissions(self, obj):
+        return "public"


### PR DESCRIPTION
Reprise de https://github.com/zestedesavoir/zds-site/pull/2891 sur la bonne branche

| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2885 |

Hotfix-prod: ne pas merge.

**Actions pour mettre en production, je sais pas si ça va dans le UPDATE.md dans ce cas la:**
- Arrêter Solr :supervisorctl stop solr
- Regénérer le schema.xml : python manage.py build_solr_schema > /votre/path/vers/solr-4.9.1/example/solr/collection1/conf/schema.xml
- Redémarrer Solr : supervisorctl start solr
- Lancer l'indexation : python manage.py rebuild_index

**QA:**
- Stopper solr
- Build le schema `python manage.py build_solr_schema > schema.xml`
- Démarrer Solr
- Rebuild index `python manage.py rebuild_index`
- Vérifier que les tutos sont présent dans la recherche 
