### PR TITLE
[hotfix v15.6] fix #2873 avec mysql

### DIFF
--- a/zds/forum/managers.py
+++ b/zds/forum/managers.py
@@ -98,7 +98,14 @@ class PostManager(InheritanceManager):
 class TopicReadManager(models.Manager):
 
     def topic_read_by_user(self, user, topic_sub_list=None):
+        """ get all the topic that the user has already read.
 
+        :param user: an authenticated user
+        :param topic_sub_list: optional list of topics. If not ``None`` no subject out of this list will be selected
+        :type topic_sub_list: list
+        :return: the queryset over the already read topics
+        :rtype: QuerySet
+        """
         base_query_set = self.filter(user__pk=user.pk)
         if topic_sub_list is not None:
             base_query_set = base_query_set.filter(topic__in=topic_sub_list)
@@ -107,4 +114,12 @@ class TopicReadManager(models.Manager):
         return base_query_set
 
     def list_read_topic_pk(self, user, topic_sub_list=None):
+        """ get all the topic that the user has already read in a flat list.
+
+        :param user: an authenticated user
+        :param topic_sub_list: optional list of topics. If not ``None`` no subject out of this list will be selected
+        :type topic_sub_list: list
+        :return: the flat list of all topics primary key
+        :rtype: list
+        """
         return self.topic_read_by_user(user, topic_sub_list).values_list('topic__pk', flat=True)

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -74,14 +74,14 @@ class MemberDetail(DetailView):
         usr = context['usr']
         profile = usr.profile
         context['profile'] = profile
-        context['topics'] = Topic.objects.last_topics_of_a_member(usr, self.request.user)
+        context['topics'] = list(Topic.objects.last_topics_of_a_member(usr, self.request.user))
         context['articles'] = Article.objects.last_articles_of_a_member_loaded(usr)
         context['tutorials'] = Tutorial.objects.last_tutorials_of_a_member_loaded(usr)
         context['old_tutos'] = Profile.objects.all_old_tutos_from_site_du_zero(profile)
         context['karmanotes'] = KarmaNote.objects.filter(user=usr).order_by('-create_at')
         context['karmaform'] = KarmaForm(profile)
         context['form'] = OldTutoForm(profile)
-        context['topic_read'] = TopicRead.objects.list_read_topic_pk(usr, context['topics'])
+        context['topic_read'] = TopicRead.objects.list_read_topic_pk(self.request.user, context['topics'])
         return context
 
 


### PR DESCRIPTION
Mysql ne permet pas d'utiliser un queryset comme si c'était une liste, j'ai donc fait des "all" juste avant.

| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | #2873 |
# note pour la QA :

Il vous faudra 2 utilisateurs

avec l'utilisateur n°1
- créez un topic

avec l'utilisateur n°2
- répondez au topic
- vérifiez dans la liste "toutes les notifications" que le topic n'est pas en gras

avec l'utilisateur n°1
- vérifiez qu'il y a une notification, mais **avant** de la lire, allez dans "toutes les notifications" et vérifiez que le topic est en gras.
- vérifiez aussi **avant** de la lire qu'elle est affichée comme non lue dans son forum
# CETTE PR A DEJE ETE QA [ici](https://github.com/zestedesavoir/zds-site/pull/2889)
