### PR TITLE
[hotfix v15.6] Corriges les liens des tutoriels

### DIFF
--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -4,8 +4,10 @@
 {% load date %}
 
 {% captureas link %}
-    {% if beta %}
+    {% if type_link == 'beta' %}
         {{ tutorial.get_absolute_url_beta }}
+    {% elif type_link == 'draft' %}
+        {{ tutorial.get_absolute_url }}
     {% else %}
         {{ tutorial.get_absolute_url_online }}
     {% endif %}

--- a/templates/tutorial/member/beta.html
+++ b/templates/tutorial/member/beta.html
@@ -31,7 +31,7 @@
         {% if tutorials %}
             <div class="tutorial-list">
                 {% for tutorial in tutorials %}
-                    {% include 'tutorial/includes/tutorial_item.part.html' with beta=True show_description=True %}
+                    {% include 'tutorial/includes/tutorial_item.part.html' with type_link='beta' show_description=True %}
                 {% endfor %}
                 <div class="fill"></div>
                 <div class="fill"></div>

--- a/templates/tutorial/member/index.html
+++ b/templates/tutorial/member/index.html
@@ -74,7 +74,7 @@
         {% if tutorials %}
             <div class="content-item-list">
                 {% for tutorial in tutorials %}
-                    {% include 'tutorial/includes/tutorial_item.part.html' with show_description=True beta=True %}
+                    {% include 'tutorial/includes/tutorial_item.part.html' with show_description=True type_link='draft' %}
                 {% endfor %}
                 <div class="fill"></div>
                 <div class="fill"></div>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2747 |
# Note de QA

**QA déjà effectuée !!**
- Créez un tutoriel nommé "A", passez le en bêta
- Éditer ensuite "A" (peu importe pour quoi, changer la description, par exemple), puis rendez vous sur la page "mes tutoriels", et vérifiez qu'en cliquant sur le lien correspondant à "A", vous êtes renvoyé sur la version brouillon et pas bêta

Puis, vérifiez, 
- Que sur la page des tutoriels en bêta de votre utilisateur actuel (`/tutoriels/recherche/{pk}/?type=beta`), le lien renvoi bien sur la version bêta de "A"
- Publiez "A" et vérifiez que sur la page des tutos en public de l'utilisateur (`/tutoriels/recherche/{pk}/`), vous êtes bien renvoyé sur la version publique dudit tuto
- Sur la liste située dans le profil dudit membre (à droite), vérifiez que vous êtes renvoyé sur la version publiée.
