### PR TITLE
Rend l'édition des Unes utilisable sur mobile (fix #2895)

### DIFF
--- a/assets/scss/components/_featured-item.scss
+++ b/assets/scss/components/_featured-item.scss
@@ -89,3 +89,10 @@
         flex: 1;
     }
 }
+
+@media only screen and #{$media-mobile} {
+    .featured-resource-edit-form {
+        flex-direction: column;
+        align-items: unset;
+    }
+}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2895 |

Rend l'édition des Unes utilisable sur mobile

**QA :**
- Générer le front avec `npm run gulp -- build`.

Puis, en redimensionnant son navigateur ou avec un téléphone portable (lancer `python manage.py runserver 0.0.0.0:8000` puis aller depuis votre téléphone sur `ip-ordinateur:8000`) :
- Se connecter avec admin ;
- Aller sur la page de Gestion des Unes (via le menu en cliquant sur l'avatar) ;
- Cliquer sur une Une pour l'éditer ;
- Vérifier que le formulaire et la prévisualisation sont utilisables.
