### PR TITLE
optimise la page d'accueil des forums

### DIFF
--- a/templates/forum/includes/forums.part.html
+++ b/templates/forum/includes/forums.part.html
@@ -27,7 +27,7 @@
         <p class="topic-last-answer">
             {% with last_message=forum.get_last_message %}
                 {% if last_message %}
-                    <a href="{{ last_message.topic.last_read_post.get_absolute_url }}">
+                    <a href="{{ last_message.topic.resolve_last_read_post_absolute_url }}">
                         <span class="forum-last-message">
                             <span class="forum-last-message-long">
                                 {{ last_message.pubdate|format_date|capfirst }}

--- a/templates/forum/includes/topic_item.part.html
+++ b/templates/forum/includes/topic_item.part.html
@@ -22,10 +22,10 @@
         </p>
 
         <p class="content-meta inline">
-            {% with answer=topic.get_last_answer last_read=topic.last_read_post %}
+            {% with answer=topic.get_last_answer last_read_url=topic.resolve_last_read_post_absolute_url %}
                 {% if answer %}
                     {% spaceless %}
-                    <a href="{{ last_read.get_absolute_url }}" class="last-read-link">
+                    <a href="{{ last_read_url }}" class="last-read-link">
                         {% trans "Dernière réponse :" %}
                         <time class="content-pubdate" pubdate="{{ answer.pubdate|date:"c" }}">
                             <span class="long">{{ answer.pubdate|format_date|capfirst }}</span>

--- a/templates/forum/includes/topic_row.part.html
+++ b/templates/forum/includes/topic_row.part.html
@@ -62,9 +62,9 @@
         </p>
     {% endwith %}
     <p class="topic-last-answer">
-        {% with answer=topic.get_last_answer last_read=topic.last_read_post %}
+        {% with answer=topic.get_last_answer last_read_url=topic.resolve_last_read_post_absolute_url %}
             {% if answer %}
-                <a href="{{ last_read.get_absolute_url }}">
+                <a href="{{ last_read_url }}">
                     <span class="topic-last-answer-long-date">
                         {% trans "Dernière réponse" %} <br>
                         {{ answer.pubdate|format_date|capfirst }}

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -320,10 +320,11 @@ class Topic(models.Model):
         :rtype: int
         """
         return TopicRead.objects\
+            .select_related('post')\
             .filter(topic__pk=self.pk,
                     user__pk=user.pk) \
             .latest('post__position')\
-            .values("pk")['pk']
+            .pk
 
     def resolve_first_post_url(self):
         """resolve the url that leads to this topic first post

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -41,7 +41,7 @@ class CategoriesForumsListView(ListView):
     def get_context_data(self, **kwargs):
         context = super(CategoriesForumsListView, self).get_context_data(**kwargs)
         for category in context.get('categories'):
-            category.forums = category.get_forums(self.request.user)
+            category.forums = category.get_forums(self.request.user, with_count=True)
         return context
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [non] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [#2904, #2084] |

Je commence donc mon inspection des pages des forums pour comprendre pourquoi on est si mauvais sur ces pages.

Comme expliqué [ici](https://zestedesavoir.com/forums/sujet/3429/la-release-v156/?page=6#p65620), la page d'accueil faisait quelques requêtes bien délirantes et en trop grand nombre.

Cette PR ne pousse pas les optimisations au max car je ne connais aps trop les effets de bord. n'oublions pas que plus on essaie d'optimiser plus les différences entre sqlite et mysql se font sentir. 

Je préfère donc faire des pr par petit paquets pour vous faciliter le test. Et surtout pour mieux détecter les goulets d'étranglement.

Les trois optimisations apportées par cette PR sont celles-ci : 
- quand on n'est pas connecté, on n'essaie pas de chercher des objets accessibles uniquement aux connectés,
- quand on veut juste une url, on ne charge que ce qui est utile à générer une url,
- quand on sait qu'on va afficher les comptages de partout, on essaie de faire un précalcul (sql est très bon pour ça, j'ai tendance à penser que la différence sera encore plus flagrante avec mysql)

Je n'ai pas vraiment de consigne pour la QA. Vérifiez juste que la page d'accueil des forums s'affiche avec les bons chiffres et les bonnes urls pour les utilisateurs anonymes comme connectés.

environ 50% de requêtes en moins, 25% de temps en moins
