### PR TITLE
La pagination accepte les caractères spéciaux dans l'url (fix #2902)

### DIFF
--- a/zds/utils/templatetags/append_to_get.py
+++ b/zds/utils/templatetags/append_to_get.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django import template
+from django.utils.http import urlquote
 from functools import wraps
 
 register = template.Library()
@@ -84,7 +85,7 @@ class AppendGetNode(template.Node):
             get[key] = self.__dict_pairs[key].resolve(context)
 
         if len(get) > 0:
-            list_arg = [u"{0}={1}".format(key, value) for key in get.keys() for value in get.getlist(key)]
+            list_arg = [u"{0}={1}".format(key, urlquote(value)) for key in get.keys() for value in get.getlist(key)]
             path += u"?" + u"&".join(list_arg)
 
         return path


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2902 |

On peut maintenant faire des recherches avec des caractères spéciaux (#, &) sur plusieurs pages.

**QA :**
- Générer des tutoriels, articles et sujets (avec `python manage.py load_fixtures size=low`) ;
- Préparer la recherche [tel que décrit dans la documentation](http://zds-site.readthedocs.org/fr/latest/install/install-solr.html#procedure-commune) ;
- Mettre `HAYSTACK_SEARCH_RESULTS_PER_PAGE = 2` dans le `settings.py` (pour avoir plusieurs pages de résultat) ;
- Faire une recherche avec "#" ou "&" ;
- Cliquer sur "Suivant" et vérifier que vous arrivez bien sur la page suivante ;
- Vérifier que la pagination fonctionne encore dans les sujets du forum et les messages privés.
