### PR TITLE
Replace le bouton de signalement de faute sur mobile (fix #2077)

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -459,3 +459,10 @@
         }
     }
 }
+
+@media only screen and #{$media-mobile} {
+    .main .content-container .article-content .btn {
+        float: none;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2077 |

Le bouton de signalement de faute n'empiète plus sur les commentaires sur mobile

**QA :**
- Générer le _front_ (avec `npm run gulp -- build`) ;
- Aller sur un tutoriel au niveau du bouton de signalement de faute (juste avant les commentaires) ;
- Redimensionner son navigateur ;
- Admirer le résultat.
