### PR TITLE
fix 2867: Masque les dates sur les elements .mini

### DIFF
--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -323,12 +323,14 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
             .content-meta {
                 padding-top: 1px;
 
-                .content-pubdate {
-                    display: none;
-                }
+                &:not(.inline) {
+                    .content-pubdate {
+                        display: none;
+                    }
 
-                &:not(.inline) > * {
-                    display: block;
+                    & > * {
+                        display: block;
+                    }
                 }
             }
         }


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2867 |

Masque bien la date sur les "petits" tutoriels de la home
