### PR TITLE
La bulle des commentaires des articles ne gène plus de texte (fix #2899)

### DIFF
--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -339,9 +339,13 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
 
 @media only screen and #{$media-mobile-tablet} {
     .full-content-wrapper .content-item {
-        .content-info * {
-            margin: 0 !important;
-            padding: 0 !important;
+        .content-info {
+            h3 {
+                padding: 0 !important;
+            }
+            p:not(.content-meta) {
+                margin: 0 !important;
+            }
         }
     }
 }


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2899 |

La bulle des commentaires des articles ne superpose plus le texte des items

**QA :**
- Générer le _front_ (avec `npm run gulp -- build`) ;
- Aller sur http://127.0.0.1:8000/articles/ ;
- Redimensionner le navigateur pour faire comme sur mobile ;
- Vérifier que la bulle des commentaires ne cache pas de texte.
