### PR TITLE
Nettoie les gabartis et les feuilles de style après la ZEP 4

### DIFF
--- a/assets/js/mobile-menu.js
+++ b/assets/js/mobile-menu.js
@@ -292,7 +292,7 @@
             var $newBtns = $(".sidebar .new-btn:not(.mobile-btn-imported)");
             if($newBtns.length > 0){
                 var $prevElem = $("#content")
-                    .find("> .content-wrapper, > .full-content-wrapper, > .content-col-2")
+                    .find("> .content-wrapper, > .content-col-2")
                     .first()
                     .find("h1, h2")
                     .first();

--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -338,7 +338,7 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
 }
 
 @media only screen and #{$media-mobile-tablet} {
-    .full-content-wrapper .content-item {
+    .content-wrapper .content-item {
         .content-info {
             h3 {
                 padding: 0 !important;

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -371,10 +371,6 @@
 }
 
 @media only screen and #{$media-extra-wide} {
-    .full-content-wrapper .tutorial-list article {
-        width: 29.3%;
-    }
-
     .main .content-container .topic-message .message .message-metadata .date {
         .short-date {
             display: none;
@@ -386,8 +382,7 @@
 }
 
 @media only screen and #{$media-wide} {
-    .content-wrapper,
-    .full-content-wrapper {
+    .content-wrapper {
         margin: 0 0 0 4%;
 
         &.without-margin {
@@ -418,8 +413,7 @@
                 font-size: 1.8ex;
             }
         }
-        .content-wrapper,
-        .full-content-wrapper {
+        .content-wrapper {
             h1:not(.ico-after),
             h2:not(.ico-after),
             h3,

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -256,14 +256,6 @@
             margin-left: 1.5%;
         }
     }
-
-    .full-content-wrapper .tutorial-list article {
-        width: 46%;
-        float: left;
-        &.extend {
-            width: 100%;
-        }
-    }
 }
 
 @media only screen and #{$media-mobile-tablet} {

--- a/templates/article/index.html
+++ b/templates/article/index.html
@@ -34,7 +34,7 @@
 
 
 {% block content_out %}
-    <section class="full-content-wrapper" itemscope itemtype="http://schema.org/ItemList">
+    <section class="content-wrapper" itemscope itemtype="http://schema.org/ItemList">
         <h2 class="ico-after ico-articles" itemprop="name">
             {% block headline %}
                 {% if tag %}

--- a/templates/article/validation/index.html
+++ b/templates/article/validation/index.html
@@ -45,7 +45,7 @@
 
 
 {% block content_out %}
-    <section class="full-content-wrapper">
+    <section class="content-wrapper">
         <h2>
             {% block headline %}
                 {% trans "Validation des articles" %}

--- a/templates/article/validation/index.html
+++ b/templates/article/validation/index.html
@@ -44,70 +44,65 @@
 
 
 
-{% block content_out %}
-    <section class="content-wrapper">
-        <h2>
-            {% block headline %}
-                {% trans "Validation des articles" %}
-                ({{ validations|length }})
-            {% endblock %}
-        </h2>
+{% block headline %}
+    {% trans "Validation des articles" %} ({{ validations|length }})
+{% endblock %}
 
-        {% block content %}
-            {% if validations %}
-                <table class="fullwidth">
-                    <thead>
-                        <tr>
-                            <th>{% trans "Titre" %}</th>
-                            <th width="10%">{% trans "Auteur(s)" %}</th>
-                            <th width="10%">{% trans "Proposé" %}</th>
-                            <th width="24%">{% trans "Statut" %}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for validation in validations %}
-                            <tr>
-                                <td>
-                                    <a href="{% url "zds.article.views.view" validation.article.pk validation.article.slug %}?version={{ validation.version }}" >
-                                        {{ validation.article.title }}
-                                    </a>
-                                    <br>
-                                    {% if validation.article.subcategory.all %}
-                                        {% trans "Catégories" %} : 
-                                        {% for subcategory in validation.article.subcategory.all %}
-                                            {% if not forloop.first %}
-                                                -
-                                            {% endif %}
-                                            <a href="{% url "zds.article.views.list_validation" %}?subcategory={{ subcategory.pk }}">
-                                                {{ subcategory.title }}</a>
-                                        {% endfor %}
-                                    {% else %}
-                                        <em>{% trans "Aucune catégorie" %}</em>
+
+
+{% block content %}
+    {% if validations %}
+        <table class="fullwidth">
+            <thead>
+                <tr>
+                    <th>{% trans "Titre" %}</th>
+                    <th width="10%">{% trans "Auteur(s)" %}</th>
+                    <th width="10%">{% trans "Proposé" %}</th>
+                    <th width="24%">{% trans "Statut" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for validation in validations %}
+                    <tr>
+                        <td>
+                            <a href="{% url "zds.article.views.view" validation.article.pk validation.article.slug %}?version={{ validation.version }}" >
+                                {{ validation.article.title }}
+                            </a>
+                            <br>
+                            {% if validation.article.subcategory.all %}
+                                {% trans "Catégories" %} : 
+                                {% for subcategory in validation.article.subcategory.all %}
+                                    {% if not forloop.first %}
+                                        -
                                     {% endif %}
-                                </td>
-                                <td>
-                                    {% for author in validation.article.authors.all %}
-                                        {% include 'misc/member_item.part.html' with member=author avatar=True %}
-                                    {% endfor %}
-                                </td>
-                                <td>
-                                    <span>{{ validation.date_proposition|format_date:True|capfirst }}</span>
-                                </td>
-                                <td>
-                                    {% captureas reservation_url %}
-                                        {% url "zds.article.views.reservation" validation.pk %}
-                                    {% endcaptureas %}
-                                    {% include "misc/validation.part.html" %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            {% else %}
-                <p>
-                    {% trans "Aucun article soumis en validation" %}.
-                </p>
-            {% endif %}
-        {% endblock %}
-    </section>
+                                    <a href="{% url "zds.article.views.list_validation" %}?subcategory={{ subcategory.pk }}">
+                                        {{ subcategory.title }}</a>
+                                {% endfor %}
+                            {% else %}
+                                <em>{% trans "Aucune catégorie" %}</em>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% for author in validation.article.authors.all %}
+                                {% include 'misc/member_item.part.html' with member=author avatar=True %}
+                            {% endfor %}
+                        </td>
+                        <td>
+                            <span>{{ validation.date_proposition|format_date:True|capfirst }}</span>
+                        </td>
+                        <td>
+                            {% captureas reservation_url %}
+                                {% url "zds.article.views.reservation" validation.pk %}
+                            {% endcaptureas %}
+                            {% include "misc/validation.part.html" %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p>
+            {% trans "Aucun article soumis en validation" %}.
+        </p>
+    {% endif %}
 {% endblock %}

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -150,7 +150,7 @@
 
     {% if profile.biography %}
         <hr class="clearfix" />
-        <section class="full-content-wrapper without-margin article-content">
+        <section class="without-margin article-content">
             <h2 id="biographie">{% trans "Biographie" %}</h2>
             {{ profile.biography|emarkdown }}
         </section>
@@ -158,7 +158,7 @@
 
     {% if stats_filename and perms.member.change_profile %}
         <hr class="clearfix" />
-        <section class="full-content-wrapper without-margin">
+        <section class="without-margin">
             <h2 id="activity">{% trans "Activité" %}</h2>
             <figure>
                 {% autoescape off %}
@@ -171,7 +171,7 @@
 
     {% if old_tutos and perms.member.change_profile %}
         <hr class="clearfix" />
-        <section class="full-content-wrapper without-margin">
+        <section class="without-margin">
             <h2 id="anciens-tutoriels-sdz">{% trans "Anciens tutoriels SdZ" %}</h2>
             <table>
                 <thead>

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -122,7 +122,7 @@
 
 
 
-    <section class="content-col-2 tutorial-list">
+    <section class="content-col-2">
         {% if tutorials %}
             <h2 class="ico-after ico-tutorials" id="derniers-tutoriels">{% trans "Derniers tutoriels" %}</h2>
             <div class="content-item-list">

--- a/templates/tutorial/index.html
+++ b/templates/tutorial/index.html
@@ -35,7 +35,7 @@
 
 
 {% block content_out %}
-    <section class="full-content-wrapper" itemscope itemtype="http://schema.org/ItemList">
+    <section class="content-wrapper" itemscope itemtype="http://schema.org/ItemList">
         <h1 class="ico-after ico-tutorials" itemprop="name">
             {% block headline %}
                 {% if tag %}

--- a/templates/tutorial/member/beta.html
+++ b/templates/tutorial/member/beta.html
@@ -29,7 +29,7 @@
         </h2>
 
         {% if tutorials %}
-            <div class="tutorial-list">
+            <div class="content-item-list">
                 {% for tutorial in tutorials %}
                     {% include 'tutorial/includes/tutorial_item.part.html' with type_link='beta' show_description=True %}
                 {% endfor %}

--- a/templates/tutorial/member/beta.html
+++ b/templates/tutorial/member/beta.html
@@ -23,7 +23,7 @@
 
 
 {% block content_out %}
-    <section class="full-content-wrapper">
+    <section class="content-wrapper">
         <h2 class="ico-after ico-tutorials">
             {% trans "Tutoriels en bêta par" %} {{ usr.username }}
         </h2>

--- a/templates/tutorial/member/index.html
+++ b/templates/tutorial/member/index.html
@@ -48,7 +48,7 @@
 
 
 {% block content_out %}
-    <section class="full-content-wrapper">
+    <section class="content-wrapper">
         <h2 class="ico-after ico-tutorials">
             {% block headline %}
                 {% trans "Mes tutoriels" %}

--- a/templates/tutorial/member/online.html
+++ b/templates/tutorial/member/online.html
@@ -22,7 +22,7 @@
 
 
 {% block content_out %}
-    <section class="full-content-wrapper">
+    <section class="content-wrapper">
         <h2 class="ico-after ico-tutorials">
             {% trans "Tutoriels publiés par" %} {{ usr.username }}
         </h2>

--- a/templates/tutorial/validation/index.html
+++ b/templates/tutorial/validation/index.html
@@ -21,84 +21,76 @@
 
 
 
-{% block content_out %}
-    <section class="content-wrapper">
-        <h1>
-            {% block headline %}
-                {% trans "Validation des tutoriels" %}
-                {% if request.GET.type == "reserved" %}
-                    / {% trans "Reservés" %}
-                {% elif request.GET.type == "orphan" %}
-                    / {% trans "Non-reservés" %}
-                {% endif %}
-                ({{ validations|length }})
-            {% endblock %}
-        </h1>
 
-        {% captureas headlinesub %}
-            {% block headline_sub %}{% endblock %}
-        {% endcaptureas %}
-        {% if headlinesub %}
-            <h2 class="subtitle">{{ headlinesub|safe }}</h2>
+{% block headline %}
+    <h1>
+        {% trans "Validation des tutoriels" %}
+        {% if request.GET.type == "reserved" %}
+            / {% trans "Reservés" %}
+        {% elif request.GET.type == "orphan" %}
+            / {% trans "Non-reservés" %}
         {% endif %}
+        ({{ validations|length }})
+    </h1>
+{% endblock %}
 
-        {% block content %}
-            {% if validations %}
-                <table class="fullwidth">
-                    <thead>
-                        <tr>
-                            <th>{% trans "Titre" %}</th>
-                            <th width="15%">{% trans "Auteur(s)" %}</th>
-                            <th width="10%">{% trans "Propos" %}é</th>
-                            <th width="24%">{% trans "Statut" %}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for validation in validations %}
-                            <tr>
-                                <td>
-                                    <a href="{% url "zds.tutorial.views.view_tutorial" validation.tutorial.pk validation.tutorial.slug %}?version={{ validation.version }}">
-                                        {{ validation.tutorial.title }}
-                                    </a>
-                                    <br>
-                                    {% if validation.tutorial.subcategory.all %}
-                                        {% trans "Catégories" %} : 
-                                        {% for subcategory in validation.tutorial.subcategory.all %}
-                                            {% if not forloop.first %}
-                                                -
-                                            {% endif %}
-                                            <a href="{% url "zds.tutorial.views.list_validation" %}?subcategory={{ subcategory.pk }}">
-                                                {{ subcategory.title }}</a>
-                                        {% endfor %}
-                                    {% else %}
-                                        <em>{% trans "Aucune catégorie" %}</em>
+
+
+{% block content %}
+    {% if validations %}
+        <table class="fullwidth">
+            <thead>
+                <tr>
+                    <th>{% trans "Titre" %}</th>
+                    <th width="15%">{% trans "Auteur(s)" %}</th>
+                    <th width="10%">{% trans "Propos" %}é</th>
+                    <th width="24%">{% trans "Statut" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for validation in validations %}
+                    <tr>
+                        <td>
+                            <a href="{% url "zds.tutorial.views.view_tutorial" validation.tutorial.pk validation.tutorial.slug %}?version={{ validation.version }}">
+                                {{ validation.tutorial.title }}
+                            </a>
+                            <br>
+                            {% if validation.tutorial.subcategory.all %}
+                                {% trans "Catégories" %} : 
+                                {% for subcategory in validation.tutorial.subcategory.all %}
+                                    {% if not forloop.first %}
+                                        -
                                     {% endif %}
-                                </td>
-                                <td>
-                                    {% for author in validation.tutorial.authors.all %}
-                                        {% include 'misc/member_item.part.html' with member=author avatar=True %}
-                                    {% endfor %}
-                                </td>
-                                <td>
-                                    <span>{{ validation.date_proposition|format_date:True|capfirst }}</span>
-                                </td>
-                                <td>
-                                    {% captureas reservation_url %}
-                                        {% url "zds.tutorial.views.reservation" validation.pk %}
-                                    {% endcaptureas %}
-                                    {% include "misc/validation.part.html" %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            {% else %}
-                <p>
-                    {% trans "Aucun tutoriel soumis en validation" %}.
-                </p>
-            {% endif %}
-        {% endblock %}
-    </section>
+                                    <a href="{% url "zds.tutorial.views.list_validation" %}?subcategory={{ subcategory.pk }}">
+                                        {{ subcategory.title }}</a>
+                                {% endfor %}
+                            {% else %}
+                                <em>{% trans "Aucune catégorie" %}</em>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% for author in validation.tutorial.authors.all %}
+                                {% include 'misc/member_item.part.html' with member=author avatar=True %}
+                            {% endfor %}
+                        </td>
+                        <td>
+                            <span>{{ validation.date_proposition|format_date:True|capfirst }}</span>
+                        </td>
+                        <td>
+                            {% captureas reservation_url %}
+                                {% url "zds.tutorial.views.reservation" validation.pk %}
+                            {% endcaptureas %}
+                            {% include "misc/validation.part.html" %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p>
+            {% trans "Aucun tutoriel soumis en validation" %}.
+        </p>
+    {% endif %}
 {% endblock %}
 
 

--- a/templates/tutorial/validation/index.html
+++ b/templates/tutorial/validation/index.html
@@ -22,7 +22,7 @@
 
 
 {% block content_out %}
-    <section class="full-content-wrapper">
+    <section class="content-wrapper">
         <h1>
             {% block headline %}
                 {% trans "Validation des tutoriels" %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | Aucun |
- Supprime `.full-content-wrapper`devenu inutile après la ZEP 4
- Nettoyage de deux gabarits
- Supprime `.tutorial-list` devenu inutile après la ZEP 4

**QA :**
- Générer le _front_ (avec `npm run gulp -- build`) ;
- Vérifier que le site (et le menu mobile) fonctionne bien sur toutes les pages modifiées :
  - la page listant tous les articles,
  - la page listant tous les tutoriels,
  - la page listant les articles en validation,
  - la page listant les tutoriels en validation,
  - la page de profil,
  - les pages listant les tutoriels de l'utilisateur (en brouillon, en béta ou en ligne)
