### PR TITLE
Corrige le texte au survol des tutoriels non publiés (fix #2879)

### DIFF
--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -23,6 +23,14 @@
     {% for category in tutorial.subcategory.all %}{% if forloop.first %}{% trans "dans" %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %} {{ category.title }}{% endfor %}
 {% endcaptureas %}
 
+{% captureas tutorial_state %}
+    {% if tutorial.pubdate %}
+        {% trans "Publié" %} {{ tutorial.pubdate|format_date }}
+    {% else %}
+        {% trans "En rédaction" %}
+    {% endif %}
+{% endcaptureas %}
+
 <article class="content-item expand-description tutorial-item{{ item_class }}">
     <a href="{{ link }}" title="{{ tutorial.title }}{% if tutorial.description and show_description %} − {{ tutorial.description }}{% endif %}">
         <div class="content-illu">
@@ -42,7 +50,7 @@
                 </p>
             {% endif %}
 
-            <div class="content-meta" title="{% trans "Publié" %} {{ tutorial.pubdate|format_date }} {{ categories_text }} {{ authors_text }}">
+            <div class="content-meta" title="{{ tutorial_state }} {{ categories_text }} {{ authors_text }}">
                 {% if tutorial.subcategory %}
                     <p class="content-categories">
                         {{ categories_text }}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2879 |

Corrige le texte au survol des tutoriels non publiés

**QA :**
- Sur un item d'un tutoriel publié, au survol de la date, vérifier que la date s'affiche bien dans une infobulle ;
- Sur un item d'un tutoriel non publié, au survol de la date, vérifier qu'aucune date n'est affiché et qu'aucun "None" n'est affiché.
