### PR TITLE
Enlève la marge du titre des sujets sur mobile (fix #2339)

### DIFF
--- a/assets/scss/components/_topic-list.scss
+++ b/assets/scss/components/_topic-list.scss
@@ -157,7 +157,7 @@
         .topic-title,
         .topic-subtitle {
             display: block;
-            margin: 0;
+            margin: 0 !important;
             padding: 0;
         }
         .topic-title {


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2339 |

Répare le décalage du titre des sujets en format mobile

**QA :**
- Générer le _front_ (avec `npm run gulp -- build`) ;
- Aller dans un forum ou il y a des sujets de listés ;
- Redimensionner son navigateur pour que ce soit au format mobile ;
- Vérifier que le titre est bien aligné au sous-titre et au nom de l'auteur.
