### PR TITLE
Rend l'en-tête compatible écran 10 pouces (fix #2163)

### DIFF
--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -409,7 +409,7 @@
 
     .header-container header .header-menu {
         float: left;
-        width: 34%;
+        width: 40%;
         margin-left: .5%;
 
         .header-menu-list > li > a {
@@ -466,7 +466,6 @@
 
 @media only screen and #{$media-extra-wide} {
     .header-container header .header-menu {
-        width: 40%;
         margin-left: 5%;
     }
 }


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2163 |

Rend l'en-tête compatible écran 10 pouces

**QA :**
- Générer le _front_ (avec `npm run gulp -- build`) ;
- Aller sur http://127.0.0.1:8000/ et redimensionner son navigateur (la largeur la plus petite possible sans passer en format tablette, c'est-à-dire environ 1000px) ;
- Vérifier que la flèche ne chevauche pas "TUTORIELS" ;
- Agrandir progressivement le navigateur (en vérifiant qu'il n'y a pas de bug visuels et que le _dropdown_ fonctionne bien).
