### PR TITLE
Les caractères de la recherche de l'en-tête ne sont plus tronqués

### DIFF
--- a/assets/scss/components/_header-search.scss
+++ b/assets/scss/components/_header-search.scss
@@ -92,8 +92,8 @@
         }
         form {
             input {
-                padding: 8px 10px;
-                height: 14px;
+                padding: 6px 10px;
+                height: 18px;
                 width: 150px;
             }
             button {


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2583 |

Les caractères de la recherche de l'en-tête ne sont plus tronqués sur Firefox

**QA :**
- Générer le _front_ (avec `npm run gulp -- build`) ;
- Aller sur une page autre que la page d'accueil ;
- Entrer "qg" dans la recherche de l'en-tête (pour les navigateurs _desktop_) et du menu latéral (pour les navigateurs mobiles) ;
- Vérifier que les caractères ne sont pas tronqués.
