### PR TITLE
Correction de l'affichage pour les tutos dont la date de publication n'existe pas

### DIFF
--- a/templates/tutorial/includes/tutorial_item.part.html
+++ b/templates/tutorial/includes/tutorial_item.part.html
@@ -24,8 +24,8 @@
 {% endcaptureas %}
 
 {% captureas tutorial_state %}
-    {% if tutorial.pubdate %}
-        {% trans "Publié" %} {{ tutorial.pubdate|format_date }}
+    {% if tutorial.on_line %}
+        {% trans "Publié" %} {% if tutorial.pubdate %}{{ tutorial.pubdate|format_date }}{% endif %}
     {% else %}
         {% trans "En rédaction" %}
     {% endif %}


### PR DESCRIPTION
close #2937 

| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2937 |
# Note de QA

La QA se fait sur l'infobulle suivante:

![screenshot from 2015-07-24 20 24 06](https://cloud.githubusercontent.com/assets/7889675/8881722/2f129226-3242-11e5-9bc3-c13544b322c6.png)
- Créer des tutos avec la commande `python manage.py load_fixtures type=tutorial` (cette commande crée des tutoriels sans `pubdate`).
- Se connecter avec un utilisateur (_user_, par exemple), et aller dans "Mes tutoriels". Vérifier qu'au passage de la souris sur la date, "en rédaction" apparait bien quand le tuto n'est pas publié, "publié" apparait bien quand c'est le cas. Vérifier non plus qu'il n'y a pas de "None" disgratieux
- Créer un tutoriel manuellement et le publier. Vérifier que l'infobulle dit bien "publié" et que la date est présente ("il y a ...").
