### PR TITLE
Desanonymisation des +/-1

### DIFF
--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -88,6 +88,48 @@
     });
 
     /**
+     * See who likes/dislikes a message
+     */
+    $(".topic-message").on("click", "button.likers", function(e){
+        var $viewer = $(this),
+            $form = $(this).parents("form:first"),
+            $message = $viewer.parents(".message-bottom:first");
+
+        var csrfmiddlewaretoken = $form.find("input[name=csrfmiddlewaretoken]").val();
+
+        $.ajax({
+            url: $form.attr("action"),
+            type: "POST",
+            dataType: "json",
+            data: {
+                "csrfmiddlewaretoken": csrfmiddlewaretoken
+            },
+            success: function(data){
+                $viewer.attr("disabled", "disabled");
+                var div = document.createElement("div");
+                div.className = "likers";
+                for (var keyLike in data.likes) {
+                    var imageLike = document.createElement("img");
+                    imageLike.src = data.likes[keyLike].avatarUrl;
+                    imageLike.title = data.likes[keyLike].username;
+                    imageLike.className = "avatar likers thumbUp";
+                    $(div).append(imageLike);
+                }
+                for (var keyDislike in data.dislikes) {
+                    var imageDislike = document.createElement("img");
+                    imageDislike.src = data.dislikes[keyDislike].avatarUrl;
+                    imageDislike.title = data.dislikes[keyDislike].username;
+                    imageDislike.className = "avatar likers thumbDown";
+                    $(div).append(imageDislike);
+                }
+                $message.prepend(div);
+            }
+        });
+
+        e.stopPropagation();
+        e.preventDefault();
+    });
+    /**
      * Follow a topic
      */
     $(".sidebar").on("click", "[data-ajax-input='follow-topic']", function(e){

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -368,6 +368,20 @@
                     }
                 }
             }
+
+            .likers img {
+                width: 30px;
+                height: 30px;
+                margin: 0 2px;
+
+                &.thumbUp {
+                    border-bottom: solid 3px $color-success;
+                }
+
+                &.thumbDown {
+                    border-bottom: solid 3px $color-danger;
+                }
+            }
         }
 
         .message-buttons {

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -63,7 +63,7 @@
 
     {% include "misc/paginator.html" with position="top" %}
 
-        <div 
+        <div
             class="alert-box success ico-after tick light {% if not topic.is_solved %}empty{% endif %}"
             data-ajax-output="solve-topic"
         >

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -18,13 +18,13 @@
         topic-message
         {% if message.is_useful %}helpful{% endif %}
         {% if is_repeated_message %}repeated{% endif %}
-    " 
+    "
     {% if comment_schema %}
-        itemscope 
+        itemscope
         itemtype="http://schema.org/Comment"
         itemprop="comment"
     {% elif answer_schema %}
-        itemscope 
+        itemscope
         itemtype="http://schema.org/Answer"
         {% if message.is_useful or message.like > message.dislike %}
             itemprop="{% if message.is_useful %}acceptedAnswer{% endif %} {% if message.like > message.dislike %}suggestedAnswer{% endif %}"
@@ -204,8 +204,8 @@
         {% if perms_change %}
             {% for alert in message.alerts.all %}
                 <div class="alert-box error">
-                    {{ alert.pubdate|format_date|capfirst }} {% trans "par" %} 
-                    {% include "misc/member_item.part.html" with member=alert.author %} : 
+                    {{ alert.pubdate|format_date|capfirst }} {% trans "par" %}
+                    {% include "misc/member_item.part.html" with member=alert.author %} :
                     <em class="alert-box-text">{{ alert.text }}</em>
 
                     <a href="#solve-alert-{{ alert.pk }}" class="open-modal close-alert-box close-alert-box-text">{% trans "Résoudre" %}</a>
@@ -315,10 +315,10 @@
                                     {{ message.like }}
                                 </span>
                             </span>
-                            <span 
+                            <span
                                 class="downvote
                                        ico-after
-                                       {% if message.like < message.dislike %}more-voted{% endif %} 
+                                       {% if message.like < message.dislike %}more-voted{% endif %}
                                        {% if message.dislike > 0 %}has-vote{% endif %}"
                                 {% if message.dislike > 0 %}
                                     title="{{ message.dislike }} personne{{ message.dislike|pluralize }} n'{% if message.dislike > 1 %}ont{% else %}a{% endif %} pas trouvé ce message utile"
@@ -329,6 +329,10 @@
                                 </span>
                             </span>
                         {% endif %}
+                        <form action="{% url 'post-find-likers' message.pk %}" method="get">
+                            {% csrf_token %}
+                            <button type="submit" title='{% trans "Voir les votants" %}' class="likers ico-after view blue"></button>
+                        </form>
                     </div>
                 {% endif %}
             </div>

--- a/zds/forum/urls.py
+++ b/zds/forum/urls.py
@@ -46,6 +46,8 @@ urlpatterns = patterns('',
                        url(r'^message/like/$', PostLike.as_view(), name='post-like'),
                        url(r'^message/dislike/$', PostDisLike.as_view(), name='post-dislike'),
                        url(r'^messages/(?P<user_pk>\d+)/$', FindPost.as_view(), name='post-find'),
+                       url(r'^message/likers/(?P<post_pk>\d+)/$', 'zds.forum.views.post_find_likers',
+                           name='post-find-likers'),
 
                        # Categories and forums list.
                        url(r'^$', CategoriesForumsListView.as_view(), name='cats-forums-list'),

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -699,3 +699,31 @@ def complete_topic(request):
     the_data = json.dumps(suggestions)
 
     return HttpResponse(the_data, content_type='application/json')
+
+
+@login_required
+def post_find_likers(request, post_pk):
+    likes = CommentDislike.objects.filter(comments__pk=post_pk).select_related('user')
+    dislikes = CommentDislike.objects.filter(comments__pk=post_pk).select_related('user')
+
+    likers = []
+    dislikers = []
+
+    for like in likes:
+        likers.append({'username': like.user.username,
+                       'avatarUrl': like.user.profile.get_avatar_url()
+                       })
+    for dislike in dislikes:
+        dislikers.append({'username': dislike.user.username,
+                          'avatarUrl': dislike.user.profile.get_avatar_url()
+                          })
+
+    if request.is_ajax():
+        resp = {
+            'likes': likers,
+            'dislikes': dislikers
+        }
+        return HttpResponse(json.dumps(resp), content_type='application/json')
+
+    post = get_object_or_404(Post, pk=post_pk)
+    return redirect(post.get_absolute_url())


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #1851 |

Ceci est un WIP qui est bien avancé.
Pour le finir il me faut un coup de main front : j'aimerais que l'affichages des avatars se placent au-dessus du karma alignés à droite

Pis c'est tout, le reste marche normalement correctement.

TODO : Faire un script qui attribue tout les anciens +1/-1 à anonyme lors de la mise en prod' pour ne pas fausser les utilisateurs ayant voté AVANT la feature.

![capture du 2015-07-29 19 50 19](https://cloud.githubusercontent.com/assets/761168/8965463/06243142-362c-11e5-99ea-3f229fcaade1.png)

PS : C'est standard, ca marche sur n'importe quel commentaire (fofo/article/etc..)
