### PR TITLE
Ajout de mark_safe pour le tag captureas (fix #2900)

### DIFF
--- a/zds/utils/templatetags/captureas.py
+++ b/zds/utils/templatetags/captureas.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django import template
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
@@ -54,5 +55,5 @@ class CaptureasNode(template.Node):
         :rtype: str
         """
         output = self.__node_list.render(context)
-        context[self.__variable_name] = output.strip()
+        context[self.__variable_name] = mark_safe(output.strip())
         return ''


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2900 |

Cette PR évite un double échappement lors de l'utilisation du tag `captureas`.
# QA
- Créer un utilisateur contenant des caractères spéciaux (genre `B&B`)
- Rédiger puis publier un article et un tutoriel (mini ou big)
- Remarquer que les pages suivantes n'affichent pas correctement le pseudo (pour l'exemple `B&amp;N`) dans le rectangle si la correction n'est pas appliquée.
  - sur la page de profil (liste des articles/tutoriels)
  - sur la page qui liste les tutoriels
  - sur la page qui liste les articles
- Vérifier que la PR corrige ce comportement et que dans la source le pseudo est bien échappé une seule fois `B&amp;B` (`B&B` correspond à du code non échappé en HTML!)
