### PR TITLE
[release v15.7] Empêche une 500 si le fichier HTML n'existe pas

### DIFF
--- a/zds/article/models.py
+++ b/zds/article/models.py
@@ -193,12 +193,17 @@ class Article(models.Model):
         json_data.close()
 
     def get_text(self):
-        path = os.path.join(self.get_path(), self.text)
-        txt = open(path, "r")
-        txt_contenu = txt.read()
-        txt.close()
+        txt_contenu = None
 
-        return txt_contenu.decode('utf-8')
+        try:
+            path = os.path.join(self.get_path(), self.text)
+            txt = open(path, "r")
+            txt_contenu = txt.read().decode('utf-8')
+            txt.close()
+        except IOError:
+            pass
+
+        return txt_contenu
 
     def save(self, *args, **kwargs):
         self.slug = slugify(self.title)

--- a/zds/article/views.py
+++ b/zds/article/views.py
@@ -154,11 +154,15 @@ def view_online(request, article_pk, article_slug):
 
     # Load the article.
     article_version = article.load_json_for_public()
-    txt = open(os.path.join(article.get_path(),
-                            article_version['text'] + '.html'),
-               "r")
-    article_version['txt'] = txt.read()
-    txt.close()
+    try:
+        txt = open(os.path.join(article.get_path(),
+                                article_version['text'] + '.html'),
+                   "r")
+        article_version['txt'] = txt.read()
+        txt.close()
+    except IOError:
+        pass
+
     article_version = article.load_dic(article_version)
 
     # If the user is authenticated

--- a/zds/tutorial/models.py
+++ b/zds/tutorial/models.py
@@ -311,17 +311,22 @@ class Tutorial(models.Model):
             return get_blob(repo.commit(sha).tree, path_tuto)
 
     def get_introduction_online(self):
-        if self.on_line():
-            intro = open(
-                os.path.join(
-                    self.get_prod_path(),
-                    self.introduction +
-                    '.html'),
-                "r")
-            intro_contenu = intro.read()
-            intro.close()
+        intro_contenu = None
 
-            return intro_contenu.decode('utf-8')
+        if self.on_line():
+            try:
+                intro = open(
+                    os.path.join(
+                        self.get_prod_path(),
+                        self.introduction +
+                        '.html'),
+                    "r")
+                intro_contenu = intro.read().decode('utf-8')
+                intro.close()
+            except IOError:
+                pass
+
+        return intro_contenu
 
     def get_conclusion(self, sha=None):
         # find hash code
@@ -338,17 +343,22 @@ class Tutorial(models.Model):
             return get_blob(repo.commit(sha).tree, path_tuto)
 
     def get_conclusion_online(self):
-        if self.on_line():
-            conclu = open(
-                os.path.join(
-                    self.get_prod_path(),
-                    self.conclusion +
-                    '.html'),
-                "r")
-            conclu_contenu = conclu.read()
-            conclu.close()
+        conclu_contenu = None
 
-            return conclu_contenu.decode('utf-8')
+        if self.on_line():
+            try:
+                conclu = open(
+                    os.path.join(
+                        self.get_prod_path(),
+                        self.conclusion +
+                        '.html'),
+                    "r")
+                conclu_contenu = conclu.read().decode('utf-8')
+                conclu.close()
+            except IOError:
+                pass
+
+        return conclu_contenu
 
     def delete_entity_and_tree(self):
         """deletes the entity and its filesystem counterpart"""
@@ -649,16 +659,20 @@ class Part(models.Model):
             return None
 
     def get_introduction_online(self):
-        intro = open(
-            os.path.join(
-                self.tutorial.get_prod_path(),
-                self.introduction +
-                '.html'),
-            "r")
-        intro_contenu = intro.read()
-        intro.close()
+        intro_contenu = None
+        try:
+            intro = open(
+                os.path.join(
+                    self.tutorial.get_prod_path(),
+                    self.introduction +
+                    '.html'),
+                "r")
+            intro_contenu = intro.read().decode('utf-8')
+            intro.close()
+        except IOError:
+            pass
 
-        return intro_contenu.decode('utf-8')
+        return intro_contenu
 
     def get_conclusion(self, sha=None):
 
@@ -683,14 +697,19 @@ class Part(models.Model):
             return None
 
     def get_conclusion_online(self):
-        conclu = open(
-            os.path.join(
-                self.tutorial.get_prod_path(),
-                self.conclusion +
-                '.html'),
-            "r")
-        conclu_contenu = conclu.read()
-        conclu.close()
+        conclu_contenu = None
+
+        try:
+            conclu = open(
+                os.path.join(
+                    self.tutorial.get_prod_path(),
+                    self.conclusion +
+                    '.html'),
+                "r")
+            conclu_contenu = conclu.read()
+            conclu.close()
+        except IOError:
+            pass
 
         return conclu_contenu.decode('utf-8')
 
@@ -944,8 +963,6 @@ class Chapter(models.Model):
                 return conclu_contenu.decode('utf-8')
             else:
                 return None
-
-            return conclu_contenu.decode('utf-8')
         else:
             return None
 

--- a/zds/tutorial/views.py
+++ b/zds/tutorial/views.py
@@ -1414,14 +1414,20 @@ def view_part_online(
         part["position_in_tutorial"] = cpt_p
         if part_pk == str(part["pk"]):
             find = True
-            intro = open(os.path.join(tutorial.get_prod_path(),
-                                      part["introduction"] + ".html"), "r")
-            part["intro"] = intro.read()
-            intro.close()
-            conclu = open(os.path.join(tutorial.get_prod_path(),
-                                       part["conclusion"] + ".html"), "r")
-            part["conclu"] = conclu.read()
-            conclu.close()
+            try:
+                intro = open(os.path.join(tutorial.get_prod_path(),
+                                          part["introduction"] + ".html"), "r")
+                part["intro"] = intro.read()
+                intro.close()
+            except IOError:
+                pass
+            try:
+                conclu = open(os.path.join(tutorial.get_prod_path(),
+                                           part["conclusion"] + ".html"), "r")
+                part["conclu"] = conclu.read()
+                conclu.close()
+            except IOError:
+                pass
             final_part = part
         cpt_c = 1
         for chapter in part["chapters"]:
@@ -1834,35 +1840,45 @@ def view_chapter_online(
                 "get_absolute_url_online"] + "{0}/{1}/".format(chapter["pk"], chapter["slug"])
             if chapter_pk == str(chapter["pk"]):
                 find = True
-                intro = open(
-                    os.path.join(
-                        tutorial.get_prod_path(),
-                        chapter["introduction"] +
-                        ".html"),
-                    "r")
-                chapter["intro"] = intro.read()
-                intro.close()
-                conclu = open(
-                    os.path.join(
-                        tutorial.get_prod_path(),
-                        chapter["conclusion"] +
-                        ".html"),
-                    "r")
-                chapter["conclu"] = conclu.read()
-                conclu.close()
+                try:
+                    intro = open(
+                        os.path.join(
+                            tutorial.get_prod_path(),
+                            chapter["introduction"] +
+                            ".html"),
+                        "r")
+                    chapter["intro"] = intro.read()
+                    intro.close()
+                except IOError:
+                    pass
+
+                try:
+                    conclu = open(
+                        os.path.join(
+                            tutorial.get_prod_path(),
+                            chapter["conclusion"] +
+                            ".html"),
+                        "r")
+                    chapter["conclu"] = conclu.read()
+                    conclu.close()
+                except IOError:
+                    pass
+
                 cpt_e = 1
                 for ext in chapter["extracts"]:
                     ext["chapter"] = chapter
                     ext["position_in_chapter"] = cpt_e
                     ext["path"] = tutorial.get_path()
-                    text = open(os.path.join(tutorial.get_prod_path(),
-                                             ext["text"] + ".html"), "r")
-                    ext["txt"] = text.read()
-                    text.close()
+
+                    try:
+                        text = open(os.path.join(tutorial.get_prod_path(),
+                                                 ext["text"] + ".html"), "r")
+                        ext["txt"] = text.read()
+                        text.close()
+                    except IOError:
+                        pass
+
                     cpt_e += 1
-            else:
-                intro = None
-                conclu = None
             chapter_tab.append(chapter)
             if chapter_pk == str(chapter["pk"]):
                 final_chapter = chapter


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2959 |

Si ce n'est pas un _betafix_, alors cette PR est inutile, la ZEP-12 s'en chargera.

(et clairement, le code est pénible, c'est ma dernière PR sur l'ancien code des tutos :o )
# Note de QA
- Créer un (big-)tutoriel avec une partie contenant un chapitre contenant un extrait. Pour la partie et le chapitre, mettre un texte d'intro et de conclusion. Le publier ;
- Aller dans le dossier de contenant les tutoriels publiés (`tutoriels-public`) et dans celui correspondant à votre tuto juste publié (`tutoriels-public/xx_slug/`) et supprimer tout les fichier finissant par `.md.html` que vous trouverez (y compris dans les dossiers). Puis naviguer sur le tutoriel et constater que les intros, conclusions et textes ont disparus mais que ça reste navigable ;
- Faire pareil avec un article (cette fois, le fichier a supprimer est `/articles-data/xx_slug/test.md.html`).
