### PR TITLE
Minifie les sprites

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -122,6 +122,7 @@ gulp.task("sprite", function() {
       style: "_sprite.scss",
       template: path.join(sourceDir, sassDir, "sprite-template.hbs")
     })
+    .pipe($.if("*.png", $.imagemin(imageminConfig)))
     .pipe($.if("*.png", gulp.dest(path.join(destDir, imagesDir)), gulp.dest(path.join(sourceDir, sassDir))));
 });
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | Aucun |

Minimise `sprite.png` et `sprite@2x.png`, ce qui divise leur taille par presque 2 !

**QA :**
- Sur `upstream/dev`, aller dans `dist/images` et regarder le poids de `sprite.png` et `sprite@2x.png` (avec la commande `ls -lh` par exemple) ;
- Aller sur ma branche, faire `npm run gulp -- build` ;
- Aller dans `dist/images` et vérifier que le poids de `sprite.png` et `sprite@2x.png` a bien diminué d'environ moitié ;
- Lancer le site `python manage.py runserver` et vérifier que les icônes s'affichent bien.
