### PR TITLE
Amélioration de la page de contact

### DIFF
--- a/templates/pages/contact.html
+++ b/templates/pages/contact.html
@@ -25,56 +25,114 @@
 
 {% block content %}
     {% set app.site.litteral_name as site_name %}
-    <h3>{% trans "L'équipe de communication" %}</h3>
+
     <p>
-        {% blocktrans with email_contact=app.site.email_contact|obfuscate_mailto_top_subject:"Contact communication" %}
-            Vous pouvez à tout moment joindre l'équipe de communication de {{ site_name }} par courriel via {{ email_contact }}.
+        {% blocktrans %}
+            Plusieurs personnes aident au fonctionnement, au développement et à la régulation de {{ site_name }}. Voici chaque groupe avec la liste de leurs membres et un moyen de les contacter. Veuillez noter que les groupes sont dissociés et ne sont pas hiérarchisés, c'est-à-dire qu'appartenir à l'un ne fait jamais appartenir automatiquement à un autre.
         {% endblocktrans %}
     </p>
-    {% if app.site.association %}
-        <h3>{% trans "L'association" %}</h3>
-        <p>
-            {% blocktrans with email_association=app.site.association.email|obfuscate_mailto_top_subject:"Contact association" %}
-                Vous pouvez joindre l'association par courriel via {{ email_association }}.
-            {% endblocktrans %}
-        </p>
-    {% endif %}
 
     <h3>{% trans "Le staff" %}</h3>
     <p>
         {% blocktrans %}
             Le staff est constitué de certains membres du site dont le but est de contrôler le contenu publié sur {{ site_name }}. Ils sont en charge de la modération des messages sur les forums et commentaires, ainsi que de la validation et publication d'articles et/ou de tutoriels de {{ site_name }}.
-            Les membres faisant partie du Staff sont les suivants :
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans %}
+            Pour contacter le staff, utilisez le bouton "Signaler" des messages du forum ou <a href="{{ staffs_contact_url }}">envoyez-leur un message privé</a> ! Dans les forums et les zones de commentaires, ils sont reconnaissables facilement grâce à l'étiquette verte "STAFF" en dessous de leur avatar.
         {% endblocktrans %}
     </p>
     <div class="authors">
-        <ul>
-            {% if staffs %}
+        {% if staffs %}
+            <ul>
                 {% for member in staffs %}
                     <li>{% include "misc/member_item.part.html" with avatar=True %}</li>
                 {% endfor %}
-            {% else %}
+            </ul>
+        {% else %}
+            <p>
                 {% trans "Il n'y a pas de membre dans ce groupe." %}
-            {% endif %}
-        </ul>
+            </p>
+        {% endif %}
+    </div>
+
+    <h3>{% trans "L'équipe de communication" %}</h3>
+    <p>
+        {% blocktrans %}
+            L'équipe de communication gère la communication du site sur les réseaux sociaux et sur la page d'accueil (notamment la partie "A la Une"). Elle a pour but de mettre en avant le contenu et les créations des membres.
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans with email_contact=app.site.email_contact|obfuscate_mailto_top_subject:"Contact communication" %}
+            Vous pouvez à tout moment joindre cette équipe par courriel via {{ email_contact }} ou <a href="{{ communication_team_contact_url }}">en leur envoyant un message privé</a>.
+        {% endblocktrans %}
+    </p>
+    <div class="authors">
+        {% if communication_team %}
+            <ul>
+                {% for member in communication_team %}
+                    <li>{% include "misc/member_item.part.html" with avatar=True %}</li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p>
+                {% trans "Il n'y a pas de membre dans ce groupe." %}
+            </p>
+        {% endif %}
     </div>
 
     <h3>{% trans "L'équipe technique" %}</h3>
     <p>
         {% blocktrans with repository=app.site.repository %}
             L'équipe technique est constituée de certains membres du site dont le but est d'une part de s'assurer que le site reste toujours disponible en ligne, et d'autre part de corriger les bogues rencontrés sur le site ainsi que d'ajouter de nouvelles fonctionnalités.
-            Des administrateurs systèmes, jusqu'aux designeurs, en passant par les développeurs back-end et intégrateurs front-end, ils s'occupent aussi de la maintenance du <a href="{{ repository }}">dépôt officiel du projet</a>. Les membres faisant partie de l'équipe technique sont les suivants :
+            Des administrateurs systèmes, jusqu'aux designeurs, en passant par les développeurs back-end et intégrateurs front-end, ils s'occupent aussi de la maintenance du <a href="{{ repository }}">dépôt officiel du projet</a>. Pour rester cohérent et organisé, le projet est orchestré par un Directeur Technique Canidé [DTC] et un Chef de Projet [CdP] (chaque développeur reste néanmoins autonome).
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans with url_forum=app.site.forum_feedback_users %}
+            Vous pouvez à tout moment joindre cette équipe <a href="{{ devs_contact_url }}">en leur envoyant un message privé</a> sauf pour les bugs et suggestions, auquel cas il est préférable de créer un sujet dans <a href="{{ url_forum }}">ce forum</a>.
         {% endblocktrans %}
     </p>
     <div class="authors">
-        <ul>
-            {% if devs %}
+        {% if devs %}
+            <ul>
                 {% for member in devs %}
                     <li>{% include "misc/member_item.part.html" with avatar=True %}</li>
                 {% endfor %}
-            {% else %}
+            </ul>
+        {% else %}
+            <p>
                 {% trans "Il n'y a pas de membre dans ce groupe." %}
-            {% endif %}
-        </ul>
+            </p>
+        {% endif %}
     </div>
+
+    {% if app.site.association %}
+        <h3>{% trans "L'association" %}</h3>
+        <p>
+            {% url "zds.pages.views.association" as assoc_page %}
+            {% blocktrans %}
+                L'association sert à assurer la pérénité du site au niveau financier et est gardienne des valeurs du site. Son conseil d'administration (dont les membres sont listés dessous) sert d'arbitre en cas de désaccord sur les nouvelles fonctionnalités du site. Pour plus d'informations, vous pouvez consulter <a href="{{ assoc_page }}">la page dédiée à l'association</a> !
+            {% endblocktrans %}
+        </p>
+        <p>
+            {% blocktrans with email_association=app.site.association.email|obfuscate_mailto_top_subject:"Contact association" %}
+                Vous pouvez joindre l'association par courriel via {{ email_association }} ou les membres du conseil d'administration <a href="{{ assoc_contact_url }}">en leur envoyant un message privé</a>.
+            {% endblocktrans %}
+        </p>
+        <div class="authors">
+            {% if assoc %}
+                <ul>
+                    {% for member in assoc %}
+                        <li>{% include "misc/member_item.part.html" with avatar=True %}</li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p>
+                    {% trans "Il n'y a pas de membre dans ce groupe." %}
+                </p>
+            {% endif %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -11,6 +11,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
 from django.shortcuts import render
+from django.utils.http import urlencode
 from zds import settings
 
 from zds.forum.models import Topic
@@ -119,15 +120,34 @@ def association(request):
 
 def contact(request):
     """Display contact page."""
+    contact_url = lambda members: reverse('mp-new') + '?' \
+        + '&'.join([urlencode({'username': member.username}) for member in members])
+
     staffs = User.objects.filter(
         groups__in=Group.objects.filter(
             name__contains='staff')).all()
+
+    communication_team = User.objects.filter(
+        groups__in=Group.objects.filter(
+            name__contains='com')).all()
+
     devs = User.objects.filter(
         groups__in=Group.objects.filter(
             name__contains='dev')).all()
+
+    assoc = User.objects.filter(
+        groups__in=Group.objects.filter(
+            name__contains='asso')).all()
+
     return render(request, 'pages/contact.html', {
         'staffs': staffs,
-        'devs': devs
+        'staffs_contact_url': contact_url(staffs),
+        'communication_team': communication_team,
+        'communication_team_contact_url': contact_url(communication_team),
+        'devs': devs,
+        'devs_contact_url': contact_url(devs),
+        'assoc': assoc,
+        'assoc_contact_url': contact_url(assoc)
     })
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2911 |
- Ajoute les membres de l'équipe de communication et le conseil d'administration sur la page de contact
- Réorganise la page de contact (l'ordre a été changé, on a maintenant "staff", puis "com", puis "dev" et enfin l'association)
- Ajoute un lien pour envoyer un MP à tous les membres d'un groupe

**QA :** Vérifier que la page fonctionne bien (il vous faudra créer les groupes "dev", "com" et "asso" depuis [l'interface d'administration](127.0.0.1:8000/admin/) puis les attribuer - manuellement un par un je crois - à quelques utilisateurs)

Vous deviez arriver à ce résultat :

![Capture d'écran de la page](https://i.gyazo.com/ec398a60e68fd06729e9fa22a8dc896a.png)

@SpaceFox : Quel est le nom du groupe de la com' en production ? Dans cette PR j'ai fait comme si il contenait "com", donc ça devrait fonctionner avec "com" ou "communication"
# Ne pas merger ! Il faut vérifier que les noms des groupes dans le code correspondent à ceux sur la prod.
