### PR TITLE
Correction d'une faute d'orthographe

### DIFF
--- a/templates/member/new_password/success.html
+++ b/templates/member/new_password/success.html
@@ -22,6 +22,6 @@
 
 {% block content %}
     <p>
-        {% trans "Votre mot de passe a bien été modifié" %}. <a href="{% url "zds.member.views.login_view" %}">{% trans "Vous connectez" %}</a>.
+        {% trans "Votre mot de passe a bien été modifié" %}. <a href="{% url "zds.member.views.login_view" %}">{% trans "Vous connecter" %}</a>.
     </p>
 {% endblock %}

--- a/templates/member/new_password/success.html
+++ b/templates/member/new_password/success.html
@@ -3,13 +3,13 @@
 
 
 {% block title %}
-    {% trans "La modification du mot de passe a été éffectuée" %}
+    {% trans "La modification du mot de passe a été effectuée" %}
 {% endblock %}
 
 
 
 {% block headline %}
-    {% trans "La modification du mot de passe a été éffectuée" %}
+    {% trans "La modification du mot de passe a été effectuée" %}
 {% endblock %}
 
 
@@ -22,6 +22,6 @@
 
 {% block content %}
     <p>
-        {% trans "Votre mot de passe a bien été modifié" %}. <a href="{% url "zds.member.views.login_view" %}">{% trans "Vous connecter" %}</a>.
+        {% trans "Votre mot de passe a bien été modifié, vous pouvez dès maintenant" %} <a href="{% url "zds.member.views.login_view" %}">{% trans "vous connecter" %}</a>.
     </p>
 {% endblock %}


### PR DESCRIPTION
Une faute d'orthographe s'est glissée dans le message de confirmation lorsqu'on a changé son mot de passe via la fonction "Mot de passe oublié".
