### PR TITLE
Ajout d'un margin sous les balises secret

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -199,7 +199,7 @@
         .spoiler-title {
             display: block;
             background: #EEE;
-            margin-top: 15px;
+            margin: 15px 0;
             padding: 3px 15px 3px 40px;
             text-decoration: none;
             border-bottom: 1px solid #DDD;


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets (_issues_) concernés | https://github.com/zestedesavoir/zds-site/issues/2925 |
### QA:

Ajouter un post sur un forum et mettre un code similaire à celui-ci:

```
>Blockquote

[[secret]]
|super secret

>Blockquote
```

Egalement tester si la balise `[[secret]]` ne pose pas problème.
