### PR TITLE
Efface le texte Suivant/Précédent sur mobile dans la pagination

### DIFF
--- a/templates/misc/paginator.html
+++ b/templates/misc/paginator.html
@@ -13,7 +13,9 @@
         {% if page_obj.has_previous %}
             <li class="prev">
                 <a href="{% append_to_get page=page_obj.previous_page_number %}{{ full_anchor }}" class="ico-after arrow-left blue">
-                    {% trans "Précédente" %}
+                    <span>
+                        {% trans "Précédente" %}
+                    </span>
                 </a>
             </li>
         {% endif %}
@@ -56,7 +58,9 @@
         {% if page_obj.has_next %}
             <li class="next">
                 <a href="{% append_to_get page=page_obj.next_page_number %}{{ full_anchor }}" class="ico-after arrow-right blue">
-                    {% trans "Suivante" %}
+                    <span>
+                        {% trans "Suivante" %}
+                    </span>
                 </a>
             </li>
         {% endif %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2597, https://github.com/artragis/zds-site/issues/339 |

Efface le texte Suivant/Précédent sur mobile dans les deux gabarits de la pagination

**QA :** Vérifier qu'à tous les endroits où il y a de la pagination, les textes "Suivant" et "Précédent" n'apparaissent pas sur mobile.

Voici une liste des pages :
- sujet du forum ;
- liste des sujets du forum ;
- commentaires d'un tutoriel ;
- commentaires d'un article ;
- page d'aide des auteurs.
