### PR TITLE
Répare le script d'installation du projet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 
 import os
 
+from pip.download import PipSession
 from pip.req import parse_requirements
 
 from setuptools import setup
@@ -14,8 +15,12 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
-pkgs = [str(pkg.req) for pkg in parse_requirements('requirements.txt')]
-pkgs = pkgs + ['django-debug-toolbar', 'sqlparse']
+
+session = PipSession()
+pkgs = ['django-debug-toolbar', 'sqlparse']
+for pkg in parse_requirements('requirements.txt', session=session):
+    if pkg.req:
+        pkgs.append(str(pkg.req))
 
 setup(
     name='zds',
@@ -39,5 +44,5 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=pkgs,
-    tests_require=[str(pkg.req) for pkg in parse_requirements('requirements-dev.txt')],
+    tests_require=[str(pkg.req) for pkg in parse_requirements('requirements-dev.txt', session=session)],
 )


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2946 |

Répare le script d'installation (et donc la documentation)

**Vérifier qu'actuellement l'installation du projet avec `setup.py` échoue :**
- Créer un environnement propre avec `virtualenv --python=python2 test`, `cd test/` et `source bin/activate`
- Tenter d'installer le projet actuel via le fichier `setup.py` avec `pip install https://github.com/zestedesavoir/zds-site/archive/v15.7-gaston.zip` (peu prendre quelques minutes)
- Voir que ça échoue avec l'erreur `TypeError: parse_requirements() missing 1 required keyword argument: 'session'` ([qui est la même erreur que lors des builds de ReadTheDocs](https://readthedocs.org/projects/zds-site/builds/3078645/))

**Vérifier que ma branche résout le problème :**
- Supprimer l'ancien environnement avec `cd ..` et `rm -rI test/`
- Créer un environnement propre avec `virtualenv --python=python2 test`, `cd test/` et `source bin/activate`
- Tenter d'installer le projet avec mon dépôt avec `pip install https://github.com/Situphen/zds-site/archive/pip-setup.zip`
- Voir que ça fonctionne !
