### PR TITLE
Les dates dans les pdf sont en francais apres une migration de la zep-12

### DIFF
--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -18,6 +18,7 @@ from django.http import Http404
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
+from django.utils import translation
 
 from zds.search.models import SearchIndexContent
 from zds.tutorialv2 import REPLACE_IMAGE_PATTERN
@@ -562,7 +563,14 @@ def publish_content(db_object, versioned, is_major_update=True):
     base_name = os.path.join(extra_contents_path, versioned.slug)
 
     # 1. markdown file (base for the others) :
-    parsed = render_to_string('tutorialv2/export/content.md', {'content': versioned})
+    # If we come from a command line, we need to activate i18n, to have the date in the french language.
+    cur_language = translation.get_language()
+    try:
+        translation.activate(settings.LANGUAGE_CODE)
+        parsed = render_to_string('tutorialv2/export/content.md', {'content': versioned})
+    finally:
+        translation.activate(cur_language)
+
     parsed_with_local_images = retrieve_and_update_images_links(parsed, directory=extra_contents_path)
 
     md_file_path = base_name + '.md'


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | https://github.com/artragis/zds-site/issues/341 |

Les dates des pdf sont généré en anglais lors de la migration de la ZEP-12. Cette branche résout ce souci.

**QA** (nécessite les outils latex) :
- Revenir dans l'historique avant le merge de la ZEP-12.
- Repartir d'une base propre
- Executer la commande `python manage.py migrate`
- Publier un tutoriel et un article
- Repasser dans l'historique sur le dernier commit de la branche dev
- Effectuer la procédure de migration
- Télécharger le pdf de votre article et de votre tutoriel et vérifier que sur la première page la date est en français
