### PR TITLE
Repare un bout d'import zip pour les galleries

### DIFF
--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -448,7 +448,7 @@ class ImportImages(GalleryMixin, FormView):
             f_im = open(ph_temp, "wb")
             f_im.write(zfile.read(i))
             f_im.close()
-            title = os.path.basename(i)
+            (title, ext) = os.path.splitext(os.path.basename(i))
 
             # if size is too large, don't save
             if os.stat(ph_temp).st_size > settings.ZDS_APP['gallery']['image_max_size']:
@@ -471,6 +471,7 @@ class ImportImages(GalleryMixin, FormView):
             pic = Image()
             pic.gallery = gallery
             pic.title = title
+            pic.legend = ""
             pic.pubdate = datetime.now()
             pic.physical = f_im
             pic.save()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | #2999 |

Cette PR permet de mettre un nom plus propre à l'image (sans l'extension) et surtout de donner une valeur "vide" à la légende pour pas avoir un "None" disgracieux.
### QA

Importer un zip d'images et constater que les titres/légendes des images sont ok.
