### PR TITLE
Règle quelques soucis du script de déploiement

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -49,7 +49,7 @@ git checkout -b $1
 
 # Update application data
 source ../bin/activate
-pip install --upgrade --use-mirrors -r requirements.txt
+pip install --upgrade -r requirements.txt
 python manage.py migrate
 python manage.py compilemessages
 # Collect all staticfiles from dist/ and python packages to static/


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | nop |

J'ai fait quelques menu bricoles sur les scripts de déploiements pour contrer des aspects filous...
- Suppression de l'option "--use-mirrors" de pip qui apparemment n'est plus utilisée par pip
- Téléchargement/Exécution de deploy.sh dans /tmp/ . En effet, avant si jamais il y avais un changement dans le script alors git partait en vrille pour la suite du déploiement (création de branches toussa). Du coup maintenant ça ne peut plus arriver, on est tranquille !

@SpaceFox tu en penses quoi ?
