### PR TITLE
[15.9 RC2]Fix #3009 : une mauvaise pk génère une 500

### DIFF
--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -374,8 +374,11 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
                     return StreamingHttpResponse(json_writer.dumps({"text": text}, ensure_ascii=False))
                 else:
                     self.quoted_reaction_text = text
-
-        return super(SendNoteFormView, self).get(request, *args, **kwargs)
+        try:
+            return super(SendNoteFormView, self).get(request, *args, **kwargs)
+        except MustRedirect:  # if someone changed the pk arguments, and reached a "must redirect" public
+            # object
+            raise Http404("Not found public content with pk " + str(self.request.GET.get("pk", 0)))
 
     def post(self, request, *args, **kwargs):
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [#3009] |

Tentez de modifier l'argument pk (et message) dans les urls du type https://beta.zestedesavoir.com/contenus/reactions/ajouter/?cite=75912&pk=205
