### PR TITLE
Rend impossible de citer un texte caché !

### DIFF
--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -4321,7 +4321,24 @@ class PublishedContentTests(TestCase):
         self.assertEqual(reaction.text_hidden, text_hidden[:80])
         self.assertEqual(reaction.editor, self.user_staff)
 
+        # test that someone else is not abble to quote the text
+        self.assertEqual(
+            self.client.login(
+                username=self.user_guest.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.get(
+            reverse("content:add-reaction") + u'?pk={}&cite={}'.format(self.tuto.pk, reaction.pk), follow=False)
+        self.assertEqual(result.status_code, 403)  # unable to quote a reaction if hidden
+
         # then, unhide it !
+        self.assertEqual(
+            self.client.login(
+                username=self.user_guest.username,
+                password='hostel77'),
+            True)
+
         result = self.client.post(
             reverse('content:show-reaction', args=[reaction.pk]), follow=False)
 

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -366,6 +366,9 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
 
             reaction = ContentReaction.objects.filter(pk=cited_pk).first()
 
+            if not reaction.is_visible:
+                raise PermissionDenied
+
             if reaction:
                 text = '\n'.join('> ' + line for line in reaction.text.split('\n'))
                 text += "\nSource: [{}]({})".format(reaction.author.username, reaction.get_absolute_url())


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3024 |
# Notes de QA
- Publier un article. Le commenter avec un utilisateur A
- Le citer avec un utilisateur B en faisant clic droit > ouvrir le lien dans un nouvel onglet. Garder l'onglet sous la main
- De nouveau avec l'utilisateur A, masquer son commentaire
- Recharger la page sur l'onglet contenant le formulaire de citation, se manger une 403
