### PR TITLE
Acccède à l'historique à partir de n'importe quelle version

### DIFF
--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -321,7 +321,7 @@
 
 
         <li>
-            <a href="{% url "content:history" content.pk content.slug %}" class="ico-after history blue">
+            <a href="{% url "content:history" content.pk content.slug_repository %}" class="ico-after history blue">
                 {% trans "Historique des versions" %}
             </a>
         </li>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3045 |
# Note de QA
- Créer un contenu (article ou tuto, osef)
- Le publier (même si c'est pas ça qui est important ici, c'est plus facile)
- Modifier le titre, vérifier qu'on sais accéder à l'historique des versions
- Aller sur la version publique, cliquer sur "voir la version hors-ligne". De cette page (dont le slug n'est pas le même que celui de la version dont vous venez de changer le titre), vérifiez que vous arrivez toujours à accéder à l'historique.
