### PR TITLE
plus de problème de https pour les features

### DIFF
--- a/templates/featured/includes/featured_resource_item.part.html
+++ b/templates/featured/includes/featured_resource_item.part.html
@@ -1,8 +1,9 @@
 {% load i18n %}
+{% load remove_url_protocole %}
 
 <article class="featured-resource-item">
     <a href="{{ featured_resource.url }}">
-        <img src="{{ featured_resource.image_url }}" alt="" class="featured-resource-illu">
+        <img src="{{ featured_resource.image_url|remove_url_protocole }}" alt="" class="featured-resource-illu">
         <div class="featured-resource-meta">
             <h3>{{ featured_resource.title }}</h3>
             <p class="featured-resource-description">{{ featured_resource.type }} {% if featured_resource.authors %} {% trans "par" %} <i>{{ featured_resource.authors }}</i>{% endif %}</p>

--- a/templates/featured/index.html
+++ b/templates/featured/index.html
@@ -1,6 +1,6 @@
 {% extends "featured/base.html" %}
 {% load i18n %}
-
+{% load remove_url_protocole %}
 
 {% block title %}
     {% trans "Liste des unes" %}
@@ -41,7 +41,7 @@
                         </div>
                         <div class="topic-description">
                             <a href="{% url 'featured-resource-update' featured_resource.pk %}" class="topic-title-link navigable-link">
-                                <img src="{{ featured_resource.image_url }}"
+                                <img src="{{ featured_resource.image_url|remove_url_protocole }}"
                                     data-caption="{{ featured_resource.title }}"
                                     alt="{{ featured_resource.title }}"
                                     class="topic-image"

--- a/zds/utils/templatetags/remove_url_protocole.py
+++ b/zds/utils/templatetags/remove_url_protocole.py
@@ -1,0 +1,20 @@
+from django import template
+from zds.settings import ZDS_APP
+
+
+register = template.Library()
+
+
+CONVERT_VALUES = ((1000, 'M'), (900, 'CM'), (500, 'D'), (400, 'CD'), (100, 'C'),
+                  (90, 'XC'), (50, 'L'), (40, 'XL'), (10, 'X'), (9, 'IX'), (5, 'V'),
+                  (4, 'IV'), (1, 'I'))
+
+
+@register.filter('remove_url_protocole')
+def remove_url_protocole(input_url):
+    """
+    make every image url pointing to this website protocol independant so that https is not broken
+    """
+    if ZDS_APP["site"]["dns"] in input_url:
+        return input_url.replace("http:/", "https:/").replace("https://" + ZDS_APP["site"]["dns"], "")
+    return input_url

--- a/zds/utils/templatetags/tests/test_remove_url_protocole.py
+++ b/zds/utils/templatetags/tests/test_remove_url_protocole.py
@@ -1,0 +1,16 @@
+from zds.settings import ZDS_APP
+from django.test import TestCase
+from zds.utils.templatetags.remove_url_protocole import remove_url_protocole
+
+
+class RemoveUrlProtocolTest(TestCase):
+
+    def test_remove_protocole_when_local_url(self):
+        self.assertEqual("/bla.html", remove_url_protocole("http://" + ZDS_APP["site"]["dns"] + "/bla.html"))
+        self.assertEqual("/bla.html", remove_url_protocole("https://" + ZDS_APP["site"]["dns"] + "/bla.html"))
+
+    def test_no_change_when_no_protocole(self):
+        self.assertEqual("/bla.html", remove_url_protocole("/bla.html"))
+
+    def test_no_change_when_extern_address(self):
+        self.assertEqual("http://www.google.com/bla.html", remove_url_protocole("http://www.google.com/bla.html"))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [non] |
| Nouvelle Fonctionnalité ? | [oui] |
| Tickets (_issues_) concernés | [#2888] |

Cette PR permet de rendre le "https" automatique pour les images de feature. Plus précisemment, on rend automatiquement les urls protocole independant quand elles sont issues de zds. Comme ça l'équipe de com' n'a plus à s'en préoccuper mais les utilisateurs n'ont pas de problème de https cassé.
