### PR TITLE
[15.9RC3]Corrige les bugs de mise à jour des dates

### DIFF
--- a/zds/tutorialv2/management/commands/migrate_to_zep12.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep12.py
@@ -95,7 +95,7 @@ def export_comments(reacts, exported, read_class, old_last_note_pk):
         for dislike in CommentDislike.objects.filter(comments__pk=note.pk).all():
             dislike.comments = new_reac
             dislike.save()
-    exported.save()
+    exported.save(update_date=False)
 
 
 def progressbar(it, prefix="", size=60):
@@ -248,7 +248,8 @@ def migrate_articles():
         exported.licence = current.licence
         exported.js_support = current.js_support
         exported.pubdate = current.pubdate
-        exported.save()  # before updating `ManyToMany` relation, we need to save !
+        exported.update_date = current.update
+        exported.save(update_date=False)  # before updating `ManyToMany` relation, we need to save !
 
         try:
             clean_commit = copy_and_clean_repo(current.get_path(False), exported.get_repo_path(False))
@@ -317,7 +318,7 @@ def migrate_articles():
         split_article_in_extracts(versioned)  # create extracts from text
         exported.sha_draft = versioned.commit_changes(u'Migration version 2')
         exported.old_pk = current.pk
-        exported.save()
+        exported.save(update_date=False)
 
         reacts = Reaction.objects.filter(article__pk=current.pk)\
                                  .select_related("author")\
@@ -343,7 +344,7 @@ def migrate_articles():
             exported.update_date = current.update
             exported.sha_public = exported.sha_draft
             exported.public_version = published
-            exported.save()
+            exported.save(update_date=False)
             published.content_public_slug = exported.slug
             published.publication_date = exported.pubdate
             published.save()
@@ -397,7 +398,7 @@ def migrate_tuto(tutos, title="Exporting mini tuto"):
             exported.js_support = current.js_support
             exported.source = current.source
             exported.pubdate = current.pubdate
-            exported.save()
+            exported.save(update_date=False)
 
             try:
                 clean_commit = copy_and_clean_repo(current.get_path(False), exported.get_repo_path(False))
@@ -418,7 +419,7 @@ def migrate_tuto(tutos, title="Exporting mini tuto"):
             [exported.subcategory.add(category) for category in current.subcategory.all()]
             [exported.helps.add(help) for help in current.helps.all()]
             [exported.authors.add(author) for author in current.authors.all()]
-            exported.save()
+            exported.save(update_date=False)
 
             # now, re create the manifest.json
             versioned = exported.load_version()
@@ -449,7 +450,7 @@ def migrate_tuto(tutos, title="Exporting mini tuto"):
             exported.sha_draft = versioned.commit_changes(u"Migration version 2")
 
             exported.old_pk = current.pk
-            exported.save()
+            exported.save(update_date=False)
             # export beta forum post
             former_topic = Topic.objects.filter(key=current.pk).first()
             if former_topic is not None:
@@ -462,7 +463,7 @@ def migrate_tuto(tutos, title="Exporting mini tuto"):
                 former_first_post.update_content(text)
                 former_first_post.save()
                 exported.beta_topic = former_topic
-                exported.save()
+                exported.save(update_date=False)
             # extract notes
             reacts = Note.objects.filter(tutorial__pk=current.pk)\
                                  .select_related("author")\
@@ -476,7 +477,7 @@ def migrate_tuto(tutos, title="Exporting mini tuto"):
                 exported.pubdate = current.pubdate
                 exported.sha_public = current.sha_public
                 exported.public_version = published
-                exported.save()
+                exported.save(update_date=False)
                 published.content_public_slug = exported.slug
                 published.publication_date = current.pubdate
                 published.save()

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -134,7 +134,9 @@ class PublishableContent(models.Model):
         Rewrite the `save()` function to handle slug uniqueness
         """
         self.slug = uuslug(self.title, instance=self, max_length=80)
-        self.update_date = datetime.now()
+        update_date = kwargs.pop("update_date", True)
+        if update_date:
+            self.update_date = datetime.now()
         super(PublishableContent, self).save(*args, **kwargs)
 
     def get_absolute_url(self):

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -588,6 +588,7 @@ def publish_content(db_object, versioned, is_major_update=True):
     # 1. markdown file (base for the others) :
     # If we come from a command line, we need to activate i18n, to have the date in the french language.
     cur_language = translation.get_language()
+    versioned.pubdate = datetime.now()
     try:
         translation.activate(settings.LANGUAGE_CODE)
         parsed = render_to_string('tutorialv2/export/content.md', {'content': versioned})


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [#3008, #3025 ] |

pour #3025 vérifiez que lors de sa première publication, un article a bien sa date
pour #3008 armez vous de courage pour faire : 

``` bash
python manage.py load_fixtures type=member,forum,tutorial,article size=high
date;
python manage.py migrate_to_zep12
```

vérifiez que toutes les dates de modifications des contenus publiés sont inférieures à la date affichée par le script.
