### PR TITLE
Les balises secret ne sont plus dupliquées lors de la prévisualisation

### DIFF
--- a/assets/js/spoiler.js
+++ b/assets/js/spoiler.js
@@ -9,28 +9,29 @@
 
     function buildSpoilers($elem) {
         $elem.each(function() {
-            $(this).addClass("spoiler-build");
-            $(this).before($("<a/>", {
-                text: "Afficher/Masquer le contenu masqué",
-                class: "spoiler-title ico-after view",
-                href: "#",
-                click: function(e) {
-                    $(this).next(".spoiler").toggle();
-                    e.preventDefault();
-                }
-            }));
+            var $this = $(this);
+
+            if(!$this.hasClass("spoiler-build")) {
+                $this.before($("<a/>", {
+                    text: "Afficher/Masquer le contenu masqué",
+                    class: "spoiler-title ico-after view",
+                    href: "#",
+                    click: function(e) {
+                        $(this).next(".spoiler").toggle();
+                        e.preventDefault();
+                    }
+                }));
+                $this.addClass("spoiler-build");
+            }
         });
     }
 
     $(document).ready(function() {
         var $content = $("#content");
         buildSpoilers($content.find(".spoiler"));
-        $content.on("DOMNodeInserted", function() {
-            var $spoilers = $(this).find(".spoiler:not(.spoiler-build)");
-            if ($spoilers.length > 0)
-                return buildSpoilers($spoilers);
-            else if ($(this).is(".spoiler:not(.spoiler-build)"))
-                return buildSpoilers($(this));
+        $content.on("DOMNodeInserted", function(e) {
+            var $spoilers = $(e.target).find(".spoiler");
+            return buildSpoilers($spoilers);
         });
     });
 })(document, jQuery);


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3070 |

Les balises secret ne sont plus dupliquées lors de la prévisualisation

**QA :**
- Générer le front avec `npm run gulp -- build`
- Puis, pour chaque test, vérifier que le nombre de lien correspond au nombre de `[[secret]]`
  - lors de la prévisualisation du message (cliquer sur "Aperçu")
  - lors de l'affichage du message (cliquer sur "Envoyer")

**Tests :**

```
Test avec 3 balises secret imbriquées

[[secret]]
| Test 1
| [[secret]]
| | Test 2
| | [[secret]]
| | | Test 3
```

```
Test avec 2 balises secret séparées

[[secret]]
| Test 1

[[secret]]
| Test 2
```

```
Test avec 1 seule balise secret

[[secret]]
| Test
```

```
Test sans balise secret
```
