### PR TITLE
[betafix 15.9] Corrige les erreurs sur `get_commit_author()`

### DIFF
--- a/zds/tutorialv2/management/commands/migrate_to_zep12.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep12.py
@@ -22,7 +22,7 @@ from zds.utils.templatetags.emarkdown import emarkdown_inline
 from zds.tutorialv2.models.models_database import PublishableContent, ContentReaction, ContentRead, PublishedContent,\
     Validation
 
-from zds.tutorialv2.utils import publish_content
+from zds.tutorialv2.utils import publish_content, get_commit_author
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from zds.gallery.models import Gallery, UserGallery, Image
@@ -218,7 +218,7 @@ def copy_and_clean_repo(path_from, path_to):
 
     if len(to_delete) != 0:
         old_repo.index.remove(to_delete)
-        sha = old_repo.index.commit('Nettoyage pré-migratoire')
+        sha = old_repo.index.commit('Nettoyage pré-migratoire', **get_commit_author())
 
     # then clone it to new repo
     old_repo.clone(path_to)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3062 |
# Note de QA
- Connectez vous avec un utilisateur (mais pas "admin", c'est le bot) ;
- Rendez vous sur [http://127.0.0.1:8000/oldtutoriels/nouveau/tutoriel/](http://127.0.0.1:8000/oldtutoriels/nouveau/tutoriel/) et créez un big-tuto v1 ;
- Créez dedans une partie, et dedans cette partie un chapitre ;
- Changez le nom de la partie (pour créer un problème que le script de migration va régler) ;
- Migrez le tutoriel avec la commande `python manage.py migrate_to_zep12 tuto` ;
- Consultez "l'historique des versions" de votre tuto migré, vérifiez que deux nouveaux commits sont apparus ("Nettoyage pré-migratoire" et "Migration v2") et que les auteurs de ces deux commits sont bien le compte de bot (donc "admin") !
