### PR TITLE
Règle le souci de gif

### DIFF
--- a/templates/gallery/image/edit.html
+++ b/templates/gallery/image/edit.html
@@ -47,13 +47,13 @@
             {% trans "Code markdown pour insérer cette image" %} : <br>
 
             {% trans "Taille normale" %} :
-            <input type="text" value="![{{ image.legend }}]({{app.site.url}}{{ image.physical.content.url }})" readonly onclick="this.select()"> <br>
+            <input type="text" value="![{{ image.legend }}]({{app.site.url}}{{ image.physical.url }})" readonly onclick="this.select()"> <br>
 
             {% trans "Miniature" %} :
             <input type="text" value="![{{ image.legend }}]({{app.site.url}}{{ image.physical.gallery.url }})" readonly onclick="this.select()"> <br>
 
             {% trans "Miniature + lien vers taille normale" %} :
-            <input type="text" value="[![{{ image.legend }}]({{app.site.url}}{{ image.physical.gallery.url }})]({{app.site.url}}{{ image.physical.content.url }})" readonly onclick="this.select()">
+            <input type="text" value="[![{{ image.legend }}]({{app.site.url}}{{ image.physical.gallery.url }})]({{app.site.url}}{{ image.physical.url }})" readonly onclick="this.select()">
         </p>
         
         {% crispy as_avatar_form %}

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -459,8 +459,7 @@ class EditImageViewTest(TestCase):
                 follow=True
             )
         self.assertEqual(200, response.status_code)
-        # should have one picture and 2 thumbnails, so 3 new images
-        self.assertEqual(nb_files + 3, len(os.listdir(self.gallery.get_gallery_path())))
+        self.assertEqual(nb_files + 2, len(os.listdir(self.gallery.get_gallery_path())))
 
         image_test = Image.objects.get(pk=self.image.pk)
         self.assertEqual('edit title', image_test.title)
@@ -634,6 +633,7 @@ class NewImageViewTest(TestCase):
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(self.gallery.get_images()))
+        self.assertEqual(2, len(os.listdir(self.gallery.get_gallery_path())))  # New image and thumbnail
         self.gallery.get_images()[0].delete()
 
     def test_fail_new_image_with_read_permission(self):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3056 |

Règle le souci des gifs dans la gallerie et le lien pour les insérer. En même temps ca fait de plus belles URL.
### QA
- S'assurer que les différents formats d'images marchent toujours bien
- Vérifier que ca n'impact pas les images déjà uploadées
- Vérifier que les gifs et leurs liens se mettent bien comme il faut
