### PR TITLE
pseudo règle le problème de fixture incomplète

### DIFF
--- a/fixtures/topics.yaml
+++ b/fixtures/topics.yaml
@@ -264,6 +264,7 @@
    serv\xE9s\n\nSi vous avez besoin d'\xE9crire un caract\xE8re r\xE9serv\xE9 entrant\
    \ en conflit avec l'une des syntaxes d\xE9crites ici (l'ast\xE9risque par exemple),\
    \ vous pouvez le faire en le pr\xE9c\xE9dent d'un antislash : `\\*`\n\n"
+        text_html: "<em>(fixture incomplète, cliquez sur \"éditer\" pour voir le vrai texte)</em>"
         like: 1337
         dislike: 0
         pubdate: 2014-01-05T18:20:30+00:00


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2860 |

Rajoute un bout de texte (instruction) pour éviter d'avoir un texte complètement vide dans les fixtures d'affichés dans le fofo. C'est pas la solution la plus clean, mais avoir le vrai texte équivalent serait un vrai cauchemar...
