### PR TITLE
feat(api): Displays unread private topics of a member.

### DIFF
--- a/zds/mp/api/tests.py
+++ b/zds/mp/api/tests.py
@@ -944,3 +944,58 @@ class PrivatePostDetailAPI(APITestCase):
             reverse('api-mp-message-detail', args=[self.private_topic.id, self.private_post.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('text'), data.get('text'))
+
+
+@skip("MP API is disable.")
+class PrivateTopicUnreadListAPITest(APITestCase):
+
+    def setUp(self):
+        self.profile = ProfileFactory()
+        self.client = APIClient()
+        client_oauth2 = create_oauth2_client(self.profile.user)
+        authenticate_client(self.client, client_oauth2, self.profile.user.username, 'hostel77')
+
+        self.another_profile = ProfileFactory()
+        self.another_client = APIClient()
+        another_client_oauth2 = create_oauth2_client(self.another_profile.user)
+        authenticate_client(self.another_client, another_client_oauth2, self.another_profile.user.username, 'hostel77')
+
+        self.bot_group = Group()
+        self.bot_group.name = ZDS_APP["member"]["bot_group"]
+        self.bot_group.save()
+
+        get_cache(extensions_api_settings.DEFAULT_USE_CACHE).clear()
+
+    def test_list_mp_unread_with_client_unauthenticated(self):
+        """
+        Gets list of private topics unread with an unauthenticated client.
+        """
+        client_unauthenticated = APIClient()
+        response = client_unauthenticated.get(reverse('api-mp-list-unread'))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_list_of_private_topics_unread_empty(self):
+        """
+        Gets empty list of private topics unread of a member.
+        """
+        response = self.client.get(reverse('api-mp-list-unread'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), 0)
+        self.assertEqual(response.data.get('results'), [])
+        self.assertIsNone(response.data.get('next'))
+        self.assertIsNone(response.data.get('previous'))
+
+    def test_list_of_private_topics_unread(self):
+        """
+        Gets list of private topics unread of a member.
+        """
+        private_topic = PrivateTopicFactory(author=self.another_profile.user)
+        private_topic.participants.add(self.profile.user)
+        private_topic.save()
+
+        response = self.client.get(reverse('api-mp-list-unread'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), 1)
+        self.assertEqual(len(response.data.get('results')), 1)
+        self.assertIsNone(response.data.get('next'))
+        self.assertIsNone(response.data.get('previous'))

--- a/zds/mp/api/urls.py
+++ b/zds/mp/api/urls.py
@@ -2,11 +2,13 @@
 
 from django.conf.urls import patterns, url
 
-from zds.mp.api.views import PrivateTopicListAPI, PrivateTopicDetailAPI, PrivatePostListAPI, PrivatePostDetailAPI
+from zds.mp.api.views import PrivateTopicListAPI, PrivateTopicDetailAPI, PrivatePostListAPI, PrivatePostDetailAPI, \
+    PrivateTopicReadAPI
 
 urlpatterns = patterns('',
                        url(r'^$', PrivateTopicListAPI.as_view(), name='api-mp-list'),
                        url(r'^(?P<pk>[0-9]+)/$', PrivateTopicDetailAPI.as_view(), name='api-mp-detail'),
                        url(r'^(?P<pk_ptopic>[0-9]+)/messages/$', PrivatePostListAPI.as_view(), name='api-mp-message-list'),
                        url(r'^(?P<pk_ptopic>[0-9]+)/messages/(?P<pk>[0-9]+)/$', PrivatePostDetailAPI.as_view(), name='api-mp-message-detail'),
+                       url(r'^unread/$', PrivateTopicReadAPI.as_view(), name='api-mp-list-unread'),
 )

--- a/zds/mp/api/views.py
+++ b/zds/mp/api/views.py
@@ -2,7 +2,7 @@
 
 from rest_framework import status, exceptions, filters
 from rest_framework.generics import RetrieveUpdateDestroyAPIView, DestroyAPIView, ListCreateAPIView, \
-    get_object_or_404, RetrieveUpdateAPIView
+    get_object_or_404, RetrieveUpdateAPIView, ListAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework_extensions.cache.decorators import cache_response
@@ -17,12 +17,18 @@ from zds.mp.api.serializers import PrivateTopicSerializer, PrivateTopicUpdateSer
     PrivatePostSerializer, PrivatePostUpdateSerializer, PrivatePostCreateSerializer
 from zds.mp.commons import LeavePrivateTopic, MarkPrivateTopicAsRead
 from zds.mp.models import PrivateTopic, PrivatePost
+from zds.utils.templatetags.interventions import interventions_privatetopics
 
 
 class PagingPrivateTopicListKeyConstructor(DefaultKeyConstructor):
     pagination = DJRF3xPaginationKeyBit()
     search = bits.QueryParamsKeyBit(['search', 'ordering'])
     list_sql_query = bits.ListSqlQueryKeyBit()
+    unique_view_id = bits.UniqueViewIdKeyBit()
+
+
+class PagingPrivateTopicUnreadListKeyConstructor(DefaultKeyConstructor):
+    pagination = DJRF3xPaginationKeyBit()
     unique_view_id = bits.UniqueViewIdKeyBit()
 
 
@@ -424,3 +430,51 @@ class PrivatePostDetailAPI(RetrieveUpdateAPIView):
 
     def get_queryset(self):
         return super(PrivatePostDetailAPI, self).get_queryset().filter(privatetopic__pk=self.kwargs['pk_ptopic'])
+
+
+class PrivateTopicReadAPI(ListAPIView):
+    """
+    Private topic unread resource to list of the member authenticated.
+    """
+
+    serializer_class = PrivateTopicSerializer
+    permission_classes = (IsAuthenticated,)
+    list_key_func = PagingPrivateTopicUnreadListKeyConstructor()
+
+    @etag(list_key_func)
+    @cache_response(key_func=list_key_func)
+    def get(self, request, *args, **kwargs):
+        """
+        Displays all private topics unread.
+        ---
+
+        parameters:
+            - name: Authorization
+              description: Bearer token to make a authenticated request.
+              required: true
+              paramType: header
+            - name: page
+              description: Displays users of the page given.
+              required: false
+              paramType: query
+            - name: page_size
+              description: Sets size of the pagination.
+              required: false
+              paramType: query
+            - name: expand
+              description: Expand a field with an identifier.
+              required: false
+              paramType: query
+        responseMessages:
+            - code: 401
+              message: Not authenticated
+            - code: 404
+              message: Not found
+        """
+        return self.list(request, *args, **kwargs)
+
+    def get_current_user(self):
+        return self.request.user
+
+    def get_queryset(self):
+        return interventions_privatetopics(user=self.get_current_user())['unread']


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets (_issues_) concernés | Aucune |

Ajoute la route `/api/mp/unread/` dans l'API des MPs.

Pour la QA :
- Décommenté l'URL de l'API des MPs dans `zds/urls.py`.
- Décommenté la ligne `@skip("MP API is disable.")` à la ligne 949 du fichier `zds/mp/api/tests.py`.
- Exécutez les tests et constatez que tout passe.
- Lancez une instance de zds et rendez-vous sur la page de l'API.
- Lancez les requêtes possibles pour cette nouvelle route (cf. la doc affichée).

Enjoy!

(Oui, vous allez tester une fonctionnalité qui ne sera pas dispo, ça vous motive ? :D)
