### PR TITLE
[beta 15.9] Corrige une erreur 500 lors de la citation d'un commentaire inexistant

### DIFF
--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -364,10 +364,10 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
 
             reaction = ContentReaction.objects.filter(pk=cited_pk).first()
 
-            if not reaction.is_visible:
-                raise PermissionDenied
-
             if reaction:
+                if not reaction.is_visible:
+                    raise PermissionDenied
+
                 text = '\n'.join('> ' + line for line in reaction.text.split('\n'))
                 text += "\nSource: [{}]({})".format(reaction.author.username, reaction.get_absolute_url())
 
@@ -485,7 +485,7 @@ class UpdateNoteView(SendNoteFormView):
                 if not self.request.user.has_perm('tutorialv2.change_contentreaction'):
                     raise PermissionDenied
         else:
-            messages.error(self.request, 'Oh non ! Une erreur est survenue dans la requête !')
+            messages.error(self.request, _(u'Oh non ! Une erreur est survenue dans la requête !'))
             return self.form_invalid(form)
 
         return super(UpdateNoteView, self).form_valid(form)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3088 |

Fin de la saison 3 + T.U.
# Note de QA
- Vérifiez que vous pouvez citer un message.
- Ouvrez le lien dans un nouvel onglet, vérifiez que vous obtenez bien le message cité
- Changez le paramètre `cite=xxx` par une valeur fantaisiste → 404 et par un pk qui n'existe pas → 200, mais formulaire vide.
- Vérifiez qu'il n'est toujours pas possible de citer un message (préalablement) masqué. 
