### PR TITLE
Gère les slugs lors de l'import

### DIFF
--- a/zds/tutorialv2/models/models_versioned.py
+++ b/zds/tutorialv2/models/models_versioned.py
@@ -516,7 +516,7 @@ class Container:
         if do_commit:
             return self.top_container().commit_changes(commit_message)
 
-    def repo_add_container(self, title, introduction, conclusion, commit_message='', do_commit=True):
+    def repo_add_container(self, title, introduction, conclusion, commit_message='', do_commit=True, slug=None):
         """
         :param title: title of the new container
         :param introduction: text of its introduction
@@ -526,11 +526,13 @@ class Container:
         :return: commit sha
         :rtype: str
         """
-        subcontainer = Container(title)
-
+        if slug is None:
+            subcontainer = Container(title)
+        else:
+            subcontainer = Container(title, slug=slug)
         # can a subcontainer be added ?
         try:
-            self.add_container(subcontainer, generate_slug=True)
+            self.add_container(subcontainer, generate_slug=slug is None)
         except InvalidOperationError:
             raise PermissionDenied
 
@@ -549,20 +551,23 @@ class Container:
         return subcontainer.repo_update(
             title, introduction, conclusion, commit_message=commit_message, do_commit=do_commit)
 
-    def repo_add_extract(self, title, text, commit_message='', do_commit=True):
+    def repo_add_extract(self, title, text, commit_message='', do_commit=True, slug=None):
         """
         :param title: title of the new extract
         :param text: text of the new extract
         :param commit_message: commit message that will be used instead of the default one
         :param do_commit: perform the commit in repository if ``True``
+        :param generate_slug: indicates that is must generate slug
         :return: commit sha
         :rtype: str
         """
-        extract = Extract(title)
-
+        if not slug:
+            extract = Extract(title)
+        else:
+            extract = Extract(title, slug)
         # can an extract be added ?
         try:
-            self.add_extract(extract, generate_slug=True)
+            self.add_extract(extract, generate_slug=slug is None)
         except InvalidOperationError:
             raise PermissionDenied
 

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -866,7 +866,9 @@ def get_content_from_json(json, sha, slug_last_draft, public=False, max_title_le
 
 
 class InvalidSlugError(ValueError):
-    pass
+
+    def __init__(self, *args, **kwargs):
+        super(InvalidSlugError, self).__init__(*args, **kwargs)
 
 
 def check_slug(slug):
@@ -948,7 +950,8 @@ def fill_containers_from_json(json_sub, parent):
                 slug = ''
                 try:
                     slug = child['slug']
-                    slugify_raise_on_empty(slug)
+                    if not check_slug(slug):
+                        raise InvalidSlugError(child['slug'])
                 except KeyError:
                     pass
                 new_extract = Extract(child['title'], slug)

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -554,7 +554,7 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
                         raise BadArchiveError(
                             _(u'Le fichier « {} » n\'est pas encodé en UTF-8'.format(child.conclusion)))
 
-                copy_to.repo_add_container(child.title, introduction, conclusion, do_commit=False)
+                copy_to.repo_add_container(child.title, introduction, conclusion, do_commit=False, slug=child.slug)
                 UpdateContentWithArchive.update_from_new_version_in_zip(copy_to.children[-1], child, zip_file)
 
             elif isinstance(child, Extract):
@@ -564,7 +564,7 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
                     raise BadArchiveError(
                         _(u'Le fichier « {} » n\'est pas encodé en UTF-8'.format(child.text)))
 
-                copy_to.repo_add_extract(child.title, text, do_commit=False)
+                copy_to.repo_add_extract(child.title, text, do_commit=False, slug=child.slug)
 
     @staticmethod
     def use_images_from_archive(request, zip_file, versioned_content, gallery):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [#3094 ] |

téléchargez l'archive de ce tutoriel https://beta.zestedesavoir.com/articles/zip/180/sortie-de-python-3-5.zip

modifiez le manifest pour qu'un des **titre** (pas slug, titre) vaille "......." 
refaite une (bonne) archive
importez
vérifiez que ça marche et que le titre est changé.

**Note :** le problème était celui-ci : on forçait la génération du slug à partir du titre quoi qu'il arrive. Donc j'ai paramétrisé tout ça.
