### PR TITLE
Utilises l'id de User dans l'api des membres et publie l'api des MPs

### DIFF
--- a/zds/member/api/serializers.py
+++ b/zds/member/api/serializers.py
@@ -10,7 +10,11 @@ from zds.member.validators import ProfileUsernameValidator, ProfileEmailValidato
 
 class UserListSerializer(serializers.ModelSerializer):
     """
-    Serializers of a user object.
+    Serializers of a user object. This serializer is necessary because
+    we have a bug between User/Profile. Sometimes, models uses a
+    foreign key to User, so we must use this serialize. Sometimes,
+    models uses a foreign key to Profile, so we must use Profile
+    serializers.
     """
 
     class Meta:
@@ -20,16 +24,17 @@ class UserListSerializer(serializers.ModelSerializer):
 
 class ProfileListSerializer(serializers.ModelSerializer):
     """
-    Serializers of a user object.
+    Serializers of a profile object.
     """
 
+    id = serializers.ReadOnlyField(source='user.id')
     username = serializers.CharField(source='user.username')
     is_active = serializers.BooleanField(source='user.is_active')
     date_joined = serializers.DateTimeField(source='user.date_joined')
 
     class Meta:
         model = Profile
-        fields = ('pk', 'username', 'is_active', 'date_joined')
+        fields = ('id', 'username', 'is_active', 'date_joined')
 
 
 class ProfileCreateSerializer(serializers.ModelSerializer, ProfileCreate, ProfileUsernameValidator,
@@ -38,13 +43,14 @@ class ProfileCreateSerializer(serializers.ModelSerializer, ProfileCreate, Profil
     Serializers of a user object to create one.
     """
 
+    id = serializers.ReadOnlyField(source='user.id')
     username = serializers.CharField(source='user.username')
     email = serializers.EmailField(source='user.email')
     password = serializers.CharField(source='user.password')
 
     class Meta:
         model = Profile
-        fields = ('pk', 'username', 'email', 'password')
+        fields = ('id', 'username', 'email', 'password')
         write_only_fields = ('password')
 
     def create(self, validated_data):
@@ -61,6 +67,7 @@ class ProfileDetailSerializer(serializers.ModelSerializer):
     Serializers of a profile object.
     """
 
+    id = serializers.ReadOnlyField(source='user.id')
     username = serializers.CharField(source='user.username')
     email = serializers.EmailField(source='user.email')
     is_active = serializers.BooleanField(source='user.is_active')
@@ -69,7 +76,7 @@ class ProfileDetailSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Profile
-        fields = ('pk', 'username', 'email', 'is_active', 'date_joined',
+        fields = ('id', 'username', 'email', 'is_active', 'date_joined',
                   'site', 'avatar_url', 'biography', 'sign', 'show_email',
                   'show_sign', 'hover_or_click', 'email_for_answer', 'last_visit')
 
@@ -92,6 +99,7 @@ class ProfileValidatorSerializer(serializers.ModelSerializer, ProfileUsernameVal
     Serializers of a profile object used to update a member.
     """
 
+    id = serializers.ReadOnlyField(source='user.id')
     username = serializers.CharField(source='user.username', required=False, allow_blank=True)
     email = serializers.EmailField(source='user.email', required=False, allow_blank=True)
     is_active = serializers.BooleanField(source='user.is_active', required=False)
@@ -99,7 +107,7 @@ class ProfileValidatorSerializer(serializers.ModelSerializer, ProfileUsernameVal
 
     class Meta:
         model = Profile
-        fields = ('pk', 'username', 'email', 'is_active', 'date_joined',
+        fields = ('id', 'username', 'email', 'is_active', 'date_joined',
                   'site', 'avatar_url', 'biography', 'sign', 'show_email',
                   'show_sign', 'hover_or_click', 'email_for_answer', 'last_visit')
         read_only_fields = ('is_active', 'date_joined', 'last_visit',)
@@ -137,10 +145,11 @@ class ProfileSanctionSerializer(serializers.ModelSerializer):
     Serializers of a profile object to set the user in reading only access.
     """
 
+    id = serializers.ReadOnlyField(source='user.id')
     username = serializers.ReadOnlyField(source='user.username')
     email = serializers.ReadOnlyField(source='user.email')
 
     class Meta:
         model = Profile
-        fields = ('pk', 'username', 'email', 'can_write', 'end_ban_write', 'can_read', 'end_ban_read')
+        fields = ('id', 'username', 'email', 'can_write', 'end_ban_write', 'can_read', 'end_ban_read')
         read_only_fields = ('can_write', 'end_ban_write', 'can_read', 'end_ban_read')

--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -340,7 +340,7 @@ class MemberMyDetailAPITest(APITestCase):
 
         response = client_authenticated.get(reverse('api-member-profile'))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(profile.pk, response.data.get('pk'))
+        self.assertEqual(profile.user.id, response.data.get('id'))
         self.assertEqual(profile.user.username, response.data.get('username'))
         self.assertEqual(profile.user.email, response.data.get('email'))
         self.assertEqual(profile.user.is_active, response.data.get('is_active'))
@@ -379,9 +379,9 @@ class MemberDetailAPITest(APITestCase):
         """
         Gets all information about a user.
         """
-        response = self.client.get(reverse('api-member-detail', args=[self.profile.pk]))
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(self.profile.pk, response.data.get('pk'))
+        self.assertEqual(self.profile.user.id, response.data.get('id'))
         self.assertEqual(self.profile.user.username, response.data.get('username'))
         self.assertIsNone(response.data.get('email'))
         self.assertEqual(self.profile.user.is_active, response.data.get('is_active'))
@@ -402,7 +402,7 @@ class MemberDetailAPITest(APITestCase):
         self.profile.show_email = True
         self.profile.save()
 
-        response = self.client.get(reverse('api-member-detail', args=[self.profile.pk]))
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.data.get('email'))
 
@@ -413,7 +413,7 @@ class MemberDetailAPITest(APITestCase):
         self.profile.show_email = True
         self.profile.save()
 
-        response = self.client_authenticated.get(reverse('api-member-detail', args=[self.profile.pk]))
+        response = self.client_authenticated.get(reverse('api-member-detail', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data.get('show_email'))
         self.assertEqual(self.profile.user.email, response.data.get('email'))
@@ -429,10 +429,10 @@ class MemberDetailAPITest(APITestCase):
         """
         Updates a member but without any changes.
         """
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]))
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(self.profile.pk, response.data.get('pk'))
+        self.assertEqual(self.profile.user.id, response.data.get('id'))
         self.assertEqual(self.profile.user.username, response.data.get('username'))
         self.assertEqual(self.profile.user.email, response.data.get('email'))
         self.assertEqual(self.profile.user.is_active, response.data.get('is_active'))
@@ -457,7 +457,7 @@ class MemberDetailAPITest(APITestCase):
         """
         Tries to update a member with a authentication not valid.
         """
-        response = self.client.put(reverse('api-member-detail', args=[self.profile.pk]))
+        response = self.client.put(reverse('api-member-detail', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_update_member_details_without_permissions(self):
@@ -465,7 +465,7 @@ class MemberDetailAPITest(APITestCase):
         Tries to update information about a member when the user isn't the target user.
         """
         another = ProfileFactory()
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[another.pk]))
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[another.user.id]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_update_member_details_username(self):
@@ -475,7 +475,7 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'username': 'Clem'
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), data.get('username'))
 
@@ -486,7 +486,7 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'email': 'clem@zestedesavoir.com'
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('email'), data.get('email'))
 
@@ -497,7 +497,7 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'email': 'wrong email'
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_member_details_site(self):
@@ -507,7 +507,7 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'site': 'www.zestedesavoir.com'
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('site'), data.get('site'))
 
@@ -518,7 +518,7 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'avatar_url': 'www.zestedesavoir.com'
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('avatar_url'), data.get('avatar_url'))
 
@@ -529,7 +529,7 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'biography': 'It is my awesome biography.'
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('biography'), data.get('biography'))
 
@@ -540,7 +540,7 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'sign': 'It is my awesome sign.'
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('sign'), data.get('sign'))
 
@@ -551,14 +551,14 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'show_email': True
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('show_email'), data.get('show_email'))
 
         data = {
             'show_email': False
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('show_email'), data.get('show_email'))
 
@@ -569,14 +569,14 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'show_sign': True
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('show_sign'), data.get('show_sign'))
 
         data = {
             'show_sign': False
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('show_sign'), data.get('show_sign'))
 
@@ -587,14 +587,14 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'hover_or_click': True
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('hover_or_click'), data.get('hover_or_click'))
 
         data = {
             'hover_or_click': False
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('hover_or_click'), data.get('hover_or_click'))
 
@@ -605,14 +605,14 @@ class MemberDetailAPITest(APITestCase):
         data = {
             'email_for_answer': True
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('email_for_answer'), data.get('email_for_answer'))
 
         data = {
             'email_for_answer': False
         }
-        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.pk]), data)
+        response = self.client_authenticated.put(reverse('api-member-detail', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('email_for_answer'), data.get('email_for_answer'))
 
@@ -620,14 +620,14 @@ class MemberDetailAPITest(APITestCase):
         """
         Gets an error when the user try to make a request with a method not allowed.
         """
-        response = self.client.post(reverse('api-member-detail', args=[self.profile.pk]))
+        response = self.client.post(reverse('api-member-detail', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_member_detail_url_with_delete_method(self):
         """
         Gets an error when the user try to make a request with a method not allowed.
         """
-        response = self.client.delete(reverse('api-member-detail', args=[self.profile.pk]))
+        response = self.client.delete(reverse('api-member-detail', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
@@ -648,7 +648,7 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         """
         Applies a read only sanction at a member given by a staff user.
         """
-        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.pk]))
+        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -661,7 +661,7 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         data = {
             'ls-jrs': 1
         }
-        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.pk]), data)
+        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -675,7 +675,7 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         data = {
             'ls-text': 'You are a bad boy!'
         }
-        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.pk]), data)
+        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -693,7 +693,7 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         Tries to apply a read only sanction at a member with a user isn't authenticated.
         """
         client = APIClient()
-        response = client.post(reverse('api-member-read-only', args=[self.profile.pk]))
+        response = client.post(reverse('api-member-read-only', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_apply_read_only_at_a_member_without_permissions(self):
@@ -704,17 +704,17 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         client_authenticated = APIClient()
         authenticate_client(client_authenticated, client_oauth2, self.profile.user.username, 'hostel77')
 
-        response = client_authenticated.post(reverse('api-member-read-only', args=[self.profile.pk]))
+        response = client_authenticated.post(reverse('api-member-read-only', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_remove_read_only_at_a_member(self):
         """
         Removes a read only sanction at a member given by a staff user.
         """
-        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.pk]))
+        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = self.client_authenticated.delete(reverse('api-member-read-only', args=[self.profile.pk]))
+        response = self.client_authenticated.delete(reverse('api-member-read-only', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -727,10 +727,10 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         data = {
             'ls-jrs': 1
         }
-        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.pk]), data)
+        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = self.client_authenticated.delete(reverse('api-member-read-only', args=[self.profile.pk]))
+        response = self.client_authenticated.delete(reverse('api-member-read-only', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -744,10 +744,10 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         data = {
             'ls-text': 'You are a bad boy!'
         }
-        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.pk]), data)
+        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = self.client_authenticated.delete(reverse('api-member-read-only', args=[self.profile.pk]))
+        response = self.client_authenticated.delete(reverse('api-member-read-only', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -765,7 +765,7 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         Tries to remove a read only sanction at a member with a user isn't authenticated.
         """
         client = APIClient()
-        response = client.delete(reverse('api-member-read-only', args=[self.profile.pk]))
+        response = client.delete(reverse('api-member-read-only', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_remove_read_only_at_a_member_without_permissions(self):
@@ -776,7 +776,7 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         client_authenticated = APIClient()
         authenticate_client(client_authenticated, client_oauth2, self.profile.user.username, 'hostel77')
 
-        response = client_authenticated.delete(reverse('api-member-read-only', args=[self.profile.pk]))
+        response = client_authenticated.delete(reverse('api-member-read-only', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_staff_apply_read_only_on_self(self):
@@ -786,7 +786,7 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         data = {
             'ls-text': 'I am a bad staff!'
         }
-        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.staff.pk]), data)
+        response = self.client_authenticated.post(reverse('api-member-read-only', args=[self.staff.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
@@ -807,7 +807,7 @@ class MemberDetailBanAPITest(APITestCase):
         """
         Applies a ban sanction at a member given by a staff user.
         """
-        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.pk]))
+        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -820,7 +820,7 @@ class MemberDetailBanAPITest(APITestCase):
         data = {
             'ban-jrs': 1
         }
-        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.pk]), data)
+        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -834,7 +834,7 @@ class MemberDetailBanAPITest(APITestCase):
         data = {
             'ban-text': 'You are a bad boy!'
         }
-        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.pk]), data)
+        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -852,7 +852,7 @@ class MemberDetailBanAPITest(APITestCase):
         Tries to apply a ban sanction at a member with a user isn't authenticated.
         """
         client = APIClient()
-        response = client.post(reverse('api-member-ban', args=[self.profile.pk]))
+        response = client.post(reverse('api-member-ban', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_apply_ban_at_a_member_without_permissions(self):
@@ -863,17 +863,17 @@ class MemberDetailBanAPITest(APITestCase):
         client_authenticated = APIClient()
         authenticate_client(client_authenticated, client_oauth2, self.profile.user.username, 'hostel77')
 
-        response = client_authenticated.post(reverse('api-member-ban', args=[self.profile.pk]))
+        response = client_authenticated.post(reverse('api-member-ban', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_remove_ban_at_a_member(self):
         """
         Removes a ban sanction at a member given by a staff user.
         """
-        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.pk]))
+        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = self.client_authenticated.delete(reverse('api-member-ban', args=[self.profile.pk]))
+        response = self.client_authenticated.delete(reverse('api-member-ban', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -886,10 +886,10 @@ class MemberDetailBanAPITest(APITestCase):
         data = {
             'ban-jrs': 1
         }
-        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.pk]), data)
+        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = self.client_authenticated.delete(reverse('api-member-ban', args=[self.profile.pk]))
+        response = self.client_authenticated.delete(reverse('api-member-ban', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -903,10 +903,10 @@ class MemberDetailBanAPITest(APITestCase):
         data = {
             'ban-text': 'You are a bad boy!'
         }
-        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.pk]), data)
+        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.profile.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = self.client_authenticated.delete(reverse('api-member-ban', args=[self.profile.pk]))
+        response = self.client_authenticated.delete(reverse('api-member-ban', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('username'), self.profile.user.username)
         self.assertEqual(response.data.get('email'), self.profile.user.email)
@@ -924,7 +924,7 @@ class MemberDetailBanAPITest(APITestCase):
         Tries to remove a ban sanction at a member with a user isn't authenticated.
         """
         client = APIClient()
-        response = client.delete(reverse('api-member-ban', args=[self.profile.pk]))
+        response = client.delete(reverse('api-member-ban', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_remove_ban_at_a_member_without_permissions(self):
@@ -935,7 +935,7 @@ class MemberDetailBanAPITest(APITestCase):
         client_authenticated = APIClient()
         authenticate_client(client_authenticated, client_oauth2, self.profile.user.username, 'hostel77')
 
-        response = client_authenticated.delete(reverse('api-member-ban', args=[self.profile.pk]))
+        response = client_authenticated.delete(reverse('api-member-ban', args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_staff_apply_ban_on_self(self):
@@ -945,7 +945,7 @@ class MemberDetailBanAPITest(APITestCase):
         data = {
             'ban-text': 'I am a bad staff!'
         }
-        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.staff.pk]), data)
+        response = self.client_authenticated.post(reverse('api-member-ban', args=[self.staff.user.id]), data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 

--- a/zds/member/api/urls.py
+++ b/zds/member/api/urls.py
@@ -8,8 +8,8 @@ from zds.member.api.views import MemberListAPI, MemberDetailAPI, \
 urlpatterns = patterns('',
                        url(r'^$', MemberListAPI.as_view(), name='api-member-list'),
                        url(r'^mon-profil/$', MemberMyDetailAPI.as_view(), name='api-member-profile'),
-                       url(r'^(?P<id>[0-9]+)/$', MemberDetailAPI.as_view(), name='api-member-detail'),
-                       url(r'^(?P<id>[0-9]+)/lecture-seule/$', MemberDetailReadingOnly.as_view(),
+                       url(r'^(?P<user__id>[0-9]+)/$', MemberDetailAPI.as_view(), name='api-member-detail'),
+                       url(r'^(?P<user__id>[0-9]+)/lecture-seule/$', MemberDetailReadingOnly.as_view(),
                            name='api-member-read-only'),
-                       url(r'^(?P<id>[0-9]+)/ban/$', MemberDetailBan.as_view(), name='api-member-ban'),
+                       url(r'^(?P<user__id>[0-9]+)/ban/$', MemberDetailBan.as_view(), name='api-member-ban'),
                        )

--- a/zds/member/api/urls.py
+++ b/zds/member/api/urls.py
@@ -8,8 +8,8 @@ from zds.member.api.views import MemberListAPI, MemberDetailAPI, \
 urlpatterns = patterns('',
                        url(r'^$', MemberListAPI.as_view(), name='api-member-list'),
                        url(r'^mon-profil/$', MemberMyDetailAPI.as_view(), name='api-member-profile'),
-                       url(r'^(?P<pk>[0-9]+)/$', MemberDetailAPI.as_view(), name='api-member-detail'),
-                       url(r'^(?P<pk>[0-9]+)/lecture-seule/$', MemberDetailReadingOnly.as_view(),
+                       url(r'^(?P<id>[0-9]+)/$', MemberDetailAPI.as_view(), name='api-member-detail'),
+                       url(r'^(?P<id>[0-9]+)/lecture-seule/$', MemberDetailReadingOnly.as_view(),
                            name='api-member-read-only'),
-                       url(r'^(?P<pk>[0-9]+)/ban/$', MemberDetailBan.as_view(), name='api-member-ban'),
+                       url(r'^(?P<id>[0-9]+)/ban/$', MemberDetailBan.as_view(), name='api-member-ban'),
                        )

--- a/zds/member/api/views.py
+++ b/zds/member/api/views.py
@@ -141,7 +141,7 @@ class MemberDetailAPI(RetrieveUpdateAPIView):
     """
 
     queryset = Profile.objects.all()
-    lookup_field = 'id'
+    lookup_field = 'user__id'
     obj_key_func = DetailKeyConstructor()
 
     @etag(obj_key_func)
@@ -202,7 +202,7 @@ class MemberDetailReadingOnly(CreateDestroyMemberSanctionAPIView):
     Profile resource to apply or remove read only sanction.
     """
 
-    lookup_field = 'id'
+    lookup_field = 'user__id'
 
     def post(self, request, *args, **kwargs):
         """
@@ -270,7 +270,7 @@ class MemberDetailBan(CreateDestroyMemberSanctionAPIView):
     Profile resource to apply or remove ban sanction.
     """
 
-    lookup_field = 'id'
+    lookup_field = 'user__id'
 
     def post(self, request, *args, **kwargs):
         """

--- a/zds/member/api/views.py
+++ b/zds/member/api/views.py
@@ -141,6 +141,7 @@ class MemberDetailAPI(RetrieveUpdateAPIView):
     """
 
     queryset = Profile.objects.all()
+    lookup_field = 'id'
     obj_key_func = DetailKeyConstructor()
 
     @etag(obj_key_func)
@@ -200,6 +201,8 @@ class MemberDetailReadingOnly(CreateDestroyMemberSanctionAPIView):
     """
     Profile resource to apply or remove read only sanction.
     """
+
+    lookup_field = 'id'
 
     def post(self, request, *args, **kwargs):
         """
@@ -266,6 +269,8 @@ class MemberDetailBan(CreateDestroyMemberSanctionAPIView):
     """
     Profile resource to apply or remove ban sanction.
     """
+
+    lookup_field = 'id'
 
     def post(self, request, *args, **kwargs):
         """

--- a/zds/member/factories.py
+++ b/zds/member/factories.py
@@ -84,6 +84,13 @@ class ProfileFactory(factory.DjangoModelFactory):
     sign = 'Please look my flavour'
 
 
+class ProfileNotSyncFactory(ProfileFactory):
+    """
+    Use this factory when you want a user with wrong identifiers.
+    """
+    id = factory.Sequence(lambda n: n + 99999)
+
+
 class StaffProfileFactory(factory.DjangoModelFactory):
     """
     Use this factory when you need a complete Profile for a staff user.

--- a/zds/mp/api/tests.py
+++ b/zds/mp/api/tests.py
@@ -23,7 +23,6 @@ overrided_drf['MAX_PAGINATE_BY'] = 20
 
 
 @override_settings(REST_FRAMEWORK=overrided_drf)
-@skip("MP API is disable.")
 class PrivateTopicListAPITest(APITestCase):
     def setUp(self):
         self.profile = ProfileFactory()
@@ -368,7 +367,6 @@ class PrivateTopicListAPITest(APITestCase):
         return [PrivateTopicFactory(author=user) for private_topic in xrange(0, number_of_users)]
 
 
-@skip("MP API is disable.")
 class PrivateTopicDetailAPITest(APITestCase):
     def setUp(self):
         self.profile = ProfileFactory()
@@ -614,7 +612,6 @@ class PrivateTopicDetailAPITest(APITestCase):
         self.assertNotIn(self.profile.user, PrivateTopic.objects.get(pk=another_private_topic.id).participants.all())
 
 
-@skip("MP API is disable.")
 class PrivatePostListAPI(APITestCase):
     def setUp(self):
         self.profile = ProfileFactory()
@@ -803,7 +800,6 @@ class PrivatePostListAPI(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
 
-@skip("MP API is disable.")
 class PrivatePostDetailAPI(APITestCase):
     def setUp(self):
         self.profile = ProfileFactory()

--- a/zds/mp/api/tests.py
+++ b/zds/mp/api/tests.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 from collections import OrderedDict
-from unittest import skip
 from django.contrib.auth.models import Group
 from django.core.cache import get_cache
 
@@ -942,7 +941,6 @@ class PrivatePostDetailAPI(APITestCase):
         self.assertEqual(response.data.get('text'), data.get('text'))
 
 
-@skip("MP API is disable.")
 class PrivateTopicUnreadListAPITest(APITestCase):
 
     def setUp(self):

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -95,7 +95,7 @@ urlpatterns += patterns('',
                         url(r'^api/', include('rest_framework_swagger.urls')),
                         url(r'^oauth2/', include('oauth2_provider.urls', namespace='oauth2_provider')),
                         url(r'^api/membres/', include('zds.member.api.urls')),
-                        # url(r'^api/mps/', include('zds.mp.api.urls')),
+                        url(r'^api/mps/', include('zds.mp.api.urls')),
                         )
 
 # SiteMap URLs


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui et Non |
| Nouvelle Fonctionnalité ? | Oui et Non |
| Tickets (_issues_) concernés | #2295 |

Enfin ! Nous allons pouvoir publier l'api des MPs ! Je me suis arrangé pour exposer uniquement l'identifiant de la classe `User` dans l'API des membres et donc, je peux publier l'API des MPs.

Pour la QA :
- Vérifier que toutes les URLs avec un identifiant fonctionnent correctement.
- Vérifiez que toutes les URLs des MPs fonctionnent correctement.

C'est vague mais une QA a déjà été faite pour les 2 fonctionnalités, il "suffit" de voir si tout reste ok. Travis sera déjà un bon indicateur puisque c'est plutôt full testé.

Enjoy! :)
