### PR TITLE
Corrige l'affichage des status de vote

### DIFF
--- a/doc/source/back-end/member.rst
+++ b/doc/source/back-end/member.rst
@@ -70,7 +70,7 @@ Le clic sur "me désinscrire" entraîne alors une série d'action (qui sont **ir
 Les membres dans les environnement de test et de développement
 ==============================================================
 
-Afin de faciliter les procédures de tests en local, 6 utilisateurs ont été créés via la fixture ``users.yaml`` (utilisateur/mot de passe):
+Afin de faciliter les procédures de tests en local, 7 utilisateurs ont été créés via la fixture ``users.yaml`` (utilisateur/mot de passe):
 
 - user/user : Utilisateur normal
 - staff/staff : Utilisateur avec les droits d'un staff
@@ -78,6 +78,7 @@ Afin de faciliter les procédures de tests en local, 6 utilisateurs ont été cr
 - anonymous/anonymous : Utilisateur qui permet l'anonymisation des messages sur les forums, dans les commentaires d'articles et de tutoriels ainsi que dans les MPs
 - external/external : Utilisateur qui permet de récupérer les tutoriels d'anciens membres et/ou de publier des tutoriels externes.
 - ïtrema/ïtrema : Utilisateur de test supplémentaire sans droit
+- decal/decal: le compte qui possède un identifiant ``Profile`` différent de l'identifiant ``user`` pour permettre de tester des cas ou ces id sont différents
 
 Pour que ces membres soient ajoutés à la base de données, il est donc nécéssaire d'exécuter la commande, suivante, à la racine du site
 

--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -371,11 +371,11 @@ Par exemple, le code suivant appliquera la classe "voted" si le message a reçu 
 .. sourcecode:: html
 
     {% load profiles %}
-    <button class="{% if profile_user|disliked:message.pk %}voted{% endif %}">
+    <button class="{% if user|disliked:message.pk %}voted{% endif %}">
         {{ message.dislike }}
     </button>
 
-où ``profile_user`` est le profil (objet ``Profile``) d'un utilisateur et ``message`` est un objet de type ``Post`` (qu'il s'agisse d'un *post* de forum, ou d'un commentaire dans un article ou tutoriel, dont les implémentations diffèrent légèrement). Ce *templatetag* est employé dans la partie affichant les réponses.
+où ``user`` est l'utilisateur (objet ``User``) et ``message`` est un objet de type ``Post`` (qu'il s'agisse d'un *post* de forum, ou d'un commentaire dans un article ou tutoriel, dont les implémentations diffèrent légèrement). Ce *templatetag* est employé dans la partie affichant les réponses.
 
 Le module ``roman``
 ===================

--- a/doc/source/utils/fixture_loaders.rst
+++ b/doc/source/utils/fixture_loaders.rst
@@ -27,6 +27,7 @@ Nous possédons un ensemble de données sérialisées dans le dossier fixtures:
     - ïtrema/ïtrema un utilisateur normal, sans problème mais qui aime l'utf8
     - Anonymous/anonymous : le compte d'anonymisation
     - External/external: le compte pour accueillir les cours externes des auteurs ne voulant pas devenir membre ou quittant le site
+    - decal/decal: le compte qui possède un identifiant ``Profile`` différent de l'identifiant ``user`` pour permettre de tester des cas ou ces id sont différents
 
 De ce fait, le moyen le plus simple de charger l'ensemble des données de base est ``python manage.py loaddata fixtures/*.yaml``.
 

--- a/fixtures/users.yaml
+++ b/fixtures/users.yaml
@@ -78,6 +78,14 @@
         is_superuser: False
         groups:
             - 2
+-   model: auth.user
+    pk: 7
+    fields:
+        first_name: decalage
+        last_name: User
+        username: decal
+        password: pbkdf2_sha256$10000$w5hhXcOg2pIT$gluvdmTKlbOJDpo9U/C3pWJOmOytbXX2N38j2iplNcM=
+        is_superuser: False
 -   model: member.Profile
     pk: 1
     fields:
@@ -107,4 +115,9 @@
     pk: 6
     fields:
         user: 6
+        last_ip_address: 192.168.0.1
+-   model: member.Profile
+    pk: 20
+    fields:
+        user: 7
         last_ip_address: 192.168.0.1

--- a/fixtures/users.yaml
+++ b/fixtures/users.yaml
@@ -84,7 +84,7 @@
         first_name: decalage
         last_name: User
         username: decal
-        password: pbkdf2_sha256$10000$w5hhXcOg2pIT$gluvdmTKlbOJDpo9U/C3pWJOmOytbXX2N38j2iplNcM=
+        password: pbkdf2_sha256$15000$SaXZhZxZQ83e$SYz/pK0z9ZcuKhttYksJxjAn2zy6UOng4bWbWd7XF/g=
         is_superuser: False
 -   model: member.Profile
     pk: 1

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -270,37 +270,35 @@
                         {% endif %}
 
                         {% if user.is_authenticated and user != message.author %}
-                            {% with profile_user=user|profile %}
-                                <form action="{{ upvote_link }}" method="post">
-                                    {% csrf_token %}
-                                    <button
-                                        type="submit"
-                                        title="Ce message est utile {% if message.like > 0 %}({{ message.like }} personne{{ message.like|pluralize }} {% if message.like > 1 %}ont{% else %}a{% endif %} trouvé ce message utile){% endif %}"
-                                        class="upvote
-                                               ico-after
-                                               {% if message.like > message.dislike %}more-voted{% endif %}
-                                               {% if message.like > 0 %}has-vote{% endif %}
-                                               {% if profile_user|liked:message.pk %}voted{% endif %}"
-                                    >
-                                        +{{ message.like }}
-                                    </button>
-                                </form>
+                            <form action="{{ upvote_link }}" method="post">
+                                {% csrf_token %}
+                                <button
+                                    type="submit"
+                                    title="Ce message est utile {% if message.like > 0 %}({{ message.like }} personne{{ message.like|pluralize }} {% if message.like > 1 %}ont{% else %}a{% endif %} trouvé ce message utile){% endif %}"
+                                    class="upvote
+                                           ico-after
+                                           {% if message.like > message.dislike %}more-voted{% endif %}
+                                           {% if message.like > 0 %}has-vote{% endif %}
+                                           {% if user|liked:message.pk %}voted{% endif %}"
+                                >
+                                    +{{ message.like }}
+                                </button>
+                            </form>
 
-                                <form action="{{ downvote_link }}" method="post">
-                                    {% csrf_token %}
-                                    <button
-                                        type="submit"
-                                        title="Ce message n'est pas utile {% if message.dislike > 0 %}({{ message.dislike }} personne{{ message.dislike|pluralize }} n'{% if message.dislike > 1 %}ont{% else %}a{% endif %} pas trouvé ce message utile){% endif %}"
-                                        class="downvote
-                                               ico-after
-                                               {% if message.like < message.dislike %}more-voted{% endif %}
-                                               {% if message.dislike > 0 %}has-vote{% endif %}
-                                               {% if profile_user|disliked:message.pk %}voted{% endif %}"
-                                    >
-                                        -{{ message.dislike }}
-                                    </button>
-                                </form>
-                            {% endwith %}
+                            <form action="{{ downvote_link }}" method="post">
+                                {% csrf_token %}
+                                <button
+                                    type="submit"
+                                    title="Ce message n'est pas utile {% if message.dislike > 0 %}({{ message.dislike }} personne{{ message.dislike|pluralize }} n'{% if message.dislike > 1 %}ont{% else %}a{% endif %} pas trouvé ce message utile){% endif %}"
+                                    class="downvote
+                                           ico-after
+                                           {% if message.like < message.dislike %}more-voted{% endif %}
+                                           {% if message.dislike > 0 %}has-vote{% endif %}
+                                           {% if user|disliked:message.pk %}voted{% endif %}"
+                                >
+                                    -{{ message.dislike }}
+                                </button>
+                            </form>
                         {% else %}
                             <span
                                 class="upvote


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #1577 |

Cette PR corrige le problème qui résidait dans les templates qui affichait le mauvais statut des éléments de vote. 

Le problème venait du fait que le filtres [liked](https://github.com/zestedesavoir/zds-site/blob/e382d5dc04f5b252f3d377da75abb57a180acb57/zds/utils/templatetags/profile.py#L58) et [disliked](https://github.com/zestedesavoir/zds-site/blob/e382d5dc04f5b252f3d377da75abb57a180acb57/zds/utils/templatetags/profile.py#L63) attendaient en paramètre un user et au lieu de ça on leur donnait un profile. Donc forcément l'affichage ne pouvait pas fonctionner correctement dès lors que l'id du profile n'était pas le même que l'id du user.

**Note pour QA**: 
- Charger les fixtures des users qui contient maintenant un utilisateur dont le profile est "décalés" (le cas qui pose problème) avec la commande `python manage.py loaddata fixtures/*.yaml`
- Connecter vous avec l'utilisateur decal dont le login/password est `decal/user`
- Allez dans le forum et likez/dislikez un post, vérifiez qu'en raffraichissant la page après le vote, le pouce est toujours vert/rouge pour montrer que vous avez effectivement voté.
- Faites votre rapport de QA :)

NB : étant donné le type de correction (template/front) je ne peux pas faire de Test unitaire pour ce cas
