### PR TITLE
Mise à jour des dépendances npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ notifications:
       - irc.smoothirc.net#zds-dev
     skip_join: true
 
-services: 
+services:
  - mysql
  - memcached
 
@@ -54,6 +54,10 @@ install:
     then
       ./scripts/install_texlive.sh
       export PATH=~/.texlive/bin/x86_64-linux:$PATH
+    else
+      nvm install 0.12
+      nvm use 0.12
+      npm install -g npm
     fi
   - export RESOURCES_URL="http://www.googledrive.com/host/0BzabS14KitJgfmV2ekdWSktmVEpieU93TG11RFNkWlZqS0JwZk93ZGhMR1lCWVg5NzFVc00"
   # Add fonts

--- a/package.json
+++ b/package.json
@@ -23,26 +23,26 @@
   "homepage": "https://github.com/zestedesavoir/zds-site",
   "dependencies": {
     "cookies-eu-banner": "1.2.7",
-    "del": "1.2.0",
+    "del": "2.0.2",
     "gulp": "3.9.0",
-    "gulp-autoprefixer": "2.3.1",
-    "gulp-concat": "2.5.2",
-    "gulp-if": "1.2.5",
+    "gulp-autoprefixer": "3.1.0",
+    "gulp-concat": "2.6.0",
+    "gulp-if": "2.0.0",
     "gulp-imagemin": "2.3.0",
-    "gulp-load-plugins": "0.10.0",
-    "gulp-minify-css": "1.1.6",
+    "gulp-load-plugins": "1.0.0",
+    "gulp-minify-css": "1.2.1",
     "gulp-notify": "2.2.0",
     "gulp-rename": "1.2.2",
-    "gulp-sass": "2.0.2",
-    "gulp-size": "1.2.2",
-    "gulp-uglify": "1.2.0",
+    "gulp-sass": "2.0.4",
+    "gulp-size": "2.0.0",
+    "gulp-uglify": "1.4.2",
     "jquery": "2.1.4",
     "normalize.css": "3.0.3",
-    "sprity": "1.0.6"
+    "sprity": "1.0.7"
   },
   "devDependencies": {
-    "gulp-jshint": "1.11.0",
-    "gulp-livereload": "3.8.0",
+    "gulp-jshint": "1.11.2",
+    "gulp-livereload": "3.8.1",
     "jshint-stylish": "2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cookies-eu-banner": "1.2.7",
     "del": "2.0.2",
     "gulp": "3.9.0",
-    "gulp-autoprefixer": "3.1.0",
+    "gulp-autoprefixer": "2.3.1",
     "gulp-concat": "2.6.0",
     "gulp-if": "2.0.0",
     "gulp-imagemin": "2.3.0",


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | - |

Simple mise à jour des dépendances npm, qui rend au passage le stack compatible avec node v4.0 (version qui a eu quelques changements non-rétrocompatibles au niveau de l'API native)
## Instruction QA

Tester l'installation du front avec node v0.11-v0.12, et avec node v4.x. Il vaut mieux réinstaller complètement les dépendances quand on change de version majeur (pour que ça recompile les bindings natifs correctement)
