### PR TITLE
Hotfix : utilise un email valide pour contacter l'association

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -374,7 +374,7 @@ ZDS_APP = {
         'abbr': u"zds",
         'url': u"http://127.0.0.1:8000",
         'dns': u"zestedesavoir.com",
-        'email_contact': u"communication@zestedesavoir.com",
+        'email_contact': u"zestedesavoir@gmail.com",
         'email_noreply': u"noreply@zestedesavoir.com",
         'repository': u"https://github.com/zestedesavoir/zds-site",
         'bugtracker': u"https://github.com/zestedesavoir/zds-site/issues",
@@ -388,7 +388,7 @@ ZDS_APP = {
         'association': {
             'name': u"Zeste de Savoir",
             'fee': u"20 €",
-            'email': u"association@zestedesavoir.com",
+            'email': u"zestedesavoir@gmail.com",
             'email_ca': u"ca-zeste-de-savoir@googlegroups.com"
         },
         'licenses': {


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #1454 |

Cette PR permet de présenter une adresse email valide pour l'association qui est injoignable depuis l'installation du nouveau serveur il y'a de celà **2 mois** maintenant (ça fait pas serieux). Je passe la PR en hotfix car c'est assez genant.

**Note pour QA**:
- Allez voir la page `/pages/contact` et vérifier que les adresse courriel de contact et de communication sont bien `zestedesavoir@gmail.com`
- Envoyer une email à l'adresse `zestedesavoir@gmail.com` et vérifier qu'on a pas de *delivery failure *
- Faite votre rapport de QA :)

PS : vue la correction, vous comprendrez qu'il est impensable de faire un test unitaire dessus.
