### PR TITLE
[beta 15.9] Corrige la gestion des slugs dans le module de contenu

### DIFF
--- a/doc/source/back-end/contents.rst
+++ b/doc/source/back-end/contents.rst
@@ -1,6 +1,6 @@
-=======================================
-Les tutoriels et articles v2.0 (ZEP 12)
-=======================================
+=========================
+Les tutoriels et articles
+=========================
 
 Vocabulaire et définitions
 ==========================
@@ -153,6 +153,12 @@ l'objet depuis le site Web et dans le nom des fichiers ou dossiers employés pou
 stocker (détails plus bas). Dès lors, cette spécification **impose** que ce 
 *slug* soit unique au sein du conteneur parent, et que le *slug* du contenu 
 soit unique au sein de tous les contenus de ZdS.
+
+La taille des *slugs* ne peut dépasser une certaine limite, définie dans le code par
+``ZDS_APP['content']['maximum_slug_size']`` (par défaut 150). Cette limite est due à
+une contrainte sur la taille maximum d'un nom de fichier sur les différents systèmes
+(généralement 255 octets sur la plupart des systèmes de fichier modernes, voir à ce sujet
+`l'article Wikipedia correspondant (en) <https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits>`_).
 
 .. note::
 

--- a/doc/source/back-end/contents_manifest.rst
+++ b/doc/source/back-end/contents_manifest.rst
@@ -31,14 +31,79 @@ Plus précisément :
 
 Sauf cas exceptionnel, la numérotation de X commence à 1, la numérotation de Y commence à 0, la numérotation de Z commence à 0.
 
-La version du manifeste est donnée par le champ éponyme situé à la racine du manifeste ( ```{ version="2.0.0"}```).
-L'absence du champ version est interprétée comme ``̀{version="1.0.0"}```.
-Les 0 non significatifs sont optionnels ainsi ```{version="1"}``` est strictement équivalent à ```{version:"1.0"}``` lui-même strictement équivalent à ```{version:"1.0.0"}```.
+La version du manifeste est donnée par le champ éponyme situé à la racine du manifeste ( ``{ version: "2.0.0"}``).
+L'absence du champ version est interprétée comme ``{version: "1.0"}``.
+Les 0 non significatifs sont optionnels ainsi ``{version: "1"}`` est strictement équivalent à ``{version: "1.0"}`` lui-même strictement équivalent à ``{version: "1.0.0"}``.
+
+Version 2.0
+-----------
+
+La version 2.0 est la version actuelement utilisée.
+
+.. sourcecode:: json
+
+    {
+        "object": "container",
+        "slug": "un-tutoriel",
+        "title": "Un tutoriel",
+        "introduction": "introduction.md",
+        "conclusion": "conclusion.md",
+        "version": 2,
+        "description": "Une description",
+        "type": "TUTORIAL",
+        "licence": "Beerware",
+        "children": [
+            {
+                "object": "container",
+                "slug": "titre-de-mon-chapitre",
+                "title": "Titre de mon chapitre",
+                "introduction": "titre-de-mon-chapitre/introduction.md",
+                "conclusion": "titre-de-mon-chapitre/conclusion.md",
+                "children": [
+                    {
+                        "object": "extract",
+                        "slug": "titre-de-mon-extrait",
+                        "title": "Titre de mon extrait",
+                        "text": "titre-de-mon-chapitre/titre-de-mon-extrait.md"
+                    },
+                    (...)
+                ]
+            },
+            (...)
+        ]
+    }
+
+1. ``type`` : Le type de contenu, vaut "TUTORIAL" ou "ARTICLE". *Si ce champ est absent ou invalide, le type vaudra par défaut "TUTORIAL".*
+2. ``description`` : La description du contenu. Est affichée comme sous-titre dans la page finale. **Obligatoire**
+3. ``title`` : Le titre du contenu. **Obligatoire**
+4. ``slug`` : slug du contenu qui permet de faire une url SEO-friendly. Pour rappel, `certaines contraintes doivent être respectées dans le choix du slug <contents.html#des-objets-en-general>`_. **Obligatoire**.  ATENTION : si ce slug existe déjà dans notre base de données, il est possible qu'un nombre lui soit ajouté
+5. ``introduction`` : le nom du fichier Mardown qui possède l'introduction. Il doit pointer vers le dossier courant. *Optionnel mais conseillé*
+6. ``conclusion`` : le nom du fichier Mardown qui possède la conclusion. Il doit pointer vers le dossier courant. *Optionnel mais conseillé*
+7. ``licence`` : nom complet de la license. *A priori* les licences "CC" et "Tous drois réservés" sont supportées. Le support de toute autre licence dépendra du site utilisant le code de ZdS (fork) que vous visez. **Obligatoire**
+8. ``children`` : tableau contenant l'architecture du contenu.
+    1. ``object`` : type d'enfant (*container* ou *extract*, selon qu'il s'agisse d'une section ou d'un texte). **Obligatoire**
+    2. ``title`` : le titre de l'enfant. **Obligatoire**
+    3. ``slug`` : le slug de l'enfant pour créer une url SEO-friendly, doit être unique dans le contenu, le slug est utilisé pour trouver le chemin vers l'enfant dans le système de fichier si c'est une section. Attention, `certaines contraintes doivent être respectées dans le choix du slug <contents.html#des-objets-en-general>`_. **Obligatoire**
+    4. ``introduction`` : nom du fichier contenant l'introduction quand l'enfant est de type *container*. *Optionnel mais conseillé*
+    5. ``conclusion`` : nom du fichier contenant la conclusion quand l'enfant est de type *container*. *Optionnel mais conseillé*
+    6. ``children`` : tableau vers les enfants de niveau inférieur si l'enfant est de type *container*. **Obligatoire**
+    7. ``text`` : nom du fichier contenant le texte quand l'enfant est de type *extract*. Nous conseillons de garder la convention ``nom de fichier = slug.md`` mais rien n'est obligatoire à ce sujet. **Obligatoire**
+
+
+
 
 Version 1.0
 -----------
 
+
+.. note::
+
+    La version 1.0 est dépréciée, et il est conseillé d'employer la version 2.0. Il est ceci dit toujours possible
+    `d'importer des contenus <contents.html#import-de-contenus>`_ dont le manifeste est toujours en version 1.0, mais à vos risques et périls.
+
+
 La version 1.0 définit trois types de manifeste selon que nous faisons face à un article,  un mini tutoriel ou un big tutoriel.
+
 
 MINI TUTO
 +++++++++
@@ -106,56 +171,3 @@ Article
         "type": "article",
         "text": "text.md"
     }
-
-
-Version 2.0
------------
-
-.. sourcecode:: json
-
-    {
-        "object": "container",
-        "slug": "un-tutoriel",
-        "title": "Un tutoriel",
-        "introduction": "introduction.md",
-        "conclusion": "conclusion.md",
-        "version": 2,
-        "description": "Une description",
-        "type": "TUTORIAL",
-        "licence": "Beerware",
-        "children": [
-            {
-                "object": "container",
-                "slug": "titre-de-mon-chapitre",
-                "title": "Titre de mon chapitre",
-                "introduction": "titre-de-mon-chapitre/introduction.md",
-                "conclusion": "titre-de-mon-chapitre/conclusion.md",
-                "children": [
-                    {
-                        "object": "extract",
-                        "slug": "titre-de-mon-extrait",
-                        "title": "Titre de mon extrait",
-                        "text": "titre-de-mon-chapitre/titre-de-mon-extrait.md"
-                    },
-                    (...)
-                ]
-            },
-            (...)
-        ]
-    }
-
-1. ``type`` : Le type de contenu, vaut "TUTORIAL" ou "ARTICLE". *Si ce champ est absent ou invalide, le type vaudra par défaut "TUTORIAL".*
-2. ``description`` : La description du contenu. Est affichée comme sous-titre dans la page finale. **Obligatoire**
-3. ``title`` : Le titre du contenu. **Obligatoire**
-4. ``slug`` : slug du contenu qui permet de faire une url SEO-friendly. **Obligatoire**. ATENTION : si ce slug existe déjà dans notre base de données, il est possible qu'un nombre lui soit ajouté
-5. ``introduction`` : le nom du fichier Mardown qui possède l'introduction. Il doit pointer vers le dossier courant. *Optionnel mais conseillé*
-6. ``conclusion`` : le nom du fichier Mardown qui possède la conclusion. Il doit pointer vers le dossier courant. *Optionnel mais conseillé*
-7. ``licence`` : nom complet de la license. *A priori* les licences "CC" et "Tous drois réservés" sont supportées. Le support de toute autre licence dépendra du site utilisant le code de ZdS (fork) que vous visez. **Obligatoire**
-8. ``children`` : tableau contenant l'architecture du contenu.
-    1. ``object`` : type d'enfant (*container* ou *extract*, selon qu'il s'agisse d'une section ou d'un texte). **Obligatoire**
-    2. ``title`` : le titre de l'enfant. **Obligatoire**
-    3. ``slug`` : le slug de l'enfant pour créer une url SEO-friendly, doit être unique dans le contenu, le slug est utilisé pour trouver le chemin vers l'enfant dans le système de fichier si c'est une section. **obligatoire**
-    4. ``introduction`` : nom du fichier contenant l'introduction quand l'enfant est de type *container*. *Optionnel mais conseillé*
-    5. ``conclusion`` : nom du fichier contenant la conclusion quand l'enfant est de type *container*. *Optionnel mais conseillé*
-    6. ``children`` : tableau vers les enfants de niveau inférieur si l'enfant est de type *container*. **Obligatoire**
-    7. ``text`` : nom du fichier contenant le texte quand l'enfant est de type *extract*. Nous conseillons de garder la convention ``nom de fichier = slug.md`` mais rien n'est obligatoire à ce sujet. **Obligatoire**

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -468,7 +468,8 @@ ZDS_APP = {
         'user_page_number': 5,
         'default_image': os.path.join(BASE_DIR, "fixtures", "noir_black.png"),
         'import_image_prefix': 'archive',
-        'build_pdf_when_published': True
+        'build_pdf_when_published': True,
+        'maximum_slug_size': 150
     },
     'forum': {
         'posts_per_page': 21,

--- a/zds/tutorialv2/__init__.py
+++ b/zds/tutorialv2/__init__.py
@@ -1,3 +1,4 @@
 import re
 
 REPLACE_IMAGE_PATTERN = re.compile(u'(?P<start>)(?P<text>!\[.*?\]\()(?P<url>.+?)(?P<end>\))')
+VALID_SLUG = re.compile(r'^[a-z0-9\-_]+$')

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from django import forms
 from django.conf import settings
-from uuslug import slugify
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
@@ -15,6 +14,7 @@ from zds.utils.models import HelpWriting
 from zds.tutorialv2.models.models_database import PublishableContent
 from django.utils.translation import ugettext_lazy as _
 from zds.member.models import Profile
+from zds.tutorialv2.utils import slugify_raise_on_invalid, InvalidSlugError
 
 
 class FormWithTitle(forms.Form):
@@ -39,8 +39,11 @@ class FormWithTitle(forms.Form):
             if 'title' in cleaned_data:
                 del cleaned_data['title']
 
-        if slugify(title).replace('-', '') == '':
-            self._errors['title'] = self.error_class([_(u'Ce titre n\'est pas autorisé, son slug est invalide !')])
+        try:
+            slugify_raise_on_invalid(title)
+        except InvalidSlugError as e:
+            self._errors['title'] = self.error_class(
+                [_(u'Ce titre n\'est pas autorisé, son slug est invalide {}!').format(e if e.message != '' else '')])
 
         return cleaned_data
 

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -494,7 +494,7 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
         except KeyError:
             raise BadArchiveError(_(u'Cette archive ne contient pas de fichier manifest.json.'))
         except UnicodeDecodeError:
-            raise BadArchiveError(_(u'L\'encodage du manifest.json n\'est pas de l\'UTF-8'))
+            raise BadArchiveError(_(u'L\'encodage du manifest.json n\'est pas de l\'UTF-8.'))
 
         # is the manifest ok ?
         try:
@@ -502,16 +502,20 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
         except ValueError:
             raise BadArchiveError(
                 _(u'Une erreur est survenue durant la lecture du manifest, '
-                  u'vérifiez qu\'il s\'agit de JSON correctement formaté'))
+                  u'vérifiez qu\'il s\'agit de JSON correctement formaté.'))
         try:
             versioned = get_content_from_json(json_, None, '',
                                               max_title_len=PublishableContent._meta.get_field('title').max_length)
         except BadManifestError as e:
             raise BadArchiveError(e.message)
-        except InvalidSlugError:
-            raise BadArchiveError(_(u'Le titre et le slug doivent être bien formés (au moins une lettre).'))
+        except InvalidSlugError as e:
+            e1 = _(u'Le slug "{}" est invalide').format(e)
+            e2 = u''
+            if e.had_source:
+                e2 = _(u' (slug généré à partir de "{}")').format(e.source)
+            raise BadArchiveError(_(u'{}{} !').format(e1, e2))
         except Exception as e:
-            raise BadArchiveError(_(u'Une erreur est survenue lors de la lecture de l\'archive : ' + e.message))
+            raise BadArchiveError(_(u'Une erreur est survenue lors de la lecture de l\'archive : {}.').format(e))
 
         # is there everything in the archive ?
         for f in UpdateContentWithArchive.walk_content(versioned):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3122 |
# Note de QA

Bon, une bonne fois pour toute (!)
- Créez un article. Ajoutez lui une section. Téléchargez l'archive.
- Tentez de réimporter l'archive en mettant des slugs incorrects dans le manifest tels que `-`, `-_-`, `a!`, `école`, `un avion` ou encore  `.................................................................................................................................................................................................................................`
  
  Constatez que vous vous faites jeter bien comme il faut.
- Enlevez le slug et éditer le titre pour mettre des choses qui généreront des slugs qui n'existent pas : `&&&`, `-_-`, `ce titre qui est tellement long qu'il génère une erreur parce qu'il est beaucoup trop long` ou encore `@@@`. 
  
  Faites vous jeter bien comme il faut (attention, certains titres sont valides [voir ici](https://github.com/zestedesavoir/zds-site/blob/release-15.9/zds/tutorialv2/tests/tests_views.py#L3626)).
- Testez également différents titres dans l'interface d'édition de la section, juste pour être certain.
