### PR TITLE
Masque les sujets fermés sur la page d'accueil

### DIFF
--- a/zds/forum/managers.py
+++ b/zds/forum/managers.py
@@ -62,6 +62,7 @@ class TopicManager(models.Manager):
     def get_last_topics(self):
         return self.order_by('-pubdate') \
                    .exclude(Q(forum__group__isnull=False)) \
+                   .exclude(is_locked=True) \
                    .all() \
                    .select_related('forum', 'author', 'last_message') \
                    .prefetch_related('tags')[:settings.ZDS_APP['topic']['home_number']]

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -194,7 +194,7 @@ class Topic(models.Model):
     pubdate = models.DateTimeField('Date de création', auto_now_add=True)
 
     is_solved = models.BooleanField('Est résolu', default=False, db_index=True)
-    is_locked = models.BooleanField('Est verrouillé', default=False)
+    is_locked = models.BooleanField('Est verrouillé', default=False, db_index=True)
     is_sticky = models.BooleanField('Est en post-it', default=False, db_index=True)
 
     tags = models.ManyToManyField(

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -46,6 +46,27 @@ class CategoriesForumsListViewTests(TestCase):
         self.assertEqual(category, current_category)
         self.assertEqual(forum, current_category.get_forums(profile.user)[0])
 
+    def test_topic_list_home_page(self):
+        staff = StaffProfileFactory()
+
+        profile = ProfileFactory()
+        category, forum = create_category()
+        topic = add_topic_in_a_forum(forum, profile)
+
+        topics_nb = len(Topic.objects.get_last_topics())
+
+        self.assertTrue(self.client.login(username=staff.user.username, password='hostel77'))
+        data = {
+            'lock': 'true',
+            'topic': topic.pk
+        }
+        response = self.client.post(reverse('topic-edit'), data, follow=False)
+
+        self.assertEqual(302, response.status_code)
+        self.assertTrue(Topic.objects.get(pk=topic.pk).is_locked)
+
+        self.assertEqual(len(Topic.objects.get_last_topics()), topics_nb - 1)
+
 
 class CategoryForumsDetailViewTest(TestCase):
     def test_success_list_all_forums_of_a_category(self):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #3107 |

**QA**
- Verouiller l'un des sujets présents sur la page d'accueil. Vérifiez qu'il ne s'y affiche plus désormais.
