### PR TITLE
[hotfix v12.0]fix les doubles notifs et la non sauvegarde de la lecture

### DIFF
--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -11,6 +11,7 @@ from django.views.generic import DetailView, FormView
 from django.utils.translation import ugettext_lazy as _
 
 from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent, ContentRead
+from zds.tutorialv2.utils import mark_read
 
 
 class SingleContentViewMixin(object):
@@ -356,7 +357,8 @@ class SingleOnlineContentViewMixin(ContentTypeMixin):
         self.is_staff = self.request.user.has_perm('tutorialv2.change_publishablecontent')
 
         self.current_content_type = obj.content_type
-
+        if obj and obj.content.last_note:
+            mark_read(obj.content)
         return obj
 
     def get_object(self):

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -429,7 +429,8 @@ class PublishableContent(models.Model):
                     .select_related('related_content__public_version')\
                     .filter(content=self, user__pk=user.pk)\
                     .latest('note__pubdate')
-                if read is not None:
+                if read is not None and read.note:  # one case can show a read without note : the author has just
+                    # published his content and one comment has been posted by someone else.
                     return read.note
 
             except ContentRead.DoesNotExist:

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -29,6 +29,8 @@ from zds.mp.models import PrivateTopic
 from django.utils.encoding import smart_text
 from zds.utils.models import HelpWriting, CommentDislike, CommentLike, Alert
 from zds.utils.factories import HelpWritingFactory
+from zds.utils.templatetags.interventions import interventions_topics
+
 try:
     import ujson as json_reader
 except ImportError:
@@ -4201,8 +4203,10 @@ class PublishedContentTests(TestCase):
             self.client.get(reverse("tutorial:view", args=[self.tuto.pk, self.tuto.slug])).status_code, 200)
 
         reads = ContentRead.objects.filter(user=self.user_staff).all()
-        # simple visit does not trigger follow
-        self.assertEqual(len(reads), 0)
+        # simple visit does not trigger follow but remembers reading
+        self.assertEqual(len(reads), 1)
+        interventions = [post["url"] for post in interventions_topics(self.user_staff)]
+        self.assertTrue(reads.first().note.get_absolute_url() not in interventions)
 
         # login with author
         self.assertEqual(

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -102,7 +102,7 @@ def interventions_topics(user):
 
     for content_read in content_to_read:
         content = content_read.content
-        if content.pk not in content_followed_pk:
+        if content.pk not in content_followed_pk and user not in content.authors.all():
             continue
         reaction = content.first_unread_note()
         if reaction is None:

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -6,10 +6,9 @@ import time
 from django import template
 from django.db.models import F
 
-from zds.article.models import Reaction, ArticleRead
 from zds.forum.models import TopicFollowed, never_read as never_read_topic, Post, TopicRead
 from zds.mp.models import PrivateTopic
-from zds.tutorial.models import Note, TutorialRead
+
 from zds.utils.models import Alert
 from zds.tutorialv2.models.models_database import ContentRead, ContentReaction
 
@@ -78,26 +77,9 @@ def interventions_topics(user):
         .select_related("topic")\
         .exclude(post=F('topic__last_message')).all()
 
-    articlesfollowed = Reaction.objects\
-        .filter(author=user, article__sha_public__isnull=False)\
-        .values('article')\
-        .distinct().all()
-
-    articles_never_read = ArticleRead.objects\
-        .filter(user=user)\
-        .filter(article__in=articlesfollowed)\
-        .select_related("article")\
-        .exclude(reaction=F('article__last_reaction')).all()
-
-    tutorialsfollowed = Note.objects\
-        .filter(author=user, tutorial__sha_public__isnull=False)\
-        .values('tutorial')\
-        .distinct().all()
-
-    tutorials_never_read = TutorialRead.objects\
-        .filter(user=user)\
-        .filter(tutorial__in=tutorialsfollowed)\
-        .exclude(note=F('tutorial__last_note')).all()
+    content_followed_pk = ContentReaction.objects\
+        .filter(author=user, related_content__public_version__isnull=False)\
+        .values_list('related_content__pk', flat=True)
 
     content_to_read = ContentRead.objects\
         .select_related('note')\
@@ -108,20 +90,6 @@ def interventions_topics(user):
         .exclude(note__pk=F('content__last_note__pk')).all()
 
     posts_unread = []
-
-    for art in articles_never_read:
-        content = art.article.first_unread_reaction()
-        posts_unread.append({'pubdate': content.pubdate,
-                             'author': content.author,
-                             'title': art.article.title,
-                             'url': content.get_absolute_url()})
-
-    for tuto in tutorials_never_read:
-        content = tuto.tutorial.first_unread_note()
-        posts_unread.append({'pubdate': content.pubdate,
-                             'author': content.author,
-                             'title': tuto.tutorial.title,
-                             'url': content.get_absolute_url()})
 
     for top in topics_never_read:
         content = top.topic.first_unread_post()
@@ -134,6 +102,8 @@ def interventions_topics(user):
 
     for content_read in content_to_read:
         content = content_read.content
+        if content.pk not in content_followed_pk:
+            continue
         reaction = content.first_unread_note()
         if reaction is None:
             reaction = content.first_note()
@@ -183,21 +153,8 @@ def alerts_list(user):
                           'pubdate': alert.pubdate,
                           'author': alert.author,
                           'text': alert.text})
-        elif alert.scope == Alert.ARTICLE:
-            reaction = Reaction.objects.select_related('article').get(pk=alert.comment.pk)
-            total.append({'title': reaction.article.title,
-                          'url': reaction.get_absolute_url(),
-                          'pubdate': alert.pubdate,
-                          'author': alert.author,
-                          'text': alert.text})
-        elif alert.scope == Alert.TUTORIAL:
-            note = Note.objects.select_related('tutorial').get(pk=alert.comment.pk)
-            total.append({'title': note.tutorial.title,
-                          'url': note.get_absolute_url(),
-                          'pubdate': alert.pubdate,
-                          'author': alert.author,
-                          'text': alert.text})
-        if alert.scope == Alert.CONTENT:
+
+        elif alert.scope == Alert.CONTENT:
             note = ContentReaction.objects.select_related('related_content').get(pk=alert.comment.pk)
             total.append({'title': note.related_content.title,
                           'url': note.get_absolute_url(),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [#3133] |

Pour la QA : 

les anciennes notifs ont disparues
les anciennes alertes ont disparu

Créez un article avec au moins commentaires
avec un user (aka nonotif) qui n'a pas posté les commentaires, lisez l'article
avec un des premiers user postez un nouveau commentaire
reconnectez vous avec "nonotif" et vérifiez ces deux assertions : 
- pas de notifications
- lorsqu'il clique sur la bulle sur la PA, il arrive à l'ancre vers le dernier message.
