### PR TITLE
[Hotfix] résoud le problème d'éditions concurentes

### DIFF
--- a/templates/tutorialv2/comment/new.html
+++ b/templates/tutorialv2/comment/new.html
@@ -45,14 +45,14 @@
         {% include "misc/previsualization.part.html" with text=form.text.value %}
     {% endif %}
 
+    <hr />
+
+
     <div class="content-wrapper">
         {% for message in notes %}
-            {% captureas edit_link %}
-                {% url "content:update-reaction" %}?message={{ message.pk }}
-            {% endcaptureas %}
 
             {% captureas cite_link %}
-                {% url "content:json-reaction" message.pk %}
+                {% url "content:add-reaction" %}?cite={{ message.pk }}&amp;pk={{ content.pk }}
             {% endcaptureas %}
 
             {% captureas upvote_link %}

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -447,6 +447,9 @@ class NoteForm(forms.Form):
         :param args:
         :param kwargs:
         """
+
+        last_note = kwargs.pop('last_note', 0)
+
         super(NoteForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_action = reverse('content:add-reaction') + u'?pk={}'.format(content.pk)
@@ -454,8 +457,7 @@ class NoteForm(forms.Form):
 
         self.helper.layout = Layout(
             CommonLayoutEditor(),
-            Field('last_note')
-
+            Field('last_note') if not last_note else Hidden('last_note', last_note)
         )
 
         if content.antispam():
@@ -472,8 +474,10 @@ class NoteForm(forms.Form):
                 placeholder=_(u'Ce contenu est verrouillé.'),
                 disabled=True
             )
+
         if reaction is not None:
             self.initial.setdefault("text", reaction.text)
+
         self.content = content
 
     def clean(self):

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -4167,7 +4167,7 @@ class PublishedContentTests(TestCase):
             reverse("content:add-reaction") + u'?pk={}'.format(self.published.content.pk),
             {
                 'text': message_to_post,
-                'last_note': '0'
+                'last_note': 0
             }, follow=True)
         self.assertEqual(result.status_code, 200)
 
@@ -4266,6 +4266,20 @@ class PublishedContentTests(TestCase):
         self.assertTrue(message_to_post in text_field_value)
         self.assertTrue(self.user_guest.username in text_field_value)
         self.assertTrue(reactions[0].get_absolute_url() in text_field_value)
+
+        # test that if the wrong last_note is given, user get a message
+        self.assertEqual(ContentReaction.objects.count(), 1)
+
+        result = self.client.post(
+            reverse("content:add-reaction") + u'?pk={}'.format(self.published.content.pk),
+            {
+                'text': message_to_post,
+                'last_note': -1  # wrong pk
+            }, follow=False)
+        self.assertEqual(result.status_code, 200)
+
+        self.assertEqual(ContentReaction.objects.count(), 1)  # no new reaction has been posted
+        self.assertTrue(result.context['newnote'])  # message appears !
 
     def test_upvote_downvote(self):
         self.assertEqual(


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3144 |
# Notes de QA
- Créer et publier un article. Y mettre un commentaire
- Avec un utilisateur A, visiter l'article et se préparer à mettre un commentaire
- Avec un utilisateur B, dans un autre navigateur (ou en navigation privée), placer un commentaire
- Commenter avec A et constater qu'on arrive bien sur la page indiquant que un autre message a déjà été posté.
