### PR TITLE
Ajoute du karma lors du changement de pseudo

### DIFF
--- a/doc/source/back-end/member.rst
+++ b/doc/source/back-end/member.rst
@@ -128,6 +128,8 @@ Cet outil à deux rôles. Permettre d'identifier les membres *perturbateurs* mai
 
 Pour modifier le karma d'un membre, il faut donc être modérateur sur le site. Sur la fiche profil d'un membre apparait alors un formulaire pour ajouter un bonus/malus et une liste des modifications précédentes montrant l'impact (+/-), le message, l'auteur du bonus/malus et la date d'effet de ce dernier.
 
+Lorsqu'un membre change de pseudo, une note de karma (de 0 point) est automatiquement ajouté au profil en faisant mention de l'ancien et du nouveau pseudo du membre (afin de garder une tracabilité pour les membres du staff).
+
 L'interface de réinitialisation de mot de passe
 -----------------------------------------------
 

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -932,6 +932,24 @@ class MemberTests(TestCase):
         result = self.client.get(reverse('zds.member.views.modify_karma'), follow=False)
         self.assertEqual(result.status_code, 405)
 
+    def test_karma_and_pseudo_change(self):
+        """
+        To test that a karma note is added when a member change its pseudo
+        """
+        tester = ProfileFactory()
+        old_pseudo = tester.user.username
+        self.client.login(username=tester.user.username, password="hostel77")
+        data = {
+            'username': 'dummy',
+            'email': ''
+        }
+        result = self.client.post(reverse('update-username-email-member'), data, follow=False)
+
+        self.assertEqual(result.status_code, 302)
+        notes = KarmaNote.objects.filter(user=tester.user).all()
+        self.assertEqual(len(notes), 1)
+        self.assertTrue(old_pseudo in notes[0].comment and 'dummy' in notes[0].comment)
+
     def tearDown(self):
         if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):
             shutil.rmtree(settings.ZDS_APP['content']['repo_private_path'])

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -222,6 +222,13 @@ class UpdateUsernameEmailMember(UpdateMember):
 
     def update_profile(self, profile, form):
         if form.data['username']:
+            # Add a karma message for the staff
+            bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
+            KarmaNote(user=profile.user,
+                      staff=bot,
+                      comment=_(u"{} s'est renommé {}").format(profile.user.username, form.data['username']),
+                      value=0).save()
+            # Change the pseudo
             profile.user.username = form.data['username']
         if form.data['email']:
             if form.data['email'].strip() != '':


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | nop |

Petite évolution toute simple. Cette PR ajoute simplement un message de karma, lorsque le membre change de pseudo. Bien sûr le karma ajouté est nul.
### QA
- Avec un membre qui n'est pas admin (car c'est aussi le bot en local), faite un changement de pseudo
- Constatez que le membre est toujours utilisable
- Vérifier avec admin qu'un message de karma est ajouté sur cet utilisateur pour notifier le changement de pseudo.
