### PR TITLE
Retabli les rapports de couverture publiques

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-social-auth==0.2.9
 
 # Explicit dependencies (references in code)
 django==1.7.10
-coverage==3.7.1
+coverage==4.0.1
 django-crispy-forms==1.4.0
 django-haystack==2.3.1
 django-model-utils==2.2


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui |
| Nouvelle Fonctionnalité ? | [oui |
| Tickets (_issues_) concernés | #3154 |

Cette PR rétabli l'envoi de rapport de couverture coveralls. Le problème venait du fait qu'on utilisait une vieille version de coverage alors que le site coveralls lui est passé à une version majeure qui casse la retro compatibilité.

**Note pour QA**:

Travis devrait suffire à valider cette PR. 

A la fin du build de travis, vérifier que [sur ce lien](https://coveralls.io/github/zestedesavoir/zds-site) on a bien un nouveau pourcentage de couverture coveralls. Si c'est le cas, la QA est OK.
