### PR TITLE
Corrige les dates dans l'historique des tutoriels

### DIFF
--- a/templates/tutorialv2/view/history.html
+++ b/templates/tutorialv2/view/history.html
@@ -107,7 +107,7 @@
                         {% endif %}
                     </td>
                     <td>
-                        {{ commit.authored_date|humane_time:commit.author_tz_offset }}
+                        {{ commit.authored_date|humane_time }}
                     </td>
                     <td>
                         <a href="{% url "content:view" content.pk content.slug %}?version={{ commit.hexsha }}" >
@@ -156,7 +156,7 @@
                                             {% trans "mettre à jour" %}
                                         {% endif %}
                                     {% endcaptureas %}
-                                    {% blocktrans with action=action date_version=commit.authored_date|humane_time:commit.author_tz_offset content_title=content.title %}
+                                    {% blocktrans with action=action date_version=commit.authored_date|humane_time content_title=content.title %}
                                         Êtes-vous certain de vouloir <strong>{{ action }}</strong> la bêta pour le contenu
                                         "<em>{{ content_title }}</em>" dans sa version de {{ date_version }} ?
                                     {% endblocktrans %}

--- a/zds/utils/templatetags/date.py
+++ b/zds/utils/templatetags/date.py
@@ -69,6 +69,6 @@ def tooltip_date(value):
 
 
 @register.filter
-def humane_time(timestamp, tz_offset=0):
+def humane_time(timestamp):
     """Render time (number of second from epoch) to an human readable string"""
-    return format_date(datetime.utcfromtimestamp(timestamp - tz_offset))
+    return format_date(datetime.fromtimestamp(timestamp))

--- a/zds/utils/templatetags/tests/tests_date.py
+++ b/zds/utils/templatetags/tests/tests_date.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import time
 from datetime import datetime, timedelta
 
 from django.test import TestCase
@@ -107,4 +108,10 @@ class DateFormatterTest(TestCase):
         tr = Template("{% load date %}"
                       "{{ date_epoch | humane_time }}"
                       ).render(self.context)
-        self.assertEqual(u"jeudi 01 janvier 1970 à 00h00", tr)
+
+        # Since ZdS is in Europe/Paris, hours can be 1 or 2
+        is_dst = time.daylight and time.localtime().tm_isdst > 0
+        utc_offset_sec = time.altzone if is_dst else time.timezone
+        hours = -1 * utc_offset_sec / 3600
+
+        self.assertEqual(tr, u"jeudi 01 janvier 1970 à 0{}h00".format(hours))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3135 |

J'ai essayé de détailler le raisonnement de la correction dans le commit. Est-ce que vous pensez que le test modifié suffit ?
## QA
1. Créer un tutorial avec un compte quelconque sur http://127.0.0.1:8000/contenus/nouveau-tutoriel/
2. Dans la barre de gauche, section "Actions", cliquer sur "Historique des versions"

Comportement attendu : la "Date" du tutoriel modifié est effectivement récente : "il y a 22 secondes" ou "il y a 2 minutes", mais pas "Dans le futur".
