### PR TITLE
Corrige le badge coverall

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/zestedesavoir/zds-site.svg?branch=dev)](https://travis-ci.org/zestedesavoir/zds-site)
-[![Coverage Status](https://coveralls.io/repos/zestedesavoir/zds-site/badge.png?branch=dev)](https://coveralls.io/r/zestedesavoir/zds-site?branch=dev)
+[![Coverage Status](https://coveralls.io/repos/zestedesavoir/zds-site/badge.svg?branch=dev&service=github)](https://coveralls.io/github/zestedesavoir/zds-site?branch=dev)
 [![Code Health](https://landscape.io/github/zestedesavoir/zds-site/dev/landscape.svg)](https://landscape.io/github/zestedesavoir/zds-site/dev)
 
 [![Requirements Status](https://requires.io/github/zestedesavoir/zds-site/requirements.svg?branch=dev)](https://requires.io/github/zestedesavoir/zds-site/requirements/?branch=dev)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | nop |

Cette PR remet juste sur pied le badge coverall pour que le site coverall.io arrete de signaler que le badge n'est pas intégré (car ils ont changé leur façon de faire apparemment). Bref, rien de transcendant.
### QA

Rien à faire.
