### PR TITLE
Rajoute email.com aux fournisseurs de mail interdits

### DIFF
--- a/forbidden_email_providers.txt
+++ b/forbidden_email_providers.txt
@@ -132,6 +132,7 @@
 @eco.wretch.twbbs.org
 @einrot.com
 @einrot.de
+@email.com
 @email-jetable.
 @email60.com
 @emailgo.de


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [non] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | nop |

Rajoute `email.com` aux fournisseurs de mail interdits (récemment utilisé par des spammeurs coréens apparemment).

Sinon : oui je sais j'ai poussé ca dans la branche de release, car je ne voulais pas faire un hotfix et je vais déployer cette release dans le weekend normalement.
