### PR TITLE
Le validateur perd le droit de validation lorsque la version change

### DIFF
--- a/templates/tutorialv2/messages/validation_change.md
+++ b/templates/tutorialv2/messages/validation_change.md
@@ -17,9 +17,4 @@ obsolète.
 Pour constater les dégâts, euh... les modifications apportées, 
 je t'invite à consulter [l'historique]({{ url_history }}).
 
-Enfin, sache que si tu comptes valider cette dernière version, il te faudra 
-réserver derechef le contenu, en te rendant sur 
-[la page des validations]({{ url_list }}).
-
 {%  endblocktrans %}
-

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -1991,7 +1991,7 @@ class ContentTests(TestCase):
 
         # ... Therefore, a new Validation object is created
         validation = Validation.objects.filter(content=tuto).last()
-        self.assertEqual(validation.status, 'PENDING')
+        self.assertEqual(validation.status, 'PENDING_V')
         self.assertEqual(validation.validator, None)
         self.assertEqual(validation.version, self.tuto_draft.current_version)
 

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -1992,26 +1992,13 @@ class ContentTests(TestCase):
         # ... Therefore, a new Validation object is created
         validation = Validation.objects.filter(content=tuto).last()
         self.assertEqual(validation.status, 'PENDING_V')
-        self.assertEqual(validation.validator, None)
+        self.assertEqual(validation.validator, self.user_staff)
         self.assertEqual(validation.version, self.tuto_draft.current_version)
 
         self.assertEqual(PublishableContent.objects.get(pk=tuto.pk).sha_validation,
                          self.tuto_draft.current_version)
 
         self.assertEqual(PrivateTopic.objects.last().author, self.user_staff)  # admin has received a PM
-
-        # re-re-reserve (!)
-        result = self.client.post(
-            reverse('validation:reserve', kwargs={'pk': validation.pk}),
-            {
-                'version': validation.version
-            },
-            follow=False)
-        self.assertEqual(result.status_code, 302)
-
-        validation = Validation.objects.filter(pk=validation.pk).last()
-        self.assertEqual(validation.status, 'PENDING_V')
-        self.assertEqual(validation.validator, self.user_staff)
 
         # ensure that author cannot publish himself
         self.assertEqual(

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -119,6 +119,7 @@ class AskValidationForContent(LoggedWithReadWriteHability, SingleContentFormView
         # warn the former validator that an update has been made, if any
         if old_validator:
             validation.validator = old_validator
+            validation.status = "PENDING_V"
 
             bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
             msg = render_to_string(

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -114,13 +114,13 @@ class AskValidationForContent(LoggedWithReadWriteHability, SingleContentFormView
         validation.date_proposition = datetime.now()
         validation.comment_authors = form.cleaned_data['text']
         validation.version = form.cleaned_data['version']
+        if old_validator:
+            validation.validator = old_validator
+            validation.status = 'PENDING_V'
         validation.save()
 
         # warn the former validator that an update has been made, if any
         if old_validator:
-            validation.validator = old_validator
-            validation.status = "PENDING_V"
-
             bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
             msg = render_to_string(
                 'tutorialv2/messages/validation_change.md',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #3076 |
# QA
- Créer un contenu
- Le mettre en validation
- Le réserver
- Le mettre à jour, ainsi que la version en validation
- Le validateur reçoit un MP l'informant de la MAJ et _reste_ validateur du contenu (n'a pas à le réserver à nouveau)
