### PR TITLE
Ajout &bull dans le titre de la page des parametres du profil

### DIFF
--- a/templates/member/settings/base.html
+++ b/templates/member/settings/base.html
@@ -3,7 +3,7 @@
 
 
 {% block title_base %}
-   {% trans "Paramètres" %}
+   &bull; {% trans "Paramètres" %}
 {% endblock %}
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2991 |

Vérifier que sur la page `/membres/parametres/profil/` on a bien `Mon profil • Paramètres • ZdS` et non pas `Mon profil Paramètres • ZdS` :)
