### PR TITLE
Force la cohérence des protocoles pour le chargement des ressources

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
 {% load captureas %}
 {% load thumbnail %}
 {% load i18n %}
-
+{% load remove_url_protocole %}
 
 
 <!DOCTYPE html>
@@ -296,7 +296,7 @@
                                                         {% endif %}
                                                         <a href="{{ topic.last_read_post.get_absolute_url }}">
                                                             {% with p=last_answer.author.profile %}
-                                                                <img src="{{ p.get_avatar_url }}" alt="" class="avatar">
+                                                                <img src="{{ p.get_avatar_url|remove_url_protocole }}" alt="" class="avatar">
                                                             {% endwith %}
                                                             <span class="username">{{ last_answer.author.username }}</span>
                                                             <span class="date">{{ last_answer.pubdate|format_date:True|capfirst }}</span>
@@ -339,7 +339,7 @@
                                                     <li>
                                                         <a href="{{ first_unread.url }}">
                                                             {% with p=first_unread.author.profile %}
-                                                                <img src="{{ p.get_avatar_url  }}" alt="" class="avatar">
+                                                                <img src="{{ p.get_avatar_url|remove_url_protocole  }}" alt="" class="avatar">
                                                             {% endwith %}
                                                             <span class="username">{{ first_unread.author.username }}</span>
                                                             <span class="date">{{ first_unread.pubdate|format_date:True|capfirst }}</span>

--- a/templates/featured/includes/featured_resource_item.part.html
+++ b/templates/featured/includes/featured_resource_item.part.html
@@ -1,8 +1,9 @@
 {% load i18n %}
+{% load remove_url_protocole %}
 
 <article class="featured-resource-item">
     <a href="{{ featured_resource.url }}">
-        <img src="{{ featured_resource.image_url }}" alt="" class="featured-resource-illu">
+        <img src="{{ featured_resource.image_url|remove_url_protocole }}" alt="" class="featured-resource-illu">
         <div class="featured-resource-meta">
             <h3>{{ featured_resource.title }}</h3>
             <p class="featured-resource-description">{{ featured_resource.type }} {% if featured_resource.authors %} {% trans "par" %} <i>{{ featured_resource.authors }}</i>{% endif %}</p>

--- a/templates/featured/index.html
+++ b/templates/featured/index.html
@@ -1,6 +1,6 @@
 {% extends "featured/base.html" %}
 {% load i18n %}
-
+{% load remove_url_protocole %}
 
 {% block title %}
     {% trans "Liste des unes" %}
@@ -41,7 +41,7 @@
                         </div>
                         <div class="topic-description">
                             <a href="{% url 'featured-resource-update' featured_resource.pk %}" class="topic-title-link navigable-link">
-                                <img src="{{ featured_resource.image_url }}"
+                                <img src="{{ featured_resource.image_url|remove_url_protocole }}"
                                     data-caption="{{ featured_resource.title }}"
                                     alt="{{ featured_resource.title }}"
                                     class="topic-image"

--- a/zds/utils/templatetags/remove_url_protocole.py
+++ b/zds/utils/templatetags/remove_url_protocole.py
@@ -1,0 +1,20 @@
+from django import template
+from zds.settings import ZDS_APP
+
+
+register = template.Library()
+
+
+CONVERT_VALUES = ((1000, 'M'), (900, 'CM'), (500, 'D'), (400, 'CD'), (100, 'C'),
+                  (90, 'XC'), (50, 'L'), (40, 'XL'), (10, 'X'), (9, 'IX'), (5, 'V'),
+                  (4, 'IV'), (1, 'I'))
+
+
+@register.filter('remove_url_protocole')
+def remove_url_protocole(input_url):
+    """
+    make every image url pointing to this website protocol independant so that https is not broken
+    """
+    if ZDS_APP["site"]["dns"] in input_url:
+        return input_url.replace("http:/", "https:/").replace("https://" + ZDS_APP["site"]["dns"], "")
+    return input_url

--- a/zds/utils/templatetags/remove_url_protocole.py
+++ b/zds/utils/templatetags/remove_url_protocole.py
@@ -5,11 +5,6 @@ from zds.settings import ZDS_APP
 register = template.Library()
 
 
-CONVERT_VALUES = ((1000, 'M'), (900, 'CM'), (500, 'D'), (400, 'CD'), (100, 'C'),
-                  (90, 'XC'), (50, 'L'), (40, 'XL'), (10, 'X'), (9, 'IX'), (5, 'V'),
-                  (4, 'IV'), (1, 'I'))
-
-
 @register.filter('remove_url_protocole')
 def remove_url_protocole(input_url):
     """

--- a/zds/utils/templatetags/tests/test_remove_url_protocole.py
+++ b/zds/utils/templatetags/tests/test_remove_url_protocole.py
@@ -1,0 +1,16 @@
+from zds.settings import ZDS_APP
+from django.test import TestCase
+from zds.utils.templatetags.remove_url_protocole import remove_url_protocole
+
+
+class RemoveUrlProtocolTest(TestCase):
+
+    def test_remove_protocole_when_local_url(self):
+        self.assertEqual("/bla.html", remove_url_protocole("http://" + ZDS_APP["site"]["dns"] + "/bla.html"))
+        self.assertEqual("/bla.html", remove_url_protocole("https://" + ZDS_APP["site"]["dns"] + "/bla.html"))
+
+    def test_no_change_when_no_protocole(self):
+        self.assertEqual("/bla.html", remove_url_protocole("/bla.html"))
+
+    def test_no_change_when_extern_address(self):
+        self.assertEqual("http://www.google.com/bla.html", remove_url_protocole("http://www.google.com/bla.html"))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [non] |
| Nouvelle Fonctionnalité ? | [oui] |
| Tickets (_issues_) concernés | [#2888] |

Cette PR permet de rendre le "https" automatique pour les images de feature. Plus précisemment, on rend automatiquement les urls protocole independant quand elles sont issues de zds. Comme ça l'équipe de com' n'a plus à s'en préoccuper mais les utilisateurs n'ont pas de problème de https cassé.

**Nota** : contrairement à ce qu'il s'était passé plus tôt, je maintiens le **besoin** de faire ce filter _a posteriori_ pour quelques raisons:
- nous avons pour but de faciliter le travail de la com' leur forcer un format d'url qui n'est pas celui par défaut sur zds est donc contreproductif
- il y a déjà des urls en http qui sont en bdd et qui du coup ne passeront pas le validateur. Le jour où les features pourront être "ramenée au top" automatiquement on s'en mordra les doigts si on ne fait pas la correction d'affichage, de plus on ne sait pas, dans le futur d'où viendront les urls, API, clients autres...
- règle de base : filter in escape out et don't trust user input, comme le validateur n'est pas en bdd, je ne sais pas si les données sont cohérentes avec le protocole de communication de l'utilisateur
- nous avons d'autres ressources qui sont aujourd'hui chargées en http même quand on est en https : les avatars notamment, avec mon filtre django, j'ai pu corriger ce bug
- pourquoi un utilisateur qui arrive sur zds en `http` devrait-il se tapper l'overhead que représente le SSL pour charger... des images?
- en forçant un validateur qui dit "on veut que du https" on s'oblige à ne pouvoir linker des ressources extérieures que si elles ont une disponibilité https

Bref, je veux bien ajouter un validateur à cette PR, mais non seulement le templatetag django que j'ai codé est utile, mais en plus il répond à notre _besoin_.

A vous la régie.
