### PR TITLE
feat(api): Displays always avatar of the member.

### DIFF
--- a/zds/member/api/serializers.py
+++ b/zds/member/api/serializers.py
@@ -16,10 +16,11 @@ class UserListSerializer(serializers.ModelSerializer):
     models uses a foreign key to Profile, so we must use Profile
     serializers.
     """
+    avatar_url = serializers.CharField(source='profile.get_avatar_url')
 
     class Meta:
         model = User
-        fields = ('id', 'username', 'is_active', 'date_joined')
+        fields = ('id', 'username', 'is_active', 'date_joined', 'avatar_url')
 
 
 class ProfileListSerializer(serializers.ModelSerializer):
@@ -31,10 +32,11 @@ class ProfileListSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username')
     is_active = serializers.BooleanField(source='user.is_active')
     date_joined = serializers.DateTimeField(source='user.date_joined')
+    avatar_url = serializers.CharField(source='get_avatar_url')
 
     class Meta:
         model = Profile
-        fields = ('id', 'username', 'is_active', 'date_joined')
+        fields = ('id', 'username', 'is_active', 'date_joined', 'avatar_url')
 
 
 class ProfileCreateSerializer(serializers.ModelSerializer, ProfileCreate, ProfileUsernameValidator,

--- a/zds/mp/api/tests.py
+++ b/zds/mp/api/tests.py
@@ -219,6 +219,7 @@ class PrivateTopicListAPITest(APITestCase):
         author = response.data.get('results')[0].get('author')
         self.assertIsInstance(author, OrderedDict)
         self.assertEqual(author.get('username'), self.profile.user.username)
+        self.assertEqual(author.get('avatar_url'), self.profile.get_avatar_url())
 
     def test_create_private_topics_with_client_unauthenticated(self):
         """


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets (_issues_) concernés | N/A |

QA :
- Vérifiez que les URLs des avatars sont bien affichés lorsque vous étendez les participants et/ou les auteurs dans l'API des MPs. (`/api/mps/?expand=author&expand=participants`)
- Vérifiez que l'API des membres se comportent toujours bien mais les TUs devraient déjà bien valider la chose.
