### PR TITLE
ajout d'une migration manquante

### DIFF
--- a/zds/forum/migrations/0003_auto_20151110_1145.py
+++ b/zds/forum/migrations/0003_auto_20151110_1145.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forum', '0002_auto_20150410_1505'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='topic',
+            name='is_locked',
+            field=models.BooleanField(default=False, db_index=True, verbose_name=b'Est verrouill\xc3\xa9'),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | nop |

Lors du déploiement de la V14 `python manage.py migrate` à grogner car il manquait un fichier de migration. Du coup le voici.

**Soyez vigilant à bien générer vos fichiers de migrations lorsque vous touchez aux modèles**, merci :)
