### PR TITLE
fix(api): Returns all info of pm when we create one.

### DIFF
--- a/zds/mp/api/serializers.py
+++ b/zds/mp/api/serializers.py
@@ -42,8 +42,9 @@ class PrivateTopicCreateSerializer(serializers.ModelSerializer, TitleValidator, 
 
     class Meta:
         model = PrivateTopic
-        fields = ('id', 'title', 'subtitle', 'participants', 'text')
-        read_only_fields = ('id',)
+        fields = ('id', 'title', 'subtitle', 'participants', 'text',
+                  'author', 'participants', 'last_message', 'pubdate')
+        read_only_fields = ('id', 'author', 'last_message', 'pubdate')
 
     def create(self, validated_data):
         # This hack is necessary because `text` isn't a field of PrivateTopic.

--- a/zds/mp/api/tests.py
+++ b/zds/mp/api/tests.py
@@ -248,6 +248,9 @@ class PrivateTopicListAPITest(APITestCase):
         self.assertEqual(response.data.get('subtitle'), private_topics[0].subtitle)
         self.assertEqual(response.data.get('participants')[0], private_topics[0].participants.all()[0].id)
         self.assertEqual(data.get('text'), private_topics[0].last_message.text)
+        self.assertEqual(response.data.get('author'), self.profile.user.id)
+        self.assertIsNotNone(response.data.get('last_message'))
+        self.assertIsNotNone(response.data.get('pubdate'))
 
     def test_create_of_private_topics_without_subtitle(self):
         """
@@ -267,6 +270,9 @@ class PrivateTopicListAPITest(APITestCase):
         self.assertEqual(response.data.get('subtitle'), private_topics[0].subtitle)
         self.assertEqual(response.data.get('participants')[0], private_topics[0].participants.all()[0].id)
         self.assertEqual(data.get('text'), private_topics[0].last_message.text)
+        self.assertEqual(response.data.get('author'), self.profile.user.id)
+        self.assertIsNotNone(response.data.get('last_message'))
+        self.assertIsNotNone(response.data.get('pubdate'))
 
     def test_create_of_private_topics_without_title(self):
         """


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui |
| Nouvelle Fonctionnalité ? | Non |
| Tickets (_issues_) concernés | N/A |

Pour toutes les routes, nous renvoyons correctement toutes les informations du MP voulu sauf quand nous en créons un nouveau. Dans ce cas, on renvoyait beaucoup moins d'information. Cette PR corrige cet oubli.

Pour la QA : Vérifiez que toutes les infos d'un MP sont renvoyées quand vous en créez un nouveau.
