### PR TITLE
Desanonymisation des +/-1

### DIFF
--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -105,6 +105,55 @@
     });
 
     /**
+     * See who likes/dislikes a message
+     */
+    $(".topic-message").on("click", "button.likers", function(e){
+        var $viewer = $(this),
+            $form = $(this).parents("form:first"),
+            $message = $viewer.parents(".message:first");
+
+        var csrfmiddlewaretoken = $form.find("input[name=csrfmiddlewaretoken]").val();
+
+        $.ajax({
+            url: $form.attr("action"),
+            type: "POST",
+            dataType: "json",
+            data: {
+                "csrfmiddlewaretoken": csrfmiddlewaretoken
+            },
+            success: function(data){
+                $viewer.attr("disabled", "disabled");
+                var div = document.createElement("div");
+                div.className = "screen";
+                div.className = "likers";
+                for (var keyLike in data.likes) {
+                    var imageLike = document.createElement("img");
+                    imageLike.src = data.likes[keyLike].avatarUrl;
+                    imageLike.title = data.likes[keyLike].username;
+                    imageLike.className = "avatar likers thumbUp";
+                    $(div).append(imageLike);
+                }
+                for (var keyDislike in data.dislikes) {
+                    var imageDislike = document.createElement("img");
+                    imageDislike.src = data.dislikes[keyDislike].avatarUrl;
+                    imageDislike.title = data.dislikes[keyDislike].username;
+                    imageDislike.className = "avatar likers thumbDown";
+                    $(div).append(imageDislike);
+                }
+                if (data.anonymous > 0) {
+                    var anonyspan = document.createElement("span");
+                    anonyspan.className = "message-content";
+                    anonyspan.innerHTML = "(" + (data.anonymous_likes+data.anonymous_dislikes) + " vote(s) anonyme(s))";
+                    $(div).append(anonyspan);
+                }
+                $message.append(div);
+            }
+        });
+
+        e.stopPropagation();
+        e.preventDefault();
+    });
+    /**
      * Follow a topic
      */
     $(".sidebar").on("click", "[data-ajax-input='follow-topic']", function(e){

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -370,6 +370,23 @@
             }
         }
 
+        .likers {
+            text-align: right;
+            img {
+                width: 30px;
+                height: 30px;
+                margin: 0 2px;
+
+                &.thumbUp {
+                    border-bottom: solid 3px $color-success;
+                }
+
+                &.thumbDown {
+                    border-bottom: solid 3px $color-danger;
+                }
+            }
+        }
+
         .message-buttons {
             margin: 0 0 0 10px;
             padding: 0;

--- a/doc/source/utils/anonym_dislikes.rst
+++ b/doc/source/utils/anonym_dislikes.rst
@@ -1,0 +1,7 @@
+======================
+Anonymisation des +/-1
+======================
+
+Sur les forums et les commentaires de contenu, les membres peuvent ajouter des +1 ou des -1 pour signifier leur émotion en un clic à propos d'un message. Pendant longtemps ces votes étaient anonymes mais suite à une décision des membres, il a été décidé de les rendre publiques. Ainsi, l'affichage de ces derniers est possible gràce à un bouton en forme d'oeil à côté des icones de vote. Lors d'un clic sur ce bouton, les pseudos/avatars des votants sont récupérés en base de données pour être affiché (appel AJAX). Pour des raisons d'ergonomie, ce bouton n'est pas affiché dans la version mobile du site.
+
+Cette décision de désanonymisation ayant eu lieu après le début de la vie du site, tous les votes antérieurs à cette décision restent anonymes. Pour cela, les votes sont filtrés selon leur clé primarire renseignés dans le fichier ``settings_prod.py`` : ``LIKES_ID_LIMIT`` et ``DISLIKES_ID_LIMIT``.

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -63,7 +63,7 @@
 
     {% include "misc/paginator.html" with position="top" %}
 
-        <div 
+        <div
             class="alert-box success ico-after tick light {% if not topic.is_solved %}empty{% endif %}"
             data-ajax-output="solve-topic"
         >

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -18,13 +18,13 @@
         topic-message
         {% if message.is_useful %}helpful{% endif %}
         {% if is_repeated_message %}repeated{% endif %}
-    " 
+    "
     {% if comment_schema %}
-        itemscope 
+        itemscope
         itemtype="http://schema.org/Comment"
         itemprop="comment"
     {% elif answer_schema %}
-        itemscope 
+        itemscope
         itemtype="http://schema.org/Answer"
         {% if message.is_useful or message.like > message.dislike %}
             itemprop="{% if message.is_useful %}acceptedAnswer{% endif %} {% if message.like > message.dislike %}suggestedAnswer{% endif %}"
@@ -204,8 +204,8 @@
         {% if perms_change %}
             {% for alert in message.alerts.all %}
                 <div class="alert-box error">
-                    {{ alert.pubdate|format_date|capfirst }} {% trans "par" %} 
-                    {% include "misc/member_item.part.html" with member=alert.author %} : 
+                    {{ alert.pubdate|format_date|capfirst }} {% trans "par" %}
+                    {% include "misc/member_item.part.html" with member=alert.author %} :
                     <em class="alert-box-text">{{ alert.text }}</em>
 
                     <a href="#solve-alert-{{ alert.pk }}" class="open-modal close-alert-box close-alert-box-text">{% trans "Résoudre" %}</a>
@@ -313,10 +313,10 @@
                                     {{ message.like }}
                                 </span>
                             </span>
-                            <span 
+                            <span
                                 class="downvote
                                        ico-after
-                                       {% if message.like < message.dislike %}more-voted{% endif %} 
+                                       {% if message.like < message.dislike %}more-voted{% endif %}
                                        {% if message.dislike > 0 %}has-vote{% endif %}"
                                 {% if message.dislike > 0 %}
                                     title="{{ message.dislike }} personne{{ message.dislike|pluralize }} n'{% if message.dislike > 1 %}ont{% else %}a{% endif %} pas trouvé ce message utile"
@@ -326,6 +326,12 @@
                                     {{ message.dislike }}
                                 </span>
                             </span>
+                        {% endif %}
+                        {% if user.is_authenticated %}
+                            <form action="{% url 'post-find-likers' message.pk %}" method="post" class="screen">
+                                {% csrf_token %}
+                                <button type="submit" title='{% trans "Voir les votants" %}' class="likers ico-after view blue"></button>
+                            </form>
                         {% endif %}
                     </div>
                 {% endif %}

--- a/update.md
+++ b/update.md
@@ -364,3 +364,18 @@ RECAPTCHA_PRIVATE_KEY = 'la-cle-ici'
 ```
 
 (les clés d'applications sont à créer auprès de l'association)
+
+Actions à faire pour mettre en prod la version 15
+=================================================
+
+Identifier les pk des [dis]likes pour la limite de désanonymisation - #1851
+---------------------------------------------------------------------------
+
+La politique du site étant devenu de désanonymiser les votes +/-1 tout en gardant les anciens votes anonymes, il faut rechercher la dernière PK de chacun des types de vote (Like ou Dislike) afin de les enregistrer dans le `settings_prod.py`. Voici les requètes à executer pour obtenir ces informations :
+
+```sql
+Select max(id) from utils_commentlike;
+Select max(id) from utils_commentdislike;
+```
+
+Le résultat de la première requète doit être placé dans le paramètre `LIKES_ID_LIMIT` et le second dans `DISLIKES_ID_LIMIT` dans le fichier `settings_prod.py`. Dorénavant tout les nouveaux +/-1 ne seront plus anonymes.

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -2,12 +2,22 @@
 
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from zds.forum.factories import CategoryFactory, ForumFactory, PostFactory, TopicFactory, TagFactory
 from zds.forum.models import TopicFollowed, Topic, Post
 from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.utils.models import CommentLike, CommentDislike
+
+try:
+    import ujson as json_reader
+except ImportError:
+    try:
+        import simplejson as json_reader
+    except ImportError:
+        import json as json_reader
 
 
 class CategoriesForumsListViewTests(TestCase):
@@ -1510,6 +1520,98 @@ class PostLikeDisLikeTest(TestCase):
 
         response = self.client.post(reverse('post-dislike') + '?message={}'.format(post.pk), follow=False)
         self.assertEqual(302, response.status_code)
+
+    def test_find_likers_and_dislikers(self):
+        profile = ProfileFactory()
+        profile2 = ProfileFactory()
+        category, forum = create_category()
+        topic = add_topic_in_a_forum(forum, profile)
+        another_profile = ProfileFactory()
+
+        upvoted_answer = PostFactory(topic=topic, author=another_profile.user, position=2)
+        upvoted_answer.like += 2
+        upvoted_answer.save()
+        like1 = CommentLike.objects.create(user=profile.user, comments=upvoted_answer)
+        CommentLike.objects.create(user=profile2.user, comments=upvoted_answer)
+
+        downvoted_answer = PostFactory(topic=topic, author=another_profile.user, position=3)
+        downvoted_answer.dislike += 2
+        downvoted_answer.save()
+        dislike1 = CommentDislike.objects.create(user=profile.user, comments=downvoted_answer)
+        CommentDislike.objects.create(user=profile2.user, comments=downvoted_answer)
+
+        equal_answer = PostFactory(topic=topic, author=another_profile.user, position=4)
+        equal_answer.like += 1
+        equal_answer.dislike += 1
+        equal_answer.save()
+        CommentLike.objects.create(user=profile.user, comments=equal_answer)
+        CommentDislike.objects.create(user=profile2.user, comments=equal_answer)
+
+        self.assertTrue(self.client.login(username=profile.user.username, password='hostel77'))
+
+        # on first message we should see 2 likes and 0 anonymous
+        response = self.client.post(reverse('post-find-likers', args=[upvoted_answer.pk]),
+                                    {}, "text/json", HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(200, response.status_code)
+        json = json_reader.loads(response.content)
+        self.assertEqual(2, len(json['likes']))
+        self.assertEqual(0, len(json['dislikes']))
+        self.assertEqual(0, json['anonymous_likes'])
+        self.assertEqual(0, json['anonymous_dislikes'])
+
+        # on second message we should see 2 dislikes and 0 anonymous
+        response = self.client.post(reverse('post-find-likers', args=[downvoted_answer.pk]),
+                                    {}, "text/json", HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(200, response.status_code)
+        json = json_reader.loads(response.content)
+        self.assertEqual(0, len(json['likes']))
+        self.assertEqual(2, len(json['dislikes']))
+        self.assertEqual(0, json['anonymous_likes'])
+        self.assertEqual(0, json['anonymous_dislikes'])
+
+        # on third message we should see 1 like and 1 dislike and 0 anonymous
+        response = self.client.post(reverse('post-find-likers', args=[equal_answer.pk]),
+                                    {}, "text/json", HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(200, response.status_code)
+        json = json_reader.loads(response.content)
+        self.assertEqual(1, len(json['likes']))
+        self.assertEqual(1, len(json['dislikes']))
+        self.assertEqual(0, json['anonymous_likes'])
+        self.assertEqual(0, json['anonymous_dislikes'])
+
+        # Now we change the settings to keep anonymous the first [dis]like
+        settings.LIKES_ID_LIMIT = like1.pk
+        settings.DISLIKES_ID_LIMIT = dislike1.pk
+        # and we run the same tests
+        # on first message we should see 1 like and 1 anonymous
+        response = self.client.post(reverse('post-find-likers', args=[upvoted_answer.pk]),
+                                    {}, "text/json", HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(200, response.status_code)
+        json = json_reader.loads(response.content)
+        self.assertEqual(1, len(json['likes']))
+        self.assertEqual(0, len(json['dislikes']))
+        self.assertEqual(1, json['anonymous_likes'])
+        self.assertEqual(0, json['anonymous_dislikes'])
+
+        # on second message we should see 1 dislikes and 1 anonymous
+        response = self.client.post(reverse('post-find-likers', args=[downvoted_answer.pk]),
+                                    {}, "text/json", HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(200, response.status_code)
+        json = json_reader.loads(response.content)
+        self.assertEqual(0, len(json['likes']))
+        self.assertEqual(1, len(json['dislikes']))
+        self.assertEqual(0, json['anonymous_likes'])
+        self.assertEqual(1, json['anonymous_dislikes'])
+
+        # on third message we should see 1 like and 1 dislike and 0 anonymous
+        response = self.client.post(reverse('post-find-likers', args=[equal_answer.pk]),
+                                    {}, "text/json", HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(200, response.status_code)
+        json = json_reader.loads(response.content)
+        self.assertEqual(1, len(json['likes']))
+        self.assertEqual(1, len(json['dislikes']))
+        self.assertEqual(0, json['anonymous_likes'])
+        self.assertEqual(0, json['anonymous_dislikes'])
 
 
 class FindPostTest(TestCase):

--- a/zds/forum/urls.py
+++ b/zds/forum/urls.py
@@ -46,6 +46,8 @@ urlpatterns = patterns('',
                        url(r'^message/like/$', PostLike.as_view(), name='post-like'),
                        url(r'^message/dislike/$', PostDisLike.as_view(), name='post-dislike'),
                        url(r'^messages/(?P<user_pk>\d+)/$', FindPost.as_view(), name='post-find'),
+                       url(r'^message/likers/(?P<post_pk>\d+)/$', 'zds.forum.views.post_find_likers',
+                           name='post-find-likers'),
 
                        # Categories and forums list.
                        url(r'^$', CategoriesForumsListView.as_view(), name='cats-forums-list'),

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -538,6 +538,10 @@ RECAPTCHA_USE_SSL = True
 RECAPTCHA_PUBLIC_KEY = 'dummy'  # noqa
 RECAPTCHA_PRIVATE_KEY = 'dummy'  # noqa
 
+# Anonymous [Dis]Likes. Authors of [dis]likes before those pk will never be shown
+LIKES_ID_LIMIT = 0
+DISLIKES_ID_LIMIT = 0
+
 # To remove a useless warning in Django 1.7.
 # See http://daniel.hepper.net/blog/2014/04/fixing-1_6-w001-when-upgrading-from-django-1-5-to-1-7/
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #1851 |

Bon, comme il est temps d'en finir avec cette histoire de +/-1 je propose qu'on avance avec cette solution. Alors comment ca se passe :
- Tout les +/-1 après une certaines PK (à récupérer à la mise en prod', cf le update.md) sont affichables ;
- Ils sont récupérés en AJAX (uniquement avatar+pseudo) ;
- Ce n'est pas affichable sur mobile, trop compliqué à gérer ;
- Le nombre de votes resté anonyme est affiché ;
- C'est standard, ca marche sur n'importe quel commentaire (fofo/article/etc..).

Voici une idée du rendu que ca peut avoir. En cas de nombreux votes il s'affiche les uns à la suite des autres puis les uns en dessous des autres.

![capture du 2015-11-12 12 19 49](https://cloud.githubusercontent.com/assets/761168/11117176/d6c6b776-8937-11e5-87f9-9a64c3c38c6d.png)
## QA
- Vérifier que les postes marchent tous bien (fofo etc)
- Vérifier la cohérence des informations renvoyés (bon pseudo+couleur de vote)
- Vérifier que le respect de la PK limite est bon

C'est un peu long à tester mais pas difficile, donc ca serait cool si ca pouvait avancer assez vite car ca devient gavant les histoires enfantines de votes.
