### PR TITLE
Erreur 500 pour poster un message dans un cas ultra précis

### DIFF
--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -44,8 +44,12 @@ urlpatterns = patterns('',
                        url(r'^beta/(?P<pk>\d+)/(?P<slug>.+)/$', DisplayBetaContent.as_view(), name='beta-view'),
 
                        # reactions:
-                       url(r'^reactions/ajouter/$', SendNoteFormView.as_view(), name="add-reaction"),
-                       url(r'^reactions/editer/$', UpdateNoteView.as_view(), name="update-reaction"),
+                       # for all those views, we do not need to redirect to the newest PublishedContent
+                       # because they just must depend on PublishableContent pk, not slug nor PublishedContent model
+                       url(r'^reactions/ajouter/$', SendNoteFormView.as_view(redirection_is_needed=False),
+                           name="add-reaction"),
+                       url(r'^reactions/editer/$', UpdateNoteView.as_view(redirection_is_needed=False),
+                           name="update-reaction"),
                        url(r'^reactions/upvote/$', UpvoteReaction.as_view(), name="up-vote"),
                        url(r'^reactions/downvote/$', DownvoteReaction.as_view(), name="down-vote"),
                        url(r'^reactions/cacher/(?P<pk>\d+)/$', HideReaction.as_view(), name="hide-reaction"),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [#3181] |

Ce dernier n'arrive que dans un cas précis :
- le tutoriel/article a été migré par la zep-12
- le modèle de publication "compatible ancien module" et le nouveau ont été créés à la meme seconde

D'une manière plus globale les vues qui n'ont pas besoin de redirection ont été exclus de cette fonctionnalité

Pour la QA faudra aller regarder sur la béta, désolé, on n'a plus de raison d'avoir des tutos à migrer là.
Pour le TU, à vous de voir ce que je dois mettre.
