### PR TITLE
Fix #3172 : Corrections des libeles des periodes dans les sujets suivis (forum)

### DIFF
--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -222,8 +222,8 @@ Ce filtre renvoit la liste des *topics* suivis par l'utilisateur, sous la forme 
 .. sourcecode:: html
 
     {% load interventions %}
-    {% with follwedtopics=user|followed_topics %}
-        {% for period, topics in follwedtopics.items %}
+    {% with followedtopics=user|followed_topics %}
+        {% for period, topics in followedtopics.items %}
         ...
         {% endfor %}
     {% endwith %}
@@ -303,7 +303,7 @@ Permet d'afficher une période en lettres. Fait le lien entre le label d'un jour
 .. sourcecode:: html
 
     {% load interventions %}
-    {% for period, topics in follwedtopics.items %}
+    {% for period, topics in followedtopics.items %}
        <h4>{{ period|humane_delta }}</h4>
     {% endfor %}
 

--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -295,6 +295,18 @@ Récupère la liste des alertes (si l'utilisateur possède les droits pour le fa
 - ``alert.pubdate`` donne la date à laquelle l'alerte à été faite ;
 - ``alert.topic`` donne le texte d'alerte.
 
+``humane_delta``
+----------------
+
+Permet d'afficher une période en lettres. Fait le lien entre le label d'un jour et sa clé.
+
+.. sourcecode:: html
+
+    {% load interventions %}
+    {% for period, topics in follwedtopics.items %}
+       <h4>{{ period|humane_delta }}</h4>
+    {% endfor %}
+
 Le module ``model_name``
 ========================
 

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -64,8 +64,8 @@
             <div class="mobile-menu-bloc mobile-all-links" data-title="Sujets suivis">
                 <h3>{% trans "Sujets suivis" %}</h3>
 
-                {% with follwedtopics=user|followed_topics %}
-                    {% for period, topics in follwedtopics.items %}
+                {% with followedtopics=user|followed_topics %}
+                    {% for period, topics in followedtopics.items %}
                         <h4>{{ period|humane_delta }}</h4>
                         <ul>
                             {% for topic in topics %}
@@ -143,7 +143,7 @@
                         </ul>
                     {% endfor %}
 
-                    {% if follwedtopics.items|length <= 0 %}
+                    {% if followedtopics.items|length <= 0 %}
                         <ul>
                             <li class="inactive">
                                 <span class="disabled">{% trans "Aucun sujet suivi" %}</span>

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -5,10 +5,10 @@ import time
 
 from django import template
 from django.db.models import F
+from django.utils.translation import ugettext_lazy as _
 
 from zds.forum.models import TopicFollowed, never_read as never_read_topic, Post, TopicRead
 from zds.mp.models import PrivateTopic
-
 from zds.utils.models import Alert
 from zds.tutorialv2.models.models_database import ContentRead, ContentReaction
 
@@ -25,8 +25,19 @@ def is_read(topic):
 
 @register.filter('humane_delta')
 def humane_delta(value):
-    # mapping between label day and key
-    const = {1: "Aujourd'hui", 2: "Hier", 3: "Cette semaine", 4: "Ce mois-ci", 5: "Cette année"}
+    """
+    Mapping between label day and key
+
+    :param int value:
+    :return: string
+    """
+    const = {
+        1: _("Aujourd'hui"),
+        2: _("Hier"),
+        3: _("Les 7 derniers jours"),
+        4: _("Les 30 derniers jours"),
+        5: _("Plus ancien")
+    }
 
     return const[value]
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3172 |
### QA
- Avoir des « Sujet suivis » de différents périodes sur le forum (plus de 2 jours requis)
- Aller sur la page d'accueil du forum (http://localhost:8000/forums/)
- Vérifier que les libélés sont maintenant : « Les n derniers jours » ou « Plus ancien » au lieu de « La Semaine dernière », etc
