### PR TITLE
feat(api): Order private post by position, pubdate and update.

### DIFF
--- a/zds/mp/api/tests.py
+++ b/zds/mp/api/tests.py
@@ -748,6 +748,49 @@ class PrivatePostListAPI(APITestCase):
         self.assertIsNotNone(response.data.get('results')[0].get('text'))
         self.assertIsNone(response.data.get('results')[0].get('text_html'))
 
+    def test_ordering_list_of_private_posts_by_position_in_topic(self):
+        """
+        Gets list of private posts ordered by position_in_topic.
+        """
+        private_topic = PrivateTopicFactory(author=self.profile.user)
+        self.create_multiple_private_posts_for_member(self.profile.user, private_topic,
+                                                      settings.REST_FRAMEWORK['PAGINATE_BY'])
+
+        response = self.client.get(reverse('api-mp-message-list', args=[private_topic.id]) +
+                                   '?ordering=position_in_topic')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), settings.REST_FRAMEWORK['PAGINATE_BY'])
+        self.assertIsNone(response.data.get('next'))
+        self.assertIsNone(response.data.get('previous'))
+
+    def test_ordering_list_of_private_posts_by_pubdate(self):
+        """
+        Gets list of private posts ordered by pubdate.
+        """
+        private_topic = PrivateTopicFactory(author=self.profile.user)
+        self.create_multiple_private_posts_for_member(self.profile.user, private_topic,
+                                                      settings.REST_FRAMEWORK['PAGINATE_BY'])
+
+        response = self.client.get(reverse('api-mp-message-list', args=[private_topic.id]) + '?ordering=pubdate')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), settings.REST_FRAMEWORK['PAGINATE_BY'])
+        self.assertIsNone(response.data.get('next'))
+        self.assertIsNone(response.data.get('previous'))
+
+    def test_ordering_list_of_private_posts_by_update(self):
+        """
+        Gets list of private posts ordered by update.
+        """
+        private_topic = PrivateTopicFactory(author=self.profile.user)
+        self.create_multiple_private_posts_for_member(self.profile.user, private_topic,
+                                                      settings.REST_FRAMEWORK['PAGINATE_BY'])
+
+        response = self.client.get(reverse('api-mp-message-list', args=[private_topic.id]) + '?ordering=update')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), settings.REST_FRAMEWORK['PAGINATE_BY'])
+        self.assertIsNone(response.data.get('next'))
+        self.assertIsNone(response.data.get('previous'))
+
     def create_multiple_private_posts_for_member(self, user, private_topic,
                                                  number_of_users=settings.REST_FRAMEWORK['PAGINATE_BY']):
         list = []

--- a/zds/mp/api/views.py
+++ b/zds/mp/api/views.py
@@ -41,6 +41,7 @@ class DetailKeyConstructor(DefaultKeyConstructor):
 
 class PagingPrivatePostListKeyConstructor(DefaultKeyConstructor):
     pagination = DJRF3xPaginationKeyBit()
+    search = bits.QueryParamsKeyBit(['ordering'])
     list_sql_query = bits.ListSqlQueryKeyBit()
     unique_view_id = bits.UniqueViewIdKeyBit()
 
@@ -279,6 +280,8 @@ class PrivatePostListAPI(MarkPrivateTopicAsRead, ListCreateAPIView):
     """
 
     permission_classes = (IsAuthenticated, IsParticipantFromPrivatePost)
+    filter_backends = (filters.OrderingFilter,)
+    ordering_fields = ('position_in_topic', 'pubdate', 'update')
     list_key_func = PagingPrivatePostListKeyConstructor()
 
     def dispatch(self, request, *args, **kwargs):
@@ -307,6 +310,9 @@ class PrivatePostListAPI(MarkPrivateTopicAsRead, ListCreateAPIView):
             - name: page_size
               description: Sets size of the pagination.
               required: false
+              paramType: query
+            - name: ordering
+              description: Applies an order at the list. You can order by (-)position_in_topic, (-)pubdate or (-)update.
               paramType: query
             - name: expand
               description: Expand a field with an identifier.


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets (_issues_) concernés | N/A |

En développant ZMessenger, j'ai remarqué l'impossibilité de trier les messages d'une conversation privée alors qu'il est possible de trier les conversations privées. Cette PR rajoute cette fonctionnalité de tri dans les messages.

QA : Sur la route qui liste les messages d'une conversation privée, constatez que vous pouvez trier par position, pubdate et update et que la documentation Swagger renseigne ce paramètre et ses différentes valeurs possibles.

PS : Je fais la PR sur release-v14 parce que ça concerne l'API des MPs mais aussi parce que j'en ai besoin pour ZMessenger et que j'ai pas envie d'attendre la release v15 pour déployer mon application. Mais si vous jugez qu'il faut faire la PR sur dev, je le ferais.
