### PR TITLE
Fix #3196 : rend le message d'explication pour les archives plus clair

### DIFF
--- a/templates/tutorialv2/import/content-new.html
+++ b/templates/tutorialv2/import/content-new.html
@@ -24,7 +24,7 @@
     <div class="alert-box info alert-box-not-closable">
     {%  blocktrans with prefix=app.content.import_image_prefix %}
         Pour importer des images, veuillez spécifier la seconde archive.
-        Les motifs <code>![légende]({{ prefix }}:chemin/vers/image.extension)</code>, référant aux images stockées dans l'archive, seront remplacés par les URLs générées par le site.
+        Pour que vos images soient automatiquement intégrées, ajoutez le préfix « {{ prefix }} » dans l'adresse de vos images. Par exemple : <code>![légende]({{ prefix }}:chemin/vers/image.extension)</code>. Les chemins seront remplacés par les URLs générées par le site.
     {% endblocktrans %}
     </div>
 

--- a/templates/tutorialv2/import/content.html
+++ b/templates/tutorialv2/import/content.html
@@ -29,7 +29,7 @@
     <div class="alert-box info alert-box-not-closable">
     {%  blocktrans with prefix=app.content.import_image_prefix %}
         Pour importer des images, veuillez spécifier la seconde archive.
-        Les motifs <code>![légende]({{ prefix }}:chemin/vers/image.extension)</code>, référant aux images stockées dans l'archive, seront remplacés par les URLs générées par le site.
+        Pour que vos images soient automatiquement intégrées, ajoutez le préfix « {{ prefix }} » dans l'adresse de vos images. Par exemple : <code>![légende]({{ prefix }}:chemin/vers/image.extension)</code>. Les chemins seront remplacés par les URLs générées par le site.
     {% endblocktrans %}
     </div>
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3196 |
### QA
- Vérifier que le nouveau message est plus compréhensible que l'ancien. Ne pas hésitez si vous avez mieux.
