### PR TITLE
Fix #3170 : previsualisation correcte avec mathjax

### DIFF
--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -303,7 +303,7 @@
                 $(data).insertAfter($form);
 
                 /* global MathJax */
-                if ($(data).find("mathjax").length > 0)
+                if ($(data).find("$").length > 0)
                     MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
             }
         });


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3170 |
### QA
- Build le front (`npm run gulp -- build`)
- Tester la prévisualisation avec du LaTeX

Message d'exemple : 

```
$\sqrt{1764} = 42$

$$\sqrt{1764} = 42$$
```
