### PR TITLE
Fix #3019 : indique que la galerie est supprimée en même temps que le contenu

### DIFF
--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -490,7 +490,7 @@
                                 {% csrf_token %}
                                 <p>
                                     {% blocktrans with content_title=content.title %}
-                                        Attention, vous vous apprêtez à <strong>supprimer définitivement</strong> « {{ content_title }} ».
+                                        Attention, vous vous apprêtez à <strong>supprimer définitivement</strong> « {{ content_title }} ». Cela aura pour effet de supprimer également la galerie associée.
                                     {% endblocktrans %}
                                     {%  if need_reason %}
                                         {% blocktrans with username=validation.validator.username %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3019 |
### QA
- Créer un article ou un tutoriel.
- Essayer de le supprimer et vérifier que le message indique bien que la galerie associée va être supprimée.
