### PR TITLE
Fix #872 : ajout de la taille des fichiers telecharges

### DIFF
--- a/templates/tutorialv2/base.html
+++ b/templates/tutorialv2/base.html
@@ -82,6 +82,11 @@
                                     <li>
                                         <a href="{{ public_object.get_absolute_url_md }}" class="ico-after download blue">
                                             {% trans "Markdown" %}
+                                            {% with size=public_object.get_size_md %}
+                                                {% if size %}
+                                                    ({{ size|filesizeformat }})
+                                                {% endif %}
+                                            {% endwith %}
                                         </a>
                                     </li>
                                 {% endif %}
@@ -90,6 +95,11 @@
                                 <li>
                                     <a href="{{ public_object.get_absolute_url_html }}" class="ico-after download blue">
                                         {% trans "HTML" %}
+                                        {% with size=public_object.get_size_html %}
+                                            {% if size %}
+                                                ({{ size|filesizeformat }})
+                                            {% endif %}
+                                        {% endwith %}
                                     </a>
                                 </li>
                             {% endif %}
@@ -97,6 +107,11 @@
                                 <li>
                                     <a href="{{ public_object.get_absolute_url_pdf }}" class="ico-after download blue">
                                         {% trans "PDF" %}
+                                        {% with size=public_object.get_size_pdf %}
+                                            {% if size %}
+                                                ({{ size|filesizeformat }})
+                                            {% endif %}
+                                        {% endwith %}
                                     </a>
                                 </li>
                             {% endif %}
@@ -104,6 +119,11 @@
                                 <li>
                                     <a href="{{ public_object.get_absolute_url_epub }}" class="ico-after download blue">
                                         {% trans "EPUB" %}
+                                        {% with size=public_object.get_size_epub %}
+                                            {% if size %}
+                                                ({{ size|filesizeformat }})
+                                            {% endif %}
+                                        {% endwith %}
                                     </a>
                                 </li>
                             {% endif %}
@@ -111,6 +131,11 @@
                                 <li>
                                     <a href="{{ public_object.get_absolute_url_zip }}" class="ico-after download blue">
                                         {% trans "Archive" %}
+                                        {% with size=public_object.get_size_zip %}
+                                            {% if size %}
+                                                ({{ size|filesizeformat }})
+                                            {% endif %}
+                                        {% endwith %}
                                     </a>
                                 </li>
                             {% endif %}

--- a/zds/tutorialv2/migrations/0010_publishedcontent_sizes.py
+++ b/zds/tutorialv2/migrations/0010_publishedcontent_sizes.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tutorialv2', '0009_publishedcontent_authors'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='publishedcontent',
+            name='sizes',
+            field=models.CharField(default=b'{}', max_length=512, verbose_name=b'Tailles des fichiers t\xc3\xa9l\xc3\xa9chargeables'),
+            preserve_default=True,
+        ),
+    ]

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -35,6 +35,9 @@ from zds.tutorialv2.models.models_versioned import NotAPublicVersion
 from zds.tutorialv2.managers import PublishedContentManager
 
 
+ALLOWED_TYPES = ['pdf', 'md', 'html', 'epub', 'zip']
+
+
 class PublishableContent(models.Model):
     """A tutorial whatever its size or an article.
 
@@ -199,6 +202,7 @@ class PublishableContent(models.Model):
 
     def in_beta(self):
         """A tutorial is not in beta if sha_beta is ``None`` or empty
+
 
         :return: ``True`` if the tutorial is in beta, ``False`` otherwise
         :rtype: bool
@@ -550,6 +554,9 @@ class PublishedContent(models.Model):
     objects = PublishedContentManager()
     versioned_model = None
 
+    # sizes contain a python dict (as a string in database) with all information about file sizes
+    sizes = models.CharField('Tailles des fichiers téléchargeables', max_length=512, default='{}')
+
     def __unicode__(self):
         return _('Version publique de "{}"').format(self.content.title)
 
@@ -628,9 +635,7 @@ class PublishedContent(models.Model):
         :rtype: bool
         """
 
-        allowed_types = ['pdf', 'md', 'html', 'epub', 'zip']
-
-        if type_ in allowed_types:
+        if type_ in ALLOWED_TYPES:
             return os.path.isfile(
                 os.path.join(self.get_extra_contents_directory(), self.content_public_slug + '.' + type_))
 
@@ -669,12 +674,74 @@ class PublishedContent(models.Model):
         return self.have_type('epub')
 
     def have_zip(self):
-        """Check if the standard epub version of the content is available
+        """Check if the standard zip version of the content is available
 
         :return: ``True`` if available, ``False`` otherwise
         :rtype: bool
         """
         return self.have_type('zip')
+
+    def get_size_file_type(self, type_):
+        """
+        Get the size of a given extra content.
+        Is the size is not in database we get it and store it for next time.
+
+        :return: size of file
+        :rtype: int
+        """
+        if type_ in ALLOWED_TYPES:
+            sizes = eval(str(self.sizes))
+            try:
+                size = sizes[type_]
+            except KeyError:
+                # if size is not in database we store it
+                sizes[type_] = os.path.getsize(os.path.join(
+                    self.get_extra_contents_directory(), self.content_public_slug + '.' + type_))
+                self.sizes = sizes
+                self.save()
+                size = sizes[type_]
+            return size
+        return None
+
+    def get_size_md(self):
+        """Get the size of md
+
+        :return: size of file
+        :rtype: int
+        """
+        return self.get_size_file_type('md')
+
+    def get_size_html(self):
+        """Get the size of html
+
+        :return: size of file
+        :rtype: int
+        """
+        return self.get_size_file_type('html')
+
+    def get_size_pdf(self):
+        """Get the size of pdf
+
+        :return: size of file
+        :rtype: int
+        """
+        return self.get_size_file_type('pdf')
+
+    def get_size_epub(self):
+        """Get the size of epub
+
+        :return: size of file
+        :rtype: int
+        """
+        return self.get_size_file_type('epub')
+
+    def get_size_zip(self):
+        """Get the size of zip
+
+        :return: size of file
+        :rtype: int
+        """
+        return self.get_size_file_type('zip')
 
     def get_absolute_url_to_extra_content(self, type_):
         """Get the url that point to the extra content the user may want to download
@@ -685,9 +752,7 @@ class PublishedContent(models.Model):
         :rtype: str
         """
 
-        allowed_types = ['pdf', 'md', 'html', 'epub', 'zip']
-
-        if type_ in allowed_types:
+        if type_ in ALLOWED_TYPES:
             reversed_ = self.content_type.lower()
 
             return reverse(

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -19,7 +19,7 @@ from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactor
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory, \
     SubCategoryFactory, PublishedContentFactory, tricky_text_content, BetaContentFactory
 from zds.tutorialv2.models.models_database import PublishableContent, Validation, PublishedContent, ContentReaction, \
-    ContentRead
+    ContentRead, ALLOWED_TYPES
 from zds.tutorialv2.utils import publish_content
 from zds.gallery.factories import UserGalleryFactory
 from zds.gallery.models import Image
@@ -5136,6 +5136,18 @@ class PublishedContentTests(TestCase):
         self.assertIn(self.user_author.username, response.content)
         self.assertNotIn(other_author.user.username, response.content)
         self.assertEqual(0, len(other_author.get_public_contents()))
+
+    def test_download_size(self):
+        """
+        Test the size of content to download.
+        """
+        sizes = self.published.sizes
+        for type_ in ALLOWED_TYPES:
+            if self.published.have_type(type_):
+                self.assertEqual(sizes[type_],
+                                 os.path.getsize(os.path.join(
+                                     self.published.get_extra_contents_directory(),
+                                     self.published.content_public_slug + '.' + type_)))
 
     def tearDown(self):
 

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -681,6 +681,15 @@ def publish_content(db_object, versioned, is_major_update=True):
     except IOError:
         pass
 
+    # store files sizes
+    from zds.tutorialv2.models.models_database import ALLOWED_TYPES
+    sizes = {}
+    for t in ALLOWED_TYPES:
+        if public_version.have_type(t):
+            sizes[t] = public_version.get_size_file_type(t)
+    public_version.sizes = sizes
+    public_version.save()
+
     return public_version
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #872 |

Alors j'ai essayé de faire quelque chose d'adaptatif. La taille des fichiers se mettra automatiquement à jour sur le site donc aucune commande à lancer lors de la MEP.
### QA
- Regarder si le code n'est pas trop vilain
- Penser à faire la migration (`python manage.py migrate`)
- Aller sur des pages d'articles ou de tuto et regarder que la taille apparait bien pour différents types de fichiers et qu'elle est correcte.
