### PR TITLE
[WIP] Fix #3226 : empeche l'acces /login/ et /logout/

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -328,7 +328,9 @@ FORCE_HTTPS_FOR_MEMBERS = False
 ENABLE_HTTPS_DECORATOR = False
 
 
-LOGIN_URL = '/membres/connexion'
+LOGIN_URL = '/membres/connexion/'
+LOGOUT_URL = '/membres/deconnexion/'
+
 
 ABSOLUTE_URL_OVERRIDES = {
     'auth.user': lambda u: '/membres/voir/{0}/'.format(urlquote(u.username.encode('utf-8')))

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -4,6 +4,7 @@ from django.conf.urls import patterns, include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.sitemaps import GenericSitemap, Sitemap
+from django.views.generic import RedirectView
 
 from zds.tutorialv2.models.models_database import PublishedContent
 from zds.forum.models import Category, Forum, Topic, Tag
@@ -70,6 +71,10 @@ admin.autodiscover()
 
 
 urlpatterns = patterns('',
+                       # redirect default django /login/ and /logout/ URLs
+                       url(r'^login/$', RedirectView.as_view(url=settings.LOGIN_URL)),
+                       url(r'^logout/$', RedirectView.as_view(url=settings.LOGOUT_URL)),
+
                        url(r'^oldtutoriels/', include('zds.tutorial.urls')),
                        url(r'^oldarticles/', include('zds.article.urls')),
                        url(r'^', include('zds.tutorialv2.urls')),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3226 |
# WIP - Besoin de savoir pourquoi on inclut les URL de Django
### QA
- Vérifier que `/login/` redirige bien vers la page de connexion au lieu de créer un erreur 500.
