### PR TITLE
enlève l'erreur 500 lorsque pas d'archive

### DIFF
--- a/zds/gallery/forms.py
+++ b/zds/gallery/forms.py
@@ -202,7 +202,10 @@ class ArchiveImageForm(forms.Form):
     def clean(self):
         cleaned_data = super(ArchiveImageForm, self).clean()
 
-        zip_file = cleaned_data.get('file')
+        zip_file = cleaned_data.get('file', None)
+        if not zip_file:
+            self.add_error("file", _(u"Le fichier n'a pas été joint."))
+            return cleaned_data
         extension = zip_file.name.split('.')[-1]
 
         if extension != "zip":

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -721,6 +721,26 @@ class NewImageViewTest(TestCase):
         self.assertEqual(302, response.status_code)
         self.assertEqual(Image.objects.filter(gallery=self.gallery).count(), 1)
 
+    def test_import_images_in_gallery_no_archive(self):
+        login_check = self.client.login(username=self.profile1.user.username, password='hostel77')
+        self.assertTrue(login_check)
+
+        with open(os.path.join(settings.BASE_DIR, 'fixtures', 'archive-gallery.zip'), 'r'):
+            response = self.client.post(
+                reverse(
+                    'gallery-image-import',
+                    args=[self.gallery.pk]
+                ),
+                {
+                    # normally we have
+                    # 'file': fp
+                    # but here we want to act as if we forgot it
+                },
+                follow=False
+            )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(Image.objects.filter(gallery=self.gallery).count(), 0)
+
     def test_denies_import_images_in_gallery(self):
         login_check = self.client.login(username=self.profile2.user.username, password='hostel77')
         self.assertTrue(login_check)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [#3244] |
## Pour la QA :

créez une galerie, essayez de valider le formulaire d'import d'archive en bypassant le JS qui demande de mettre une archive
vérifiez qu'on a une page normale avec simplement un avertissement disant que le fichier n'a pas été joint
