### PR TITLE
ajoute une indication d'accessibilité sur le champ de recherche

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -497,7 +497,7 @@
                     </div>
                     <div class="search header-right" id="search">
                         <form action="{% url "haystack_search" %}">
-                            <input type="text" name="q" placeholder="{% trans "Rechercher" %}">
+                            <input type="text" name="q" placeholder="{% trans "Rechercher" %}" title="{% trans "Contenu de la recherche" %}">
                             <button type="submit" class="ico-after search-submit" title="{% trans "Lancer la recherche" %}">{% trans "OK" %}</button>
                         </form>
                         <a href="{% url "haystack_search" %}" title="{% trans "Recherche avancée" %}" class="search-more"></a>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [non] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [aucun] |

Il s'agit ici d'implémenter un conseil donné par Dareboost quant à l'accessibilité du champ de recherche :

> Expliquez le but de chaque champ de formulaire
> 
> Préciser l'objectif de chaque champ facilitera l'expérience utilisateur sur votre site.
> 
> Un formulaire est composé de plusieurs champs qui doivent être les plus explicites possibles pour que l'utilisateur comprenne rapidement leur fonction.
> 2 solutions : l'attribut title / le label
> 
> Pour indiquer l'objectif d'un champ, deux alternatives sont possibles :
> 
> ```
> utiliser un attribut title :
> 
> `<input title="Renseignez votre nom" type="text" name="nom">`
> 
> utiliser un label :
> ```
> 
> ``` html
>     <label for="nom">Renseignez votre nom :</label>
>     <input id="nom" type="text" name="nom">
> ```
> 
> En savoir plus sur l'association de texte à un champ de formulaire.
> 
> Cette page contient 1 champ sans explication sur son objectif :
> 
> ```
> `<input type="text" name="q" placeholder="Rechercher">`
> ```
