### PR TITLE
Désactive et postpose la génération des PDFs

### DIFF
--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -439,7 +439,7 @@
                             </li>
                             <li>
                                 <a href="#valid-publish" class="open-modal ico-after tick green">{% trans "Valider et publier" %}</a>
-                                <div class="modal modal-big" id="valid-publish">
+                                <div class="modal modal-big" id="valid-publish" style="height: 400px; margin-top: -200px;">
                                     {% crispy formValid %}
                                 </div>
                             </li>

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -130,6 +130,14 @@
                         {% crispy formRevokeValidation %}
                     </div>
                 </li>
+                <li>
+                    <a href="#buildpdf" class="ico-after open-modal gear blue">
+                        {% trans "Générer le PDF" %}
+                    </a>
+                    <div class="modal modal-small" id="buildpdf">
+                        {% crispy formBuildPdf %}
+                    </div>
+                </li>
                 {% endif %}
             </ul>
         </div>

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -601,7 +601,7 @@ class AcceptValidationForm(forms.Form):
         widget=forms.Textarea(
             attrs={
                 'placeholder': _(u'Commentaire de publication.'),
-                'rows': '2'
+                'rows': '3'
             }
         )
     )
@@ -610,6 +610,13 @@ class AcceptValidationForm(forms.Form):
         label=_(u'Version majeure ?'),
         required=False,
         initial=True
+    )
+
+    build_pdf = forms.BooleanField(
+        label=_(u'Générer le PDF'),
+        required=False,
+        initial=settings.ZDS_APP['content']['build_pdf_when_published'],
+        widget=forms.CheckboxInput()
     )
 
     source = forms.CharField(
@@ -642,6 +649,10 @@ class AcceptValidationForm(forms.Form):
 
         super(AcceptValidationForm, self).__init__(*args, **kwargs)
 
+        # disable pdf generation if not allowed
+        if not settings.ZDS_APP['content']['build_pdf_when_published']:
+            self.fields['build_pdf'].widget.attrs['disabled'] = True
+
         # if content is already published, it's probably a minor change, so do not check `is_major`
         self.fields['is_major'].initial = not validation.content.sha_public
 
@@ -653,6 +664,7 @@ class AcceptValidationForm(forms.Form):
             CommonLayoutModalText(),
             Field('source'),
             Field('is_major'),
+            Field('build_pdf'),
             StrictButton(_(u'Publier'), type='submit')
         )
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1002,3 +1002,27 @@ class WarnTypoForm(forms.Form):
                 del cleaned_data['text']
 
         return cleaned_data
+
+
+class BuildPdfForm(forms.Form):
+
+    version = forms.CharField(widget=forms.HiddenInput())
+
+    def __init__(self, content, *args, **kwargs):
+        super(BuildPdfForm, self).__init__(*args, **kwargs)
+
+        # modal form, send back to previous page:
+        self.previous_page_url = content.get_absolute_url_online()
+
+        self.helper = FormHelper()
+        self.helper.form_action = reverse('validation:rebuild-pdf', kwargs={'pk': content.pk, 'slug': content.slug})
+        self.helper.form_method = 'post'
+
+        self.helper.layout = Layout(
+            Field('version'),
+            HTML(_(u'<p><bold>Attention :</bold> cette action est très gourmande en ressources. '
+                   u'Usez en avec parcimonie.</p>')),
+            StrictButton(
+                _(u'Générer le PDF'),
+                type='submit')
+        )

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1015,7 +1015,7 @@ class BuildPdfForm(forms.Form):
         self.previous_page_url = content.get_absolute_url_online()
 
         self.helper = FormHelper()
-        self.helper.form_action = reverse('validation:rebuild-pdf', kwargs={'pk': content.pk, 'slug': content.slug})
+        self.helper.form_action = reverse('validation:build-pdf', kwargs={'pk': content.pk, 'slug': content.slug})
         self.helper.form_method = 'post'
 
         self.helper.layout = Layout(

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -5150,6 +5150,215 @@ class PublishedContentTests(TestCase):
                                      self.published.get_extra_contents_directory(),
                                      self.published.content_public_slug + '.' + type_)))
 
+    def test_choose_pdf_generation(self):
+        """Ensure that we are allowed to delay pdf generation"""
+
+        published = PublishedContent.objects.get(pk=self.published.pk)
+        self.assertFalse(published.have_pdf())
+
+        settings.ZDS_APP['content']['build_pdf_when_published'] = True
+
+        # 1. No pdf generation
+        # connect with author:
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        # update
+        tuto = PublishableContent.objects.get(pk=self.tuto.pk)
+        random = u'All I waaaaant for christmaaaass iiiiiiiis ... Yooooooou !'
+
+        result = self.client.post(
+            reverse('content:edit', args=[tuto.pk, tuto.slug]),
+            {
+                'title': self.tuto.title,
+                'description': random,
+                'introduction': random,
+                'conclusion': random,
+                'type': u'TUTORIAL',
+                'licence': self.tuto.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': tuto.load_version().compute_hash(),
+                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR))
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        tuto = PublishableContent.objects.get(pk=self.tuto.pk)
+
+        # ask validation
+        text_validation = u'Valide, ou je te tue.'
+        text_publication = u'Ah, oui, quand même ...'
+        self.assertEqual(Validation.objects.count(), 0)
+
+        result = self.client.post(
+            reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
+            {
+                'text': text_validation,
+                'source': '',
+                'version': tuto.sha_draft
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # login with staff and publish
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        validation = Validation.objects.filter(content__pk=tuto.pk).last()
+
+        result = self.client.post(
+            reverse('validation:reserve', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # accept
+        result = self.client.post(
+            reverse('validation:accept', kwargs={'pk': validation.pk}),
+            {
+                'text': text_publication,
+                'is_major': False,  # minor modification (just the title)
+                'source': u'',
+                'build_pdf': False
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        published = PublishedContent.objects.get(pk=self.published.pk)
+        self.assertFalse(published.have_pdf())
+
+        # 2. PDF generation
+        # connect with author:
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        # update
+        random = u'So, now, we will now change this text'
+
+        result = self.client.post(
+            reverse('content:edit', args=[tuto.pk, tuto.slug]),
+            {
+                'title': self.tuto.title,
+                'description': random,
+                'introduction': random,
+                'conclusion': random,
+                'type': u'TUTORIAL',
+                'licence': self.tuto.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': tuto.load_version().compute_hash(),
+                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR))
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        tuto = PublishableContent.objects.get(pk=self.tuto.pk)
+
+        # ask validation
+        result = self.client.post(
+            reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
+            {
+                'text': text_validation,
+                'source': '',
+                'version': tuto.sha_draft
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # login with staff and publish
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        validation = Validation.objects.filter(content__pk=tuto.pk).last()
+
+        result = self.client.post(
+            reverse('validation:reserve', kwargs={'pk': validation.pk}),
+            {
+                'version': validation.version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # accept
+        result = self.client.post(
+            reverse('validation:accept', kwargs={'pk': validation.pk}),
+            {
+                'text': text_publication,
+                'is_major': False,  # minor modification (just the title)
+                'source': u'',
+                'build_pdf': True
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        published = PublishedContent.objects.get(pk=self.published.pk)
+        self.assertTrue(published.have_pdf())
+
+    def test_generate_pdf_when_published(self):
+
+        self.assertFalse(self.published.have_pdf())
+
+        settings.ZDS_APP['content']['build_pdf_when_published'] = True
+
+        self.client.logout()
+
+        # cannot do that if not connected
+        result = self.client.post(
+            reverse('validation:build-pdf', kwargs={'pk': self.tuto.pk, 'slug': self.tuto.slug}),
+            {
+                'version': self.published.sha_public
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)  # redirect to login
+        self.assertFalse(self.published.have_pdf())
+
+        # cannot do that if author
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('validation:build-pdf', kwargs={'pk': self.tuto.pk, 'slug': self.tuto.slug}),
+            {
+                'version': self.published.sha_public
+            },
+            follow=True)
+        self.assertEqual(result.status_code, 403)
+        self.assertFalse(self.published.have_pdf())
+
+        self.client.logout()
+
+        # login with staff and generate PDF
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('validation:build-pdf', kwargs={'pk': self.tuto.pk, 'slug': self.tuto.slug}),
+            {
+                'version': self.published.sha_public
+            },
+            follow=True)
+        self.assertEqual(result.status_code, 200)
+        self.assertTrue(self.published.have_pdf())
+
     def tearDown(self):
 
         if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -3245,7 +3245,8 @@ class ContentTests(TestCase):
             {
                 'text': u'Je valide !',
                 'is_major': True,
-                'source': u''
+                'source': u'',
+                'build_pdf': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)

--- a/zds/tutorialv2/urls/urls_validations.py
+++ b/zds/tutorialv2/urls/urls_validations.py
@@ -24,6 +24,6 @@ urlpatterns = patterns('',
                        url(r'^depublier/(?P<pk>\d+)/(?P<slug>.+)/$', RevokeValidation.as_view(),
                            name="revoke"),
                        url(r'^generer-pdf/(?P<pk>\d+)/(?P<slug>.+)/$', BuildPdf.as_view(),
-                           name="rebuild-pdf"),
+                           name="build-pdf"),
 
                        url(r'^$', ValidationListView.as_view(), name="list"))

--- a/zds/tutorialv2/urls/urls_validations.py
+++ b/zds/tutorialv2/urls/urls_validations.py
@@ -4,7 +4,7 @@ from django.conf.urls import patterns, url
 
 from zds.tutorialv2.views.views_validations import AskValidationForContent, ReserveValidation, \
     HistoryOfValidationDisplay, AcceptValidation, RejectValidation, RevokeValidation, CancelValidation, \
-    ValidationListView
+    ValidationListView, BuildPdf
 
 urlpatterns = patterns('',
                        url(r'^proposer/(?P<pk>\d+)/(?P<slug>.+)/$', AskValidationForContent.as_view(),
@@ -23,5 +23,7 @@ urlpatterns = patterns('',
 
                        url(r'^depublier/(?P<pk>\d+)/(?P<slug>.+)/$', RevokeValidation.as_view(),
                            name="revoke"),
+                       url(r'^generer-pdf/(?P<pk>\d+)/(?P<slug>.+)/$', BuildPdf.as_view(),
+                           name="rebuild-pdf"),
 
                        url(r'^$', ValidationListView.as_view(), name="list"))

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -544,7 +544,7 @@ def publish_container(db_object, base_dir, container):
             publish_container(db_object, base_dir, child)
 
 
-def publish_content(db_object, versioned, is_major_update=True):
+def publish_content(db_object, versioned, is_major_update=True, build_pdf=True):
     """Publish a given content.
 
     Note: create a manifest.json without the introduction and conclusion if not needed. Also remove the "text" field
@@ -556,6 +556,9 @@ def publish_content(db_object, versioned, is_major_update=True):
     :type versioned: VersionedContent
     :param is_major_update: if set to `True`, will update the publication date
     :type is_major_update: bool
+    :param build_pdf: If the publication generate the PDF. Note that this parameter have a lower priority than
+    ``settings.ZDS_APP['content']['build_pdf_when_published']``.
+    :type generate_pdf: bool
     :raise FailureDuringPublication: if something goes wrong
     :return: the published representation
     :rtype: zds.tutorialv2.models.models_database.PublishedContent
@@ -622,7 +625,7 @@ def publish_content(db_object, versioned, is_major_update=True):
         cwd=extra_contents_path)
 
     # 4. PDF
-    if ZDS_APP['content']['build_pdf_when_published']:
+    if ZDS_APP['content']['build_pdf_when_published'] and build_pdf:
         subprocess.call(
             settings.PANDOC_LOC + "pandoc " + settings.PANDOC_PDF_PARAM + " " + md_file_path + " -o " +
             base_name + ".pdf" + pandoc_debug_str,

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -16,7 +16,7 @@ from django.views.generic import RedirectView, FormView
 import os
 from zds.member.decorator import LoggedWithReadWriteHability, LoginRequiredMixin, PermissionRequiredMixin
 from zds.member.views import get_client_ip
-from zds.tutorialv2.forms import RevokeValidationForm, WarnTypoForm, NoteForm, NoteEditForm
+from zds.tutorialv2.forms import RevokeValidationForm, WarnTypoForm, NoteForm, NoteEditForm, BuildPdfForm
 from zds.tutorialv2.mixins import SingleOnlineContentDetailViewMixin, SingleOnlineContentViewMixin, DownloadViewMixin, \
     ContentTypeMixin, SingleOnlineContentFormViewMixin, MustRedirect
 from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent, ContentReaction
@@ -59,6 +59,8 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
 
         if context['is_staff']:
             context['formRevokeValidation'] = RevokeValidationForm(
+                self.versioned_object, initial={'version': self.versioned_object.sha_public})
+            context['formBuildPdf'] = BuildPdfForm(
                 self.versioned_object, initial={'version': self.versioned_object.sha_public})
 
         context['formWarnTypo'] = WarnTypoForm(self.versioned_object, self.versioned_object)

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -13,10 +13,10 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.generic import ListView, FormView
 from zds.member.decorator import LoginRequiredMixin, PermissionRequiredMixin, LoggedWithReadWriteHability
 from zds.tutorialv2.forms import AskValidationForm, RejectValidationForm, AcceptValidationForm, RevokeValidationForm, \
-    CancelValidationForm
+    CancelValidationForm, BuildPdfForm
 from zds.tutorialv2.mixins import SingleContentFormViewMixin, SingleContentDetailViewMixin, ModalFormView
 from zds.tutorialv2.models.models_database import Validation, PublishableContent, ContentRead
-from zds.tutorialv2.utils import publish_content, FailureDuringPublication, unpublish_content
+from zds.tutorialv2.utils import publish_content, FailureDuringPublication, unpublish_content, build_pdf_of_published
 from zds.utils.models import SubCategory
 from zds.utils.mps import send_mp
 
@@ -509,3 +509,33 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleConten
         self.success_url = self.versioned_object.get_absolute_url() + "?version=" + validation.version
 
         return super(RevokeValidation, self).form_valid(form)
+
+
+class BuildPdf(LoginRequiredMixin, PermissionRequiredMixin, SingleContentFormViewMixin):
+    """Rebuild the PDF.
+    """
+
+    permissions = ["tutorialv2.change_validation"]
+    form_class = BuildPdfForm
+    is_public = True
+
+    modal_form = True
+
+    def get_form_kwargs(self):
+        kwargs = super(BuildPdf, self).get_form_kwargs()
+        kwargs['content'] = self.versioned_object
+        return kwargs
+
+    def form_valid(self, form):
+
+        public = self.public_content_object
+
+        build_pdf_of_published(public)
+
+        if public.have_type('pdf'):
+            messages.success(self.request, _(u'Le PDF a bien été généré.'))
+        else:
+            messages.error(self.request, _(u'Le PDF n\'a pas été généré, pandoc a terminé sur une erreur.'))
+
+        self.success_url = public.get_absolute_url_online()
+        return super(BuildPdf, self).form_valid(form)

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -372,8 +372,14 @@ class AcceptValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
         versioned = db_object.load_version(sha=validation.version)
         self.success_url = versioned.get_absolute_url(version=validation.version)
 
+        # does we need pdf ?
+        build_pdf = settings.ZDS_APP['content']['build_pdf_when_published']
+        if 'build_pdf' in form.cleaned_data:
+            build_pdf = form.cleaned_data['build_pdf']
+
         try:
-            published = publish_content(db_object, versioned, is_major_update=form.cleaned_data['is_major'])
+            published = publish_content(
+                db_object, versioned, is_major_update=form.cleaned_data['is_major'], build_pdf=build_pdf)
         except FailureDuringPublication as e:
             messages.error(self.request, e.message)
         else:


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~ non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #3080 |
- Donne la possibilité de ne pas générer les PDFs dans la modale de validation ;
- Ajoute un bouton pour générer le PDF à postériori (ou pas) ;
# Notes de QA
- Mettre un contenu (simple, il faut que la génération de PDF sois faisable avec pandoc)  en validation et le valider **sans** activer la génération de PDF (décocher la case correspondante). Vérifier que le PDF n'est pas généré ni dans la liste des contenus à télécharger, ni dans le dossier correspondant (à trouver dans `/contents-public/xxx/extra_contents/` ou `xxx` est le slug).
- Aller sur la version publié du contenu et générer le PDF à l'aide du bouton correspondant. Vérifier que tout à fonctionné.
- Mettre en validation un second contenu et vérifier qu'on peut générer directement le PDF à la validation si la case est cochée.
