### PR TITLE
Rend la génération des extra_contents asynchrone (non bloquant)

### DIFF
--- a/doc/source/back-end-code/tutorialv2.rst
+++ b/doc/source/back-end-code/tutorialv2.rst
@@ -62,3 +62,8 @@ Les utilitaires (``utils.py``)
 .. automodule:: zds.tutorialv2.utils
     :members:
 
+Les utilitaires de publication (``publication_utils.py``)
+=========================================================
+
+.. automodule:: zds.tutorialv2.publication_utils.py
+    :members:

--- a/doc/source/back-end/contents.rst
+++ b/doc/source/back-end/contents.rst
@@ -596,7 +596,7 @@ Ces paramètres sont à surcharger dans le dictionnaire ZDS_APP['content']
 - ``notes_per_page``: Nombre de réaction nouvelles par page (donc sans compter la répétition de la dernière note de la page précédente)
 - ``helps_per_page`` : Nombre de contenus ayant besoin d'aide dans la page ZEP03
 - ``feed_length``: Nombre de contenus affiché dans un flux RSS ou ATOM,
-- ``user_page_number``: 5,
+- ``user_page_number``:  Nombre de contenu de chaque type qu'on affiche sur le profil d'un utilisateur par défaut 5,
 - ``default_image``: chemin vers l'image utilisée par défaut dans les icônes de contenu,
 - ``import_image_prefix``: préfixe mnémonique permettant d'indiquer que l'image se trouve dans l'archive jointe lors de l'import de contenu
 - ``build_pdf_when_published``: indique que la publication génèrera un PDF (quelque soit la politique, si ``False`` les PDF ne seront pas générés, sauf à appeler la commande adéquate,

--- a/doc/source/back-end/contents.rst
+++ b/doc/source/back-end/contents.rst
@@ -239,6 +239,8 @@ peuvent donc continuer à travailler chacun de leur côté.
 La publication
 --------------
 
+**Le cas général**
+
 Une fois que le contenu est passé en validation et a satisfait les critères 
 éditoriaux, il est publié. Il faut bien préciser que le processus de 
 validation peut être assez long. De plus, un historique de validation est 
@@ -263,6 +265,29 @@ qui devraient être réglés plus tard avec la
 Enfin, signalons qu'il est possible à tout moment pour un membre de l'équipe 
 de dépublier un contenu. Le cas échéant, un message sera envoyé aux auteurs, 
 indiquant les raisons de la dépublication.
+
+**Les politiques de génération**
+
+La manière dont l'application réagira à une publication dans le but de générer -- ou non -- des documents téléchargeables
+est configurable selon trois niveaux à affecter au paramètre ``ZDS_APP['content']['extra_content_generation_policy']``:
+
+- NOTHING : ne génère aucun document téléchargeable autre que le fichier markdown et l'archive zip des sources
+- SYNC : génère tous les documents téléchargeables que le système peut générer de manière synchrone à la publication. C'est à dire que la génération est élevée au rang de tâche bloquante
+- WATCHDOG : seul un "marqueur de publication" est généré lors de la publication, c'est un observateur externe qui viendra publier le nouveau contenu. Le site fourni un observateur externe : ``python mangage.py publication_watchdog``.
+
+.. attention::
+
+    Le mode ``WATCHDOG`` est soumis à l'utilisation d'un autre paramètre : ``ZDS_APP['content']['extra_content_watchdog_dir']`` qui, par défaut, créera un dossier watchdog-build à la racine de l'application
+
+
+**Ajouter un nouveau format d'export**
+
+Les fichiers téléchargeables générés le sont à partir d'un registre de créateur.
+Par défaut le registre contient les 3 formats pandoc HTML, PDF et EPUB.
+
+Vous pouvez définir votre propre formatteur qui devra alors hériter de la classe ``zds.tutorialv2.publication_utils.Publicator`` et implémenter la méthode ``publish``.
+Si vous désirez vous passer de pandoc, il vous suffira d'appeler ``map(PublicatorRegistry.unregister, ["pdf", "epub", "html"])``.
+Vous pouvez aussi simplement surcharger chacun des ``Publicator`` par défaut en en enregistrant un nouveau sous le même nom.
 
 L'entraide
 ----------
@@ -554,3 +579,25 @@ Migrer la base de données
 
 Si vous faites tourner une instance du code de Zeste de Savoir sous la version 1.X et que vous passez à la v2.X, vous allez
 devoir migrer les différents tutoriels. Pour cela, il faudra simplement exécuter la commande ``python manage.py migrate_to_zep12.py``.
+
+Récapitulatif des paramètres du module
+======================================
+
+Ces paramètres sont à surcharger dans le dictionnaire ZDS_APP['content']
+
+- ``repo_private_path`` : chemin vers le dossier qui contiend les contenus durant leur rédaction, par défaut le dossier sera contents-private à la racine de l'application
+- ``repo_public_path``: chemin vers le dossier qui contient les fichiers permettant l'affichage des contenus publiés ainsi que les fichiers téléchargeables, par défaut contents-public
+- ``extra_contents_dirname``: nom du sous-dosssier qui contient les fichiers téléchargeables (pdf, epub...), par défaut extra_contents
+- ``extra_content_generation_policy``: Contient la politique de génération des fichiers téléchargeable, 'SYNC', 'WATCHDOG' ou 'NOTHING'
+- ``extra_content_watchdog_dir``: dossier qui permet à l'observateur (si ``extra_content_generation_policy`` vaut ``"WATCHDOG"``) de savoir qu'un contenu a été publié
+- ``max_tree_depth``: Profondeur maximal de la hiérarchie des tutoriels : par défaut ``3`` pour partie/chapitre/extrait
+- ``default_licence_pk``: Clef primaire de la licence par défaut (TOUS DROITS RESERVES en français), 7 si vous utilisez les fixtures
+- ``content_per_page``: Nombre de contenus dans les listing (article, tutoriels)
+- ``notes_per_page``: Nombre de réaction nouvelles par page (donc sans compter la répétition de la dernière note de la page précédente)
+- ``helps_per_page`` : Nombre de contenus ayant besoin d'aide dans la page ZEP03
+- ``feed_length``: Nombre de contenus affiché dans un flux RSS ou ATOM,
+- ``user_page_number``: 5,
+- ``default_image``: chemin vers l'image utilisée par défaut dans les icônes de contenu,
+- ``import_image_prefix``: préfixe mnémonique permettant d'indiquer que l'image se trouve dans l'archive jointe lors de l'import de contenu
+- ``build_pdf_when_published``: indique que la publication génèrera un PDF (quelque soit la politique, si ``False`` les PDF ne seront pas générés, sauf à appeler la commande adéquate,
+- ``maximum_slug_size``: taille maximale du slug d'un contenu

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ autopep8==1.1.1
 sphinx==1.3.1
 sphinx_rtd_theme==0.1.8
 fake-factory==0.5.0
+mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ dry-rest-permissions==0.1.6
 
 # Zep 12 dependency
 django-uuslug==1.0.3
-watchdog<0.9.0 # use last non-bc-breaking version
+watchdog==0.8.3 # use last non-bc-breaking version

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ dry-rest-permissions==0.1.6
 
 # Zep 12 dependency
 django-uuslug==1.0.3
+watchdog<0.9.0 # use last non-bc-breaking version

--- a/update.md
+++ b/update.md
@@ -388,3 +388,12 @@ devient :
 ```
 ExecStart=/opt/zdsenv/bin/python /opt/zdsenv/ZesteDeSavoir/manage.py update_index --remove --age=1
 ```
+
+Changer la politique de génération des documents #3080
+------------------------------------------------------
+
+Mettre à jour le paramètre ZDS_APP["content"]["extra_content_generation_policy"] à "WATCHDOG"
+Lancer en parallèle du site le watchdog `python manage.py publication_watchdog &`.
+
+Il est possible de configurer le logging de ce module en surchargeant les logger `logging.getLogger("zds.pandoc-publicator")`, `logging.getLogger("zds.watchdog-publicator")`.
+

--- a/zds/search/tests/tests.py
+++ b/zds/search/tests/tests.py
@@ -13,7 +13,7 @@ from zds.search.utils import filter_keyword, filter_text, reindex_content
 from zds.settings import BASE_DIR
 from zds.tutorialv2.factories import LicenceFactory, SubCategoryFactory, PublishableContentFactory, ContainerFactory, \
     ExtractFactory
-from zds.tutorialv2.utils import publish_content
+from zds.tutorialv2.publication_utils import publish_content
 
 overrided_zds_app = settings.ZDS_APP
 overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -473,8 +473,10 @@ ZDS_APP = {
         'repo_private_path': os.path.join(BASE_DIR, 'contents-private'),
         'repo_public_path': os.path.join(BASE_DIR, 'contents-public'),
         'extra_contents_dirname': 'extra_contents',
-        'extra_content_generation_policy': "WATCHDOG",
-        'extra_content_watchdog_dir': 'public-contents/build',
+        # can also be 'extra_content_generation_policy': "WATCHDOG"
+        # or 'extra_content_generation_policy': "NOTHING"
+        'extra_content_generation_policy': "SYNC",
+        'extra_content_watchdog_dir': './build',
         'max_tree_depth': 3,
         'default_licence_pk': 7,
         'content_per_page': 50,

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -479,7 +479,7 @@ ZDS_APP = {
         # can also be 'extra_content_generation_policy': "WATCHDOG"
         # or 'extra_content_generation_policy': "NOTHING"
         'extra_content_generation_policy': "SYNC",
-        'extra_content_watchdog_dir': './build',
+        'extra_content_watchdog_dir': os.path.join(BASE_DIR, "watchdog-build"),
         'max_tree_depth': 3,
         'default_licence_pk': 7,
         'content_per_page': 50,

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -479,7 +479,7 @@ ZDS_APP = {
         # can also be 'extra_content_generation_policy': "WATCHDOG"
         # or 'extra_content_generation_policy': "NOTHING"
         'extra_content_generation_policy': "SYNC",
-        'extra_content_watchdog_dir': os.path.join(BASE_DIR, "watchdog-build"),
+        'extra_content_watchdog_dir': './build',
         'max_tree_depth': 3,
         'default_licence_pk': 7,
         'content_per_page': 50,

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -2,6 +2,8 @@
 
 import os
 import sys
+from os.path import dirname
+from os.path import join
 
 from django.contrib.messages import constants as message_constants
 from django.utils.http import urlquote
@@ -338,10 +340,11 @@ SERVE = False
 
 PANDOC_LOC = ''
 PANDOC_PDF_PARAM = ("--latex-engine=xelatex "
-                    "--template=../../../assets/tex/template.tex -s -S -N "
+                    "--template={} -s -S -N "
                     "--toc -V documentclass=scrbook -V lang=francais "
                     "-V mainfont=Merriweather -V monofont=\"Andale Mono\" "
-                    "-V fontsize=12pt -V geometry:margin=1in ")
+                    "-V fontsize=12pt -V geometry:margin=1in ".format(join(dirname(__file__), ".."
+                                                                           "assets", "tex", "template.tex")))
 # LOG PATH FOR PANDOC LOGGING
 PANDOC_LOG = './pandoc.log'
 PANDOC_LOG_STATE = False

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -473,6 +473,8 @@ ZDS_APP = {
         'repo_private_path': os.path.join(BASE_DIR, 'contents-private'),
         'repo_public_path': os.path.join(BASE_DIR, 'contents-public'),
         'extra_contents_dirname': 'extra_contents',
+        'extra_content_generation_policy': "WATCHDOG",
+        'extra_content_watchdog_dir': 'public-contents/build',
         'max_tree_depth': 3,
         'default_licence_pk': 7,
         'content_per_page': 50,

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -340,11 +340,10 @@ SERVE = False
 
 PANDOC_LOC = ''
 PANDOC_PDF_PARAM = ("--latex-engine=xelatex "
-                    "--template={} -s -S -N "
+                    "--template=../../../assets/tex/template.tex -s -S -N "
                     "--toc -V documentclass=scrbook -V lang=francais "
                     "-V mainfont=Merriweather -V monofont=\"Andale Mono\" "
-                    "-V fontsize=12pt -V geometry:margin=1in ".format(join(dirname(__file__), "..",
-                                                                           "assets", "tex", "template.tex")))
+                    "-V fontsize=12pt -V geometry:margin=1in ")
 # LOG PATH FOR PANDOC LOGGING
 PANDOC_LOG = './pandoc.log'
 PANDOC_LOG_STATE = False

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -343,7 +343,7 @@ PANDOC_PDF_PARAM = ("--latex-engine=xelatex "
                     "--template={} -s -S -N "
                     "--toc -V documentclass=scrbook -V lang=francais "
                     "-V mainfont=Merriweather -V monofont=\"Andale Mono\" "
-                    "-V fontsize=12pt -V geometry:margin=1in ".format("..", "..", "..",
+                    "-V fontsize=12pt -V geometry:margin=1in ".format(join("..", "..", "..",
                                                                            "assets", "tex", "template.tex")))
 # LOG PATH FOR PANDOC LOGGING
 PANDOC_LOG = './pandoc.log'

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -343,7 +343,7 @@ PANDOC_PDF_PARAM = ("--latex-engine=xelatex "
                     "--template={} -s -S -N "
                     "--toc -V documentclass=scrbook -V lang=francais "
                     "-V mainfont=Merriweather -V monofont=\"Andale Mono\" "
-                    "-V fontsize=12pt -V geometry:margin=1in ".format(join(dirname(__file__), ".."
+                    "-V fontsize=12pt -V geometry:margin=1in ".format(join(dirname(__file__), "..",
                                                                            "assets", "tex", "template.tex")))
 # LOG PATH FOR PANDOC LOGGING
 PANDOC_LOG = './pandoc.log'
@@ -478,8 +478,8 @@ ZDS_APP = {
         'extra_contents_dirname': 'extra_contents',
         # can also be 'extra_content_generation_policy': "WATCHDOG"
         # or 'extra_content_generation_policy': "NOTHING"
-        'extra_content_generation_policy': "SYNC",
-        'extra_content_watchdog_dir': './build',
+        'extra_content_generation_policy': "WATCHDOG",
+        'extra_content_watchdog_dir': os.path.join(BASE_DIR, "watchdog-build"),
         'max_tree_depth': 3,
         'default_licence_pk': 7,
         'content_per_page': 50,

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -340,10 +340,11 @@ SERVE = False
 
 PANDOC_LOC = ''
 PANDOC_PDF_PARAM = ("--latex-engine=xelatex "
-                    "--template=../../../assets/tex/template.tex -s -S -N "
+                    "--template={} -s -S -N "
                     "--toc -V documentclass=scrbook -V lang=francais "
                     "-V mainfont=Merriweather -V monofont=\"Andale Mono\" "
-                    "-V fontsize=12pt -V geometry:margin=1in ")
+                    "-V fontsize=12pt -V geometry:margin=1in ".format(join(dirname(__file__), ".."
+                                                                           "assets", "tex", "template.tex")))
 # LOG PATH FOR PANDOC LOGGING
 PANDOC_LOG = './pandoc.log'
 PANDOC_LOG_STATE = False

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -478,7 +478,7 @@ ZDS_APP = {
         'extra_contents_dirname': 'extra_contents',
         # can also be 'extra_content_generation_policy': "WATCHDOG"
         # or 'extra_content_generation_policy': "NOTHING"
-        'extra_content_generation_policy': "WATCHDOG",
+        'extra_content_generation_policy': "SYNC",
         'extra_content_watchdog_dir': os.path.join(BASE_DIR, "watchdog-build"),
         'max_tree_depth': 3,
         'default_licence_pk': 7,

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -343,7 +343,7 @@ PANDOC_PDF_PARAM = ("--latex-engine=xelatex "
                     "--template={} -s -S -N "
                     "--toc -V documentclass=scrbook -V lang=francais "
                     "-V mainfont=Merriweather -V monofont=\"Andale Mono\" "
-                    "-V fontsize=12pt -V geometry:margin=1in ".format(join(dirname(__file__), ".."
+                    "-V fontsize=12pt -V geometry:margin=1in ".format("..", "..", "..",
                                                                            "assets", "tex", "template.tex")))
 # LOG PATH FOR PANDOC LOGGING
 PANDOC_LOG = './pandoc.log'
@@ -479,7 +479,7 @@ ZDS_APP = {
         # can also be 'extra_content_generation_policy': "WATCHDOG"
         # or 'extra_content_generation_policy': "NOTHING"
         'extra_content_generation_policy': "SYNC",
-        'extra_content_watchdog_dir': os.path.join(BASE_DIR, "watchdog-build"),
+        'extra_content_watchdog_dir': './build',
         'max_tree_depth': 3,
         'default_licence_pk': 7,
         'content_per_page': 50,

--- a/zds/tutorialv2/factories.py
+++ b/zds/tutorialv2/factories.py
@@ -9,7 +9,8 @@ from zds.tutorialv2.models.models_database import PublishableContent, Validation
 from zds.tutorialv2.models.models_versioned import Container, Extract
 from zds.utils.models import SubCategory, Licence
 from zds.gallery.factories import GalleryFactory, UserGalleryFactory
-from zds.tutorialv2.utils import publish_content, init_new_repo
+from zds.tutorialv2.utils import init_new_repo
+from zds.tutorialv2.publication_utils import publish_content
 
 text_content = u'Ceci est un texte bidon, **avec markown**'
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -6,6 +6,8 @@ from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Layout, Submit, Field, ButtonHolder, Hidden
 from django.core.urlresolvers import reverse
+from django.utils.html import format_html
+
 
 from zds.utils.forms import CommonLayoutModalText, CommonLayoutEditor, CommonLayoutVersionEditor
 from zds.utils.models import SubCategory, Licence

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -6,11 +6,6 @@ from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Layout, Submit, Field, ButtonHolder, Hidden
 from django.core.urlresolvers import reverse
-from django.forms import Widget
-from django.forms.widgets import ChoiceInput, ChoiceFieldRenderer, CheckboxFieldRenderer, CheckboxChoiceInput
-from django.utils.html import format_html
-from django.utils.safestring import mark_safe
-from gitdb.utils.encoding import force_text
 
 from zds.utils.forms import CommonLayoutModalText, CommonLayoutEditor, CommonLayoutVersionEditor
 from zds.utils.models import SubCategory, Licence

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -6,8 +6,6 @@ from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Layout, Submit, Field, ButtonHolder, Hidden
 from django.core.urlresolvers import reverse
-from django.utils.html import format_html
-
 
 from zds.utils.forms import CommonLayoutModalText, CommonLayoutEditor, CommonLayoutVersionEditor
 from zds.utils.models import SubCategory, Licence

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -190,7 +190,7 @@ class ContentForm(ContainerForm):
         label=_(u"Pour m'aider, je cherche un..."),
         queryset=HelpWriting.objects.all(),
         required=False,
-        widget=forms.MultipleChoiceField()
+        widget=forms.SelectMultiple()
     )
 
     def __init__(self, *args, **kwargs):

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -195,7 +195,7 @@ class ContentForm(ContainerForm):
         label=_(u"Pour m'aider, je cherche un..."),
         queryset=HelpWriting.objects.all(),
         required=False,
-        widget=ImageTextCheckbox()
+        widget=forms.MultipleChoiceField()
     )
 
     def __init__(self, *args, **kwargs):
@@ -1009,50 +1009,3 @@ class WarnTypoForm(forms.Form):
                 del cleaned_data['text']
 
         return cleaned_data
-
-
-class ImageTextCheckbox(CheckboxChoiceInput):
-
-    def __init__(self, name, value, attrs, choice, index):
-        super(ImageTextCheckbox, self).__init__(self, name, value, attrs, choice, index)
-        self.choice_image = choice[2]
-
-    def render(self, name=None, value=None, attrs=None, choices=()):
-        if self.id_for_label:
-            label_for = format_html(' for="{0}"', self.id_for_label)
-        else:
-            label_for = ''
-        return format_html('<label{0}><img src="{3}" alt="{2}"/>{1} {2}</label>',
-                           label_for, self.tag(), self.choice_label, self.choice_image)
-
-
-class ImageTextCheckboxRenderer(ChoiceFieldRenderer):
-    choice_input_class = ImageTextCheckbox
-    def render(self):
-        """
-        Outputs a <ul> for this set of choice fields.
-        If an id was given to the field, it is applied to the <ul> (each
-        item in the list will get an id of `$id_$i`).
-        """
-        id_ = self.attrs.get('id', None)
-        start_tag = format_html('<ul id="{0}">', id_) if id_ else '<ul>'
-        output = [start_tag]
-        for i, choice in enumerate(self.choices):
-            choice_value, choice_label = choice
-            if isinstance(choice_label, (tuple, list)):
-                attrs_plus = self.attrs.copy()
-                if id_:
-                    attrs_plus['id'] += '_{0}'.format(i)
-                sub_ul_renderer = ChoiceFieldRenderer(name=self.name,
-                                                      value=self.value,
-                                                      attrs=attrs_plus,
-                                                      choices=choice_label)
-                sub_ul_renderer.choice_input_class = self.choice_input_class
-                output.append(format_html('<li>{0}{1}</li>', choice_value,
-                                          sub_ul_renderer.render()))
-            else:
-                w = self.choice_input_class(self.name, self.value,
-                                            self.attrs.copy(), choice, i)
-                output.append(format_html('<li>{0}</li>', force_text(w)))
-        output.append('</ul>')
-        return mark_safe('\n'.join(output))

--- a/zds/tutorialv2/management/commands/publication_watchdog.py
+++ b/zds/tutorialv2/management/commands/publication_watchdog.py
@@ -31,7 +31,6 @@ class TutorialIsPublished(FileSystemEventHandler):
                                      pandoc_debug_str, overload_settings=True)
             for listed in listdir(extra_contents_path, recursive=False):
                 try:
-                    print(listed)
                     shutil.copy(join(extra_contents_path, listed), extra_contents_path.replace("__building", ""))
                 except Exception:
                     pass

--- a/zds/tutorialv2/management/commands/publication_watchdog.py
+++ b/zds/tutorialv2/management/commands/publication_watchdog.py
@@ -23,7 +23,7 @@ class TutorialIsPublished(FileSystemEventHandler):
                 os.makedirs(extra_contents_path)
 
     @staticmethod
-    def __cleanup_build_and_watchdog(self, extra_contents_path, watchdog_file_path):
+    def __cleanup_build_and_watchdog(extra_contents_path, watchdog_file_path):
         for listed in listdir(extra_contents_path, recursive=False):
             try:
                 shutil.copy(join(extra_contents_path, listed), extra_contents_path.replace("__building", ""))

--- a/zds/tutorialv2/management/commands/publication_watchdog.py
+++ b/zds/tutorialv2/management/commands/publication_watchdog.py
@@ -1,0 +1,42 @@
+from os.path import dirname
+
+import time
+from django.core.management import BaseCommand
+from watchdog.observers import Observer
+from watchdog.events import FileCreatedEvent, FileSystemEventHandler
+from zds import settings
+from zds.tutorialv2.publication_utils import generate_exernal_content
+from codecs import open
+
+
+class TutorialIsPublished(FileSystemEventHandler):
+    def on_created(self, event):
+        pandoc_debug_str = ""
+        if settings.PANDOC_LOG_STATE:
+            pandoc_debug_str = " 2>&1 | tee -a " + settings.PANDOC_LOG
+        if isinstance(event, FileCreatedEvent):
+            with open(event.src_path, encoding="utf-8") as f:
+                infos = f.read().strip().split(";")
+            md_file_path = infos[0]
+            base_name = infos[1]
+            extra_contents_path = dirname(md_file_path)
+
+            generate_exernal_content(base_name, extra_contents_path, md_file_path,
+                                     pandoc_debug_str, overload_settings=True)
+
+
+class Command(BaseCommand):
+    help = 'Launch a watchdog that generate all exported formats (epub, pdf...) files without blocking request handling'
+
+    def handle(self, *args, **options):
+        path = settings.ZDS_APP['content']['extra_content_watchdog_dir']
+        event_handler = TutorialIsPublished()
+        observer = Observer()
+        observer.schedule(event_handler, path, recursive=True)
+        observer.start()
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            observer.stop()
+        observer.join()

--- a/zds/tutorialv2/management/commands/publication_watchdog.py
+++ b/zds/tutorialv2/management/commands/publication_watchdog.py
@@ -1,9 +1,12 @@
-from os.path import dirname
-
+from os.path import dirname, join
+import os
 import time
+
+import shutil
 from django.core.management import BaseCommand
+from pathtools.path import listdir
 from watchdog.observers import Observer
-from watchdog.events import FileCreatedEvent, FileSystemEventHandler
+from watchdog.events import FileCreatedEvent, FileSystemEventHandler, LoggingEventHandler
 from zds import settings
 from zds.tutorialv2.publication_utils import generate_exernal_content
 from codecs import open
@@ -11,18 +14,29 @@ from codecs import open
 
 class TutorialIsPublished(FileSystemEventHandler):
     def on_created(self, event):
+        super(TutorialIsPublished, self).on_created(event)
         pandoc_debug_str = ""
+
         if settings.PANDOC_LOG_STATE:
             pandoc_debug_str = " 2>&1 | tee -a " + settings.PANDOC_LOG
         if isinstance(event, FileCreatedEvent):
             with open(event.src_path, encoding="utf-8") as f:
                 infos = f.read().strip().split(";")
-            md_file_path = infos[0]
-            base_name = infos[1]
+            md_file_path = infos[1]
+            base_name = infos[0]
             extra_contents_path = dirname(md_file_path)
-
+            if not os.path.exists(extra_contents_path):
+                os.makedirs(extra_contents_path)
             generate_exernal_content(base_name, extra_contents_path, md_file_path,
                                      pandoc_debug_str, overload_settings=True)
+            for listed in listdir(extra_contents_path, recursive=False):
+                try:
+                    print(listed)
+                    shutil.copy(join(extra_contents_path, listed), extra_contents_path.replace("__building", ""))
+                except Exception:
+                    pass
+            shutil.rmtree(extra_contents_path)
+            os.remove(event.src_path)
 
 
 class Command(BaseCommand):
@@ -33,6 +47,7 @@ class Command(BaseCommand):
         event_handler = TutorialIsPublished()
         observer = Observer()
         observer.schedule(event_handler, path, recursive=True)
+        observer.schedule(LoggingEventHandler(), path)
         observer.start()
         try:
             while True:

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -1,19 +1,23 @@
+# coding: utf-8
 import codecs
 import copy
 import os
 import shutil
 import subprocess
+import zipfile
 from datetime import datetime
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
 from django.utils import translation
 from django.utils.translation import ugettext_lazy as _
 from os.path import isdir, join
 
 from zds import settings
+from zds.search.models import SearchIndexContent
 from zds.settings import ZDS_APP
-from zds.tutorialv2.utils import publish_container, retrieve_and_update_images_links, FailureDuringPublication, \
-    make_zip_file
+from zds.tutorialv2.utils import retrieve_and_update_images_links
+from zds.utils.templatetags.emarkdown import emarkdown
 
 
 def publish_content(db_object, versioned, is_major_update=True):
@@ -234,3 +238,152 @@ class WatchdogFilePublicator(Publicator):
 
         with codecs.open(join(self.watched_directory, base_name), "w", encoding='utf-8') as w_file:
             w_file.write(";".join([base_name, md_file_path]))
+
+
+class FailureDuringPublication(Exception):
+    """Exception raised if something goes wrong during publication process
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(FailureDuringPublication, self).__init__(*args, **kwargs)
+
+
+def publish_container(db_object, base_dir, container):
+    """ "Publish" a given container, in a recursive way
+
+    :param db_object: database representation of the content
+    :type db_object: PublishableContent
+    :param base_dir: directory of the top container
+    :type base_dir: str
+    :param container: a given container
+    :type container: Container
+    :raise FailureDuringPublication: if anything goes wrong
+    """
+
+    from zds.tutorialv2.models.models_versioned import Container
+
+    if not isinstance(container, Container):
+        raise FailureDuringPublication(_(u'Le conteneur n\'en est pas un !'))
+
+    template = 'tutorialv2/export/chapter.html'
+
+    # jsFiddle support
+    if db_object.js_support:
+        is_js = "js"
+    else:
+        is_js = ""
+
+    current_dir = os.path.dirname(os.path.join(base_dir, container.get_prod_path(relative=True)))
+
+    if not os.path.isdir(current_dir):
+        os.makedirs(current_dir)
+
+    if container.has_extracts():  # the container can be rendered in one template
+        parsed = render_to_string(template, {'container': container, 'is_js': is_js})
+        f = codecs.open(os.path.join(base_dir, container.get_prod_path(relative=True)), 'w', encoding='utf-8')
+
+        try:
+            f.write(parsed)
+        except (UnicodeError, UnicodeEncodeError):
+            raise FailureDuringPublication(
+                _(u'Une erreur est survenue durant la publication de « {} », vérifiez le code markdown')
+                .format(container.title))
+
+        f.close()
+
+        for extract in container.children:
+            extract.text = None
+
+        container.introduction = None
+        container.conclusion = None
+
+    else:  # separate render of introduction and conclusion
+
+        current_dir = os.path.join(base_dir, container.get_prod_path(relative=True))  # create subdirectory
+
+        if not os.path.isdir(current_dir):
+            os.makedirs(current_dir)
+
+        if container.introduction:
+            path = os.path.join(container.get_prod_path(relative=True), 'introduction.html')
+            f = codecs.open(os.path.join(base_dir, path), 'w', encoding='utf-8')
+
+            try:
+                f.write(emarkdown(container.get_introduction(), db_object.js_support))
+            except (UnicodeError, UnicodeEncodeError):
+                raise FailureDuringPublication(
+                    _(u'Une erreur est survenue durant la publication de l\'introduction de « {} »,'
+                      u' vérifiez le code markdown').format(container.title))
+
+            container.introduction = path
+
+        if container.conclusion:
+            path = os.path.join(container.get_prod_path(relative=True), 'conclusion.html')
+            f = codecs.open(os.path.join(base_dir, path), 'w', encoding='utf-8')
+
+            try:
+                f.write(emarkdown(container.get_conclusion(), db_object.js_support))
+            except (UnicodeError, UnicodeEncodeError):
+                raise FailureDuringPublication(
+                    _(u'Une erreur est survenue durant la publication de la conclusion de « {} »,'
+                      u' vérifiez le code markdown').format(container.title))
+
+            container.conclusion = path
+
+        for child in container.children:
+            publish_container(db_object, base_dir, child)
+
+
+def make_zip_file(published_content):
+    """Create the zip archive extra content from the published content
+
+    :param published_content: a PublishedContent object
+    :return:
+    """
+
+    publishable = published_content.content
+    publishable.sha_public = publishable.sha_draft  # ensure sha update so that archive is updated to
+    path = os.path.join(published_content.get_extra_contents_directory(),
+                        published_content.content_public_slug + ".zip")
+    zip_file = zipfile.ZipFile(path, 'w')
+    versioned = publishable.load_version(None, True)
+    from zds.tutorialv2.views.views_contents import DownloadContent
+    DownloadContent.insert_into_zip(zip_file, versioned.repository.commit(versioned.current_version).tree)
+    zip_file.close()
+
+
+def unpublish_content(db_object):
+    """Remove the given content from the public view
+
+    :param db_object: Database representation of the content
+    :type db_object: PublishableContent
+    :return: ``True`` if unpublished, ``False`` otherwise
+    :rtype: bool
+    """
+
+    from zds.tutorialv2.models.models_database import PublishedContent
+
+    try:
+        public_version = PublishedContent.objects.get(pk=db_object.public_version.pk)
+
+        # clean files
+        old_path = public_version.get_prod_path()
+
+        if os.path.exists(old_path):
+            shutil.rmtree(old_path)
+
+        # remove public_version:
+        public_version.delete()
+
+        db_object.public_version = None
+        db_object.save()
+
+        # We just delete all index that correspond to the content
+        SearchIndexContent.objects.filter(publishable_content=db_object).delete()
+
+        return True
+
+    except (ObjectDoesNotExist, IOError):
+        pass
+
+    return False

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -230,6 +230,7 @@ class Publicator:
 @PublicatorRegistery.register("epub", settings.PANDOC_LOC, "epub")
 @PublicatorRegistery.register("html", settings.PANDOC_LOC, "html")
 class PandocPublicator(Publicator):
+
     """
     Wrapper arround pandoc commands
     """

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -182,6 +182,14 @@ class PublicatorRegistery:
 
     @classmethod
     def get_all_registered(cls, exclude=None):
+        """
+
+        Args:
+            exclude: A list of excluded publicator
+
+        Returns:
+
+        """
         if exclude is None:
             exclude = []
         for key, value in cls.registry.items():

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -188,6 +188,19 @@ class PublicatorRegistery:
                 yield key, value
 
     @classmethod
+    def unregister(cls, name):
+        """
+        Remove Publicator registered at name if exists, run silently otherwise
+        Args:
+            name:
+
+        Returns:
+
+        """
+        if name in cls.registry:
+            del cls.registry[name]
+
+    @classmethod
     def get(cls, name):
         """
         get publicator with required name

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -129,7 +129,8 @@ def publish_content(db_object, versioned, is_major_update=True):
     # move the stuffs into the good position
     if settings.ZDS_APP['content']['extra_content_generation_policy'] != "WATCHDOG":
         shutil.move(tmp_path, public_version.get_prod_path())
-    else:
+    else:  # if we use watchdog, we use copy to get md and zip file in prod but everything else will be handled by
+        # watchdog
         shutil.copytree(tmp_path, public_version.get_prod_path())
     # save public version
     if is_major_update or not is_update:
@@ -229,7 +230,6 @@ class Publicator:
 @PublicatorRegistery.register("epub", settings.PANDOC_LOC, "epub")
 @PublicatorRegistery.register("html", settings.PANDOC_LOC, "html")
 class PandocPublicator(Publicator):
-
     """
     Wrapper arround pandoc commands
     """

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -1,0 +1,203 @@
+import codecs
+import copy
+import os
+import shutil
+import subprocess
+from datetime import datetime
+
+from django.template.loader import render_to_string
+from django.utils import translation
+from django.utils.translation import ugettext_lazy as _
+
+from zds import settings
+from zds.settings import ZDS_APP
+from zds.tutorialv2.utils import publish_container, retrieve_and_update_images_links, FailureDuringPublication, \
+    make_zip_file
+
+
+def publish_content(db_object, versioned, is_major_update=True):
+    """Publish a given content.
+
+    Note: create a manifest.json without the introduction and conclusion if not needed. Also remove the "text" field
+    of extracts.
+
+    :param db_object: Database representation of the content
+    :type db_object: PublishableContent
+    :param versioned: version of the content to publish
+    :type versioned: VersionedContent
+    :param is_major_update: if set to `True`, will update the publication date
+    :type is_major_update: bool
+    :raise FailureDuringPublication: if something goes wrong
+    :return: the published representation
+    :rtype: zds.tutorialv2.models.models_database.PublishedContent
+    """
+
+    from zds.tutorialv2.models.models_database import PublishedContent
+
+    if is_major_update:
+        versioned.pubdate = datetime.now()
+
+    # First write the files in a temporary directory: if anything goes wrong,
+    # the last published version is not impacted !
+    tmp_path = os.path.join(settings.ZDS_APP['content']['repo_public_path'], versioned.slug + '__building')
+
+    if os.path.exists(tmp_path):
+        shutil.rmtree(tmp_path)  # erase previous attempt, if any
+
+    # render HTML:
+    altered_version = copy.deepcopy(versioned)
+    publish_container(db_object, tmp_path, altered_version)
+    altered_version.dump_json(os.path.join(tmp_path, 'manifest.json'))
+
+    # make room for "extra contents"
+    extra_contents_path = os.path.join(tmp_path, settings.ZDS_APP['content']['extra_contents_dirname'])
+    os.makedirs(extra_contents_path)
+
+    base_name = os.path.join(extra_contents_path, versioned.slug)
+
+    # 1. markdown file (base for the others) :
+    # If we come from a command line, we need to activate i18n, to have the date in the french language.
+    cur_language = translation.get_language()
+    versioned.pubdate = datetime.now()
+    try:
+        translation.activate(settings.LANGUAGE_CODE)
+        parsed = render_to_string('tutorialv2/export/content.md', {'content': versioned})
+    finally:
+        translation.activate(cur_language)
+
+    parsed_with_local_images = retrieve_and_update_images_links(parsed, directory=extra_contents_path)
+
+    md_file_path = base_name + '.md'
+    md_file = codecs.open(md_file_path, 'w', encoding='utf-8')
+    try:
+        md_file.write(parsed_with_local_images)
+    except (UnicodeError, UnicodeEncodeError):
+        raise FailureDuringPublication(_(u'Une erreur est survenue durant la génération du fichier markdown '
+                                         u'à télécharger, vérifiez le code markdown'))
+    md_file.close()
+
+    pandoc_debug_str = ""
+    if settings.PANDOC_LOG_STATE:
+        pandoc_debug_str = " 2>&1 | tee -a " + settings.PANDOC_LOG
+
+    generate_exernal_content(base_name, extra_contents_path, md_file_path, pandoc_debug_str)# ok, now we can really publish the thing !
+    is_update = False
+
+    if db_object.public_version:
+        public_version = db_object.public_version
+        is_update = True
+
+        # the content have been published in the past, so clean old files !
+        old_path = public_version.get_prod_path()
+        shutil.rmtree(old_path)
+
+        # if the slug change, instead of using the same object, a new one will be created
+        if versioned.slug != public_version.content_public_slug:
+            public_version.must_redirect = True  # set redirection
+            publication_date = public_version.publication_date
+            public_version.save()
+            db_object.public_version = PublishedContent()
+            public_version = db_object.public_version
+
+            # if content have already been published, keep publication date !
+            public_version.publication_date = publication_date
+
+    else:
+        public_version = PublishedContent()
+
+    # make the new public version
+    public_version.content_public_slug = versioned.slug
+    public_version.content_type = versioned.type
+    public_version.content_pk = db_object.pk
+    public_version.content = db_object
+    public_version.must_reindex = True
+
+    public_version.save()
+    for author in db_object.authors.all():
+        public_version.authors.add(author)
+    public_version.save()
+    # move the stuffs into the good position
+    shutil.move(tmp_path, public_version.get_prod_path())
+
+    # save public version
+    if is_major_update or not is_update:
+        public_version.publication_date = datetime.now()
+    elif is_update:
+        public_version.update_date = datetime.now()
+
+    public_version.sha_public = versioned.current_version
+    public_version.save()
+    try:
+        make_zip_file(public_version)
+    except IOError:
+        pass
+
+    return public_version
+
+
+def generate_exernal_content(base_name, extra_contents_path, md_file_path, pandoc_debug_str, overload_settings=False):
+    """generate all static file that allow offline access to content
+
+    :param base_name: base nae of file (without extension)
+    :param extra_contents_path: internal directory where all files will be pushed
+    :param md_file_path: bundled markdown file path
+    :param pandoc_debug_str: *specific to pandoc publication : avoid subprocess to be errored*
+    :param overload_settings: this option force the function to generate all registered formats even when settings
+    ask for PDF not to be published
+    :return:
+    """
+    excluded = []
+    if ZDS_APP['content']['build_pdf_when_published'] and not overload_settings:
+        excluded.append("pdf")
+    for _, publicator in PublicatorRegistery.get_all_registered(excluded):
+
+        publicator.publish(md_file_path, base_name, change_dir=extra_contents_path, pandoc_debug_str=pandoc_debug_str)
+
+
+class PublicatorRegistery:
+    registry = {}
+
+    @classmethod
+    def register(cls,  publicator_name, *args):
+        def decorated(func):
+            cls.registry[publicator_name] = func(args)
+            return func
+        return decorated
+
+
+    @classmethod
+    def get_all_registered(cls, exclude=None):
+        if exclude is None:
+            exclude = []
+        for key, value in cls.registry.items():
+            if key not in exclude:
+                yield key, value
+
+
+class Publicator:
+    def publish(self, md_file_path, base_name, **kwargs):
+        raise NotImplemented()
+
+
+@PublicatorRegistery.register("pdf", settings.PANDOC_LOC, "pdf", settings.PANDOC_PDF_PARAM)
+@PublicatorRegistery.register("epub", settings.PANDOC_LOC, "epub")
+@PublicatorRegistery.register("html", settings.PANDOC_LOC, "html")
+class PandocPublicator:
+    def __init__(self, pandoc_loc, _format, pandoc_pdf_param=None):
+        self.pandoc_loc = pandoc_loc
+        self.pandoc_pdf_param = pandoc_pdf_param
+        self.format = _format
+
+    def publish(self, md_file_path, base_name, change_dir=".", pandoc_debug_str="", **kwargs):
+        if self.pandoc_pdf_param:
+            subprocess.call(
+                self.pandoc_loc + "pandoc " + self.pandoc_pdf_param + " " + md_file_path + " -o " +
+                base_name + "." + self.format + " " + pandoc_debug_str,
+                shell=True,
+                cwd=change_dir)
+        else:
+            subprocess.call(
+                self.pandoc_loc + "pandoc -s -S --toc " + md_file_path + " -o " +
+                base_name + "." + self.format + " " + pandoc_debug_str,
+                shell=True,
+                cwd=change_dir)

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -165,6 +165,9 @@ def generate_exernal_content(base_name, extra_contents_path, md_file_path, pando
 
 
 class PublicatorRegistery:
+    """
+    Register all publicator as a "human-readable name/publicator" instance key/value list
+    """
     registry = {}
 
     @classmethod
@@ -174,7 +177,6 @@ class PublicatorRegistery:
             return func
         return decorated
 
-
     @classmethod
     def get_all_registered(cls, exclude=None):
         if exclude is None:
@@ -182,6 +184,7 @@ class PublicatorRegistery:
         for key, value in cls.registry.items():
             if key not in exclude:
                 yield key, value
+
     @classmethod
     def get(cls, name):
         """
@@ -198,6 +201,12 @@ class Publicator:
     Publicator base object, all methods must be overriden
     """
     def publish(self, md_file_path, base_name, **kwargs):
+        """called function to generate a content export
+
+        :param md_file_path: base markdown file path
+        :param base_name: file name without extension
+        :param kwargs: other publicator dependant options
+        """
         raise NotImplemented()
 
 
@@ -205,12 +214,24 @@ class Publicator:
 @PublicatorRegistery.register("epub", settings.PANDOC_LOC, "epub")
 @PublicatorRegistery.register("html", settings.PANDOC_LOC, "html")
 class PandocPublicator(Publicator):
+    """
+    Wrapper arround pandoc commands
+    """
     def __init__(self, pandoc_loc, _format, pandoc_pdf_param=None):
         self.pandoc_loc = pandoc_loc
         self.pandoc_pdf_param = pandoc_pdf_param
         self.format = _format
 
     def publish(self, md_file_path, base_name, change_dir=".", pandoc_debug_str="", **kwargs):
+        """
+
+        :param md_file_path: base markdown file path
+        :param base_name: file name without extension
+        :param change_dir: directory in wich pandoc commands will be executed
+        :param pandoc_debug_str: end of command to allow debugging
+        :param kwargs: othe publicator dependant options ignored by this one
+        :return:
+        """
         if self.pandoc_pdf_param:
             subprocess.call(
                 self.pandoc_loc + "pandoc " + self.pandoc_pdf_param + " " + md_file_path + " -o " +
@@ -227,6 +248,9 @@ class PandocPublicator(Publicator):
 
 @PublicatorRegistery.register("watchdog", settings.ZDS_APP['content']['extra_content_watchdog_dir'])
 class WatchdogFilePublicator(Publicator):
+    """
+    Just create a meta data file for watchdog
+    """
     def __init__(self, watched_dir):
         self.watched_directory = watched_dir
         if not isdir(self.watched_directory):

--- a/zds/tutorialv2/tests/tests_feeds.py
+++ b/zds/tutorialv2/tests/tests_feeds.py
@@ -16,8 +16,7 @@ from zds.tutorialv2.models.models_database import PublishedContent
 from zds.tutorialv2.feeds import LastTutorialsFeedRSS, LastTutorialsFeedATOM, LastArticlesFeedRSS, LastArticlesFeedATOM
 from zds.tutorialv2.factories import LicenceFactory, SubCategoryFactory, PublishableContentFactory, ContainerFactory, \
     ExtractFactory
-from zds.tutorialv2.utils import publish_content
-
+from zds.tutorialv2.publication_utils import publish_content
 
 overrided_zds_app = settings.ZDS_APP
 overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')

--- a/zds/tutorialv2/tests/tests_models.py
+++ b/zds/tutorialv2/tests/tests_models.py
@@ -14,7 +14,7 @@ from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory
     PublishedContentFactory, SubCategoryFactory
 from zds.gallery.factories import UserGalleryFactory
 from zds.tutorialv2.models.models_database import PublishableContent
-from zds.tutorialv2.utils import publish_content
+from zds.tutorialv2.publication_utils import publish_content
 
 overrided_zds_app = settings.ZDS_APP
 overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -17,9 +17,10 @@ from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory
     PublishedContentFactory
 from zds.gallery.factories import UserGalleryFactory
 from zds.tutorialv2.models.models_versioned import Container
-from zds.tutorialv2.utils import get_target_tagged_tree_for_container, unpublish_content, \
+from zds.tutorialv2.utils import get_target_tagged_tree_for_container, \
     get_target_tagged_tree_for_extract, retrieve_and_update_images_links, last_participation_is_old, \
     InvalidSlugError, BadManifestError, get_content_from_json, get_commit_author, slugify_raise_on_invalid, check_slug
+from zds.tutorialv2.publication_utils import unpublish_content
 from zds.tutorialv2.publication_utils import publish_content, unpublish_content
 from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent, ContentReaction, ContentRead
 from django.core.management import call_command

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -20,7 +20,7 @@ from zds.tutorialv2.models.models_versioned import Container
 from zds.tutorialv2.utils import get_target_tagged_tree_for_container, unpublish_content, \
     get_target_tagged_tree_for_extract, retrieve_and_update_images_links, last_participation_is_old, \
     InvalidSlugError, BadManifestError, get_content_from_json, get_commit_author, slugify_raise_on_invalid, check_slug
-from zds.tutorialv2.publication_utils import publish_content
+from zds.tutorialv2.publication_utils import publish_content, unpublish_content
 from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent, ContentReaction, ContentRead
 from django.core.management import call_command
 from zds.tutorial.factories import BigTutorialFactory, MiniTutorialFactory, PublishedMiniTutorial, NoteFactory, \

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -8,6 +8,7 @@ import datetime
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
+from zds.forum.models import Topic
 from zds.settings import BASE_DIR
 from django.core.urlresolvers import reverse
 
@@ -15,10 +16,23 @@ from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, LicenceFactory, ExtractFactory, \
     PublishedContentFactory
 from zds.gallery.factories import UserGalleryFactory
-from zds.tutorialv2.utils import get_target_tagged_tree_for_container, publish_content, unpublish_content, \
-    get_target_tagged_tree_for_extract, retrieve_and_update_images_links
-from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent
+from zds.tutorialv2.models.models_versioned import Container
+from zds.tutorialv2.utils import get_target_tagged_tree_for_container, unpublish_content, \
+    get_target_tagged_tree_for_extract, retrieve_and_update_images_links, last_participation_is_old, \
+    InvalidSlugError, BadManifestError, get_content_from_json, get_commit_author, slugify_raise_on_invalid, check_slug
+from zds.tutorialv2.publication_utils import publish_content
+from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent, ContentReaction, ContentRead
 from django.core.management import call_command
+from zds.tutorial.factories import BigTutorialFactory, MiniTutorialFactory, PublishedMiniTutorial, NoteFactory, \
+    BetaMiniTutorialFactory, PublishedBigTutorial
+from zds.article.factories import ArticleFactory, PublishedArticleFactory, ReactionFactory
+from zds.utils.models import CommentLike
+from zds.article.models import ArticleRead
+from zds.tutorial.models import TutorialRead, Chapter
+from zds.tutorial.models import Validation as OldTutoValidation
+from zds.article.models import Validation as OldArticleValidation
+from zds.tutorialv2.models.models_database import Validation
+from zds.forum.factories import ForumFactory, CategoryFactory
 
 try:
     import ujson as json_reader
@@ -369,6 +383,158 @@ class UtilsTests(TestCase):
 
         # finally, clean up:
         shutil.rmtree(tempdir)
+
+    def test_migrate_zep12(self):
+        private_mini_tuto = MiniTutorialFactory(title="Private Mini tuto")
+        private_mini_tuto.authors.add(self.user_author)
+        private_mini_tuto.save()
+        multi_author_tuto = MiniTutorialFactory(title="Multi User Tuto")
+        multi_author_tuto.authors.add(self.user_author)
+        multi_author_tuto.authors.add(self.staff)
+        multi_author_tuto.save()
+        public_mini_tuto = PublishedMiniTutorial(title="Public Mini Tuto")
+        public_mini_tuto.authors.add(self.user_author)
+        public_mini_tuto.save()
+        OldTutoValidation(tutorial=public_mini_tuto,
+                          version=public_mini_tuto.sha_public,
+                          date_proposition=datetime.datetime.now(),
+                          comment_authors=u"La vie est belle, le destin s'en écarte.",
+                          comment_validator=u"Personne ne joue avec les mêmes cartes.",
+                          validator=self.staff,
+                          status="ACCEPT",
+                          date_reserve=datetime.datetime.now(),
+                          date_validation=datetime.datetime.now()).save()
+        staff_note = NoteFactory(
+            tutorial=public_mini_tuto,
+            position=1,
+            author=self.staff)
+        liked_note = NoteFactory(
+            tutorial=public_mini_tuto,
+            position=2,
+            author=self.user_author)
+        t_read = TutorialRead()
+        t_read.tutorial = public_mini_tuto
+        t_read.user = self.staff
+        t_read.note = staff_note
+        t_read.save()
+        like = CommentLike()
+        like.comments = liked_note
+        like.user = self.staff
+        like.save()
+        big_tuto = BigTutorialFactory(title="Big tuto")
+        big_tuto.authors.add(self.user_author)
+        big_tuto.save()
+        public_big_tuto = PublishedBigTutorial(light=False, title="Public Big Tuto")
+        public_big_tuto.authors.add(self.user_author)
+        public_big_tuto.save()
+        private_article = ArticleFactory(title="Private Article")
+        private_article.authors.add(self.user_author)
+        private_article.save()
+        multi_author_article = ArticleFactory(title="Multi Author Article")
+        multi_author_article.authors.add(self.user_author)
+        multi_author_article.authors.add(self.staff)
+        multi_author_article.save()
+        public_article = PublishedArticleFactory(title="Public Article")
+        public_article.authors.add(self.user_author)
+        public_article.save()
+        OldArticleValidation(article=public_article,
+                             version=public_article.sha_public,
+                             date_proposition=datetime.datetime.now(),
+                             comment_authors=u"Pourquoi fortune et infortune?",
+                             comment_validator=u"Pourquoi suis-je né les poches vides?",
+                             validator=self.staff,
+                             status="ACCEPT",
+                             date_reserve=datetime.datetime.now(),
+                             date_validation=datetime.datetime.now()).save()
+        staff_note = ReactionFactory(
+            article=public_article,
+            position=1,
+            author=self.staff)
+        liked_reaction = ReactionFactory(
+            article=public_article,
+            position=2,
+            author=self.user_author)
+        a_read = ArticleRead()
+        a_read.article = public_article
+        a_read.user = self.staff
+        a_read.reaction = staff_note
+        a_read.save()
+        like = CommentLike()
+        like.comments = liked_reaction
+        like.user = self.staff
+        like.save()
+        category1 = CategoryFactory(position=1)
+        forum11 = ForumFactory(
+            category=category1,
+            position_in_category=1)
+        beta_tuto = BetaMiniTutorialFactory(title=u"Beta Tuto", forum=forum11, author=self.user_author)
+        beta_tuto.authors.add(self.user_author)
+        beta_tuto.save()
+        call_command('migrate_to_zep12')
+        # 1 tuto in setup, 4 mini tutos, 1 big tuto, 3 articles
+        self.assertEqual(PublishableContent.objects.filter(authors__pk__in=[self.user_author.pk]).count(), 10)
+        # if we had n published content we must have 2 * n PublishedContent entities to handle redirections.
+        self.assertEqual(PublishedContent.objects.filter(content__authors__pk__in=[self.user_author.pk]).count(), 2 * 3)
+        self.assertEqual(ContentReaction.objects.filter(author__pk=self.staff.pk).count(), 2)
+        migrated_pulished_article = PublishableContent.objects.filter(authors__in=[self.user_author],
+                                                                      title=public_article.title,
+                                                                      type="ARTICLE").first()
+        self.assertIsNotNone(migrated_pulished_article)
+        self.assertIsNotNone(migrated_pulished_article.last_note)
+        self.assertEqual(2, ContentReaction.objects.filter(related_content=migrated_pulished_article).count())
+        self.assertEqual(1, ContentRead.objects.filter(content=migrated_pulished_article).count())
+        self.assertTrue(migrated_pulished_article.is_public(migrated_pulished_article.sha_public))
+        self.assertTrue(migrated_pulished_article.load_version(migrated_pulished_article.sha_public).has_extracts())
+        self.assertEqual(len(migrated_pulished_article.load_version(migrated_pulished_article.sha_public).children), 2)
+
+        migrated_pulished_tuto = PublishableContent.objects.filter(authors__in=[self.user_author],
+                                                                   title=public_mini_tuto.title,
+                                                                   type="TUTORIAL").first()
+        self.assertIsNotNone(migrated_pulished_tuto)
+        self.assertIsNotNone(migrated_pulished_tuto.last_note)
+        self.assertEqual(2, ContentReaction.objects.filter(related_content=migrated_pulished_tuto).count())
+        self.assertEqual(1, ContentRead.objects.filter(content=migrated_pulished_tuto).count())
+        self.assertTrue(migrated_pulished_tuto.is_public(migrated_pulished_tuto.sha_public))
+        beta_content = PublishableContent.objects.filter(title=beta_tuto.title).first()
+        self.assertIsNotNone(beta_content)
+        self.assertEqual(beta_content.sha_beta, beta_tuto.sha_beta)
+        self.assertEqual(Topic.objects.filter(key=beta_tuto.pk).first().pk, beta_content.beta_topic.pk)
+
+        multi_author_content = PublishableContent.objects.filter(type="TUTORIAL", title=multi_author_tuto.title)\
+            .first()
+        self.assertIsNotNone(multi_author_content)
+        self.assertEqual(multi_author_content.authors.count(), multi_author_tuto.authors.count())
+        multi_author_content = PublishableContent.objects.filter(type="ARTICLE", title=multi_author_article.title)\
+            .first()
+        self.assertIsNotNone(multi_author_content)
+        self.assertEqual(multi_author_content.authors.count(), multi_author_article.authors.count())
+        old_tutorial_module_prefix = "oldtutoriels"
+        old_article_module_prefix = "oldarticles"
+        new_tutorial_module_prefix = "tutoriels"
+        new_article_module_prefix = "articles"
+        public_article_url = public_article.get_absolute_url_online()\
+            .replace(old_article_module_prefix, new_article_module_prefix)
+        public_tutorial_url = public_mini_tuto.get_absolute_url_online()\
+            .replace(old_tutorial_module_prefix, new_tutorial_module_prefix)
+        self.assertEqual(301, self.client.get(public_article_url).status_code)
+        self.assertEqual(301, self.client.get(public_tutorial_url).status_code)
+        public_chapter = Chapter.objects.filter(part__tutorial__pk=public_big_tuto.pk).first()
+        self.assertIsNotNone(public_chapter)
+        public_chapter_url = public_chapter.get_absolute_url_online()
+        public_chapter_url = public_chapter_url.replace(old_tutorial_module_prefix, new_tutorial_module_prefix)
+
+        self.assertEqual(301, self.client.get(public_chapter_url).status_code)
+        self.assertEqual(200, self.client.get(public_chapter_url, follow=True).status_code)
+        self.assertEqual(200, self.client.get(public_article_url, follow=True).status_code)
+        self.assertEqual(200, self.client.get(public_tutorial_url, follow=True).status_code)
+        tuto_validation = Validation.objects.filter(content__pk=migrated_pulished_tuto.pk).first()
+        self.assertIsNotNone(tuto_validation)
+        self.assertEqual(tuto_validation.status, "ACCEPT")
+        self.assertEqual(tuto_validation.validator.pk, self.staff.pk)
+        article_validation = Validation.objects.filter(content__pk=migrated_pulished_article.pk).first()
+        self.assertIsNotNone(article_validation)
+        self.assertEqual(article_validation.status, "ACCEPT")
+        self.assertEqual(article_validation.validator.pk, self.staff.pk)
 
     def test_generate_pdf(self):
         """ensure the behavior of the `python manage.py generate_pdf` commmand"""

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -20,7 +20,6 @@ from zds.tutorialv2.models.models_versioned import Container
 from zds.tutorialv2.utils import get_target_tagged_tree_for_container, \
     get_target_tagged_tree_for_extract, retrieve_and_update_images_links, last_participation_is_old, \
     InvalidSlugError, BadManifestError, get_content_from_json, get_commit_author, slugify_raise_on_invalid, check_slug
-from zds.tutorialv2.publication_utils import unpublish_content
 from zds.tutorialv2.publication_utils import publish_content, unpublish_content
 from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent, ContentReaction, ContentRead
 from django.core.management import call_command

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from zds.settings import BASE_DIR
+from django.core.urlresolvers import reverse
 
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, LicenceFactory, ExtractFactory, \

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -19,8 +19,8 @@ from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactor
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory, \
     SubCategoryFactory, PublishedContentFactory, tricky_text_content, BetaContentFactory
 from zds.tutorialv2.models.models_database import PublishableContent, Validation, PublishedContent, ContentReaction, \
-    ContentRead, ALLOWED_TYPES
-from zds.tutorialv2.utils import publish_content
+    ContentRead
+from zds.tutorialv2.publication_utils import publish_content
 from zds.gallery.factories import UserGalleryFactory
 from zds.gallery.models import Image
 from zds.forum.factories import ForumFactory, CategoryFactory
@@ -5136,18 +5136,6 @@ class PublishedContentTests(TestCase):
         self.assertIn(self.user_author.username, response.content)
         self.assertNotIn(other_author.user.username, response.content)
         self.assertEqual(0, len(other_author.get_public_contents()))
-
-    def test_download_size(self):
-        """
-        Test the size of content to download.
-        """
-        sizes = self.published.sizes
-        for type_ in ALLOWED_TYPES:
-            if self.published.have_type(type_):
-                self.assertEqual(sizes[type_],
-                                 os.path.getsize(os.path.join(
-                                     self.published.get_extra_contents_directory(),
-                                     self.published.content_public_slug + '.' + type_)))
 
     def tearDown(self):
 

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -43,6 +43,7 @@ except ImportError:
 overrided_zds_app = settings.ZDS_APP
 overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
 overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['extra_content_generation_policy'] = "SYNC"
 
 
 @override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
@@ -3262,7 +3263,7 @@ class ContentTests(TestCase):
 
         # test existence and access for admin
         for extra in avail_extra:
-            self.assertTrue(published.have_type(extra))
+            self.assertTrue(published.have_type(extra), "no extra content" + extra)
             result = self.client.get(published.get_absolute_url_to_extra_content(extra))
             self.assertEqual(result.status_code, 200)
 

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -44,7 +44,6 @@ def search_container_or_404(base_content, kwargs_array):
 
     from zds.tutorialv2.models.models_versioned import Container
 
-    container = None
     if isinstance(kwargs_array, basestring):
         dic = {}
         dic["parent_container_slug"] = kwargs_array.split("/")[0]
@@ -147,6 +146,7 @@ def mark_read(content, user=None):
     """Mark the last tutorial note as read for the user.
 
     :param content: the content to mark
+    :param user: user that read the content, if ``None`` will use currrent user
     """
 
     from zds.tutorialv2.models.models_database import ContentRead
@@ -177,10 +177,8 @@ class TooDeepContainerError(ValueError):
 
 def try_adopt_new_child(adoptive_parent, child):
     """Try the adoptive parent to take the responsability of the child
-
-    :param parent_full_path:
-    :param child_slug:
-    :param root:
+    :param adoptive_parent: the new parent for child if all check pass
+    :param child: content child to be moved
     :raise Http404: if adoptive_parent_full_path is not found on root hierarchy
     :raise TypeError: if the adoptive parent is not allowed to adopt the child due to its type
     :raise TooDeepContainerError: if the child is a container that is too deep to be adopted by the proposed parent
@@ -452,6 +450,8 @@ def get_content_from_json(json, sha, slug_last_draft, public=False, max_title_le
 
     :param json: JSON data from a `manifest.json` file
     :param sha: version
+    :param slug_last_draft: the slug for draft marked version
+    :param max_title_len: max str length for title
     :param public: the function will fill a PublicContent instead of a VersionedContent if `True`
     :return: a Public/VersionedContent with all the information retrieved from JSON
     :rtype: models.models_versioned.VersionedContent|models.models_database.PublishedContent

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -16,8 +16,8 @@ from zds.tutorialv2.forms import AskValidationForm, RejectValidationForm, Accept
     CancelValidationForm
 from zds.tutorialv2.mixins import SingleContentFormViewMixin, SingleContentDetailViewMixin, ModalFormView
 from zds.tutorialv2.models.models_database import Validation, PublishableContent, ContentRead
-from zds.tutorialv2.utils import FailureDuringPublication, unpublish_content
-from zds.tutorialv2.publication_utils import publish_content
+from zds.tutorialv2.publication_utils import publish_content, FailureDuringPublication, unpublish_content,\
+    FailureDuringPublication, unpublish_content
 from zds.utils.models import SubCategory
 from zds.utils.mps import send_mp
 

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -16,7 +16,8 @@ from zds.tutorialv2.forms import AskValidationForm, RejectValidationForm, Accept
     CancelValidationForm
 from zds.tutorialv2.mixins import SingleContentFormViewMixin, SingleContentDetailViewMixin, ModalFormView
 from zds.tutorialv2.models.models_database import Validation, PublishableContent, ContentRead
-from zds.tutorialv2.utils import publish_content, FailureDuringPublication, unpublish_content
+from zds.tutorialv2.utils import FailureDuringPublication, unpublish_content
+from zds.tutorialv2.publication_utils import publish_content
 from zds.utils.models import SubCategory
 from zds.utils.mps import send_mp
 

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -16,8 +16,7 @@ from zds.tutorialv2.forms import AskValidationForm, RejectValidationForm, Accept
     CancelValidationForm
 from zds.tutorialv2.mixins import SingleContentFormViewMixin, SingleContentDetailViewMixin, ModalFormView
 from zds.tutorialv2.models.models_database import Validation, PublishableContent, ContentRead
-from zds.tutorialv2.publication_utils import publish_content, FailureDuringPublication, unpublish_content,\
-    FailureDuringPublication, unpublish_content
+from zds.tutorialv2.publication_utils import publish_content, FailureDuringPublication, unpublish_content
 from zds.utils.models import SubCategory
 from zds.utils.mps import send_mp
 

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -23,7 +23,7 @@ from django.db import transaction
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, \
     Validation as CValidation, ContentReactionFactory
 from zds.tutorialv2.models.models_database import PublishableContent
-from zds.tutorialv2.utils import publish_content
+from zds.tutorialv2.publication_utils import publish_content
 
 
 def load_member(cli, size, fake, root):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [oui] |
| Tickets (_issues_) concernés | [#3080] |

Pour l'activer : changez les paramètres dans le `settings_prod.py`

``` python
        ZDS_APP['content']['extra_content_generation_policy'] = "WATCHDOG",
        ZDS_APP['content']['extra_content_watchdog_dir']: 'public-contents/build', #mettez le dossier que vous voulez
```

Une fois cela fait, lancez la commande `python manage.py publication_watchdog`
et ensuite lancez le serveur.
- [x] Création des politiques de génération
- [x] Création du watchdog
- [x] Création de la doc
- [x] TestUnitaire
- [x] supprimer *__build
- [x] maj le update.md
