### PR TITLE
Affiche les permissions dans les réponses de l'API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ django-oauth-toolkit==0.9.0
 drf-extensions==0.2.7
 django-rest-swagger==0.2.9
 django-cors-headers==1.0.0
-dry-rest-permissions==0.1.5
+dry-rest-permissions==0.1.6
 
 # Zep 12 dependency
 django-uuslug==1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ django-oauth-toolkit==0.9.0
 drf-extensions==0.2.7
 django-rest-swagger==0.2.9
 django-cors-headers==1.0.0
+dry-rest-permissions==0.1.5
 
 # Zep 12 dependency
 django-uuslug==1.0.3

--- a/zds/member/api/generics.py
+++ b/zds/member/api/generics.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.conf import settings
+from dry_rest_permissions.generics import DRYPermissions
 from rest_framework import status
 from rest_framework.generics import CreateAPIView, DestroyAPIView
 from rest_framework.permissions import IsAuthenticated
@@ -18,7 +19,6 @@ class CreateDestroyMemberSanctionAPIView(CreateAPIView, DestroyAPIView):
 
     queryset = Profile.objects.all()
     serializer_class = ProfileSanctionSerializer
-    permission_classes = (IsAuthenticated, IsStaffUser)
 
     def post(self, request, *args, **kwargs):
         return self.process_request(request)
@@ -54,6 +54,12 @@ class CreateDestroyMemberSanctionAPIView(CreateAPIView, DestroyAPIView):
                     settings.ZDS_APP['site']['litteral_name'])
         state.notify_member(ban, msg)
         return Response(serializer.data)
+
+    def get_permissions(self):
+        permission_classes = [IsAuthenticated, IsStaffUser, ]
+        if self.request.method == 'POST' or self.request.method == 'DELETE':
+            permission_classes.append(DRYPermissions)
+        return [permission() for permission in permission_classes]
 
     def get_state_instance(self, request):
         raise NotImplementedError('`get_state_instance()` must be implemented.')

--- a/zds/member/api/serializers.py
+++ b/zds/member/api/serializers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.contrib.auth.models import User
-
+from dry_rest_permissions.generics import DRYPermissionsField
 from rest_framework import serializers
 
 from zds.member.commons import ProfileCreate
@@ -33,10 +33,11 @@ class ProfileListSerializer(serializers.ModelSerializer):
     is_active = serializers.BooleanField(source='user.is_active')
     date_joined = serializers.DateTimeField(source='user.date_joined')
     avatar_url = serializers.CharField(source='get_avatar_url')
+    permissions = DRYPermissionsField(additional_actions=['ban'])
 
     class Meta:
         model = Profile
-        fields = ('id', 'username', 'is_active', 'date_joined', 'avatar_url')
+        fields = ('id', 'username', 'is_active', 'date_joined', 'avatar_url', 'permissions')
 
 
 class ProfileCreateSerializer(serializers.ModelSerializer, ProfileCreate, ProfileUsernameValidator,
@@ -49,10 +50,11 @@ class ProfileCreateSerializer(serializers.ModelSerializer, ProfileCreate, Profil
     username = serializers.CharField(source='user.username')
     email = serializers.EmailField(source='user.email')
     password = serializers.CharField(source='user.password')
+    permissions = DRYPermissionsField(additional_actions=['ban'])
 
     class Meta:
         model = Profile
-        fields = ('id', 'username', 'email', 'password')
+        fields = ('id', 'username', 'email', 'password', 'permissions')
         write_only_fields = ('password')
 
     def create(self, validated_data):
@@ -75,12 +77,14 @@ class ProfileDetailSerializer(serializers.ModelSerializer):
     is_active = serializers.BooleanField(source='user.is_active')
     date_joined = serializers.DateTimeField(source='user.date_joined')
     avatar_url = serializers.CharField(source='get_avatar_url')
+    permissions = DRYPermissionsField(additional_actions=['ban'])
 
     class Meta:
         model = Profile
         fields = ('id', 'username', 'email', 'is_active', 'date_joined',
                   'site', 'avatar_url', 'biography', 'sign', 'show_email',
-                  'show_sign', 'hover_or_click', 'allow_temp_visual_changes', 'email_for_answer', 'last_visit')
+                  'show_sign', 'hover_or_click', 'allow_temp_visual_changes',
+                  'email_for_answer', 'last_visit', 'permissions')
 
     def __init__(self, *args, **kwargs):
         """
@@ -106,13 +110,15 @@ class ProfileValidatorSerializer(serializers.ModelSerializer, ProfileUsernameVal
     email = serializers.EmailField(source='user.email', required=False, allow_blank=True)
     is_active = serializers.BooleanField(source='user.is_active', required=False)
     date_joined = serializers.DateTimeField(source='user.date_joined', required=False)
+    permissions = DRYPermissionsField(additional_actions=['ban'])
 
     class Meta:
         model = Profile
         fields = ('id', 'username', 'email', 'is_active', 'date_joined',
                   'site', 'avatar_url', 'biography', 'sign', 'show_email',
-                  'show_sign', 'hover_or_click', 'email_for_answer', 'last_visit')
-        read_only_fields = ('is_active', 'date_joined', 'last_visit',)
+                  'show_sign', 'hover_or_click', 'email_for_answer', 'last_visit',
+                  'permissions')
+        read_only_fields = ('is_active', 'date_joined', 'last_visit', 'permissions',)
 
     def update(self, instance, validated_data):
         """

--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -993,6 +993,134 @@ class MemberDetailBanAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
+class PermissionMemberAPITest(APITestCase):
+    def setUp(self):
+        self.profile = ProfileFactory()
+        self.staff = StaffProfileFactory()
+
+        get_cache(extensions_api_settings.DEFAULT_USE_CACHE).clear()
+
+    def test_has_read_permission_for_anonymous_users(self):
+        """
+        Anonymous users have the permission to read any member.
+        """
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data.get('permissions').get('read'))
+
+    def test_has_read_permission_for_authenticated_users(self):
+        """
+        Authenticated users have the permission to read any member.
+        """
+        authenticate_client(self.client, create_oauth2_client(self.profile.user),
+                            self.profile.user.username, 'hostel77')
+
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data.get('permissions').get('read'))
+
+    def test_has_read_permission_for_staff_users(self):
+        """
+        Staff users have the permission to read any member.
+        """
+        authenticate_client(self.client, create_oauth2_client(self.staff.user),
+                            self.staff.user.username, 'hostel77')
+
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data.get('permissions').get('read'))
+
+    def test_has_not_write_permission_for_anonymous_user(self):
+        """
+        An anonymous user haven't write permissions.
+        """
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data.get('permissions').get('write'))
+
+    def test_has_write_permission_for_authenticated_user(self):
+        """
+        A user authenticated have write permissions.
+        """
+        authenticate_client(self.client, create_oauth2_client(self.profile.user),
+                            self.profile.user.username, 'hostel77')
+
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data.get('permissions').get('write'))
+
+    def test_has_write_permission_for_staff(self):
+        """
+        A staff user have write permissions.
+        """
+        authenticate_client(self.client, create_oauth2_client(self.staff.user),
+                            self.staff.user.username, 'hostel77')
+
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data.get('permissions').get('write'))
+
+    def test_has_not_update_permission_for_anonymous_user(self):
+        """
+        Only the user authenticated have update permissions.
+        """
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data.get('permissions').get('update'))
+
+    def test_has_update_permission_for_authenticated_user(self):
+        """
+        Only the user authenticated have update permissions.
+        """
+        authenticate_client(self.client, create_oauth2_client(self.profile.user),
+                            self.profile.user.username, 'hostel77')
+
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data.get('permissions').get('update'))
+
+    def test_has_not_update_permission_for_staff(self):
+        """
+        Only the user authenticated have update permissions.
+        """
+        authenticate_client(self.client, create_oauth2_client(self.staff.user),
+                            self.staff.user.username, 'hostel77')
+
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data.get('permissions').get('update'))
+
+    def test_has_not_ban_permission_for_anonymous_user(self):
+        """
+        Only staff have ban permission.
+        """
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data.get('permissions').get('ban'))
+
+    def test_has_not_ban_permission_for_authenticated_user(self):
+        """
+        Only staff have ban permission.
+        """
+        authenticate_client(self.client, create_oauth2_client(self.profile.user),
+                            self.profile.user.username, 'hostel77')
+
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data.get('permissions').get('ban'))
+
+    def test_has_ban_permission_for_staff(self):
+        """
+        Only staff have ban permission.
+        """
+        authenticate_client(self.client, create_oauth2_client(self.staff.user),
+                            self.staff.user.username, 'hostel77')
+
+        response = self.client.get(reverse('api-member-detail', args=[self.profile.user.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data.get('permissions').get('ban'))
+
+
 def create_oauth2_client(user):
     client = Application.objects.create(user=user,
                                         client_type=Application.CLIENT_CONFIDENTIAL,

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -360,6 +360,30 @@ class Profile(models.Model):
         return Topic.objects.filter(topicfollowed__user=self.user)\
             .order_by('-last_message__pubdate')
 
+    @staticmethod
+    def has_read_permission(request):
+        return True
+
+    def has_object_read_permission(self, request):
+        return True
+
+    @staticmethod
+    def has_write_permission(request):
+        return True
+
+    def has_object_write_permission(self, request):
+        return self.has_object_update_permission(request) or request.user.has_perm("member.change_profile")
+
+    def has_object_update_permission(self, request):
+        return request.user.is_authenticated() and request.user == self.user
+
+    @staticmethod
+    def has_ban_permission(request):
+        return True
+
+    def has_object_ban_permission(self, request):
+        return request.user and request.user.has_perm("member.change_profile")
+
 
 @receiver(models.signals.post_delete, sender=User)
 def auto_delete_token_on_unregistering(sender, instance, **kwargs):

--- a/zds/mp/api/permissions.py
+++ b/zds/mp/api/permissions.py
@@ -11,7 +11,7 @@ class IsParticipant(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj):
-        return obj.author == request.user or request.user in obj.participants.all()
+        return obj.is_participant(request.user)
 
 
 class IsParticipantFromPrivatePost(permissions.BasePermission):
@@ -21,7 +21,7 @@ class IsParticipantFromPrivatePost(permissions.BasePermission):
 
     def has_permission(self, request, view):
         private_topic = get_object_or_404(PrivateTopic, pk=view.kwargs.get('pk_ptopic'))
-        return private_topic.author == request.user or request.user in private_topic.participants.all()
+        return private_topic.is_participant(request.user)
 
 
 class IsAloneInPrivatePost(permissions.BasePermission):
@@ -31,7 +31,7 @@ class IsAloneInPrivatePost(permissions.BasePermission):
 
     def has_permission(self, request, view):
         private_topic = get_object_or_404(PrivateTopic, pk=view.kwargs.get('pk_ptopic'))
-        return private_topic.participants.count() > 0
+        return private_topic.participants.count() == 0
 
 
 class IsLastPrivatePostOfCurrentUser(permissions.BasePermission):
@@ -41,7 +41,7 @@ class IsLastPrivatePostOfCurrentUser(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         private_topic = get_object_or_404(PrivateTopic, pk=view.kwargs.get('pk_ptopic'))
-        return private_topic.last_message == obj and obj.author == request.user
+        return obj.is_last_message(private_topic) and obj.is_author(request.user)
 
 
 class IsAuthor(permissions.BasePermission):
@@ -50,4 +50,4 @@ class IsAuthor(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj):
-        return obj.author == request.user
+        return obj.is_author(request.user)

--- a/zds/mp/api/serializers.py
+++ b/zds/mp/api/serializers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
+from dry_rest_permissions.generics import DRYPermissionsField
 from rest_framework import serializers
 from zds.api.serializers import ZdSModelSerializer
 
@@ -15,21 +16,25 @@ class PrivatePostSerializer(ZdSModelSerializer):
     """
     Serializers of a private post object.
     """
+    permissions = DRYPermissionsField()
 
     class Meta:
         model = PrivatePost
         serializers = (UserListSerializer,)
         formats = {'Html': 'text_html', 'Markdown': 'text'}
+        read_only_fields = ('permissions',)
 
 
 class PrivateTopicSerializer(ZdSModelSerializer):
     """
     Serializers of a private topic object.
     """
+    permissions = DRYPermissionsField()
 
     class Meta:
         model = PrivateTopic
         serializers = (PrivatePostSerializer, UserListSerializer,)
+        read_only_fields = ('permissions',)
 
 
 class PrivateTopicCreateSerializer(serializers.ModelSerializer, TitleValidator, TextValidator,
@@ -39,12 +44,14 @@ class PrivateTopicCreateSerializer(serializers.ModelSerializer, TitleValidator, 
     """
     participants = serializers.PrimaryKeyRelatedField(many=True, queryset=User.objects.all(), required=True, )
     text = serializers.CharField()
+    permissions = DRYPermissionsField()
 
     class Meta:
         model = PrivateTopic
         fields = ('id', 'title', 'subtitle', 'participants', 'text',
-                  'author', 'participants', 'last_message', 'pubdate')
-        read_only_fields = ('id', 'author', 'last_message', 'pubdate')
+                  'author', 'participants', 'last_message', 'pubdate',
+                  'permissions')
+        read_only_fields = ('id', 'author', 'last_message', 'pubdate', 'permissions')
 
     def create(self, validated_data):
         # This hack is necessary because `text` isn't a field of PrivateTopic.
@@ -73,11 +80,12 @@ class PrivateTopicUpdateSerializer(serializers.ModelSerializer, TitleValidator, 
     title = serializers.CharField(required=False, allow_blank=True)
     subtitle = serializers.CharField(required=False, allow_blank=True)
     participants = serializers.PrimaryKeyRelatedField(many=True, queryset=User.objects.all(), required=False, )
+    permissions = DRYPermissionsField()
 
     class Meta:
         model = PrivateTopic
-        fields = ('id', 'title', 'subtitle', 'participants',)
-        read_only_fields = ('id',)
+        fields = ('id', 'title', 'subtitle', 'participants', 'permissions',)
+        read_only_fields = ('id', 'permissions',)
 
     def update(self, instance, validated_data):
         for attr, value in validated_data.items():
@@ -99,11 +107,14 @@ class PrivatePostUpdateSerializer(serializers.ModelSerializer, TextValidator, Up
     """
     Serializer to update the last private post of a private topic.
     """
+    permissions = DRYPermissionsField()
 
     class Meta:
         model = PrivatePost
-        fields = ('id', 'privatetopic', 'author', 'text', 'text_html', 'pubdate', 'update', 'position_in_topic')
-        read_only_fields = ('id', 'privatetopic', 'author', 'text_html', 'pubdate', 'update', 'position_in_topic')
+        fields = ('id', 'privatetopic', 'author', 'text', 'text_html', 'pubdate', 'update', 'position_in_topic',
+                  'permissions')
+        read_only_fields = ('id', 'privatetopic', 'author', 'text_html', 'pubdate', 'update', 'position_in_topic',
+                            'permissions')
 
     def update(self, instance, validated_data):
         return self.perform_update(instance, validated_data)
@@ -116,11 +127,14 @@ class PrivatePostCreateSerializer(serializers.ModelSerializer, TextValidator):
     """
     Serializer to update the last private post of a private topic.
     """
+    permissions = DRYPermissionsField()
 
     class Meta:
         model = PrivatePost
-        fields = ('id', 'privatetopic', 'author', 'text', 'text_html', 'pubdate', 'update', 'position_in_topic')
-        read_only_fields = ('id', 'privatetopic', 'author', 'text_html', 'pubdate', 'update', 'position_in_topic')
+        fields = ('id', 'privatetopic', 'author', 'text', 'text_html', 'pubdate', 'update', 'position_in_topic',
+                  'permissions')
+        read_only_fields = ('id', 'privatetopic', 'author', 'text_html', 'pubdate', 'update', 'position_in_topic',
+                            'permissions')
 
     def create(self, validated_data):
         # Get topic

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -166,6 +166,7 @@ INSTALLED_APPS = (
     'social.apps.django_app.default',
     'rest_framework',
     'rest_framework_swagger',
+    'dry_rest_permissions',
     'corsheaders',
     'oauth2_provider',
     'captcha',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets (_issues_) concernés | ZEP-30 |

Affiche les permissions partout où on affiche un membre ou un MP (et ses messages) à partir de l'API. Voici un exemple d'affichage :

``` json
{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [{
        "id": 1,
        "username": "firm1",
        "is_active": true,
        "date_joined": "2016-01-02T00:45:58.025816",
        "avatar_url": "https://secure.gravatar.com/avatar/8684a174694f1724697f66c6f668f440?d=identicon",
        "permissions": {
            "write": true,
            "read": true,
            "update": true,
            "ban": false
        }
    }]
}
```

Pour la QA : Vérifiez que les routes de l'API des membres et des MPs retourne bien les permissions. Les règles liées aux permissions sont les suivantes :
# Membres
- `read` : `true` pour tout le monde.
- `write` : `true` pour l'utilisateur authentifié et pour le staff.
- `update` : `true` uniquement pour l'utilisateur authentifié.
- `ban` : `true` uniquement pour le staff.
# MP
- `read` : `true` pour tous les utilisateurs authentifiés et participant à la conversation.
- `write` : `true`pour tous les utilisateurs authentifiés et participant à la conversation.
- `update` : `true` pour tous les utilisateurs authentifiés et auteur de la conversation.
# Poste
- `read` : `true` pour tous les utilisateurs authentifiés et participant à la conversation.
- `write` : `true`pour tous les utilisateurs authentifiés et participant à la conversation.
- `update` : `true` pour tous les utilisateurs authentifiés, où le message est le dernier de la conversation et auteur de la conversation.

Enjoy!
