### PR TITLE
Passage à la derniere version de Haystack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ python-social-auth==0.2.9
 django==1.7.10
 coverage==4.0.1
 django-crispy-forms==1.4.0
-django-haystack==2.3.1
+django-haystack==2.4.1
 django-model-utils==2.2
 django-munin==0.2.0
 python-memcached==1.54

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -73,9 +73,9 @@
         {% include "misc/pagination.part.html" with position="top" %}
 
 
-        {% if page.object_list %}
+        {% if object_list %}
             <div class="topic-list navigable-list">
-                {% for result in page.object_list %}
+                {% for result in object_list %}
                     {% if result and result.object %}
                         {% if result.content_type == "search.searchindexcontent" %}
                             {% include "search/includes/content/content.html" with result=result query=query %}

--- a/update.md
+++ b/update.md
@@ -364,3 +364,11 @@ RECAPTCHA_PRIVATE_KEY = 'la-cle-ici'
 ```
 
 (les clés d'applications sont à créer auprès de l'association)
+
+Actions à faire pour mettre en prod la version 16
+=================================================
+
+Mise à jours de la version de Haystack à la 4.1 
+-----------------------------------------------
+
+Pour mettre à jours la librairie, il vous faut lancer la commande `pip install --upgrade -r requirements.txt`

--- a/zds/search/urls.py
+++ b/zds/search/urls.py
@@ -6,12 +6,7 @@ from haystack.views import search_view_factory
 from zds.search.form import CustomSearchForm
 from zds.search.views import CustomSearchView
 
-urlpatterns = patterns('haystack.views',
-                       url(r'^$', search_view_factory(
-                           view_class=CustomSearchView,
-                           template='search/search.html',
-                           form_class=CustomSearchForm
-                       ), name='haystack_search'))
+urlpatterns = patterns('haystack.views', url(r'^$', CustomSearchView.as_view(), name='haystack_search'))
 
 urlpatterns += patterns('',
                         url(r'^opensearch\.xml$', 'zds.search.views.opensearch')


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | Aucun |

Cette PR propose une migration vers la dernière version de Haystack. Elle n'embarque pas la compatibilité avec [Django 1.9](https://github.com/django-haystack/django-haystack/pull/1277) mais ça devrait être fait bientôt. Cela permettra de passer rapidement à la dernière version de Haystack et supprimer un peu de travail à @gustavi pour le passage à Django 1.9. 

Comme j'ai bougé pas mal de chose, je veux bien une grosse QA:
- Généré des données grâce à la commande « python manage.py loadfixatures »
- Créé des tutoriels et des articles
- Lancer Solr grâce à la commande « java -jar example.jar » dans le dossier « exemple » du dossier d'installation de Solr
  - Lancer les commandes d'indexation: « python manage.py index_content » et « python manage.py rebuild_index »
  - Jouer avec le menu de gauche (les restrictions de recherche)
  - Jouer avec la pagination, aller sur la dernière page, première page, etc.
- Important, créer un sujet et des messages dans un forum accessible qu'au admin, indexer ce sujet puis vérifier qu'on peut y accéder en tant qu'admin mais pas en tant que visiteur ni membre.

Edit: il faut bien sur la commande pour mettre à jours les deps `pip install --upgrade -r requirements.txt -r requirements-dev.txt`
