### PR TITLE
enlève une requête lente car elle récupérait trop de données.

### DIFF
--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -87,7 +87,7 @@
                                                 {% if first_unread %}
                                                     {{ first_unread.get_absolute_url }}
                                                 {% else %}
-                                                    {{ topic.last_read_post.get_absolute_url }}
+                                                    {{ topic.last_read_post.resolve_last_read_post_absolute_url }}
                                                 {% endif %}
                                             {% endwith %}
                                             {% endspaceless %}"

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -71,7 +71,7 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
             .prefetch_related('author__post_disliked')\
             .prefetch_related('alerts')\
             .prefetch_related('alerts__author')\
-            .filter(related_content=self.object)\
+            .filter(related_content__pk=self.object.pk)\
             .order_by("pubdate")
 
         # pagination of articles
@@ -114,7 +114,7 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
             context["is_js"] = False
 
         # optimize requests:
-        reaction_ids = [reaction.pk for reaction in queryset_reactions]
+        reaction_ids = list(set([reaction.pk for reaction in context['reactions']]))
         context["user_dislike"] = CommentDislike.objects\
             .select_related('note')\
             .filter(user__pk=self.request.user.pk, comments__pk__in=reaction_ids)\
@@ -377,8 +377,6 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
             .select_related('author')\
             .select_related('author__profile')\
             .select_related('editor')\
-            .prefetch_related('author__post_liked')\
-            .prefetch_related('author__post_disliked')\
             .prefetch_related('alerts')\
             .prefetch_related('alerts__author')\
             .filter(related_content=self.object)\

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -67,8 +67,6 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
             .select_related('author')\
             .select_related('author__profile')\
             .select_related('editor')\
-            .prefetch_related('author__post_liked')\
-            .prefetch_related('author__post_disliked')\
             .prefetch_related('alerts')\
             .prefetch_related('alerts__author')\
             .filter(related_content__pk=self.object.pk)\
@@ -114,18 +112,18 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
             context["is_js"] = False
 
         # optimize requests:
-        reaction_ids = list(set([reaction.pk for reaction in context['reactions']]))
+
         context["user_dislike"] = CommentDislike.objects\
             .select_related('note')\
-            .filter(user__pk=self.request.user.pk, comments__pk__in=reaction_ids)\
+            .filter(user__pk=self.request.user.pk, comments__in=context['reactions'])\
             .values_list('comments__pk', flat=True)
         context["user_like"] = CommentLike.objects\
             .select_related('note')\
-            .filter(user__pk=self.request.user.pk, comments__pk__in=reaction_ids)\
+            .filter(user__pk=self.request.user.pk, comments__in=context['reactions'])\
             .values_list('comments__pk', flat=True)
 
         if self.request.user.has_perm('tutorialv2.change_contentreaction'):
-            context["user_can_modify"] = reaction_ids
+            context["user_can_modify"] = [reaction.pk for reaction in context['reactions']]
         else:
             queryset_reactions_user = ContentReaction.objects\
                 .filter(author__pk=self.request.user.pk, related_content__pk=self.object.pk)\


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [IRC, #3134] |

enlève une requête lente car elle récupérait trop de données.

il faut vérifier que les +/- fonctionnent encore (le cas typique c'est qu'il ne sont pas pris en compte à la regenération de la page ou que le pouce n'apparait jamais vert)
