### PR TITLE
Réduit la requête de la topbar

### DIFF
--- a/zds/utils/templatetags/topbar.py
+++ b/zds/utils/templatetags/topbar.py
@@ -1,15 +1,13 @@
 # coding: utf-8
 
 from collections import OrderedDict
-import itertools
-
 from django import template
 from django.conf import settings
 
 from zds.forum.models import Forum, Topic
 from zds.tutorialv2.models.models_database import PublishedContent
-from zds.utils.models import CategorySubCategory, Tag
-
+from zds.utils.models import CategorySubCategory
+from django.db.models import Count
 
 register = template.Library()
 
@@ -35,29 +33,12 @@ def top_categories(user):
         else:
             cats[key] = [forum]
 
-    tgs = Topic.objects\
-        .values('tags', 'pk')\
+    tags = Topic.objects\
+        .values_list('tags', flat=True)\
         .distinct()\
-        .filter(forum__in=forums, tags__isnull=False)
-
-    cts = {}
-    for key, group in itertools.groupby(tgs, lambda item: item["tags"]):
-        for thing in group:
-            if key in cts:
-                cts[key] += 1
-            else:
-                cts[key] = 1
-
-    cpt = 0
-    top_tag = []
-    sort_list = reversed(sorted(cts.iteritems(), key=lambda k_v: (k_v[1], k_v[0])))
-    for key, value in sort_list:
-        top_tag.append(key)
-        cpt += 1
-        if cpt >= settings.ZDS_APP['forum']['top_tag_max']:
-            break
-
-    tags = Tag.objects.filter(pk__in=top_tag)
+        .filter(forum__in=forums, tags__isnull=False)\
+        .annotate(nb_tags=Count("tags"))\
+        .order_by("-nb_tags")[:settings.ZDS_APP['forum']['top_tag_max']]
 
     return {"tags": tags, "categories": cats}
 

--- a/zds/utils/templatetags/topbar.py
+++ b/zds/utils/templatetags/topbar.py
@@ -6,7 +6,7 @@ from django.conf import settings
 
 from zds.forum.models import Forum, Topic
 from zds.tutorialv2.models.models_database import PublishedContent
-from zds.utils.models import CategorySubCategory
+from zds.utils.models import CategorySubCategory, Tag
 from django.db.models import Count
 
 register = template.Library()
@@ -34,13 +34,13 @@ def top_categories(user):
             cats[key] = [forum]
 
     tags = Topic.objects\
-        .values_list('tags', flat=True)\
+        .values_list('tags__pk', flat=True)\
         .distinct()\
         .filter(forum__in=forums, tags__isnull=False)\
         .annotate(nb_tags=Count("tags"))\
         .order_by("-nb_tags")[:settings.ZDS_APP['forum']['top_tag_max']]
 
-    return {"tags": tags, "categories": cats}
+    return {"tags": Tag.objects.filter(pk__in=[pk for pk in tags]), "categories": cats}
 
 
 @register.filter('top_categories_content')


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [non] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [] |

Notre topbar prenant exemple sur maven (la moitié d'internet tout ça...) j'ai donc modifié l'enchaînement de base de l'ORM pour que ça soit SQL qui fasse les calculs et qu'on se tappe pas les 10K tags et quelques à chaque fois.
