### PR TITLE
Rewrite du module de modales

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -169,7 +169,7 @@ gulp.task("jshint", function() {
  * Merge vendors and app scripts
  */
 gulp.task("merge-scripts", ["vendors", "scripts"], function() {
-  return gulp.src(path.join(destDir, scriptsDir, "{vendors,main}.js"))
+  return gulp.src([path.join(destDir, scriptsDir, "vendors.js"), path.join(destDir, scriptsDir, "main.js")])
     .pipe($.sourcemaps.init({ loadMaps: true }))
       .pipe($.concat("all.js"))
     .pipe($.sourcemaps.write(".", { includeContent: true, sourceRoot: path.join("../../", sourceDir, scriptsDir) }))

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -93,11 +93,12 @@
         titles: {
             "link" :    "Lien hypertexte",
             "abbr" :    "Abréviation",
-            "image":    "Image"
+            "image":    "Image",
         },
 
         init: function() {
-            var listTexta = document.getElementsByTagName("textarea");
+            var self = this,
+                listTexta = document.getElementsByTagName("textarea");
 
             for (var i=0, c=listTexta.length; i<c; i++) {
                 if (/md.editor/.test(listTexta[i].className)) {
@@ -116,81 +117,52 @@
                 };
             }) (this));
 
-            var overlay = document.body.appendChild(document.createElement("div"));
-                overlay.id = "zform-modal-overlay";
+            var validateButton = document.createElement("a");
+            validateButton.className = "btn btn-submit";
+            validateButton.innerHTML = "Valider";
 
-            var wrapper = document.body.appendChild(document.createElement("div"));
-                wrapper.id = "zform-modal-wrapper";
+            function buildButton(type) {
+                var btn = validateButton.cloneNode(true);
+                btn.addEventListener("click", self.validatePopup.bind(self, type));
+                return btn;
+            }
 
-            wrapper.innerHTML =
-            "<div>" +
-                "<header id=\"zform-modal-header\"></header>" +
+            this.modals = {};
+            this.modals.link = new window.Modal({
+                "title": this.titles.link,
+                "body": "<div>" +
+                            "<label for=zform-modal-link-href>Lien :</label>" +
+                            "<input type=text id=zform-modal-link-href />" +
+                        "</div><div>" +
+                            "<label for=zform-modal-link-text>Texte :</label>" +
+                            "<input type=text id=zform-modal-link-text />" +
+                        "</div>",
+                "footer": buildButton("link")
+            });
 
-                "<section class=\"zform-modal\" id=\"zform-modal-link\">" +
-                    "<div>" +
-                        "<label for=\"zform-modal-link-href\">Lien :</label>" +
-                        "<input type=\"text\" id=\"zform-modal-link-href\" />" +
-                    "</div>" +
+            this.modals.image = new window.Modal({
+                "title": this.titles.image,
+                "body": "<div>" +
+                            "<label for=zform-modal-image-src>URL :</label>" +
+                            "<input type=text id=zform-modal-image-src />" +
+                        "</div><div>" +
+                            "<label for=zform-modal-image-text>Texte :</label>" +
+                            "<input type=text id=zform-modal-image-text />" +
+                        "</div>",
+                "footer": buildButton("image")
+            });
 
-                    "<div>" +
-                        "<label for=\"zform-modal-link-text\">Texte :</label>" +
-                        "<input type=\"text\" id=\"zform-modal-link-text\" />" +
-                    "</div>" +
-                "</section>" +
-
-                "<section class=\"zform-modal\" id=\"zform-modal-image\">" +
-                    "<div>" +
-                        "<label for=\"zform-modal-image-src\">URL :</label>" +
-                        "<input type=\"text\" id=\"zform-modal-image-src\" />" +
-                    "</div>" +
-
-                    "<div>" +
-                        "<label for=\"zform-modal-image-text\">Texte :</label>" +
-                        "<input type=\"text\" id=\"zform-modal-image-text\" />" +
-                    "</div>" +
-                "</section>" +
-
-                "<section class=\"zform-modal\" id=\"zform-modal-abbr\">" +
-                    "<div>" +
-                        "<label for=\"zform-modal-abbr-abbr\">Abréviation :</label>" +
-                        "<input type=\"text\" id=\"zform-modal-abbr-abbr\" />" +
-                    "</div>" +
-
-                    "<div>" +
-                        "<label for=\"zform-modal-abbr-text\">Texte :</label>" +
-                        "<input type=\"text\" id=\"zform-modal-abbr-text\" />" +
-                    "</div>" +
-                "</section>" +
-
-                "<section class=\"zform-modal\" id=\"zform-modal-footnote\">" +
-                    "<div>" +
-                        "<label for=\"zform-modal-footnote-guid\">Identifiant :</label>" +
-                        "<input type=\"text\" id=\"zform-modal-footnote-guid\" />" +
-                    "</div>" +
-
-                    "<div>" +
-                        "<label for=\"zform-modal-footnote-text\">Texte :</label>" +
-                    "</div>" +
-
-                    "<div>" +
-                        "<textarea id=\"zform-modal-footnote-text\"></textarea>" +
-                    "</div>" +
-                "</section>" +
-
-                "<footer><a id=\"zform-modal-validate\" class=\"btn btn-submit\">Valider</a> <a id=\"zform-modal-cancel\" class=\"btn btn-cancel secondary tiny\">Annuler</a></footer>" +
-            "</div>";
-
-            this.addEvent(document.getElementById("zform-modal-validate"), "click", (function(_this) {
-                return function() {
-                    _this.validatePopup();
-                };
-            }) (this));
-
-            this.addEvent(document.getElementById("zform-modal-cancel"), "click", (function(_this) {
-                return function() {
-                    _this.closePopup();
-                };
-            }) (this));
+            this.modals.abbr = new window.Modal({
+                "title": this.titles.abbr,
+                "body": "<div>" +
+                            "<label for=zform-modal-abbr-abbr>Abbréviation :</label>" +
+                            "<input type=text id=zform-modal-abbr-abbr />" +
+                        "</div><div>" +
+                            "<label for=zform-modal-abbr-text>Texte :</label>" +
+                            "<input type=text id=zform-modal-abbr-text />" +
+                        "</div>",
+                "footer": buildButton("abbr")
+            });
         },
 
         setup: function(textareaId) {
@@ -278,36 +250,21 @@
         },
 
         openPopup: function(popupGuid) {
-            this.closePopup();
-
-            document.getElementById("zform-modal-overlay").style.display = "block";
-            document.getElementById("zform-modal-wrapper").style.display = "block";
-
-            document.getElementById("zform-modal-header").innerHTML = this.titles[popupGuid] || "Markdown";
-
-            document.getElementById("zform-modal-" + popupGuid).style.display = "block";
+            this.modals[popupGuid].open();
 
             return false;
         },
 
         closePopup: function() {
-            var modals = document.getElementsByTagName("section");
-
-            for (var i=0, c=modals.length; i<c; i++) {
-                if (modals[i].className === "zform-modal") {
-                    modals[i].style.display = "none";
-                }
-            }
-
-            document.getElementById("zform-modal-overlay").style.display = "none";
-            document.getElementById("zform-modal-wrapper").style.display = "none";
+            window.Modal.closeCurrent();
         },
 
-        validatePopup: function() {
+        validatePopup: function(type) {
             //var wrapper = document.getElementById("zform-modal-wrapper");
+            type = type || this.selection.type;
 
             if (this.selection && this.selection.type) {
-                this.wrap("___", "+++", this.selection.textareaId, this.selection.type, null, true);
+                this.wrap("___", "+++", this.selection.textareaId, type, null, true);
             }
 
             this.closePopup();

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -120,6 +120,7 @@
             var validateButton = document.createElement("a");
             validateButton.className = "btn btn-submit";
             validateButton.innerHTML = "Valider";
+            validateButton.href = "#";
 
             function buildButton(type) {
                 var btn = validateButton.cloneNode(true);

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -51,6 +51,11 @@
                 if(Modal.current && e.which === 27){
                     Modal.closeCurrent();
                     e.stopPropagation();
+                } else if(Modal.current && e.which === 13) {
+                    if(document.activeElement.tagName !== "TEXTAREA" || e.ctrlKey) {
+                        var elem = Modal.current.footer.find(".btn-submit").get(0);
+                        if(elem) elem.click();
+                    }
                 }
             });
         },

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -1,7 +1,5 @@
 /* ===== Zeste de Savoir ====================================================
    Manage modals boxes
-   ---------------------------------
-   Author: Alex-D / Alexandre Demode
    ========================================================================== */
 
 (function(document, $, undefined) {
@@ -24,9 +22,9 @@
     };
 
     Modal.openModal = function(id) {
-       if(Modal.list[id]) {
-           Modal.list[id].open();
-       }
+        if(Modal.list[id]) {
+            Modal.list[id].open();
+        }
     };
 
     Modal.prototype = {
@@ -64,9 +62,13 @@
             this.modal = this.options.modal || $("<div>", { class: "modal modal-flex" });
             this.id = this.modal.attr("id") || "noid-" + (Modal.nextId++);
             this.title = $("<div>", {
-                class: "modal-title" + this.options.titleIcon,
+                class: "modal-title",
                 text: this.options.title
             });
+
+            if(this.options.titleIcon) {
+                this.title.addClass(this.options.titleIcon + " ico-after");
+            }
 
             this.body = $("<div>", {
                 class: "modal-body"
@@ -110,7 +112,14 @@
     function buildModals($elems){
         $elems.each(function(){
             var $link = $("[href=#"+$(this).attr("id")+"]:first");
-            var linkIco = $link.hasClass("ico-after") ? " light " + $link.attr("class").replace(/btn[a-z-]*/g, "") : "";
+
+            var linkIco = "";
+            if($link.hasClass("ico-after")) {
+                linkIco = $link.attr("class").split(" ").concat(["light"]).filter(function(c) {
+                    return ["", "ico-after", "open-modal", "blue"].indexOf(c) === -1 && c.indexOf("btn-") === -1;
+                }).join(" ");
+            }
+
             new Modal({
                 title: $link.text(),
                 footer: $(this).find(".btn, [type=submit]").filter(":not(.modal-inner)").detach(),

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -4,69 +4,129 @@
    Author: Alex-D / Alexandre Demode
    ========================================================================== */
 
-(function(document, $, undefined){
+(function(document, $, undefined) {
     "use strict";
-    
+
+    var Modal = function(options) {
+        this.options = $.extend(options, {
+            titleIcon: "",
+            closeText: "Annuler"
+        });
+        if(!Modal._initialized) this.firstRun();
+        this.init();
+    };
+
+    Modal.closeCurrent = function() {
+        Modal.current.modal.removeClass("open");
+        Modal.container.removeClass("open");
+        $("html").removeClass("dropdown-active");
+        Modal.current = null;
+    };
+
+    Modal.openModal = function(id) {
+       if(Modal.list[id]) {
+           Modal.list[id].open();
+       }
+    };
+
+    Modal.prototype = {
+        firstRun: function() {
+            Modal.container = $("<div>", { class: "modals-container" });
+            Modal.wrapper = $("<div>", { class: "modals-wrapper" });
+            Modal.overlay = $("<div>", { class: "modals-overlay" });
+            Modal.container.append(Modal.wrapper).append(Modal.overlay).appendTo($("body"));
+            Modal.list = [];
+            Modal._initialized = true;
+            Modal.nextId = 0;
+
+            Modal.overlay.on("click", Modal.closeCurrent);
+
+            $("body").on("click", ".open-modal", function(e) {
+                Modal.openModal($(this).attr("href").substring(1));
+
+                e.preventDefault();
+                e.stopPropagation();
+            }).on("keydown", function(e) {
+                // Escape close modal
+                if(Modal.current && e.which === 27){
+                    Modal.closeCurrent();
+                    e.stopPropagation();
+                }
+            });
+        },
+
+        init: function() {
+            this.modal = this.options.modal || $("<div>", { class: "modal modal-flex" });
+            this.id = this.modal.attr("id") || "noid-" + (Modal.nextId++);
+            this.title = $("<div>", {
+                class: "modal-title" + this.options.titleIcon,
+                text: this.options.title
+            });
+
+            this.body = $("<div>", {
+                class: "modal-body"
+            }).append(this.options.body);
+
+            this.footer = $("<div>", {
+                class: "modal-footer"
+            }).append(this.options.footer).append($("<a>", {
+                class: "btn btn-cancel",
+                href: "#close-modal",
+                text: this.options.closeText,
+                click: function(e){
+                    Modal.closeCurrent();
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            }));
+
+            this.modal.addClass("tab-modalize").append(this.title, this.body, this.footer).appendTo(Modal.wrapper);
+
+            Modal.list[this.id] = this;
+        },
+
+        open: function() {
+            if(Modal.current) Modal.closeCurrent();
+            this.modal.addClass("open");
+            Modal.container.addClass("open");
+
+            Modal.current = this;
+
+            this.body.find("input:visible, select, textarea").first().focus();
+            if(!$("html").hasClass("enable-mobile-menu"))
+                $("html").addClass("dropdown-active");
+        },
+
+        close: function() {
+            Modal.closeCurrent();
+        }
+    };
+
+    /*
     var $overlay = $("<div/>", {
         "id": "modals-overlay"
     }).on("click", function(e){
         closeModal();
         e.preventDefault();
         e.stopPropagation();
-    });
-
-    var $modals = $("<div/>", { "id": "modals" });
-    $("body").append($modals);
-    $modals.append($overlay);
+    });*/
 
     function buildModals($elems){
         $elems.each(function(){
-            $modals.append($(this).addClass("tab-modalize"));
-            $(this).append($("<a/>", {
-                class: "btn btn-cancel " + ($(this).is("[data-modal-close]") ? "btn-modal-fullwidth" : ""),
-                href: "#close-modal",
-                text: $(this).is("[data-modal-close]") ? $(this).attr("data-modal-close") : "Annuler",
-                click: function(e){
-                    closeModal();
-                    e.preventDefault();
-                    e.stopPropagation();
-                }
-            }));
             var $link = $("[href=#"+$(this).attr("id")+"]:first");
             var linkIco = $link.hasClass("ico-after") ? " light " + $link.attr("class").replace(/btn[a-z-]*/g, "") : "";
-            $(this).prepend($("<span/>", {
-                class: "modal-title" + linkIco,
-                text: $link.text()
-            }));
+            new Modal({
+                title: $link.text(),
+                footer: $(this).find(".btn, [type=submit]").detach(),
+                body: $(this).children(),
+                modal: $(this),
+                closeText: $(this).is("[data-modal-close]") ? $(this).attr("data-modal-close") : "Annuler",
+                titleIcon: linkIco
+            });
         });
     }
 
-    $("body").on("click", ".open-modal", function(e){
-        $overlay.show();
-        $($(this).attr("href")).show(0, function(){
-            $(this).find("input:visible, select, textarea").first().focus();
-        });
-        if(!$("html").hasClass("enable-mobile-menu"))
-            $("html").addClass("dropdown-active");
-
-        e.preventDefault();
-        e.stopPropagation();
-    });
-
-    $("body").on("keydown", function(e){
-        // Escape close modal
-        if($(".modal:visible", $modals).length > 0 && e.which === 27){
-            closeModal();
-            e.stopPropagation();
-        }
-    });
-
-    function closeModal(){
-        $(".modal:visible", $modals).fadeOut(150);
-        $overlay.fadeOut(150);
-        $("html").removeClass("dropdown-active");
-    }
-
+    window.Modal = Modal;
 
     $(document).ready(function(){
         buildModals($(".modal"));

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -108,7 +108,7 @@
             var linkIco = $link.hasClass("ico-after") ? " light " + $link.attr("class").replace(/btn[a-z-]*/g, "") : "";
             new Modal({
                 title: $link.text(),
-                footer: $(this).find(".btn, [type=submit]").detach(),
+                footer: $(this).find(".btn, [type=submit]").filter(":not(.modal-inner)").detach(),
                 body: $(this).children(),
                 modal: $(this),
                 closeText: $(this).is("[data-modal-close]") ? $(this).attr("data-modal-close") : "Annuler",

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -5,6 +5,18 @@
 (function(document, $, undefined) {
     "use strict";
 
+    /**
+     * Create a new Modal
+     *
+     * @constructor
+     * @param {Object} options
+     * @param {string} options.title
+     * @param {(Node|jQuery)} options.body
+     * @param {(Node|jQuery)} options.footer
+     * @param {string} [options.titleIcon=""] - Icon to add to the title
+     * @param {string} [options.closeText="Annuler"] - The text of the close button
+     * @param {(Node|jQuery)} [options.modal] - The modal element to wrap the content
+     */
     var Modal = function(options) {
         this.options = $.extend({
             titleIcon: "",
@@ -14,6 +26,11 @@
         this.init();
     };
 
+    /**
+     * Close the current modal
+     *
+     * @static
+     */
     Modal.closeCurrent = function() {
         Modal.current.modal.removeClass("open");
         Modal.container.removeClass("open");
@@ -21,6 +38,12 @@
         Modal.current = null;
     };
 
+    /**
+     * Open a modal
+     *
+     * @static
+     * @param {string} id - The id of the modal to open
+     */
     Modal.openModal = function(id) {
         if(Modal.list[id]) {
             Modal.list[id].open();
@@ -28,11 +51,32 @@
     };
 
     Modal.prototype = {
+        /**
+         * To be run on first modal creation
+         *
+         * @access private
+         */
         firstRun: function() {
+            /**
+             * The Node that contains all the modals and the overlay
+             * @type {jQuery}
+             */
             Modal.container = $("<div>", { class: "modals-container" });
+            /**
+             * The Node that wrap all the modals
+             * @type {jQuery}
+             */
             Modal.wrapper = $("<div>", { class: "modals-wrapper" });
+            /**
+             * The overlay
+             * @type {jQuery}
+             */
             Modal.overlay = $("<div>", { class: "modals-overlay" });
             Modal.container.append(Modal.wrapper).append(Modal.overlay).appendTo($("body"));
+            /**
+             * The list of all the modals
+             * @type {Modal[]}
+             */
             Modal.list = [];
             Modal._initialized = true;
             Modal.nextId = 0;
@@ -58,9 +102,26 @@
             });
         },
 
+        /**
+         * Initialize a Modal
+         *
+         * @access private
+         */
         init: function() {
+            /**
+             * The modal DOM Node
+             * @member {jQuery}
+             */
             this.modal = this.options.modal || $("<div>", { class: "modal modal-flex" });
+            /**
+             * The ID of the modal
+             * @member {string}
+             */
             this.id = this.modal.attr("id") || "noid-" + (Modal.nextId++);
+            /**
+             * The title of the modal
+             * @member {jQuery}
+             */
             this.title = $("<div>", {
                 class: "modal-title",
                 text: this.options.title
@@ -70,10 +131,18 @@
                 this.title.addClass(this.options.titleIcon + " ico-after");
             }
 
+            /**
+             * The body of the modal
+             * @member {jQuery}
+             */
             this.body = $("<div>", {
                 class: "modal-body"
             }).append(this.options.body);
 
+            /**
+             * The footer of the modal (contains the buttons)
+             * @member {jQuery}
+             */
             this.footer = $("<div>", {
                 class: "modal-footer"
             }).append(this.options.footer).append($("<a>", {
@@ -92,6 +161,9 @@
             Modal.list[this.id] = this;
         },
 
+        /**
+         * Open the Modal
+         */
         open: function() {
             if(Modal.current) Modal.closeCurrent();
             this.modal.addClass("open");
@@ -104,11 +176,19 @@
                 $("html").addClass("dropdown-active");
         },
 
+        /**
+         * Close the Modal
+         */
         close: function() {
             Modal.closeCurrent();
         }
     };
 
+    /**
+     * Build the modal from the given elements
+     *
+     * @param {jQuery} $elems
+     */
     function buildModals($elems){
         $elems.each(function(){
             var $link = $("[href=#"+$(this).attr("id")+"]:first");

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -8,10 +8,10 @@
     "use strict";
 
     var Modal = function(options) {
-        this.options = $.extend(options, {
+        this.options = $.extend({
             titleIcon: "",
             closeText: "Annuler"
-        });
+        }, options);
         if(!Modal._initialized) this.firstRun();
         this.init();
     };
@@ -101,15 +101,6 @@
             Modal.closeCurrent();
         }
     };
-
-    /*
-    var $overlay = $("<div/>", {
-        "id": "modals-overlay"
-    }).on("click", function(e){
-        closeModal();
-        e.preventDefault();
-        e.stopPropagation();
-    });*/
 
     function buildModals($elems){
         $elems.each(function(){

--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -238,7 +238,9 @@
         margin: 0 auto;
         text-align: center;
     }
+}
 
+.content-container {
     .btn-holder,
     .buttonHolder /* specifix for crispy */ {
         margin-top: 25px;
@@ -248,7 +250,7 @@
 
 .wf-active {
     .content-container,
-    #modals {
+    .modals-container {
         textarea {
             font-family: $font-monospace-active;
         }
@@ -256,7 +258,7 @@
 }
 
 .main-container,
-#modals {
+.modals-container {
     input[type=radio],
     input[type=checkbox] {
         float: left;
@@ -299,7 +301,7 @@
 
 @media only screen and #{$media-wide} {
     .content-container,
-    #modals {
+    .modals-container {
         form.content-wrapper {
             margin: 0;
             width: 100%;

--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -1,5 +1,5 @@
 .content-container,
-#modals {
+.modals-container {
     form {
         width: 100%;
 

--- a/assets/scss/base/_icons.scss
+++ b/assets/scss/base/_icons.scss
@@ -17,8 +17,16 @@
         @include sprite();
     }
 
-    &.alert:after {
-        @include sprite-position($alert);
+    &.alert {
+        &:after {
+            @include sprite-position($alert);
+        }
+        &.blue:after {
+            @include sprite-position($alert-blue);
+        }
+        &.light:after {
+            @include sprite-position($alert-light);
+        }
     }
 
     &.arrow-left {

--- a/assets/scss/components/_autocomplete.scss
+++ b/assets/scss/components/_autocomplete.scss
@@ -30,6 +30,5 @@
 }
 
 .modal .autocomplete-dropdown {
-    margin-top: -10px;
-    margin-left: 15px;
+    margin-top: -15px;
 }

--- a/assets/scss/components/_editor.scss
+++ b/assets/scss/components/_editor.scss
@@ -34,7 +34,7 @@
             left: 12px;
             // TODO : remake icons
             display: none;
-        }        
+        }
     }
     button {
         padding: 0 15px;
@@ -42,7 +42,7 @@
         border-top: none;
         border-right: none;
         border-left: none;
-        
+
         &[type=submit] {
             background: #084561;
             border-bottom-color: #084561;
@@ -109,7 +109,7 @@
 div.zform-popup {
     top: 18px;
     z-index: 100;
-    background: transparent;    
+    background: transparent;
     background-color: #fff;
     background-image: linear-gradient(center bottom , #EBEBE5 8%, #F9F9F6 75%);
     border: 1px solid #CCCCCC;
@@ -140,150 +140,5 @@ div.zform-popup {
         &:focus {
             color: #C87B02;
         }
-    }
-}
-
-
-
-/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   Modal box
-   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-/* Overlay gris clair */
-#zform-modal-overlay {
-    position: fixed; 
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: #000;
-    opacity: 0.5;
-    filter: alpha(opacity=50);
-    display: none;
-    z-index: 99;
-}
-
-/* HTML Structure
-====================================================================================
-<div id="zform-modal-wrapper">
-    <div>
-        <header id="zform-modal-header"></header>
-        
-        <section class="zform-modal" id="zform-modal-link">
-            <div>
-                <label for="zform-modal-link-href">Lien :</label>
-                <input type="text" id="zform-modal-link-href" />
-            </div>
-            
-            <div>
-                <label for="zform-modal-link-text">Texte :</label>
-                <input type="text" id="zform-modal-link-text" />
-            </div>
-        </section>
-        
-        <section class="zform-modal" id="zform-modal-image">...</section>
-        <section class="zform-modal" id="zform-modal-abbr">...</section>
-        <section class="zform-modal" id="zform-modal-footnote">...</section>
-        
-        <footer>
-            <a id="zform-modal-validate">Valider</a>
-            <a id="zform-modal-cancel">Annuler</a>
-        </footer>
-    </div>
-</div>
-==================================================================================== */
-
-/* Modal box container */
-#zform-modal-wrapper {
-    position: fixed; 
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: none;
-    margin-top: 10%;
-    text-align: center; 
-    z-index: 100;
-
-    & > div {
-        position: relative;
-        display: inline-block;
-        text-align: left;
-        background: #f4f6f6;
-        border: 1px solid #555;
-        border-radius: 2px;
-        box-shadow: 0 2px 26px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 0, 0, 0.1);
-        min-height: 220px;
-        min-width: 400px;
-
-        & > header {
-            color: #fff;
-            padding-left: 6px;
-            padding-right: 6px;
-            white-space: nowrap;
-            border-bottom: 3px solid #f8ad32;
-            line-height: 53px;
-            height: 50px;
-            text-indent: 15px;
-            margin-bottom: 20px;
-            background: #084561;
-            font-size: 1.6rem;
-            font-size: 16px;
-            text-shadow: rgba(0,0,0,.75)0 0 3px;
-        }
-    }
-
-    section {
-        display: block;
-        margin: 8px;
-        min-width: 200px;
-        min-height: 50px;
-        div {
-            input {
-                min-width: 260px;
-                margin: 7px 15px;
-            }
-        }
-    }
-
-    .btn,
-    [type=submit] {
-        position: absolute;
-        width: 50%;
-        height: 50px;
-        line-height: 50px;
-        bottom: 0;
-        right: 0;
-        margin: 0 !important;
-        padding: 0 !important;
-        text-align: center;
-        background: none !important;
-        border-top: 1px solid #CCC;
-        color: #333;
-        cursor: pointer;
-
-        &:hover,
-        &:focus {
-            background: #DDD !important;
-        }
-    }
-    .btn-submit,
-    [type=submit] {
-        color: $color-primary;
-        font-weight: bold;
-    }
-    .btn-cancel {
-        right: auto;
-        left: 0;
-        border-right: 1px solid #CCC;
-        color: #555;
-    }
-}
-
-.zform-modal {
-    label {
-        display: inline-block;
-        width: 70px;
-        text-align: left;
     }
 }

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -122,32 +122,16 @@
         }
     }
 }
+
 .enable-mobile-menu .modals-container .modal {
     margin: $modal-margin;
     box-shadow: 0 0 5px #000;
     max-width: 100%;
 
-    &.modal-small,
-    &.modal-medium,
-    &.modal-big,
-    &.modal-flex{
+    &.modal-flex {
         min-width: 400px;
         width: auto;
     }
-
-/*    &.modal-small {
-        height: 220px;
-    }
-    &.modal-medium {
-        height: 250px;
-
-        textarea {
-            height: 80px;
-        }
-    }
-    &.modal-big {
-        height: 320px;
-    }*/
 }
 
 @media only screen and #{$media-wide} {

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -76,8 +76,12 @@
             width: 370px;
         }
 
+        table {
+            margin-top: 0;
+        }
+
         p,
-        input,
+        input:not([type=checkbox]):not([type=radio]),
         select,
         textarea {
             margin: 0 0 15px;

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -69,9 +69,12 @@
     }
 
     .modal-body {
-        padding: 20px 15px 0;
-        min-height: 80px;
+        padding: 20px 15px 5px;
         flex: 1;
+
+        p {
+            width: 370px;
+        }
 
         p,
         input,

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -1,16 +1,51 @@
 .modal {
     display: none;
 }
-#modals .modal {
+
+.modals-container {
+    display: none;
     position: fixed;
-    z-index: 50;
-    width: auto !important;
     top: 0;
-    right: 0;
-    bottom: 0;
     left: 0;
+    height: 100vh;
+    width: 100vw;
+    overflow-y: auto;
+    z-index: 50;
+
+    &.open {
+        display: block;
+    }
+
+    .modals-wrapper {
+        display: flex;
+        width: 100vw;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: space-around;
+        flex-direction: column;
+    }
+
+    .modals-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 1;
+        background-color: rgba(0, 0, 0, 0.7);
+    }
+}
+
+.modals-container .modal {
+    position: relative;
+    z-index: 2;
     background: #EEE;
-    min-height: 220px;
+    flex: 0;
+    flex-direction: column;
+
+    &.open {
+        display: flex;
+    }
 
     .modal-title {
         display: block;
@@ -18,7 +53,6 @@
         line-height: 53px;
         height: 50px;
         text-indent: 15px;
-        margin-bottom: 20px;
         background: $color-primary;
         color: #FFF;
         font-size: 16px;
@@ -34,79 +68,71 @@
         }
     }
 
-    p,
-    input,
-    select,
-    textarea {
-        margin: 10px 15px;
-        resize: none;
+    .modal-body {
+        padding: 20px 15px 0;
+        min-height: 80px;
+        flex: 1;
 
-        &:not([type=checkbox]):not([type=radio]) {
-            width: calc(98% - 32px) !important;
+        p,
+        input,
+        select,
+        textarea {
+            margin: 0 0 15px;
         }
     }
-    label {
-        margin: 0 15px;
-    }
-    textarea {
-        margin-top: 0;
-    }
 
-    .btn:not(.modal-inner),
-    [type=submit]:not(.modal-inner) {
-        position: absolute;
-        width: 50%;
-        height: 50px;
-        line-height: 50px;
-        bottom: 0;
-        right: 0;
-        margin: 0 !important;
-        padding: 0 !important;
-        text-align: center;
-        background: none !important;
+    .modal-footer {
+        display: flex;
         border-top: 1px solid #CCC;
-        color: #333;
-    }
-    .btn-submit:not(.modal-inner),
-    [type=submit]:not(.modal-inner) {
-        height: 51px;
-        color: $color-primary;
-        font-weight: bold;
-    }
-    .btn-cancel {
-        right: auto;
-        left: 0;
-        border-right: 1px solid #CCC;
-        color: #555;
-    }
-    .btn.btn-modal-fullwidth {
-        width: 100%;
-        border-right: none;
-        font-weight: bold;
+        flex-direction: row-reverse;
+
+        & > * {
+            flex: 1;
+            height: 50px;
+            line-height: 50px;
+            margin: 0;
+            padding: 0;
+            text-align: center;
+            background: none!important;
+            color: #333;
+
+            &:not(:first-child) {
+                border-right: 1px solid #CCC;
+            }
+
+            &:only-child {
+                font-weight: bold;
+            }
+        }
+
+        .btn-submit, [type=submit] {
+            color: $color-primary;
+            font-weight: bold;
+        }
+
+        .btn-cancel {
+            color: #555;
+        }
     }
 }
-.enable-mobile-menu #modals .modal {
-    top: $modal-margin;
-    right: $modal-margin;
-    bottom: $modal-margin;
-    left: $modal-margin;
+.enable-mobile-menu .modals-container .modal {
+    margin: $modal-margin;
     box-shadow: 0 0 5px #000;
+    max-width: 100%;
 
     &.modal-small,
     &.modal-medium,
-    &.modal-big {
-        top: 50%;
-        bottom: auto;
-        max-width: 400px;
+    &.modal-big,
+    &.modal-flex{
+        min-width: 400px;
+        width: auto;
     }
 
-    &.modal-small {
+/*    &.modal-small {
         height: 220px;
-        margin: -110px auto 0;
     }
     &.modal-medium {
         height: 250px;
-        margin: -125px auto 0;
 
         textarea {
             height: 80px;
@@ -114,22 +140,11 @@
     }
     &.modal-big {
         height: 320px;
-        margin: -160px auto 0;
-    }
-}
-.enable-mobile-menu #modals-overlay {
-    position: fixed;
-    display: none;
-    z-index: 49;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    background: rgba(0, 0, 0, .7);
+    }*/
 }
 
 @media only screen and #{$media-wide} {
-    .enable-mobile-menu #modals .modal {
+    .enable-mobile-menu .modals-container .modal {
         box-shadow: 0 2px 7px rgba(0, 0, 0, .7);
 
         .modal-title {

--- a/doc/source/front-end/elements-specifiques-au-site.rst
+++ b/doc/source/front-end/elements-specifiques-au-site.rst
@@ -26,7 +26,7 @@ Il arrive souvent d'avoir donc ceci :
 
 .. sourcecode:: html
 
-   <form action="{{ url }}" method="post" id="une-ancre" class="modal">
+   <form action="{{ url }}" method="post" id="une-ancre" class="modal modal-flex">
        Voici un formulaire !
 
        <textarea>Voici un champ de texte...</textarea>
@@ -46,7 +46,7 @@ On peut se dire qu'avec ce code tout va bien fonctionner :
 
 .. sourcecode:: html
 
-   <div id="une-ancre" class="modal">
+   <div id="une-ancre" class="modal modal-flex">
        Une super boîte modale !
    </div>
 
@@ -75,12 +75,31 @@ La création du lien affichant la boîte modale est tout aussi simple : il suffi
 
    Attention, le texte du lien sera le titre de la boîte modale.
 
-Changer la taille de la boîte
------------------------------
+Les tailles des modales
+-----------------------
 
-Par défaut, la boîte modale prend toute la place possible sur l'écran (avec quand même une petite marge). Pour
-spécifier la taille, il faut simplement ajouter une classe CSS (du plus petit au plus grand) : ``modal-small``,
-``modal-medium`` ou ``modal-big``.
+Par défaut, les modales vont prendre tout l'écran en largeur, mais en ajoutant une classe ``modal-flex``, la modale va prendre la taille du contenu, avec comme taille minimum 400px. La modale va automatiquement s'adapter en hauteur et en largeur. Si une modale prend quand même toute la taille en largeur, c'est sûrement que le contenu de votre modale a une taille à 100% !
+
+API Javascript pour manipuler les modales
+-----------------------------------------
+
+Il est possible de créer des modales en Javascript. Exemple:
+
+.. sourcecore:: javascript
+
+  var m = new Modal({
+      title: "Titre de la modale",
+      body: "<p>Contenu de la modale</p>", // Peut être un DOMNode ou un objet jQuery
+      footer: $("<a>", { href: "#", class: "btn btn-submit", text: "Valider" }), // Bouton dans le footer, en plus du bouton annuler
+      closeText: "Fermez-moi !", // Texte du bouton pour fermer. "Annuler" par défaut
+      titleIcon: "light alert", // Ajoute une icone au titre de la modale
+      modal: $("<form>", { action: "/submit", class: "modal modal-flex" }); // Node qui deviendra la modale. Peut-être un formulaire.
+  });
+
+  m.open(); // Ouvre la modale
+  m.close(); // Ferme la modale
+  Modal.current; // Contient la modale courante (utile pour savoir si une modale est ouverte)
+  Modal.closeCurrent(); // Ferme la modale courante
 
 
 La lecture zen

--- a/templates/featured/resource/update.html
+++ b/templates/featured/resource/update.html
@@ -38,7 +38,7 @@
                 <a href="#delete-featured-resource" class="open-modal ico-after cross blue">
                     {% trans "Supprimer la une" %}
                 </a>
-                <form action="{% url "featured-resource-delete" featured_resource.pk %}" method="post" id="delete-featured-resource" class="modal modal-small">
+                <form action="{% url "featured-resource-delete" featured_resource.pk %}" method="post" id="delete-featured-resource" class="modal modal-flex">
                     <p>
                         {% trans "Attention, vous vous apprêtez à supprimer définitivement cette une." %}
                     </p>

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -63,7 +63,7 @@
 
     {% include "misc/paginator.html" with position="top" %}
 
-        <div 
+        <div
             class="alert-box success ico-after tick light {% if not topic.is_solved %}empty{% endif %}"
             data-ajax-output="solve-topic"
         >
@@ -287,9 +287,7 @@
 
                 <li>
                     <a href="#move-topic" class="ico-after arrow-right blue open-modal">{% trans "Déplacer le sujet" %}</a>
-                    <div class="modal modal-small" id="move-topic">
-                        {% crispy form_move %}
-                    </div>
+                    {% crispy form_move %}
                 </li>
             </ul>
         </div>

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -242,7 +242,7 @@
                             {% trans "Fermer le sujet" %}
                         {% endif %}
                     </a>
-                    <form action="{% url 'topic-edit' %}" method="post" id="lock-open-topic-{{ topic.pk }}" class="modal modal-small">
+                    <form action="{% url 'topic-edit' %}" method="post" id="lock-open-topic-{{ topic.pk }}" class="modal modal-flex">
                         <input type="hidden" name="topic" value="{{ topic.pk }}">
                         <input type="hidden" name="nb" value="{{ nb }}">
                         <input type="hidden" name="page" value="{{ nb }}">

--- a/templates/gallery/base.html
+++ b/templates/gallery/base.html
@@ -44,7 +44,7 @@
                                     <a href="#delete-galleries" class="open-modal ico-after cross red">
                                         {% trans "Supprimer la galerie" %}
                                     </a>
-                                    <form action="{% url "zds.gallery.views.modify_gallery" %}" method="post" id="delete-galleries" class="modal modal-small">
+                                    <form action="{% url "zds.gallery.views.modify_gallery" %}" method="post" id="delete-galleries" class="modal modal-flex">
                                             <input
                                                 name="items"
                                                 type="checkbox"

--- a/templates/gallery/gallery/details.html
+++ b/templates/gallery/gallery/details.html
@@ -50,9 +50,7 @@
             {% if gallery_mode.can_write %}
                 <li>
                     <a href="#add-user-modal" class="open-modal ico-after more blue">{% trans "Ajouter un utilisateur" %}</a>
-                    <div id="add-user-modal" class="modal modal-big">
-                        {% crispy form %}
-                    </div>
+                    {% crispy form %}
                 </li>
             {% endif %}
         </ul>

--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -91,12 +91,12 @@
                     <a href="#delete-galleries" class="open-modal ico-after cross red">
                         {% trans "Supprimer les galeries sélectionnées" %}
                     </a>
-                    
-                    <form action="{% url "zds.gallery.views.modify_gallery" %}" method="post" id="delete-galleries" class="modal modal-small">
+
+                    <form action="{% url "zds.gallery.views.modify_gallery" %}" method="post" id="delete-galleries" class="modal modal-flex">
                         <p>
                             {% trans "Attention, vous vous appretez à supprimer toutes les galeries sélectionnées" %}.
                         </p>
-                        
+
                         {% csrf_token %}
                         <button type="submit" name="delete_multi" class="btn">{% trans "Confirmer" %}</button>
                     </form>

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -184,7 +184,7 @@
                             <td>{{ titre }}</td>
                             <td>
                                 <a href="#delete-old-tutorial-{{ id }}" class="btn btn-submit open-modal">{% trans "Supprimer" %}</a>
-                                <div class="modal modal-small" id="delete-old-tutorial-{{ id }}">
+                                <div class="modal modal-flex" id="delete-old-tutorial-{{ id }}">
                                     <p>
                                         {% blocktrans with tutotitle=titre%}
                                             Attention ! Vous êtes sur le point de supprimer le tutoriel "<em>{{ tutotitle }}</em>".
@@ -507,7 +507,7 @@
                         <a href="#ls-temp-{{ profile.pk }}" class="open-modal">
                             {% trans "Lecture seule temporaire" %}
                         </a>
-                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="ls-temp-{{ profile.pk }}" class="modal modal-big">
+                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="ls-temp-{{ profile.pk }}" class="modal modal-flex">
                             <p>
                                 {% blocktrans %}
                                     Pour quelle raison souhaitez-vous mettre ce membre en lecture seule <em>temporairement</em> ?
@@ -525,7 +525,7 @@
                         <a href="#ls-{{ profile.pk }}" class="open-modal">
                             {% trans "Lecture seule" %}
                         </a>
-                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="ls-{{ profile.pk }}" class="modal modal-medium">
+                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="ls-{{ profile.pk }}" class="modal modal-flex">
                             <p>
                                 {% trans "Pour quelle raison souhaitez-vous mettre ce membre en lecture seule" %} ?
                             </p>
@@ -541,7 +541,7 @@
                         <a href="#ls-temp-{{ profile.pk }}" class="open-modal">
                             {% trans "Ôter la lecture seule" %}
                         </a>
-                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="ls-temp-{{ profile.pk }}" class="modal modal-medium">
+                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="ls-temp-{{ profile.pk }}" class="modal modal-flex">
                             <p>
                                 {% blocktrans %}
                                 Pour quelle raison souhaitez-vous <strong>lever la sanction</strong> de ce membre ?
@@ -561,7 +561,7 @@
                         <a href="#ban-temp-{{ profile.pk }}" class="open-modal">
                             {% trans "Bannir temporairement" %}
                         </a>
-                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="ban-temp-{{ profile.pk }}" class="modal modal-big">
+                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="ban-temp-{{ profile.pk }}" class="modal modal-flex">
                             <p>
                                 {% blocktrans %}
                                     Pour quelle raison souhaitez-vous bannir ce membre <em>temporairement</em> ?
@@ -579,7 +579,7 @@
                         <a href="#ban-{{ profile.pk }}" class="open-modal">
                             {% trans "Bannir définitivement" %}
                         </a>
-                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="ban-{{ profile.pk }}" class="modal modal-small">
+                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="ban-{{ profile.pk }}" class="modal modal-flex">
                             <p>
                                 {% trans "Pour quelle raison souhaitez-vous bannir ce membre" %} ?
                             </p>
@@ -595,7 +595,7 @@
                         <a href="#unban-{{ profile.pk }}" class="open-modal">
                             {% trans "Ôter le bannissement" %}
                         </a>
-                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="unban-{{ profile.pk }}" class="modal modal-small">
+                        <form action="{% url "zds.member.views.modify_profile" profile.user.pk %}" method="post" id="unban-{{ profile.pk }}" class="modal modal-flex">
                             <p>
                                 {% trans "Pour quelle raison souhaitez vous lever la sanction de ce membre" %} ?
                             </p>

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -98,9 +98,7 @@
                 {% endif %}
                 </ul>
                 <a href="#karmatiser-modal" class="open-modal">{% trans "Ajouter une remarque" %}</a>
-                <div id="karmatiser-modal" class="modal modal-big">
-                    {% crispy karmaform %}
-                </div>
+                {% crispy karmaform %}
             </div>
         {% endif %}
 
@@ -238,15 +236,10 @@
                     {% endif %}
                     {% if perms.member.change_profile %}
                         <li>
-                            <a href="#link-tuto-{{ profile.pk }}" class="open-modal ico-after tick green">
+                            <a href="#link-tuto-modal" class="open-modal ico-after tick green">
                                 {% trans "Attribuer un tuto SdZ" %}
                             </a>
-                            <div id="link-tuto-{{ profile.pk }}" class="modal modal-small">
-                                <p>
-                                    {% trans "Choisissez un tutoriel du SdZ à attribuer au membre" %}.
-                                </p>
-                                {% crispy form %}
-                            </div>
+                            {% crispy form %}
                         </li>
                     {% endif %}
                     {% if profile.is_private and not perms.member.change_profile %}

--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -90,7 +90,7 @@
         method="post"
         action="{% url "zds.member.views.unregister" %}"
         id="unregister"
-        class="modal modal-small"
+        class="modal modal-flex"
     >
         <p>
             {% trans "C'est votre dernière chance de rester parmi nous" %}...

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -18,13 +18,13 @@
         topic-message
         {% if message.is_useful %}helpful{% endif %}
         {% if is_repeated_message %}repeated{% endif %}
-    " 
+    "
     {% if comment_schema %}
-        itemscope 
+        itemscope
         itemtype="http://schema.org/Comment"
         itemprop="comment"
     {% elif answer_schema %}
-        itemscope 
+        itemscope
         itemtype="http://schema.org/Answer"
         {% if message.is_useful or message.like > message.dislike %}
             itemprop="{% if message.is_useful %}acceptedAnswer{% endif %} {% if message.like > message.dislike %}suggestedAnswer{% endif %}"
@@ -56,7 +56,7 @@
                                     <a href="#hide-message-{{ message.id }}" class="ico-after hide open-modal">
                                         {% trans "Masquer" %}
                                     </a>
-                                    <form action="{{ edit_link|safe }}" method="post" id="hide-message-{{ message.id }}" class="modal modal-medium">
+                                    <form action="{{ edit_link|safe }}" method="post" id="hide-message-{{ message.id }}" class="modal modal-flex">
                                         {% csrf_token %}
                                         {% if perms_change %}
                                             <p>
@@ -92,7 +92,7 @@
                                 <a href="#signal-message-{{ message.id }}" class="ico-after alert open-modal">
                                     {% trans "Signaler" %}
                                 </a>
-                                <form action="{{ edit_link|safe }}" method="post" id="signal-message-{{ message.id }}" class="modal modal-big">
+                                <form action="{{ edit_link|safe }}" method="post" id="signal-message-{{ message.id }}" class="modal modal-flex">
                                     {% csrf_token %}
                                     <label for="signal-message-{{ message.id }}-field">
                                         {% trans "Pour quelle raison signalez-vous ce message" %} ?
@@ -124,7 +124,7 @@
                         <a href="#show-message-{{ message.id }}" class="ico-after hide open-modal">
                             {% trans "Démasquer" %}
                         </a>
-                        <form action="{{ edit_link|safe }}" method="post" id="show-message-{{ message.id }}" class="modal modal-small">
+                        <form action="{{ edit_link|safe }}" method="post" id="show-message-{{ message.id }}" class="modal modal-flex">
                             {% csrf_token %}
                             <p>
                                 {% blocktrans with editor=message.editor %}
@@ -204,12 +204,12 @@
         {% if perms_change %}
             {% for alert in message.alerts.all %}
                 <div class="alert-box error">
-                    {{ alert.pubdate|format_date|capfirst }} {% trans "par" %} 
-                    {% include "misc/member_item.part.html" with member=alert.author %} : 
+                    {{ alert.pubdate|format_date|capfirst }} {% trans "par" %}
+                    {% include "misc/member_item.part.html" with member=alert.author %} :
                     <em class="alert-box-text">{{ alert.text }}</em>
 
                     <a href="#solve-alert-{{ alert.pk }}" class="open-modal close-alert-box close-alert-box-text">{% trans "Résoudre" %}</a>
-                    <form id="solve-alert-{{ alert.pk }}" method="post" action="{{ alert_solve_link }}" class="modal modal-medium">
+                    <form id="solve-alert-{{ alert.pk }}" method="post" action="{{ alert_solve_link }}" class="modal modal-flex">
                         <textarea name="text" class="input" placeholder="Message à envoyer au membre ayant signalé l'alerte"></textarea>
                         <input type="hidden" name="alert_pk" value="{{ alert.pk }}">
 
@@ -313,10 +313,10 @@
                                     {{ message.like }}
                                 </span>
                             </span>
-                            <span 
+                            <span
                                 class="downvote
                                        ico-after
-                                       {% if message.like < message.dislike %}more-voted{% endif %} 
+                                       {% if message.like < message.dislike %}more-voted{% endif %}
                                        {% if message.dislike > 0 %}has-vote{% endif %}"
                                 {% if message.dislike > 0 %}
                                     title="{{ message.dislike }} personne{{ message.dislike|pluralize }} n'{% if message.dislike > 1 %}ont{% else %}a{% endif %} pas trouvé ce message utile"

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -39,7 +39,7 @@
             {% else %}
                 <li>
                     <a href="#pagination-{{ position }}" class="open-modal">...</a>
-                    <form action="." method="get" class="modal modal-small" id="pagination-{{ position }}" data-modal-title='{% trans "Aller à la page" %}...'>
+                    <form action="." method="get" class="modal modal-flex" id="pagination-{{ position }}" data-modal-title='{% trans "Aller à la page" %}...'>
                         {% for key,val in request.GET.iterlists %}
                             {% if key != "page" %}
                                 {% for v in val %}
@@ -58,7 +58,7 @@
                 </li>
             {% endif %}
         {% endfor %}
-        
+
         {% if pages|last > 0 and pages|last != nb %}
             <li class="next">
                 {% with next=nb|add:1 %}

--- a/templates/misc/paginator.html
+++ b/templates/misc/paginator.html
@@ -35,7 +35,7 @@
             {% else %}
                 <li>
                     <a href="#pagination-{{ position }}" class="open-modal">...</a>
-                    <form action="." method="get" class="modal modal-small" id="pagination-{{ position }}" data-modal-title='{% trans "Aller à la page" %}...'>
+                    <form action="." method="get" class="modal modal-flex" id="pagination-{{ position }}" data-modal-title='{% trans "Aller à la page" %}...'>
                         {% for key,val in request.GET.iterlists %}
                             {% if key != "page" %}
                                 {% for v in val %}

--- a/templates/misc/validation.part.html
+++ b/templates/misc/validation.part.html
@@ -60,7 +60,7 @@
             <a href="#view-comment-validator-{{ validation.pk }}" class="open-modal">
                 {% trans "Motif du rejet" %}
             </a>
-            <div class="modal modal-big" id="view-comment-validator-{{ validation.pk }}" data-modal-close="Fermer">
+            <div class="modal modal-flex" id="view-comment-validator-{{ validation.pk }}" data-modal-close="Fermer">
                 <p>
                     {{ validation.comment_validator|emarkdown }}
                 </p>

--- a/templates/misc/validation.part.html
+++ b/templates/misc/validation.part.html
@@ -28,7 +28,7 @@
         <a href="#unreservation-{{ validation.pk }}" class="open-modal">
             {% trans "Annuler la réservation" %}
         </a>
-        <form action="{{ reservation_url }}" method="post" class="modal modal-small" id="unreservation-{{ validation.pk }}">
+        <form action="{{ reservation_url }}" method="post" class="modal modal-flex" id="unreservation-{{ validation.pk }}">
         	{% csrf_token %}
             <p>
                 {% trans "Actuellement réservé par" %} {% include "misc/member_item.part.html" with member=validation.validator %}. <br>
@@ -47,7 +47,7 @@
             <a href="#view-comment-validator-{{ validation.pk }}" class="open-modal">
                 {% trans "Commentaire du validateur" %}
             </a>
-            <div class="modal modal-big" id="view-comment-validator-{{ validation.pk }}" data-modal-close="Fermer">
+            <div class="modal modal-flex" id="view-comment-validator-{{ validation.pk }}" data-modal-close="Fermer">
                 <p>
                     {{ validation.comment_validator }}
                 </p>

--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -94,12 +94,12 @@
                 <a href="#delete-conversations" class="open-modal ico-after cross red">
                     {% trans "Supprimer les conversations sélectionnées" %}
                 </a>
-                
-                <form action="{% url "mp-list-delete" %}" method="post" id="delete-conversations" class="modal modal-small">
+
+                <form action="{% url "mp-list-delete" %}" method="post" id="delete-conversations" class="modal modal-flex">
                     <p>
                         {% trans "Attention, vous vous appretez à supprimer toutes les conversations sélectionnées" %}.
                     </p>
-                    
+
                     {% csrf_token %}
                     <button type="submit" name="delete" class="btn">{% trans "Confirmer" %}</button>
                 </form>

--- a/templates/mp/post/edit.html
+++ b/templates/mp/post/edit.html
@@ -46,7 +46,7 @@
             <ul>
                 <li>
                     <a href="#add-participant" class="open-modal">{% trans "Ajouter un membre" %}</a>
-                    <form action="{% url "mp-edit-participant" topic.pk topic.slug %}" method="post" id="add-participant" class="modal modal-medium">
+                    <form action="{% url "mp-edit-participant" topic.pk topic.slug %}" method="post" id="add-participant" class="modal modal-flex">
                         <p>
                             {% trans "Vous allez rajouter un nouveau membre dans la conversation privé" %}.
                         </p>

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -55,7 +55,7 @@
 
     {% include "misc/paginator.html" with position="top" %}
 
-    
+
     <div>
         {% for message in posts %}
             {% captureas edit_link %}
@@ -71,7 +71,7 @@
             {% else %}
                 {% set False as can_edit %}
             {% endif %}
-    
+
             {% include "misc/message.part.html" with can_hide=False %}
         {% endfor %}
     </div>
@@ -80,7 +80,7 @@
     {% include "misc/paginator.html" with position="bottom" %}
 
 
-    
+
     {% captureas form_action %}
         {% url "private-posts-new" topic.pk topic.slug %}
     {% endcaptureas %}
@@ -99,7 +99,7 @@
                     <a href="#add-participant" class="open-modal ico-after more blue">
                         {% trans "Ajouter un membre" %}
                     </a>
-                    <form action="{% url "mp-edit-participant" topic.pk topic.slug %}" method="post" id="add-participant" class="modal modal-medium">
+                    <form action="{% url "mp-edit-participant" topic.pk topic.slug %}" method="post" id="add-participant" class="modal modal-flex">
                         <p>
                             {% trans "Vous allez rajouter un nouveau membre dans la conversation privée" %}.
                         </p>
@@ -125,7 +125,7 @@
                 <a href="#leave-conversation" class="open-modal ico-after cross blue">
                     {% trans "Quitter la conversation" %}
                 </a>
-                <form action="{% url "mp-delete" topic.pk topic.slug %}" method="post" id="leave-conversation" class="modal modal-small">
+                <form action="{% url "mp-delete" topic.pk topic.slug %}" method="post" id="leave-conversation" class="modal modal-flex">
                     <p>
                         {% trans "Attention, vous vous apprêtez à quitter définitivement cette conversation" %}.
                     </p>

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -27,7 +27,7 @@
                 {% trans "Éditer" %}
             </a>
             <a href="#move-{{ child.slug }}" class="open-modal ico-after move btn btn-grey">{% trans "Déplacer" %}</a>
-                <form action="{% url "content:move-element" %}" method="post" class="modal modal-small" id="move-{{ child.slug }}">
+                <form action="{% url "content:move-element" %}" method="post" class="modal modal-flex" id="move-{{ child.slug }}">
                     <select name="moving_method">
                         <option disabled="disabled">{% trans "Déplacer" %}</option>
                         {% if child.position_in_parent > 1 %}
@@ -39,14 +39,14 @@
                         {% endif %}
                         <option disabled="disabled">&mdash; {% trans "Déplacer avant" %}</option>
                         {% for element in child|target_tree %}
-                                <option value="before:{{element.0}}" 
+                                <option value="before:{{element.0}}"
                                 {% if not element.3 %} disabled {% endif %}>
                                      &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1 }}
                                 </option>
                         {% endfor %}
                         <option disabled="disabled">&mdash; {% trans "Déplacer après" %}</option>
                         {% for element in child|target_tree %}
-                                <option value="after:{{element.0}}" 
+                                <option value="after:{{element.0}}"
                                 {% if not element.3 %} disabled {% endif %}>
                                      &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1 }}
                                 </option>

--- a/templates/tutorialv2/includes/delete.part.html
+++ b/templates/tutorialv2/includes/delete.part.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <a href="#delete-{{ object.slug }}" class="open-modal{% if additional_classes %} {{ additional_classes }}{% endif %}">{% trans "Supprimer" %}</a>
-<form action="{{ object.get_delete_url }}" method="post" id="delete-{{ object.slug }}" class="modal modal-small">
+<form action="{{ object.get_delete_url }}" method="post" id="delete-{{ object.slug }}" class="modal modal-flex">
     <p>
         {% blocktrans with object_title=object.title %}
         Êtes-vous certain de vouloir supprimer <strong>définitivement</strong> « {{ object_title }} » ?

--- a/templates/tutorialv2/includes/reaction_message.part.html
+++ b/templates/tutorialv2/includes/reaction_message.part.html
@@ -18,13 +18,13 @@
         topic-message
         {% if message.is_useful %}helpful{% endif %}
         {% if is_repeated_message %}repeated{% endif %}
-    " 
+    "
     {% if comment_schema %}
-        itemscope 
+        itemscope
         itemtype="http://schema.org/Comment"
         itemprop="comment"
     {% elif answer_schema %}
-        itemscope 
+        itemscope
         itemtype="http://schema.org/Answer"
         {% if message.is_useful or message.like > message.dislike %}
             itemprop="{% if message.is_useful %}acceptedAnswer{% endif %} {% if message.like > message.dislike %}suggestedAnswer{% endif %}"
@@ -56,7 +56,7 @@
                                     <a href="#hide-message-{{ message.id }}" class="ico-after hide open-modal">
                                         {% trans "Masquer" %}
                                     </a>
-                                    <form action="{{ hide_link|safe }}" method="post" id="hide-message-{{ message.id }}" class="modal modal-medium">
+                                    <form action="{{ hide_link|safe }}" method="post" id="hide-message-{{ message.id }}" class="modal modal-flex">
                                         {% csrf_token %}
                                         {% if perms_change %}
                                             <p>
@@ -92,7 +92,7 @@
                                 <a href="#signal-message-{{ message.id }}" class="ico-after alert open-modal">
                                     {% trans "Signaler" %}
                                 </a>
-                                <form action="{{ alert_link|safe }}" method="post" id="signal-message-{{ message.id }}" class="modal modal-big">
+                                <form action="{{ alert_link|safe }}" method="post" id="signal-message-{{ message.id }}" class="modal modal-flex">
                                     {% csrf_token %}
                                     <label for="signal-message-{{ message.id }}-field">
                                         {% trans "Pour quelle raison signalez-vous ce message" %} ?
@@ -124,7 +124,7 @@
                         <a href="#show-message-{{ message.id }}" class="ico-after hide open-modal">
                             {% trans "Démasquer" %}
                         </a>
-                        <form action="{{ show_link|safe }}" method="post" id="show-message-{{ message.id }}" class="modal modal-small">
+                        <form action="{{ show_link|safe }}" method="post" id="show-message-{{ message.id }}" class="modal modal-flex">
                             {% csrf_token %}
                             <p>
                                 {% blocktrans with editor=message.editor %}
@@ -204,12 +204,12 @@
         {% if perms_change %}
             {% for alert in message.alerts.all %}
                 <div class="alert-box error">
-                    {{ alert.pubdate|format_date|capfirst }} {% trans "par" %} 
-                    {% include "misc/member_item.part.html" with member=alert.author %} : 
+                    {{ alert.pubdate|format_date|capfirst }} {% trans "par" %}
+                    {% include "misc/member_item.part.html" with member=alert.author %} :
                     <em class="alert-box-text">{{ alert.text }}</em>
 
                     <a href="#solve-alert-{{ alert.pk }}" class="open-modal close-alert-box close-alert-box-text">{% trans "Résoudre" %}</a>
-                    <form id="solve-alert-{{ alert.pk }}" method="post" action="{{ alert_solve_link }}" class="modal modal-medium">
+                    <form id="solve-alert-{{ alert.pk }}" method="post" action="{{ alert_solve_link }}" class="modal modal-flex">
                         <textarea name="text" class="input" placeholder="Message à envoyer au membre ayant signalé l'alerte"></textarea>
                         <input type="hidden" name="alert_pk" value="{{ alert.pk }}">
 
@@ -315,10 +315,10 @@
                                     {{ message.like }}
                                 </span>
                             </span>
-                            <span 
+                            <span
                                 class="downvote
                                        ico-after
-                                       {% if message.like < message.dislike %}more-voted{% endif %} 
+                                       {% if message.like < message.dislike %}more-voted{% endif %}
                                        {% if message.dislike > 0 %}has-vote{% endif %}"
                                 {% if message.dislike > 0 %}
                                     title="{{ message.dislike }} personne{{ message.dislike|pluralize }} n'{% if message.dislike > 1 %}ont{% else %}a{% endif %} pas trouvé ce message utile"

--- a/templates/tutorialv2/includes/warn_typo.part.html
+++ b/templates/tutorialv2/includes/warn_typo.part.html
@@ -15,8 +15,7 @@
         {% trans "ce chapitre" %}
     {% endif %}
 </a>
-<div class="modal modal-big" id="warn-typo-modal">
-    {% crispy formWarnTypo %}
-</div>
+
+{% crispy formWarnTypo %}
 
 {% endif %}

--- a/templates/tutorialv2/validation/history.html
+++ b/templates/tutorialv2/validation/history.html
@@ -59,7 +59,7 @@
                                 <a href="#view-comment-authors-{{ validation.pk }}" class="open-modal">
                                     {% trans "Message laissé à la validation" %}
                                 </a>
-                                <div class="modal modal-big" id="view-comment-authors-{{ validation.pk }}" data-modal-close="Fermer">
+                                <div class="modal modal-flex" id="view-comment-authors-{{ validation.pk }}" data-modal-close="Fermer">
                                     <p>
                                         {{ validation.comment_authors|emarkdown }}
                                     </p>

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -164,7 +164,7 @@
                         Déplacer <span class="wide">{{ prev }} {{ name }}</span>
                     {% endblocktrans %}
                 </a>
-                <form action="{% url "content:move-element" %}" method="POST" class="modal modal-small" id="move-chapter">
+                <form action="{% url "content:move-element" %}" method="POST" class="modal modal-flex" id="move-chapter">
                     <input type="hidden" name="pk" value="{{ content.pk }}"/>
 
                     <select name="moving_method" class="select-autosubmit">

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -198,7 +198,7 @@
                 <a href="#add-author" class="open-modal ico-after more blue">
                     {% trans "Ajouter un auteur" %}
                 </a>
-                <form action="{% url "content:add-author" content.pk %}" method="post" class="modal modal-small" id="add-author">
+                <form action="{% url "content:add-author" content.pk %}" method="post" class="modal modal-flex" id="add-author">
                     {% csrf_token %}
                     <input type="text" name="username" placeholder="Pseudo de l'utilisateur à ajouter" data-autocomplete="{ 'type': 'single' }">
                     <button type="submit" name="add_author">
@@ -244,7 +244,7 @@
                 <a href="#activ-beta" class="open-modal ico-after beta blue">
                     {% trans "Mettre cette version en bêta" %}
                 </a>
-                <form action="{% url "content:set-beta" content.pk content.slug %}" method="post" class="modal modal-small" id="activ-beta">
+                <form action="{% url "content:set-beta" content.pk content.slug %}" method="post" class="modal modal-flex" id="activ-beta">
                     {% csrf_token %}
                     <input type="hidden" name="version" value="{% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}">
                     <p>
@@ -271,7 +271,7 @@
                     <a href="#update-beta" class="open-modal ico-after beta blue">
                         {% trans "Mettre à jour la bêta avec cette version" %}
                     </a>
-                    <form action="{% url "content:set-beta" content.pk content.slug %}" method="post" class="modal modal-small" id="update-beta">
+                    <form action="{% url "content:set-beta" content.pk content.slug %}" method="post" class="modal modal-flex" id="update-beta">
                         {% csrf_token %}
                         <input type="hidden" name="version" value="{% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}">
                         <p>
@@ -296,7 +296,7 @@
                 <a href="#desactiv-beta" class="open-modal ico-after cross blue">
                     {% trans "Désactiver la bêta" %}
                 </a>
-                <form action="{% url "content:inactive-beta" content.pk content.slug %}" method="post" class="modal modal-small" id="desactiv-beta">
+                <form action="{% url "content:inactive-beta" content.pk content.slug %}" method="post" class="modal modal-flex" id="desactiv-beta">
                     {% csrf_token %}
                     <input type="hidden" name="version" value="{% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}">
                     <p>
@@ -452,7 +452,7 @@
                                         Réservé par <strong>{{ validator_name }}</strong>, le retirer
                                     {% endblocktrans %}
                                 </a>
-                                <form action="{% url "validation:reserve" validation.pk %}" method="post" class="modal modal-small" id="unreservation">
+                                <form action="{% url "validation:reserve" validation.pk %}" method="post" class="modal modal-flex" id="unreservation">
                                     {% csrf_token %}
                                     <p>
                                         {% trans "La validation de ce tutoriel est actuellement réservée par" %} {% include "misc/member_item.part.html" with member=validation.validator %}. {% trans "Êtes-vous certain de vouloir le retirer" %} ?

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -210,11 +210,11 @@
                 <a href="#manage-authors" class="open-modal ico-after gear blue">
                     {% trans "Gérer les auteurs" %}
                 </a>
-                <form action="{% url "content:remove-author" content.pk  %}" method="post" class="modal" id="manage-authors" data-modal-close="Fermer">
+                <form action="{% url "content:remove-author" content.pk  %}" method="post" class="modal modal-flex" id="manage-authors" data-modal-close="Fermer">
                     <table class="fullwidth">
                         <thead>
                             <th>{% trans "Auteur" %}</th>
-                            <th>{% trans "Actions" %}</th>
+                            <th width="100px">{% trans "Actions" %}</th>
                         </thead>
                         <tbody>
                             {% for member in content.authors.all %}
@@ -344,9 +344,7 @@
         {% else %}
             <li>
                 <a href="#cancel-validation" class="open-modal ico-after cross blue">{% trans "Annuler la validation" %}</a>
-                <div class="modal modal-big" id="cancel-validation">
-                    {% crispy formCancel %}
-                </div>
+                {% crispy formCancel %}
             </li>
             {% if not content.is_validation %}
                 <li>
@@ -359,9 +357,7 @@
                 <span class="ico-after tick disabled">{% trans "En attente de validation" %}</span>
             </li>
         {% endif %}
-        <div id="ask-validation" class="modal modal-big">
-            {% crispy formAskValidation %}
-        </div>
+        {% crispy formAskValidation %}
     {% endif %}
 
 
@@ -410,18 +406,14 @@
                         </a>
                     {% endif %}
                 </li>
-                <div id="js-activation" class="modal modal-small">
-                    {% crispy formJs %}
-                </div>
+                {% crispy formJs %}
 
                 {% if content.is_public %}
                     <li>
                         <a href="#unpublish" class="ico-after open-modal cross blue">
                             {% trans "Dépublier" %}
                         </a>
-                        <div class="modal modal-big" id="unpublish">
-                            {% crispy formRevokeValidation %}
-                        </div>
+                        {% crispy formRevokeValidation %}
                     </li>
                 {% endif %}
 
@@ -447,15 +439,11 @@
                             </li>
                             <li>
                                 <a href="#valid-publish" class="open-modal ico-after tick green">{% trans "Valider et publier" %}</a>
-                                <div class="modal modal-big" id="valid-publish">
-                                    {% crispy formValid %}
-                                </div>
+                                {% crispy formValid %}
                             </li>
                             <li>
                                 <a href="#reject" class="open-modal ico-after cross red">{% trans "Rejeter" %}</a>
-                                <div class="modal modal-big" id="reject">
-                                    {% crispy formReject %}
-                                </div>
+                                {% crispy formReject %}
                             </li>
                         {% else %}
                             <li>

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -126,9 +126,7 @@
                     <a href="#unpublish" class="ico-after open-modal cross blue">
                         {% trans "Dépublier" %}
                     </a>
-                    <div class="modal modal-big" id="unpublish">
-                        {% crispy formRevokeValidation %}
-                    </div>
+                    {% crispy formRevokeValidation %}
                 </li>
                 {% endif %}
             </ul>

--- a/templates/tutorialv2/view/history.html
+++ b/templates/tutorialv2/view/history.html
@@ -145,7 +145,7 @@
                                     {% trans "Mettre à jour" %}
                                 {% endif %}
                             </a>
-                            <form action="{% url "content:set-beta" content.pk content.slug %}" method="post" class="modal modal-small" id="activ-beta-{{ commit.hexsha }}">
+                            <form action="{% url "content:set-beta" content.pk content.slug %}" method="post" class="modal modal-flex" id="activ-beta-{{ commit.hexsha }}">
                                 {% csrf_token %}
                                 <input type="hidden" name="version" value="{{ commit.hexsha }}"/>
                                 <p>

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -163,7 +163,8 @@ class MoveTopicForm(forms.Form):
         super(MoveTopicForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_action = reverse('topic-edit')
-        self.helper.form_class = 'content-wrapper'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'move-topic'
         self.helper.form_method = 'post'
 
         self.helper.layout = Layout(

--- a/zds/gallery/forms.py
+++ b/zds/gallery/forms.py
@@ -93,7 +93,8 @@ class UserGalleryForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super(UserGalleryForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.form_class = 'clearfix'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'add-user-modal'
         self.helper.form_action = reverse('zds.gallery.views.modify_gallery')
         self.helper.form_method = 'post'
 

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -38,11 +38,13 @@ class OldTutoForm(forms.Form):
     def __init__(self, profile, *args, **kwargs):
         super(OldTutoForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.form_class = 'content-wrapper'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'link-tuto-modal'
         self.helper.form_method = 'post'
         self.helper.form_action = reverse('zds.member.views.add_oldtuto')
 
         self.helper.layout = Layout(
+            HTML(_(u'<p>Choisissez un tutoriel du SdZ à attribuer au membre</p>')),
             Field('id'),
             Hidden('profile_pk', '{{ profile.pk }}'),
             ButtonHolder(
@@ -666,6 +668,8 @@ class KarmaForm(forms.Form):
         super(KarmaForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_action = reverse('zds.member.views.modify_karma')
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'karmatiser-modal'
         self.helper.form_method = 'post'
 
         self.helper.layout = Layout(

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -561,6 +561,8 @@ class AskValidationForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_action = reverse('validation:ask', kwargs={'pk': content.pk, 'slug': content.slug})
         self.helper.form_method = 'post'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'ask-validation'
 
         self.helper.layout = Layout(
             CommonLayoutModalText(),
@@ -648,6 +650,8 @@ class AcceptValidationForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_action = reverse('validation:accept', kwargs={'pk': validation.pk})
         self.helper.form_method = 'post'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'valid-publish'
 
         self.helper.layout = Layout(
             CommonLayoutModalText(),
@@ -703,6 +707,8 @@ class CancelValidationForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_action = reverse('validation:cancel', kwargs={'pk': validation.pk})
         self.helper.form_method = 'post'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'cancel-validation'
 
         self.helper.layout = Layout(
             HTML("<p>Êtes-vous certain de vouloir annuler la validation de ce contenu ?</p>"),
@@ -768,6 +774,8 @@ class RejectValidationForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_action = reverse('validation:reject', kwargs={'pk': validation.pk})
         self.helper.form_method = 'post'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'reject'
 
         self.helper.layout = Layout(
             CommonLayoutModalText(),
@@ -821,6 +829,8 @@ class RevokeValidationForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_action = reverse('validation:revoke', kwargs={'pk': content.pk, 'slug': content.slug})
         self.helper.form_method = 'post'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'unpublish'
 
         self.helper.layout = Layout(
             CommonLayoutModalText(),
@@ -863,6 +873,8 @@ class JsFiddleActivationForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_action = reverse('content:activate-jsfiddle')
         self.helper.form_method = 'post'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'js-activation'
 
         self.helper.layout = Layout(
             Field('js_support'),
@@ -963,6 +975,8 @@ class WarnTypoForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_action = reverse('content:warn-typo') + '?pk={}'.format(content.pk)
         self.helper.form_method = 'post'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'warn-typo-modal'
         self.helper.layout = Layout(
             Field('target'),
             Field('text'),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #3087 |

Actuellement, les modales ont plusieurs souci, le plus embêtant étant le fait que les modales ont une taille fixe. Cette PR réécrit toute la partie JS de comment sont gérées les modales, et passe les modales en flexbox.

En gros, le flexbox permet d'avoir la modale centrée sans connaître sa taille, et même de gérer le scroll si la fenêtre est trop petite en hauteur, ou la modale trop grande (on utilise déjà des flexbox sur la home, et on a drop le support d'IE9 depuis un moment, donc ça devrait aller niveau support des navigateurs).

Par contre, alors que la taille était avant explicite dans le code (classe `modal-[taille]`), elle est maintenant implicite en fonction de la taille du contenu. Du coup, il faut des tests. Beaucoup de tests. Dans l'idéal, il faudrait tester _toutes_ les modales du sites, et ça fait beaucoup. Du coup, même si cette PR est pas encore totalement finie (doc, clean des anciennes modales), ça serait bien de tester le maximum de modales dans cette PR.

---

Les modales sont maintenant gérées comme des objets que l'on peut construire, avec des méthodes. Du coup, on peut maintenant dans le JS créer une modale à la volée, via:

``` js
var m = new Modal({
  "title": "Ma modale",
  "body": "<p>Le contenu de ma modale</p>", // Ca peut être un objet jQuery aussi
});
m.open();
```

Je vais bien sûr documenter tout ça

---

**Cette PR est assez importante pour débloquer #3281 et #3265**
### Todo
- [x] Passer les modales en flexbox
- [x] API JS pour ouvrir des modales
- [x] Documenter l'API JS
- [x] Tester le maximum d'anciennes modales
- [x] Clean les anciennes modales (typiquement, les classes `modal-*` qui servent plus)
- [x] Passer les modales de l'éditeur par la nouvelle API
### Notes QA
- Build le front
- Tester un maximum de modales existantes (`grep -r modal templates/` peut vous donner une idée de où elles sont utilisées)
- Tester d'agrandir une modale (typiquement, signaler un message -> agrandir la textarea du signalement)
- Tester le scroll des modales (en agrandissant la modale et/ou en réduisant la taille de la fenêtre)
