### PR TITLE
Simplifie les textes de présentation sur la page d'accueil

### DIFF
--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -48,8 +48,12 @@ $content-width: 1145px;
             margin: 0;
             padding: 0;
             color: white;
-            line-height: normal;
             text-align: justify;
+        }
+        p, ul {
+            font-size: 16px;
+            font-size: 1.6rem;
+            color: white;
         }
 
         a:not(.home-description-button) {
@@ -400,6 +404,10 @@ $content-width: 1145px;
                 h2 {
                     font-size: 22px;
                     font-size: 2.2rem;
+                }
+                p, ul {
+                    font-size: 16px;
+                    font-size: 1.6rem;
                 }
             }
             &.connected {

--- a/templates/home.html
+++ b/templates/home.html
@@ -49,48 +49,34 @@
             </section>
             <section class="home-description">
                 <div class="column">
-                    <h2>
-                        {% trans "La connaissance pour tous" %}
-                    </h2>
-                    <p>
+                    <h2>{% trans "La connaissance pour tous" %}</h2>
                     {% blocktrans with site_name=app.site.litteral_name %}
-                        {{site_name}} est un site de <strong>partage de connaissances</strong> sur lequel vous trouverez
-                        des <a href="{{url_tutorials}}">tutoriels de tous niveaux</a>, des
-                        <a href='{{url_articles}}'>articles</a> et des <a href='{{url_forums}}'>forums d'entraide</a>
-                        animés par et pour la communauté. Les sujets abordés sont, pour l'instant, l'informatique et les
-                        sciences, mais nous n'attendons que vous pour élargir les domaines présentés !
+                        <p>{{site_name}}&nbsp;: un site de <strong>partage de connaissances</strong> où vous trouverez,
+                            <strong>gratuitement</strong> et <strong>sans publicité</strong>&nbsp;:</p>
+                        <ul>
+                            <li>des <a href="{{url_tutorials}}">tutoriels de tous niveaux</a>&nbsp;;</li>
+                            <li>des <a href='{{url_articles}}'>articles</a>&nbsp;;</li>
+                            <li>et des <a href='{{url_forums}}'>forums d'entraide</a>.</li>
+                        </ul>
+                        <p>Tout est animé par la communauté, tous les sujets sont abordés&nbsp;!</p>
                     {% endblocktrans %}
-                    </p>
                 </div>
                 <div class="column">
-                    <h2>
-                        {% trans "Partagez vos connaissances" %}
-                    </h2>
-                    <p>
+                    <h2>{% trans "Partagez vos savoirs…" %}</h2>
                     {% blocktrans %}
-                        Tous les membres peuvent écrire et <strong>publier des tutoriels et articles sur le site</strong>.
-                        Pour assurer la qualité et la pédagogie du contenu, l'équipe du site valide chaque cours avant
-                        publication.
+                        <p><strong>Tous les membres</strong> peuvent écrire et <strong>publier des contenus</strong>.</p>
+                        <p>Pour assurer la qualité, l'équipe du site valide chaque tutoriel et article.</p>
                     {% endblocktrans %}
-                    </p>
-                </div>
-                <div class="column">
-                    <h2>
-                        {% trans "Gratuit et sans publicité" %}
-                    </h2>
-                    <p>
-                    {% blocktrans %}
-                        Tout cela est <strong>entièrement gratuit et garanti sans publicité</strong>, le site est géré
-                        et financé par une <a href="{{url_association}}">association</a> à but non lucratif.
-                    {% endblocktrans %}
-                    </p>
-                    {% if app.site.contribute_link %}
-                    <p>
-                        <a class="home-description-button" href="{{ app.site.contribute_link }}">
-                            {% trans "Aider à développer la plateforme" %}
-                        </a>
-                    </p>
-                    {% endif %}
+                    <h2>{% trans "… sur une plate-forme libre" %}</h2>
+                        {% blocktrans %}
+                            <p>Le site est géré et financé par une <a href="{{url_association}}">association</a> à but non lucratif.</p>
+                        {% endblocktrans %}
+                        {% if app.site.contribute_link %}
+                            {% blocktrans %}
+                                <p>Chacun peut  <a href="{{ app.site.contribute_link }}">contribuer au code source</a>
+                                    de la plate-forme, qui est ouvert.</p>
+                            {% endblocktrans %}
+                        {% endif %}
                 </div>
             </section>
         {% endif %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets (_issues_) concernés | Je pensais qu'il y en avait un, mais je ne le retrouve pas |

Aujourd'hui quand un quidam découvre Zeste de Savoir par la page d'accueil, on lui « présente » le site via 3 pavés de textes longs et écrit petit. Autant dire que personne ne doit lire ça.

Le but de cette PR est de rendre cet textes plus simples et percutants, pour présenter notre site au mieux, sans perdre le lecteur à la 3ème seconde de sa visite.

Étant donné mes capacités de design et de présentation SCSS, n'hésitez pas à améliorer la chose…

Rendu :

![capture d ecran de 2016-01-10 00-19-37](https://cloud.githubusercontent.com/assets/5786268/12218970/e19e0240-b730-11e5-8f1b-1cb9d5371d75.png)

**QA :**
1. Vérifier les modifications du texte
2. Vérifier que le changement de design n'a rien cassé sur les différents navigateurs, en différentes tailles, connecté ou non
