### PR TITLE
Indexation delta des forums

### DIFF
--- a/update.md
+++ b/update.md
@@ -372,3 +372,19 @@ Mise à jours de la version de Haystack à la 4.1
 -----------------------------------------------
 
 Pour mettre à jours la librairie, il vous faut lancer la commande `pip install --upgrade -r requirements.txt`
+
+Indexation delta des forums
+---------------------------
+
+Mettre à jour la commande d'indexation, dans `/etc/systemd/system/zds-index-solr.service` :
+
+```
+ExecStart=/opt/zdsenv/bin/python /opt/zdsenv/ZesteDeSavoir/manage.py update_index
+```
+
+devient :
+
+
+```
+ExecStart=/opt/zdsenv/bin/python /opt/zdsenv/ZesteDeSavoir/manage.py update_index --remove --age=1
+```

--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -68,6 +68,9 @@ class TopicEditMixin(object):
             for follower in followers:
                 if not forum.can_read(follower.user):
                     follower.delete()
+
+            # Save topic to update update_index_date
+            topic.save()
             messages.success(request,
                              _(u"Le sujet « {0} » a bien été déplacé dans « {1} ».").format(topic.title, forum.title))
         else:

--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -206,6 +206,10 @@ class PostEditMixin(object):
         post.update = datetime.now()
         post.editor = user
         post.save()
+
+        if post.position == 1:
+            # Save topic to update update_index_date
+            post.topic.save()
         return post
 
 

--- a/zds/forum/migrations/0004_topic_update_index_date.py
+++ b/zds/forum/migrations/0004_topic_update_index_date.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forum', '0003_auto_20151110_1145'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='topic',
+            name='update_index_date',
+            field=models.DateTimeField(default='1000-01-01 00:00:00', auto_now=True, verbose_name=b'Date de derni\xc3\xa8re modification pour la r\xc3\xa9indexation partielle', db_index=True),
+            preserve_default=False,
+        ),
+    ]

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -193,6 +193,10 @@ class Topic(models.Model):
                                      related_name='last_message',
                                      verbose_name='Dernier message')
     pubdate = models.DateTimeField('Date de création', auto_now_add=True)
+    update_index_date = models.DateTimeField(
+        'Date de dernière modification pour la réindexation partielle',
+        auto_now=True,
+        db_index=True)
 
     is_solved = models.BooleanField('Est résolu', default=False, db_index=True)
     is_locked = models.BooleanField('Est verrouillé', default=False, db_index=True)

--- a/zds/forum/search_indexes.py
+++ b/zds/forum/search_indexes.py
@@ -32,6 +32,9 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
     def prepare_tags(self, obj):
         return [tag.title for tag in obj.tags.all()] or None
 
+    def get_updated_field(self):
+        return "update_index_date"
+
 
 class PostIndex(indexes.SearchIndex, indexes.Indexable):
     """Indexes Post data"""
@@ -69,3 +72,6 @@ class PostIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_permissions(self, obj):
         return [group.name for group in obj.topic.forum.group.all()] or "public"
+
+    def get_updated_field(self):
+        return "update_index_date"

--- a/zds/tutorialv2/search_indexes.py
+++ b/zds/tutorialv2/search_indexes.py
@@ -70,9 +70,6 @@ class ContainerIndex(indexes.SearchIndex, indexes.Indexable):
     def get_model(self):
         return SearchIndexContainer
 
-    def get_updated_field(self):
-        return "update_date"
-
     def index_queryset(self, using=None):
         return self.get_model().objects.select_related()
 
@@ -127,9 +124,6 @@ class ExtractIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return SearchIndexExtract
-
-    def get_updated_field(self):
-        return "update_date"
 
     def index_queryset(self, using=None):
         return self.get_model().objects.select_related()

--- a/zds/utils/migrations/0002_comment_update_index_date.py
+++ b/zds/utils/migrations/0002_comment_update_index_date.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('utils', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='comment',
+            name='update_index_date',
+            field=models.DateTimeField(default='1000-01-01 00:00:00', auto_now=True, verbose_name=b'Date de derni\xc3\xa8re modification pour la r\xc3\xa9indexation partielle', db_index=True),
+            preserve_default=False,
+        ),
+    ]

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -145,6 +145,10 @@ class Comment(models.Model):
 
     pubdate = models.DateTimeField('Date de publication', auto_now_add=True, db_index=True)
     update = models.DateTimeField('Date d\'édition', null=True, blank=True)
+    update_index_date = models.DateTimeField(
+        'Date de dernière modification pour la réindexation partielle',
+        auto_now=True,
+        db_index=True)
 
     is_visible = models.BooleanField('Est visible', default=True)
     text_hidden = models.CharField(


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets (_issues_) concernés | #2402 |

Cette PR permet de n'indexer que les topics et messages nouveaux / modifiés. En local, je passe de presque 9 minutes d'indexation à moins de 30 secondes. Les contenus sont eux, toujours indexés en entier à chaque passe.

Il n'y a aucune autre amélioration sur cette PR.

**QA :** Avec un Solr actif et la nouvelle commande d'indexation `python manage.py update_index --remove --age=1`, vérifier que :
- Un nouveau sujet est indexé, avec tous ses messages (1 ou plus)
- Un nouveau message dans un vieux sujet est indexé
- Éditer un message autre que le premier message d'un sujet et vérifier que l'indexation comprends le nouveau contenu
- Éditer le premier message d'un sujet et vérifier que l'indexation comprends le nouveau contenu
- Éditer un sujet (titre, sous-titre, tags, …) et vérifier que l'indexation fait son boulot
- Déplacer un sujet et vérifier que ça le bouge dans la recherche :
  - Si on cherche une info du sujet (titre, sous-titre, tags, …) 
  - Si on cherche une info du premier message
  - Si on cherche une info d'un autre message
- Vérifier que si on déplace un sujet vers un forum caché (ex : corbeille) il disparaît bien pour tout membre non staff
- Vérifier que si on masque un message, il disparaît bien des résultats de recherche
