### PR TITLE
Mail d'inscription

### DIFF
--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -266,8 +266,8 @@ class MemberTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 200)
 
-        # check a new email has been sent at the new user.
-        self.assertEquals(len(mail.outbox), 2)
+        # check a new email hasn't been sent at the new user.
+        self.assertEquals(len(mail.outbox), 1)
 
         # check if the new user is active.
         self.assertTrue(User.objects.get(username='firm1').is_active)

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -821,7 +821,7 @@ def active_account(request):
             _(u"Bienvenue sur {}").format(settings.ZDS_APP['site']['litteral_name']),
             _(u"Le manuel du nouveau membre"),
             msg,
-            True,
+            False,
             True,
             False)
     token.delete()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | ~ |
| Nouvelle Fonctionnalité ? | ~ |
| Tickets (_issues_) concernés | #3312 |

Cette PR permet d'annuler l'envoi du mail indiquant la réception du message de bienvenue de Clem', afin d'éviter de multiplier les mails dans le processus de création d'un compte.
