### PR TITLE
[betav16]fix les urls de sujet suivi

### DIFF
--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -87,7 +87,7 @@
                                                 {% if first_unread %}
                                                     {{ first_unread.get_absolute_url }}
                                                 {% else %}
-                                                    {{ topic.last_read_post.resolve_last_read_post_absolute_url }}
+                                                    {{ topic.resolve_last_read_post_absolute_url }}
                                                 {% endif %}
                                             {% endwith %}
                                             {% endspaceless %}"

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -314,9 +314,11 @@ class Topic(models.Model):
         else:
             try:
                 pk, pos = self.resolve_last_post_pk_and_pos_read_by_user(user)
+                page_nb = 1
+                if pos > ZDS_APP["forum"]["posts_per_page"]:
+                    page_nb += (pos - 1) // ZDS_APP["forum"]["posts_per_page"]
                 return '{}?page={}#p{}'.format(
-                    self.get_absolute_url(),
-                    (pos - 1) / ZDS_APP["forum"]["posts_per_page"] + 1, pk)
+                    self.get_absolute_url(), page_nb, pk)
             except TopicRead.DoesNotExist:
                 return self.resolve_first_post_url()
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | #3380 |

Pour la QA : dans les forums, suivez un sujet et observez une fois la page rechargée que le lien qui apparait dans les "sujets suivis" mène bien au dernier message.

PS : pour ceux qui veulent des TU : il y en a déjà un sur les méthodes utilisées, mon code ne vient que clarifier la pagination et surtout corriger le template qui avait une typo. 
