### PR TITLE
Corrige le sommaire des conteneurs de parties (fix #3315)

### DIFF
--- a/templates/tutorialv2/includes/child_online.part.html
+++ b/templates/tutorialv2/includes/child_online.part.html
@@ -3,17 +3,19 @@
 {% load times %}
 {% load target_tree %}
 
-<h2 id="{{ child.position_in_parent }}-{{ child.slug }}">
-    <a
-        {%  if child.text %}
-            href="{{ child.container.get_absolute_url_online }}#{{ child.position_in_parent }}-{{ child.slug }}"
-        {% else %}
-            href="{{ child.get_absolute_url_online }}"
-        {% endif %}
-    >
-        {{ child.title }}
-    </a>
-</h2>
+{% if not hide_title %}
+    <h2 id="{{ child.position_in_parent }}-{{ child.slug }}">
+        <a
+            {%  if child.text %}
+                href="{{ child.container.get_absolute_url_online }}#{{ child.position_in_parent }}-{{ child.slug }}"
+            {% else %}
+                href="{{ child.get_absolute_url_online }}"
+            {% endif %}
+        >
+            {{ child.title }}
+        </a>
+    </h2>
+{% endif %}
 {% if child.text %}
     {# child is an extract #}
     {% if child.get_text.strip|length == 0 %}

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -66,9 +66,7 @@
             <hr />
         {% endif %}
 
-        {% for child in container.children %}
-            {%  include "tutorialv2/includes/child_online.part.html" with child=child %}
-        {% endfor %}
+        {%  include "tutorialv2/includes/child_online.part.html" with child=container hide_title=True %}
 
         <hr class="clearfix" />
         <hr />

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -66,17 +66,9 @@
             <hr />
         {% endif %}
 
-        {%  if not container.has_extracts %}
-            <ol class="summary-part">
-        {% endif %}
-
         {% for child in container.children %}
             {%  include "tutorialv2/includes/child_online.part.html" with child=child %}
         {% endfor %}
-
-        {%  if not container.has_extracts %}
-            </ol>
-        {% endif %}
 
         <hr class="clearfix" />
         <hr />


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3315 |

Enlève un `<ol>` utilisé avec l'ancien sommaire.
### Instructions QA

Créer un big-tuto, avec une partie -> publier -> naviguer vers le sommaire de la partie en question 

Vérifier que l'affichage est similaire à ça: 
![image](https://cloud.githubusercontent.com/assets/1549952/12696244/7e8d150c-c765-11e5-809d-726c35984f18.png)
