### PR TITLE
Corrige les checkbox sur mobile

### DIFF
--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -268,18 +268,31 @@
         border: 1px solid #BBB;
         background: #FCFCFC;
         transition: none;
+        position: relative;
 
-        &:checked {
+        &:after {
+            display: block;
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+            opacity: 0;
             @include sprite();
+        }
+
+        &:checked:after {
+            opacity: 1;
         }
     }
     input[type=radio] {
         border-radius: 50%;
     }
-    input[type=radio]:checked {
+    input[type=radio]:after {
         @include sprite-position($radio);
     }
-    input[type=checkbox]:checked {
+    input[type=checkbox]:after {
         @include sprite-position($check);
     }
 

--- a/assets/scss/base/_high-pixel-ratio.scss
+++ b/assets/scss/base/_high-pixel-ratio.scss
@@ -10,10 +10,16 @@
     }
     .ico,
     .ico-after:after,
-    .breadcrumb ol li:not(:last-child):after,
-    input[type=radio]:checked,
-    input[type=checkbox]:checked {
+    .breadcrumb ol li:not(:last-child):after {
         @include sprite-2x();
+    }
+
+    .main-container,
+    .modals-container {
+        input[type=radio]:after,
+        input[type=checkbox]:after {
+            @include sprite-2x();
+        }
     }
 }
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2310, #3243 |

Corrige les checkbox + radio sur mobile, qui ne s'affichait pas comme cochée.

Ferme #2310 et #3243
### Instructions QA

Build le front -> tester une checkbox (login, par exemple) et une radio (permissions des galeries, par exemple) sur mobile
