### PR TITLE
[beta v16]fix un sha qui aurait été altéré par un vieux bug

### DIFF
--- a/zds/tutorialv2/tests/tests_models.py
+++ b/zds/tutorialv2/tests/tests_models.py
@@ -466,6 +466,16 @@ class ContentTests(TestCase):
         self.assertEqual(old_date, article.public_version.publication_date)
         self.assertNotEqual(old_date, article.public_version.update_date)
 
+    def test_fix_sha(self):
+        fake_tuto = PublishableContent(title="un-deux-trois", slug="un-deux-trois")
+        self.assertRaises(OSError, fake_tuto.repare_commit)
+        real_tuto = PublishableContentFactory()
+        old_sha = real_tuto.sha_draft
+        real_tuto.sha_draft = ""
+        real_tuto.save()
+        real_tuto.repare_commit()
+        self.assertEqual(old_sha, real_tuto.sha_draft)
+
     def tearDown(self):
         if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):
             shutil.rmtree(settings.ZDS_APP['content']['repo_private_path'])


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [non] |
| Tickets (_issues_) concernés | [#3328] |

Ce bug est assez spécial, il ne touche que certains tutoriels, notamment le tutoriels "entretien d'embauche".

Le problème que l'on trouve est celui-ci (étudié avec @sandhose sur la bdd de la béta) :
pour une raison ou pour une autre, sur ce tuto et uniquement sur celui-là, le sha_draft vaut "".

Du coup cette PR propose un moyen de réparer les dégats quand il y en a eu.
