### PR TITLE
[v16] Suppression de l'espace en trop dans l'entête d'un tutoriel avec plusieurs auteurs

### DIFF
--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -37,8 +37,8 @@
 {% include "misc/zen_button.part.html" %}
 
 <div class="authors">
-    <span class="authors-label">{% trans "Auteur" %}
-        {{ publishablecontent|displayable_authors:online|pluralize }} :
+    <span class="authors-label">
+        {% trans "Auteur" %}{{ publishablecontent|displayable_authors:online|pluralize }} :
     </span>
     <ul>
         {% for member in publishablecontent|displayable_authors:online %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3362 |

Cette PR retire l'espace en trop lors de la pluralisation des auteurs d'un tutoriel.

**Avant :**
![Interface avant modification](http://image.noelshack.com/fichiers/2016/06/1455285291-pr-3362.png)

**Après :**
![Interface après modification](http://image.noelshack.com/fichiers/2016/06/1455285291-pr-3362-1.png)
