### PR TITLE
Affiche le karma en dessous des avatars

### DIFF
--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -75,14 +75,9 @@
                 color: #424242;
                 height: 25px;
                 line-height: 26px;
-                width: 28px;
+                width: 58px;
                 color: #777;
                 transition: all $transition-duration ease;
-
-                &:first-child {
-                    border-right: 0;
-                    width: 29px;
-                }
 
                 &:hover,
                 &:focus {
@@ -96,6 +91,7 @@
                 }
                 &.negative {
                     color: #c0392b;
+                    font-weight: bold;
                 }
             }
         }

--- a/templates/misc/message_user.html
+++ b/templates/misc/message_user.html
@@ -10,18 +10,19 @@
 
         {% include 'misc/badge.part.html' %}
 
-        {% comment %}
-            {# TODO : properly display metadata (karma) #}
-            {% if perms.forum.change_post %}
-                <div class="user-metadata">
-                    {% if profile.karma < 0 %}
-                        <a href="{{ member.get_absolute_url }}" class="user-karma negative">{{ profile.karma }}</a>
-                    {% else %}
-                        <a href="{{ member.get_absolute_url }}" class="user-karma">{{ profile.karma }}</a>
-                    {% endif %}
-                    <a href="{{ member.get_absolute_url }}">IPs</a>
-                </div>
-            {% endif %}
-        {% endcomment %}
+        {% if perms.forum.change_post and profile.karma != 0 %}
+            <div class="user-metadata">
+                <a href="{{ member.get_absolute_url }}"
+                   class="user-karma
+                          {% if profile.karma < 0 %}
+                              negative
+                          {% elif profile.karma > 0 %}
+                              positive
+                          {% endif %}"
+                >
+                   {{ profile.karma }}
+                </a>
+            </div>
+        {% endif %}
     {% endwith %}
 </div>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #1444 |

Affiche le karma en dessous des avatars

**QA :** Tester le karma et vérifier que ça s'affiche bien

**Affichage attendu :**

_user_ a un karma positif, _staff_ a un karma négatif et _admin_ a un karma nul donc ce n'est pas affiché

![version-situphen](https://cloud.githubusercontent.com/assets/6664636/13027927/2cdd275a-d260-11e5-9ad3-e7f3847f557e.png)
