### PR TITLE
Correction du bug de la perte de l'extension des images issues d'une archive

### DIFF
--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -720,6 +720,7 @@ class NewImageViewTest(TestCase):
             )
         self.assertEqual(302, response.status_code)
         self.assertEqual(Image.objects.filter(gallery=self.gallery).count(), 1)
+        self.assertEqual("jpg", self.gallery.get_images()[0].get_extension())
 
     def test_import_images_in_gallery_no_archive(self):
         login_check = self.client.login(username=self.profile1.user.username, password='hostel77')

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -460,7 +460,7 @@ class ImportImages(GalleryMixin, FormView):
 
             # create picture in database:
             f_im = File(open(ph_temp, "rb"))
-            f_im.name = title
+            f_im.name = title + ext
 
             pic = Image()
             pic.gallery = gallery


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3366 |

Lorsque l'on exporte des images depuis une archive dans une galerie, l'extension de l'image est perdue dans son url. Cette PR corrige ce bug. 

**Procédure pour reproduire le bug :**
- Avoir une archive contenant au moins une image.
- Importer l'archive dans une galerie.
- Sélectionner une image importée
- Constater l'absence d'extension.
