### PR TITLE
Capture de l'exception MultiValueDictKeyError lors  de l'attribution d'un tuto SdZ vide

### DIFF
--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -957,3 +957,25 @@ class MemberTests(TestCase):
             shutil.rmtree(settings.ZDS_APP['content']['repo_public_path'])
         if os.path.isdir(settings.MEDIA_ROOT):
             shutil.rmtree(settings.MEDIA_ROOT)
+
+    def test_errors_assign_tuto_sdz(self):
+        """
+        To test the errors of assigning a SdZ tutorial.
+        """
+        # we need staff right for assign a tutorial
+        self.client.logout()
+        self.client.login(username=self.staff.username, password="hostel77")
+
+        # without the parameter "profile_pk" and "id"
+        result = self.client.post(
+            reverse('member-add-oldtuto'),
+            {},
+            follow=False)
+        self.assertEqual(result.status_code, 404)
+
+        # without the parameter "profile_pk"
+        result = self.client.post(
+            reverse('member-add-oldtuto'),
+            {'id': '1'},
+            follow=False)
+        self.assertEqual(result.status_code, 404)

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -21,6 +21,7 @@ from django.utils.decorators import method_decorator
 from django.utils.http import urlunquote
 from django.utils.translation import string_concat
 from django.utils.translation import ugettext_lazy as _
+from django.utils.datastructures import MultiValueDictKeyError
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, UpdateView, CreateView, FormView
 
@@ -892,8 +893,12 @@ def date_to_chart(posts):
 @login_required
 @require_POST
 def add_oldtuto(request):
-    identifier = request.POST["id"]
-    profile_pk = request.POST["profile_pk"]
+    try:
+        identifier = request.POST["id"]
+        profile_pk = request.POST["profile_pk"]
+    except MultiValueDictKeyError:
+        raise Http404
+
     profile = get_object_or_404(Profile, pk=profile_pk)
     if profile.sdz_tutorial:
         olds = profile.sdz_tutorial.strip().split(":")


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #2948 |

Un `try/except` a été rajouté pour capturer l'exception `MultiValueDictKeyError`, générée lorsque l'on cherche à attribuer un tuto SdZ vide. Une exception `Http404` est retournée le cas échéant.
