### PR TITLE
[v16][Fix3377] Définition de la largeur des modales

### DIFF
--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -129,8 +129,7 @@
     max-width: 100%;
 
     &.modal-flex {
-        min-width: 400px;
-        width: auto;
+        width: 400px;
     }
 }
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3377 |

Depuis leur réécriture, les modales dépassent dans les écrans ayant une largeur inférieure à 400px _(voir le ticket pour les screenshots)_.  

Ce bug intervient à cause de définition de `min-width` à 400px et qui ne laisse pas la possibilité au navigateur d'adapter la largeur à l'écran.

Après discussion avec @sandhose sur le IRC, on a décidé de contourner le problème en définissant la propriété `width` à 400px. En sachant que si le navigateur n'a pas la place suffisante, il redimensionnera automatiquement.

**Exemple avec une résolution (320x480) :**

![Prévisualisation](http://image.noelshack.com/fichiers/2016/07/1455722792-capture-d-ecran-2016-02-17-a-16-25-35.png)
