### PR TITLE
Lien de retour à la liste des sujets du forum

### DIFF
--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -128,6 +128,9 @@
 
 
 {% block new_btn %}
+    <a href="{{ topic.forum.get_absolute_url }}" class="new-btn ico-after arrow-left blue">
+        {% trans "Retour à la liste des sujets" %}
+    </a>
     <a href="{% url 'topic-new' %}?forum={{ topic.forum.pk }}" class="new-btn ico-after more blue">
         {% trans "Nouveau sujet" %}
     </a>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | non |
| Nouvelle Fonctionnalité ? | oui |
| Tickets (_issues_) concernés | #3234 |

Sur la version mobile, il n'est pas aisé de revenir à la liste des sujets du forum car le fil d’Ariane est absent. Comme suggéré dans le ticket, un lien a été ajouté dans le menu qui redirige vers la liste des sujets.

**Version ordinateur :**
![Rendu version ordinateur](http://image.noelshack.com/fichiers/2016/07/1455738339-3234-0.png)

**Version smartphone :**
![Rendu version smartphone](http://image.noelshack.com/fichiers/2016/07/1455738338-3234-1.png)
