### PR TITLE
Rend les forum https friendly

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -421,7 +421,7 @@
                                            data-active="open-my-account"
                                        {% endif %}
                                     >
-                                        <img src="{{ profile.get_avatar_url }}" alt="" class="avatar">
+                                        <img src="{{ profile.get_avatar_url|remove_url_protocole }}" alt="" class="avatar">
                                         <span class="username label">{{ user.username }}</span>
                                     </a>
                                 {% endwith %}

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -4,6 +4,7 @@
 {% load date %}
 {% load profile %}
 {% load i18n %}
+{% load remove_url_protocole %}
 
 
 {% block title_base %}
@@ -123,7 +124,7 @@
                                         {% with answer=topic.get_last_answer %}
                                             {% if answer %}
                                                 {% with profile=answer.author|profile %}
-                                                    <img src="{{ profile.get_avatar_url }}" alt="" class="avatar">
+                                                    <img src="{{ profile.get_avatar_url|remove_url_protocole }}" alt="" class="avatar">
                                                 {% endwith %}
                                                 <span class="topic-last-answer">
                                                     {% trans "Dernière réponse" %}

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -6,7 +6,7 @@
 {% load profile %}
 {% load crispy_forms_tags %}
 {% load i18n %}
-
+{% load remove_url_protocole %}
 
 
 {% block title %}
@@ -33,7 +33,7 @@
 
         <div class="member-card">
             <div class="member-avatar">
-                <img src="{{ profile.get_avatar_url }}" alt="" class="avatar">
+                <img src="{{ profile.get_avatar_url|remove_url_protocole }}" alt="" class="avatar">
 
                 {% include 'misc/badge.part.html' with member=usr %}
             </div>

--- a/templates/member/settings/memberip.html
+++ b/templates/member/settings/memberip.html
@@ -1,6 +1,7 @@
 {% extends "member/base.html" %}
 {% load date %}
 {% load i18n %}
+{% load remove_url_protocole %}
 
 {% block title %}
     {% trans "Membres par IP" %}
@@ -32,7 +33,7 @@
                     itemscope
                     itemtype="http://schema.org/Person"
                 >{% spaceless %}
-                <img src="{{ member.get_avatar_url }}" alt="" class="avatar" itemprop="image">
+                <img src="{{ member.get_avatar_url|remove_url_protocole }}" alt="" class="avatar" itemprop="image">
                 <span itemprop="name">{{ member.user.username }}</span>
             {% endspaceless %}</a> <span class="info">{% blocktrans with last_visit=member.last_visit|format_date:True %} "le" {{last_visit}} {% endblocktrans %}</span>
             </li>

--- a/templates/misc/member_item.part.html
+++ b/templates/misc/member_item.part.html
@@ -1,6 +1,6 @@
 {% load profile %}
 {% load i18n %}
-
+{% load remove_url_protocole %}
 
 {% with profile=member|profile %}
     <a
@@ -13,7 +13,7 @@
         {% endif %}
     >{% spaceless %}
         {% if avatar %}
-            <img src="{{ profile.get_avatar_url }}" alt="" class="avatar" itemprop="image">
+            <img src="{{ profile.get_avatar_url|remove_url_protocole }}" alt="" class="avatar" itemprop="image">
         {% endif %}
 
         <span itemprop="name">{{ member.username }}</span>

--- a/templates/misc/message_user.html
+++ b/templates/misc/message_user.html
@@ -1,11 +1,12 @@
 {% load profile %}
 {% load i18n %}
+{% load remove_url_protocole %}
 
 
 <div class="user">
     {% with profile=member|profile %}
         <a href="{{ member.get_absolute_url }}" class="avatar-link">
-            <img src="{{ profile.get_avatar_url }}" alt="" class="avatar">
+            <img src="{{ profile.get_avatar_url|remove_url_protocole }}" alt="" class="avatar">
         </a>
 
         {% include 'misc/badge.part.html' %}

--- a/zds/utils/templatetags/remove_url_protocole.py
+++ b/zds/utils/templatetags/remove_url_protocole.py
@@ -10,6 +10,8 @@ def remove_url_protocole(input_url):
     """
     make every image url pointing to this website protocol independant so that https is not broken
     """
-    if ZDS_APP["site"]["dns"] in input_url:
-        return input_url.replace("http:/", "https:/").replace("https://" + ZDS_APP["site"]["dns"], "")
+    if ZDS_APP["site"]["dns"] in input_url or ZDS_APP["site"]["url"] in input_url:
+        return input_url.replace("http:/", "https:/")\
+                        .replace("https://" + ZDS_APP["site"]["dns"], "")\
+                        .replace(ZDS_APP["site"]["url"], "")
     return input_url


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | - |

mais cette PR permet de rendre la page de listing des forum https friendly.

J'ajouterai qu'il est fortement probable que cette ligne puisse être totalement supprimée puisque l'avatar n'est jamais affiché.

J'ajouterai que selon la décision de @SpaceFox et @GerardPaligot ou @pierre-24 il est probable que cette PR passe en hotfix.

si vous désirez, je peux faire une commande qui permettra de nettoyer les messages du forum de toute trace d'image chargée en https.
## QA

Assurez vous qu'un utilisateur possède un avatar qui ne soit pas un gravatar.
Ensuite, allez sur les forums et vérifiez que lorsqu'il poste un message, cela ne génère pas de `<img src="http://whatever"/>`.
