### PR TITLE
[hotfix] Règle les problèmes avec python-slugify et les slugs des contenus

### DIFF
--- a/doc/source/back-end/contents.rst
+++ b/doc/source/back-end/contents.rst
@@ -177,6 +177,16 @@ une contrainte sur la taille maximum d'un nom de fichier sur les différents sys
     *slug*, pour des raisons de stockage (voir plus bas). Il ne faut pas 
     oublier la contrainte d'unicité à l'intérieur d'un conteneur.
 
+.. attention::
+
+    Suite à un changement majeur dans la librairie ``python-slugify``, une différence peu apparaitre dans le *slug*
+    généré à partir de titres contenant des espaces. Dès lors, pour des raisons de rétro-compatibilités, c'est la version
+    1.1.4 de cette librairie qui est utilisée par ZdS. Par ailleurs, la commande ``python manage.py adjust_slugs`` a été
+    créée pour réparer les éventuels dommages, en détectant les titres posant potentielement des problèmes et en tentant
+    de les faire correspondre à nouveau à leur contrepartie dans le système de fichier.
+
+    `Plus d'information ici <https://github.com/zestedesavoir/zds-site/issues/3383#issuecomment-187282828>`_.
+
 Cycle de vie des contenus
 =========================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,5 @@ dry-rest-permissions==0.1.6
 
 # Zep 12 dependency
 django-uuslug==1.0.3
+python-slugify==1.1.4 # next versions of this library break previous behavior for slug generation from string with single quotes
 watchdog==0.8.3 # use last non-bc-breaking version

--- a/update.md
+++ b/update.md
@@ -432,3 +432,11 @@ systemctl start zds-watchdog.service
 
 Il est possible de configurer le logging de ce module en surchargeant les logger `logging.getLogger("zds.pandoc-publicator")`, `logging.getLogger("zds.watchdog-publicator")`.
 
+Repasser à l'ancienne version de `python-slugify` et sauver les contenus (#3383)
+--------------------------------------------------------------------------------
+
+1. Passer en maintenance ;
+2. Mettre à jour les dépendances de zds afin de *downgrader* `python-slugify` : `pip install --upgrade -r requirements.txt` ;
+3. Exécuter la commande suivante : `python manage.py adjust_slugs`. Noter les éventuels contenus pour lesquels cela ne fonctionnerai pas ;
+4. Si pour certains contenus la commande échoue, il faut retrouver le dossier correspondant dans `/contents-private/` et donner à ce contenu le même slug ;
+5. Quitter la maintenance.

--- a/zds/tutorialv2/management/commands/adjust_slugs.py
+++ b/zds/tutorialv2/management/commands/adjust_slugs.py
@@ -5,6 +5,7 @@ from uuslug import slugify
 from django.core.management.base import BaseCommand
 from zds.settings import ZDS_APP
 from zds.tutorialv2.models.models_database import PublishableContent
+from django.utils.translation import ugettext_lazy as _
 
 
 class Command(BaseCommand):
@@ -19,13 +20,35 @@ class Command(BaseCommand):
                 good_slug = slugify(c.title)
                 if c.slug != good_slug:
                     if os.path.isdir(os.path.join(ZDS_APP['content']['repo_private_path'], good_slug)):
-                        self.stdout.write(u'Fixing content #{} (« {} ») ... '.format(c.pk, c.title), ending='')
+                        # this content was created before v16 and is probably broken
+                        self.stdout.write(u'Fixing pre-v16 content #{} (« {} ») ... '.format(c.pk, c.title), ending='')
                         c.save()
                         if os.path.isdir(c.get_repo_path()):
                             self.stdout.write(u'[OK]')
                         else:
                             self.stdout.write(u'[KO]')
+                    elif os.path.isdir(os.path.join(ZDS_APP['content']['repo_private_path'], c.slug)):
+                        # this content was created during v16 and will be broken if nothing is done
+                        self.stdout.write(u'Fixing in-v16 content #{} (« {} ») ... '.format(c.pk, c.title), ending='')
+                        try:
+                            versioned = c.load_version()
+                        except IOError:
+                            self.stdout.write(u'[KO]')
+                        else:
+                            c.sha_draft = versioned.repo_update_top_container(
+                                c.title,
+                                good_slug,
+                                versioned.get_introduction(),
+                                versioned.get_conclusion(),
+                                commit_message=_(u'[hotfix] Corrige le slug pour éviter un bug'))
+
+                            c.save()
+
+                            if os.path.isdir(c.get_repo_path()):
+                                self.stdout.write(u'[OK]')
+                            else:
+                                self.stdout.write(u'[KO]')
                     else:
                         self.stderr.write(
-                            u'Content #{} (« {} ») cannot be fixed: there is no directory named "{}" in "{}".\n'.
-                            format(c.pk, c.title, good_slug, ZDS_APP['content']['repo_private_path']))
+                            u'Content #{} (« {} ») is an orphan: there is no directory named "{}" or "{}".\n'.
+                            format(c.pk, c.title, good_slug, c.slug))

--- a/zds/tutorialv2/management/commands/adjust_slugs.py
+++ b/zds/tutorialv2/management/commands/adjust_slugs.py
@@ -1,0 +1,31 @@
+# coding: utf-8
+import os
+from uuslug import slugify
+
+from django.core.management.base import BaseCommand
+from zds.settings import ZDS_APP
+from zds.tutorialv2.models.models_database import PublishableContent
+
+
+class Command(BaseCommand):
+    """
+    `python manage.py adjust_slugs`; fix content's slugs for which the title contains single quote(s).
+    """
+
+    def handle(self, *args, **options):
+
+        for c in PublishableContent.objects.all():
+            if '\'' in c.title:
+                good_slug = slugify(c.title)
+                if c.slug != good_slug:
+                    if os.path.isdir(os.path.join(ZDS_APP['content']['repo_private_path'], good_slug)):
+                        self.stdout.write(u'Fixing content #{} (« {} ») ... '.format(c.pk, c.title), ending='')
+                        c.save()
+                        if os.path.isdir(c.get_repo_path()):
+                            self.stdout.write(u'[OK]')
+                        else:
+                            self.stdout.write(u'[KO]')
+                    else:
+                        self.stderr.write(
+                            u'Content #{} (« {} ») cannot be fixed: there is no directory named "{}" in "{}".\n'.
+                            format(c.pk, c.title, good_slug, ZDS_APP['content']['repo_private_path']))

--- a/zds/tutorialv2/management/commands/adjust_slugs.py
+++ b/zds/tutorialv2/management/commands/adjust_slugs.py
@@ -5,7 +5,6 @@ from uuslug import slugify
 from django.core.management.base import BaseCommand
 from zds.settings import ZDS_APP
 from zds.tutorialv2.models.models_database import PublishableContent
-from django.utils.translation import ugettext_lazy as _
 
 
 class Command(BaseCommand):
@@ -40,7 +39,7 @@ class Command(BaseCommand):
                                 good_slug,
                                 versioned.get_introduction(),
                                 versioned.get_conclusion(),
-                                commit_message=_(u'[hotfix] Corrige le slug pour éviter un bug'))
+                                commit_message='[hotfix] Corrige le slug')
 
                             c.save()
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui (!!) |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3383 |
# Note de QA

Je vous conseille très fortement l'utilisation d'un _virtualenv_, il faut mettre trois fois à jour ses _requirements_.
## Première partie
- Chargez ma branche et mettez à jour vos _requirements_ (`pip install --upgrade -r requirements.txt`). Vous avez alors la version 1.1.4 de `python-slugify`.
- Créez un tuto (ou un article, peu importe) dont le titre contient des apostrophes. Par exemple, « L'histoire de l'algèbre ».
- Chargez la branche de prod : `git checkout upstream/prod` et re-mettez à jour vos _requirements_ (`pip install --upgrade -r requirements.txt`). Vous avez alors la version 1.2 de `python-slugify`.
- Rajoutez une section. Constatez que vous avez une erreur 404.
- Maudissez [un33k](https://github.com/un33k) en transperçant une poupée vaudou à son effigie de tout objet pointu que vous aurez à proximité.
- Chargez ma branche et re-re-mettez à jour vos _requirements_ (`pip install --upgrade -r requirements.txt`). Vous avez alors à nouveau la version 1.1.4 de `python-slugify`. J'insiste, **il faut que ce soit la version 1.1.4 pour lancer l'instruction suivante**.
- Exécutez la commande suivante : `python manage.py adjust_slugs`. Constatez que tout est OK.
- Vérifiez que vous pouvez à nouveau accéder à votre contenu sans erreur 404, et que vous pouvez bien ajouter une autre section.

Par sécurité, recommencez la même QA, mais cette fois, au lieu d'ajouter des sections, rajoutez des auteurs.
## Deuxième partie

Merci @DevHugo qui a probablement sauvé un contenu ou deux (ou pas, mais mieux vaux prévenir que guérir).
- Chargez la branche de prod : `git checkout upstream/prod` et re-mettez à jour vos _requirements_ (`pip install --upgrade -r requirements.txt`). Vous avez alors la version 1.2 de `python-slugify`.
- Créez un contenu dont le titre est  « L'histoire de l'algèbre ».  Constatez que sont slug est `l-histoire-de-l-algebre`.
- Chargez ma branche et re-mettez à jour vos _requirements_ (`pip install --upgrade -r requirements.txt`). Vous avez alors à nouveau la version 1.1.4 de `python-slugify`. **N'éditez surtout pas votre contenu**.
- Exécutez la commande suivante : `python manage.py adjust_slugs`. Constatez que tout est OK.
- Vérifiez que le slug de votre contenu à changé de slug pour `lhistoire-de-lalgebre` et que dans l'historique du contenu, un _commit_ est venu se rajouter.
- Vérifiez que vous pouvez rajouter une section ou un auteur à votre contenu et que tout est bon.
