### PR TITLE
Correction de l'affichage dans les paramètres d'un compte

### DIFF
--- a/templates/member/settings/account.html
+++ b/templates/member/settings/account.html
@@ -4,19 +4,19 @@
 
 
 {% block title %}
-   {% trans "Mon compte" %}
+   {% trans "Mot de passe" %}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li>{% trans "Mon Compte" %}</li>
+    <li>{% trans "Mot de passe" %}</li>
 {% endblock %}
 
 
 
 {% block headline %}
-    {% trans "Mon compte" %}
+    {% trans "Mot de passe" %}
 {% endblock %}
 
 

--- a/templates/member/settings/base.html
+++ b/templates/member/settings/base.html
@@ -26,7 +26,7 @@
             <h3>{% trans "Navigation" %}</h3>
             <ul>
                 <li><a href="{% url "update-member" %}">{% trans "Mon profil" %}</a></li>
-                <li><a href="{% url "update-password-member" %}">{% trans "Mon compte" %}</a></li>
+                <li><a href="{% url "update-password-member" %}">{% trans "Mot de passe" %}</a></li>
                 <li><a href="{% url "update-username-email-member" %}">{% trans "Pseudo et courriel" %}</a></li>
 				<li><a href="{% url "member-warning-unregister" %}">{% trans "Se désinscrire" %}</a></li>
             </ul>

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -191,6 +191,7 @@ class UpdatePasswordMember(UpdateMember):
     """User's settings about his password."""
 
     form_class = ChangePasswordForm
+    template_name = 'member/settings/account.html'
 
     def post(self, request, *args, **kwargs):
         form = self.form_class(request.user, request.POST)
@@ -217,6 +218,7 @@ class UpdateUsernameEmailMember(UpdateMember):
     """User's settings about his username and email."""
 
     form_class = ChangeUserForm
+    template_name = 'member/settings/user.html'
 
     def get_form(self, form_class=ChangeUserForm):
         return form_class(self.request.POST)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | oui |
| Nouvelle Fonctionnalité ? | non |
| Tickets (_issues_) concernés | #3390 |

Bonjour, j'ai corrigé le fait qu'il soit écrit "Mon profil" sur les pages "Mon compte" et "Pseudo et courriel" dans les modifications des paramètres d'un compte.
