### PR TITLE
Envoi d'un message lors de la réservation d'un contenu

### DIFF
--- a/templates/tutorialv2/messages/validation_reserve.md
+++ b/templates/tutorialv2/messages/validation_reserve.md
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+{% blocktrans with title=content.title %}
+
+Salut !
+
+Je viens de prendre en charge la validation de ton contenu, « [{{ title }}]({{ url }}) ».
+
+À bientôt !
+
+{% endblocktrans %}

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -1941,6 +1941,7 @@ class ContentTests(TestCase):
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+        self.assertEqual(PrivateTopic.objects.filter(author=self.user_author).count(), 1)
 
         validation = Validation.objects.filter(pk=validation.pk).last()
         self.assertEqual(validation.status, 'PENDING_V')
@@ -2117,7 +2118,8 @@ class ContentTests(TestCase):
 
         self.assertIsNone(PublishableContent.objects.get(pk=tuto.pk).sha_validation)
 
-        self.assertEqual(PrivateTopic.objects.filter(author=self.user_author).count(), 2)
+        self.assertEqual(PrivateTopic.objects.filter(author=self.user_author).count(), 5)
+        # Note : a PM is sent when the content is reserved by a validator
         self.assertEqual(PrivateTopic.objects.last().author, self.user_author)  # author has received another PM
 
         self.assertEqual(PublishedContent.objects.filter(content=tuto).count(), 1)
@@ -2185,7 +2187,7 @@ class ContentTests(TestCase):
         self.assertEqual(PublishedContent.objects.filter(content=tuto).count(), 0)
         self.assertFalse(os.path.exists(published.get_prod_path()))
 
-        self.assertEqual(PrivateTopic.objects.filter(author=self.user_author).count(), 3)
+        self.assertEqual(PrivateTopic.objects.filter(author=self.user_author).count(), 6)
         self.assertEqual(PrivateTopic.objects.last().author, self.user_author)  # author has received another PM
 
         # so, reserve it

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -257,6 +257,25 @@ class ReserveValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
             validation.date_reserve = datetime.now()
             validation.status = "PENDING_V"
             validation.save()
+
+            versioned = validation.content.load_version(sha=validation.version)
+            msg = render_to_string(
+                'tutorialv2/messages/validation_reserve.md',
+                {
+                    'content': versioned,
+                    'url': versioned.get_absolute_url() + '?version=' + validation.version,
+                })
+
+            send_mp(
+                validation.validator,
+                validation.content.authors.all(),
+                _(u"Contenu réservé - {0}").format(validation.content.title),
+                validation.content.title,
+                msg,
+                True,
+                direct=False
+            )
+
             messages.info(request, _(u"Ce contenu a bien été réservé par {0}.").format(request.user.username))
 
             return redirect(


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Non |
| Nouvelle Fonctionnalité ? | Oui |
| Tickets (_issues_) concernés | #3385 |

**QA :** 
- Créer un contenu, le passer en validation ;
- Réserver le contenu en validation ;
- Vérifier que le(s) auteur(s) ont bien reçu le MP les informant que leur contenu a été réservé.
