### PR TITLE
MAJ de plus de dépendances

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 coverage==4.0.3
 PyYAML==3.11
 django-debug-toolbar==1.4
-flake8==2.4.0
+flake8==2.5.4
 autopep8==1.1.1
 sphinx==1.2.3
 sphinx_rtd_theme==0.1.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ coverage==4.0.3
 PyYAML==3.11
 django-debug-toolbar==1.4
 flake8==2.5.4
-autopep8==1.1.1
+autopep8==1.2.2
 sphinx==1.2.3
 sphinx_rtd_theme==0.1.6
 fake-factory==0.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,6 @@ django-debug-toolbar==1.4
 flake8==2.5.4
 autopep8==1.2.2
 sphinx==1.3.6
-sphinx_rtd_theme==0.1.6
+sphinx_rtd_theme==0.1.9
 fake-factory==0.5.0
 mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ PyYAML==3.11
 django-debug-toolbar==1.4
 flake8==2.5.4
 autopep8==1.2.2
-sphinx==1.2.3
+sphinx==1.3.6
 sphinx_rtd_theme==0.1.6
 fake-factory==0.5.0
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pillow==3.1.1
 gitpython==1.0.1
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.7.zip
 easy-thumbnails==2.2
-CairoSVG==1.0.19
+CairoSVG==1.0.20
 beautifulsoup4==4.4.1
 django-recaptcha==1.0.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Implicit dependencies (optional dependencies of dependencies)
 pysolr==3.3.1
-pygments==2.0.2
+pygments==2.1.2
 python-social-auth==0.2.9
 
 # Explicit dependencies (references in code)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.7.zip
 easy-thumbnails==2.2
 CairoSVG==1.0.20
 beautifulsoup4==4.4.1
-django-recaptcha==1.0.4
+django-recaptcha==1.0.5
 
 # Api dependencies
 djangorestframework==3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ djangorestframework-xml==1.3.0
 django-filter==0.12
 django-oauth-toolkit==0.10.0
 drf-extensions==0.2.8
-django-rest-swagger==0.3.4
+django-rest-swagger==0.3.5
 django-cors-middleware==1.2.0
 dry-rest-permissions==0.1.6
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-haystack==2.4.1
 django-model-utils==2.4
 django-munin==0.2.1
 python-memcached==1.54
-lxml==3.4.4
+lxml==3.5.0
 factory-boy==2.6.1
 pygeoip==0.3.2
 pillow==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pygeoip==0.3.2
 pillow==3.1.1
 gitpython==1.0.1
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.7.zip
-easy-thumbnails==2.2
+easy-thumbnails==2.3
 CairoSVG==1.0.20
 beautifulsoup4==4.4.1
 django-recaptcha==1.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Implicit dependencies (optional dependencies of dependencies)
-pysolr==3.3.1
+pysolr==3.4.0
 pygments==2.1.2
 python-social-auth==0.2.9
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Implicit dependencies (optional dependencies of dependencies)
 pysolr==3.4.0
 pygments==2.1.2
-python-social-auth==0.2.9
+python-social-auth==0.2.14
 
 # Explicit dependencies (references in code)
 Django==1.8.10


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | Oui (indirectement) |
| Nouvelle Fonctionnalité ? | Non |
| Tickets (_issues_) concernés | - |

Puisqu'on était partis pour faire une version technique, j'ai [pris la liste des dépendances pas à jour](https://requires.io/github/zestedesavoir/zds-site/requirements/?branch=release-v17) malgré le travail déjà fait, et j'ai mis à jour ce que j'ai pu.

À noter que :
- Je n'ai pas touché aux uubidules
- [GitPython prétend avoir fait une simple MAJ corrective](http://gitpython.readthedocs.org/en/stable/changes.html#fixes), mais si je passe en v1.0.2 j'ai des bugs atroces à base de stack overflow et autres joyeusetés du même tonneau…

QA : Vérifier que ce qui dépend des libs mises à jour n'est pas cassé (si nos 749 test passent, c'est déjà un très bon début).
