### PR TITLE
Correction de la couleur du bouton recherche sur l'accueil

### DIFF
--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -259,7 +259,7 @@ $content-width: 1145px;
             height: 50px;
 
             &:hover, &:focus {
-                background-color: #CCC;
+                background-color: #CCC !important;
             }
 
             &:after {


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | Correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3213 |

Au clic du bouton recherche sur la page d'accueil, celui-ci est vert au lieu d'être gris. Cette PR corrige ce défaut de priorité en CSS. N'ayant pas réussi à trouver le moyen de me passer du `!important`, je propose néanmoins ce correctif qui a au moins le mérite de corriger ce problème de priorité des règles.

**Rendu** : 

_Avant_
![Rendu avant](https://cloud.githubusercontent.com/assets/634461/11459974/8a5bf89c-96e3-11e5-89e2-b144b35b7649.png)

_Après_
![Rendu après](http://image.noelshack.com/fichiers/2016/09/1457188893-3213-1.png)
