### PR TITLE
Verification backside formulaire ajout karma (#3400)

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -652,7 +652,8 @@ class KarmaForm(forms.Form):
         max_length=KarmaNote._meta.get_field('comment').max_length,
         widget=forms.TextInput(
             attrs={
-                'placeholder': u'Commentaire sur le comportement de ce membre'
+                'placeholder': u'Commentaire sur le comportement de ce membre',
+                'required': u'required'
             }),
         required=True,
     )

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -91,6 +91,7 @@ class MemberDetail(DetailView):
         context['topic_read'] = TopicRead.objects.list_read_topic_pk(self.request.user, context['topics'])
         return context
 
+
 class UpdateMember(UpdateView):
     """Updates a profile."""
 
@@ -190,7 +191,7 @@ class UpdatePasswordMember(UpdateMember):
     """User's settings about his password."""
 
     form_class = ChangePasswordForm
-    
+
     def post(self, request, *args, **kwargs):
         form = self.form_class(request.user, request.POST)
 
@@ -198,10 +199,10 @@ class UpdatePasswordMember(UpdateMember):
             return self.form_valid(form)
 
         return render(request, self.template_name, {'form': form})
-    
+
     def get_form(self, form_class=ChangePasswordForm):
         return form_class(self.request.user)
-    
+
     def update_profile(self, profile, form):
         profile.user.set_password(form.data['password_new'])
 
@@ -1089,12 +1090,12 @@ def modify_karma(request):
     note.user = profile.user
     note.staff = request.user
     note.comment = request.POST["warning"]
-    
+
     try:
         note.value = int(request.POST["points"])
     except (KeyError, ValueError):
         note.value = 0
-    
+
     try:
         if note.comment == "" or (note.value > 100 or note.value < -100):
              raise ValueError

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1098,7 +1098,7 @@ def modify_karma(request):
 
     try:
         if note.comment == "" or (note.value > 100 or note.value < -100):
-             raise ValueError
+            raise ValueError
         else:
             note.save()
             profile.karma += note.value


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Correction de bugs ? | [oui] |
| Nouvelle Fonctionnalité ? | [oui] |
| Tickets (_issues_) concernés | #3400 |

QA:
Côté front on a le symbole « \* » rouge qui indique que le champs Commentaire est requis mais il est possible d'ajouter une remarque sans commentaire.

2 options :

```
C'est côté front qu'on a un mauvais affichage;
C'est côté back et on check mal si le formulaire est valide (je penche pour ça).
```

_note_
La vérification comprend : 
- Commentaire vide
- Intervalle de la valeur karma
  Dans le cas où ces informations sont incorrectes, la validation du formulaire n'ajoute ni le commentaire ni la valeur karma au profil du membre.
