### PR TITLE
Ajout du filtre "featured" pour les images en une

### DIFF
--- a/templates/gallery/image/edit.html
+++ b/templates/gallery/image/edit.html
@@ -1,6 +1,7 @@
 {% extends "gallery/base.html" %}
 {% load crispy_forms_tags %}
 {% load thumbnail %}
+{% load remove_url_protocole %}
 {% load i18n %}
 
 
@@ -30,12 +31,23 @@
         <p>
             {% trans "Image" %} :
         </p>
-        <a href="{{ image.physical.url }}"><img src="{{ image.physical.url }}" alt="{{ image.legend }}"></a>
-        
+        <a href="{{ image.physical.url|remove_url_protocole }}">
+            <img src="{{ image.physical.gallery_illu.url|remove_url_protocole }}" alt="{{ image.legend }}">
+        </a>
+
         <p>
             {% trans "Miniature" %} :
         </p>
-        <a href="{{ image.physical.gallery.url }}"><img src="{{ image.physical.gallery.url }}" alt="{{ image.legend }}"></a>
+        <a href="{{ image.physical.gallery.url|remove_url_protocole }}">
+            <img src="{{ image.physical.gallery.url|remove_url_protocole }}" alt="{{ image.legend }}">
+        </a>
+
+        {% if perms.featured.change_featuredresource %}
+        <p>
+            {% trans "Lien pour utiliser cette image en une" %} : <br>
+            <input type="text" value="{{ app.site.url }}{{ image.physical.featured.url }}" readonly onclick="this.select()">
+        </p>
+        {% endif %}
     </div>
     <div class="gallery-col-edit">
         {% if gallery_mode.can_write %}
@@ -55,7 +67,7 @@
             {% trans "Miniature + lien vers taille normale" %} :
             <input type="text" value="[![{{ image.legend }}]({{app.site.url}}{{ image.physical.gallery.url }})]({{app.site.url}}{{ image.physical.url }})" readonly onclick="this.select()">
         </p>
-        
+
         {% crispy as_avatar_form %}
     </div>
 {% endblock %}

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -459,7 +459,7 @@ class EditImageViewTest(TestCase):
                 follow=True
             )
         self.assertEqual(200, response.status_code)
-        self.assertEqual(nb_files + 2, len(os.listdir(self.gallery.get_gallery_path())))
+        self.assertEqual(nb_files + 3, len(os.listdir(self.gallery.get_gallery_path())))
 
         image_test = Image.objects.get(pk=self.image.pk)
         self.assertEqual('edit title', image_test.title)
@@ -633,7 +633,7 @@ class NewImageViewTest(TestCase):
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(self.gallery.get_images()))
-        self.assertEqual(2, len(os.listdir(self.gallery.get_gallery_path())))  # New image and thumbnail
+        self.assertEqual(3, len(os.listdir(self.gallery.get_gallery_path())))  # New image and thumbnail
         self.gallery.get_images()[0].delete()
 
     def test_fail_new_image_with_read_permission(self):

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -204,6 +204,8 @@ THUMBNAIL_ALIASES = {
         'help_illu': {'size': (48, 48), 'crop': True},
         'help_mini_illu': {'size': (26, 26), 'crop': True},
         'gallery': {'size': (120, 120), 'crop': True},
+        'featured': {'size': (228, 228), 'crop': True},
+        'gallery_illu': {'size': (480, 270), 'crop': True},
         'content': {'size': (960, 960), 'crop': False},
     },
 }
@@ -568,4 +570,3 @@ try:
     from settings_prod import *
 except ImportError:
     pass
-


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | Évolution / _"Correction d'un bogue"_ |
| Ticket(s) (_issue(s)_) concerné(s) | #3339 |

La taille des images à la une sont assez variables et on trouve parfois des images avec une taille gigantesque _(cf la une [Zeste d'artistes 3D](https://zestedesavoir.com))_ pour finalement être redimensionnée en 228x228px. J'ai donc ajouté : 
- un filtre pour redimensionner les images en 228x228px. 
- un champ avec le lien de l'image dimensionnée pour être utilisée en une. 

Le nouveau champ n'est accessible que par ceux qui peuvent gérer les unes.

**QA** :
- Avec le compte _admin_ : 
  - Ajouter une image à une galerie ou sélectionner une image déjà uploadée.
  - Constater l'apparition du nouveau champ (cf image ci-dessous).
- Avec le compte _user_ :
  - Ajouter une image à une galerie ou sélectionner une image déjà uploadée.
  - Constater que le nouveau champ n'est pas présent. 

Rendu avec le compte _admin_ :
![Rendu](http://image.noelshack.com/fichiers/2016/10/1457727470-3339.png)
