### PR TITLE
Correction du message sur la page d'inscription

### DIFF
--- a/templates/member/login.html
+++ b/templates/member/login.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "member/base.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
 

--- a/templates/member/register/index.html
+++ b/templates/member/register/index.html
@@ -57,9 +57,13 @@
                 </div>
             </div>
         {% else %}
-            <p>
-                {% trans "Vous êtes déjà connecté" %}.
-            </p>
+            <div>
+                <p class="alert-box warning">
+                    <strong>
+                        {% trans "Vous êtes déjà inscrit." %}
+                    </strong>
+                </p>
+            </div>
         {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | (#3395) |
### QA
- Se connecter avec n'importe quel compte
- Une fois connecté, aller sur la page d'inscription (en passant par l'url)
- Le message n'est plus `Vous êtes déjà connecté` mais `Vous êtes déjà inscrit`, dans un encart orange.

Je refais une PR sur cette issue parce qu'on ne peut plus faire de modification (si il y en a faire) sur la PR précédente (voir #3425), le dépôt étant inconnu.
