### PR TITLE
Correction des erreurs/alertes de flake8

### DIFF
--- a/doc/source/utils/git-pre-hook.rst
+++ b/doc/source/utils/git-pre-hook.rst
@@ -18,7 +18,7 @@ restera propre et lisible au cours du temps !
 
     #!/bin/sh
 
-    flake8 --exclude=migrations,settings.py --max-line-length=120 zds
+    flake8 --exclude=migrations --max-line-length=120 zds
 
     # Store tests result
     RESULT=$?

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,6 @@ commands = flake8 {posargs}
 [flake8]
 #show-source = True
 max-line-length = 120
-exclude = .tox,.venv,build,dist,doc,migrations,settings.py,settings_prod.py,settings_test.py
+exclude = .tox,.venv,build,dist,doc,migrations,settings_prod.py,settings_test.py
 # Ignore N802 (functions in lowercase) because the setUp() function in tests
 ignore = N802

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-from os.path import dirname
 from os.path import join
 
 from django.contrib.messages import constants as message_constants
@@ -94,7 +93,7 @@ STATICFILES_FINDERS = (
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = 'n!01nl+318#x75_%le8#s0=-*ysw&amp;y49uc#t=*wvi(9hnyii0z' # noqa
+SECRET_KEY = 'n!01nl+318#x75_%le8#s0=-*ysw&amp;y49uc#t=*wvi(9hnyii0z'  # noqa
 
 FILE_UPLOAD_HANDLERS = (
     "django.core.files.uploadhandler.MemoryFileUploadHandler",
@@ -147,7 +146,7 @@ TEMPLATES = [
                 'zds.utils.context_processor.git_version',
             ],
             'debug': DEBUG,
-            }
+        }
     },
 ]
 
@@ -220,14 +219,14 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PARSER_CLASSES': (
         'rest_framework.parsers.JSONParser',
-        #'rest_framework.parsers.XMLParser',
+        # 'rest_framework.parsers.XMLParser',
         'rest_framework_xml.parsers.XMLParser',
         'rest_framework.parsers.FormParser',
         'rest_framework.parsers.MultiPartParser',
     ),
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
-        #'rest_framework.renderers.XMLRenderer',
+        # 'rest_framework.renderers.XMLRenderer',
         'rest_framework_xml.renderers.XMLRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
@@ -366,7 +365,6 @@ GEOIP_PATH = os.path.join(BASE_DIR, 'geodata')
 # Fake mails (in console)
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-from django.contrib.messages import constants as message_constants
 MESSAGE_TAGS = {
     message_constants.DEBUG: 'debug',
     message_constants.INFO: 'info',
@@ -549,7 +547,7 @@ SOCIAL_AUTH_PIPELINE = (
 SOCIAL_AUTH_FACEBOOK_KEY = ""
 SOCIAL_AUTH_FACEBOOK_SECRET = ""
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = "696570367703-r6hc7mdd27t1sktdkivpnc5b25i0uip2.apps.googleusercontent.com"
-SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = "mApWNh3stCsYHwsGuWdbZWP8" # noqa
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = "mApWNh3stCsYHwsGuWdbZWP8"  # noqa
 
 # ReCaptcha stuff
 USE_CAPTCHA = False
@@ -572,6 +570,6 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Load the production settings, overwrite the existing ones if needed
 try:
-    from settings_prod import *
+    from settings_prod import *  # noqa
 except ImportError:
     pass


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | Refactoring |
| Ticket(s) (_issue(s)_) concerné(s) |  |

Mon linter Flake8 sur Atom a vu rouge sur le fichier `settings.py`.
Voici toutes les erreurs répertoriées :

``` diff
- Flake8 Warning F401 — 'dirname' imported but unusedat line 5 col 21
- Flake8 Error E261 — at least two spaces before inline commentat line 97 col 70
- Flake8 Error E123 — closing bracket does not match indentation of opening bracket's lineat line 150 col 13
- Flake8 Error E265 — block comment should start with '# 'at line 223 col 9
- Flake8 Error E265 — block comment should start with '# 'at line 230 col 9
- Flake8 Error E402 — module level import not at top of fileat line 369 col 1
- Flake8 Warning F811 — redefinition of unused 'message_constants' from line 8at line 369 col 1
- Flake8 Error E261 — at least two spaces before inline commentat line 552 col 62
- Flake8 Warning F403 — 'from settings_prod import *' used; unable to detect undefined namesat line 575 col 5
```
