### PR TITLE
Fix #3444 : Indication du nombre de sujets créés éroné

### DIFF
--- a/templates/forum/find/topic.html
+++ b/templates/forum/find/topic.html
@@ -67,7 +67,7 @@
         </table>
     {% else %}
         <p>
-            {% trans "Aucun sujet n'a été créé par" %} {{ usr.username }}.
+            {% trans "Aucun sujet public n'a été créé par" %} {{ usr.username }}.
         </p>
     {% endif %}
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | Évolution |
| Ticket(s) (_issue(s)_) concerné(s) | #3444 |
### QA

Sur la page des sujets créés par un membre : si aucun sujet public n'a été créé la page affiche désormais "Aucun sujet public n'a été créé par ... " au lieu de "Aucun sujet n'a été créé par ... ".
