### PR TITLE
Fix #3451 : Suppression des RemovedInDjango19Warning dans zds.notific…

### DIFF
--- a/zds/notification/__init__.py
+++ b/zds/notification/__init__.py
@@ -1,3 +1,0 @@
-# flake8: noqa
-
-import receivers

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -299,3 +299,7 @@ class TopicFollowed(models.Model):
     def __unicode__(self):
         return u'<Sujet "{0}" suivi par {1}>'.format(self.topic.title,
                                                      self.user.username)
+
+# used to fix Django 1.9 Warning
+# https://github.com/zestedesavoir/zds-site/issues/3451
+import receivers  # noqa


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3451 |
### QA
- Vérifier qu'il n'y a plus de Warning pour ZdS dans Travis

La réponse a été trouvée ici : http://stackoverflow.com/a/33775302 (si vous pouvez mettez lui un +1)

Ça vient du fait que lorsqu'on charge l'application on charge le `__init__.py` qui contient un import utilisant un modèle qui se trouve dans cette application (et qui donc n'est pas encore chargé).
