### PR TITLE
Fix #3397 : corriges les incoherences du modele PublishableContent

### DIFF
--- a/zds/tutorialv2/migrations/0014_auto_20160331_0415.py
+++ b/zds/tutorialv2/migrations/0014_auto_20160331_0415.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tutorialv2', '0013_auto_20160320_0908'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='publishablecontent',
+            name='beta_topic',
+            field=models.ForeignKey(default=None, blank=True, to='forum.Topic', null=True, verbose_name=b'Sujet beta associ\xc3\xa9'),
+        ),
+        migrations.AlterField(
+            model_name='publishablecontent',
+            name='helps',
+            field=models.ManyToManyField(to='utils.HelpWriting', db_index=True, verbose_name=b'Aides', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='publishablecontent',
+            name='source',
+            field=models.CharField(max_length=200, null=True, verbose_name=b'Source', blank=True),
+        ),
+    ]

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -60,7 +60,7 @@ class PublishableContent(models.Model):
     title = models.CharField('Titre', max_length=80)
     slug = models.CharField('Slug', max_length=80)
     description = models.CharField('Description', max_length=200)
-    source = models.CharField('Source', max_length=200)
+    source = models.CharField('Source', max_length=200, blank=True, null=True)
     authors = models.ManyToManyField(User, verbose_name='Auteurs', db_index=True)
     old_pk = models.IntegerField(db_index=True, default=0)
     subcategory = models.ManyToManyField(SubCategory,
@@ -93,17 +93,14 @@ class PublishableContent(models.Model):
                                       blank=True, null=True, max_length=80, db_index=True)
     sha_draft = models.CharField('Sha1 de la version de rédaction',
                                  blank=True, null=True, max_length=80, db_index=True)
-    beta_topic = models.ForeignKey(Topic,
-                                   verbose_name='Contenu associé',
-                                   default=None,
-                                   null=True)
+    beta_topic = models.ForeignKey(Topic, verbose_name='Sujet beta associé', default=None, blank=True, null=True)
     licence = models.ForeignKey(Licence,
                                 verbose_name='Licence',
                                 blank=True, null=True, db_index=True)
     # as of ZEP 12 this field is no longer the size but the type of content (article/tutorial)
     type = models.CharField(max_length=10, choices=TYPE_CHOICES, db_index=True)
     # zep03 field
-    helps = models.ManyToManyField(HelpWriting, verbose_name='Aides', db_index=True)
+    helps = models.ManyToManyField(HelpWriting, verbose_name='Aides', blank=True, db_index=True)
 
     relative_images_path = models.CharField(
         'chemin relatif images',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3397 |
### QA
- Mettre à jour la base de données : `python manage.py migrate`
- Aller dans l'administration Django (/admin/) -> Tutorialv2 -> [Contenus](http://localhost:8000/admin/tutorialv2/publishablecontent)
- Éditer un contenu
- Vérifier que les champs « Source », « Sujet beta associé » et « Aides » ne sont plus requis (pas en gras)
- Vérifier que l'enregistrement de l'objet se fait bien (en cliquant sur « Enregistrer » en bas de page)
