### PR TITLE
Fix #3286 : ajoute la possibilite de supprimer un auteur bot

### DIFF
--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -86,6 +86,25 @@ class AuthorForm(forms.Form):
         return super(AuthorForm, self).is_valid() and "users" in self.clean()
 
 
+class RemoveAuthorForm(AuthorForm):
+
+    def clean(self):
+        """Check every username and send it to the cleaned_data["user"] list
+
+        :return: a dictionary of all treated data with the users key added
+        """
+        cleaned_data = super(AuthorForm, self).clean()
+        users = []
+        for username in cleaned_data.get('username').split(","):
+            # we can remove all users (bots inclued)
+            user = Profile.objects.filter(user__username__iexact=username.strip().lower()).first()
+            if user is not None:
+                users.append(user.user)
+        if len(users) > 0:
+            cleaned_data["users"] = users
+        return cleaned_data
+
+
 class ContainerForm(FormWithTitle):
 
     introduction = forms.CharField(

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -37,7 +37,7 @@ from zds.member.models import Profile
 from zds.notification.models import TopicAnswerSubscription
 from zds.tutorialv2.forms import ContentForm, JsFiddleActivationForm, AskValidationForm, AcceptValidationForm, \
     RejectValidationForm, RevokeValidationForm, WarnTypoForm, ImportContentForm, ImportNewContentForm, ContainerForm, \
-    ExtractForm, BetaForm, MoveElementForm, AuthorForm, CancelValidationForm
+    ExtractForm, BetaForm, MoveElementForm, AuthorForm, RemoveAuthorForm, CancelValidationForm
 from zds.tutorialv2.mixins import SingleContentDetailViewMixin, SingleContentFormViewMixin, SingleContentViewMixin, \
     SingleContentDownloadViewMixin, SingleContentPostMixin
 from zds.tutorialv2.models import TYPE_CHOICES_DICT
@@ -1740,6 +1740,8 @@ class AddAuthorToContent(LoggedWithReadWriteHability, SingleContentFormViewMixin
 
 class RemoveAuthorFromContent(AddAuthorToContent):
 
+    form_class = RemoveAuthorForm
+
     @staticmethod
     def remove_author(content, user):
         """Remove an user from the authors and ensure that he is access to the content's gallery is also removed.
@@ -1795,10 +1797,10 @@ class RemoveAuthorFromContent(AddAuthorToContent):
 
         if not current_user:  # if the removed author is not current user
             messages.success(
-                self.request, _(u'Vous avez enlevé {} de la liste des auteurs de « {} ».').format(authors_list, _type))
+                self.request, _(u'Vous avez enlevé {} de la liste des auteurs de {}.').format(authors_list, _type))
             self.success_url = self.object.get_absolute_url()
         else:  # if current user is leaving the content's redaction, redirect him to a more suitable page
-            messages.success(self.request, _(u'Vous avez bien quitté la rédaction de « {} ».').format(_type))
+            messages.success(self.request, _(u'Vous avez bien quitté la rédaction de {}.').format(_type))
             self.success_url = reverse('content:find-' + self.object.type.lower(), args=[self.request.user.pk])
         self.already_finished = True  # this one is kind of tricky : because of inheritance we used to force redirection
         # to the content itself. This does not please me but I think it is better to do that like that instead of


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug / nouvelle fonctionnalité / évolution |
| Ticket(s) (_issue(s)_) concerné(s) | #3286 |
### QA
- Aller sur un contenu sur l'administration Django (/admin/)
- Ajouter manuellement un auteur bot (external par exemple) au contenu
- Aller sur la page du contenu et essayer de supprimer l'auteur bot
