### PR TITLE
Ajoute un cache pour les top tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ base.db
 /contents-public
 /media
 /articles-data
+django_cache
 
 /tutoriels-private-test
 /tutoriels-public-test

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -511,7 +511,9 @@ ZDS_APP = {
         'old_post_limit_days': 90,
         # Exclude tags from top tags list. Tags listed here should not be relevant for most of users.
         # Be warned exclude too much tags can restrict performance
-        'top_tag_exclu': ['bug', 'suggestion', 'tutoriel', 'beta', 'article']
+        'top_tag_exclu': ['bug', 'suggestion', 'tutoriel', 'beta', 'article'],
+        # Cache in second
+        'top_tag_cache': 60 * 60 * 24,
     },
     'topic': {
         'home_number': 6,


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | performance |
| Ticket(s) (_issue(s)_) concerné(s) |  |
### QA
- Activer memcache ou changer la configuration du cache selon vos envies
- Rafraîchir la page et vérifier que les pages ne font la requête sur les top tags

PS: Todo docs
