### PR TITLE
fixes 3057 : ajout d'envoi de mp aux auteurs d'un contenu

### DIFF
--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -86,7 +86,21 @@
     {% endif %}
 {% endblock %}
 
+{% block sidebar_actions %}
 
+    {% if not user in content.authors.all and user.is_authenticated %}
+    <li>
+        <a href="{{ pm_link }}" class="ico-after cite blue">
+        {% blocktrans count counter=content.authors.all|length %}
+            Contacter l'auteur par MP
+        {% plural %}
+            Contacter les auteurs par MP
+        {% endblocktrans %}
+        </a>
+    </li>
+    {% endif %}
+
+{% endblock %}
 
 {% block sidebar_blocks %}
     {% if is_staff or is_author %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -133,6 +133,18 @@
         </form>
     {% endwith %}
     </li>
+    
+    {% if not user in content.authors.all and user.is_authenticated %}
+    <li>
+        <a href="{{ pm_link }}" class="ico-after cite blue">
+        {% blocktrans count counter=content.authors.all|length %}
+            Contacter l'auteur par MP
+        {% plural %}
+            Contacter les auteurs par MP
+        {% endblocktrans %}
+        </a>
+    </li>
+    {% endif %}
 
 {% endblock %}
 

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -125,7 +125,7 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
                                           if reaction.author == self.request.user]
 
         context['isantispam'] = self.object.antispam()
-        context['pm_link'] = self.object.get_absolute_contact_url(_(u'À propos de')) 
+        context['pm_link'] = self.object.get_absolute_contact_url(_(u'À propos de'))
 
         # handle reactions:
         if last_participation_is_old(self.object, self.request.user):

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -125,6 +125,7 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
                                           if reaction.author == self.request.user]
 
         context['isantispam'] = self.object.antispam()
+        context['pm_link'] = self.object.get_absolute_contact_url(u'À propos de')
 
         # handle reactions:
         if last_participation_is_old(self.object, self.request.user):
@@ -231,6 +232,7 @@ class DisplayOnlineContainer(SingleOnlineContentDetailViewMixin):
         container = search_container_or_404(self.versioned_object, self.kwargs)
 
         context['container'] = container
+        context['pm_link'] = self.object.get_absolute_contact_url(u'À propos de')
 
         context['formWarnTypo'] = WarnTypoForm(
             self.versioned_object, container, initial={'target': container.get_path(relative=True)})

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -125,7 +125,7 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
                                           if reaction.author == self.request.user]
 
         context['isantispam'] = self.object.antispam()
-        context['pm_link'] = self.object.get_absolute_contact_url(u'À propos de')
+        context['pm_link'] = self.object.get_absolute_contact_url(`_(u'À propos de')`) 
 
         # handle reactions:
         if last_participation_is_old(self.object, self.request.user):
@@ -232,7 +232,7 @@ class DisplayOnlineContainer(SingleOnlineContentDetailViewMixin):
         container = search_container_or_404(self.versioned_object, self.kwargs)
 
         context['container'] = container
-        context['pm_link'] = self.object.get_absolute_contact_url(u'À propos de')
+        context['pm_link'] = self.object.get_absolute_contact_url(`_(u'À propos de')`) 
 
         context['formWarnTypo'] = WarnTypoForm(
             self.versioned_object, container, initial={'target': container.get_path(relative=True)})

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -125,6 +125,7 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
                                           if reaction.author == self.request.user]
 
         context['isantispam'] = self.object.antispam()
+        context['pm_link'] = self.object.get_absolute_contact_url(_(u'À propos de')) 
 
         # handle reactions:
         if last_participation_is_old(self.object, self.request.user):
@@ -231,6 +232,7 @@ class DisplayOnlineContainer(SingleOnlineContentDetailViewMixin):
         container = search_container_or_404(self.versioned_object, self.kwargs)
 
         context['container'] = container
+        context['pm_link'] = self.object.get_absolute_contact_url(_(u'À propos de'))
 
         context['formWarnTypo'] = WarnTypoForm(
             self.versioned_object, container, initial={'target': container.get_path(relative=True)})

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -125,11 +125,7 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
                                           if reaction.author == self.request.user]
 
         context['isantispam'] = self.object.antispam()
-<<<<<<< HEAD
         context['pm_link'] = self.object.get_absolute_contact_url(_(u'À propos de')) 
-=======
-        context['pm_link'] = self.object.get_absolute_contact_url(`_(u'À propos de')`) 
->>>>>>> 32b2953a6f280b9640e0292ef6bd38196aa744ec
 
         # handle reactions:
         if last_participation_is_old(self.object, self.request.user):
@@ -236,11 +232,7 @@ class DisplayOnlineContainer(SingleOnlineContentDetailViewMixin):
         container = search_container_or_404(self.versioned_object, self.kwargs)
 
         context['container'] = container
-<<<<<<< HEAD
         context['pm_link'] = self.object.get_absolute_contact_url(_(u'À propos de'))
-=======
-        context['pm_link'] = self.object.get_absolute_contact_url(`_(u'À propos de')`) 
->>>>>>> 32b2953a6f280b9640e0292ef6bd38196aa744ec
 
         context['formWarnTypo'] = WarnTypoForm(
             self.versioned_object, container, initial={'target': container.get_path(relative=True)})


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | nouvelle fonctionnalité |
| Ticket(s) (_issue(s)_) concerné(s) | #3057 |
### QA
- Creer un tutoriel avec un ou plusieurs auteurs, demander la validation (user)
- Valider le tutoriel (admin)
- Dans la version en ligne constater qu'un lien de contact est présent dans la sidebar
- Au clic un nouveau MP est créé avec le/les auteurs

C'est ma première PR sur ce projet (et sur Django en général) donc n'hésitez pas à me taper sur les doigts ;)
