### PR TITLE
Rend les trailing slashes des ressources de l'API optionnels 

### DIFF
--- a/zds/forum/api/urls.py
+++ b/zds/forum/api/urls.py
@@ -3,5 +3,5 @@ from django.conf.urls import url
 from .views import PostKarmaView
 
 urlpatterns = [
-    url(r'^message/(?P<pk>\d+)/karma$', PostKarmaView.as_view(), name='post-karma'),
+    url(r'^message/(?P<pk>\d+)/karma/?$', PostKarmaView.as_view(), name='post-karma'),
 ]

--- a/zds/member/api/urls.py
+++ b/zds/member/api/urls.py
@@ -7,8 +7,8 @@ from zds.member.api.views import MemberListAPI, MemberDetailAPI, MemberDetailRea
 
 urlpatterns = [
     url(r'^$', MemberListAPI.as_view(), name='list'),
-    url(r'^mon-profil/$', MemberMyDetailAPI.as_view(), name='profile'),
-    url(r'^(?P<user__id>[0-9]+)/$', MemberDetailAPI.as_view(), name='detail'),
-    url(r'^(?P<user__id>[0-9]+)/lecture-seule/$', MemberDetailReadingOnly.as_view(), name='read-only'),
-    url(r'^(?P<user__id>[0-9]+)/ban/$', MemberDetailBan.as_view(), name='ban'),
+    url(r'^mon-profil/?$', MemberMyDetailAPI.as_view(), name='profile'),
+    url(r'^(?P<user__id>[0-9]+)/?$', MemberDetailAPI.as_view(), name='detail'),
+    url(r'^(?P<user__id>[0-9]+)/lecture-seule/?$', MemberDetailReadingOnly.as_view(), name='read-only'),
+    url(r'^(?P<user__id>[0-9]+)/ban/?$', MemberDetailBan.as_view(), name='ban'),
 ]

--- a/zds/mp/api/urls.py
+++ b/zds/mp/api/urls.py
@@ -7,8 +7,8 @@ from zds.mp.api.views import PrivateTopicListAPI, PrivateTopicDetailAPI, Private
 
 urlpatterns = [
     url(r'^$', PrivateTopicListAPI.as_view(), name='list'),
-    url(r'^(?P<pk>[0-9]+)/$', PrivateTopicDetailAPI.as_view(), name='detail'),
+    url(r'^(?P<pk>[0-9]+)/?$', PrivateTopicDetailAPI.as_view(), name='detail'),
     url(r'^(?P<pk_ptopic>[0-9]+)/messages/$', PrivatePostListAPI.as_view(), name='message-list'),
-    url(r'^(?P<pk_ptopic>[0-9]+)/messages/(?P<pk>[0-9]+)/$', PrivatePostDetailAPI.as_view(), name='message-detail'),
+    url(r'^(?P<pk_ptopic>[0-9]+)/messages/(?P<pk>[0-9]+)/?$', PrivatePostDetailAPI.as_view(), name='message-detail'),
     url(r'^unread/$', PrivateTopicReadAPI.as_view(), name='list-unread'),
 ]

--- a/zds/tutorialv2/api/urls.py
+++ b/zds/tutorialv2/api/urls.py
@@ -5,5 +5,5 @@ from django.conf.urls import url
 from zds.tutorialv2.api.views import ContentReactionKarmaView
 
 urlpatterns = [
-    url(r'^reactions/(?P<pk>\d+)/karma$', ContentReactionKarmaView.as_view(), name='reaction-karma'),
+    url(r'^reactions/(?P<pk>\d+)/karma/?$', ContentReactionKarmaView.as_view(), name='reaction-karma'),
 ]


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3512 |

Avec cette PR, les ressources "seules" sont accessibles avec et sans slash final. J'entend par seul tout ce qui n'est pas une liste de resources, par exemple `/api/membres/1` (et pas `/api/membres/`, par exemple). Cela assure aussi que les votes fonctionnent même si nginx redirige pour ajouter un slash à la fin (bien que la modification de config _doit_ aussi être fait en prod ; je suis en train de revoir la config)
### QA
- Vérifier que les ressources de l'API sont accessibles avec et sans slash final
