### PR TITLE
Fix #3507 : correction de l'affichage des noms des filtres

### DIFF
--- a/templates/tutorialv2/index_online.html
+++ b/templates/tutorialv2/index_online.html
@@ -8,6 +8,8 @@
 {% block title %}
     {% if tag %}
         {{ tag }}
+    {% elif category %}
+        {{ category }}
     {% else %}
         {% trans "Tous les" %} {{ verbose_type_name_plural }}
     {% endif %}
@@ -19,6 +21,10 @@
     {% if tag %}
         {% blocktrans %}
             Découvrez tous nos {{ verbose_type_name_plural }} sur {{ tag }}. Vous pourrez également découvrir divers sujets tous plus intéressants les uns que les autres !
+        {% endblocktrans %}
+    {% elif category %}
+        {% blocktrans %}
+            Découvrez toutes nos {{ verbose_type_name_plural }} sur {{ category }}. Vous pourrez également découvrir divers sujets tous plus intéressants les uns que les autres !
         {% endblocktrans %}
     {% else %}
         {% blocktrans %}
@@ -32,6 +38,8 @@
 {% block breadcrumb %}
     {% if tag %}
         <li>{{ tag }}</li>
+    {% elif category %}
+        <li>{{ category }}</li>
     {% else %}
         <li>{% trans "Tous les" %} {{ verbose_type_name_plural }}</li>
     {% endif %}
@@ -45,6 +53,8 @@
             {% block headline %}
                 {% if tag %}
                     {{ verbose_type_name_plural|title }} : {{ tag }}
+                {% elif category %}
+                    {{ verbose_type_name_plural|title }} : {{ category }}
                 {% else %}
                     {% trans "Tous les" %} {{ verbose_type_name_plural }}
                 {% endif %}

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -310,6 +310,7 @@ class ListOnlineContents(ContentTypeMixin, ZdSPagingListView):
                 public_content.content.public_version = public_content
                 public_content.content.count_note = public_content.count_note
         context['category'] = self.category
+        context['tag'] = self.tag
         context['top_categories'] = top_categories_content(self.current_content_type)
 
         return context


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3507 |
### QA
- Filtrer les contenus par tag ou catégorie et vérifier que l'affiche se fait correctement (cf #3507)
