### PR TITLE
Utilise le bon sprite sur écran rétina

### DIFF
--- a/assets/scss/base/_high-pixel-ratio.scss
+++ b/assets/scss/base/_high-pixel-ratio.scss
@@ -10,6 +10,8 @@
     }
     .ico,
     .ico-after:after,
+    .content-item .content-reactions,
+    .content-item .content-reactions::before,
     .breadcrumb ol li:not(:last-child):after {
         @include sprite-2x();
     }
@@ -19,6 +21,16 @@
         input[type=radio]:after,
         input[type=checkbox]:after {
             @include sprite-2x();
+        }
+    }
+
+    .home .home-search-box::before {
+        background-image: url('../images/home-clem@2x.png');
+
+        @at-root {
+            body.vc-clem-christmas.home .home-search-box::before {
+                background-image: url('../images/home-clem-christmas@2x.png');
+            }
         }
     }
 }
@@ -36,15 +48,5 @@
 
     .page-container .header-logo-link {
         background-image: url('../images/logo-mobile@2x.png') !important;
-    }
-
-    .home .home-search-box::before {
-        background-image: url('../images/home-clem@2x.png');
-
-        @at-root {
-            body.vc-clem-christmas.home .home-search-box::before {
-                background-image: url('../images/home-clem-christmas@2x.png');
-            }
-        }
     }
 }


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3511 |
### QA
- `npm run build`
- Vérifier que c'est bien le sprite `@2x` qui est utilisé sur écran rétina sur les bulles des réactions et la clem de la home. Pour tester sans écran rétina, les devs tools de Chrome (et sûrement de Firefox aussi) permettent de forcer une certaine densité de pixels.
