### PR TITLE
Corrige la marge sur la home "connectée"

### DIFF
--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -415,7 +415,7 @@ $content-width: 1145px;
             &.connected {
                 // Rules to don't be hidden by the .home-search-box::before background-image
                 max-width: 740px;
-                margin: 0px auto;
+                margin: 15px auto 0;
             }
         }
     }


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3501 |

Suite à la modif du texte de bienvenue, j'ai changé une marge, qui ne rend pas bien sur la version "connectée" de l'accueil. Cette PR rétablit donc cette marge.

![home-margin](https://cloud.githubusercontent.com/assets/1549952/14349697/0e2c02ec-fcc5-11e5-87cb-1aa47725d3b0.gif)
