### PR TITLE
Fix #2707 : ne pas afficher les bannis dans l'autocomplete

### DIFF
--- a/zds/member/api/urls.py
+++ b/zds/member/api/urls.py
@@ -2,12 +2,11 @@
 
 from django.conf.urls import url
 
-from zds.member.api.views import MemberListAPI, ContactableMemberListAPI, MemberDetailAPI, MemberDetailReadingOnly, MemberDetailBan, \
+from zds.member.api.views import MemberListAPI, MemberDetailAPI, MemberDetailReadingOnly, MemberDetailBan, \
     MemberMyDetailAPI
 
 urlpatterns = [
     url(r'^$', MemberListAPI.as_view(), name='list'),
-    url(r'^contactable/$', ContactableMemberListAPI.as_view(), name='list'),
     url(r'^mon-profil/$', MemberMyDetailAPI.as_view(), name='profile'),
     url(r'^(?P<user__id>[0-9]+)/$', MemberDetailAPI.as_view(), name='detail'),
     url(r'^(?P<user__id>[0-9]+)/lecture-seule/$', MemberDetailReadingOnly.as_view(), name='read-only'),

--- a/zds/member/api/urls.py
+++ b/zds/member/api/urls.py
@@ -2,11 +2,12 @@
 
 from django.conf.urls import url
 
-from zds.member.api.views import MemberListAPI, MemberDetailAPI, MemberDetailReadingOnly, MemberDetailBan, \
+from zds.member.api.views import MemberListAPI, ContactableMemberListAPI, MemberDetailAPI, MemberDetailReadingOnly, MemberDetailBan, \
     MemberMyDetailAPI
 
 urlpatterns = [
     url(r'^$', MemberListAPI.as_view(), name='list'),
+    url(r'^contactable/$', ContactableMemberListAPI.as_view(), name='list'),
     url(r'^mon-profil/$', MemberMyDetailAPI.as_view(), name='profile'),
     url(r'^(?P<user__id>[0-9]+)/$', MemberDetailAPI.as_view(), name='detail'),
     url(r'^(?P<user__id>[0-9]+)/lecture-seule/$', MemberDetailReadingOnly.as_view(), name='read-only'),

--- a/zds/member/api/views.py
+++ b/zds/member/api/views.py
@@ -108,6 +108,53 @@ class MemberListAPI(ListCreateAPIView, ProfileCreate, TokenGenerator):
             permission_classes.append(DRYPermissions)
         return [permission() for permission in permission_classes]
 
+        
+class ContactableMemberListAPI(ListCreateAPIView, ProfileCreate, TokenGenerator):
+    """
+    Profile resource to list all contactable members
+    """
+
+    queryset = Profile.objects.contactable_members()
+    filter_backends = (filters.SearchFilter,)
+    search_fields = ('user__username',)
+    list_key_func = PagingSearchListKeyConstructor()
+
+    @etag(list_key_func)
+    @cache_response(key_func=list_key_func)
+    def get(self, request, *args, **kwargs):
+        """
+        Lists all users in the system.
+        ---
+
+        parameters:
+            - name: page
+              description: Restricts output to the given page number.
+              required: false
+              paramType: query
+            - name: page_size
+              description: Sets the number of profiles per page.
+              required: false
+              paramType: query
+            - name: search
+              description: Filters by username.
+              required: false
+              paramType: query
+        responseMessages:
+            - code: 404
+              message: Not Found
+        """
+        return self.list(request, *args, **kwargs)
+
+    def get_serializer_class(self):
+        if self.request.method == 'GET':
+            return ProfileListSerializer
+
+    def get_permissions(self):
+        permission_classes = [AllowAny, ]
+        if self.request.method == 'GET':
+            permission_classes.append(DRYPermissions)
+        return [permission() for permission in permission_classes]
+
 
 class MemberMyDetailAPI(RetrieveAPIView):
     """

--- a/zds/member/api/views.py
+++ b/zds/member/api/views.py
@@ -51,13 +51,12 @@ class MemberListAPI(ListCreateAPIView, ProfileCreate, TokenGenerator):
     filter_backends = (filters.SearchFilter,)
     search_fields = ('user__username',)
     list_key_func = PagingSearchListKeyConstructor()
-    
-    
+
     def get_queryset(self):
         contactable = self.request.query_params.get('contactable', None)
         if contactable is not None:
             queryset = Profile.objects.contactable_members()
-        else :
+        else:
             queryset = Profile.objects.all_members_ordered_by_date_joined()
         return queryset
 

--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -21,7 +21,7 @@ class PrivateTopicForm(forms.Form, ParticipantsStringValidator, TitleValidator, 
                 'placeholder': _(u'Les participants doivent '
                                  u'être séparés par une virgule.'),
                 'required': 'required',
-                'data-autocomplete': '{ "type": "multiple" }'}))
+                'data-autocomplete': '{ "type": "multiple", "url": "/api/membres/contactable/?search=%s" }'}))
 
     title = forms.CharField(
         label=_('Titre'),

--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -21,7 +21,7 @@ class PrivateTopicForm(forms.Form, ParticipantsStringValidator, TitleValidator, 
                 'placeholder': _(u'Les participants doivent '
                                  u'être séparés par une virgule.'),
                 'required': 'required',
-                'data-autocomplete': '{ "type": "multiple", "url": "/api/membres/contactable/?search=%s" }'}))
+                'data-autocomplete': '{ "type": "multiple", "url": "/api/membres/?contactable&search=%s" }'}))
 
     title = forms.CharField(
         label=_('Titre'),


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) | #2707 |

Ce fix modifie un fichier js, il est donc necessaire de re builder le front.
### QA
- S'assurez que vous avez un membre banni
- Ecrire un nouveau mp
- Dans l'autocomplete du destinataire, son pseudo ne doit pas apparaitre (les autres oui)
