### PR TITLE
Fix 3481 : Le select ne depasse plus de la boite modale lors du deplacement de section

### DIFF
--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -41,14 +41,14 @@
                         {% for element in child|target_tree %}
                                 <option value="before:{{element.0}}"
                                 {% if not element.3 %} disabled {% endif %}>
-                                     &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1 }}
+                                     &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
                                 </option>
                         {% endfor %}
                         <option disabled="disabled">&mdash; {% trans "Déplacer après" %}</option>
                         {% for element in child|target_tree %}
                                 <option value="after:{{element.0}}"
                                 {% if not element.3 %} disabled {% endif %}>
-                                     &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1 }}
+                                     &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
                                 </option>
                         {% endfor %}
                     </select>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3481 |

J'ai choisi l'option de tronquer le texte. Cela suffit pout identifier le titre de la section a deplacer, évite de toucher au css des modales (ce qui impacterai beaucoup d'autres endroits) et règle le problème de manière définitive.
### QA
- Creez un tutoriel avec une section portant un titre très long
- Essayez de deplacer cette section, dans la boite modale le select ne doit pas depasser de la boite.
