### PR TITLE
fix 3459 : regle le soucis de lien dans les filtres des tutoriels

### DIFF
--- a/templates/tutorialv2/index.html
+++ b/templates/tutorialv2/index.html
@@ -118,7 +118,11 @@
             <h3>Filtrer</h3>
             <ul>
                 {% for current_filter in filters %}
-                    <li><a href="{% append_to_get filter=current_filter.key %}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
+                    {% if tutorials != None %}
+                        <li><a href="{% url "content:find-tutorial" usr.pk %}?filter={{ current_filter.key }}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
+                    {% elif articles != None %}
+                        <li><a href="{% url "content:find-article" usr.pk %}?filter={{ current_filter.key }}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
+                    {% endif %}
                 {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3459 |
### QA
- avoir assez de contenus pour en avoir sur 2 pages (50 contenus dans le settings par defaut)
- aller sur la page mes tutoriels ou mes articles, se rendre en page 2
- sélectionner un filtre
- le contenu est bien filtré, vous etes dans le bon type de contenu, en première page
