### PR TITLE
[v18]corrige le nombre de tuto par tag

### DIFF
--- a/zds/tutorialv2/urls/urls_articles.py
+++ b/zds/tutorialv2/urls/urls_articles.py
@@ -2,7 +2,8 @@
 
 from django.conf.urls import url
 
-from zds.tutorialv2.views.views_published import ListArticles, DisplayOnlineArticle, DownloadOnlineArticle
+from zds.tutorialv2.views.views_published import ListArticles, DisplayOnlineArticle, DownloadOnlineArticle, \
+    TagsListView
 from zds.tutorialv2.feeds import LastArticlesFeedRSS, LastArticlesFeedATOM
 
 urlpatterns = [
@@ -25,5 +26,6 @@ urlpatterns = [
         name='download-zip'),
 
     # Listing
-    url(r'^$', ListArticles.as_view(), name='list')
+    url(r'^$', ListArticles.as_view(), name='list'),
+    url(r'tags/*', TagsListView.as_view(displayed_types=["ARTICLE"]), name="tags")
 ]

--- a/zds/tutorialv2/urls/urls_tutorials.py
+++ b/zds/tutorialv2/urls/urls_tutorials.py
@@ -4,8 +4,9 @@ from django.conf.urls import url
 from zds.tutorialv2.views.views_contents import RedirectOldBetaTuto
 
 from zds.tutorialv2.views.views_published import ListTutorials, DisplayOnlineTutorial, DisplayOnlineContainer, \
-    DownloadOnlineTutorial, RedirectContentSEO
+    DownloadOnlineTutorial, RedirectContentSEO, TagsListView
 from zds.tutorialv2.feeds import LastTutorialsFeedRSS, LastTutorialsFeedATOM
+
 
 urlpatterns = [
     # flux
@@ -40,5 +41,6 @@ urlpatterns = [
     url('^beta/(?P<pk>\d+)/(?P<slug>.+)', RedirectOldBetaTuto.as_view(), name="old-beta-url"),
 
     # Listing
-    url(r'^$', ListTutorials.as_view(), name='list')
+    url(r'^$', ListTutorials.as_view(), name='list'),
+    url(r'tags/$', TagsListView.as_view(displayed_types=["TUTORIAL"]), name="tags")
 ]

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -671,11 +671,16 @@ class TagsListView(ListView):
     model = Tag
     template_name = "tutorialv2/view/tags.html"
     context_object_name = 'tags'
+    displayed_types = ["TUTORIAL", "ARTICLE"]
 
     def get_queryset(self):
-        tags_pk = [tag['content__tags'] for tag in PublishedContent.objects.values('content__tags').distinct()]
+        published = PublishedContent.objects.filter(
+            must_redirect=False,
+            content__type__in=self.displayed_types).values('content__tags').distinct()
+        tags_pk = [tag['content__tags'] for tag in published]
         queryset = Tag.objects\
-            .filter(pk__in=tags_pk)\
+            .filter(pk__in=tags_pk, publishablecontent__public_version__isnull=False,
+                    publishablecontent__type__in=self.displayed_types)\
             .annotate(num_content=Count('publishablecontent__publishedcontent'))\
             .order_by('-num_content', 'title')
         return queryset

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -681,6 +681,6 @@ class TagsListView(ListView):
         queryset = Tag.objects\
             .filter(pk__in=tags_pk, publishablecontent__public_version__isnull=False,
                     publishablecontent__type__in=self.displayed_types)\
-            .annotate(num_content=Count('publishablecontent__publishedcontent'))\
+            .annotate(num_content=Count('publishablecontent'))\
             .order_by('-num_content', 'title')
         return queryset


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug / nouvelle fonctionnalité / évolution |
| Ticket(s) (_issue(s)_) concerné(s) | (#3495) |

je reprends #3518
### QA
- Dans la page de tous les tags, sélectionnez un tag, retenez le nombre de tutos qu'il y a à l'interrieur
- Naviguer sur un des tutos de ce tag
- Modifiez son titre
- publiez la nouvelle version
- observez dans la page de tous les tags que rien n'a changé

SQASH A VENIR.
