### PR TITLE
 [beta v18] Empêche de créer un tag en double

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -222,7 +222,7 @@
                                                             {% trans "Tags les plus utilisés" %}
                                                         </li>
                                                         {% for tag in categories.tags %}
-                                                            <li><a href="{% url 'tutorial:list' %}?tag={{ tag.slug }}">{{ tag }}</a></li>
+                                                            <li><a href="{% url 'tutorial:list' %}?tag={{ tag.title|urlencode }}">{{ tag }}</a></li>
                                                         {% endfor %}
                                                         <li><a href="{% url 'content:tags' %}">Tous les tags</a></li>
                                                     </ul>
@@ -272,7 +272,7 @@
                                                             {% trans "Tags les plus utilisés" %}
                                                         </li>
                                                         {% for tag in categories.tags %}
-                                                            <li><a href="{% url 'article:list' %}?tag={{ tag.slug }}">{{ tag }}</a></li>
+                                                            <li><a href="{% url 'article:list' %}?tag={{ tag.title|urlencode }}">{{ tag }}</a></li>
                                                         {% endfor %}
                                                         <li><a href="{% url 'content:tags' %}">Tous les tags</a></li>
                                                     </ul>

--- a/templates/tutorialv2/includes/content_item.part.html
+++ b/templates/tutorialv2/includes/content_item.part.html
@@ -118,7 +118,7 @@
         <ul class="content-tags" itemprop="keywords">
             {% for tag in content.tags.all|slice:":3" %}
                 <li>
-                  <a href="{% url 'content:list' %}?tag={{ tag.slug }}">
+                  <a href="{% url 'content:list' %}?tag={{ tag.title|urlencode }}">
                     {{ tag.title }}
                   </a>
                 </li>

--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -7,7 +7,7 @@
 {% if publishablecontent.tags.all|length > 0 %}
     <ul class="taglist" itemprop="keywords">
         {% for tag in publishablecontent.tags.all %}
-            <li><a href="{% url 'content:list' %}?tag={{ tag.slug }}">{{ tag.title }}</a></li>
+            <li><a href="{% url 'content:list' %}?tag={{ tag.title|urlencode }}">{{ tag.title }}</a></li>
         {% endfor %}
     </ul>
 {% endif %}

--- a/templates/tutorialv2/index_online.html
+++ b/templates/tutorialv2/index_online.html
@@ -52,7 +52,7 @@
         <h1 class="ico-after ico-{% if current_content_type == "TUTORIAL" %}tutorials{% elif current_content_type == "ARTICLE" %}articles{% else %}articles{% endif %}" itemprop="name">
             {% block headline %}
                 {% if tag %}
-                    {{ verbose_type_name_plural|title }} : {{ tag }}
+                    {{ verbose_type_name_plural|title }} : {{ tag.title }}
                 {% elif category %}
                     {{ verbose_type_name_plural|title }} : {{ category }}
                 {% else %}

--- a/templates/tutorialv2/view/tags.html
+++ b/templates/tutorialv2/view/tags.html
@@ -27,7 +27,7 @@
         <div class="content-tags-list">
             {% for tag in tags %}
                 <div class="content-tag">
-                    <a href="{% url 'content:list' %}?tag={{ tag.slug }}">
+                    <a href="{% url 'content:list' %}?tag={{ tag.title|urlencode }}">
                         <div class="tag-title">{{ tag }}</div>
                         <div class="tag-count">{{ tag.num_content }} {% trans "contenu" %}{{ tag.num_content|pluralize }}</div>
                     </a>

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -37,6 +37,7 @@ from zds.utils.tutorials import get_blob
 from zds.tutorialv2.models import TYPE_CHOICES, STATUS_CHOICES
 from zds.tutorialv2.models.models_versioned import NotAPublicVersion
 from zds.tutorialv2.managers import PublishedContentManager, PublishableContentManager
+import logging
 
 ALLOWED_TYPES = ['pdf', 'md', 'html', 'epub', 'zip']
 
@@ -527,13 +528,12 @@ class PublishableContent(models.Model):
         """
         for tag in tag_collection:
             tag_title = smart_text(tag.strip().lower())
-            current_tag = Tag.objects.filter(title=tag_title).first()
-            if len(tag_title) > 0:
-                if current_tag is None:
-                    current_tag = Tag(title=tag_title)
-                    current_tag.save()
-
+            try:
+                current_tag = Tag.objects.get_from_title(tag_title)
                 self.tags.add(current_tag)
+            except ValueError as e:
+                logging.getLogger("zds.tutorialv2").warn(e)
+
         self.save()
 
 

--- a/zds/tutorialv2/tests/tests_models.py
+++ b/zds/tutorialv2/tests/tests_models.py
@@ -499,7 +499,8 @@ class ContentTests(TestCase):
         tuto.add_tags(tags)
         tags_len += 2
         tuto_tags_len += 2
-        self.assertEqual(tags_len, len(Tag.objects.all()))
+        self.assertEqual(tags_len, Tag.objects.count(),
+                         'all tags are "{}"'.format('","'.join([str(t) for t in Tag.objects.all()])))
         self.assertEqual(tuto_tags_len, len(tuto.tags.all()))
 
     def tearDown(self):

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -297,8 +297,11 @@ class ListOnlineContents(ContentTypeMixin, ZdSPagingListView):
             self.category = get_object_or_404(SubCategory, slug=self.request.GET.get('category'))
             queryset = queryset.filter(content__subcategory__in=[self.category])
         if 'tag' in self.request.GET:
-            self.tag = get_object_or_404(Tag, slug=self.request.GET.get('tag'))
-            queryset = queryset.filter(content__tags__in=[self.tag])
+            self.tag = Tag.objects.filter(slug=self.request.GET.get('tag').lower())
+            if not self.tag:
+                raise Http404("tag not found " + self.request.GET.get('tag'))
+            queryset = queryset.filter(content__tags__in=list(self.tag))  # different tags can have same
+            # slug such as C/C#/C++, as a first version we get all of them
         queryset = queryset.extra(select={"count_note": sub_query})
         return queryset.order_by('-publication_date')
 

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -297,7 +297,7 @@ class ListOnlineContents(ContentTypeMixin, ZdSPagingListView):
             self.category = get_object_or_404(SubCategory, slug=self.request.GET.get('category'))
             queryset = queryset.filter(content__subcategory__in=[self.category])
         if 'tag' in self.request.GET:
-            self.tag = Tag.objects.filter(slug=self.request.GET.get('tag').lower())
+            self.tag = Tag.objects.filter(title=self.request.GET.get('tag').lower().strip())
             if not self.tag:
                 raise Http404("tag not found " + self.request.GET.get('tag'))
             queryset = queryset.filter(content__tags__in=list(self.tag))  # different tags can have same

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -287,17 +287,6 @@ class CommentVote(models.Model):
     positive = models.BooleanField("Est un vote positif", default=True)
 
 
-class TagManager(models.Manager):
-    def get_from_title(self, title):
-        if not title.strip() or not slugify(title.strip().replace("-", "")):
-            raise ValueError('tag "{}" is not correct'.format(title))
-        current_tag = self.filter(title=title).first()
-        if current_tag is None:
-            current_tag = Tag(title=title)
-            current_tag.save()
-        return current_tag
-
-
 class Tag(models.Model):
 
     """Set of tags."""
@@ -307,7 +296,6 @@ class Tag(models.Model):
         verbose_name_plural = 'Tags'
     title = models.CharField(max_length=20, verbose_name='Titre')
     slug = models.SlugField(max_length=20)
-    objects = TagManager()
 
     def __unicode__(self):
         """Textual Link Form."""

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -287,6 +287,17 @@ class CommentVote(models.Model):
     positive = models.BooleanField("Est un vote positif", default=True)
 
 
+class TagManager(models.Manager):
+    def get_from_title(self, title):
+        if not title.strip() or not slugify(title.strip().replace("-", "")):
+            raise ValueError('tag "{}" is not correct'.format(title))
+        current_tag = self.filter(title=title).first()
+        if current_tag is None:
+            current_tag = Tag(title=title)
+            current_tag.save()
+        return current_tag
+
+
 class Tag(models.Model):
 
     """Set of tags."""
@@ -296,6 +307,7 @@ class Tag(models.Model):
         verbose_name_plural = 'Tags'
     title = models.CharField(max_length=20, verbose_name='Titre')
     slug = models.SlugField(max_length=20)
+    objects = TagManager()
 
     def __unicode__(self):
         """Textual Link Form."""


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug / nouvelle fonctionnalité / évolution |
| Ticket(s) (_issue(s)_) concerné(s) | (#3535) |
### QA
- Créez deux tags qui ont le même slug (C/C++/C#)
- Publiez un tuto dans chaque tag
- vérifiez que si vous allez dans la liste des tutos et que vous ajoutez "?tag=c" dans l'url, tous les tuto apparaissent bien que le tag qui leur soit associé est bien celui qui leur est propre (C/C++)

Il s'agit d'un quickfix le temps de la béta, un travail plus conséquent sera fait pour la v19.
