### PR TITLE
Corrige l'input de recherche sur la page d'accueil sur Safari

### DIFF
--- a/assets/scss/components/_home-search-box.scss
+++ b/assets/scss/components/_home-search-box.scss
@@ -29,6 +29,7 @@
             border-right: none;
             width: 85%;
             width: calc(100% - 71px);
+            outline: none;
         }
         button {
             height: 36px;


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | [voir le forum](https://zestedesavoir.com/forums/sujet/5844/champ-de-recherche-avec-outline-par-defaut-rend-mal-sous-safari/) |
### QA
- `npm run gulp build`
- Vérifier sous Safari que tout est normal (pas de "bordure" qui apparît) lorsqu'on clique sur l'input de recherche en page d'accueil
