### PR TITLE
Corrige les sujets suivis

### DIFF
--- a/zds/notification/managers.py
+++ b/zds/notification/managers.py
@@ -2,6 +2,8 @@
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
+
+from zds.forum.models import Topic
 from zds.utils import get_current_user
 
 
@@ -114,19 +116,6 @@ class SubscriptionManager(models.Manager):
 
         return [subscription.user for subscription in subscription_list]
 
-    def get_objects_followed_by(self, user):
-        """
-        Gets objects followed by the given user.
-
-        :param user: concerned user.
-        :type user: django.contrib.auth.models.User
-        :return: All objects followed by given user.
-        """
-        subscription_list = self.filter(user=user, is_active=True) \
-            .order_by('last_notification__pubdate')
-
-        return [subscription.content_object for subscription in subscription_list]
-
     def toggle_follow(self, content_object, user=None, by_email=False):
         """
         Toggle following of a resource notifiable for a user.
@@ -158,6 +147,20 @@ class TopicAnswerSubscriptionManager(SubscriptionManager):
     """
     Custom topic answer subscription manager.
     """
+
+    def get_objects_followed_by(self, user):
+        """
+        Gets objects followed by the given user.
+
+        :param user: concerned user.
+        :type user: django.contrib.auth.models.User
+        :return: All objects followed by given user.
+        """
+        topic_list = self.filter(user=user, is_active=True, content_type=ContentType.objects.get_for_model(Topic)) \
+            .values_list('object_id', flat=True)
+
+        return Topic.objects.filter(id__in=topic_list).order_by('-last_message__pubdate')
+
     def unfollow_and_mark_read_everybody_at(self, topic):
         """
         Deactivate a subscription at a topic and mark read the notification associated if exist.

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -65,10 +65,7 @@ def humane_delta(value):
 
 @register.filter('followed_topics')
 def followed_topics(user):
-    topics_followed = TopicAnswerSubscription.objects.filter(user=user,
-                                                             content_type__model='topic',
-                                                             is_active=True)\
-        .order_by('-last_notification__pubdate')[:10]
+    topics_followed = TopicAnswerSubscription.objects.get_objects_followed_by(user)[:10]
     # This period is a map for link a moment (Today, yesterday, this week, this month, etc.) with
     # the number of days for which we can say we're still in the period
     # for exemple, the tuple (2, 1) means for the period "2" corresponding to "Yesterday" according
@@ -76,14 +73,14 @@ def followed_topics(user):
     # Number is use for index for sort map easily
     periods = ((1, 0), (2, 1), (3, 7), (4, 30), (5, 360))
     topics = {}
-    for topic_followed in topics_followed:
+    for topic in topics_followed:
         for period in periods:
-            if topic_followed.content_object.last_message.pubdate.date() \
-                    >= (datetime.now() - timedelta(days=int(period[1]), hours=0, minutes=0, seconds=0)).date():
+            if topic.last_message.pubdate.date() >= \
+                    (datetime.now() - timedelta(days=int(period[1]), hours=0, minutes=0, seconds=0)).date():
                 if period[0] in topics:
-                    topics[period[0]].append(topic_followed.content_object)
+                    topics[period[0]].append(topic)
                 else:
-                    topics[period[0]] = [topic_followed.content_object]
+                    topics[period[0]] = [topic]
                 break
     return topics
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3536 #3498 |
### QA
- Rendez-vous sur une instance de la précédente release (v17).
- Souscrivez à plusieurs sujets avec des derniers messages de dates différentes (si besoin, utilisez l'admin). Les sujets avec des derniers messages de plus de 30 jours ne doivent pas figurer dans la sidebar plus loin dans la QA.
- Retenez bien l'ordre de ces sujets suivis (screen des 2 listes).
- Passez sur cette branche et exécutez le script de migration : `python manage.py migrate_subscriptions`.
- Assurez-vous que vous pouvez voir correctement les sujets suivis sur la liste de tous les sujets suivis (via le menu en haut à gauche) et ceux où il y a une activité depuis les 30 derniers jours via la sidebar sur les forums. 
- Comparez l'ordre des sujets suivis avec les screens que vous avez fais sur la version 17. Constatez que l'ordre est identique.
- Assurez-vous que vous pouvez souscrire à de nouveaux sujets.
