### PR TITLE
N'affiche plus "Suivre ce contenu" pour les visiteurs.

### DIFF
--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -106,7 +106,7 @@
 {% endblock %}
 
 {% block sidebar_actions %}
-
+    {% if user.is_authenticated %}
     <li>
     {% with content_is_followed=object|is_content_followed %}
         <form action="{% url "content:follow" object.pk %}" method="post">
@@ -133,7 +133,7 @@
         </form>
     {% endwith %}
     </li>
-
+    {% endif %}
 {% endblock %}
 
 {% block sidebar_blocks %}


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3545 |
### QA
- Ne vous connectez pas.
- Rendez-vous sur un tutoriel en ligne.
- Constatez que "Suivre ce contenu" n'est pas affiché.
- Connectez-vous.
- Constatez que "Suivre ce contenu" est affiché et vous permet de suivre ou non un contenu.
