### PR TITLE
Fix #3563 : correction du titre de la page de validation

### DIFF
--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -4,15 +4,18 @@
 {% load i18n %}
 
 {% block title_base %}
-    &bull; {% trans "Validation" %}
+    {% trans "Validation" %}
 {% endblock %}
 
 {% block title %}
-    {% trans "Validation" %}
     {% if request.GET.type == "reserved" %}
-        / {% trans "Réservés" %}
+        {% trans "Reservés" %} &bull;
     {% elif request.GET.type == "orphan" %}
-        / {% trans "Non-réservés" %}
+        {% trans "Non-reservés" %} &bull;
+    {% elif request.GET.type == "article" %}
+        {% trans "Articles" %} &bull;
+    {% elif request.GET.type == "tuto" %}
+        {% trans "Tutoriels" %} &bull;
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3563 |
### QA
- Aller sur la page de validation ([http://localhost:8000/validations/](http://localhost:8000/validations/))
- Vérifier que le titre de la page est cohérent avec les filtres utilisés
