### PR TITLE
(#3396) Ajout pagination sur l'historique des commits d'un contenu

### DIFF
--- a/templates/tutorialv2/view/history.html
+++ b/templates/tutorialv2/view/history.html
@@ -55,6 +55,8 @@
         <button class="btn btn-grey" type="submit">{% trans "Comparer les versions sélectionnées" %}</button>
     </form>
 
+    {% include "misc/paginator.html" with position="top" %}
+
     <table class="fullwidth commits-list">
         <thead>
             <tr>
@@ -115,12 +117,12 @@
                         </a>
                     </td>
                     <td>
-                        {% if not forloop.last %}
+                        {% if forloop.last and not page_obj.has_next %}
+                            {{ commit.hexsha|truncatechars:8 }}
+                        {% else %}
                             <a href="{% url "content:diff" content.pk content.slug %}?from={{ commit.parents.0.hexsha|default:empty_sha }}&amp;to={{ commit.hexsha }}" >
                                 {{ commit.hexsha|truncatechars:8 }}
                             </a>
-                        {% else %}
-                            {{ commit.hexsha|truncatechars:8 }}
                         {% endif %}
                     </td>
                     <td>
@@ -173,4 +175,6 @@
             {% endfor %}
         </tbody>
     </table>
+
+    {% include "misc/paginator.html" with position="bottom" %}
 {% endblock %}

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -491,6 +491,7 @@ ZDS_APP = {
         'content_per_page': 50,
         'notes_per_page': 25,
         'helps_per_page': 20,
+        'commits_per_page': 20,
         'feed_length': 5,
         'user_page_number': 5,
         'default_image': os.path.join(BASE_DIR, "fixtures", "noir_black.png"),

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -50,7 +50,7 @@ from zds.utils.forums import send_post, lock_topic, create_topic, unlock_topic
 from zds.utils.models import Licence
 from zds.utils.models import Tag, HelpWriting
 from zds.utils.mps import send_mp
-from zds.utils.paginator import ZdSPagingListView
+from zds.utils.paginator import ZdSPagingListView, make_pagination
 
 
 class RedirectOldBetaTuto(RedirectView):
@@ -1209,7 +1209,15 @@ class DisplayHistory(LoggedWithReadWriteHability, SingleContentDetailViewMixin):
         context = super(DisplayHistory, self).get_context_data(**kwargs)
 
         repo = self.versioned_object.repository
-        context['commits'] = objects.commit.Commit.iter_items(repo, 'HEAD')
+        commits = list(objects.commit.Commit.iter_items(repo, 'HEAD'))
+
+        # Pagination of commits
+        make_pagination(
+            context,
+            self.request,
+            commits,
+            settings.ZDS_APP['content']['commits_per_page'],
+            context_list_name="commits")
 
         # Git empty tree is 4b825dc642cb6eb9a060e54bf8d69288fbee4904, see
         # http://stackoverflow.com/questions/9765453/gits-semi-secret-empty-tree


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3396 |

Bon par contre la mise en place d'une pagination sur le tableau fait qu'on peut pas comparer des commits qui se trouvent sur deux pages différentes :/
### QA
- Checker la pagination sur la liste des commits d'un contenu
