### PR TITLE
Fix #3570 : corrige l'utilisation de debug_toolbar en prod

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -284,11 +284,6 @@ CORS_EXPOSE_HEADERS = (
     'link'
 )
 
-if DEBUG:
-    INSTALLED_APPS += (
-        'debug_toolbar',
-    )
-
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
 # the site admins on every HTTP 500 error when DEBUG=False.
@@ -581,3 +576,9 @@ try:
     from settings_prod import *  # noqa
 except ImportError:
     pass
+
+# MUST BE after settings_prog import
+if DEBUG:
+    INSTALLED_APPS += (
+        'debug_toolbar',
+    )


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3570 |
### QA
- Si la django_debug_toolbar est installé", désinstallez-la avec `pip uninstall django_debug_toolbar`
- Créer un fichier `settings_prod.py` qui contient `DEBUG = False` et `ALLOWED_HOSTS = ['127.0.0.1', 'localhost']`
- Vérifier que le site est utilisable (par d'erreur liée à la django_debug_toolbar)

Note : le design et les médias ne sont pas gérés automatiquement en `DEBUG = False` ce qui explique que le design est "cassé".
