### PR TITLE
Prépare un meilleur front pour la validation.

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -478,25 +478,25 @@
     }
 }
 
-.small-content-title{
+.small-content-title {
     // here front guys can manage how small content (i.e article or one page tutorial) title
     // are displayed in validation list
 }
 
-.medium-content-title{
+.medium-content-title {
     // here front guys can manage how medium content (i.e 1 hierarchy level tutorials) title
     // are displayed in validation list
     font-weight: bold;
 }
 
-.big-content-title{
+.big-content-title {
     // here front guys can manage how big content (i.e multi-part tutorial) title
     // are displayed in validation list
     font-weight: bold;
     font-style: italic;
 }
 
-.my-validation-content-title{
+.my-validation-content-title {
     // how validation row are handled when current validator is current user
     background-color: $color-my-validation;
 }

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -477,3 +477,26 @@
         text-align: center;
     }
 }
+
+.small-content-title{
+    // here front guys can manage how small content (i.e article or one page tutorial) title
+    // are displayed in validation list
+}
+
+.medium-content-title{
+    // here front guys can manage how medium content (i.e 1 hierarchy level tutorials) title
+    // are displayed in validation list
+    font-weight: bold;
+}
+
+.big-content-title{
+    // here front guys can manage how big content (i.e multi-part tutorial) title
+    // are displayed in validation list
+    font-weight: bold;
+    font-style: italic;
+}
+
+.my-validation-content-title{
+    // how validation row are handled when current validator is current user
+    background-color: $color-my-validation;
+}

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -479,18 +479,18 @@
 }
 
 .small-content-title {
-    // here front guys can manage how small content (i.e article or one page tutorial) title
+    // here front developers can manage how small content (i.e article or one page tutorial) titles
     // are displayed in validation list
 }
 
 .medium-content-title {
-    // here front guys can manage how medium content (i.e 1 hierarchy level tutorials) title
+    // here front developers can manage how medium content (i.e 1 hierarchy level tutorials) titles
     // are displayed in validation list
     font-weight: bold;
 }
 
 .big-content-title {
-    // here front guys can manage how big content (i.e multi-part tutorial) title
+    // here front developers can manage how big content (i.e multi-part tutorial) titles
     // are displayed in validation list
     font-weight: bold;
     font-style: italic;

--- a/assets/scss/variables/_colors.scss
+++ b/assets/scss/variables/_colors.scss
@@ -15,3 +15,4 @@ $color-danger: #c0392b;
 $color-keyboard: #F8F6EA;
 
 $color-staff-link: $color-secondary;
+$color-my-validation: #AAA;

--- a/templates/tutorialv2/includes/validation_history.part.html
+++ b/templates/tutorialv2/includes/validation_history.part.html
@@ -1,7 +1,9 @@
-<ul class="validation_history">
-{% for validation in validations %}
-    <li class="{% if validation.status == "REJECT" or validation.status == "CANCEL" %}validation-reject
-               {% elif validation.status == "ACCEPT" %}validation-accept
-               {%  endif %}"></li>
-{% endfor %}
-</ul>
+{% if validations %}
+    <ul class="validation_history">
+    {% for validation in validations %}
+        <li class="{% if validation.status == "REJECT" or validation.status == "CANCEL" %}validation-reject
+                   {% elif validation.status == "ACCEPT" %}validation-accept
+                   {%  endif %}"></li>
+    {% endfor %}
+    </ul>
+{% endif %}

--- a/templates/tutorialv2/includes/validation_history.part.html
+++ b/templates/tutorialv2/includes/validation_history.part.html
@@ -1,0 +1,7 @@
+<ul class="validation_history">
+{% for validation in validations %}
+    <li class="{% if validation.status == "REJECT" or validation.status == "CANCEL" %}validation-reject
+               {% elif validation.status == "ACCEPT" %}validation-accept
+               {%  endif %}"></li>
+{% endfor %}
+</ul>

--- a/templates/tutorialv2/includes/validation_history.part.html
+++ b/templates/tutorialv2/includes/validation_history.part.html
@@ -1,9 +1,11 @@
 {% if validations %}
     <ul class="validation_history">
     {% for validation in validations %}
-        <li class="{% if validation.status == "REJECT" or validation.status == "CANCEL" %}validation-reject
-                   {% elif validation.status == "ACCEPT" %}validation-accept
-                   {%  endif %}"></li>
+        {% if validation.status != "PENDING_V" %}
+            <li class="{% if validation.status == "REJECT" or validation.status == "CANCEL" %}validation-reject
+                       {% elif validation.status == "ACCEPT" %}validation-accept
+                       {%  endif %}">{{ validation.comment_authors }}</li>
+        {% endif %}
     {% endfor %}
     </ul>
 {% endif %}

--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -74,7 +74,7 @@
                                 my-validation-content-title
                                 {% endif %}">
                                 <td>
-                                    <a href="{% url "content:view" validation.content.pk validation.content.slug %}?version={{ validation.version }}"
+                                    <a href="{% url 'content:view' validation.content.pk validation.content.slug %}?version={{ validation.version }}"
                                        class="{% if validation.versioned_content.has_extracts %}
                                             small-content-title
                                         {% elif not validation.versioned_content.has_chapters %}
@@ -101,9 +101,9 @@
                                 </td>
                                 <td>
                                     {% if validation.content.type == "ARTICLE" %}
-                                        <a href="{% url "validation:list" %}?type=article">Article</a>
+                                        <a href="{% url 'validation:list' %}?type=article">Article</a>
                                     {% else %}
-                                        <a href="{% url "validation:list" %}?type=tuto">Tutoriel</a>
+                                        <a href="{% url 'validation:list' %}?type=tuto">Tutoriel</a>
                                     {% endif %}
                                 </td>
                                 <td>

--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -70,7 +70,7 @@
                     </thead>
                     <tbody>
                         {% for validation in validations %}
-                            <tr class="{% if validation.validator and validation.validator.username == user.username %}
+                            <tr class="{% if validation.validator and validation.validator.pk == user.pk %}
                                 my-validation-content-title
                                 {% endif %}">
                                 <td>

--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -75,10 +75,9 @@
                                 {% endif %}">
                                 <td>
                                     <a href="{% url "content:view" validation.content.pk validation.content.slug %}?version={{ validation.version }}"
-                                       class="
-                                        {% if validation.versioned_content.get_tree_depth == 0 %}
+                                       class="{% if validation.versioned_content.has_extracts %}
                                             small-content-title
-                                        {% elif validation.versioned_content.get_tree_depth == 1 %}
+                                        {% elif not validation.versioned_content.has_chapters %}
                                             medium-content-title
                                         {% else %}
                                             big-content-title

--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -70,9 +70,19 @@
                     </thead>
                     <tbody>
                         {% for validation in validations %}
-                            <tr>
+                            <tr class="{% if validation.validator and validation.validator.username == user.username %}
+                                my-validation-content-title
+                                {% endif %}">
                                 <td>
-                                    <a href="{% url "content:view" validation.content.pk validation.content.slug %}?version={{ validation.version }}">
+                                    <a href="{% url "content:view" validation.content.pk validation.content.slug %}?version={{ validation.version }}"
+                                       class="
+                                        {% if validation.versioned_content.get_tree_depth == 0 %}
+                                            small-content-title
+                                        {% elif validation.versioned_content.get_tree_depth == 1 %}
+                                            medium-content-title
+                                        {% else %}
+                                            big-content-title
+                                        {% endif %}">
                                         {{ validation.versioned_content.title }}
                                     </a>
                                     <br>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -8,7 +8,6 @@
 {% load captureas %}
 {% load pluralize_fr %}
 
-
 {% block title %}
     {{ content.title }}
 {% endblock %}
@@ -48,46 +47,52 @@
 
     {% if is_staff or can_edit %}
         {% if content.in_validation %}
-            {% if validation.version == content.current_version %}
-                {% if validation.is_pending %}
-                    <p class="content-wrapper alert-box alert">
-                        {% trans "Ce contenu est en attente d'un validateur." %}
-                    </p>
-                {% elif validation.is_pending_valid %}
-                    <p class="content-wrapper alert-box info">
-                        {% trans "Ce contenu est en cours de validation par" %}
-                        {% include "misc/member_item.part.html" with member=validation.validator %}
-                    </p>
-                {% endif %}
-                {% if validation.comment_authors %}
-                    <div class="content-wrapper comment-author">
-                        <p>
-                            {% trans "Le message suivant a été laissé à destination des validateurs" %} :
+            {% with validations|first as validation %}
+                {% if validation.version == content.current_version %}
+                    {% if validation.is_pending %}
+                        <p class="content-wrapper alert-box alert">
+                            {% trans "Ce contenu est en attente d'un validateur." %}
                         </p>
+                    {% elif validation.is_pending_valid %}
+                        <p class="content-wrapper alert-box info">
+                            {% trans "Ce contenu est en cours de validation par" %}
+                            {% include "misc/member_item.part.html" with member=validation.validator %}
+                        </p>
+                    {% endif %}
+                    {% if validation.comment_authors %}
+                        <div class="content-wrapper comment-author">
+                            <p>
+                                {% trans "Le message suivant a été laissé à destination des validateurs" %} :
+                            </p>
 
-                        <blockquote>
-                            {{ validation.comment_authors|emarkdown }}
-                        </blockquote>
+                            <blockquote>
+                                {{ validation.comment_authors|emarkdown }}
+                            </blockquote>
+                        </div>
+                    {% endif %}
+                    <p class="content-wrapper alert-box info">{% trans "Historique de validation" %}</p>
+                    <div>
+                        {% include "tutorialv2/includes/validation_history.part.html" with member=validation.validator %}
                     </div>
+                {% else %}
+                    {% if validation.is_pending %}
+                        <p class="content-wrapper alert-box alert">
+                            <a href="{{ object.get_absolute_url }}?version={{ validation.version }}">
+                                {% trans "Une autre version de ce contenu" %}
+                            </a>
+                            {% trans "est en attente d'un validateur" %}
+                        </p>
+                    {% elif validation.is_pending_valid %}
+                        <p class="content-wrapper alert-box info">
+                            <a href="{{ content.get_absolute_url }}?version={{ validation.version }}">
+                                {% trans "Une autre version de ce contenu" %}
+                            </a>
+                            {% trans "est en cours de validation par" %}
+                            {% include "misc/member_item.part.html" with member=validation.validator %}
+                        </p>
+                    {% endif %}
                 {% endif %}
-            {% else %}
-                {% if validation.is_pending %}
-                    <p class="content-wrapper alert-box alert">
-                        <a href="{{ object.get_absolute_url }}?version={{ validation.version }}">
-                            {% trans "Une autre version de ce contenu" %}
-                        </a>
-                        {% trans "est en attente d'un validateur" %}
-                    </p>
-                {% elif validation.is_pending_valid %}
-                    <p class="content-wrapper alert-box info">
-                        <a href="{{ content.get_absolute_url }}?version={{ validation.version }}">
-                            {% trans "Une autre version de ce contenu" %}
-                        </a>
-                        {% trans "est en cours de validation par" %}
-                        {% include "misc/member_item.part.html" with member=validation.validator %}
-                    </p>
-                {% endif %}
-            {% endif %}
+            {% endwith %}
         {% endif %}
     {% endif %}
 

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -7,7 +7,10 @@ from django.contrib.auth.models import User, Group
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from captcha.fields import ReCaptchaField
+try:
+    from captcha.fields import ReCaptchaField
+except ImportError:
+    pass
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Layout, \

--- a/zds/tutorialv2/models/models_versioned.py
+++ b/zds/tutorialv2/models/models_versioned.py
@@ -74,6 +74,9 @@ class Container:
             return False
         return isinstance(self.children[0], Extract)
 
+    def has_chapters(self):
+        return self.has_sub_containers() and self.children[0].has_sub_containers()
+
     def has_sub_containers(self):
         """Note : this function rely on the fact that the children can only be of one type.
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) | Pouèr l'instant c'est sur le forum |

Cette PR aura pour but d'implémenter deux suggestions simples qui amélioreront l'ergonomie de la validation.
Elle extrait deux propositions de la zep-18 : 
- [X] donner un style spécial en fonction du type de contenu et du validateur actuel
- [x] Mettre l'historique de validation en page de garde du tutoriel à valider.

Ce n'est qu'une proposition, les gens du front qui ont sûrement plus de goût que moi pourront passer derrière pour changer les styles que j'ai proposés.
### QA
#### adaptation de la liste
- Mettre un tutoriel avec que des extraits en validation
- Mettre un tutoriel avec extrait et chapitre en validation
- Mettre un tutoriel avec extrait, chapitre et partie en validation
- observer que l'affichage du titre de chaque tuto est différent
- Réservez un tuto, observez la surbrillance de la ligne
#### Affichage de l'historique de validation (à venir)
- Mettre en validation un tuto, puis le retirer
- modifier et remettre en validation le tuto, puis le **refuser**
- modifier et remettre en validation le tuto, puis l'accepter
- modifier et remettre en validation le tuto
- avec le validateur, observez que l'historique de validation apparait avec :
  - les retraits et refus en rouge
  - les acceptations en vert
  - l'historique est par ordre décroissant de dates
