### PR TITLE
Mise a jour de zMarkdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ factory-boy==2.6.1
 pygeoip==0.3.2
 pillow==3.1.1
 gitpython==1.0.1
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.7.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.8.zip
 easy-thumbnails==2.3
 CairoSVG==1.0.20
 beautifulsoup4==4.4.1


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | - |

Mise a jour de zMarkdown. Principalement mise a jour de maintenance pour faire passer les tests, montrer à @ArnaudCalmettes comment faire une release en attendant qu'on passe sur Pypi et au passage on corrige quelques problèmes sur les liens.
### QA

Pas grand chose, vérifier que ça s'installe et transforme le markdown. Ça devrait corriger aussi quelques problèmes de liens, entre autre : https://github.com/zestedesavoir/Python-ZMarkdown/issues/77 et ceux de la forme `[...]()` cités dans https://github.com/zestedesavoir/Python-ZMarkdown/issues/68 (pas les liens automatique, donc)
