### PR TITLE
Fix #3584 : correction des commandes de migration de la v18

### DIFF
--- a/update.md
+++ b/update.md
@@ -528,7 +528,7 @@ DROP TABLE article_article_subcategory;
 DROP TABLE tutorial_tutorial_subcategory;
 ```
 
-Avant de continuer il faut s'assurer d'avoir lancé les migrations. La commande `python manage.py migrate_to_zep25` permet de migrer automatiquement les contenus et de notifier les auteurs. Les logs sont très détaillés. En cas de contenus non-migrés automatiquement il y aura un message à la fin ainsi que des `[WARNING]` dans les logs. **La commande peut être assez longue.**
+Avant de continuer il faut s'assurer d'avoir lancé les migrations. La commande `python manage.py migrate_to_zep25` permet de migrer automatiquement les contenus et de notifier les auteurs. Les logs sont très détaillés. **La commande peut être assez longue.** Pensez à modifier manuellement (via l'interface d'admin si besoin) les contenus publiés après la date spécifiés à la fin de la commande).
 
 Les contenus non migrés automatiquement doivent l'être fait à la main, par les auteurs ou les validateurs. Seuls les contenus publiés sont migrés automatiquement.
 
@@ -545,12 +545,14 @@ SELECT max(id) FROM utils_commentvote;
 
 Le résultat de la requète doit être placé dans le paramètre `VOTES_ID_LIMIT` dans le fichier `settings_prod.py`. Dorénavant tout les nouveaux +/-1 ne seront plus anonymes.
 
-# Supprimer toute trace des tables pré-zep-12
+Supprimer toute trace des tables pré-zep-12
+-------------------------------------------
 
 Il faudra supprimer en SQL:
 
-- `UPDATE tutorial_tutorial SET last_note_pk=NULL;`
-- `UPDATE article_article SET last_reaction=NULL;`
+- `SET FOREIGN_KEY_CHECKS=0;`
+- `UPDATE tutorial_tutorial SET last_note_id=NULL;`
+- `UPDATE article_article SET last_reaction_id=NULL;`
 - `DROP TABLE tutorial_tutorial_subcategory;`
 - `DROP TABLE tutorial_tutorial_authors;`
 - `DROP TABLE tutorial_note;`
@@ -561,8 +563,9 @@ Il faudra supprimer en SQL:
 - `DROP TABLE article_reaction;`
 - `DROP TABLE article_articleread;`
 - `DROP TABLE article_article;`
+- `SET FOREIGN_KEY_CHECKS=1;`
  
-
+S'il y a une erreur pour `article_article_subcategory` et `DROP TABLE tutorial_tutorial_subcategory;` c'est que les tables ont déjà été supprimées précédement (ZEP-25).
 
 ---
 

--- a/zds/tutorialv2/management/commands/migrate_to_zep25.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep25.py
@@ -174,10 +174,9 @@ class Command(BaseCommand):
 
         :return: None
         """
-        sucess = 0
+        success = 0
         fail = 0
-        missing = 0
-        # LAST UPDATE : 20/03/2016 10:30
+        # LAST UPDATE : 05/05/2016 12:30
         contents = {
             # Informatique
             'Bureautique et rédaction': [244, 409, 439, 508, 601, 602, 630],
@@ -185,43 +184,39 @@ class Command(BaseCommand):
                 253, 255, 264, 279, 343, 349, 364, 365, 371, 374, 428, 429, 507, 599, 613, 640, 686, 749, 757, 895, 917,
                 1116],
             'Programmation et algorithmique': [5, 28, 30, 39, 43, 54, 56, 60, 61, 65, 66, 67, 78, 96, 100, 152, 158,
-                                               159,
-                                               160, 164, 175, 209, 223, 247, 248, 260, 262, 272, 274, 281, 292, 309,
-                                               312,
-                                               315, 325, 331, 334, 427, 460, 461, 476, 484, 496, 528, 531, 553, 558,
-                                               574,
-                                               582, 591, 597, 609, 612, 621, 624, 634, 644, 645, 646, 674, 681, 685,
-                                               706,
-                                               723, 755, 799, 839, 870, 884, 912, 945, 954, 962],
+                                               159, 160, 164, 175, 209, 223, 247, 248, 260, 262, 272, 274, 281, 292,
+                                               309, 312, 315, 325, 331, 334, 427, 460, 461, 476, 484, 496, 528, 531,
+                                               553, 558, 574, 582, 591, 597, 609, 612, 621, 624, 634, 644, 645, 646,
+                                               674, 681, 685, 706, 723, 755, 799, 839, 870, 884, 912, 944, 945, 954,
+                                               962, 1186, 1226],
             'Site Web': [57, 193, 232, 241, 246, 248, 292, 295, 312, 344, 351, 352, 358, 411, 446, 449, 449, 527, 574,
-                         591,
-                         597, 598, 599, 612, 620, 622, 925, 945],
-            'Systèmes d’exploitation': [37, 39, 97, 100, 130, 143, 158, 268, 317, 357, 507, 607, 624, 609, 662, 683],
+                         591, 597, 598, 599, 612, 620, 622, 925, 945],
+            'Systèmes d\'exploitation': [
+                37, 39, 97, 100, 130, 143, 158, 268, 317, 357, 507, 607, 624, 609, 662, 683, 1034],
             'Autres (informatique)': [4, 12, 88, 193, 245, 250, 297, 299, 321, 323, 324, 351, 379, 415, 723, 730, 925],
             # Sciences de la nature
             'Astronomie': [63, 85, 102, 105, 378, 408],
             'Géologie et géographie physique': [169, 378, 403, 404, 405, 408, 526],
-            'Biologie': [105, 148, 157, 223, 410, 451, 493],
-            'Physique': [74, 148, 164, 279, 381, 428, 614, 895, 1052],
+            'Biologie': [105, 148, 157, 223, 410, 451, 493, 587, 835],
+            'Physique': [74, 148, 164, 279, 381, 428, 614, 857, 895, 1052, 1134],
             'Chimie': [73, 166, 253, 569],
-            'Mathématiques': [27, 43, 54, 65, 66, 67, 160, 244, 281, 329, 484, 528, 596, 676, 735, 803, 810, 829, 1184],
+            'Mathématiques': [
+                27, 43, 54, 65, 66, 67, 160, 244, 281, 329, 484, 528, 596, 676, 735, 763, 803, 810, 829, 1184],
             'Autres (sciences de la nature)': [44],
             # Sciences humaines et sociales
             'Droit': [59, 261, 444],
             'Histoire': [12, 54, 65, 66, 155, 183, 381, 614, 676],
             'Langues': [155, 162, 376, 452, 748],
             'Psychologie': [4, 163, 171, 305, 352, 410, 421, 479, 488, 604, 793],
-            'Économie': [197, 500],
+            'Économie': [197, 500, 1039],
             'Autres (sciences humaines et sociales)': [127],
             # Autres
-            'Arts, graphisme et multimédia': [151, 153, 212, 251, 334, 599, 626, 655, 656, 671, 706, 751, 913],
+            'Arts, graphisme et multimédia': [151, 153, 212, 251, 334, 599, 626, 655, 656, 671, 706, 751, 913, 1186],
             'Communication et management': [305, 341, 391],
             'Zeste de Savoir': [1, 8, 9, 11, 13, 14, 15, 20, 22, 36, 38, 40, 48, 49, 52, 59, 64, 71, 72, 77, 82, 83, 86,
-                                90,
-                                93, 99, 108, 115, 137, 138, 142, 145, 173, 174, 185, 194, 195, 196, 198, 206, 216, 222,
-                                244,
-                                249, 261, 877, 978, 1002, 1120, 1162, ],
-            'Autres': [11, 13, 14, 15, 52, 69, 90, 95, 103, 104, 142, 173, 196, 195, 936, 950, 1139],
+                                90, 93, 99, 108, 115, 137, 138, 142, 145, 173, 174, 185, 194, 195, 196, 198, 206, 216,
+                                222, 244, 249, 261, 877, 978, 1002, 1120, 1062, 1254],
+            'Autres': [11, 13, 14, 15, 52, 69, 90, 95, 103, 104, 142, 173, 196, 195, 936, 950, 1128, 1139, 1214],
         }
         contents_pk = [item['pk'] for item in PublishableContent.objects.values('pk')]
         for subcat, cts in contents.items():
@@ -237,30 +232,21 @@ class Command(BaseCommand):
                         # contents with more than one category
                         pass
                     self.stdout.write('[ZEP-25] : New category "{}" for content "{}"'.format(subcategory, content))
-                    sucess += 1
+                    success += 1
                 except PublishableContent.DoesNotExist:
                     self.stdout.write(
                         '[ZEP-25][WARNING] : Content with pk "{}" is not in list, it should not happend in production'
                         .format(ct))
                     fail += 1
 
-        # alert for content not in list
-        for pk in contents_pk:
-            content = PublishableContent.objects.get(pk=pk)
-            self.stdout.write(
-                '[ZEP-25][WARNING] : Content "{}" (pk = {}) is not migrate (not in list), please check it'.format(
-                    content,
-                    pk))
-            missing += 1
-
         # migration details
         self.stdout.write('\n================================================================================\n')
-        self.stdout.write('{} content(s) migrated with succes'.format(sucess))
+        self.stdout.write('{} content(s) migrated with succes'.format(success))
         self.stdout.write('{} content(s) failed'.format(fail))
-        self.stdout.write('{} content(s) unmigrated'.format(missing))
-        if fail != 0 or missing != 0:
+        if fail != 0:
             self.stdout.write('\nPLEASE CHECKS LOGS.')
         self.stdout.write('\n================================================================================\n')
+        self.stdout.write('PLEASE, update by yourself content published after 4 may 2016')
 
     def handle(self, *args, **options):
         if len(args) > 0:


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3584 |
### Corrections
- Corrige l'erreur sur la migration ZEP-25
- Enlève les faux positifs sur les contenus publiés
- Ajout des derniers contenus publiés
- Enlève le check sur les FK pour la tables à supprimer
### QA
-  Ça a été testé sur la bêta et ça fonctionne parfaitement. À re-tester si vous le souhaitez.

**Note** : il reste des erreurs sur la commande de suppression des tables. (cf http://paste.awesom.eu/5z8K ), une PR qui fixe entièrement ça est la bienvenue !
