### PR TITLE
Fix #3592: Problème avec le lien vers "CONTRIBUTING.md"

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -72,9 +72,8 @@
                             <p>Le site est géré et financé par une <a href="{{url_association}}">association</a> à but non lucratif.</p>
                         {% endblocktrans %}
                         {% if app.site.contribute_link %}
-                            {% blocktrans %}
-                                <p>Chacun peut  <a href="{{ app.site.contribute_link }}">contribuer au code source</a>
-                                    de la plate-forme, qui est ouvert.</p>
+                            {% blocktrans with contribute_link=app.site.contribute_link %}
+                                <p>Chacun peut <a href="{{contribute_link}}">contribuer au code source</a> de la plate-forme, qui est ouvert.</p>
                             {% endblocktrans %}
                         {% endif %}
                 </div>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3592 |

Dans son commit https://github.com/zestedesavoir/zds-site/commit/10df18c1b405a9e56ee316f8999055dbb6121330, @SpaceFox a ajouté les blocs de traduction, responsables de la disparition du lien. La présence de points dans la variable semble déranger au moment de l'évaluation.
### QA
- Aller sur la page d'accueil sans être connecté.
- Vérifier que le lien _"contribuer au code source"_ dirige vers https://github.com/zestedesavoir/zds-site/blob/dev/CONTRIBUTING.md
