### PR TITLE
Correction affichage du tag

### DIFF
--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -296,10 +296,8 @@ class ListOnlineContents(ContentTypeMixin, ZdSPagingListView):
             self.category = get_object_or_404(SubCategory, slug=self.request.GET.get('category'))
             queryset = queryset.filter(content__subcategory__in=[self.category])
         if 'tag' in self.request.GET:
-            self.tag = Tag.objects.filter(title=self.request.GET.get('tag').lower().strip())
-            if not self.tag:
-                raise Http404("tag not found " + self.request.GET.get('tag'))
-            queryset = queryset.filter(content__tags__in=list(self.tag))  # different tags can have same
+            self.tag = get_object_or_404(Tag, title=self.request.GET.get('tag').lower().strip())
+            queryset = queryset.filter(content__tags__in=[self.tag])  # different tags can have same
             # slug such as C/C#/C++, as a first version we get all of them
         queryset = queryset.extra(select={"count_note": sub_query})
         return queryset.order_by('-publication_date')


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3589 |

Cette PR a le mérite de corriger le bug, mais je ne suis pas satisfait du fix. 

Dans la template, j'appelle trois fois le même filtre `join` pour avoir systématiquement le même résultat _(beurk!)_. J'ai tenté de définir une variable dans la template, mais en vain. J'ai tenté de mettre mon nez dans le back, mais je me suis vite paumé. ^^ 

Si quelqu'un a une meilleure idée/piste, je suis preneur !
### QA
- Faire une recherche par tag (exemple windows comme dans le ticket)
- Vérifier dans **tout le code source** de la page l'absence de `[&lt;Tag: windows&gt;]` _(remplacer windows par le tag que vous aurez choisi)_
