### PR TITLE
Fix #3588 : correction de la commande de migration pour les slugs (ZE…

### DIFF
--- a/zds/tutorialv2/management/commands/migrate_to_zep25.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep25.py
@@ -34,9 +34,9 @@ class Command(BaseCommand):
             categories = content.subcategory.all()
             for cat in categories:
                 tag_title = smart_text(cat.slug.replace('-', ' ').strip().lower())
-                current_tag = Tag.objects.filter(title=tag_title).first()
+                current_tag = Tag.objects.filter(slug=tag_title).first()
                 if current_tag is None:
-                    current_tag = Tag(title=tag_title)
+                    current_tag = Tag(title=cat, slug=tag_title)
                     current_tag.save()
                     self.stdout.write('[ZEP-25] : Tag "{}" added'.format(current_tag))
                     n += 1


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3588 |
### QA
- Lancer la commande `python manage.py migrate_to_zep25` et vérifier que les tags sont bien créés avec un vrai titre et non un slug à la place du titre.
