### PR TITLE
Update markdown version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ factory-boy==2.7.0
 pygeoip==0.3.2
 pillow==3.2.0
 gitpython==1.0.1
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.8.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.9.zip
 easy-thumbnails==2.3
 CairoSVG==1.0.20
 beautifulsoup4==4.4.1


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug / nouvelle fonctionnalité |
| Ticket(s) (_issue(s)_) concerné(s) | - |

Mise a jour du markdown. Au programme : 
- Majoritairement de l'ajout de tests
- Correction d'un bug sur les alignements répétés : https://github.com/zestedesavoir/Python-ZMarkdown/issues/62
- Correction de deux bugs sur les liens auto : https://github.com/zestedesavoir/Python-ZMarkdown/issues/68 et https://github.com/zestedesavoir/Python-ZMarkdown/issues/46
- Correction du bug sur les "channel" des liens youtube : https://github.com/zestedesavoir/Python-ZMarkdown/issues/72
- Support des jsfiddle non anonymes (merci à @fazouane-marouane pour avoir préparer le travail)
- Ajout du support des vidéo de l'INA et suppression de celles de metacafe et veoh (voir #2927 )
### QA
- Vérifier que le markdown s'installe et se lance
- Dans l'idéal vérifier que les dits bugs sont corrigés (même si c'est testé de notre coté).

Dans l'idéal cette PR serait mergé avant le lancement de la v19, le support des jsfiddle non anonymes étant attendu (et les liens posant régulièrement des bugs sur le site).
