### PR TITLE
Mise en cache du menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,14 +1,14 @@
-{% load staticfiles %}
-{% load profile %}
-{% load interventions %}
-{% load topbar %}
+{% load cache %}
 {% load captureas %}
 {% load date %}
-{% load set %}
-{% load captureas %}
-{% load thumbnail %}
 {% load i18n %}
+{% load interventions %}
+{% load profile %}
 {% load remove_url_protocole %}
+{% load set %}
+{% load staticfiles %}
+{% load thumbnail %}
+{% load topbar %}
 
 
 <!DOCTYPE html>
@@ -181,108 +181,111 @@
                             {% endwith %}
                         {% endif %}
                     >
-                        <ul class="header-menu-list">
-                            <li>
-                                <a href="{% url "tutorial:list" %}" class="mobile-menu-link {% block menu_tutorial %}{% endblock %}">
-                                    {% trans "Tutoriels" %}
-                                </a>
-                                <div class="dropdown header-menu-dropdown">
-                                    <a href="{% url "tutorial:list" %}" class="dropdown-link-all">
-                                        {% trans "Tous les tutoriels" %}
-                                    </a>
 
-                                    <ul class="dropdown-list">
-                                        {% with categories='TUTORIAL'|top_categories_content %}
-                                            {% for title, subcats in categories.categories.items %}
-                                                <li>
+                        {% cache 1800 menu user.pk|default_if_none:"0" %}
+                            <ul class="header-menu-list">
+                                <li>
+                                    <a href="{% url "tutorial:list" %}" class="mobile-menu-link {% block menu_tutorial %}{% endblock %}">
+                                        {% trans "Tutoriels" %}
+                                    </a>
+                                    <div class="dropdown header-menu-dropdown">
+                                        <a href="{% url "tutorial:list" %}" class="dropdown-link-all">
+                                            {% trans "Tous les tutoriels" %}
+                                        </a>
+
+                                        <ul class="dropdown-list">
+                                            {% with categories='TUTORIAL'|top_categories_content %}
+                                                {% for title, subcats in categories.categories.items %}
+                                                    <li>
+                                                        <ul>
+                                                            <li class="dropdown-title">
+                                                                {{ title }}
+                                                            </li>
+                                                            {% for subcat,slug in subcats %}
+                                                                <li>
+                                                                    <a href="{% url "tutorial:list" %}?category={{ slug }}">
+                                                                        {{  subcat }}
+                                                                    </a>
+                                                                </li>
+                                                            {% endfor %}
+                                                        </ul>
+                                                    </li>
+                                                {% empty %}
                                                     <ul>
                                                         <li class="dropdown-title">
-                                                            {{ title }}
+                                                            {% trans "Aucun tutoriel disponible." %}
                                                         </li>
-                                                        {% for subcat,slug in subcats %}
-                                                            <li>
-                                                                <a href="{% url "tutorial:list" %}?category={{ slug }}">
-                                                                    {{  subcat }}
-                                                                </a>
-                                                            </li>
-                                                        {% endfor %}
                                                     </ul>
-                                                </li>
-                                            {% empty %}
-                                                <ul>
-                                                    <li class="dropdown-title">
-                                                        {% trans "Aucun tutoriel disponible." %}
+                                                {% endfor %}
+                                                {% if categories.tags %}
+                                                    <li>
+                                                        <ul>
+                                                            <li class="dropdown-title">
+                                                                {% trans "Tags les plus utilisés" %}
+                                                            </li>
+                                                            {% for tag in categories.tags %}
+                                                                <li><a href="{% url 'tutorial:list' %}?tag={{ tag.slug }}">{{ tag }}</a></li>
+                                                            {% endfor %}
+                                                            <li><a href="{% url 'content:tags' %}">Tous les tags</a></li>
+                                                        </ul>
                                                     </li>
-                                                </ul>
-                                            {% endfor %}
-                                            {% if categories.tags %}
+                                                {% endif %}
+                                            {% endwith %}
+                                        </ul>
+                                    </div>
+                                </li>
+                                <li>
+                                    <a href="{% url "article:list" %}" class="mobile-menu-link {% block menu_article %}{% endblock %}">
+                                        {% trans "Articles" %}
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="{% url "cats-forums-list" %}" class="mobile-menu-link {% block menu_forum %}{% endblock %}">
+                                        {% trans "Forums" %}
+                                    </a>
+                                    <div class="dropdown header-menu-dropdown">
+                                        <a href="{% url "cats-forums-list" %}" class="dropdown-link-all">
+                                            {% trans "Tous les forums" %}
+                                        </a>
+
+                                        <ul class="dropdown-list">
+                                            {% with top=user|top_categories %}
+                                                {% for title, forums in top.categories.items %}
+                                                    <li>
+                                                        <ul>
+                                                            <li class="dropdown-title">
+                                                                {{ title }}
+                                                            </li>
+                                                            {% for forum in forums %}
+                                                                <li><a href="{{ forum.get_absolute_url }}">{{ forum.title }}</a></li>
+                                                            {% endfor %}
+                                                        </ul>
+                                                    </li>
+                                                {% empty %}
+                                                    <ul>
+                                                        <li class="dropdown-title">
+                                                            {% trans "Aucun forum disponible." %}
+                                                        </li>
+                                                    </ul>
+                                                {% endfor %}
+                                                {% if top.tags %}
                                                 <li>
                                                     <ul>
                                                         <li class="dropdown-title">
                                                             {% trans "Tags les plus utilisés" %}
                                                         </li>
-                                                        {% for tag in categories.tags %}
-                                                            <li><a href="{% url 'tutorial:list' %}?tag={{ tag.slug }}">{{ tag }}</a></li>
-                                                        {% endfor %}
-                                                        <li><a href="{% url 'content:tags' %}">Tous les tags</a></li>
-                                                    </ul>
-                                                </li>
-                                            {% endif %}
-                                        {% endwith %}
-                                    </ul>
-                                </div>
-                            </li>
-                            <li>
-                                <a href="{% url "article:list" %}" class="mobile-menu-link {% block menu_article %}{% endblock %}">
-                                    {% trans "Articles" %}
-                                </a>
-                            </li>
-                            <li>
-                                <a href="{% url "cats-forums-list" %}" class="mobile-menu-link {% block menu_forum %}{% endblock %}">
-                                    {% trans "Forums" %}
-                                </a>
-                                <div class="dropdown header-menu-dropdown">
-                                    <a href="{% url "cats-forums-list" %}" class="dropdown-link-all">
-                                        {% trans "Tous les forums" %}
-                                    </a>
-
-                                    <ul class="dropdown-list">
-                                        {% with top=user|top_categories %}
-                                            {% for title, forums in top.categories.items %}
-                                                <li>
-                                                    <ul>
-                                                        <li class="dropdown-title">
-                                                            {{ title }}
-                                                        </li>
-                                                        {% for forum in forums %}
-                                                            <li><a href="{{ forum.get_absolute_url }}">{{ forum.title }}</a></li>
+                                                        {% for tag in top.tags %}
+                                                            <li><a href="{{ tag.get_absolute_url }}">{{ tag.title }}</a></li>
                                                         {% endfor %}
                                                     </ul>
                                                 </li>
-                                            {% empty %}
-                                                <ul>
-                                                    <li class="dropdown-title">
-                                                        {% trans "Aucun forum disponible." %}
-                                                    </li>
-                                                </ul>
-                                            {% endfor %}
-                                            {% if top.tags %}
-                                            <li>
-                                                <ul>
-                                                    <li class="dropdown-title">
-                                                        {% trans "Tags les plus utilisés" %}
-                                                    </li>
-                                                    {% for tag in top.tags %}
-                                                        <li><a href="{{ tag.get_absolute_url }}">{{ tag.title }}</a></li>
-                                                    {% endfor %}
-                                                </ul>
-                                            </li>
-                                            {% endif %}
-                                        {% endwith %}
-                                    </ul>
-                                </div>
-                            </li>
-                        </ul>
+                                                {% endif %}
+                                            {% endwith %}
+                                        </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                        {% endcache %}
                     </nav>
 
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) | ?? |

Cette PR est la première d'une longue série, elle va ajouter du cache sur le menu. On économise 7 requêtes SQL sur _l'ensemble des pages du site_\* ! Cette PR va servir de POC, j'en ai commencé d'autres pour cacher les pages les plus visités et les éléments qui ne bougent que très peu mais qui nécessitent des requêtes afin de soulager le serveur.

Un tuto là dessus de MicroJoe que j'ai repris devrait arriver soon sur ZdS (cc @artragis ).
### QA
- Vérifier le nombre de requêtes SQL sur une page avec Django Debug Toolbar
- Changer son système de cache (avec https://docs.djangoproject.com/fr/1.9/topics/cache/#filesystem-caching par exemple).
- Charger à nouveau la page 2 fois et vérifier qu'on a bien 7 requêtes en moins.
