### PR TITLE
ZEP-25 : correction mineure de la commande de migration

### DIFF
--- a/zds/tutorialv2/management/commands/migrate_to_zep25.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep25.py
@@ -32,9 +32,10 @@ class Command(BaseCommand):
         for content in contents:
             categories = content.subcategory.all()
             for cat in categories:
+                cat_name = cat.title.strip().lower()
                 # do not add "autre" tag (useless)
-                if cat.strip() != 'autre':
-                    current_tag, created = Tag.objects.get_or_create(title=cat.lower())
+                if cat_name != 'autre':
+                    current_tag, created = Tag.objects.get_or_create(title=cat_name)
                     content.tags.add(current_tag)
                     if created:
                         self.stdout.write('[ZEP-25] : Tag "{}" added'.format(current_tag))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) |  |
### QA
- Lancer la commande `python manage.py migrate_to_zep25`
