### PR TITLE
[v18-RC6] Fix #3614 - ZEP-25 : corrige les URL dans le mp de migration

### DIFF
--- a/zds/tutorialv2/management/commands/migrate_to_zep25.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep25.py
@@ -151,10 +151,9 @@ class Command(BaseCommand):
                   's** ont fait leur apparition et les catégories ont été revues afin de faciliter et d\'aléger cette' \
                   ' classification.\n\nLes anciennes catégories ont été transformées en tags et de nouvelles catégori' \
                   'es plus générales ont été ajoutés. L\'équipe de Zeste de Savoir va ou a déjà changé les catégories' \
-                  ' des contenus publiés.\n\nNous vous invitons à vérifier la catégorie de vos [articles](https://zes' \
-                  'tedesavoir.com/contenus/articles/{1}/) et [tutoriels](https://zestedesavoir.com/contenus/tutoriels' \
-                  '/{1}/) mais également la pertinence des tags et en ajouter si besoin.\n\n\nNous restons à votre di' \
-                  'sposition et votre écoute pour toutes suggestions ou remarques,\n\nL\'équipe de Zeste de Savoir'
+                  ' des contenus publiés.\n\nNous vous invitons à vérifier les catégories de vos articles et tutoriel' \
+                  's mais également la pertinence des tags et en ajouter si besoin.\n\n\nNous restons à votre disposi' \
+                  'tion et votre écoute pour toutes suggestions ou remarques,\n\nL\'équipe de Zeste de Savoir'
             send_mp(
                 bot,
                 [user],


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3614 |
### QA
- lancer la commade `python manage.py migrate_to_zep25` et vérifier que le mp envoyé est OK
