### PR TITLE
Supprime les acces API lors d'une desinscription

### DIFF
--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -75,6 +75,9 @@
                 </li>
             </ul>
         </li>
+        <li>
+            {% trans "Toutes vos clés API (si vous en possédez) seront supprimées" %}.
+        </li>
     </ul>
 
     <p>

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -3,6 +3,8 @@
 import uuid
 from datetime import datetime, timedelta
 
+from oauth2_provider.models import AccessToken
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, logout
@@ -431,6 +433,10 @@ def unregister(request):
             anonymous_gallery.gallery = gallery.gallery
             anonymous_gallery.save()
         gallery.delete()
+
+    # remove API access (tokens + applications)
+    for token in AccessToken.objects.filter(user=current):
+        token.revoke()
 
     logout(request)
     User.objects.filter(pk=current.pk).delete()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3350 |
### QA
- Créer des clés API pour un utilisateur via l'admin
- Se connecter avec et utilisateur et se désinscrire
- Vérifier que les clés ont été supprimées (et par la même occasion les applications liées)
