### PR TITLE
Correction d'une faute d'orthographe sur la page de désinscription

### DIFF
--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -47,11 +47,11 @@
             <ul>
                 <li>
                     {% blocktrans %}
-                        si vous étiez seul, ils seront placés sous la gouvernance du compte "Auteur Externe", sauf demande contraire de votre part à un membre du staff <strong>avant</strong> votre désinscription.
+                        Si vous étiez seul, ils seront placés sous la gouvernance du compte « Auteur Externe », sauf demande contraire de votre part à un membre du staff <strong>avant</strong> votre désinscription.
                     {% endblocktrans %}
                 </li>
                 <li>
-                    {% trans "si vous étiez plusieurs auteurs, vous quitterez le groupe de rédacteurs. Les autres pourront dès lors continuer sans vous" %}.
+                    {% trans "Si vous étiez plusieurs auteurs, vous quitterez le groupe de rédacteurs. Les autres pourront dès lors continuer sans vous" %}.
                 </li>
             </ul>
         </li>
@@ -60,17 +60,17 @@
             <ul>
                 <li>
                     {% blocktrans %}
-                        si la galerie est liée à un tutoriel, elle subira le même sort que ce dernier (attribution à <em>Auteur externe</em> ou aux autres auteurs du contenu).
+                        Si la galerie est liée à un tutoriel, elle subira le même sort que ce dernier (attribution à « Auteur externe » ou aux autres auteurs du contenu).
                     {% endblocktrans %}
                 </li>
                 <li>
                     {% blocktrans %}
-                        si vous êtes plusieurs possesseurs, vous serez simplement supprimé du groupe.
+                        Si vous êtes plusieurs possesseurs, vous serez simplement supprimé du groupe.
                     {% endblocktrans %}
                 </li>
                 <li>
                     {% blocktrans %}
-                        sinon, elle sera supprimée (ainsi que son contenu).
+                        Sinon, elle sera supprimée (ainsi que son contenu).
                     {% endblocktrans %}
                 </li>
             </ul>

--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -43,7 +43,7 @@
             {% trans "Vos tutoriels et articles non publiés (brouillon, bêta ou en cours de validation) seront supprimés sans possibilité de récuperation (sauf si d'autres auteurs sont présents lors de la rédaction" %}).
         </li>
         <li>
-            {% trans "Vos tutoriels et articles publiés subiront les modifications suivantes" %}.
+            {% trans "Vos tutoriels et articles publiés subiront les modifications suivantes :" %}
             <ul>
                 <li>
                     {% blocktrans %}
@@ -56,21 +56,21 @@
             </ul>
         </li>
         <li>
-            {% trans "Vos galeries d'image subiront les modifications suivantes" %}.
+            {% trans "Vos galeries d'image subiront les modifications suivantes :" %}
             <ul>
                 <li>
                     {% blocktrans %}
-                        Si la gallerie est liée à un tutoriel, elle subira le même sort que ce dernier (attribution à <em>Auteur externe</em> ou aux autres auteurs du contenu).
+                        si la galerie est liée à un tutoriel, elle subira le même sort que ce dernier (attribution à <em>Auteur externe</em> ou aux autres auteurs du contenu).
                     {% endblocktrans %}
                 </li>
                 <li>
                     {% blocktrans %}
-                        Si vous êtes plusieurs possesseurs, vous serez simplement supprimé du groupe.
+                        si vous êtes plusieurs possesseurs, vous serez simplement supprimé du groupe.
                     {% endblocktrans %}
                 </li>
                 <li>
                     {% blocktrans %}
-                        Sinon, elle sera supprimée (ainsi que son contenu).
+                        sinon, elle sera supprimée (ainsi que son contenu).
                     {% endblocktrans %}
                 </li>
             </ul>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction d'une faute d'orthographe |
| Ticket(s) (_issue(s)_) concerné(s) | aucun |

J'ai souhaité remplacer « gallerie » par « galerie » mais j'ai aussi vu que sur la première liste il y avait une lettre minuscule à chaque début de phrase alors j'ai décidé de corriger la seconde liste pour avoir une cohérence. J'ai aussi ajouté le signe deux-points avant chaque liste.

Si vous souhaitez corriger seulement la faute d'orthographe, je peux faire machine arrière sur les deux derniers points.

**Modification :** j'ai finalement ajouté une majuscule à chaque ligne. J'en ai aussi profité pour utiliser les guillemets français et j'ai modifié la seconde occurrence de `« Auteur externe »`, en l'écrivant de la même façon que la première (c'est-à-dire avec les guillemets et non en italique). Peut-être devrais-je modifier le nom du commit par « Relecture du texte de la page de désinscription » ?
