### PR TITLE
Fix #3626 : corrige les espaces dans l'ajout de tags sur les contenus

### DIFF
--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -527,7 +527,7 @@ class PublishableContent(models.Model):
         """
         for tag in tag_collection:
             try:
-                current_tag, created = Tag.objects.get_or_create(title=tag.lower())
+                current_tag, created = Tag.objects.get_or_create(title=tag.lower().strip())
                 self.tags.add(current_tag)
             except ValueError as e:
                 logging.getLogger("zds.tutorialv2").warn(e)

--- a/zds/tutorialv2/tests/tests_models.py
+++ b/zds/tutorialv2/tests/tests_models.py
@@ -503,6 +503,18 @@ class ContentTests(TestCase):
                          'all tags are "{}"'.format('","'.join([str(t) for t in Tag.objects.all()])))
         self.assertEqual(tuto_tags_len, len(tuto.tags.all()))
 
+        # test space in tags (first and last space deleted)
+        tags = ['foo bar', ' azerty', 'qwerty ', ' another tag ']
+        tuto.add_tags(tags)
+        tuto_tags_list = [tag['title'] for tag in tuto.tags.values('title')]
+        self.assertIn('foo bar', tuto_tags_list)
+        self.assertNotIn(' azerty', tuto_tags_list)
+        self.assertIn('azerty', tuto_tags_list)
+        self.assertNotIn('qwerty ', tuto_tags_list)
+        self.assertIn('qwerty', tuto_tags_list)
+        self.assertNotIn(' another tag', tuto_tags_list)
+        self.assertIn('another tag', tuto_tags_list)
+
     def tearDown(self):
         if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):
             shutil.rmtree(settings.ZDS_APP['content']['repo_private_path'])


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3626 |

**À QA LE PLUS RAPIDEMENT POSSIBLE**
### QA
- ajouter à un contenu les tags « foo, bar » (l'espace est importante).
- Vérifier que le tag créé ne comprend pas d'espace et ne renvoie pas de 404
