### PR TITLE
Hotfix #3639 : supression des notifications lorsqu'on quitte un MP

### DIFF
--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -4,8 +4,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
-from django.core.exceptions import ObjectDoesNotExist
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.http import Http404, StreamingHttpResponse
@@ -19,11 +18,11 @@ from django.views.generic.list import MultipleObjectMixin
 from zds.member.models import Profile
 from zds.mp.commons import LeavePrivateTopic, UpdatePrivatePost
 from zds.mp.decorator import is_participant
+from zds.mp.forms import PrivateTopicForm, PrivatePostForm, PrivateTopicEditForm
+from zds.mp.models import PrivateTopic, PrivatePost, mark_read
 from zds.utils.forums import CreatePostView
 from zds.utils.mps import send_mp, send_message_mp
 from zds.utils.paginator import ZdSPagingListView
-from .forms import PrivateTopicForm, PrivatePostForm, PrivateTopicEditForm
-from .models import PrivateTopic, PrivatePost, mark_read
 
 
 class PrivateTopicList(ZdSPagingListView):
@@ -153,6 +152,7 @@ class PrivateTopicLeaveDetail(LeavePrivateTopic, SingleObjectMixin, RedirectView
 
     def post(self, request, *args, **kwargs):
         topic = self.get_object()
+        mark_read(topic, self.request.user)
         self.perform_destroy(topic)
         messages.success(request, _(u'Vous avez quitté la conversation avec succès.'))
         return redirect(reverse('mp-list'))

--- a/zds/notification/management/commands/fix_3639.py
+++ b/zds/notification/management/commands/fix_3639.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import BaseCommand
+
+from zds.mp.models import PrivatePost, mark_read
+from zds.notification.models import Notification
+
+
+class Command(BaseCommand):
+
+    help = 'Fix https://github.com/zestedesavoir/zds-site/issues/3639 (notifications not deleted on mp leave)'
+
+    def handle(self, *args, **options):
+        mp_content_type = ContentType.objects.get(model='privatepost')
+        # get all mp notifications unread
+        for notification in Notification.objects.filter(is_read=False, content_type=mp_content_type):
+            print('notif', notification)
+            topic = PrivatePost.objects.get(pk=notification.object_id).privatetopic
+            user = notification.sender
+            if not topic.is_participant(user):
+                mark_read(topic, user)
+                self.stdout.write(u'Notification #{} for PM #{} and user "" deleted'.format(notification.pk,
+                                                                                            topic.pk,
+                                                                                            user))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3639 |

**PR à traiter en priorité**
### QA

(A et B sont des utilisateurs)
- Se connecter avec A
- Envoyer un MP à B
- Se connecter avec B
- Aller sur la page avec tous les MP (/mp/)
- Supprimer le MP reçu de A *_sans le lire_
- Vérifier que la notification a bien été supprimée

La QA de la commande sera faite sur la beta pour s'assurer de son bon fonctionnement, juste après que la PR soit OK au niveau du fix (je déployerai temporairement ma branche).
