### PR TITLE
fix_pref_query

### DIFF
--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -230,6 +230,10 @@ Ce filtre renvoit la liste des *topics* suivis par l'utilisateur, sous la forme 
 
 où ``period`` est un nombre au format attendu par ``humane_delta`` (entre 1 et 5, voir plus haut) et ``topics`` la liste des *topics* dont le dernier message est situé dans cette période de temps. Les *topics* sont des objets ``Topic`` (`voir le détail de son implémentation ici <../back-end-code/forum.html#zds.forum.models.Topic>`__).
 
+.. attention::
+    Lorsque vous touchez à cette fonction, vous risquez d'altérer les performances du site de manière importante.
+    N'hésitez pas à demander une relecture complémentaire si c'est le cas.
+
 ``interventions_topics``
 ------------------------
 

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -8,6 +8,7 @@ from math import ceil
 
 from django.conf import settings
 from django.contrib.auth.models import Group, User
+from django.contrib.contenttypes.fields import GenericRelation
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.encoding import smart_text
@@ -214,6 +215,7 @@ class Topic(models.Model):
     key = models.IntegerField('cle', null=True, blank=True)
 
     objects = TopicManager()
+    notifications = GenericRelation("zds.notification.Subscription", related_query_name="content_object")
 
     def __unicode__(self):
         return self.title

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -19,7 +19,6 @@ from zds.settings import ZDS_APP
 from zds.utils import get_current_user
 from zds.utils import slugify
 from zds.utils.models import Comment, Tag
-import zds.notification.models
 
 
 def sub_tag(tag):
@@ -216,7 +215,6 @@ class Topic(models.Model):
     key = models.IntegerField('cle', null=True, blank=True)
 
     objects = TopicManager()
-    notifications = GenericRelation(zds.notification.models.Subscription, related_query_name="content_object")
 
     def __unicode__(self):
         return self.title

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -19,6 +19,7 @@ from zds.settings import ZDS_APP
 from zds.utils import get_current_user
 from zds.utils import slugify
 from zds.utils.models import Comment, Tag
+import zds.notification.models
 
 
 def sub_tag(tag):
@@ -215,7 +216,7 @@ class Topic(models.Model):
     key = models.IntegerField('cle', null=True, blank=True)
 
     objects = TopicManager()
-    notifications = GenericRelation("zds.notification.Subscription", related_query_name="content_object")
+    notifications = GenericRelation(zds.notification.models.Subscription, related_query_name="content_object")
 
     def __unicode__(self):
         return self.title

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -40,7 +40,6 @@ from zds.utils.tutorials import get_blob
 from zds.tutorialv2.models import TYPE_CHOICES, STATUS_CHOICES
 from zds.tutorialv2.models.models_versioned import NotAPublicVersion
 from zds.tutorialv2.managers import PublishedContentManager, PublishableContentManager
-import zds.notification.models
 
 ALLOWED_TYPES = ['pdf', 'md', 'html', 'epub', 'zip']
 
@@ -125,7 +124,6 @@ class PublishableContent(models.Model):
 
     public_version = models.ForeignKey(
         'PublishedContent', verbose_name=u'Version publiée', blank=True, null=True, on_delete=models.SET_NULL)
-    notifications = GenericRelation(zds.notification.models.Subscription, related_query_name="content_object")
     objects = PublishableContentManager()
 
     def __unicode__(self):

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -40,6 +40,7 @@ from zds.utils.tutorials import get_blob
 from zds.tutorialv2.models import TYPE_CHOICES, STATUS_CHOICES
 from zds.tutorialv2.models.models_versioned import NotAPublicVersion
 from zds.tutorialv2.managers import PublishedContentManager, PublishableContentManager
+import zds.notification.models
 
 ALLOWED_TYPES = ['pdf', 'md', 'html', 'epub', 'zip']
 
@@ -124,7 +125,7 @@ class PublishableContent(models.Model):
 
     public_version = models.ForeignKey(
         'PublishedContent', verbose_name=u'Version publiée', blank=True, null=True, on_delete=models.SET_NULL)
-    notifications = GenericRelation("zds.notification.Subscription", related_query_name="content_object")
+    notifications = GenericRelation(zds.notification.models.Subscription, related_query_name="content_object")
     objects = PublishableContentManager()
 
     def __unicode__(self):

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 
 from datetime import datetime
+
+from django.contrib.contenttypes.fields import GenericRelation
+
 try:
     import ujson as json_reader
 except ImportError:
@@ -121,7 +124,7 @@ class PublishableContent(models.Model):
 
     public_version = models.ForeignKey(
         'PublishedContent', verbose_name=u'Version publiée', blank=True, null=True, on_delete=models.SET_NULL)
-
+    notifications = GenericRelation("zds.notification.Subscription", related_query_name="content_object")
     objects = PublishableContentManager()
 
     def __unicode__(self):

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 from django import template
 from django.contrib.contenttypes.models import ContentType
+from django.db.models.expressions import F
 from django.utils.translation import ugettext_lazy as _
 
 from zds.forum.models import Post, never_read as never_read_topic
@@ -85,10 +86,9 @@ def followed_topics(user):
     :return:
     """
     topics_followed = TopicAnswerSubscription.objects\
-        .prefetch_related("content_object", "content_object__last_message", "last_notification")\
-        .extra(
-            select=dict(sort_date="last_notification__pubdate",
-                        displayed_date="content_object__last_message__pubdate")
+        .prefetch_related("content_object", "content_object__last_message")\
+        .annotate(sort_date=F("last_notification__pubdate"),
+                  displayed_date=F("content_object__last_message__pubdate")
         )\
         .filter(user=user,
                 content_type__model='topic',

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -7,6 +7,7 @@ from django import template
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.expressions import F
 from django.utils.translation import ugettext_lazy as _
+from lxml.html.builder import Q
 
 from zds.forum.models import Post, never_read as never_read_topic
 from zds.mp.models import PrivateTopic
@@ -86,8 +87,8 @@ def followed_topics(user):
     :return:
     """
     topics_followed = TopicAnswerSubscription.objects\
-        .prefetch_related("content_object", "content_object__last_message")\
         .annotate(sort_date=F("last_notification__pubdate"),
+                  content_object=Q("content_object"),
                   displayed_date=F("content_object__last_message__pubdate")
         )\
         .filter(user=user,

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -79,14 +79,21 @@ def humane_delta(value):
 
 @register.filter('followed_topics')
 def followed_topics(user):
+    """
+    gets the ten last followed topics.
+    @TODO : make the "10" parameter a configuration one
+    :param user:
+    :return:
+    """
     topics_followed = TopicAnswerSubscription.objects\
-                          .fetch_related("content_object", "content_object__last_message")\
-                          .extra(sort_date=F("last_notification__pubdate"))\
-                          .extra(displayed_date=F("content_object__last_message__pubdate"))\
-                          .filter(user=user,
-                                  content_type__model='topic',
-                                  is_active=True)\
-                          .order_by('-sort_date')[:10]
+                        .prefetch_related("content_object",
+                                          "content_object__last_message")\
+                        .extra(sort_date=F("last_notification__pubdate"))\
+                        .extra(displayed_date=F("content_object__last_message__pubdate"))\
+                        .filter(user=user,
+                                content_type__model='topic',
+                                is_active=True)\
+                        .order_by('-sort_date')[:10]
     # This period is a map for link a moment (Today, yesterday, this week, this month, etc.) with
     # the number of days for which we can say we're still in the period
     # for exemple, the tuple (2, 1) means for the period "2" corresponding to "Yesterday" according

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 
 from django import template
 from django.contrib.contenttypes.models import ContentType
-from django.db.models.expressions import F
 from django.utils.translation import ugettext_lazy as _
 
 from zds.forum.models import Post, never_read as never_read_topic
@@ -88,8 +87,8 @@ def followed_topics(user):
     topics_followed = TopicAnswerSubscription.objects\
         .prefetch_related("content_object", "content_object__last_message")\
         .extra(
-            select=dict(sort_date=F("last_notification__pubdate"),
-                        displayed_date=F("content_object__last_message__pubdate"))
+            select=dict(sort_date="last_notification__pubdate",
+                        displayed_date="content_object__last_message__pubdate")
         )\
         .filter(user=user,
                 content_type__model='topic',

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -86,14 +86,15 @@ def followed_topics(user):
     :return:
     """
     topics_followed = TopicAnswerSubscription.objects\
-                        .prefetch_related("content_object",
-                                          "content_object__last_message")\
-                        .extra(sort_date=F("last_notification__pubdate"))\
-                        .extra(displayed_date=F("content_object__last_message__pubdate"))\
-                        .filter(user=user,
-                                content_type__model='topic',
-                                is_active=True)\
-                        .order_by('-sort_date')[:10]
+        .prefetch_related("content_object", "content_object__last_message")\
+        .extra(
+            select=dict(sort_date=F("last_notification__pubdate"),
+                        displayed_date=F("content_object__last_message__pubdate"))
+        )\
+        .filter(user=user,
+                content_type__model='topic',
+                is_active=True)\
+        .order_by('-sort_date')[:10]
     # This period is a map for link a moment (Today, yesterday, this week, this month, etc.) with
     # the number of days for which we can say we're still in the period
     # for exemple, the tuple (2, 1) means for the period "2" corresponding to "Yesterday" according

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -86,10 +86,9 @@ def followed_topics(user):
     :return:
     """
     topics_followed = TopicAnswerSubscription.objects\
-        .prefetch_related("content_object")\
-        .annotate(sort_date=F("last_notification__pubdate"),
-                  displayed_date=F("content_object__last_message__pubdate")
-        )\
+        .select_related("content_object")\
+        .annotate(sort_date=F("last_notification__pubdate")
+                  )\
         .filter(user=user,
                 content_type__model='topic',
                 is_active=True)\

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -85,7 +85,7 @@ def followed_topics(user):
     :return:
     """
     topics_followed = TopicAnswerSubscription.objects\
-        .prefetch_related("content_object", "content_object__last_message")\
+        .prefetch_related("content_object", "content_object__last_message", "last_notification")\
         .extra(
             select=dict(sort_date="last_notification__pubdate",
                         displayed_date="content_object__last_message__pubdate")

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -7,7 +7,6 @@ from django import template
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.expressions import F
 from django.utils.translation import ugettext_lazy as _
-from lxml.html.builder import Q
 
 from zds.forum.models import Post, never_read as never_read_topic
 from zds.mp.models import PrivateTopic
@@ -87,8 +86,8 @@ def followed_topics(user):
     :return:
     """
     topics_followed = TopicAnswerSubscription.objects\
+        .prefetch_related("content_object")\
         .annotate(sort_date=F("last_notification__pubdate"),
-                  content_object=Q("content_object"),
                   displayed_date=F("content_object__last_message__pubdate")
         )\
         .filter(user=user,


### PR DESCRIPTION
pycharm ne prenant toujours pas en charge les templates de PR, le tableau viendra plus tard.

Cette PR a pour but d'améliorer les performances associées au chargement de la page des forums lorsque le site
subit une charge importante.

Comme nous n'avons toujours pas de tests de perfs, j'ai fait cette modification "par expérience" plus qu'avec un profileur précis.

Une relecture attentive est demandée, c'est primordial que nous gardions les mêmes fonctionnalités tout en améliorant les perfs.

Pour la QA : vérifiez les derniers edge cases qu'on a eu pour les notifs :
- un topic suivi apparaît bien dans la colonne de gauche
- un topic suivi a bien le bon état (lu/pas lu) 
- les notifs sont bien générées.
