### PR TITLE
Refacto de template tags et de Topic never_read

### DIFF
--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -480,21 +480,20 @@ def get_last_topics(user):
     return tops
 
 
-def never_read(topic, user=None):
+def is_read(topic, user=None):
     """
-    Check if the user has read the **last post** of the topic.
-    Note if the user has already read the topic but not the last post, it will consider it has never read the topic...
-    Technically this is done by check if there is a `TopicRead` for the topic, its last post and the user.
+    Checks if the user has read the **last post** of the topic.
+    Returns false if the user read the topic except its last post.
+    Technically this is done by checking if the user has a `TopicRead` object
+    for the last post of this topic.
     :param topic: A topic
     :param user: A user. If undefined, the current user is used.
     :return:
     """
-    # TODO: cette méthode est très mal nommée en plus d'avoir un nom "booléen négatif" !
     if user is None:
         user = get_current_user()
 
-    return not TopicRead.objects \
-        .filter(post=topic.last_message, topic=topic, user=user).exists()
+    return TopicRead.objects.filter(post=topic.last_message, topic=topic, user=user).exists()
 
 
 def mark_read(topic, user=None):

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -10,8 +10,7 @@ from django.test import TestCase
 
 from zds.forum.factories import CategoryFactory, ForumFactory, \
     TopicFactory, PostFactory, TagFactory
-from zds.forum.models import Forum, TopicRead
-from zds.forum.models import Post, Topic
+from zds.forum.models import Forum, TopicRead, Post, Topic, is_read
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.notification.models import TopicAnswerSubscription
 from zds.utils import slugify
@@ -1272,3 +1271,15 @@ class ManagerTests(TestCase):
             TopicRead(post=topic.last_post, user=self.staff.user, topic=topic).save()
             self.assertEqual(1, len(TopicRead.objects.list_read_topic_pk(self.staff.user)))
             self.assertEqual(0, len(TopicRead.objects.list_read_topic_pk(author.user)))
+
+        def test_is_read(self):
+            author = ProfileFactory()
+            reader = ProfileFactory()
+            topic = TopicFactory(author=author.user, forum=self.forum1)
+            post = PostFactory(topic=topic, position=1, author=author.user)
+            topic.last_post = post
+            topic.save()
+            TopicRead(post=topic.last_post, user=self.staff.user, topic=topic).save()
+            self.assertFalse(is_read(topic, author.user))
+            self.assertTrue(is_read(topic, self.staff.user))
+            self.assertFalse(is_read(topic, reader.user))

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -23,7 +23,7 @@ from haystack.query import SearchQuerySet
 
 from zds.forum.commons import TopicEditMixin, PostEditMixin, SinglePostObjectMixin, ForumEditMixin
 from zds.forum.forms import TopicForm, PostForm, MoveTopicForm
-from zds.forum.models import Category, Forum, Topic, Post, never_read, mark_read, TopicRead
+from zds.forum.models import Category, Forum, Topic, Post, is_read, mark_read, TopicRead
 from zds.member.decorator import can_write_and_read_now
 from zds.notification.models import TopicAnswerSubscription
 from zds.utils import slugify
@@ -169,7 +169,7 @@ class TopicPostsListView(ZdSPagingListView, SingleObjectMixin):
             context["user_can_modify"] = [post.pk for post in context['posts'] if post.author == self.request.user]
 
         if self.request.user.is_authenticated():
-            if never_read(self.object):
+            if not is_read(self.object):
                 mark_read(self.object)
         return context
 

--- a/zds/notification/managers.py
+++ b/zds/notification/managers.py
@@ -10,6 +10,22 @@ class SubscriptionManager(models.Manager):
     Custom subscription manager
     """
 
+    def __create_lookup_args(self, user, content_object, is_active, by_email):
+        """
+        Generates QuerySet lookup parameters for use with get(), filter(), ...
+        """
+        content_type = ContentType.objects.get_for_model(content_object)
+        lookup = dict(
+            object_id=content_object.pk,
+            content_type__pk=content_type.pk,
+            user=user
+        )
+        if is_active is not None:
+            lookup['is_active'] = is_active
+        if by_email is not None:
+            lookup['by_email'] = by_email
+        return lookup
+
     def get_existing(self, user, content_object, is_active=None, by_email=None):
         """
         If exists, return the existing subscription for the given user and content object.
@@ -24,7 +40,7 @@ class SubscriptionManager(models.Manager):
         :type by_email: Boolean
         :return: subscription or None
         """
-        content_type = ContentType.objects.get_for_model(content_object)
+        lookup = self.__create_lookup_args(user, content_object, is_active, by_email)
         try:
             lookup = dict(
                 object_id=content_object.pk,

--- a/zds/notification/managers.py
+++ b/zds/notification/managers.py
@@ -26,27 +26,16 @@ class SubscriptionManager(models.Manager):
         """
         content_type = ContentType.objects.get_for_model(content_object)
         try:
-            if is_active is None and by_email is None:
-                existing = self.get(
-                    object_id=content_object.pk,
-                    content_type__pk=content_type.pk,
-                    user=user)
-            elif is_active is not None and by_email is None:
-                existing = self.get(
-                    object_id=content_object.pk,
-                    content_type__pk=content_type.pk,
-                    user=user, is_active=is_active)
-            elif is_active is None and by_email is not None:
-                existing = self.get(
-                    object_id=content_object.pk,
-                    content_type__pk=content_type.pk,
-                    user=user, by_email=by_email)
-            else:
-                existing = self.get(
-                    object_id=content_object.pk,
-                    content_type__pk=content_type.pk,
-                    user=user, is_active=is_active,
-                    by_email=by_email)
+            lookup = dict(
+                object_id=content_object.pk,
+                content_type__pk=content_type.pk,
+                user=user
+            )
+            if is_active is not None:
+                lookup['is_active'] = is_active
+            if by_email is not None:
+                lookup['by_email'] = by_email
+            existing = self.get(**lookup)
         except ObjectDoesNotExist:
             existing = None
         return existing

--- a/zds/notification/managers.py
+++ b/zds/notification/managers.py
@@ -42,19 +42,27 @@ class SubscriptionManager(models.Manager):
         """
         lookup = self.__create_lookup_args(user, content_object, is_active, by_email)
         try:
-            lookup = dict(
-                object_id=content_object.pk,
-                content_type__pk=content_type.pk,
-                user=user
-            )
-            if is_active is not None:
-                lookup['is_active'] = is_active
-            if by_email is not None:
-                lookup['by_email'] = by_email
             existing = self.get(**lookup)
         except ObjectDoesNotExist:
             existing = None
         return existing
+
+    def does_exist(self, user, content_object, is_active=None, by_email=None):
+        """
+        Check if there is a subscription for the given user and content object.
+
+        :param user: concerned user.
+        :type user: django.contrib.auth.models.User
+        :param content_object: Generic content concerned.
+        :type content_object: instance concerned by notifications
+        :param is_active: Boolean to know if we want a subscription active or not.
+        :type is_active: Boolean
+        :param by_email: Boolean to know if we want a subscription for email or not.
+        :type by_email: Boolean
+        :return: Boolean, whether this subscription exists or not
+        """
+        lookup = self.__create_lookup_args(user, content_object, is_active, by_email)
+        return self.filter(**lookup).exists()
 
     def get_or_create_active(self, user, content_object):
         """

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -7,7 +7,7 @@ from django import template
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _
 
-from zds.forum.models import Post, never_read as never_read_topic
+from zds.forum.models import Post, is_read as topic_is_read
 from zds.mp.models import PrivateTopic
 from zds.notification.models import Notification, TopicAnswerSubscription, ContentReactionAnswerSubscription, \
     NewTopicSubscription
@@ -20,10 +20,7 @@ register = template.Library()
 
 @register.filter('is_read')
 def is_read(topic):
-    if never_read_topic(topic):
-        return False
-    else:
-        return True
+    return topic_is_read(topic)
 
 
 @register.filter('is_followed')

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -60,7 +60,7 @@ def is_content_followed(content):
 @register.filter('humane_delta')
 def humane_delta(value):
     """
-    Mapping between label day and key
+    Associating a key to a named period
 
     :param int value:
     :return: string
@@ -82,12 +82,11 @@ def followed_topics(user):
                                                              content_type__model='topic',
                                                              is_active=True)\
         .order_by('-last_notification__pubdate')[:10]
-    # This period is a map for link a moment (Today, yesterday, this week, this month, etc.) with
-    # the number of days for which we can say we're still in the period
-    # for exemple, the tuple (2, 1) means for the period "2" corresponding to "Yesterday" according
-    # to humane_delta, means if your pubdate hasn't exceeded one day, we are always at "Yesterday"
-    # Number is use for index for sort map easily
-    periods = ((1, 0), (2, 1), (3, 7), (4, 30), (5, 360))
+    # periods is a map associating a period (Today, Yesterday, Last n days)
+    # with its corresponding number of days: (humane_delta index, number of days).
+    # (3, 7) thus means that passing 3 to humane_delta would return "This week", for which
+    # we'd like pubdate not to exceed 7 days.
+    periods = ((1, 0), (2, 1), (3, 7), (4, 30), (5, 365))
     topics = {}
     for topic_followed in topics_followed:
         for period in periods:

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -29,32 +29,32 @@ def is_read(topic):
 @register.filter('is_followed')
 def is_followed(topic):
     user = get_current_user()
-    return TopicAnswerSubscription.objects.get_existing(user, topic, is_active=True) is not None
+    return TopicAnswerSubscription.objects.does_exist(user, topic, is_active=True)
 
 
 @register.filter('is_email_followed')
 def is_email_followed(topic):
     user = get_current_user()
-    return TopicAnswerSubscription.objects.get_existing(user, topic, is_active=True, by_email=True) is not None
+    return TopicAnswerSubscription.objects.does_exist(user, topic, is_active=True, by_email=True)
 
 
 @register.filter('is_forum_followed')
 def is_forum_followed(forum):
     user = get_current_user()
-    return NewTopicSubscription.objects.get_existing(user, forum, is_active=True) is not None
+    return NewTopicSubscription.objects.does_exist(user, forum, is_active=True)
 
 
 @register.filter('is_forum_email_followed')
 def is_forum_email_followed(forum):
     user = get_current_user()
-    return NewTopicSubscription.objects.get_existing(user, forum, is_active=True, by_email=True) is not None
+    return NewTopicSubscription.objects.does_exist(user, forum, is_active=True, by_email=True)
 
 
 @register.filter('is_content_followed')
 def is_content_followed(content):
     user = get_current_user()
-    return user.is_authenticated() and ContentReactionAnswerSubscription.objects.get_existing(
-        user, content, is_active=True) is not None
+    return user.is_authenticated() and ContentReactionAnswerSubscription.objects.does_exist(
+        user, content, is_active=True)
 
 
 @register.filter('humane_delta')


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) |  |

Je suis tombé sur un commentaire que j'ai voulu changé, puis j'ai suivi un [lapin blanc](http://www.oxforddictionaries.com/us/definition/american_english/rabbit-hole). Un bon moyen de se refamiliariser avec la codebase.

Si vous cherchez la logique, je suis parti de `zds/utils/templatetags/interventions.py`. La première volée de commits visait à refactorer ses `get_existing()`, puis j'ai creusé son `never_read()`.
### QA
- vérifier que les souscriptions aux topics s'ajoutent bien dans les différents éléments de l'interface
- vérifier que les topics/posts se marquent bien et s'indiquent bien lus/non-lus
