### PR TITLE
Remplacement de l'adresse d'OVH par celle de Gandi

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -444,8 +444,8 @@ ZDS_APP = {
             'licence_info_link': u'Le droit d\'auteur, Creative Commons et les licences sur Zeste de Savoir'
         },
         'hosting': {
-            'name': u"OVH",
-            'address': u"2 rue Kellermann - 59100 Roubaix - France"
+            'name': u"GANDI SAS",
+            'address': u"63-65 boulevard Massena - 75013 Paris - France"
         },
         'social': {
             'facebook': u'https://www.facebook.com/ZesteDeSavoir',


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | Mise à jour |
| Ticket(s) (_issue(s)_) concerné(s) | n/a |
### QA
- Consulter la page des CGU et vérifiez que l'adresse de Gandi a bien remplacée celle d'OVH.
  Adresse prise ici: https://www.gandi.net/qui-est-gandi/

**A NE MERGER QUE LORSQUE LA MIGRATION VERS GANDI SERA DEFINITIVE**
