### PR TITLE
[Hotfix] Corrige le suivi des sujets par e-mail

### DIFF
--- a/update.md
+++ b/update.md
@@ -575,7 +575,14 @@ Actions à faire pour mettre en prod la version 18.2
 Notifications
 -------------
 
+### Supprime les notifications inutiles
+
 Lancez la commande `python manage.py delete_useless_notif` pour supprimer toutes les notifications inutiles.
+
+### Migre les souscriptions par e-mail
+
+Lancez la commande `python manage.py migrate_email_subscription` pour migrer tous les sujets suivis par e-mail vers
+les nouveaux modèles de souscriptions.
 
 ---
 

--- a/zds/notification/management/commands/migrate_email_subscription.py
+++ b/zds/notification/management/commands/migrate_email_subscription.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+from django.core.management import BaseCommand
+
+from zds.member.models import Profile
+from zds.notification.models import TopicFollowed, TopicAnswerSubscription
+
+
+class Command(BaseCommand):
+    help = 'Migrate old email subscriptions to new models.'
+
+    def handle(self, *args, **options):
+        for profile in Profile.objects.all():
+            self.stdout.write(u'Starting migration for {}'.format(profile.user.username))
+
+            # Get alls topic followed by the user.
+            topics_followed = TopicFollowed.objects \
+                .filter(user=profile.user, email=True) \
+                .values("topic").distinct().all()
+
+            # And update email attribute in the TopicAnswerSubscription model.
+            for topic in topics_followed:
+                active = TopicAnswerSubscription.objects.get_or_create_active(user=profile.user, content_object=topic)
+                active.email = True
+                active.save()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3630 |
### QA

Elle est un peu chiante ...
- Placez-vous sur la v17 et inscrivez-vous par mail à au moins un sujet et à un autre sujet où vous ne le suivez pas par e-mail.
- Placez-vous sur la branche de cette PR et lancez la commande `python manage.py migrate_subscriptions.py`. Constatez que vous suivez bien les sujet mais que vous ne recevez pas des e-mail au sujet que vous avez suivi par e-mail.
- Maintenant, lancez-la commande `python manage.py migrate_email_subscription`. Constatez que vous suivez bien par e-mail le bon sujet et que vous ne suivez pas par e-mail l'autre sujet.
