### PR TITLE
[Hotfix] Corrige la date dans les notifications

### DIFF
--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -137,6 +137,7 @@ class SingleNotificationMixin(object):
             notification.sender = sender
             notification.url = self.get_notification_url(content)
             notification.title = self.get_notification_title(content)
+            notification.pubdate = content.pubdate
             notification.is_read = False
             notification.save()
             self.set_last_notification(notification)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3628 |
### QA
- Suivez un sujet avec l'utilisateur A.
- Postez dans ce même sujet avec l'utilisateur B.
- Lisez le message avec l'utilisateur A.
- Attendez 5 minutes et postez un message dans ce même sujet avec l'utilisateur C.
- Constatez que la notification est à la bonne date.
