### PR TITLE
[Hotfix] Evite les notifications persistantes à la suppression d'un MP.

### DIFF
--- a/update.md
+++ b/update.md
@@ -569,6 +569,14 @@ Il faudra supprimer en SQL:
  
 S'il y a une erreur pour `article_article_subcategory` et `DROP TABLE tutorial_tutorial_subcategory;` c'est que les tables ont déjà été supprimées précédement (ZEP-25).
 
+Actions à faire pour mettre en prod la version 18.2
+===================================================
+
+Notifications
+-------------
+
+Lancez la commande `python manage.py delete_useless_notif` pour supprimer toutes les notifications inutiles.
+
 ---
 
 **Notes auxquelles penser lors de l'édition de ce fichier (à laisser en bas) :**

--- a/zds/notification/management/commands/delete_useless_notif.py
+++ b/zds/notification/management/commands/delete_useless_notif.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import BaseCommand
+
+from zds.member.models import Profile
+from zds.notification.models import Notification
+
+
+class Command(BaseCommand):
+    help = 'Remove useless notifications for private topics.'
+
+    def handle(self, *args, **options):
+        for profile in Profile.objects.all():
+            self.stdout.write(u'Remove all useless notifications of {}...'.format(profile.user.username))
+            content_type = ContentType.objects.get(model='privatepost')
+            for notification in Notification.objects\
+                    .filter(is_read=False, content_type=content_type, subscription__user=profile.user):
+                if notification.content_object is None:
+                    notification.is_read = True
+                    notification.save()
+                    self.stdout.write(u'Notification #{} marked as read.'.format(notification.id))

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -232,6 +232,17 @@ def add_participant_topic_event(sender, **kwargs):
                     subscription.deactivate()
 
 
+@receiver(pre_delete, sender=PrivateTopic)
+def delete_private_topic_event(sender, instance, **kwargs):
+    """
+    A private topic is deleted when there is nobody in this private topic.
+    """
+    subscriptions = PrivateTopicAnswerSubscription.objects.get_subscriptions(content_object=instance, is_active=True)
+    for subscription in subscriptions:
+        subscription.mark_notification_read()
+        subscription.deactivate()
+
+
 @receiver(pre_delete, sender=User)
 def delete_notifications(sender, instance, **kwargs):
     """


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3639 |
### QA
- Placez-vous sur la version 18.1.
- Créez un MP entre 2 membres et supprimer les 2 membres de la conversation privée **sans lire le MP**.
- Constatez que vous avez une notification qui pointe vers une 404.
- Placez-vous sur la branche de cette PR.
- Lancez la commande `python manage.py delete_useless_notif`
- Constatez que la notification n'est plus là.
- Refaite la création et suppression d'un MP entre 2 membres.
- Constatez qu'il n'y a plus aucune notification.
