### PR TITLE
[Hotfix] Marque comme lu une notification d'un contenu non suivi

### DIFF
--- a/zds/notification/managers.py
+++ b/zds/notification/managers.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
 from zds.forum.models import Topic
+from zds.notification import signals
 from zds.utils import get_current_user
 
 
@@ -136,6 +137,7 @@ class SubscriptionManager(models.Manager):
             if by_email:
                 subscription.activate_email()
             return subscription
+        signals.content_read.send(sender=content_object.__class__, instance=content_object, user=user)
         if by_email:
             existing.deactivate_email()
         else:

--- a/zds/notification/tests.py
+++ b/zds/notification/tests.py
@@ -517,3 +517,22 @@ class NotificationTest(TestCase):
         notifications = Notification.objects.filter(subscription__user=self.user1)
         self.assertEqual(1, len(notifications))
         self.assertIsNotNone(notifications.first())
+
+    def test_mark_all_notifications_as_read_when_toggle_follow(self):
+        """
+        When a user unsubscribe to a content, we mark as read all notifications about this content.
+        """
+        category = CategoryFactory(position=1)
+        forum = ForumFactory(category=category, position_in_category=1)
+        topic = TopicFactory(forum=forum, author=self.user1)
+        PostFactory(topic=topic, author=self.user1, position=1)
+        PostFactory(topic=topic, author=self.user2, position=2)
+
+        notifications = Notification.objects.get_unread_notifications_of(self.user1)
+        self.assertEqual(1, len(notifications))
+        self.assertIsNotNone(notifications.first())
+        self.assertEqual(topic.last_message, notifications.first().content_object)
+
+        TopicAnswerSubscription.objects.toggle_follow(topic, self.user1)
+
+        self.assertEqual(0, len(Notification.objects.get_unread_notifications_of(self.user1)))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3659 |
### QA
- Créez un sujet avec un utilisateur A.
- Répondez avec un utilisateur B.
- Sans lire la notification avec l'utilisateur A, ne suivez plus le sujet que vous avez créé.
- Constatez qu'il n'y a plus de notification.
