### PR TITLE
Correction du nombre de messages postés par Clem

### DIFF
--- a/templates/forum/find/post.html
+++ b/templates/forum/find/post.html
@@ -75,4 +75,14 @@
     {% endif %}
 
     {% include "misc/paginator.html" with position="bottom" %}
+
+    {% if hidden_messages_count %}
+        <em>
+            {% blocktrans count counter=hidden_messages_count %}
+                Note : {{ counter }} message est invisible car dans un sujet inaccessible.
+            {% plural %}
+                Note : {{ counter }} messages sont invisibles car dans un sujet inaccessible.
+            {% endblocktrans %}
+        </em>
+    {% endif %}
 {% endblock %}

--- a/templates/forum/find/topic.html
+++ b/templates/forum/find/topic.html
@@ -72,4 +72,14 @@
     {% endif %}
 
     {% include "misc/paginator.html" with position="bottom" %}
+
+    {% if hidden_topics_count %}
+        <em>
+            {% blocktrans count counter=hidden_topics_count %}
+                Note : {{ counter }} sujet est invisible car dans un forum inaccessible.
+            {% plural %}
+                Note : {{ counter }} sujets sont invisibles car dans un forum inaccessible.
+            {% endblocktrans %}
+        </em>
+    {% endif %}
 {% endblock %}

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -376,7 +376,8 @@ class FindTopic(ZdSPagingListView, SingleObjectMixin):
     def get_context_data(self, **kwargs):
         context = super(FindTopic, self).get_context_data(**kwargs)
         context.update({
-            'usr': self.object
+            'usr': self.object,
+            'hidden_topics_count': Topic.objects.filter(author=self.object).count() - context['paginator'].count,
         })
         return context
 
@@ -620,8 +621,10 @@ class FindPost(FindTopic):
     template_name = 'forum/find/post.html'
     paginate_by = settings.ZDS_APP['forum']['posts_per_page']
 
-    def get_queryset(self):
-        return Post.objects.get_all_messages_of_a_user(self.request.user, self.object)
+    def get_context_data(self, **kwargs):
+        context = super(FindPost, self).get_context_data(**kwargs)
+        context.update(Post.objects.get_all_messages_of_a_user(self.request.user, self.object))
+        return context
 
 
 @can_write_and_read_now


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug / évolution |
| Ticket(s) (_issue(s)_) concerné(s) | #3637 |

---

~~J'ouvre cette PR non terminée maintenant afin d'avoir quelques retours :~~

~~\* Récupération du nombre de messages inaccessibles : j'ai modifié `get_all_messages_of_a_user()`, car c'est là que les messages sont récupérés, mais ça oblige à modifier la CBV (méthode `get_queryset()`), c'est un hack pas très propre je trouve. Est ce que ça passe ? Si non, des idée pour améliorer ça ?~~
~~\* Message affiché : Il faut que je mette un soupçon de CSS peut être, mais la base est là.~~

HS : une raison pour laquelle seuls les membres de l'organisation zds peuvent mettre les tags ?

---

**QA:**

Prérequis : avoir un compte admin (qui peut créer des forums et sujets privés) et un compte non admin (un utilisateur non connecté suffira)
- Aller sur la page de profil du membre admin (par ex. https://zestedesavoir.com/membres/voir/Clem/) et voir le nombre de "Sujets créés" et de "Messages postés" sur la gauche (en version admin et utilisateur non connecté). Aller voir le nombre de messages et sujets visibles réellement affichés en cliquant sur les deux liens. Cette PR ajoute un message avec le nombre de messages ou de sujets masqué, dans le cas où des sujets ou des messages sont innaccesibles (car dans un forum privé).
- Créer un sujet dans un forum publique, puis dans un forum privé, puis poster un message dans le sujet publique, puis dans le sujet privé ; et vérifier à chaque fois que le compte s'incrémente de manière logique sur la page de profil et dans la liste des sujets et messages du membre admin.
