### PR TITLE
masquage de la biographie lors du Ban

### DIFF
--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -306,7 +306,7 @@ class BanSanction(MemberSanctionState):
     def apply_sanction(self, profile, ban):
         profile.end_ban_read = None
         profile.can_read = False
-        profile.biography = u"Biographie masquée car le membre est bannie"
+        profile.biography = u"Biographie masquée car le membre est banni."
         profile.save()
         ban.save()
         logout_user(profile.user.username)

--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -306,6 +306,7 @@ class BanSanction(MemberSanctionState):
     def apply_sanction(self, profile, ban):
         profile.end_ban_read = None
         profile.can_read = False
+        profile.biography = u"Biographie masquée car le membre est bannie"
         profile.save()
         ban.save()
         logout_user(profile.user.username)

--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -306,7 +306,7 @@ class BanSanction(MemberSanctionState):
     def apply_sanction(self, profile, ban):
         profile.end_ban_read = None
         profile.can_read = False
-        profile.biography = u"Biographie masquée car le membre est banni."
+        profile.biography = _(u"Biographie masquée car le membre est banni.")
         profile.save()
         ban.save()
         logout_user(profile.user.username)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) | (ex #3673) |
### QA
-  modifiez la biographie d'un membre 
-  avec un compte staf, banissez-le
- observez que sa biographie est masquée
- débanissez-le et modifiez sa biographie
- banissez-le temporairement, observez que sa biographie n'est pas masquée.
