### PR TITLE
Empêche les erreurs 500 lors d'un tag trop long

### DIFF
--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -15,6 +15,7 @@ from zds.tutorialv2.models.models_database import PublishableContent
 from django.utils.translation import ugettext_lazy as _
 from zds.member.models import Profile
 from zds.tutorialv2.utils import slugify_raise_on_invalid, InvalidSlugError
+from zds.utils.forms import TagValidator
 
 
 class FormWithTitle(forms.Form):
@@ -264,7 +265,8 @@ class ContentForm(ContainerForm):
             self._errors['image'] = self.error_class(
                 [_(u'Votre logo est trop lourd, la limite autorisée est de {} Ko')
                  .format(settings.ZDS_APP['gallery']['image_max_size'] / 1024)])
-
+        if not TagValidator.validate_raw_string(cleaned_data.get("tags")):
+            self._errors['image'] = self.error_class([_(u'Vous avez entré un tag trop long.')])
         return cleaned_data
 
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -266,7 +266,7 @@ class ContentForm(ContainerForm):
                 [_(u'Votre logo est trop lourd, la limite autorisée est de {} Ko')
                  .format(settings.ZDS_APP['gallery']['image_max_size'] / 1024)])
         if not TagValidator.validate_raw_string(cleaned_data.get("tags")):
-            self._errors['image'] = self.error_class([_(u'Vous avez entré un tag trop long.')])
+            self._errors['tags'] = self.error_class([_(u'Vous avez entré un tag trop long.')])
         return cleaned_data
 
 

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -65,10 +65,11 @@ class TagValidator(object):
     """"
     validate tags
     """"
+
     @staticmethod
     def validate_raw_string(raw_string):
         return TagValidator.validate_string_list(raw_string.split(","))
 
     @staticmethod
     def validate_string_list(string_list):
-        return all(len(_) <= Tag._meta.get_field("title").max_length for _ in string_list])
+        return all([len(_) <= Tag._meta.get_field("title").max_length for _ in string_list])

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -3,6 +3,7 @@
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.layout import Layout, ButtonHolder, Field, Div, HTML
 from django.utils.translation import ugettext_lazy as _
+from zds.utils.models import Tag
 
 
 class CommonLayoutEditor(Layout):
@@ -58,3 +59,16 @@ class CommonLayoutModalText(Layout):
             Field('text'),
             *args, **kwargs
         )
+
+
+class TagValidator(object):
+    """"
+    validate tags
+    """"
+    @staticmethod
+    def validate_raw_string(raw_string):
+        return TagValidator.validate_string_list(raw_string.split(","))
+
+    @staticmethod
+    def validate_string_list(string_list):
+        return all(len(_) <= Tag._meta.get_field("title").max_length for _ in string_list])

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -62,9 +62,9 @@ class CommonLayoutModalText(Layout):
 
 
 class TagValidator(object):
-    """"
+    """
     validate tags
-    """"
+    """
 
     @staticmethod
     def validate_raw_string(raw_string):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug / nouvelle fonctionnalité / évolution |
| Ticket(s) (_issue(s)_) concerné(s) | (ex #3642) |
### QA
- créez un tuto
- modifiez-le et ajoutez-lui un tag long
- vérifiez que vous obtenez un retour UI et non une erreur 500
