### PR TITLE
utf8mb4 Script de migration & doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
+dist: trusty
+sudo: required
+addons:
+  apt:
+    packages:
+    - mysql-server-5.6
+    - mysql-client-core-5.6
+    - mysql-client-5.6
+    - language-pack-fr
+    - unzip
+
 git:
   depth: 1
 
@@ -21,10 +32,8 @@ notifications:
     skip_join: true
 
 services:
- - mysql
  - memcached
 
-sudo: false
 cache:
   apt: true
   pip: true
@@ -36,21 +45,19 @@ cache:
     - $HOME/.texlive
     - $HOME/bin
 
-addons:
-  apt:
-    packages:
-      - libmysqlclient-dev
-      - language-pack-fr
-      - unzip
-
 before_script:
-  # configure mysql
-  - mysql -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'" # Travis default
-  # try to avoid mysql has gone away errors
-  - mysql -e "SET GLOBAL wait_timeout = 36000;"
-  - mysql -e "SET GLOBAL max_allowed_packet = 134209536;"
-  # database services
-  - mysql -e 'CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"
+  # MySQL config
+  - sudo sed -i'' 's/\[client\]/\[client\]\ndefault-character-set=utf8mb4/' /etc/mysql/my.cnf
+  - sudo sed -i'' 's/\[mysql\]/\[mysql\]\ndefault-character-set=utf8mb4/' /etc/mysql/my.cnf
+  - sudo sed -i'' 's/\[mysqld\]/\[mysqld\]\ninnodb_file_per_table=on\ninnodb_file_format=barracuda\ninnodb_large_prefix=on\ncharacter-set-client-handshake=false\ncharacter-set-server=utf8mb4\ncollation-server=utf8mb4_unicode_ci/' /etc/mysql/my.cnf
+  - sudo /etc/init.d/mysql restart
+  # Travis should fail as soon as possible
+  - mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';"
+  # Avoid "mysql has gone away" errors
+  - mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
+  - mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
+  # Create database with the correct charset and collation
+  - mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"
   - mv zds/settings_test_travis.py zds/settings_prod.py
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
   - mysql -e "SET GLOBAL wait_timeout = 36000;"
   - mysql -e "SET GLOBAL max_allowed_packet = 134209536;"
   # database services
-  - mysql -e 'create database zds_test;'
+  - mysql -e 'CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"
   - mv zds/settings_test_travis.py zds/settings_prod.py
 
 install:

--- a/manage.py
+++ b/manage.py
@@ -1,10 +1,55 @@
-#!/usr/bin/env python
 import os
 import sys
 
 
+def patch_mysql_sql_create_model(original):
+    """
+    Inspired by github.com/miyagi389/zipcode-django-python - The MIT License - Copyright (c) 2014 miyagi389
+
+    :param :class:`django.db.backends.creation.BaseDatabaseCreation` original: BaseDatabaseCreation
+    :return: BaseDatabaseCreation
+    :rtype: :class:`django.db.backends.creation.BaseDatabaseCreation`
+    """
+
+    def revised(self, model, style, known_models=set()):
+        """
+        :class:`django.db.backends.creation.BaseDatabaseCreation`
+        """
+
+        fullname = self.__module__ + "." + self.__class__.__name__
+        if fullname == 'django.db.backends.mysql.creation.DatabaseCreation':
+            # the migration will run MySQL
+            sql_statements, pending_references = original(self, model, style, known_models)
+
+            final_output = []
+            for statement in sql_statements:
+                if not statement.startswith('CREATE TABLE'):
+                    continue
+
+                end = ''
+                if statement.endswith(';'):
+                    end = ';'
+                    statement = statement[:-1]
+
+                statement += 'ROW_FORMAT=DYNAMIC{}'.format(end)
+
+                final_output.append(statement)
+
+            return final_output, pending_references
+        else:
+            return original(self, model, style, known_models)
+
+    return revised
+
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "zds.settings")
+
+    if len(sys.argv) > 1 and sys.argv[1] in ['migrate', 'test']:
+        from django.db.backends.base.creation import BaseDatabaseCreation
+        BaseDatabaseCreation.sql_create_model = patch_mysql_sql_create_model(BaseDatabaseCreation.sql_create_model)
+
+        from django.db.backends.mysql.schema import DatabaseSchemaEditor
+        DatabaseSchemaEditor.sql_create_table += ' ROW_FORMAT=DYNAMIC'
 
     from django.core.management import execute_from_command_line
 

--- a/scripts/migrations/20160718_01_mysql-5.6-innodb-tables.sql
+++ b/scripts/migrations/20160718_01_mysql-5.6-innodb-tables.sql
@@ -1,0 +1,102 @@
+USE mysql;
+--
+-- Table structure for table `innodb_index_stats`
+--
+
+DROP TABLE IF EXISTS `innodb_index_stats`;
+CREATE TABLE `innodb_index_stats` (
+  `database_name` varchar(64) COLLATE utf8_bin NOT NULL,
+  `table_name` varchar(64) COLLATE utf8_bin NOT NULL,
+  `index_name` varchar(64) COLLATE utf8_bin NOT NULL,
+  `last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `stat_name` varchar(64) COLLATE utf8_bin NOT NULL,
+  `stat_value` bigint(20) unsigned NOT NULL,
+  `sample_size` bigint(20) unsigned DEFAULT NULL,
+  `stat_description` varchar(1024) COLLATE utf8_bin NOT NULL,
+  PRIMARY KEY (`database_name`,`table_name`,`index_name`,`stat_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin STATS_PERSISTENT=0;
+
+--
+-- Table structure for table `innodb_table_stats`
+--
+
+DROP TABLE IF EXISTS `innodb_table_stats`;
+CREATE TABLE `innodb_table_stats` (
+  `database_name` varchar(64) COLLATE utf8_bin NOT NULL,
+  `table_name` varchar(64) COLLATE utf8_bin NOT NULL,
+  `last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `n_rows` bigint(20) unsigned NOT NULL,
+  `clustered_index_size` bigint(20) unsigned NOT NULL,
+  `sum_of_other_index_sizes` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`database_name`,`table_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin STATS_PERSISTENT=0;
+
+--
+-- Table structure for table `slave_master_info`
+--
+
+DROP TABLE IF EXISTS `slave_master_info`;
+CREATE TABLE `slave_master_info` (
+  `Number_of_lines` int(10) unsigned NOT NULL COMMENT 'Number of lines in the file.',
+  `Master_log_name` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'The name of the master binary log currently being read from the master.',
+  `Master_log_pos` bigint(20) unsigned NOT NULL COMMENT 'The master log position of the last read event.',
+  `Host` char(64) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '' COMMENT 'The host name of the master.',
+  `User_name` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The user name used to connect to the master.',
+  `User_password` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The password used to connect to the master.',
+  `Port` int(10) unsigned NOT NULL COMMENT 'The network port used to connect to the master.',
+  `Connect_retry` int(10) unsigned NOT NULL COMMENT 'The period (in seconds) that the slave will wait before trying to reconnect to the master.',
+  `Enabled_ssl` tinyint(1) NOT NULL COMMENT 'Indicates whether the server supports SSL connections.',
+  `Ssl_ca` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The file used for the Certificate Authority (CA) certificate.',
+  `Ssl_capath` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The path to the Certificate Authority (CA) certificates.',
+  `Ssl_cert` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The name of the SSL certificate file.',
+  `Ssl_cipher` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The name of the cipher in use for the SSL connection.',
+  `Ssl_key` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The name of the SSL key file.',
+  `Ssl_verify_server_cert` tinyint(1) NOT NULL COMMENT 'Whether to verify the server certificate.',
+  `Heartbeat` float NOT NULL,
+  `Bind` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'Displays which interface is employed when connecting to the MySQL server',
+  `Ignored_server_ids` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The number of server IDs to be ignored, followed by the actual server IDs',
+  `Uuid` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The master server uuid.',
+  `Retry_count` bigint(20) unsigned NOT NULL COMMENT 'Number of reconnect attempts, to the master, before giving up.',
+  `Ssl_crl` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The file used for the Certificate Revocation List (CRL)',
+  `Ssl_crlpath` text CHARACTER SET utf8 COLLATE utf8_bin COMMENT 'The path used for Certificate Revocation List (CRL) files',
+  `Enabled_auto_position` tinyint(1) NOT NULL COMMENT 'Indicates whether GTIDs will be used to retrieve events from the master.',
+  PRIMARY KEY (`Host`,`Port`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 STATS_PERSISTENT=0 COMMENT='Master Information';
+
+--
+-- Table structure for table `slave_relay_log_info`
+--
+
+DROP TABLE IF EXISTS `slave_relay_log_info`;
+CREATE TABLE `slave_relay_log_info` (
+  `Number_of_lines` int(10) unsigned NOT NULL COMMENT 'Number of lines in the file or rows in the table. Used to version table definitions.',
+  `Relay_log_name` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'The name of the current relay log file.',
+  `Relay_log_pos` bigint(20) unsigned NOT NULL COMMENT 'The relay log position of the last executed event.',
+  `Master_log_name` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'The name of the master binary log file from which the events in the relay log file were read.',
+  `Master_log_pos` bigint(20) unsigned NOT NULL COMMENT 'The master log position of the last executed event.',
+  `Sql_delay` int(11) NOT NULL COMMENT 'The number of seconds that the slave must lag behind the master.',
+  `Number_of_workers` int(10) unsigned NOT NULL,
+  `Id` int(10) unsigned NOT NULL COMMENT 'Internal Id that uniquely identifies this record.',
+  PRIMARY KEY (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 STATS_PERSISTENT=0 COMMENT='Relay Log Information';
+
+--
+-- Table structure for table `slave_worker_info`
+--
+
+DROP TABLE IF EXISTS `slave_worker_info`;
+CREATE TABLE `slave_worker_info` (
+  `Id` int(10) unsigned NOT NULL,
+  `Relay_log_name` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `Relay_log_pos` bigint(20) unsigned NOT NULL,
+  `Master_log_name` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `Master_log_pos` bigint(20) unsigned NOT NULL,
+  `Checkpoint_relay_log_name` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `Checkpoint_relay_log_pos` bigint(20) unsigned NOT NULL,
+  `Checkpoint_master_log_name` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `Checkpoint_master_log_pos` bigint(20) unsigned NOT NULL,
+  `Checkpoint_seqno` int(10) unsigned NOT NULL,
+  `Checkpoint_group_size` int(10) unsigned NOT NULL,
+  `Checkpoint_group_bitmap` blob NOT NULL,
+  PRIMARY KEY (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 STATS_PERSISTENT=0 COMMENT='Worker Information';

--- a/scripts/migrations/20160718_02_utf8mb4.sh
+++ b/scripts/migrations/20160718_02_utf8mb4.sh
@@ -1,0 +1,554 @@
+#!/bin/bash
+
+# This script was used to convert the mysql database and all tables and fields
+# to utf8mb4. It was part of the tagged release 20. It requires MySQL 5.6.
+# See `update.md` for more info.
+
+MYSQL_VERSION=$(mysql -V | awk '{print $5}')
+MIN_MYSQL_VERSION="5.6"
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
+if [ $(version $MYSQL_VERSION) -lt $(version $MIN_MYSQL_VERSION) ]; then
+    echo "This script will only work with MySQL >= 5.6" >&2
+    echo "Please update MySQL" >&2
+    exit 1
+fi
+
+mysql -u zds -p zdsdb << EOF
+    # General settings for our database:
+    ALTER DATABASE zdsdb CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;
+EOF
+
+if [ $? -eq 0 ]; then
+    echo "Database-wide settings updated."
+else
+    echo "Database-wide modification failed." >&2
+    exit 1
+fi
+
+
+mysql -u zds -p zdsdb << EOF
+    SET foreign_key_checks = 0;
+    ### Convert each table to ROW_FORMAT=DYNAMIC, the newest MySQL default
+    ALTER TABLE \`article_validation\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`auth_group\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`auth_group_permissions\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`auth_permission\` ROW_FORMAT=DYNAMIC;
+    # auth_user # this one stays
+    ALTER TABLE \`auth_user_groups\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`auth_user_user_permissions\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`corsheaders_corsmodel\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`django_admin_log\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`django_content_type\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`django_migrations\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`django_session\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`django_site\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`easy_thumbnails_source\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`easy_thumbnails_thumbnail\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`easy_thumbnails_thumbnaildimensions\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`featured_featuredmessage\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`featured_featuredresource\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`forum_category\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`forum_forum\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`forum_forum_group\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`forum_post\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`forum_topic\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`forum_topic_tags\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`forum_topicread\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`gallery_gallery\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`gallery_image\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`gallery_usergallery\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`member_ban\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`member_karmanote\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`member_profile\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`member_tokenforgotpassword\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`member_tokenregister\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`mp_privatepost\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`mp_privatetopic\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`mp_privatetopic_participants\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`mp_privatetopicread\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`munin_test\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`newsletter_newsletter\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`notification_answersubscription\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`notification_contentreactionanswersubscription\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`notification_newtopicsubscription\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`notification_notification\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`notification_privatetopicanswersubscription\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`notification_subscription\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`notification_topicanswersubscription\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`notification_topicfollowed\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`oauth2_provider_accesstoken\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`oauth2_provider_application\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`oauth2_provider_grant\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`oauth2_provider_refreshtoken\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`pages_groupcontact\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`search_searchindexauthors\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`search_searchindexcontainer\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`search_searchindexcontent\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`search_searchindexcontent_authors\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`search_searchindexcontent_tags\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`search_searchindexextract\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`search_searchindextag\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`social_auth_association\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`social_auth_code\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`social_auth_nonce\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`social_auth_usersocialauth\` ROW_FORMAT=DYNAMIC;
+    # south_migrationhistory # this one stays
+    ALTER TABLE \`tutorial_chapter\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorial_extract\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorial_part\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorial_tutorial_helps\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorial_validation\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorialv2_contentreaction\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorialv2_contentread\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorialv2_publishablecontent\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorialv2_publishablecontent_authors\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorialv2_publishablecontent_helps\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorialv2_publishablecontent_subcategory\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorialv2_publishablecontent_tags\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorialv2_publishedcontent\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorialv2_publishedcontent_authors\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`tutorialv2_validation\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`utils_alert\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`utils_category\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`utils_categorysubcategory\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`utils_comment\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`utils_commentvote\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`utils_helpwriting\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`utils_licence\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`utils_subcategory\` ROW_FORMAT=DYNAMIC;
+    ALTER TABLE \`utils_tag\` ROW_FORMAT=DYNAMIC;
+
+    ########
+
+    ALTER TABLE \`article_validation\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`auth_group\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`auth_group_permissions\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`auth_permission\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    # auth_user # this one stays in utf8_bin
+    ALTER TABLE \`auth_user_groups\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`auth_user_user_permissions\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`corsheaders_corsmodel\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`django_admin_log\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`django_content_type\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`django_migrations\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`django_session\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`django_site\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`easy_thumbnails_source\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`easy_thumbnails_thumbnail\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`easy_thumbnails_thumbnaildimensions\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`featured_featuredmessage\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`featured_featuredresource\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`forum_category\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`forum_forum\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`forum_forum_group\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`forum_post\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`forum_topic\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`forum_topic_tags\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`forum_topicread\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`gallery_gallery\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`gallery_image\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`gallery_usergallery\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`member_ban\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`member_karmanote\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`member_profile\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`member_tokenforgotpassword\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`member_tokenregister\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`mp_privatepost\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`mp_privatetopic\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`mp_privatetopic_participants\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`mp_privatetopicread\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`munin_test\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`newsletter_newsletter\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`notification_answersubscription\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`notification_contentreactionanswersubscription\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`notification_newtopicsubscription\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`notification_notification\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`notification_privatetopicanswersubscription\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`notification_subscription\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`notification_topicanswersubscription\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`notification_topicfollowed\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`oauth2_provider_accesstoken\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`oauth2_provider_application\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`oauth2_provider_grant\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`oauth2_provider_refreshtoken\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`pages_groupcontact\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexauthors\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexcontainer\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexcontent\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexcontent_authors\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexcontent_tags\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexextract\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindextag\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`social_auth_association\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`social_auth_code\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`social_auth_nonce\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`social_auth_usersocialauth\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    # no changes: south_migrationhistory
+    ALTER TABLE \`tutorial_chapter\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorial_extract\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorial_part\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorial_tutorial_helps\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorial_validation\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_contentreaction\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_contentread\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_publishablecontent\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_publishablecontent_authors\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_publishablecontent_helps\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_publishablecontent_subcategory\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_publishablecontent_tags\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_publishedcontent\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_publishedcontent_authors\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_validation\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`utils_alert\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`utils_category\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`utils_categorysubcategory\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`utils_comment\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`utils_commentvote\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`utils_helpwriting\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`utils_licence\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`utils_subcategory\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`utils_tag\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    SET foreign_key_checks = 1;
+EOF
+
+if [ $? -eq 0 ]; then
+    echo "Tables have been successfully modified."
+else
+    echo "Tables modification failed." >&2
+    exit 1
+fi
+
+
+mysql -u zds -p zdsdb << EOF
+    SET foreign_key_checks = 0;
+    ### Convert each field
+
+    # article_validation
+    ALTER TABLE \`article_validation\` CHANGE version version VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`article_validation\` CHANGE comment_authors comment_authors LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`article_validation\` CHANGE comment_validator comment_validator LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`article_validation\` CHANGE status status VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # auth_group
+    ALTER TABLE \`auth_group\` CHANGE name name VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # auth_permission
+    ALTER TABLE \`auth_permission\` CHANGE name name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`auth_permission\` CHANGE codename codename VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # auth_user # this one stays in utf8_bin
+
+    # corsheaders_corsmodel
+    ALTER TABLE \`corsheaders_corsmodel\` CHANGE cors cors VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # django_admin_log
+    ALTER TABLE \`django_admin_log\` CHANGE object_id object_id LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`django_admin_log\` CHANGE object_repr object_repr VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`django_admin_log\` CHANGE change_message change_message LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # django_content_type
+    ALTER TABLE \`django_content_type\` CHANGE app_label app_label VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`django_content_type\` CHANGE model model VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # django_migrations
+    ALTER TABLE \`django_migrations\` CHANGE app app VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`django_migrations\` CHANGE name name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # django_session
+    ALTER TABLE \`django_session\` CHANGE session_key session_key VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`django_session\` CHANGE session_data session_data LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # django_site
+    ALTER TABLE \`django_site\` CHANGE domain domain VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`django_site\` CHANGE name name VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # easy_thumbnails_source
+    ALTER TABLE \`easy_thumbnails_source\` CHANGE name name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`easy_thumbnails_source\` CHANGE storage_hash storage_hash VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # easy_thumbnails_thumbnail
+    ALTER TABLE \`easy_thumbnails_thumbnail\` CHANGE name name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`easy_thumbnails_thumbnail\` CHANGE storage_hash storage_hash VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # featured_featuredmessage
+    ALTER TABLE \`featured_featuredmessage\` CHANGE message message VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`featured_featuredmessage\` CHANGE url url VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`featured_featuredmessage\` CHANGE hook hook VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+    # featured_featuredresource
+    ALTER TABLE \`featured_featuredresource\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`featured_featuredresource\` CHANGE type type VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`featured_featuredresource\` CHANGE image_url image_url VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`featured_featuredresource\` CHANGE url url VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`featured_featuredresource\` CHANGE authors authors VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+    # forum_category
+    ALTER TABLE \`forum_category\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`forum_category\` CHANGE slug slug VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # forum_forum
+    ALTER TABLE \`forum_forum\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`forum_forum\` CHANGE subtitle subtitle VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`forum_forum\` CHANGE image image VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`forum_forum\` CHANGE slug slug VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # forum_topic
+    ALTER TABLE \`forum_topic\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`forum_topic\` CHANGE subtitle subtitle VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # gallery_gallery
+    ALTER TABLE \`gallery_gallery\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`gallery_gallery\` CHANGE subtitle subtitle VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`gallery_gallery\` CHANGE slug slug VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # gallery_image
+    ALTER TABLE \`gallery_image\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`gallery_image\` CHANGE slug slug VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`gallery_image\` CHANGE physical physical VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`gallery_image\` CHANGE thumb thumb VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`gallery_image\` CHANGE medium medium VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`gallery_image\` CHANGE legend legend VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+    # gallery_usergallery
+    ALTER TABLE \`gallery_usergallery\` CHANGE mode mode VARCHAR(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # member_ban
+    ALTER TABLE \`member_ban\` CHANGE type type VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`member_ban\` CHANGE text text LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # member_karmanote
+    ALTER TABLE \`member_karmanote\` CHANGE comment comment VARCHAR(150) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # member_profile
+    ALTER TABLE \`member_profile\` CHANGE last_ip_address last_ip_address VARCHAR(39) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`member_profile\` CHANGE site site VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`member_profile\` CHANGE avatar_url avatar_url VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`member_profile\` CHANGE biography biography LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`member_profile\` CHANGE sign sign LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`member_profile\` CHANGE sdz_tutorial sdz_tutorial LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+    # member_tokenforgotpassword
+    ALTER TABLE \`member_tokenforgotpassword\` CHANGE token token VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # member_tokenregister
+    ALTER TABLE \`member_tokenregister\` CHANGE token token VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # mp_privatepost
+    ALTER TABLE \`mp_privatepost\` CHANGE text text LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`mp_privatepost\` CHANGE text_html text_html LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # mp_privatetopic
+    ALTER TABLE \`mp_privatetopic\` CHANGE title title VARCHAR(130) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`mp_privatetopic\` CHANGE subtitle subtitle VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # munin_test
+    ALTER TABLE \`munin_test\` CHANGE name name VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # newsletter_newsletter
+    ALTER TABLE \`newsletter_newsletter\` CHANGE email email VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`newsletter_newsletter\` CHANGE ip ip VARCHAR(39) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # notification_notification
+    ALTER TABLE \`notification_notification\` CHANGE url url VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`notification_notification\` CHANGE title title VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # oauth2_provider_accesstoken
+    ALTER TABLE \`oauth2_provider_accesstoken\` CHANGE token token VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`oauth2_provider_accesstoken\` CHANGE scope scope LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # oauth2_provider_application
+    ALTER TABLE \`oauth2_provider_application\` CHANGE client_id client_id VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`oauth2_provider_application\` CHANGE redirect_uris redirect_uris LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`oauth2_provider_application\` CHANGE client_type client_type VARCHAR(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`oauth2_provider_application\` CHANGE authorization_grant_type authorization_grant_type VARCHAR(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`oauth2_provider_application\` CHANGE client_secret client_secret VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`oauth2_provider_application\` CHANGE name name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # oauth2_provider_grant
+    ALTER TABLE \`oauth2_provider_grant\` CHANGE code code VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`oauth2_provider_grant\` CHANGE redirect_uri redirect_uri VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`oauth2_provider_grant\` CHANGE scope scope LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # oauth2_provider_refreshtoken
+    ALTER TABLE \`oauth2_provider_refreshtoken\` CHANGE token token VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # pages_groupcontact
+    ALTER TABLE \`pages_groupcontact\` CHANGE name name VARCHAR(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`pages_groupcontact\` CHANGE description description LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`pages_groupcontact\` CHANGE email email VARCHAR(254) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+    # search_searchindexauthors
+    ALTER TABLE \`search_searchindexauthors\` CHANGE username username VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # search_searchindexcontainer
+    ALTER TABLE \`search_searchindexcontainer\` CHANGE title title VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`search_searchindexcontainer\` CHANGE url_to_redirect url_to_redirect VARCHAR(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`search_searchindexcontainer\` CHANGE introduction introduction LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexcontainer\` CHANGE conclusion conclusion LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexcontainer\` CHANGE level level VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`search_searchindexcontainer\` CHANGE keywords keywords LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # search_searchindexcontent
+    ALTER TABLE \`search_searchindexcontent\` CHANGE title title VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`search_searchindexcontent\` CHANGE description description LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexcontent\` CHANGE licence licence VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`search_searchindexcontent\` CHANGE url_image url_image VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`search_searchindexcontent\` CHANGE url_to_redirect url_to_redirect VARCHAR(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`search_searchindexcontent\` CHANGE introduction introduction LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexcontent\` CHANGE conclusion conclusion LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexcontent\` CHANGE keywords keywords LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`search_searchindexcontent\` CHANGE type type VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # search_searchindexextract
+    ALTER TABLE \`search_searchindexextract\` CHANGE title title VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`search_searchindexextract\` CHANGE url_to_redirect url_to_redirect VARCHAR(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`search_searchindexextract\` CHANGE extract_content extract_content LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`search_searchindexextract\` CHANGE keywords keywords LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # search_searchindextag
+    ALTER TABLE \`search_searchindextag\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # social_auth_association
+    ALTER TABLE \`social_auth_association\` CHANGE server_url server_url VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`social_auth_association\` CHANGE handle handle VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`social_auth_association\` CHANGE secret secret VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`social_auth_association\` CHANGE assoc_type assoc_type VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # social_auth_code
+    ALTER TABLE \`social_auth_code\` CHANGE email email VARCHAR(254) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`social_auth_code\` CHANGE code code VARCHAR(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # social_auth_nonce
+    ALTER TABLE \`social_auth_nonce\` CHANGE server_url server_url VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`social_auth_nonce\` CHANGE salt salt VARCHAR(65) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # social_auth_usersocialauth
+    ALTER TABLE \`social_auth_usersocialauth\` CHANGE provider provider VARCHAR(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`social_auth_usersocialauth\` CHANGE uid uid VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`social_auth_usersocialauth\` CHANGE extra_data extra_data LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # south_migrationhistory # this one stays in utf8_bin
+
+    # tutorial_chapter
+    ALTER TABLE \`tutorial_chapter\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorial_chapter\` CHANGE slug slug VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorial_chapter\` CHANGE introduction introduction VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`tutorial_chapter\` CHANGE conclusion conclusion VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+    # tutorial_extract
+    ALTER TABLE \`tutorial_extract\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorial_extract\` CHANGE text text VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+    # tutorial_part
+    ALTER TABLE \`tutorial_part\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorial_part\` CHANGE slug slug VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorial_part\` CHANGE introduction introduction VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`tutorial_part\` CHANGE conclusion conclusion VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+    # tutorial_validation
+    ALTER TABLE \`tutorial_validation\` CHANGE version version VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`tutorial_validation\` CHANGE comment_authors comment_authors LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorial_validation\` CHANGE comment_validator comment_validator LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorial_validation\` CHANGE status status VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # tutorialv2_publishablecontent
+    ALTER TABLE \`tutorialv2_publishablecontent\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorialv2_publishablecontent\` CHANGE slug slug VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorialv2_publishablecontent\` CHANGE description description VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorialv2_publishablecontent\` CHANGE source source VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`tutorialv2_publishablecontent\` CHANGE sha_public sha_public VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`tutorialv2_publishablecontent\` CHANGE sha_beta sha_beta VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`tutorialv2_publishablecontent\` CHANGE sha_validation sha_validation VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`tutorialv2_publishablecontent\` CHANGE sha_draft sha_draft VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`tutorialv2_publishablecontent\` CHANGE type type VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorialv2_publishablecontent\` CHANGE relative_images_path relative_images_path VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+    # tutorialv2_publishedcontent
+    ALTER TABLE \`tutorialv2_publishedcontent\` CHANGE content_type content_type VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorialv2_publishedcontent\` CHANGE content_public_slug content_public_slug VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`tutorialv2_publishedcontent\` CHANGE sha_public sha_public VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`tutorialv2_publishedcontent\` CHANGE sizes sizes VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # tutorialv2_validation
+    ALTER TABLE \`tutorialv2_validation\` CHANGE version version VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`tutorialv2_validation\` CHANGE comment_authors comment_authors LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_validation\` CHANGE comment_validator comment_validator LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    ALTER TABLE \`tutorialv2_validation\` CHANGE status status VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # utils_alert
+    ALTER TABLE \`utils_alert\` CHANGE text text LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_alert\` CHANGE scope scope VARCHAR(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # utils_category
+    ALTER TABLE \`utils_category\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_category\` CHANGE description description LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_category\` CHANGE slug slug VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # utils_comment
+    ALTER TABLE \`utils_comment\` CHANGE ip_address ip_address VARCHAR(39) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_comment\` CHANGE text text LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_comment\` CHANGE text_html text_html LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_comment\` CHANGE text_hidden text_hidden VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # utils_helpwriting
+    ALTER TABLE \`utils_helpwriting\` CHANGE title title VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_helpwriting\` CHANGE slug slug VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_helpwriting\` CHANGE tablelabel tablelabel VARCHAR(150) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_helpwriting\` CHANGE image image VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # utils_licence
+    ALTER TABLE \`utils_licence\` CHANGE code code VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_licence\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_licence\` CHANGE description description LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # utils_subcategory
+    ALTER TABLE \`utils_subcategory\` CHANGE title title VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_subcategory\` CHANGE subtitle subtitle VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_subcategory\` CHANGE image image VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+    ALTER TABLE \`utils_subcategory\` CHANGE slug slug VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+    # utils_tag
+    ALTER TABLE \`utils_tag\` CHANGE title title VARCHAR(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    ALTER TABLE \`utils_tag\` CHANGE slug slug VARCHAR(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    SET foreign_key_checks = 1;
+EOF
+
+if [ $? -eq 0 ]; then
+    echo "Fields have been successfully modified."
+else
+    echo "Fields modification failed." >&2
+    exit 1
+fi
+
+echo "Database updated successfully."
+echo "Next steps are:"
+echo
+echo "1. Add the following to the MySQL config block in your Django settings:"
+echo "    'OPTIONS': {'charset': 'utf8mb4'},"
+echo
+read -p "Done? "
+echo
+echo "2. Modify /etc/mysql/my.cnf"
+echo "2.2. Add to [client] section:"
+echo "    default-character-set = utf8mb4"
+echo
+read -p "Done? "
+echo
+echo "2.3. Add to [mysql] section:"
+echo "    default-character-set = utf8mb4"
+echo
+read -p "Done? "
+echo
+echo "2.4. Add to [mysqld] section:"
+echo "    character-set-client-handshake = FALSE"
+echo "    character-set-server = utf8mb4"
+echo "    collation-server = utf8mb4_unicode_ci"
+echo
+read -p "Done? "
+echo
+echo "Almost there."
+echo "* Restart mysql"
+echo "* Restart django"
+echo
+echo "Enjoy your funky emojis."

--- a/scripts/migrations/20160718_02_utf8mb4.sh
+++ b/scripts/migrations/20160718_02_utf8mb4.sh
@@ -10,7 +10,7 @@ function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4
 
 if [ $(version $MYSQL_VERSION) -lt $(version $MIN_MYSQL_VERSION) ]; then
     echo "This script will only work with MySQL >= 5.6" >&2
-    echo "Please update MySQL" >&2
+    echo "Please update MySQL. See update.md." >&2
     exit 1
 fi
 
@@ -28,7 +28,6 @@ fi
 
 
 mysql -u zds -p zdsdb << EOF
-    SET foreign_key_checks = 0;
     ### Convert each table to ROW_FORMAT=DYNAMIC, the newest MySQL default
     ALTER TABLE \`article_validation\` ROW_FORMAT=DYNAMIC;
     ALTER TABLE \`auth_group\` ROW_FORMAT=DYNAMIC;
@@ -119,7 +118,7 @@ mysql -u zds -p zdsdb << EOF
     ALTER TABLE \`utils_subcategory\` ROW_FORMAT=DYNAMIC;
     ALTER TABLE \`utils_tag\` ROW_FORMAT=DYNAMIC;
 
-    ########
+    # Next, ALTER these tables to the utf8mb4 charset and collation
 
     ALTER TABLE \`article_validation\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
     ALTER TABLE \`auth_group\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -209,7 +208,6 @@ mysql -u zds -p zdsdb << EOF
     ALTER TABLE \`utils_licence\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
     ALTER TABLE \`utils_subcategory\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
     ALTER TABLE \`utils_tag\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-    SET foreign_key_checks = 1;
 EOF
 
 if [ $? -eq 0 ]; then
@@ -221,8 +219,7 @@ fi
 
 
 mysql -u zds -p zdsdb << EOF
-    SET foreign_key_checks = 0;
-    ### Convert each field
+    ### Convert each text field (*text, varchar) to utf8mb4 charset and collation
 
     # article_validation
     ALTER TABLE \`article_validation\` CHANGE version version VARCHAR(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;
@@ -511,7 +508,6 @@ mysql -u zds -p zdsdb << EOF
     # utils_tag
     ALTER TABLE \`utils_tag\` CHANGE title title VARCHAR(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
     ALTER TABLE \`utils_tag\` CHANGE slug slug VARCHAR(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
-    SET foreign_key_checks = 1;
 EOF
 
 if [ $? -eq 0 ]; then

--- a/scripts/migrations/20160718_02_utf8mb4.sh
+++ b/scripts/migrations/20160718_02_utf8mb4.sh
@@ -518,6 +518,7 @@ else
 fi
 
 echo "Database updated successfully."
+echo "This script is over, here are some instructions (also available in update.md):"
 echo "Next steps are:"
 echo
 echo "1. Add the following to the MySQL config block in your Django settings:"
@@ -542,9 +543,5 @@ echo "    character-set-server = utf8mb4"
 echo "    collation-server = utf8mb4_unicode_ci"
 echo
 read -p "Done? "
-echo
-echo "Almost there."
-echo "* Restart mysql"
-echo "* Restart django"
 echo
 echo "Enjoy your funky emojis."

--- a/update.md
+++ b/update.md
@@ -629,7 +629,11 @@ Actions à faire pour mettre en prod la version 20
 **(pré-migration)** Rendre unique les subscriptions
 ---------------------------------------------------
 
-1. Lancer la commande `python manage.py uniquify_subscriptions >> mep_v20.log`
+1. Lancer les 2 migrations suivantes :
+  * `python manage.py migrate forum 0006_auto_20160720_2259`
+  * `python manage.py migrate notification 0010_newpublicationsubscription`
+1. Lancer la commande suivante :
+  * `python manage.py uniquify_subscriptions >> mep_v20.log`
 1. Jeter un oeil aux logs pour s'assurer que tout s'est bien passé.
 
 **(pré-migration)** Nettoyer les tags existants
@@ -655,19 +659,21 @@ Actions à faire pour mettre en prod la version 20
 
     mysqldump --lock-all-tables -u zds -p --all-databases > ~/mysql-5.5-backup/database/dump.sql
 
-    sudo apt-get remove mysql-server
+    sudo apt-get remove mysql-server-5.5 mysql-server-core-5.5 mysql-client-5.5
     sudo apt-get autoremove
 
     # check that the innodb transactions files are gone (ibdata1, ib_logfile0 and ib_logfile1
     mkdir ~/mysql-5.5-backup/innodb
     sudo ls /var/lib/mysql/ | grep -e '^ib'
     # if they are still there, move them as root
-    sudo mv /var/lib/mysql/ib* /home/zds/mysql-5.5-backup/innodb
+    sudo sh -c 'mv /var/lib/mysql/ib* /home/zds/mysql-5.5-backup/innodb'
     sudo ls /var/lib/mysql/ | grep -e '^ib'
     # shouldn't show anything
 
     sudo aptitude -t jessie-backports install mysql-server mysql-client
-    # if there's a conflict because of mysql-client-5.5, accept the fix removing mysql-client-5.5
+    # if apt complains that mysql-server-5.6 wasn't configured, run the following:
+    # sudo dpkg-reconfigure mysql-server-5.6
+    # if there's a conflict because of mysql-client-5.5, accept the fix which suggests removing mysql-client-5.5
 
     sudo systemctl restart mysql
 
@@ -739,6 +745,8 @@ Issue 3620
 ----------
 
 Dans le `settings_prod.py` : ajouter `ZDS_APP['site']['secure_url'] = 'https://zestedesavoir.com'`
+
+(Ne pas oublier de lancer les migrations en terminant cette MEP !)
 
 ---
 

--- a/update.md
+++ b/update.md
@@ -626,21 +626,114 @@ Ces descriptions peuvent être modifiées via l'administration Django après la 
 Actions à faire pour mettre en prod la version 20
 =================================================
 
-Notifications
--------------
-
-### **(pré-migration)** Rendre unique les subscriptions
+**(pré-migration)** Rendre unique les subscriptions
+---------------------------------------------------
 
 1. Lancer la commande `python manage.py uniquify_subscriptions >> mep_v20.log`
 1. Jeter un oeil aux logs pour s'assurer que tout s'est bien passé.
 
-Tags
-----
-
-### **(pré-migration)** Nettoyer les tags existants
+**(pré-migration)** Nettoyer les tags existants
+-----------------------------------------------
 
 1. Lancer la commande `python manage.py clean_tags >> mep_v20.log`
 1. Jeter un oeil aux logs pour s'assurer que tout s'est bien passé.
+
+**(pré-migration)** Base de donnée
+----------------------------------
+
+(utilisateur `zds`)
+
+1. Upgrade MySQL
+
+    ```bash
+    sudo aptitude update
+
+    mkdir ~/mysql-5.5-backup
+    sudo cp -r /etc/mysql ~/mysql-5.5-backup/etc_mysql
+
+    mkdir ~/mysql-5.5-backup/database
+
+    mysqldump --lock-all-tables -u zds -p --all-databases > ~/mysql-5.5-backup/database/dump.sql
+
+    sudo apt-get remove mysql-server
+    sudo apt-get autoremove
+
+    # check that the innodb transactions files are gone (ibdata1, ib_logfile0 and ib_logfile1
+    mkdir ~/mysql-5.5-backup/innodb
+    sudo ls /var/lib/mysql/ | grep -e '^ib'
+    # if they are still there, move them as root
+    sudo mv /var/lib/mysql/ib* /home/zds/mysql-5.5-backup/innodb
+    sudo ls /var/lib/mysql/ | grep -e '^ib'
+    # shouldn't show anything
+
+    sudo aptitude -t jessie-backports install mysql-server mysql-client
+    # if there's a conflict because of mysql-client-5.5, accept the fix removing mysql-client-5.5
+
+    sudo systemctl restart mysql
+
+    # create missing innodb tables
+    mysql -u zds -p mysql <  ./scripts/migrations/20160718_01_mysql-5.6-innodb-tables.sql
+
+    sudo systemctl restart mysql
+
+    mysql -u zds -p < ~/mysql-5.5-backup/database/dump.sql
+    ```
+
+1. Modifier le fichier `/etc/mysql/my.cnf`, ajouter la ligne suivante dans la section `[mysqld]`, près des autres configs innodb:
+
+    ```diff
+    # * InnoDB
+    #
+    # InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+    # Read the manual for more InnoDB related options. There are many!
+    #
+    +innodb_file_per_table=on
+    +innodb_file_format=barracuda
+    +innodb_large_prefix=on
+    ```
+
+1. Relancer les services
+
+    ```bash
+    sudo systemctl restart mysql
+    sudo systemctl restart zds.{service,socket}
+    sudo systemctl restart solr
+    sudo systemctl restart zds-index-solr.service
+    # this one takes ages
+    ```
+
+1. (sans sudo,) lancer le script de migration: `./scripts/migrations/20160718_02_utf8mb4.sh`
+1. En cas d'erreur MySQL dans le script, le script va s'arrêter pour qu'on corrige les erreurs. Relancer le script ne pose aucun problème, il peut tourner autant de fois que nécessaire jusqu'à ce qu'il termine avec succès une fois toutes les erreurs corrigées.
+1. Ajouter la bonne option à `settings_prod.py` :
+
+    ```diff
+    DATABASES = {
+        'default': {
+    [...]
+            'CONN_MAX_AGE': 600,
+    +       'OPTIONS': {'charset': 'utf8mb4'},
+        }
+    }
+    ```
+
+1. Modifier le `/etc/mysql/my.cnf` pour que les sections correspondantes contiennent bien les infos suivantes :
+
+    ```
+    [client]
+    default-character-set=utf8mb4
+
+    [mysql]
+    default-character-set=utf8mb4
+
+    [mysqld]
+    character-set-client-handshake=false
+    character-set-server=utf8mb4
+    collation-server=utf8mb4_unicode_ci
+    ```
+
+1. Relancer MySQL
+
+    `sudo systemctl restart mysql`
 
 Issue 3620
 ----------
@@ -656,4 +749,3 @@ Le déploiement doit être autonome. Ce qui implique que :
 1. La mise à jour de dépendances est automatique et systématique,
 2. La personne qui déploie ne doit pas réfléchir (parce que c'est source d'erreur),
 3. La personne qui déploie ne doit pas avoir connaissance de ce qui est déployé (techniquement et fonctionnellement).
-

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -185,7 +185,7 @@ class ForumMemberTests(TestCase):
         TopicAnswerSubscription.objects.toggle_follow(topic1, user2, True)
         TopicAnswerSubscription.objects.toggle_follow(topic1, self.user, True)
 
-        # check if we send ane empty text
+        # check if we send an empty text
         result = self.client.post(
             reverse('post-new') + '?sujet={0}'.format(topic1.pk),
             {
@@ -199,17 +199,18 @@ class ForumMemberTests(TestCase):
         # check posts count (should be 3 for the moment)
         self.assertEqual(Post.objects.all().count(), 3)
 
-        # now check what happen if everything is fine
+        # now check a valid post containing utf8mb4 characters
+        post_content = u'Une famille 👩‍👩‍👦 mangeant un gratin d\'🍆🍆 ne blesse pas les innocents 🐙🐙🐙.'
         result = self.client.post(
             reverse('post-new') + '?sujet={0}'.format(topic1.pk),
             {
                 'last_post': topic1.last_message.pk,
-                'text': u'C\'est tout simplement l\'histoire de la ville de Paris que je voudrais vous conter '
+                'text': post_content
             },
             follow=False)
 
         self.assertEqual(result.status_code, 302)
-        self.assertEquals(len(mail.outbox), 2)
+        self.assertEqual(len(mail.outbox), 2)
 
         # check topics count
         self.assertEqual(Topic.objects.all().count(), 1)
@@ -227,9 +228,7 @@ class ForumMemberTests(TestCase):
         self.assertEqual(post_final.topic, topic1)
         self.assertEqual(post_final.position, 4)
         self.assertEqual(post_final.editor, None)
-        self.assertEqual(
-            post_final.text,
-            u'C\'est tout simplement l\'histoire de la ville de Paris que je voudrais vous conter ')
+        self.assertEqual(post_final.text, post_content)
 
         # test antispam return 403
         result = self.client.post(
@@ -831,11 +830,11 @@ class ForumMemberTests(TestCase):
             PostFactory(topic=topic, author=profiles[i % 2].user, position=i + 2)
         self.client.login(username=profiles[1].user.username, password="hostel77")
 
-        templateResponse = self.client.get(topic.get_absolute_url())
-        self.assertIn(expected, templateResponse.content.decode('utf-8'))
+        template_response = self.client.get(topic.get_absolute_url())
+        self.assertIn(expected, template_response.content.decode('utf-8'))
 
-        templateResponse = self.client.get(topic.get_absolute_url() + "?page=2")
-        self.assertNotIn(expected, templateResponse.content.decode('utf-8'))
+        template_response = self.client.get(topic.get_absolute_url() + "?page=2")
+        self.assertNotIn(expected, template_response.content.decode('utf-8'))
 
 
 class ForumGuestTests(TestCase):

--- a/zds/settings_test_travis.py
+++ b/zds/settings_test_travis.py
@@ -4,7 +4,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'zds_test',
-        'USER': 'travis',
+        'USER': 'root',
         'PASSWORD': '',
         'HOST': '127.0.0.1',
         'PORT': '',

--- a/zds/settings_test_travis.py
+++ b/zds/settings_test_travis.py
@@ -9,5 +9,6 @@ DATABASES = {
         'HOST': '127.0.0.1',
         'PORT': '',
         'CONN_MAX_AGE': 600,
+        'OPTIONS': {'charset': 'utf8mb4'},
     }
 }

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -425,22 +425,22 @@ class UtilsTests(TestCase):
 
     def test_last_participation_is_old(self):
         article = PublishedContentFactory(author_list=[self.user_author], type="ARTICLE")
-        newUser = ProfileFactory().user
+        new_user = ProfileFactory().user
         reac = ContentReaction(author=self.user_author, position=1, related_content=article)
         reac.update_content("I will find you. And I Will Kill you.")
         reac.save()
         article.last_note = reac
         article.save()
 
-        self.assertFalse(last_participation_is_old(article, newUser))
+        self.assertFalse(last_participation_is_old(article, new_user))
         ContentRead(user=self.user_author, note=reac, content=article).save()
-        reac = ContentReaction(author=newUser, position=2, related_content=article)
+        reac = ContentReaction(author=new_user, position=2, related_content=article)
         reac.update_content("I will find you. And I Will Kill you.")
         reac.save()
         article.last_note = reac
         article.save()
-        ContentRead(user=newUser, note=reac, content=article).save()
-        self.assertFalse(last_participation_is_old(article, newUser))
+        ContentRead(user=new_user, note=reac, content=article).save()
+        self.assertFalse(last_participation_is_old(article, new_user))
         self.assertTrue(last_participation_is_old(article, self.user_author))
 
     def testParseBadManifest(self):

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -4853,22 +4853,22 @@ class PublishedContentTests(TestCase):
 
     def test_cant_edit_not_owned_note(self):
         article = PublishedContentFactory(author_list=[self.user_author], type="ARTICLE")
-        newUser = ProfileFactory().user
-        newReaction = ContentReaction(related_content=article, position=1)
-        newReaction.update_content("I will find you. And I will Kill you.")
-        newReaction.author = self.user_guest
+        new_user = ProfileFactory().user
+        new_reaction = ContentReaction(related_content=article, position=1)
+        new_reaction.update_content("I will find you. And I will Kill you.")
+        new_reaction.author = self.user_guest
 
-        newReaction.save()
+        new_reaction.save()
         self.assertEqual(
             self.client.login(
-                username=newUser.username,
+                username=new_user.username,
                 password='hostel77'),
             True)
         resp = self.client.get(
-            reverse('content:update-reaction') + "?message={}&pk={}".format(newReaction.pk, article.pk))
+            reverse('content:update-reaction') + "?message={}&pk={}".format(new_reaction.pk, article.pk))
         self.assertEqual(403, resp.status_code)
         resp = self.client.post(
-            reverse('content:update-reaction') + "?message={}&pk={}".format(newReaction.pk, article.pk),
+            reverse('content:update-reaction') + "?message={}&pk={}".format(new_reaction.pk, article.pk),
             {
                 'text': "I edited it"
             })


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3416 |
## QA

La QA ne peut être faite qu'après merge de #3728 et rebase de cette PR.
1. vérifier qu'on est bien sur 5.5
2. faire une synchro prod -> beta
3. passer à 5.6
4. QA la procédure de cette PR
## Notes

Cette PR contient
- La procédure d'installation et de migration de MySQL 5.5 vers 5.6.
- Un fichier SQL qui créé les tables manquantes dans la base `mysql` de 5.5 après installation de 5.6.
- Un script de transformation des tables et de conversion de leur contenu.
- Un test à base de 🐙.
- Travis avec MySQL 5.6, ce qui requiert Trusty et donc pas de Travis container-based.
- La bonne config MySQL de Travis.
- Un `manage.py` qui gère correctement le format des tables lors des migrations et des tests, mais seulement pour MySQL.
