### PR TITLE
[ci skip] Nouvelle stratégie de tagging

### DIFF
--- a/doc/source/workflow.rst
+++ b/doc/source/workflow.rst
@@ -50,21 +50,21 @@ Stratégie de *tagging* des tickets
 
 Les étiquettes (ou *labels* ou *tags*) utilisées pour classifier les tickets sont classées en 4 catégories (seuls les niveaux 2 représentent les tags utilisables) :
 
--  Compétence
-   -  part:Back
-   -  part:Front
-   -  part:API
-   -  part:Documentation
-   -  part:Infra
--  Priorité
-   -  prio:Bloquant
-   -  prio:Haute
-   -  prio:Basse
--  Statut
-   -  statut:Evolution
-   -  statut:Bug
-   -  statut:Régression
-   -  statut:Zombie
+-  C: Compétence
+   -  C-Back
+   -  C-Front
+   -  C-API
+   -  C-Documentation
+   -  C-Infra
+-  P: Priorité
+   -  P-Bloquant
+   -  P-Haute
+   -  P-Basse
+-  S: Statut
+   -  S-Evolution
+   -  S-Bug
+   -  S-Régression
+   -  S-Zombie
 -  Autres
    -  Facile
    -  Feedback

--- a/doc/source/workflow.rst
+++ b/doc/source/workflow.rst
@@ -65,8 +65,9 @@ Les étiquettes (ou *labels* ou *tags*) utilisées pour classifier les tickets s
    -  statut:Bug
    -  statut:Régression
    -  statut:Zombie
--  Difficulté
+-  Autres
    -  Facile
+   -  Feedback
 
 Explications
 ------------
@@ -74,7 +75,8 @@ Explications
 -  Compétence : Quelle(s) partie(s) du système est/sont impactée(s) ? Permet notamment aux développeurs de choisir de se concentrer uniquement sur le front, aux admins de s'occuper de l'infra, …
 -  Priorité : Un **bug** ou une **régression** est **bloquant**e si ça empêche une utilisation correcte du site (impossible de rédiger un article, forte atteinte aux performances, etc). Il s'agit d'un problème critique. Les autres tickets ou PR peuvent être de **Haute** ou **Basse** priorité, ces étiquettes étant facultatives. Par exemple, une ZEP aura rarement une priorité attribuée, par contre si elle touche à sa fin mais nécessite une petite évolution pour pouvoir être mergée, la PR de cette petite évolution pourrait à l'approche de la release se voir attribuer une haute priorité.
 -  Statut : **Régression** ou **Bug** ? : Une régression est un retour en arrière en terme de qualité. Il s'agit d'un bug, mais on le différencie parce que ce bug vient d'être introduit dans une partie du code qui auparavant fonctionnait comme voulu. Un problème qui n'est pas une régression est indiqué *Bug*. Il s'agit par exemple d'un problème impactant une nouvelle fonctionnalité. Les tickets sous le tag **Zombie** sont des bugs mineurs n'ayant pas donnés signe de vie depuis longtemps. Ils sont donc non-résolus mais fermés et placés sous cette étiquette pour garder propre la pile des tickets actifs. Dans l'idéal il faudrait les rouvrir pour les résoudre un jour…
--  Le tag **Facile** : Ce tag est facultatif. Il est là uniquement pour guider les nouveaux contributeurs vers des tâches accessibles. Pour pouvoir utiliser cette étiquette, une proposition de solution doit être écrite dans le ticket.
+-  Le tag **Facile** : Ce tag est là uniquement pour guider les nouveaux contributeurs vers des tâches accessibles. Pour pouvoir utiliser cette étiquette, une proposition de solution doit être écrite dans le ticket.
+-  Le tag **Feedback** : Ce tag indique les tickets sur lesquels l'auteur souhaite recevoir un retour, discuter une approche, proposer quelque chose, ouvrir le débat.
 
 La priorité est mise sur ce qui est Bloquant, puis Haut. Les autres tickets ou PRs n'ont pas de priorité particulière. La basse priorité vient en dernier. Chacun est invité à choisir ce sur quoi concentrer ses efforts en fonction de ces priorités ou de ses intérêts.
 

--- a/doc/source/workflow.rst
+++ b/doc/source/workflow.rst
@@ -2,21 +2,21 @@
 *Workflow* et détails pratiques
 ===============================
 
-Cette page détaille le *workflow* utilisé sur Zeste de Savoir. La `page de contribution <https://github.com/zestedesavoir/zds-site/blob/dev/CONTRIBUTING.md>`__ devrait répondre à vos questions quant au processus de développement. Ici sera aussi décrit quelques détails sur la gestion des tickets sur Github (*tagging* et priorité).
+Cette page détaille le *workflow* utilisé lors du développement de Zeste de Savoir. La `page de contribution <https://github.com/zestedesavoir/zds-site/blob/dev/CONTRIBUTING.md>`__ devrait répondre à vos questions quant au processus de développement. Ici seront aussi décrit quelques détails sur la gestion des tickets sur Github (*tagging* et priorité).
 
-Ce *workflow* est très fortement fondé sur le `Git flow <http://nvie.com/posts/a-successful-git-branching-model/>`__.
+Ce *workflow* est très fortement basé sur le `Git flow <http://nvie.com/posts/a-successful-git-branching-model/>`__.
 
 *Workflow* général
 ==================
 
 L'idée générale est très simple :
 
--  Le développement se fait sur la branche ``dev`` ;
--  La branche ``prod`` contient la version en production ;
--  Lorsqu'on juge qu'on a assez de matière pour un nouveau déploiement, on crée une branche dédiée (par exemple ``release-v1.7``) que l'on teste en pré-production (les bugs trouvés seront corrigés sur cette branche) ;
--  En cas de bug ultra-urgent à corriger en production, on crée une branche spéciale.
+-  Le développement se fait sur la branche ``dev``;
+-  La branche ``prod`` contient la version en production;
+-  Lorsqu'on juge qu'on a assez de matière pour un nouveau déploiement, on crée une branche dédiée (par exemple ``release-v1.7``) que l'on teste en pré-production (les bugs trouvés seront corrigés sur cette branche);
+-  En cas de bug ultra-urgent à corriger en production, on crée une branche spéciale (`hotfix <http://nvie.com/posts/a-successful-git-branching-model/#hotfix-branches>`__).
 
-La pré-production (ou béta) est disponible via `ce lien <https://beta.zestedesavoir.com>`_. Vous pouvez y accéder avec le nom d'utilisateur "clementine" et le mot de passe "orange".
+La pré-production (ou bêta) est disponible sur `beta.zestedesavoir.com <https://beta.zestedesavoir.com>`_.
 
 *Workflow* de développement
 ===========================
@@ -25,7 +25,7 @@ Description
 -----------
 
 1. Les fonctionnalités et corrections de bugs se font via des *Pull Requests* (PR) depuis des *forks* via `GitHub <https://github.com/zestedesavoir.com/zds-site>`_.
-2. Ces PR sont unitaires. Aucune PR qui corrige plusieurs problèmes ou apporte plusieurs fonctionnalité ne sera acceptée ; la règle est : une fonctionnalité ou une correction = une PR.
+2. Ces PR sont unitaires. Aucune PR qui corrige plusieurs problèmes ou apporte plusieurs fonctionnalité ne sera acceptée; la règle est : une PR = une fonctionnalité ou une correction.
 3. Ces PR sont mergées dans la branche ``dev`` (appelée ``develop`` dans le git flow standard), après une *Quality Assurance* (QA) légère.
 4. La branche ``prod`` (appelée ``master`` dans le git flow standard) contient exclusivement le code en production, pas la peine d'essayer de faire le moindre *commit* dessus !
 5. Les branches du dépôt principal (``dev``, ``prod`` et la branche de release) ne devraient contenir que des merge de PR, aucun commit direct.
@@ -41,39 +41,42 @@ Tous ces détails sont `dans la page de contribution <https://github.com/zestede
 
 C'est s'assurer que le code fait ce qu'il devrait sans passer des heures à re-tester l'intégralité du site. Concrètement, cela implique :
 
--  une revue de code ;
--  la vérification que des tests correspondants à la fonctionnalité ou à la correction sont présents, cohérents et passent ;
+-  une revue de code (*Code Review* (CR));
+-  la vérification que des tests correspondants à la fonctionnalité ou à la correction sont présents, cohérents et passent;
 -  des tests manuels dans le cas de fonctionnalités ou corrections complexes et/ou critiques (au cas par cas).
 
 Stratégie de *tagging* des tickets
 ==================================
 
-Les étiquettes (ou *labels* ou *tags*) utilisées pour classifier les tickets sont classées en différentes catégories (seuls les niveaux 2 représentent les tags utilisables) :
+Les étiquettes (ou *labels* ou *tags*) utilisées pour classifier les tickets sont classées en 4 catégories (seuls les niveaux 2 représentent les tags utilisables) :
 
--  Compétences
-   -  Back
-   -  Front
-   -  API
-   -  Documentation
-   -  Infra
+-  Compétence
+   -  part:Back
+   -  part:Front
+   -  part:API
+   -  part:Documentation
+   -  part:Infra
 -  Priorité
-   -  Bloquant
+   -  prio:Bloquant
+   -  prio:Haute
+   -  prio:Basse
 -  Statut
-   -  Evolution
-   -  Bug
-   -  Régression
-   -  Zombie
+   -  statut:Evolution
+   -  statut:Bug
+   -  statut:Régression
+   -  statut:Zombie
 -  Difficulté
    -  Facile
 
-Certains de ces tags possèdent cependant quelques règles d'applications :
+Explications
+------------
 
+-  Compétence : Quelle(s) partie(s) du système est/sont impactée(s) ? Permet notamment aux développeurs de choisir de se concentrer uniquement sur le front, aux admins de s'occuper de l'infra, …
+-  Priorité : Un **bug** ou une **régression** est **bloquant**e si ça empêche une utilisation correcte du site (impossible de rédiger un article, forte atteinte aux performances, etc). Il s'agit d'un problème critique. Les autres tickets ou PR peuvent être de **Haute** ou **Basse** priorité, ces étiquettes étant facultatives. Par exemple, une ZEP aura rarement une priorité attribuée, par contre si elle touche à sa fin mais nécessite une petite évolution pour pouvoir être mergée, la PR de cette petite évolution pourrait à l'approche de la release se voir attribuer une haute priorité.
+-  Statut : **Régression** ou **Bug** ? : Une régression est un retour en arrière en terme de qualité. Il s'agit d'un bug, mais on le différencie parce que ce bug vient d'être introduit dans une partie du code qui auparavant fonctionnait comme voulu. Un problème qui n'est pas une régression est indiqué *Bug*. Il s'agit par exemple d'un problème impactant une nouvelle fonctionnalité. Les tickets sous le tag **Zombie** sont des bugs mineurs n'ayant pas donnés signe de vie depuis longtemps. Ils sont donc non-résolus mais fermés et placés sous cette étiquette pour garder propre la pile des tickets actifs. Dans l'idéal il faudrait les rouvrir pour les résoudre un jour…
 -  Le tag **Facile** : Ce tag est facultatif. Il est là uniquement pour guider les nouveaux contributeurs vers des tâches accessibles. Pour pouvoir utiliser cette étiquette, une proposition de solution doit être écrite dans le ticket.
--  Le tag **Bloquant** : Il ne concerne que les tickets désignant un **bug** ou une **régression** qui empêchent une utilisation correcte du site (connexion impossible, forte atteinte aux performances, etc).
--  **Régression** ou **Bug** ? : Une régression *est* un bug. La différence est temporelle. Un bug peut apparaitre suite à la mise en place d'une nouvelle fonctionnalité. Une régression quant à elle est un bug apparu suite à une correction incomplète, ratée ou encore si une nouvelle fonctionnalité altère un comportement antérieur.
--  **Zombie** : Les tickets sous ce tag sont des évolutions ou bugs mineurs n'ayant pas donnée signe de vie depuis longtemps. Ils sont donc non-résolu mais fermé et placé sous cette étiquette pour garder propre la pile des tickets actifs. Dans l'idéal il faudrait les résoudre un jour...
 
-Dans un monde parfait, les priorités de développement devraient être les suivantes : Bloquant > Régression > Bug > Évolution > Zombie.
+La priorité est mise sur ce qui est Bloquant, puis Haut. Les autres tickets ou PRs n'ont pas de priorité particulière. La basse priorité vient en dernier. Chacun est invité à choisir ce sur quoi concentrer ses efforts en fonction de ces priorités ou de ses intérêts.
 
 *Workflow* de mise en production
 ================================
@@ -118,7 +121,7 @@ Vous l'avez lu : les corrections de ``master`` **ne sont pas remontées sur** ``
    2. Les merges de PR sur ``dev`` qui impliquent un risque même vague de conflit sont bloqués.
    3. S'il y a quand même un conflit (à cause d'une PR mergée sur ``dev`` avant la détection du problème), la personne qui règle le problème fournit 2 correctifs : un pour la branche de *release* et un pour la branche de de ``dev``.
 
-Ceci fonctionne bien si les développements sont de bonne qualité, donc avec peu de correctifs sur la branche de *release* (idéalement aucun !)... les codes approximatifs et non testés seront donc refusés sans la moindre pitié !
+Ceci fonctionne bien si les développements sont de bonne qualité, donc avec peu de correctifs sur la branche de *release* (idéalement aucun !)… les codes approximatifs et non testés seront donc refusés.
 
 Rôles et Responsabilités
 ========================
@@ -167,3 +170,4 @@ Glossaire
 -  **MEP** : Mise En Production
 -  **PR** : *Pull Request* (proposition d'une modification de code à un projet)
 -  **QA** : *Quality Assurance* (`Assurance Qualité <https://fr.wikipedia.org/wiki/Assurance_qualit%C3%A9>`_)
+-  **CR** : *Code Review* (`Revue de code <https://fr.wikipedia.org/wiki/Revue_de_code>`_)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution - processus |
| Ticket(s) (_issue(s)_) concerné(s) |  |

**à discuter**

Je propose de revoir la stratégie de tagging. Actuellement c'est un joyeux mélange de types de tickets et de priorités. Je propose de lever ces ambigüités et de rendre le tout plus explicite.

On a plus de 200 issues, s'y retrouver n'est pas facile. On a 16 PRs, prioriser la QA ou les merges n'est pas facile. Avoir une vue d'ensemble n'est pas facile. Revoir le système pourrait, à mon avis, permettre d'être plus efficace, d'en faire plus sans prendre plus de temps.

Notez que ça ne nécessite pas de perdre des tags existant, il suffit d'en ajouter quelques uns et d'en renommer quelques autres.
