### PR TITLE
Retire les avertissements en lecture zen

### DIFF
--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -176,7 +176,8 @@
 
                 .comments-title,
                 .pagination:not(.pagination-chapter),
-                .topic-message {
+                .topic-message,
+                .alert-box {
                     display: none;
                 }
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3732 |

Quand on n’est pas connecté, la boîte qui demande de se connecter ou s’inscrire pour poster un message n’est plus présente en mode zen.
### QA
- Créer un contenu avec plus d’une page de commentaires. 
- Vérifier que lorsqu’on est connecté, qu’on n’est pas sur la dernière page de commentaires et que l’on est en mode zen, la boîte d’avertissement avec le message « Attention, vous n'êtes pas sur la dernière page de ce sujet, assurez-vous de l'avoir lu dans son intégralité avant d'y répondre » n’apparaît pas. 
- Vérifier que lorsqu’on n’est pas connecté et qu’on est en mode zen, la boîte proposant de s’inscrire ou de se connecter n’apparaît. 
