### PR TITLE
(fix) Corrige la PR #3686

### DIFF
--- a/zds/notification/management/commands/uniquify_subscriptions.py
+++ b/zds/notification/management/commands/uniquify_subscriptions.py
@@ -21,7 +21,8 @@ class Command(BaseCommand):
             pks = Subscription.objects.filter(**sub).order_by('-pubdate') \
                                       .values_list('id', flat=True)[1:]
             count = count + len(pks)
-            # Delete them
-            Subscription.objects.filter(pk__in=pks).delete()
+            # Delete each of them
+            for pk in pks:
+                Subscription.objects.filter(pk=pk).delete()
 
         self.stdout.write(u'Deleted {} duplicates'.format(count))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3685 #3686 |
### QA
- J'ai QA sur la beta. L'erreur ne se produit que sur MySQL. On peut merger, c'est garanti sans amiante.
### Notes

`django.db.utils.NotSupportedError: (1235, "This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'")`

Un ORM, c'est bien. Ça abstrait la DB qu'il y a derrière. Et ça génère des requêtes SQL que la DB supporte pas.
