### PR TITLE
Cache menu par fragments

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -182,12 +182,13 @@
                         {% endif %}
                     >
 
-                        {% cache 1800 menu user.pk|default_if_none:"0" %}
-                            <ul class="header-menu-list">
-                                <li>
-                                    <a href="{% url "tutorial:list" %}" class="mobile-menu-link {% block menu_tutorial %}{% endblock %}">
-                                        {% trans "Tutoriels" %}
-                                    </a>
+
+                        <ul class="header-menu-list">
+                            <li>
+                                <a href="{% url "tutorial:list" %}" class="mobile-menu-link {% block menu_tutorial %}{% endblock %}">
+                                    {% trans "Tutoriels" %}
+                                </a>
+                                {% cache 1800 menu_tutorial user|groups %}
                                     <div class="dropdown header-menu-dropdown">
                                         <a href="{% url "tutorial:list" %}" class="dropdown-link-all">
                                             {% trans "Tous les tutoriels" %}
@@ -233,16 +234,17 @@
                                             {% endwith %}
                                         </ul>
                                     </div>
-                                </li>
-                                <li>
-                                    <a href="{% url "article:list" %}" class="mobile-menu-link {% block menu_article %}{% endblock %}">
-                                        {% trans "Articles" %}
-                                    </a>
+                                {% endcache %}
+                            </li>
+                            <li>
+                                <a href="{% url "article:list" %}" class="mobile-menu-link {% block menu_article %}{% endblock %}">
+                                    {% trans "Articles" %}
+                                </a>
+                                {% cache 1800 menu_article user|groups %}
                                     <div class="dropdown header-menu-dropdown">
                                         <a href="{% url "article:list" %}" class="dropdown-link-all">
                                             {% trans "Tous les articles" %}
                                         </a>
-
                                         <ul class="dropdown-list">
                                             {% with categories='ARTICLE'|top_categories_content %}
                                                 {% for title, subcats in categories.categories.items %}
@@ -283,11 +285,13 @@
                                             {% endwith %}
                                         </ul>
                                     </div>
-                                </li>
-                                <li>
-                                    <a href="{% url "cats-forums-list" %}" class="mobile-menu-link {% block menu_forum %}{% endblock %}">
-                                        {% trans "Forums" %}
-                                    </a>
+                                {% endcache %}
+                            </li>
+                            <li>
+                                <a href="{% url "cats-forums-list" %}" class="mobile-menu-link {% block menu_forum %}{% endblock %}">
+                                    {% trans "Forums" %}
+                                </a>
+                                {% cache 1800 menu_forum user|groups %}
                                     <div class="dropdown header-menu-dropdown">
                                         <a href="{% url "cats-forums-list" %}" class="dropdown-link-all">
                                             {% trans "Tous les forums" %}
@@ -328,9 +332,9 @@
                                             {% endwith %}
                                         </ul>
                                     </div>
-                                </li>
-                            </ul>
-                        {% endcache %}
+                                {% endcache %}
+                            </li>
+                        </ul>
                     </nav>
 
 

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -106,10 +106,10 @@ class ForumMemberTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        # check topic's number
+        # check topics count
         self.assertEqual(Topic.objects.all().count(), 1)
         topic = Topic.objects.first()
-        # check post's number
+        # check posts count
         self.assertEqual(Post.objects.all().count(), 1)
         post = Post.objects.first()
 
@@ -133,7 +133,7 @@ class ForumMemberTests(TestCase):
         # Check view
         response = self.client.get(topic.get_absolute_url())
         self.assertContains(response, self.category1.title)
-        self.assertContains(response, self.forum11.title)
+        self.assertContains(response, self.forum12.title)
         self.assertContains(response, topic.title)
         self.assertContains(response, topic.subtitle)
 
@@ -194,9 +194,9 @@ class ForumMemberTests(TestCase):
             },
             follow=False)
         self.assertEqual(result.status_code, 200)
-        # check topic's number
+        # check topics count
         self.assertEqual(Topic.objects.all().count(), 1)
-        # check post's number (should be 3 for the moment)
+        # check posts count (should be 3 for the moment)
         self.assertEqual(Post.objects.all().count(), 3)
 
         # now check what happen if everything is fine
@@ -211,10 +211,10 @@ class ForumMemberTests(TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEquals(len(mail.outbox), 2)
 
-        # check topic's number
+        # check topics count
         self.assertEqual(Topic.objects.all().count(), 1)
 
-        # check post's number
+        # check posts count
         self.assertEqual(Post.objects.all().count(), 4)
 
         # check topic and post
@@ -310,10 +310,10 @@ class ForumMemberTests(TestCase):
 
         self.assertEqual(result.status_code, 302)
 
-        # check topic's number
+        # check topics count
         self.assertEqual(Topic.objects.all().count(), 3)
 
-        # check post's number
+        # check posts count
         self.assertEqual(Post.objects.all().count(), 3)
 
         # check topic and post
@@ -389,10 +389,10 @@ class ForumMemberTests(TestCase):
 
         self.assertEqual(result.status_code, 302)
 
-        # check topic's number
+        # check topics count
         self.assertEqual(Topic.objects.all().count(), 1)
 
-        # check post's number
+        # check posts count
         self.assertEqual(Post.objects.all().count(), 3)
 
         # check topic and post
@@ -919,9 +919,9 @@ class ForumGuestTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        # check topic's number
+        # check topics count
         self.assertEqual(Topic.objects.all().count(), 0)
-        # check post's number
+        # check posts count
         self.assertEqual(Post.objects.all().count(), 0)
 
     def test_answer(self):
@@ -942,10 +942,10 @@ class ForumGuestTests(TestCase):
 
         self.assertEqual(result.status_code, 302)
 
-        # check topic's number
+        # check topics count
         self.assertEqual(Topic.objects.all().count(), 1)
 
-        # check post's number
+        # check posts count
         self.assertEqual(Post.objects.all().count(), 3)
 
     def test_tag_parsing(self):

--- a/zds/settings_test_local.py
+++ b/zds/settings_test_local.py
@@ -1,2 +1,10 @@
 from zds.settings import *
 from zds.settings_test import *
+
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/tmp/django_cache',
+    }
+}

--- a/zds/utils/templatetags/profile.py
+++ b/zds/utils/templatetags/profile.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 
 from django import template
-
 from django.contrib.auth.models import User
+from django.core.cache import cache
 
 from zds.member.models import Profile
 
@@ -28,6 +28,30 @@ def user(user_pk):
     except User.DoesNotExist:
         current_user = None
     return current_user
+
+
+@register.filter(name='groups')
+def user_groups(user):
+    if user.pk is None:
+        user_identifier = 'unauthenticated'
+    else:
+        user_identifier = user.pk
+
+    key = 'user_pk={}_groups'.format(user_identifier)
+    groups = cache.get(key)
+
+    if groups is None:
+        try:
+            current_user_groups = User.objects.filter(pk=user.pk)\
+                                      .prefetch_related('groups').values_list('groups', flat=True)
+        except User.DoesNotExist:
+            current_user_groups = ['none']
+        groups = '{}-{}'.format(
+            'groups',
+            '-'.join(str(current_user_groups))
+        )
+        cache.set(key, groups, 4 * 60 * 60)
+    return groups
 
 
 @register.filter('state')


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3695 #3607 |
### QA
- Vérifier que l'onglet de menu `.current` est bien celui sur lequel on se trouve après avoir navigué entre différentes sections du site.
- Vérifier qu'on se prend la requête de groupe qu'une seule fois au premier chargement, et idem pour le menu. Normalement ça fait une grosse différence. Sur une page comme `/pages/apropos`, on passe de 10 requêtes au premier chargement à 0 (oui, 0) requête aux chargements suivants par tranche de 30 minutes. (0 pour visiteur pas connecté, hein, sinon y'a quand même les notifs, toussa)
### Notes
- Je pense que c'est bien si cette régression est réparée dans la v20. C'est moche comme bug, et le fix est bénin.
- Ajout d'un filtre `groups` à appliquer à la variable `user` dans les templates. Son contenu est toujours caché, donc on peut l'utilisé comme clé partout où on a besoin de cacher un fragment d'après les groupes. Vu qu'on change rarement de groupes et qu'il s'agit que de visuel, pas de fonctionnalité, j'ai mis un cache de 4h.
