### PR TITLE
(fix) Coveralls ne passe pas sur les build front

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,10 @@ script:
     fi
 
 after_success:
-  - coveralls
+  - |
+    if [[ "$TEST_APP" == *"back"* ]]; then
+      coveralls
+    fi
   - |
     COMMIT_MSG=`git rev-list --format=%B --max-count=1 $TRAVIS_COMMIT`
     if [[ "$TEST_APP" == *"front"* ]] && [[ "$TRAVIS_PULL_REQUEST" == false ]] && [[ ! -z "$TRAVIS_TAG" ]] && [[ ! "$TRAVIS_TAG" == *"-build" ]]


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) |  |

Disclaimer : je suis pas expert en travis+tox+coveralls.

J'ai la désagréable impression que coveralls dit des bêtises 9 fois sur 10 sur mes PRs. Ces temps, il dit systèmatiquement `-34%` ou un truc du genre. D'après `tox.ini`, coverage ne passe que sur les builds `back`. Du coup, peut-être que ne lancer coveralls que lorsque coverage est passé pourrait régler le problème.

Des avis/idées ?
