### PR TITLE
doc(workflow) Documente les milestones

### DIFF
--- a/doc/source/workflow.rst
+++ b/doc/source/workflow.rst
@@ -45,27 +45,51 @@ C'est s'assurer que le code fait ce qu'il devrait sans passer des heures à re-t
 -  la vérification que des tests correspondants à la fonctionnalité ou à la correction sont présents, cohérents et passent;
 -  des tests manuels dans le cas de fonctionnalités ou corrections complexes et/ou critiques (au cas par cas).
 
+Milestones
+==========
+
+Pour avoir une vue d'ensemble des modifications inclues ou à inclure dans chaque release, nous utilisons des *milestones*. Il existe une *milestone* par release majeure (e.g. une pour v19, aucune pour v19.1), les PRs mergées dans une version mineure appartenant à la *milestone* de la version majeure correspondante.
+
+Les *milestones* sont également utilisées par le script de génération de rapport de release, rapport contenant quelques détails sur la release en question.
+
+Une *milestone* n'est attribuée que sur une PR, pas sur un ticket. Elle est attribuée au plus tôt par le DTC à l'ouverture de la PR si cette PR doit impérativement passer dans la prochaine release, au plus tard par la personne qui merge la PR lors de son merge.
+
+* Toute PR mergée dans dev doit porter la *milestone* « Version de développement »
+* Toute PR mergée ailleurs (la branche de release si c'est une correction de bêta, prod en cas de hotfix) doit porter la *milestone* « Version N »
+
+La *milestone* « Version de développement » s'appelle comme ça parce qu'elle contient les modifications apportées depuis la dernière release. Cette *milestone* étant largement la plus utilisée, son nom a l'avantage qu'on voit immédiatement si on attribue ou non la bonne *milestone*, sans avoir à réfléchir au numéro de version.
+
+Lors de la clôture de chaque release, la *milestone* « Version de développement » est renommée « Version N » et une nouvelle *milestone* « Version de développement » est créée.
+
+
 Stratégie de *tagging* des tickets
 ==================================
 
 Les étiquettes (ou *labels* ou *tags*) utilisées pour classifier les tickets sont classées en 4 catégories (seuls les niveaux 2 représentent les tags utilisables) :
 
 -  C: Compétence
+
    -  C-Back
    -  C-Front
    -  C-API
    -  C-Documentation
    -  C-Infra
+
 -  P: Priorité
+
    -  P-Bloquant
    -  P-Haute
    -  P-Basse
+
 -  S: Statut
+
    -  S-Evolution
    -  S-Bug
    -  S-Régression
    -  S-Zombie
+
 -  Autres
+
    -  Facile
    -  Feedback
 
@@ -153,13 +177,16 @@ Le Sysadmin (administrateur système et réseau)
 ----------------------------------------------
 
   - Roles
+
     - Gérer et monitorer l'infra (configuration des logiciels, logs, sécurité) [pré]prod'
     - Assister/remplacer le DTC sur les histoires de migration prod -> préprod quand nécessaire
     - Donner un avis sur les contraintes de changement de serveur (ou prévenir sur les limites de l'actuel quand nécessaire, cf. premier point)
     - Suivre les tickets "infra" sur GH et faire les actions nécessaires
     - Gérer les personnes ayant accès au serveur [pré]prod'
     - Maintenir de la doc. sur les actions pour faire un suivi et assurer la relève/remplacement quand c'est nécessaire (maladie, vacances…)
+
   - Responsabilités
+
     - **Confidentialité** vis-a-vis des données privées présente sur les serveurs (email, contenu de MP…)
     - Si possible, toujours tester en preprod' avant de reproduire en prod'
     - **Professionnalisme**, "si on sait pas on fait pas" pour ne pas mettre la production en péril (sauf en preprod entre les releases)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) | #3742 |
### Notes

(suite à #3742)

Je suggère de modifier le process comme ceci : 
- « Abandon / Ferme / Doublon / etc. » On supprime cette milestone.
- Toute PR qui devra impérativement faire partie de la prochaine release → « Version de développement »
- Toute PR mergée ailleurs (la branche de release si c'est une correction de bêta, prod en cas de hotfix) → « Version N »

Plusieurs raisons aux 2 dernières modifications : 
1. Théoriquement chaque PR est associé à une issue et celle-ci est mentionnée dans le cartouche.
2. Il est pénible de vérifier que chaque issue **ou** PR fermée ou mergée a bien reçu une milestone. Il sera facile de vérifier ça : https://github.com/zestedesavoir/zds-site/pulls?q=is%3Apr+is%3Aclosed+no%3Amilestone
3. En s'autorisant à mettre une milestone à une PR ouverte, on utilise enfin les milestones à bon escient. On peut ainsi cantonner les tags de priorité aux issues, et mettre une milestone aux PRs importantes ou bloquantes. Si une release doit avoir lieu alors que la milestone n'est pas fermée, le DTC peut, mais ne devrait le faire qu'exceptionnellement, enlever cette PR de la release.
