### PR TITLE
Invalide le cache de l'API à chaque entrée dans la base

### DIFF
--- a/zds/api/bits.py
+++ b/zds/api/bits.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-
-from rest_framework_extensions.key_constructor.bits import QueryParamsKeyBit
+import datetime
+from django.core.cache import cache
+from django.utils.encoding import force_text
+from rest_framework_extensions.key_constructor.bits import QueryParamsKeyBit, KeyBitBase
 
 
 class DJRF3xPaginationKeyBit(QueryParamsKeyBit):
@@ -15,6 +17,7 @@ class DJRF3xPaginationKeyBit(QueryParamsKeyBit):
     This class should be deleted when an upstream solution will be proposed.
     This class should be replaced by using bits.PaginationKeyBit() instead.
     """
+
     def get_data(self, **kwargs):
         kwargs['params'] = []
 
@@ -28,3 +31,18 @@ class DJRF3xPaginationKeyBit(QueryParamsKeyBit):
             kwargs['params'].append(rqp_pv)
 
         return super(DJRF3xPaginationKeyBit, self).get_data(**kwargs)
+
+
+class UpdatedAtKeyBit(KeyBitBase):
+    update_key = None
+
+    def __init__(self, update_key, params=None):
+        super(UpdatedAtKeyBit, self).__init__(params)
+        self.update_key = update_key
+
+    def get_data(self, **kwargs):
+        value = cache.get(self.update_key)
+        if value is None:
+            value = datetime.datetime.utcnow()
+            cache.set(self.update_key, value=value)
+        return force_text(value)

--- a/zds/api/bits.py
+++ b/zds/api/bits.py
@@ -34,6 +34,12 @@ class DJRF3xPaginationKeyBit(QueryParamsKeyBit):
 
 
 class UpdatedAtKeyBit(KeyBitBase):
+    """
+    A custom key to allow invalidation of a cache.
+
+    See official documentation to know more about the usage of this class:
+    http://chibisov.github.io/drf-extensions/docs/#custom-key-bit
+    """
     update_key = None
 
     def __init__(self, update_key, params=None):

--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -1141,6 +1141,30 @@ class CacheMemberAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(another_profile.user.username, response.data.get('username'))
 
+    def test_cache_invalided_when_new_member(self):
+        """
+        When we create a new member, the api cache is invalided and returns the new member.
+        """
+        count = self.client.get(reverse('api:member:list')).data.get('count')
+
+        ProfileFactory()
+
+        response = self.client.get(reverse('api:member:list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), count + 1)
+
+        second = ProfileFactory()
+
+        response = self.client.get(reverse('api:member:list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), count + 2)
+
+        second.delete()
+
+        response = self.client.get(reverse('api:member:list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), count + 1)
+
 
 def create_oauth2_client(user):
     client = Application.objects.create(user=user,

--- a/zds/utils/api/views.py
+++ b/zds/utils/api/views.py
@@ -1,12 +1,14 @@
 # coding: utf-8
-
+import datetime
+from django.core.cache import cache
+from django.db.models.signals import post_save, post_delete
 from rest_framework import filters
 from rest_framework.generics import ListAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework_extensions.key_constructor.constructors import DefaultKeyConstructor
 from rest_framework_extensions.cache.decorators import cache_response
 from rest_framework_extensions.etag.decorators import etag
 from rest_framework_extensions.key_constructor import bits
-from zds.api.DJRF3xPaginationKeyBit import DJRF3xPaginationKeyBit
+from zds.api.bits import DJRF3xPaginationKeyBit, UpdatedAtKeyBit
 from zds.utils.models import Comment, Tag
 from zds.utils.api.serializers import KarmaSerializer, TagSerializer
 
@@ -21,6 +23,15 @@ class PagingSearchListKeyConstructor(DefaultKeyConstructor):
     search = bits.QueryParamsKeyBit(['search'])
     list_sql_query = bits.ListSqlQueryKeyBit()
     unique_view_id = bits.UniqueViewIdKeyBit()
+    updated_at = UpdatedAtKeyBit('api_updated_tag')
+
+
+def change_api_tag_updated_at(sender=None, instance=None, *args, **kwargs):
+    cache.set('api_updated_tag', datetime.datetime.utcnow())
+
+
+post_save.connect(receiver=change_api_tag_updated_at, sender=Tag)
+post_delete.connect(receiver=change_api_tag_updated_at, sender=Tag)
 
 
 class TagListAPI(ListAPIView):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #2329 |

Enfin ! Je suis parvenu à comprendre comment invalider le cache de l'API quand une insertion est faite dans les modèles couverts par l'API.

Je vais tagguer cette PR en `P-Haute` parce que ça fait longtemps que ce bug traine et que l'API est inutilisable pour plusieurs projets.
### QA
- Configuez un système de cache sur votre environnement local.
- Pour la liste des messages privés, des membres et des tags :
  - Faite une première requête pour mettre en cache
  - Faite une insertion (nouveau message, nouveau membre ou nouveau tag)
  - Refaite la première requête et remarquez que la nouvelle donnée est dans la réponse.
