### PR TITLE
#3620 Fix url images import

### DIFF
--- a/update.md
+++ b/update.md
@@ -642,6 +642,11 @@ Tags
 1. Lancer la commande `python manage.py clean_tags >> mep_v20.log`
 1. Jeter un oeil aux logs pour s'assurer que tout s'est bien passé.
 
+Issue 3620
+----------
+
+Dans le `settings_prod.py` : ajouter `ZDS_APP['site']['secure_url'] = 'https://zestedesavoir.com'`
+
 ---
 
 **Notes auxquelles penser lors de l'édition de ce fichier (à laisser en bas) :**
@@ -651,3 +656,4 @@ Le déploiement doit être autonome. Ce qui implique que :
 1. La mise à jour de dépendances est automatique et systématique,
 2. La personne qui déploie ne doit pas réfléchir (parce que c'est source d'erreur),
 3. La personne qui déploie ne doit pas avoir connaissance de ce qui est déployé (techniquement et fonctionnellement).
+

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -393,6 +393,7 @@ ZDS_APP = {
         'slogan': u"Zeste de Savoir, la connaissance pour tous et sans pépins",
         'abbr': u"zds",
         'url': u"http://127.0.0.1:8000",
+        'secure_url': u"https://127.0.0.1:8000",
         'dns': u"zestedesavoir.com",
         'email_contact': u"zestedesavoir@gmail.com",
         'email_noreply': u"noreply@zestedesavoir.com",

--- a/zds/settings_test_local.py
+++ b/zds/settings_test_local.py
@@ -8,3 +8,9 @@ CACHES = {
         'LOCATION': '/tmp/django_cache',
     }
 }
+
+ZDS_APP = {
+    'site': {
+        'secure_url': u"http://127.0.0.1:8000"
+    }
+}

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -1696,7 +1696,7 @@ class ContentTests(TestCase):
         # check links:
         text = versioned.children[0].get_text()
         for img in Image.objects.filter(gallery=new_article.gallery).all():
-            self.assertTrue('![]({})'.format(settings.ZDS_APP['site']['url'] + img.physical.url) in text)
+            self.assertTrue('![]({})'.format(settings.ZDS_APP['site']['secure_url'] + img.physical.url) in text)
 
         # import into first article (that will only change the images)
         result = self.client.post(
@@ -1723,7 +1723,7 @@ class ContentTests(TestCase):
         # check links:
         text = versioned.children[0].get_text()
         for img in Image.objects.filter(gallery=new_version.gallery).all():
-            self.assertTrue('![]({})'.format(settings.ZDS_APP['site']['url'] + img.physical.url) in text)
+            self.assertTrue('![]({})'.format(settings.ZDS_APP['site']['secure_url'] + img.physical.url) in text)
 
         # clean up
         os.remove(draft_zip_path)

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -625,7 +625,7 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
             pic.pubdate = datetime.now()
             pic.save()
 
-            translation_dic[image_path] = settings.ZDS_APP['site']['url'] + pic.physical.url
+            translation_dic[image_path] = settings.ZDS_APP['site']['secure_url'] + pic.physical.url
 
             # finally, remove image
             if os.path.exists(temp_image_path):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3620 |
### QA
- Créez un article/tuto via la fonction d'import, avec des images
- Vérifier que les images sont bien insérées avec le lien https

Je joints un zip contenant un article formatté correctement pour l'import (avec référence `archive:` pour les images, et un zip avec les images référencées maos n'hésitez pas à tester avec un autre contenu (un tuto par exemple).

[arbres-phylo.zip](https://github.com/zestedesavoir/zds-site/files/396965/arbres-phylo.zip)
[images.zip](https://github.com/zestedesavoir/zds-site/files/396966/images.zip)
