### PR TITLE
Masque la biographie des membres bannis définitivement

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -152,7 +152,7 @@
         <section class="full-content-wrapper without-margin article-content">
             <h2 id="biographie">{% trans "Biographie" %}</h2>
             {% if not profile.end_ban_read and not profile.can_read %}
-                La biographie de ce membre est masquée car il a été banni définitivement.
+                <em>{% trans "La biographie de ce membre est masquée car il a été banni définitivement." %}</em>
             {% else %}
                 {{ profile.biography|emarkdown }}
             {% endif %}

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -151,7 +151,11 @@
         <hr class="clearfix" />
         <section class="full-content-wrapper without-margin article-content">
             <h2 id="biographie">{% trans "Biographie" %}</h2>
-            {{ profile.biography|emarkdown }}
+            {% if not profile.end_ban_read and not profile.can_read %}
+                La biographie de ce membre est masquée car il a été banni définitivement.
+            {% else %}
+                {{ profile.biography|emarkdown }}
+            {% endif %}
         </section>
     {% endif %}
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) | #3673 |
### QA
- Bannir un membre définitivement.
- Vérifier que sa biographie n’apparaît pas et que le message « La biographie de ce membre est masquée car il a été banni définitivement. » apparaît à la place.

Il faut également vérifier que le masquage n’est fait que pour les membres bannis définitivement (donc pas pour les non bannis, ni pour les bannis temporaires).
