### PR TITLE
[ci skip] Répare la config des tests locaux

### DIFF
--- a/zds/settings_test_local.py
+++ b/zds/settings_test_local.py
@@ -9,8 +9,4 @@ CACHES = {
     }
 }
 
-ZDS_APP = {
-    'site': {
-        'secure_url': u"http://127.0.0.1:8000"
-    }
-}
+ZDS_APP['site']['secure_url'] = u'http://127.0.0.1:8000'


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3761 |
### QA
- Lancer les tests en local. Ils doivent se lancer et pas planter immédiatement en disant que plein de variables manquent dans la config. Par exemple `python manage.py test --settings zds.settings_test_local zds.mp` histoire d'éviter d'avoir besoin de pandoc et companie.
