### PR TITLE
[hotfix] Gère le déplacement d'un sujet.

### DIFF
--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -76,12 +76,10 @@ class TopicEditMixin(object):
             forum = get_object_or_404(Forum, pk=forum_pk)
             topic.forum = forum
 
-            # If the topic is moved in a restricted forum, users that cannot read this topic any more un-follow it.
-            # This avoids unreachable notifications.
-            TopicAnswerSubscription.objects.unfollow_and_mark_read_everybody_at(topic)
-
             # Save topic to update update_index_date
             topic.save()
+
+            signals.edit_content.send(sender=topic.__class__, instance=topic, action='move')
 
             messages.success(request,
                              _(u"Le sujet « {0} » a bien été déplacé dans « {1} ».").format(topic.title, forum.title))

--- a/zds/notification/migrations/0010_notification_is_dead.py
+++ b/zds/notification/migrations/0010_notification_is_dead.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('notification', '0009_newtopicsubscription'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='notification',
+            name='is_dead',
+            field=models.BooleanField(default=False, verbose_name='Morte'),
+        ),
+    ]

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -293,6 +293,7 @@ class Notification(models.Model):
     object_id = models.PositiveIntegerField(db_index=True)
     content_object = GenericForeignKey('content_type', 'object_id')
     is_read = models.BooleanField(_(u'Lue'), default=False, db_index=True)
+    is_dead = models.BooleanField(_(u'Morte'), default=False)
     url = models.CharField('URL', max_length=255)
     sender = models.ForeignKey(User, related_name='sender', db_index=True)
     title = models.CharField('Titre', max_length=200)

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 
 try:
     from functools import wraps
@@ -13,7 +14,7 @@ from zds.forum.models import Topic, Post
 from zds.mp.models import PrivateTopic, PrivatePost
 from zds.notification.models import TopicAnswerSubscription, ContentReactionAnswerSubscription, \
     PrivateTopicAnswerSubscription, Subscription, Notification, NewTopicSubscription
-from zds.notification.signals import answer_unread, content_read, new_content
+from zds.notification.signals import answer_unread, content_read, new_content, edit_content
 from zds.tutorialv2.models.models_database import PublishableContent, ContentReaction
 
 
@@ -71,6 +72,14 @@ def mark_topic_notifications_read(sender, **kwargs):
     if subscription:
         subscription.mark_notification_read(content=topic)
 
+    content_type = ContentType.objects.get_for_model(topic)
+    notifications = Notification.objects.filter(subscription__user=user, object_id=topic.pk,
+                                                content_type__pk=content_type.pk, is_read=False,
+                                                is_dead=True)
+    for notification in notifications:
+        notification.is_read = True
+        notification.save()
+
 
 @receiver(content_read, sender=PublishableContent)
 def mark_content_reactions_read(sender, **kwargs):
@@ -103,6 +112,36 @@ def mark_pm_reactions_read(sender, **kwargs):
     subscription = PrivateTopicAnswerSubscription.objects.get_existing(user, private_topic, is_active=True)
     if subscription:
         subscription.mark_notification_read()
+
+
+@receiver(edit_content, sender=Topic)
+def edit_topic_event(sender, **kwargs):
+    """
+    :param kwargs: contains
+        - instance: the topic edited.
+        - action: action of the edit.
+    """
+    if kwargs.get('action') == 'move':
+        topic = kwargs.get('instance')
+
+        # If the topic is moved in a restricted forum, users that cannot read this topic any more un-follow it.
+        # This avoids unreachable notifications.
+        TopicAnswerSubscription.objects.unfollow_and_mark_read_everybody_at(topic)
+
+        # If the topic is moved in a forum followed by the user, we update the subscription of the notification.
+        # Otherwise, we update the notification has dead.
+        content_type = ContentType.objects.get_for_model(topic)
+        notifications = Notification.objects \
+            .filter(object_id=topic.pk, content_type__pk=content_type.pk, is_read=False).all()
+        for notification in notifications:
+            subscription = NewTopicSubscription.objects \
+                .get_existing(notification.subscription.user, topic.forum, is_active=True)
+            if subscription:
+                notification.subscription = subscription
+                notification.save()
+            elif notification.subscription.content_object != notification.content_object.forum:
+                notification.is_dead = True
+                notification.save()
 
 
 @receiver(post_save, sender=Topic)

--- a/zds/notification/signals.py
+++ b/zds/notification/signals.py
@@ -8,5 +8,8 @@ answer_unread = Signal(providing_args=["instance", "user"])
 # is sent whenever a resource is created.
 new_content = Signal(providing_args=['instance', 'by_email'])
 
+# is sent whenever a content is edited.
+edit_content = Signal(providing_args=['instance', 'action'])
+
 # is sent when a content is read (topic, article or tutorial)
 content_read = Signal(providing_args=["instance", "user"])

--- a/zds/notification/tests.py
+++ b/zds/notification/tests.py
@@ -304,6 +304,67 @@ class NotificationForumTest(TestCase):
         notifications = Notification.objects.filter(object_id=topic.pk, is_read=False).all()
         self.assertEqual(0, len(notifications))
 
+    def test_move_topic_from_forum_to_another_one(self):
+        NewTopicSubscription.objects.toggle_follow(self.forum11, self.user1)
+
+        topic = TopicFactory(forum=self.forum11, author=self.user2)
+        PostFactory(topic=topic, author=self.user2, position=1)
+        self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=False).all()))
+
+        # Move the topic in another forum.
+        self.client.logout()
+        staff = StaffProfileFactory()
+        self.assertTrue(self.client.login(username=staff.user.username, password='hostel77'))
+        data = {
+            'move': '',
+            'forum': self.forum12.pk,
+            'topic': topic.pk
+        }
+        response = self.client.post(reverse('topic-edit'), data, follow=False)
+        self.assertEqual(302, response.status_code)
+
+        topic = Topic.objects.get(pk=topic.pk)
+        self.assertEqual(self.forum12, topic.forum)
+        self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=False, is_dead=True).all()))
+
+        self.client.logout()
+        self.assertTrue(self.client.login(username=self.user1.username, password='hostel77'))
+        response = self.client.get(reverse('topic-posts-list', args=[topic.pk, topic.slug()]))
+        self.assertEqual(200, response.status_code)
+
+        self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=True, is_dead=True).all()))
+
+    def test_move_topic_from_forum_followed_to_forum_followed_too(self):
+        NewTopicSubscription.objects.toggle_follow(self.forum11, self.user1)
+        NewTopicSubscription.objects.toggle_follow(self.forum12, self.user1)
+
+        topic = TopicFactory(forum=self.forum11, author=self.user2)
+        PostFactory(topic=topic, author=self.user2, position=1)
+        self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=False).all()))
+
+        # Move the topic in another forum.
+        self.client.logout()
+        staff = StaffProfileFactory()
+        self.assertTrue(self.client.login(username=staff.user.username, password='hostel77'))
+        data = {
+            'move': '',
+            'forum': self.forum12.pk,
+            'topic': topic.pk
+        }
+        response = self.client.post(reverse('topic-edit'), data, follow=False)
+        self.assertEqual(302, response.status_code)
+
+        topic = Topic.objects.get(pk=topic.pk)
+        self.assertEqual(self.forum12, topic.forum)
+        self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=False, is_dead=False).all()))
+
+        self.client.logout()
+        self.assertTrue(self.client.login(username=self.user1.username, password='hostel77'))
+        response = self.client.get(reverse('topic-posts-list', args=[topic.pk, topic.slug()]))
+        self.assertEqual(200, response.status_code)
+
+        self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=True, is_dead=False).all()))
+
 
 class NotificationPublishableContentTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3762 |
### QA
- Avec un utilisateur X, suivez un forum A et B.
- Avec un utilisateur Y, créez un sujet dans le forum A.
- Avec un staff, déplacez le sujet du forum A vers le forum B.
- Avec l'utilisateur X, consultez la notification du sujet et constatez que c'est marqué comme lu.
- Avec l'utilisateur Y, créez un sujet dans le forum A.
- Avec le staff, déplacez le sujet du forum A vers le forum C.
- Avec l'utilisateur X, consultez la notification du sujet et constatez que c'est marqué comme lu.
- Avec un admin, regardez les deux notifications dans l'admin.
- Constatez que la première notification est vivante (`is_dead=False`).
- Constatez que la seconde notification est morte (`is_dead=True`).

@gustavi et @vhf Cette PR est un hotfix et engendre certainement des conflits avec la branche dev, surtout sur les migrations de l'app `notification`. Gardez ça à l'esprit lors de la MEP.
