### PR TITLE
Résout le bug de notification lors du déplacement de sujet

### DIFF
--- a/update.md
+++ b/update.md
@@ -746,6 +746,14 @@ Issue 3620
 
 Dans le `settings_prod.py` : ajouter `ZDS_APP['site']['secure_url'] = 'https://zestedesavoir.com'`
 
+Issue 3762
+----------
+
+1. Après avoir lancé les migrations, lancer la commande :
+
+    1. `python manage.py fix_persistent_notifications >> mep_v20.log`
+    1. Jeter un oeil aux logs pour s'assurer que tout s'est bien passé.
+
 (Ne pas oublier de lancer les migrations en terminant cette MEP !)
 
 ---

--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -76,12 +76,10 @@ class TopicEditMixin(object):
             forum = get_object_or_404(Forum, pk=forum_pk)
             topic.forum = forum
 
-            # If the topic is moved in a restricted forum, users that cannot read this topic any more un-follow it.
-            # This avoids unreachable notifications.
-            TopicAnswerSubscription.objects.unfollow_and_mark_read_everybody_at(topic)
-
             # Save topic to update update_index_date
             topic.save()
+
+            signals.edit_content.send(sender=topic.__class__, instance=topic, action='move')
 
             messages.success(request,
                              _(u"Le sujet « {0} » a bien été déplacé dans « {1} ».").format(topic.title, forum.title))

--- a/zds/notification/management/commands/fix_persistent_notifications.py
+++ b/zds/notification/management/commands/fix_persistent_notifications.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+from django.core.management import BaseCommand
+from django.contrib.contenttypes.models import ContentType
+
+from zds.notification.models import Notification
+from zds.forum.models import Topic
+
+
+class Command(BaseCommand):
+    help = 'Fix all persistent notifications.'
+
+    def handle(self, *args, **options):
+        content_type = ContentType.objects.get_for_model(Topic)
+        notifications = Notification.objects.filter(content_type=content_type, is_read=False).all()
+        count = 0
+        print ""
+        for notification in notifications:
+            if notification.subscription.content_object != notification.content_object.forum:
+                notification.is_read = True
+                notification.is_dead = True
+                notification.save()
+                print notification
+                count += 1
+        print '{} notifications have been fixed'.format(count)

--- a/zds/notification/migrations/0010_notification_is_dead.py
+++ b/zds/notification/migrations/0010_notification_is_dead.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('notification', '0009_newtopicsubscription'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='notification',
+            name='is_dead',
+            field=models.BooleanField(default=False, verbose_name='Morte'),
+        ),
+    ]

--- a/zds/notification/migrations/0012_notification_is_dead.py
+++ b/zds/notification/migrations/0012_notification_is_dead.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('notification', '0009_newtopicsubscription'),
+        ('notification', '0011_auto_20160703_2255'),
     ]
 
     operations = [

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -319,6 +319,7 @@ class Notification(models.Model):
     object_id = models.PositiveIntegerField(db_index=True)
     content_object = GenericForeignKey('content_type', 'object_id')
     is_read = models.BooleanField(_(u'Lue'), default=False, db_index=True)
+    is_dead = models.BooleanField(_(u'Morte'), default=False)
     url = models.CharField('URL', max_length=255)
     sender = models.ForeignKey(User, related_name='sender', db_index=True)
     title = models.CharField('Titre', max_length=200)

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -132,12 +132,12 @@ def edit_topic_event(sender, **kwargs):
     if kwargs.get('action') == 'move':
         topic = kwargs.get('instance')
 
-        # If the topic is moved in a restricted forum, users that cannot read this topic any more un-follow it.
+        # If the topic is moved to a restricted forum, users who cannot read this topic any more unfollow it.
         # This avoids unreachable notifications.
         TopicAnswerSubscription.objects.unfollow_and_mark_read_everybody_at(topic)
 
-        # If the topic is moved in a forum followed by the user, we update the subscription of the notification.
-        # Otherwise, we update the notification has dead.
+        # If the topic is moved to a forum followed by the user, we update the subscription of the notification.
+        # Otherwise, we update the notification as dead.
         content_type = ContentType.objects.get_for_model(topic)
         notifications = Notification.objects \
             .filter(object_id=topic.pk, content_type__pk=content_type.pk, is_read=False).all()

--- a/zds/notification/signals.py
+++ b/zds/notification/signals.py
@@ -8,5 +8,8 @@ answer_unread = Signal(providing_args=['instance', 'user'])
 # is sent whenever a resource is created.
 new_content = Signal(providing_args=['instance', 'by_email'])
 
+# is sent whenever a content is edited.
+edit_content = Signal(providing_args=['instance', 'action'])
+
 # is sent when a content is read (topic, article or tutorial)
 content_read = Signal(providing_args=['instance', 'user', 'target'])

--- a/zds/notification/tests.py
+++ b/zds/notification/tests.py
@@ -313,7 +313,7 @@ class NotificationForumTest(TestCase):
         PostFactory(topic=topic, author=self.user2, position=1)
         self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=False).all()))
 
-        # Move the topic in another forum.
+        # Move the topic to another forum.
         self.client.logout()
         staff = StaffProfileFactory()
         self.assertTrue(self.client.login(username=staff.user.username, password='hostel77'))
@@ -344,7 +344,7 @@ class NotificationForumTest(TestCase):
         PostFactory(topic=topic, author=self.user2, position=1)
         self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=False).all()))
 
-        # Move the topic in another forum.
+        # Move the topic to another forum.
         self.client.logout()
         staff = StaffProfileFactory()
         self.assertTrue(self.client.login(username=staff.user.username, password='hostel77'))


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3762 |

Cette PR est un remake de #3784 , dont j'ai repris l'intégralité du code et le contenu de ce message.
### QA
- Suivre les instructions `update.md`, vérifier que tout s'est bien passé.

---

> - Avec un utilisateur X, suivez un forum A et B.
> - Avec un utilisateur Y, créez un sujet dans le forum A.
> - Avec un staff, déplacez le sujet du forum A vers le forum B.
> - Avec l'utilisateur X, consultez la notification du sujet et constatez que c'est marqué comme lu.
> - Avec l'utilisateur Y, créez un sujet dans le forum A.
> - Avec le staff, déplacez le sujet du forum A vers le forum C.
> - Avec l'utilisateur X, consultez la notification du sujet et constatez que c'est marqué comme lu.
> - Avec un admin, regardez les deux notifications dans l'admin.
> - Constatez que la première notification est vivante (`is_dead=False`).
> - Constatez que la seconde notification est morte (`is_dead=True`).
