### PR TITLE
Ajoute l'autocompletion pour les tags des sujets.

### DIFF
--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -11,7 +11,6 @@ from django.views.generic.detail import SingleObjectMixin
 from zds.forum.models import Forum, Post, TopicRead
 from zds.notification import signals
 from zds.notification.models import TopicAnswerSubscription, Notification, NewTopicSubscription
-from zds.utils.forums import get_tag_by_title
 from zds.utils.models import Alert
 
 
@@ -88,8 +87,7 @@ class TopicEditMixin(object):
 
     @staticmethod
     def perform_edit_info(topic, data, editor):
-        (tags, title) = get_tag_by_title(data.get('title'))
-        topic.title = title
+        topic.title = data.get('title')
         topic.subtitle = data.get('subtitle')
         topic.save()
 
@@ -97,7 +95,8 @@ class TopicEditMixin(object):
 
         # add tags
         topic.tags.clear()
-        topic.add_tags(tags)
+        if data.get('tags'):
+            topic.add_tags(data.get('tags').split(','))
         return topic
 
 

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -283,7 +283,8 @@ class TopicNewTest(TestCase):
         data = {
             'title': 'Title of the topic',
             'subtitle': 'Subtitle of the topic',
-            'text': 'A new post!'
+            'text': 'A new post!',
+            'tags': ''
         }
         self.client.post(reverse('topic-new') + '?forum={}'.format(forum.pk), data, follow=False)
         self.client.logout()
@@ -291,7 +292,8 @@ class TopicNewTest(TestCase):
         data = {
             'title': 'Title of the topic',
             'subtitle': 'Subtitle of the topic',
-            'text': 'A new post!'
+            'text': 'A new post!',
+            'tags': ''
         }
         self.client.post(reverse('topic-new') + '?forum={}'.format(forum.pk), data, follow=False)
         self.client.logout()
@@ -350,7 +352,8 @@ class TopicNewTest(TestCase):
         data = {
             'title': 'Title of the topic',
             'subtitle': 'Subtitle of the topic',
-            'text': 'A new post!'
+            'text': 'A new post!',
+            'tags': ''
         }
         response = self.client.post(reverse('topic-new') + '?forum={}'.format(forum.pk), data, follow=False)
 

--- a/zds/notification/tests.py
+++ b/zds/notification/tests.py
@@ -45,7 +45,8 @@ class NotificationForumTest(TestCase):
             {
                 'title': u'Super sujet',
                 'subtitle': u'Pour tester les notifs',
-                'text': u'En tout cas l\'un abonnement'
+                'text': u'En tout cas l\'un abonnement',
+                'tags': ''
             },
             follow=False)
         self.assertEqual(result.status_code, 302)

--- a/zds/utils/forums.py
+++ b/zds/utils/forums.py
@@ -14,52 +14,6 @@ from zds.utils.mixins import QuoteMixin
 from zds.utils.models import CommentVote
 
 
-def get_tag_by_title(title):
-    """
-    Extract tags from title.
-    In a title, tags can be set this way:
-    > [Tag 1][Tag 2] There is the real title
-    Rules to detect tags:
-    - Tags are enclosed in square brackets. This allows multi-word tags instead of hashtags.
-    - Tags can embed square brackets: [Tag] is a valid tag and must be written [[Tag]] in the raw title
-    - All tags must be declared at the beginning of the title. Example: _"Title [tag]"_ will not create a tag.
-    - Tags and title correctness (example: empty tag/title detection) is **not** checked here
-    :param title: The raw title
-    :return: A tuple: (the tag list, the title without the tags).
-    """
-    nb_bracket = 0
-    current_tag = u""
-    current_title = u""
-    tags = []
-    continue_parsing_tags = True
-    original_title = title
-    for char in title:
-
-        if char == u"[" and nb_bracket == 0 and continue_parsing_tags:
-            nb_bracket += 1
-        elif nb_bracket > 0 and char != u"]" and continue_parsing_tags:
-            current_tag = current_tag + char
-            if char == u"[":
-                nb_bracket += 1
-        elif char == u"]" and nb_bracket > 0 and continue_parsing_tags:
-            nb_bracket -= 1
-            if nb_bracket == 0 and current_tag.strip() != u"":
-                tags.append(current_tag.strip())
-                current_tag = u""
-            elif current_tag.strip() != u"" and nb_bracket > 0:
-                current_tag = current_tag + char
-
-        elif (char != u"[" and char.strip() != "") or not continue_parsing_tags:
-            continue_parsing_tags = False
-            current_title = current_title + char
-    title = current_title
-    # if we did not succed in parsing the tags
-    if nb_bracket != 0:
-        return [], original_title
-
-    return tags, title.strip()
-
-
 def create_topic(
         request,
         author,
@@ -67,16 +21,15 @@ def create_topic(
         title,
         subtitle,
         text,
+        tags='',
         key=None,
         related_publishable_content=None):
     """create topic in forum"""
 
-    (tags, title_only) = get_tag_by_title(title[:Topic._meta.get_field('title').max_length])
-
     # Creating the thread
     n_topic = Topic()
     n_topic.forum = forum
-    n_topic.title = title_only
+    n_topic.title = title
     n_topic.subtitle = subtitle
     n_topic.pubdate = datetime.now()
     n_topic.author = author
@@ -86,7 +39,8 @@ def create_topic(
     if related_publishable_content is not None:
         related_publishable_content.beta_topic = n_topic
         related_publishable_content.save()
-    n_topic.add_tags(tags)
+    if tags:
+        n_topic.add_tags(tags.split(','))
     n_topic.save()
 
     # Add the first message


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) | N/A |
### QA

Sur une instance avec des tags existants :
- Créez un sujet et constatez que l'autocompletion fonctionne sur les tags.
- Validez et constatez que les tags ont été rajoutés correctement.
- Editez ce même sujet, vérifiez que l'autocompletion fonctionne toujours et que les anciennes informations ont été récupérées.
- Validez et constatez que les tags ont été mis à jour (ou pas si vous n'avez fais aucune modification).
