### PR TITLE
Corrige le pluriel pour le nombre d’abonnés

### DIFF
--- a/templates/notification/subscription_count_template.html
+++ b/templates/notification/subscription_count_template.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 
 <span class="disabled mobile-menu-link">
-  {% blocktrans count subscriber_count=subscriber_count %}
-    Il y a {{ subscriber_count }} abonné
-  {% plural %}
-    Il y a {{ subscriber_count }} abonnés
-  {% endblocktrans %}
+    {% blocktrans count subscriber_count=subscriber_count %}
+        Il y a {{ subscriber_count }} abonné
+    {% plural %}
+        Il y a {{ subscriber_count }} abonnés
+    {% endblocktrans %}
 </span>

--- a/templates/notification/subscription_count_template.html
+++ b/templates/notification/subscription_count_template.html
@@ -1,3 +1,9 @@
 {% load i18n %}
 
-<span class="disabled mobile-menu-link">{% blocktrans %}Il y a {{ subscriber_count }} abonné{{ subscriber_count|pluralize }}{% endblocktrans %}</span>
+<span class="disabled mobile-menu-link">
+  {% blocktrans count subscriber_count=subscriber_count %}
+    Il y a {{ subscriber_count }} abonné
+  {% plural %}
+    Il y a {{ subscriber_count }} abonnés
+  {% endblocktrans %}
+</span>


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3797 |
### QA
- Vérifier que quand un membre a plusieurs abonnés, le mot « abonné » est au pluriel.
- Vérifier que quand il en a 0, il est au singulier (dans certaines langues, 0 est pluriel).

Vu que le template du compteur est commun aux suivis des forums, des contenus et des membres, je ne sais pas s’il est nécessaire de le tester pour les trois.
