### PR TITLE
Renvoie les notifications lues et non lues.

### DIFF
--- a/zds/notification/api/tests.py
+++ b/zds/notification/api/tests.py
@@ -10,6 +10,7 @@ from rest_framework_extensions.settings import extensions_api_settings
 from zds.member.api.tests import create_oauth2_client, authenticate_client
 from zds.member.factories import ProfileFactory
 from zds.mp.factories import PrivateTopicFactory
+from zds.notification.models import Notification
 from zds.utils.mps import send_message_mp
 
 
@@ -38,7 +39,6 @@ class NotificationListAPITest(APITestCase):
         """
         self.create_notification_for_pm(ProfileFactory().user, self.profile.user)
         response = self.client.get(reverse('api:notification:list'))
-        print response
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('count'), 1)
 
@@ -60,7 +60,23 @@ class NotificationListAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('count'), 0)
 
+    def test_list_of_all_notifications(self):
+        """
+        Gets list of read and unread notifications.
+        """
+        topic1 = self.create_notification_for_pm(ProfileFactory().user, self.profile.user)
+        self.create_notification_for_pm(ProfileFactory().user, self.profile.user)
+
+        notification = Notification.objects.get(object_id=topic1.last_message.pk, is_read=False)
+        notification.is_read = True
+        notification.save()
+
+        response = self.client.get(reverse('api:notification:list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), 2)
+
     def create_notification_for_pm(self, sender, target):
         topic = PrivateTopicFactory(author=sender)
         topic.participants.add(target)
         send_message_mp(author=sender, n_topic=topic, text='Testing')
+        return topic

--- a/zds/notification/api/views.py
+++ b/zds/notification/api/views.py
@@ -79,7 +79,7 @@ class NotificationListAPI(ListAPIView):
         return self.list(request, *args, **kwargs)
 
     def get_queryset(self):
-        queryset = Notification.objects.get_unread_notifications_of(self.request.user)
+        queryset = Notification.objects.get_notifications_of(self.request.user)
         subscription_type = self.request.query_params.get('subscription_type', None)
         if subscription_type:
             queryset = queryset.filter(subscription__content_type__model=subscription_type)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3805 |
### QA
- Avec un compte avec des notifications lues et non lues, interrogez l'API pour récupérer les notifications.
- Constatez qu'il y a les notifications lues et non lues.
