### PR TITLE
Fix #3810 : ajout d'un template filter pluralize_fr

### DIFF
--- a/templates/forum/includes/topic_row.part.html
+++ b/templates/forum/includes/topic_row.part.html
@@ -1,6 +1,7 @@
 {% load date %}
 {% load profile %}
 {% load i18n %}
+{% load pluralize_fr %}
 
 
 
@@ -56,9 +57,9 @@
     {% endwith %}
     {% with nb_post=topic.get_post_count %}
         <p class="topic-answers {% if nb_post <= 1 %}topic-no-answer{% endif %}">
-            {% if nb_post > 1 %}
-                {{ nb_post|add:"-1" }} {% trans "réponse" %}{{ nb_post|add:"-1"|pluralize }}
-            {% endif %}
+            {% blocktrans with plural=nb_post|pluralize_fr %}
+                réponse{{ plural }}
+            {% endblocktrans %}
         </p>
     {% endwith %}
     <p class="topic-last-answer">

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -3,6 +3,7 @@
 {% load date %}
 {% load set %}
 {% load i18n %}
+{% load pluralize_fr %}
 
 
 {% if topic.author == message.author and helpful_link %}
@@ -265,7 +266,7 @@
                         {% if user.is_authenticated and user != message.author %}
                             <button
                                 value="{% if message.pk in user_like %}neutral{% else %}like{% endif %}"
-                                title="Ce message est utile {% if message.like > 0 %}({{ message.like }} personne{{ message.like|pluralize }} {% if message.like > 1 %}ont{% else %}a{% endif %} trouvé ce message utile){% endif %}"
+                                title="{% trans "Ce message est utile" %} {% if message.like > 0 %}{% blocktrans with like_count=message.like plural=message.like|pluralize_fr plural_word=message.like|pluralize_fr:"a,ont" %}({{ like_count }} personne{{ plural }} {{ plural_word }} trouvé ce message utile){% endblocktrans %}{% endif %}"
                                 class="upvote
                                        ico-after
                                        {% if message.like > message.dislike %}more-voted{% endif %}
@@ -277,7 +278,7 @@
 
                             <button
                                 value="{% if message.pk in user_dislike %}neutral{% else %}dislike{% endif %}"
-                                title="Ce message n'est pas utile {% if message.dislike > 0 %}({{ message.dislike }} personne{{ message.dislike|pluralize }} n'{% if message.dislike > 1 %}ont{% else %}a{% endif %} pas trouvé ce message utile){% endif %}"
+                                title="{% trans "Ce message n'est pas utile" %}{% if message.dislike > 0 %}{% blocktrans with dislike_count=message.dislike plural=message.dislike|pluralize_fr plural_word=message.dislike|pluralize_fr:"a,ont" %}({{ dislike_count }} personne{{ plural }} n'{{ plural_word }} pas trouvé ce message utile){% endblocktrans %}{% endif %}"
                                 class="downvote
                                        ico-after
                                        {% if message.like < message.dislike %}more-voted{% endif %}
@@ -293,7 +294,7 @@
                                        {% if message.like > message.dislike %}more-voted{% endif %}
                                        {% if message.like > 0 %}has-vote{% endif %}"
                                 {% if message.like > 0 %}
-                                    title="{{ message.like }} personne{{ message.like|pluralize }} {% if message.like > 1 %}ont{% else %}a{% endif %} trouvé ce message utile"
+                                    title="{% blocktrans with like_count=message.like plural=message.like|pluralize_fr plural_word=message.like|pluralize_fr:"a,ont" %}{{ like_count }} personne{{ plural }} {{ plural_word }} trouvé ce message utile{% endblocktrans %}"
                                 {% endif %}
                             >
                                 +{{ message.like }}
@@ -304,7 +305,7 @@
                                        {% if message.like < message.dislike %}more-voted{% endif %}
                                        {% if message.dislike > 0 %}has-vote{% endif %}"
                                 {% if message.dislike > 0 %}
-                                    title="{{ message.dislike }} personne{{ message.dislike|pluralize }} n'{% if message.dislike > 1 %}ont{% else %}a{% endif %} pas trouvé ce message utile"
+                                    title="{% blocktrans with dislike_count=message.dislike plural=message.dislike|pluralize_fr plural_word=message.dislike|pluralize_fr:"a,ont" %}{{ dislike_count }} personne{{ plural }} n'{{ plural_word }} pas trouvé ce message utile{% endblocktrans %}"
                                 {% endif %}
                             >
                                 -{{ message.dislike }}

--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -2,6 +2,7 @@
 {% load date %}
 {% load profile %}
 {% load i18n %}
+{% load pluralize_fr %}
 
 
 
@@ -39,7 +40,11 @@
                         {% endspaceless %}</a>
 
                         <p class="topic-members">
-                            <span class="topic-members-label">{% trans "Participant" %}{{ topic.participants.all|length|add:"1"|pluralize }} :</span>
+                            <span class="topic-members-label">
+                                {% blocktrans with plural=topic.participants.all|length|pluralize_fr %}
+                                    Participant{{ plural }} :
+                                {% endblocktrans %}
+                            </span>
                             <em>
                                 {% include "misc/member_item.part.html" with member=topic.author avatar=True %}
                             </em>{% spaceless %}
@@ -50,11 +55,13 @@
                         </p>
                     </div>
                 {% endwith %}
-                <p class="topic-answers {% if topic.get_post_count <= 1 %}topic-no-answer{% endif %}">
-                    {% if topic.get_post_count > 1 %}
-                        {{ topic.get_post_count|add:"-1" }} {% trans "réponse" %}{{ topic.get_post_count|add:"-1"|pluralize }}
-                    {% endif %}
-                </p>
+                {% with post_count=opic.get_post_count %}
+                    <p class="topic-answers {% if post_count <= 1 %}topic-no-answer{% endif %}">
+                        {% blocktrans with plural=post_count|pluralize_fr %}
+                            réponse{{ plural }}
+                        {% endblocktrans %}
+                    </p>
+                {% endwith %}
                 <p class="topic-last-answer">
                     {% with answer=topic.get_last_answer %}
                         {% if answer %}

--- a/templates/notification/subscription_count_template.html
+++ b/templates/notification/subscription_count_template.html
@@ -1,21 +1,16 @@
 {% load i18n %}
+{% load pluralize_fr %}
 
 {% if own_profile %}
-    {% blocktrans count subscriber_count=subscriber_count %}
-        Vous avez {{ subscriber_count }} abonné
-    {% plural %}
-        Vous avez {{ subscriber_count }} abonnés
+    {% blocktrans with plural=subscriber_count|pluralize_fr %}
+        Vous avez {{ subscriber_count }} abonné{{ plural }}
     {% endblocktrans %}
 {% elif own_profile == False %}
-    {% blocktrans count subscriber_count=subscriber_count %}
-        {{ subscriber_count }} abonné
-    {% plural %}
-        {{ subscriber_count }} abonnés
+    {% blocktrans with plural=subscriber_count|pluralize_fr %}
+        {{ subscriber_count }} abonné{{ plural }}
     {% endblocktrans %}
 {% else %}
-    {% blocktrans count subscriber_count=subscriber_count %}
-        ({{ subscriber_count }} abonné)
-    {% plural %}
-        ({{ subscriber_count }} abonnés)
+    {% blocktrans with plural=subscriber_count|pluralize_fr %}
+        ({{ subscriber_count }} abonné{{ plural }})
     {% endblocktrans %}
 {% endif %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -7,6 +7,7 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load interventions %}
+{% load pluralize_fr %}
 
 
 {% block title %}
@@ -172,7 +173,7 @@
             <span itemprop="commentCount">
                 {{ content.get_note_count }}
             </span>
-            {% trans "commentaire" %}{{ content.get_note_count|pluralize }}
+            {% trans "commentaire" %}{{ content.get_note_count|pluralize_fr }}
         {% else %}
             {% trans "Aucun commentaire" %}
         {% endif %}

--- a/templates/tutorialv2/view/tags.html
+++ b/templates/tutorialv2/view/tags.html
@@ -4,6 +4,7 @@
 {% load date %}
 {% load i18n %}
 {% load captureas %}
+{% load pluralize_fr %}
 
 
 {% block title %}
@@ -29,7 +30,11 @@
                 <div class="content-tag">
                     <a href="{% url 'content:list' %}?tag={{ tag.title|urlencode }}">
                         <div class="tag-title">{{ tag }}</div>
-                        <div class="tag-count">{{ tag.num_content }} {% trans "contenu" %}{{ tag.num_content|pluralize }}</div>
+                        <div class="tag-count">
+                            {%  blocktrans with tag_count=tag.num_content plural=tag.num_content|pluralize_fr %}
+                                {{ tag_count }} contenu{{ plural }}
+                            {%  endblocktrans %}
+                        </div>
                     </a>
                 </div>
             {% empty %}

--- a/zds/utils/templatetags/pluralize_fr.py
+++ b/zds/utils/templatetags/pluralize_fr.py
@@ -1,0 +1,32 @@
+# coding: utf-8
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter(is_safe=False)
+def pluralize_fr(value, arg='s'):
+    """
+    Based on default pluralize filter : https://github.com/django/django/blob/master/django/template/defaultfilters.py
+    Support french (-1, 0 and 1 are singular).
+    """
+    if ',' not in arg:
+        arg = ',' + arg
+    bits = arg.split(',')
+    if len(bits) > 2:
+        return ''
+    singular_suffix, plural_suffix = bits[:2]
+
+    try:
+        if not (-2 < float(value) < 2):
+            return plural_suffix
+    except ValueError:  # Invalid string that's not a number.
+        pass
+    except TypeError:  # Value isn't a string or a number; maybe it's a list?
+        try:
+            if not (-2 < len(value) < 2):
+                return plural_suffix
+        except TypeError:  # len() of unsized object.
+            pass
+    return singular_suffix

--- a/zds/utils/templatetags/tests/tests_pluralize_fr.py
+++ b/zds/utils/templatetags/tests/tests_pluralize_fr.py
@@ -1,0 +1,42 @@
+# coding: utf-8
+
+# Based on default pluralize filter tests :
+# https://github.com/django/django/blob/master/tests/template_tests/filter_tests/test_pluralize.py
+
+from decimal import Decimal
+
+from django.test import SimpleTestCase
+
+from zds.utils.templatetags.pluralize_fr import pluralize_fr
+
+
+class FunctionTests(SimpleTestCase):
+
+    def test_integers(self):
+        self.assertEqual(pluralize_fr(1), '')
+        self.assertEqual(pluralize_fr(0), '')
+        self.assertEqual(pluralize_fr(2), 's')
+
+    def test_floats(self):
+        self.assertEqual(pluralize_fr(0.5), '')
+        self.assertEqual(pluralize_fr(1.5), '')
+        self.assertEqual(pluralize_fr(2.5), 's')
+
+    def test_decimals(self):
+        self.assertEqual(pluralize_fr(Decimal(1)), '')
+        self.assertEqual(pluralize_fr(Decimal(0)), '')
+        self.assertEqual(pluralize_fr(Decimal(2)), 's')
+
+    def test_lists(self):
+        self.assertEqual(pluralize_fr([1]), '')
+        self.assertEqual(pluralize_fr([]), '')
+        self.assertEqual(pluralize_fr([1, 2, 3]), 's')
+
+    def test_suffixes(self):
+        self.assertEqual(pluralize_fr(1, 'es'), '')
+        self.assertEqual(pluralize_fr(0, 'es'), '')
+        self.assertEqual(pluralize_fr(2, 'es'), 'es')
+        self.assertEqual(pluralize_fr(1, 'y,ies'), 'y')
+        self.assertEqual(pluralize_fr(0, 'y,ies'), 'y')
+        self.assertEqual(pluralize_fr(2, 'y,ies'), 'ies')
+        self.assertEqual(pluralize_fr(0, 'y,ies,error'), '')


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3810 |
### QA

Vérifier dans les morceaux d'HTML qui suivent si la marque du pluriel est bien appliquée comme il se doit avec pour quantité 0, 1 et 2 (marque du pluriel uniquement sur 2) : 
- Nombre de réponses à un topic
- Nombre de +1/-1 sur un message
- Nombre de participants à un MP
- Nombre de réponses à un MP
- Nombre de personne qui suivent un membre
