### PR TITLE
Fix #3692 : Ajout doc HTTP/2 + reset du cache lors d'une MEP

### DIFF
--- a/doc/source/install/configs/nginx/sites-available/zestedesavoir
+++ b/doc/source/install/configs/nginx/sites-available/zestedesavoir
@@ -12,8 +12,8 @@ map $http_host $robots_tag_header {
 server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
-	listen 443 ssl spdy default_server;
-	listen [::]:443 ssl spdy default_server;
+	listen 443 ssl http2 default_server;
+	listen [::]:443 ssl http2 default_server;
 
 	server_name zestedesavoir.com;
 

--- a/doc/source/install/deploy-in-production.rst
+++ b/doc/source/install/deploy-in-production.rst
@@ -105,7 +105,11 @@ Gunicorn
 Nginx
 ~~~~~
 
-Installer nginx. La configuration nginx de Zeste de Savoir est séparée en plusieurs fichiers, en plus des quelques fichiers de configuration par défaut de nginx:
+Installer nginx.
+
+Une version récente de nginx est nécessaire pour utiliser HTTP/2. Si la version installée est inférieure à la version 1.9.5 il faut la mettre à jour avec celle du dépot backports : ``sudo apt-get -t jessie-backports install nginx openssl``. Toutefois, HTTP/2 n'est pas nécessaire au bon fonctionnement de Zeste de Savoir, pensez juste à adapter ``sites-available/zestedesavoir``.
+
+La configuration nginx de Zeste de Savoir est séparée en plusieurs fichiers, en plus des quelques fichiers de configuration par défaut de nginx:
 
 .. code:: text
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -61,6 +61,9 @@ deactivate
 # Restart zds
 sudo systemctl restart zds.{service,socket}
 
+# clean the cache by restarting it
+sudo service memcached restart
+
 # Exit maintenance mode
 sudo rm $ENV_PATH/webroot/maintenance.html
 

--- a/update.md
+++ b/update.md
@@ -756,6 +756,29 @@ Issue 3762
 
 (Ne pas oublier de lancer les migrations en terminant cette MEP !)
 
+HTTP/2
+------
+
+Installer une version plus récente de nginx qui supporte HTTP/2 et vérifier la configuration de nginx :
+
+```
+sudo apt-get update && apt-get -t jessie-backports install nginx openssl
+sudo nginx -t
+```
+
+Pour chaque fichier dans `/etc/nginx/sites-enabled/`, remplacer spdy par http2:
+
+```diff
+-        listen 443 ssl spdy default_server;
+-        listen [::]:443 ssl spdy default_server;
++        listen 443 ssl http2 default_server;
++        listen [::]:443 ssl http2 default_server;
+```
+
+Relancer nginx : `sudo service nginx restart``
+
+Vérifier que zds fonctionne comme il faut en HTTP et HTTPS.
+
 ---
 
 **Notes auxquelles penser lors de l'édition de ce fichier (à laisser en bas) :**


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) | #3692 |
### QA
- Je laisse @sandhose, @vhf ou @SpaceFox valider tout ça.
