### PR TITLE
Empêche d’éditer un message masqué

### DIFF
--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -139,7 +139,7 @@
     <a href="{% url 'topic-new' %}?forum={{ topic.forum.pk }}" class="new-btn ico-after more blue">
         {% trans "Nouveau sujet" %}
     </a>
-    {% if topic.author.pk == user.pk or is_staff %}
+    {% if topic.author.pk == user.pk and topic.first_post.is_visible or is_staff %}
     <a href="{% url 'topic-edit' %}?topic={{ topic.pk }}" class="new-btn ico-after edit blue">
         {% trans "Éditer le sujet" %}
     </a>

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -1260,6 +1260,28 @@ class PostEditTest(TestCase):
         self.assertEqual(1, len(post.alerts.all()))
         self.assertEqual(text_expected, post.alerts.all()[0].text)
 
+    def test_failure_edit_post_hidden_message_by_non_staff(self):
+        """Test that a non staff cannot access the page to edit a hidden message"""
+
+        profile = ProfileFactory()
+        category, forum = create_category()
+        topic = add_topic_in_a_forum(forum, profile)
+
+        self.assertTrue(self.client.login(username=profile.user.username, password='hostel77'))
+        data = {
+            'delete_message': ''
+        }
+
+        response = self.client.post(
+            reverse('post-edit') + '?message={}'.format(topic.last_message.pk), data, follow=False)
+        self.assertEqual(302, response.status_code)
+
+        response = self.client.get(reverse('post-edit') + '?message={}'.format(topic.last_message.pk))
+        self.assertEqual(403, response.status_code)
+
+        response = self.client.get(reverse('topic-edit') + '?topic={}'.format(topic.pk), follow=False)
+        self.assertEqual(403, response.status_code)
+
 
 class PostUsefulTest(TestCase):
     def test_failure_post_useful_require_method_post(self):

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -262,6 +262,8 @@ class TopicEdit(UpdateView, SingleObjectMixin, TopicEditMixin):
         if ('text' in request.POST or request.method == 'GET') \
                 and self.object.author != request.user and not request.user.has_perm('forum.change_topic'):
             raise PermissionDenied
+        if not self.object.first_post().is_visible and not request.user.has_perm('forum.change_topic'):
+            raise PermissionDenied
         if 'page' in request.POST:
             try:
                 self.page = int(request.POST.get('page'))
@@ -479,6 +481,8 @@ class PostEdit(UpdateView, SinglePostObjectMixin, PostEditMixin):
             raise PermissionDenied
         if self.object.author != request.user and not request.user.has_perm(
                 'forum.change_post') and 'signal_message' not in request.POST:
+            raise PermissionDenied
+        if not self.object.is_visible and not request.user.has_perm('forum.change_post'):
             raise PermissionDenied
         return super(PostEdit, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3804 |
### QA
- Créer un topic avec un membre non staff.
- Masquer le premier message.
- Vérifier que le bouton « Éditer le sujet » n’apparaît plus.
- Vérifier qu’on ne peut pas éditer le message en passant par l’url `forums/message/editer/?message={pk_mesasage}`.
-  Vérifier qu’on ne peut pas éditer le sujet en passant par l’url `forums/sujet/editer/?topic={pk_topic}`.
- Vérifier qu’un membre staff a toujours accès au bouton « Éditer le sujet » et qu’il peut éditer le sujet et le message.
