### PR TITLE
[beta][v20] Pas de signalement MP; tests

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -116,6 +116,7 @@
                         </form>
                     </li>
                 {% endif %}
+                {% if not is_mp %}
                 <li>
                     <a href="#signal-message-{{ message.id }}" class="ico-after alert open-modal">
                         {% trans "Signaler" %}
@@ -132,6 +133,7 @@
                         </button>
                     </form>
                 </li>
+                {% endif %}
             </ul>
         {% endif %}
 

--- a/templates/mp/post/new.html
+++ b/templates/mp/post/new.html
@@ -62,7 +62,7 @@
                 {% url "private-posts-new" topic.pk topic.slug %}?cite={{ message.pk }}
             {% endcaptureas %}
 
-            {% include "misc/message.part.html" with can_hide=False %}
+            {% include "misc/message.part.html" with can_hide=False is_mp=True %}
         {% endfor %}
     </div>
 {% endblock %}

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -72,7 +72,7 @@
                 {% set False as can_edit %}
             {% endif %}
 
-            {% include "misc/message.part.html" with can_hide=False %}
+            {% include "misc/message.part.html" with can_hide=False is_mp=True %}
         {% endfor %}
     </div>
 

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -217,6 +217,26 @@ class TopicViewTest(TestCase):
                                                    }) + '?page=42')
         self.assertEqual(response.status_code, 404)
 
+    def test_available_actions(self):
+        """we should be able to cite, but not hide or alert"""
+
+        login_check = self.client.login(
+            username=self.profile1.user.username,
+            password='hostel77'
+        )
+        self.assertTrue(login_check)
+
+        response = self.client.get(reverse('private-posts-list',
+                                           kwargs={'pk': self.topic1.pk,
+                                                   'topic_slug': self.topic1.slug,
+                                                   }))
+        # Citation button
+        self.assertContains(response, 'Citer')
+        # no Alert button
+        self.assertNotContains(response, 'Signaler')
+        # no Hide button
+        self.assertNotContains(response, 'Masquer')
+
     def test_more_than_one_message(self):
         """ test get second page """
 


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3844 |
### QA
- Le bouton "Signaler" ne doit pas s'afficher dans les MPs.
