### PR TITLE
[v20] L'éditeur ne se duplique plus lors d'un copier-coller sur Safari 9.x

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -173,8 +173,11 @@
 
             this.addEvent(document.getElementById("content"), "DOMNodeInserted", (function(_this){
                 return function(e) {
-                    if (/md.editor/.test(e.target.className)) {
-                        _this.setup(e.target.id);
+                    var element = e.target;
+                    if (/md.editor/.test(element.className)) {
+                        if(element.previousElementSibling.indexOf("zform-toolbar") > -1) {
+                            _this.setup(element.id);
+                        }
                     }
                 };
             }) (this));


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3835 |

La barre d'outil de l'éditeur de texte ne se duplique plus lors d'un copier-coller sur ~~Chrome~~.

**Apparemment c'est sur Safari donc je ne suis pas sûr que le bug soit corrigé !**

**QA :**
- Vérifier que le bug ne se produit plus ~~sur Chrome~~
- Vérifier que la barre d'outil fonctionne encore
