### PR TITLE
Rend le boutton 'cette réponse m'a aidé' disponible sur les message de l'OP

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -235,30 +235,28 @@
 
                 {% if karma_link %}
                     <div class="message-karma{% if user.is_authenticated and user != message.author %} can-vote{% endif %}" data-karma-uri="{{ karma_link }}">
-                        {% if user.is_authenticated and helpful_link and not is_author %}
-                            {% if message.author != user or perms_change %}
-                                {% if topic.author == user or perms_change %}
-                                    <form action="{{ helpful_link }}" method="post">
-                                        {% csrf_token %}
-                                        <button
-                                            type="submit"
-                                            class="tick ico-after {% if message.is_useful %}green{% endif %}"
-                                            data-ajax-input="mark-message-as-useful"
-                                            data-content-on-click="
-                                                {% if message.is_useful %}
-                                                    {% trans "Cette réponse m'a aidé" %}
-                                                {% else %}
-                                                    {% trans "Cette réponse ne m'a pas aidé" %}
-                                                {% endif %}"
-                                        >
+                        {% if user.is_authenticated and helpful_link %}
+                            {% if topic.author == user or perms_change %}
+                                <form action="{{ helpful_link }}" method="post">
+                                  {% csrf_token %}
+                                    <button
+                                        type="submit"
+                                        class="tick ico-after {% if message.is_useful %}green{% endif %}"
+                                        data-ajax-input="mark-message-as-useful"
+                                        data-content-on-click="
                                             {% if message.is_useful %}
-                                                {% trans "Cette réponse ne m'a pas aidé" %}
-                                            {% else %}
                                                 {% trans "Cette réponse m'a aidé" %}
-                                            {% endif %}
-                                        </button>
-                                    </form>
-                                {% endif %}
+                                            {% else %}
+                                                {% trans "Cette réponse ne m'a pas aidé" %}
+                                            {% endif %}"
+                                    >
+                                        {% if message.is_useful %}
+                                            {% trans "Cette réponse ne m'a pas aidé" %}
+                                        {% else %}
+                                            {% trans "Cette réponse m'a aidé" %}
+                                        {% endif %}
+                                    </button>
+                                </form>
                             {% endif %}
                         {% endif %}
 

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -568,9 +568,9 @@ class ForumMemberTests(TestCase):
 
         # useful the first post
         result = self.client.post(reverse('post-useful') + '?message={0}'.format(post1.pk), follow=False)
-        self.assertEqual(result.status_code, 403)
+        self.assertEqual(result.status_code, 302)
 
-        self.assertEqual(Post.objects.get(pk=post1.pk).is_useful, False)
+        self.assertEqual(Post.objects.get(pk=post1.pk).is_useful, True)
         self.assertEqual(Post.objects.get(pk=post2.pk).is_useful, True)
         self.assertEqual(Post.objects.get(pk=post3.pk).is_useful, False)
 
@@ -581,10 +581,10 @@ class ForumMemberTests(TestCase):
 
         result = self.client.post(reverse('post-useful') + '?message={0}'.format(post5.pk), follow=False)
 
-        self.assertEqual(result.status_code, 403)
+        self.assertEqual(result.status_code, 302)
 
         self.assertEqual(Post.objects.get(pk=post4.pk).is_useful, False)
-        self.assertEqual(Post.objects.get(pk=post5.pk).is_useful, False)
+        self.assertEqual(Post.objects.get(pk=post5.pk).is_useful, True)
 
         # useful if you are staff
         StaffProfileFactory().user
@@ -595,7 +595,7 @@ class ForumMemberTests(TestCase):
         result = self.client.post(reverse('post-useful') + '?message={0}'.format(post4.pk), follow=False)
         self.assertNotEqual(result.status_code, 403)
         self.assertEqual(Post.objects.get(pk=post4.pk).is_useful, True)
-        self.assertEqual(Post.objects.get(pk=post5.pk).is_useful, False)
+        self.assertEqual(Post.objects.get(pk=post5.pk).is_useful, True)
 
     def test_failing_useful_post(self):
         """To test some failing cases when a member mark a post is useful."""

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -1312,7 +1312,7 @@ class PostUsefulTest(TestCase):
         self.assertTrue(self.client.login(username=profile.user.username, password='hostel77'))
         response = self.client.post(reverse('post-useful') + '?message={}'.format(topic.last_message.pk))
 
-        self.assertEqual(403, response.status_code)
+        self.assertEqual(302, response.status_code)
 
     def test_failure_post_useful_when_not_author_of_topic(self):
         another_profile = ProfileFactory()

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -549,7 +549,7 @@ class PostUseful(UpdateView, SinglePostObjectMixin, PostEditMixin):
         self.object = self.get_object()
         if not self.object.topic.forum.can_read(request.user):
             raise PermissionDenied
-        if self.object.author == request.user or self.object.topic.author != request.user:
+        if self.object.topic.author != request.user:
             if not request.user.has_perm("forum.change_post"):
                 raise PermissionDenied
         return super(PostUseful, self).dispatch(request, *args, **kwargs)


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) | #3867 |
### QA
- Vérifier qu'un OP peut cliquer sur "cette réponse m'a aidé" sur tous les messages de son topic
- Vérifier qu'un utilisateur qui n'est pas auteur ne peut pas cliquer sur ce boutton
- Vu qu'il s'agit surtout de la suppression d'un peu de code, il faut vérifier que ça ne casse pas d'autres tests 
