### PR TITLE
Marque le MP de réservation du staff comme lue.

### DIFF
--- a/templates/forum/find/post.html
+++ b/templates/forum/find/post.html
@@ -45,7 +45,7 @@
                 {% for post in posts %}
                 <tr>
                     <td>
-                        <div class="forum-entry-title {% if user.is_authenticated %} {% if topic.never_read %} unread {% endif %} {% endif %}">
+                        <div class="forum-entry-title {% if user.is_authenticated %} {% if topic.is_unread %} unread {% endif %} {% endif %}">
                             <a href="{{ post.get_absolute_url }}">{{ post.topic.title }} </a>
                             {% if post.topic.subtitle %} <p> {{ post.topic.subtitle }} </p> {% endif %}
                         </div>

--- a/templates/forum/find/topic.html
+++ b/templates/forum/find/topic.html
@@ -43,7 +43,7 @@
                 {% for topic in topics %}
                 <tr>
                     <td>
-                        <div class="forum-entry-title {% if user.is_authenticated %} {% if topic.never_read %} unread {% endif %} {% endif %}">
+                        <div class="forum-entry-title {% if user.is_authenticated %} {% if topic.is_unread %} unread {% endif %} {% endif %}">
                         <a href="{{ topic.get_absolute_url }}">{{ topic.title }} </a>
                             {% if topic.subtitle %} <p> {{ topic.subtitle }} </p> {% endif %}
                         </div>

--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -27,14 +27,14 @@
 {% block content %}
     <div class="topic-list navigable-list">
         {% for topic in privatetopics %}
-            <div class="topic {% if topic.never_read %}unread{% endif %} navigable-elem">
+            <div class="topic {% if topic.is_unread %}unread{% endif %} navigable-elem">
                 <div class="topic-infos">
                     <input name="items" type="checkbox" value="{{ topic.pk }}" form="delete-conversations">
                 </div>
                 {% with profile=topic.author|profile %}
                     <div class="topic-description">
                         <a href="{{ topic.get_absolute_url }}" class="topic-title-link navigable-link">{% spaceless %}
-                            {% if topic.never_read %}<span class="a11y">{% trans "Non-lu" %} :</span>{% endif %}
+                            {% if topic.is_unread %}<span class="a11y">{% trans "Non-lu" %} :</span>{% endif %}
                             <span class="topic-title">{{ topic.title }}</span>
                             <span class="topic-subtitle">{{ topic.subtitle }}</span>
                         {% endspaceless %}</a>

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -155,7 +155,7 @@ class PrivateTopic(models.Model):
         """
         return self.participants.count() == 0
 
-    def never_read(self, user=None):
+    def is_unread(self, user=None):
         """
         Check if an user has never read the current PrivateTopic.
 
@@ -168,7 +168,7 @@ class PrivateTopic(models.Model):
         if user is None:
             user = get_current_user()
 
-        return never_privateread(self, user)
+        return is_privatetopic_unread(self, user)
 
     def is_author(self, user):
         """
@@ -307,7 +307,7 @@ class PrivateTopicRead(models.Model):
         return u'<Sujet « {0} » lu par {1}, #{2}>'.format(self.privatetopic, self.user, self.privatepost.pk)
 
 
-def never_privateread(privatetopic, user=None):
+def is_privatetopic_unread(privatetopic, user=None):
     """
     Check if a private topic has been read by an user since it last post was added.
 

--- a/zds/mp/tests/tests_models.py
+++ b/zds/mp/tests/tests_models.py
@@ -6,7 +6,7 @@ from math import ceil
 
 from zds.member.factories import ProfileFactory
 from zds.mp.factories import PrivateTopicFactory, PrivatePostFactory
-from zds.mp.models import mark_read, never_privateread, PrivateTopicRead
+from zds.mp.models import mark_read, is_privatetopic_unread, PrivateTopicRead
 from zds import settings
 
 # by moment, i wrote the scenario to be simpler
@@ -120,13 +120,13 @@ class PrivateTopicTest(TestCase):
         # scenario - topic1 :
         # post1 - user1 - unread
         # post2 - user2 - unread
-        self.assertTrue(self.topic1.never_read(self.profile1.user))
+        self.assertTrue(self.topic1.is_unread(self.profile1.user))
 
         # scenario - topic1 :
         # post1 - user1 - read
         # post2 - user2 - read
         mark_read(self.topic1, self.profile1.user)
-        self.assertFalse(self.topic1.never_read(self.profile1.user))
+        self.assertFalse(self.topic1.is_unread(self.profile1.user))
 
         # scenario - topic1 :
         # post1 - user1 - read
@@ -137,7 +137,7 @@ class PrivateTopicTest(TestCase):
             author=self.profile2.user,
             position_in_topic=3)
 
-        self.assertTrue(self.topic1.never_read(self.profile1.user))
+        self.assertTrue(self.topic1.is_unread(self.profile1.user))
 
     def test_topic_never_read_get_last_read(self):
         """ Trying to read last message of a never read Private Topic
@@ -242,18 +242,18 @@ class FunctionTest(TestCase):
             position_in_topic=2)
 
     def test_never_privateread(self):
-        self.assertTrue(never_privateread(self.topic1, self.profile1.user))
+        self.assertTrue(is_privatetopic_unread(self.topic1, self.profile1.user))
         mark_read(self.topic1, self.profile1.user)
-        self.assertFalse(never_privateread(self.topic1, self.profile1.user))
+        self.assertFalse(is_privatetopic_unread(self.topic1, self.profile1.user))
 
     def test_mark_read(self):
-        self.assertTrue(self.topic1.never_read(self.profile1.user))
+        self.assertTrue(self.topic1.is_unread(self.profile1.user))
 
         # scenario - topic1 :
         # post1 - user1 - read
         # post2 - user2 - read
         mark_read(self.topic1, self.profile1.user)
-        self.assertFalse(self.topic1.never_read(self.profile1.user))
+        self.assertFalse(self.topic1.is_unread(self.profile1.user))
 
         # scenario - topic1 :
         # post1 - user1 - read
@@ -263,4 +263,4 @@ class FunctionTest(TestCase):
             privatetopic=self.topic1,
             author=self.profile2.user,
             position_in_topic=3)
-        self.assertTrue(self.topic1.never_read(self.profile1.user))
+        self.assertTrue(self.topic1.is_unread(self.profile1.user))

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -18,7 +18,7 @@ from zds.gallery.factories import UserGalleryFactory
 from zds.gallery.models import GALLERY_WRITE, UserGallery, Gallery
 from zds.gallery.models import Image
 from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactory
-from zds.mp.models import PrivateTopic, never_privateread
+from zds.mp.models import PrivateTopic, is_privatetopic_unread
 from zds.notification.models import TopicAnswerSubscription, ContentReactionAnswerSubscription, \
     NewPublicationSubscription, Notification
 from zds.settings import BASE_DIR
@@ -5290,7 +5290,7 @@ class PublishedContentTests(TestCase):
         # Check that the staff user doesn't have a notification for their reservation and their private topic is read.
         self.assertEqual(0, len(Notification.objects.get_unread_notifications_of(self.user_staff)))
         last_pm = PrivateTopic.objects.get_private_topics_of_user(self.user_staff.pk).last()
-        self.assertFalse(never_privateread(last_pm, self.user_staff))
+        self.assertFalse(is_privatetopic_unread(last_pm, self.user_staff))
 
         # publish the article
         result = self.client.post(

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -18,7 +18,7 @@ from zds.gallery.factories import UserGalleryFactory
 from zds.gallery.models import GALLERY_WRITE, UserGallery, Gallery
 from zds.gallery.models import Image
 from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactory
-from zds.mp.models import PrivateTopic
+from zds.mp.models import PrivateTopic, never_privateread
 from zds.notification.models import TopicAnswerSubscription, ContentReactionAnswerSubscription, \
     NewPublicationSubscription, Notification
 from zds.settings import BASE_DIR
@@ -5286,6 +5286,11 @@ class PublishedContentTests(TestCase):
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        # Check that the staff user doesn't have a notification for their reservation and their private topic is read.
+        self.assertEqual(0, len(Notification.objects.get_unread_notifications_of(self.user_staff)))
+        last_pm = PrivateTopic.objects.get_private_topics_of_user(self.user_staff.pk).last()
+        self.assertFalse(never_privateread(last_pm, self.user_staff))
 
         # publish the article
         result = self.client.post(

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -278,7 +278,8 @@ class ReserveValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
                 msg,
                 True,
                 leave=False,
-                direct=False
+                direct=False,
+                mark_as_read=True
             )
 
             messages.info(request, _(u"Ce contenu a bien été réservé par {0}.").format(request.user.username))

--- a/zds/utils/mps.py
+++ b/zds/utils/mps.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 
-from zds.mp.models import PrivateTopic, PrivatePost
+from zds.mp.models import PrivateTopic, PrivatePost, mark_read
 from zds.notification import signals
 from zds.utils.templatetags.emarkdown import emarkdown
 
@@ -19,7 +19,8 @@ def send_mp(
         text,
         send_by_mail=True,
         leave=True,
-        direct=False):
+        direct=False,
+        mark_as_read=False):
     """
     Send MP at members.
     Most of the param are obvious, excepted :
@@ -41,6 +42,8 @@ def send_mp(
         n_topic.participants.add(part)
 
     topic = send_message_mp(author, n_topic, text, send_by_mail, direct)
+    if mark_as_read:
+        mark_read(topic, author)
 
     if leave:
         move = topic.participants.first()


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3842 |
### QA
- Réservez un contenu en validation
- Constatez un MP marqué comme lu.
