### PR TITLE
La prévisualisation affiche les formules (fix #3170)

### DIFF
--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -236,7 +236,7 @@
                 $(data).insertAfter($form);
 
                 /* global MathJax */
-                if ($(data).find("$").length > 0)
+                if (data.indexOf("$") > 0)
                     MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
             }
         });


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | correction de bug |
| Ticket(s) (_issue(s)_) concerné(s) | #3170 |
### QA

Bon, il est temps de réparer [mes conneries d'il y a un an](https://github.com/zestedesavoir/zds-site/pull/3255). Cette fois-ci, on l'a, la prévisualisation Mathjax fonctionnelle !
- Build le front (`npm run gulp -- build`)
- Tester la prévisualisation avec du LaTeX dans un nouveau message du forum, dans une réponse du forum, dans un contenu, en réponse à un article, ...

Message d'exemple : 

```
$\sqrt{\pi} = 1.77245\ldots$

$$\sqrt{1764} = \frac{84}{2}$$
```
