### PR TITLE
Ajout de install-archlinux dans le Makefile et de la doc qui va avec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install-fedora:
 	sudo dnf install git python-devel python-setuptools libxml2-devel python-lxml libxslt-devel zlib-devel python-sqlparse libjpeg-turbo-devel libjpeg-turbo-devel freetype freetype-devel libffi-devel python-pip python-tox gcc redhat-rpm-config
 
 install-archlinux:
-	sudo pacman -S git python2 python2-setuptools python2-pip libxml2 python2-lxml libxslt zlib python2-sqlparse libffi libjpeg-turbo freetype2 python2-tox base-devel
+	sudo pacman -Sy git python2 python2-setuptools python2-pip libxml2 python2-lxml libxslt zlib python2-sqlparse libffi libjpeg-turbo freetype2 python2-tox base-devel
 
 install-osx:
 	brew install virtualenv_select py27-virtualenv py27-virtualenvwrapper py27-tox node

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ install-ubuntu:
 install-fedora:
 	sudo dnf install git python-devel python-setuptools libxml2-devel python-lxml libxslt-devel zlib-devel python-sqlparse libjpeg-turbo-devel libjpeg-turbo-devel freetype freetype-devel libffi-devel python-pip python-tox gcc redhat-rpm-config
 
+install-archlinux:
+	sudo pacman -S git python2 python2-setuptools python2-pip libxml2 python2-lxml libxslt zlib python2-sqlparse libffi libjpeg-turbo freetype2 python2-tox base-devel
+
 install-osx:
 	brew install virtualenv_select py27-virtualenv py27-virtualenvwrapper py27-tox node
 
@@ -91,6 +94,7 @@ help:
 	@echo "  install-debian    to install debian dependencies"
 	@echo "  install-ubuntu    to install ubuntu dependencies"
 	@echo "  install-fedora    to install fedora dependencies"
+	@echo "  install-archlinux to install archlinux dependencies"
 	@echo "  install-osx       to install os x dependencies"
 	@echo "  lint-back         to lint backend code (flake8)"
 	@echo "  lint-front        to lint frontend code (jshint)"

--- a/doc/source/install/backend-linux-install.rst
+++ b/doc/source/install/backend-linux-install.rst
@@ -30,6 +30,8 @@ ZdS a besoin des dépendances suivantes, installables manuellement ou à l'aide 
 - libjpeg62-turbo libjpeg62-turbo-dev libfreetype6 libfreetype6-dev : ``apt-get install libjpeg62-turbo libjpeg62-turbo-dev libfreetype6 libfreetype6-dev`` (peut être appelée libjpeg8 et libjpeg8-dev sur  certains OS comme Ubuntu)
 - gcc : ``apt-get install build-essential``
 
+**NB** : pour les utilisateurs d'Archlinux, les outils python doivent être ceux de python 2, généralement sous la forme ``python2-smth``
+
 Ou à l'aide du Makefile (``sudo`` sera appelé automatiquement, ne l'ajoutez jamais si on ne le précise pas) :
 
 Pour Debian.
@@ -49,6 +51,12 @@ Pour Fedora.
 .. sourcecode:: bash
 
     make install-fedora
+
+Pour Archlinux.
+
+.. sourcecode:: bash
+                
+   make install-archlinux
 
 Installation et configuration de `virtualenv`
 =============================================


### PR DESCRIPTION
| Q | R |
| --- | --- |
| Type de modification | évolution |
| Ticket(s) (_issue(s)_) concerné(s) | #3910 |
### QA
- Lancez `make install-archlinux` sur une Archlinux ne possédant pas déjà les dépendances
- Faite le reste de l'installation en suivant la [doc](https://zds-site.readthedocs.io/fr/latest/install/backend-linux-install.html)
- Lancez ZdS

Les possibles problèmes viendront sans doute de l'oublie d'un paquet.
