### PR TITLE
Migration pour enlever le champ forum.image

### DIFF
--- a/zds/forum/migrations/0001_initial.py
+++ b/zds/forum/migrations/0001_initial.py
@@ -35,6 +35,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('title', models.CharField(max_length=80, verbose_name=b'Titre')),
                 ('subtitle', models.CharField(max_length=200, verbose_name=b'Sous-titre')),
+                ('image', models.ImageField(upload_to='forum/normal')),
                 ('position_in_category', models.IntegerField(db_index=True, null=True, verbose_name=b'Position dans la cat\xc3\xa9gorie', blank=True)),
                 ('slug', models.SlugField(unique=True, max_length=80)),
                 ('category', models.ForeignKey(verbose_name=b'Cat\xc3\xa9gorie', to='forum.Category')),

--- a/zds/forum/migrations/0008_remove_forum_image.py
+++ b/zds/forum/migrations/0008_remove_forum_image.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forum', '0007_auto_20160827_2035'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='forum',
+            name='image',
+        ),
+    ]


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #3931

J'ai été obligé de modifier la vieille migration modifiée par @AmarOk1412 . La raison est que le chemin d'upload était donné par une méthode qui a été supprimée par le PR en question, du coup aucune migration ne pouvait passer sans cette méthode. Remplacée par une string.