### PR TITLE
Nouvelle version markdown supportant @ping

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -317,6 +317,18 @@
             padding: 0 5px;
         }
 
+        // @ping
+        .ping {
+            color: inherit;
+            font-weight: bold;
+            text-decoration: none;
+
+            &:hover,
+            &:focus {
+                text-decoration: underline;
+            }
+        }
+
         .mathjax-wrapper {
             max-width: 100%;
             overflow: auto;

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ factory-boy==2.7.0
 pygeoip==0.3.2
 pillow==3.2.0
 gitpython==1.0.1
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.11.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.12.zip
 easy-thumbnails==2.3
 CairoSVG==1.0.20
 beautifulsoup4==4.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ factory-boy==2.7.0
 pygeoip==0.3.2
 pillow==3.2.0
 gitpython==1.0.1
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.12.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.13.zip
 easy-thumbnails==2.3
 CairoSVG==1.0.20
 beautifulsoup4==4.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ factory-boy==2.7.0
 pygeoip==0.3.2
 pillow==3.2.0
 gitpython==1.0.1
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.13.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.14.zip
 easy-thumbnails==2.3
 CairoSVG==1.0.20
 beautifulsoup4==4.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ factory-boy==2.7.0
 pygeoip==0.3.2
 pillow==3.2.0
 gitpython==1.0.1
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.15.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.16.zip
 easy-thumbnails==2.3
 CairoSVG==1.0.20
 beautifulsoup4==4.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ factory-boy==2.7.0
 pygeoip==0.3.2
 pillow==3.2.0
 gitpython==1.0.1
-https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.14.zip
+https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.15.zip
 easy-thumbnails==2.3
 CairoSVG==1.0.20
 beautifulsoup4==4.4.1

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -405,6 +405,9 @@ class Post(Comment):
             page,
             self.pk)
 
+    def get_notification_title(self):
+        return self.topic.title
+
 
 class TopicRead(models.Model):
     """

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -175,9 +175,9 @@ class TopicPostsListView(ZdSPagingListView, SingleObjectMixin):
         else:
             context['user_can_modify'] = [post.pk for post in context['posts'] if post.author == self.request.user]
 
-        for post in posts:
-            signals.content_read.send(sender=post.__class__, instance=post, user=self.request.user)
         if self.request.user.is_authenticated():
+            for post in posts:
+                signals.content_read.send(sender=post.__class__, instance=post, user=self.request.user)
             if not is_read(self.object):
                 mark_read(self.object)
         return context

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -564,7 +564,7 @@ class AnswerViewTest(TestCase):
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(3, PrivatePost.objects.all().count())
-        self.assertContains(response, 'Luc !?')
+        self.assertContains(response, 'Luc&#x202F;!?')
 
     def test_fail_answer_with_no_right(self):
 

--- a/zds/notification/migrations/0013_pingsubscription.py
+++ b/zds/notification/migrations/0013_pingsubscription.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import zds.notification.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('notification', '0012_auto_20160703_2255'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PingSubscription',
+            fields=[
+                ('answersubscription_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='notification.AnswerSubscription')),
+            ],
+            bases=('notification.answersubscription', zds.notification.models.MultipleNotificationsMixin),
+        ),
+    ]

--- a/zds/notification/migrations/0014_pingsubscription.py
+++ b/zds/notification/migrations/0014_pingsubscription.py
@@ -8,7 +8,7 @@ import zds.notification.models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('notification', '0012_auto_20160703_2255'),
+        ('notification', '0013_clean_notifications'),
     ]
 
     operations = [

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -320,7 +320,7 @@ class PingSubscription(AnswerSubscription, MultipleNotificationsMixin):
 
     def get_notification_title(self, answer):
         assert hasattr(answer, 'author')
-        assert hasattr(answer, "get_notification_title")
+        assert hasattr(answer, 'get_notification_title')
 
         return _(u'{0} vous a mentionné sur {1}.').format(answer.author, answer.get_notification_title())
 

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -4,6 +4,7 @@ from smtplib import SMTPException
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import EmailMultiAlternatives
 from django.db import models
 from django.template.loader import render_to_string
@@ -11,6 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from zds import settings
 from zds.forum.models import Topic
+from zds.member.models import Profile
 from zds.notification.managers import NotificationManager, SubscriptionManager, TopicFollowedManager, \
     TopicAnswerSubscriptionManager
 from zds.utils.misc import convert_camel_to_underscore
@@ -36,7 +38,7 @@ class Subscription(models.Model):
     last_notification = models.ForeignKey(u'Notification', related_name="last_notification", null=True, default=None)
 
     def __unicode__(self):
-        return _(u'<Abonnement du membre "{0}" aux notifications pour le {1}, #{2}>')\
+        return _(u'<Abonnement du membre "{0}" aux notifications pour le {1}, #{2}>') \
             .format(self.user.username, self.content_type, self.object_id)
 
     def activate(self):
@@ -122,6 +124,7 @@ class SingleNotificationMixin(object):
     """
     Mixin for the subscription that can only have one active notification at a time
     """
+
     def send_notification(self, content=None, send_email=True, sender=None):
         """
         Sends the notification about the given content
@@ -171,7 +174,6 @@ class SingleNotificationMixin(object):
 
 
 class MultipleNotificationsMixin(object):
-
     def send_notification(self, content=None, send_email=True, sender=None):
         """
         Sends the notification about the given content
@@ -222,8 +224,9 @@ class AnswerSubscription(Subscription):
     Subscription to new answer, either in a topic, a article or a tutorial
     NOT used directly, use one of its subtype
     """
+
     def __unicode__(self):
-        return _(u'<Abonnement du membre "{0}" aux réponses au {1} #{2}>')\
+        return _(u'<Abonnement du membre "{0}" aux réponses au {1} #{2}>') \
             .format(self.user.username, self.content_type, self.object_id)
 
     def get_notification_url(self, answer):
@@ -241,7 +244,7 @@ class TopicAnswerSubscription(AnswerSubscription, SingleNotificationMixin):
     objects = TopicAnswerSubscriptionManager()
 
     def __unicode__(self):
-        return _(u'<Abonnement du membre "{0}" aux réponses au sujet #{1}>')\
+        return _(u'<Abonnement du membre "{0}" aux réponses au sujet #{1}>') \
             .format(self.user.username, self.object_id)
 
 
@@ -253,7 +256,7 @@ class PrivateTopicAnswerSubscription(AnswerSubscription, SingleNotificationMixin
     objects = SubscriptionManager()
 
     def __unicode__(self):
-        return _(u'<Abonnement du membre "{0}" aux réponses à la conversation privée #{1}>')\
+        return _(u'<Abonnement du membre "{0}" aux réponses à la conversation privée #{1}>') \
             .format(self.user.username, self.object_id)
 
 
@@ -265,7 +268,7 @@ class ContentReactionAnswerSubscription(AnswerSubscription, SingleNotificationMi
     objects = SubscriptionManager()
 
     def __unicode__(self):
-        return _(u'<Abonnement du membre "{0}" aux réponses du contenu #{1}>')\
+        return _(u'<Abonnement du membre "{0}" aux réponses du contenu #{1}>') \
             .format(self.user.username, self.object_id)
 
 
@@ -277,7 +280,7 @@ class NewTopicSubscription(Subscription, MultipleNotificationsMixin):
     objects = SubscriptionManager()
 
     def __unicode__(self):
-        return _(u'<Abonnement du membre "{0}" aux nouveaux sujets du {1} #{2}>')\
+        return _(u'<Abonnement du membre "{0}" aux nouveaux sujets du {1} #{2}>') \
             .format(self.user.username, self.content_type, self.object_id)
 
     def get_notification_url(self, topic):
@@ -305,10 +308,35 @@ class NewPublicationSubscription(Subscription, MultipleNotificationsMixin):
         return content.title
 
 
+class PingSubscription(AnswerSubscription, MultipleNotificationsMixin):
+    """
+    Subscription to ping of a user
+    """
+    module = _(u'Ping')
+    objects = SubscriptionManager()
+
+    def __unicode__(self):
+        return _(u'<Abonnement du membre "{0}" aux mentions>').format(self.profile, self.object_id)
+
+    def get_notification_title(self, answer):
+        assert hasattr(answer, 'author')
+        assert hasattr(answer, "get_notification_title")
+
+        return _(u'{0} vous a mentionné sur {1}.').format(answer.author, answer.get_notification_title())
+
+
+def ping_url(user=None):
+    try:
+        return Profile.objects.get(user__username=user).get_absolute_url()
+    except ObjectDoesNotExist:
+        pass
+
+
 class Notification(models.Model):
     """
     A notification
     """
+
     class Meta:
         verbose_name = _(u'Notification')
         verbose_name_plural = _(u'Notifications')
@@ -326,7 +354,7 @@ class Notification(models.Model):
     objects = NotificationManager()
 
     def __unicode__(self):
-        return _(u'Notification du membre "{0}" à propos de : {1} #{2} ({3})')\
+        return _(u'Notification du membre "{0}" à propos de : {1} #{2} ({3})') \
             .format(self.subscription.user, self.content_type, self.content_object.pk, self.subscription)
 
     @staticmethod
@@ -356,6 +384,7 @@ class TopicFollowed(models.Model):
     def __unicode__(self):
         return u'<Sujet "{0}" suivi par {1}>'.format(self.topic.title,
                                                      self.user.username)
+
 
 # used to fix Django 1.9 Warning
 # https://github.com/zestedesavoir/zds-site/issues/3451

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -13,7 +13,8 @@ from django.dispatch import receiver
 from zds.forum.models import Topic, Post
 from zds.mp.models import PrivateTopic, PrivatePost
 from zds.notification.models import TopicAnswerSubscription, ContentReactionAnswerSubscription, \
-    PrivateTopicAnswerSubscription, Subscription, Notification, NewTopicSubscription, NewPublicationSubscription
+    PrivateTopicAnswerSubscription, Subscription, Notification, NewTopicSubscription, NewPublicationSubscription, \
+    PingSubscription
 from zds.notification.signals import answer_unread, content_read, new_content, edit_content
 from zds.tutorialv2.models.models_database import PublishableContent, ContentReaction
 
@@ -120,6 +121,17 @@ def mark_pm_reactions_read(sender, **kwargs):
     subscription = PrivateTopicAnswerSubscription.objects.get_existing(user, private_topic, is_active=True)
     if subscription:
         subscription.mark_notification_read()
+
+
+@receiver(content_read, sender=ContentReaction)
+@receiver(content_read, sender=Post)
+def mark_comment_read(sender, **kwargs):
+    comment = kwargs.get('instance')
+    user = kwargs.get('user')
+
+    subscription = PingSubscription.objects.get_existing(user, comment, is_active=True)
+    if subscription:
+        subscription.mark_notification_read(comment)
 
 
 @receiver(edit_content, sender=Topic)
@@ -233,6 +245,18 @@ def content_published_event(sender, **kwargs):
         for subscription in NewPublicationSubscription.objects.get_subscriptions(user):
             by_email = subscription.by_email and subscription.user.profile.email_for_answer
             subscription.send_notification(content=content, sender=user, send_email=by_email)
+
+
+@receiver(new_content, sender=ContentReaction)
+@receiver(new_content, sender=Post)
+@disable_for_loaddata
+def answer_comment_event(sender, **kwargs):
+    comment = kwargs.get('instance')
+    user = kwargs.get('user')
+    by_email = kwargs.get('by_email')
+
+    subscription = PingSubscription.objects.get_or_create_active(user, comment)
+    subscription.send_notification(content=comment, sender=comment.author, send_email=by_email)
 
 
 @receiver(new_content, sender=PrivatePost)

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -253,10 +253,12 @@ def content_published_event(sender, **kwargs):
 def answer_comment_event(sender, **kwargs):
     comment = kwargs.get('instance')
     user = kwargs.get('user')
-    by_email = kwargs.get('by_email')
+
+    assert comment is not None
+    assert user is not None
 
     subscription = PingSubscription.objects.get_or_create_active(user, comment)
-    subscription.send_notification(content=comment, sender=comment.author, send_email=by_email)
+    subscription.send_notification(content=comment, sender=comment.author, send_email=False)
 
 
 @receiver(new_content, sender=PrivatePost)

--- a/zds/notification/signals.py
+++ b/zds/notification/signals.py
@@ -6,7 +6,7 @@ from django.dispatch import Signal
 answer_unread = Signal(providing_args=['instance', 'user'])
 
 # is sent whenever a resource is created.
-new_content = Signal(providing_args=['instance', 'by_email'])
+new_content = Signal(providing_args=['instance', 'user', 'by_email'])
 
 # is sent whenever a content is edited.
 edit_content = Signal(providing_args=['instance', 'action'])

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -516,7 +516,8 @@ ZDS_APP = {
         'home_number': 6,
     },
     'comment': {
-        'max_pings': 15
+        'max_pings': 15,
+        'enable_pings': False,
     },
     'featured_resource': {
         'featured_per_page': 100,

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -515,6 +515,9 @@ ZDS_APP = {
     'topic': {
         'home_number': 6,
     },
+    'comment': {
+        'max_pings': 15
+    },
     'featured_resource': {
         'featured_per_page': 100,
         'home_number': 5,

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -853,6 +853,9 @@ class ContentReaction(Comment):
         page = int(ceil(float(self.position) / settings.ZDS_APP["content"]["notes_per_page"]))
         return '{0}?page={1}#p{2}'.format(self.related_content.get_absolute_url_online(), page, self.pk)
 
+    def get_notification_title(self):
+        return self.related_content.title
+
 
 class ContentRead(models.Model):
     """

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -4239,7 +4239,7 @@ class PublishedContentTests(TestCase):
 
     def test_add_note(self):
 
-        message_to_post = u'la ZEP-12, c\'est énorme ! (CMB)'
+        message_to_post = u'la ZEP-12, c\'est énorme (CMB)'
 
         self.assertEqual(
             self.client.login(

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -4940,8 +4940,8 @@ class PublishedContentTests(TestCase):
         article = PublishedContentFactory(author_list=[self.user_author], type="ARTICLE")
         new_user = ProfileFactory().user
         new_reaction = ContentReaction(related_content=article, position=1)
-        new_reaction.update_content("I will find you. And I will Kill you.")
         new_reaction.author = self.user_guest
+        new_reaction.update_content("I will find you. And I will Kill you.")
 
         new_reaction.save()
         self.assertEqual(
@@ -4969,8 +4969,8 @@ class PublishedContentTests(TestCase):
 
         # add note :
         reaction = ContentReaction(related_content=tuto, position=1)
-        reaction.update_content(text)
         reaction.author = self.user_guest
+        reaction.update_content(text)
         reaction.save()
 
         self.assertEqual(

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -4239,7 +4239,7 @@ class PublishedContentTests(TestCase):
 
     def test_add_note(self):
 
-        message_to_post = u'la ZEP-12, c\'est énorme (CMB)'
+        message_to_post = u'la ZEP-12'
 
         self.assertEqual(
             self.client.login(

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -130,11 +130,10 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
         context['subscriber_count'] = ContentReactionAnswerSubscription.objects.get_subscriptions(self.object).count()
 
         if self.request.user.is_authenticated():
+            for reaction in context['reactions']:
+                signals.content_read.send(sender=reaction.__class__, instance=reaction, user=self.request.user)
             signals.content_read.send(
                 sender=self.object.__class__, instance=self.object, user=self.request.user, target=PublishableContent)
-        # handle reactions:
-        for reaction in context['reactions']:
-            signals.content_read.send(sender=reaction.__class__, instance=reaction, user=self.request.user)
         if last_participation_is_old(self.object, self.request.user):
             mark_read(self.object, self.request.user)
 

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -133,6 +133,8 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
             signals.content_read.send(
                 sender=self.object.__class__, instance=self.object, user=self.request.user, target=PublishableContent)
         # handle reactions:
+        for reaction in context['reactions']:
+            signals.content_read.send(sender=reaction.__class__, instance=reaction, user=self.request.user)
         if last_participation_is_old(self.object, self.request.user):
             mark_read(self.object, self.request.user)
 

--- a/zds/utils/forums.py
+++ b/zds/utils/forums.py
@@ -101,12 +101,12 @@ def send_post(request, topic, author, text,):
     post = Post()
     post.topic = topic
     post.author = author
-    post.update_content(text)
     post.pubdate = datetime.now()
     if topic.last_message is not None:
         post.position = topic.last_message.position + 1
     else:
         post.position = 1
+    post.update_content(text)
     post.ip_address = get_client_ip(request)
     post.save()
 

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -185,7 +185,7 @@ class Comment(models.Model):
         md_instance = get_markdown_instance(ping_url=ping_url)
         self.text_html = render_markdown(md_instance, self.text)
         self.save()
-        for username in list(md_instance.metadata.get("ping", []))[:settings.ZDS_APP['comment']['max_pings']]:
+        for username in list(md_instance.metadata.get('ping', []))[:settings.ZDS_APP['comment']['max_pings']]:
             signals.new_content.send(sender=self.__class__, instance=self, user=User.objects.get(username=username))
 
     def hide_comment_by_user(self, user, text_hidden):

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import os
 import string
 import uuid
+
 from django.conf import settings
 
 from django.contrib.auth.models import User
@@ -184,9 +185,8 @@ class Comment(models.Model):
         md_instance = get_markdown_instance(ping_url=ping_url)
         self.text_html = render_markdown(md_instance, self.text)
         self.save()
-        for username in md_instance.metadata.get("ping", []):
-            signals.new_content.send(
-                sender=self.__class__, instance=self, user=User.objects.get(username=username), by_email=False)
+        for username in list(md_instance.metadata.get("ping", []))[:settings.ZDS_APP['comment']['max_pings']]:
+            signals.new_content.send(sender=self.__class__, instance=self, user=User.objects.get(username=username))
 
     def hide_comment_by_user(self, user, text_hidden):
         """Hide a comment and save it

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -50,7 +50,7 @@ def process_pings(pings):
     for pseudo in pings:
         pass
 
-    
+
 def render_markdown(text, inline=False, js_support=False, is_pingeable=None):
     """
     Render a markdown text to html.
@@ -99,7 +99,7 @@ def emarkdown_inline(text):
     except:
         return mark_safe(u'<p>{}</p>'.format(__MD_ERROR_PARSING))
 
-    
+
 def sub_hd(match, count):
     """Replace header shifted."""
     subt = match.group(1)

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -45,12 +45,6 @@ def get_markdown_instance(inline=False, js_support=False, ping_url=None):
     return markdown
 
 
-def process_pings(pings):
-    """Process all pseudos found in markdown document"""
-    for pseudo in pings:
-        pass
-
-
 def render_markdown(markdown, text, inline=False):
     """
     Render a markdown text to html.

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -32,14 +32,7 @@ def get_markdown_instance(inline=False, js_support=False, ping_url=None):
     # Generate parser
     markdown = Markdown(
         extensions=(zdsext,),
-        safe_mode='escape',       # Protect use of html by escape it
         inline=inline,            # Parse only inline content.
-        enable_attributes=False,  # Disable the conversion of attributes.
-                                  # This could potentially allow an untrusted user to inject JavaScript into documents.
-        tab_length=4,             # Length of tabs in the source (default value).
-        output_format='html5',    # HTML5 output (default value).
-        smart_emphasis=True,      # Enable smart emphasis for underscore syntax
-        lazy_ol=True,             # Enable smart ordered list start support
     )
 
     return markdown

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -45,6 +45,12 @@ def get_markdown_instance(inline=False, js_support=False, is_pingeable=None):
     return markdown
 
 
+def process_pings(pings):
+    """Process all pseudos found in markdown document"""
+    for pseudo in pings:
+        pass
+
+    
 def render_markdown(text, inline=False, js_support=False, is_pingeable=None):
     """
     Render a markdown text to html.
@@ -55,7 +61,10 @@ def render_markdown(text, inline=False, js_support=False, is_pingeable=None):
     :return: Equivalent html string.
     :rtype: str
     """
-    return get_markdown_instance(inline=inline, js_support=js_support, is_pingeable=is_pingeable).convert(text).encode('utf-8').strip()
+    md = get_markdown_instance(inline=inline, js_support=js_support, is_pingeable=is_pingeable)
+    content = md.convert(text).encode('utf-8').strip()
+    process_pings(md.metadata["ping"])
+    return content
 
 
 @register.filter(needs_autoescape=False)

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -51,8 +51,7 @@ def process_pings(pings):
         pass
 
 
-
-def render_markdown(text, inline=False, js_support=False, ping_url=ping_url):
+def render_markdown(text, inline=False, js_support=False, ping_url=None):
     """
     Render a markdown text to html.
 

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -2,6 +2,7 @@
 
 import re
 
+from django.conf import settings
 from django import template
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -28,6 +29,8 @@ def get_markdown_instance(inline=False, js_support=False, ping_url=None):
     :param bool inline: If `True`, configure parser to parse only inline content.
     :return: A ZMarkdown parser.
     """
+    if not settings.ZDS_APP['comment']['enable_pings']:
+        ping_url = None
     zdsext = ZdsExtension(inline=inline, emoticons=smileys, js_support=js_support, ping_url=ping_url)
     # Generate parser
     markdown = Markdown(

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -63,7 +63,7 @@ def render_markdown(text, inline=False, js_support=False, is_pingeable=None):
     """
     md = get_markdown_instance(inline=inline, js_support=js_support, is_pingeable=is_pingeable)
     content = md.convert(text).encode('utf-8').strip()
-    process_pings(md.metadata["ping"])
+    process_pings(md.metadata.get("ping", []))
     return content
 
 

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -21,14 +21,14 @@ Markdown related filters.
 __MD_ERROR_PARSING = _(u'Une erreur est survenue dans la génération de texte Markdown. Veuillez rapporter le bug.')
 
 
-def get_markdown_instance(inline=False, js_support=False, is_pingeable=None):
+def get_markdown_instance(inline=False, js_support=False, ping_url=None):
     """
     Provide a pre-configured markdown parser.
 
     :param bool inline: If `True`, configure parser to parse only inline content.
     :return: A ZMarkdown parser.
     """
-    zdsext = ZdsExtension(inline=inline, emoticons=smileys, js_support=js_support, is_pingeable=is_pingeable)
+    zdsext = ZdsExtension(inline=inline, emoticons=smileys, js_support=js_support, ping_url=ping_url)
     # Generate parser
     markdown = Markdown(
         extensions=(zdsext,),
@@ -51,7 +51,8 @@ def process_pings(pings):
         pass
 
 
-def render_markdown(text, inline=False, js_support=False, is_pingeable=None):
+
+def render_markdown(text, inline=False, js_support=False, ping_url=ping_url):
     """
     Render a markdown text to html.
 
@@ -61,7 +62,7 @@ def render_markdown(text, inline=False, js_support=False, is_pingeable=None):
     :return: Equivalent html string.
     :rtype: str
     """
-    md = get_markdown_instance(inline=inline, js_support=js_support, is_pingeable=is_pingeable)
+    md = get_markdown_instance(inline=inline, js_support=js_support, ping_url=ping_url)
     content = md.convert(text).encode('utf-8').strip()
     process_pings(md.metadata.get("ping", []))
     return content
@@ -77,9 +78,9 @@ def emarkdown(text, use_jsfiddle=''):
     :rtype: str
     """
     is_js = (use_jsfiddle == 'js')
-    is_pingeable = None
+    ping_url = None
     try:
-        return mark_safe(render_markdown(text, inline=False, js_support=is_js, is_pingeable=is_pingeable))
+        return mark_safe(render_markdown(text, inline=False, js_support=is_js, ping_url=ping_url))
     except:
         return mark_safe(u'<div class="error ico-after"><p>{}</p></div>'.format(__MD_ERROR_PARSING))
 
@@ -95,7 +96,7 @@ def emarkdown_inline(text):
     """
 
     try:
-        return mark_safe(render_markdown(text, inline=True, is_pingeable=None))
+        return mark_safe(render_markdown(text, inline=True, ping_url=None))
     except:
         return mark_safe(u'<p>{}</p>'.format(__MD_ERROR_PARSING))
 

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -98,3 +98,42 @@ def emarkdown_inline(text):
         return mark_safe(render_markdown(text, inline=True, is_pingeable=None))
     except:
         return mark_safe(u'<p>{}</p>'.format(__MD_ERROR_PARSING))
+
+    
+def sub_hd(match, count):
+    """Replace header shifted."""
+    subt = match.group(1)
+    lvl = match.group('level')
+    header = match.group('header')
+    end = match.group(4)
+
+    new_content = subt + '#' * count + lvl + header + end
+
+    return new_content
+
+
+def decale_header(text, count):
+    """
+    Shift header in markdown document.
+
+    :param str text: Text to filter.
+    :param int count:
+    :return: Filtered text.
+    :rtype: str
+    """
+    return re.sub(r'(^|\n)(?P<level>#{1,4})(?P<header>.*?)#*(\n|$)', lambda t: sub_hd(t, count), text.encode('utf-8'))
+
+
+@register.filter('decale_header_1')
+def decale_header_1(text):
+    return decale_header(text, 1)
+
+
+@register.filter('decale_header_2')
+def decale_header_2(text):
+    return decale_header(text, 2)
+
+
+@register.filter('decale_header_3')
+def decale_header_3(text):
+    return decale_header(text, 3)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug / nouvelle fonctionnalité 
| Ticket(s) (_issue(s)_) concerné(s)  | -

### QA

Beaucoup de modifications. La principale est le support du ping grâce à @GerardPaligot 

Concernant le markdown, il y a beaucoup de corrections de bugs, principalement : 

 - Support des règles de typographie (voir https://github.com/zestedesavoir/Python-ZMarkdown/blob/master-zds/tests/test_zds.py#L195 pour des exemples)
 - Bug sur les tableaux et des cellules qui disparaissent : https://github.com/zestedesavoir/Python-ZMarkdown/issues/119 ou https://github.com/zestedesavoir/Python-ZMarkdown/issues/107
 - Le support des légendes qui corrigent beaucoup des bugs, dont les légendes de balises math qui n'avaient jamais vraiment marché.

