### PR TITLE
Correction du libellé du nombre de messages dans un sujet

### DIFF
--- a/templates/forum/includes/topic_row.part.html
+++ b/templates/forum/includes/topic_row.part.html
@@ -58,7 +58,7 @@
     {% with nb_post=topic.get_post_count %}
         <p class="topic-answers {% if nb_post <= 1 %}topic-no-answer{% endif %}">
             {% blocktrans with plural=nb_post|pluralize_fr %}
-                {{ nb_post }} réponse{{ plural }}
+                {{ nb_post }} message{{ plural }}
             {% endblocktrans %}
         </p>
     {% endwith %}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket concerné  | #3946

### QA

* Créer un sujet et vérifier que "1 message" s'affiche bien au lieu de "1 réponse" dans la liste des sujets
* Répondre à un sujet et vérifier que "2 messages" s'affiche bien au lieu de "2 réponses" dans la liste des sujets

