### PR TITLE
[Hotfix] Corrige le renvoi d'email à la validation du compte

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -432,32 +432,6 @@ class UsernameAndEmailForm(forms.Form):
             # run validators
             if username:
                 validate_not_empty(username)
-                validate_zds_username(username)
-            if email:
-                validate_not_empty(email)
-                validate_zds_email(email)
-
-        return cleaned_data
-
-
-class ForgotPasswordForm(UsernameAndEmailForm):
-
-    def clean(self):
-        cleaned_data = super(UsernameAndEmailForm, self).clean()
-
-        # Clean data
-        username = cleaned_data.get('username')
-        email = cleaned_data.get('email')
-
-        if username and email:
-            self._errors['username'] = self.error_class([_(u'Les deux champs ne doivent pas être rempli. Remplissez soi'
-                                                           u't l\'adresse de courriel soit le nom d\'utilisateur')])
-        elif not username and not email:
-            self._errors['username'] = self.error_class([_(u'Il vous faut remplir au moins un des deux champs')])
-        else:
-            # run validators
-            if username:
-                validate_not_empty(username)
                 validate_zds_username(username, check_username_available=False)
             else:
                 validate_not_empty(email)

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 
 from zds.member.factories import ProfileFactory, NonAsciiProfileFactory
 from zds.member.forms import LoginForm, RegisterForm, MiniProfileForm, ProfileForm, ChangeUserForm, ChangePasswordForm,\
-    NewPasswordForm, KarmaForm, ForgotPasswordForm
+    NewPasswordForm, KarmaForm, UsernameAndEmailForm
 
 stringof77chars = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789-----"
 stringof251chars = u'abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy' \
@@ -436,7 +436,7 @@ class ChangePasswordFormTest(TestCase):
         self.assertFalse(form.is_valid())
 
 
-class ForgotPasswordFormTest(TestCase):
+class UsernameAndEmailFormTest(TestCase):
     """
     Check the form to ask for a new password.
     """
@@ -450,7 +450,7 @@ class ForgotPasswordFormTest(TestCase):
             'username': self.user1.user.username,
             'email': ''
         }
-        form = ForgotPasswordForm(data=data)
+        form = UsernameAndEmailForm(data=data)
         self.assertTrue(form.is_valid())
 
     def test_non_valid_non_ascii_forgot_password_form(self):
@@ -458,7 +458,7 @@ class ForgotPasswordFormTest(TestCase):
             'username': self.userNonAscii.user.username,
             'email': ''
         }
-        form = ForgotPasswordForm(data=data)
+        form = UsernameAndEmailForm(data=data)
         self.assertTrue(form.is_valid())
 
     def test_non_valid_non_ascii_email_forgot_password_form(self):
@@ -466,7 +466,7 @@ class ForgotPasswordFormTest(TestCase):
             'username': '',
             'email': self.userNonAscii.user.email
         }
-        form = ForgotPasswordForm(data=data)
+        form = UsernameAndEmailForm(data=data)
         self.assertTrue(form.is_valid())
 
     def test_valid_email_forgot_password_form(self):
@@ -474,7 +474,7 @@ class ForgotPasswordFormTest(TestCase):
             'email': self.user1.user.email,
             'username': ''
         }
-        form = ForgotPasswordForm(data=data)
+        form = UsernameAndEmailForm(data=data)
         self.assertTrue(form.is_valid())
 
     def test_empty_name_forgot_password_form(self):
@@ -482,7 +482,7 @@ class ForgotPasswordFormTest(TestCase):
             'username': '',
             'email': ''
         }
-        form = ForgotPasswordForm(data=data)
+        form = UsernameAndEmailForm(data=data)
         self.assertFalse(form.is_valid())
 
     def test_full_forgot_password_form(self):
@@ -490,7 +490,7 @@ class ForgotPasswordFormTest(TestCase):
             'username': 'John Doe',
             'email': 'john.doe@gmail.com'
         }
-        form = ForgotPasswordForm(data=data)
+        form = UsernameAndEmailForm(data=data)
         self.assertFalse(form.is_valid())
 
     def test_unknow_username_forgot_password_form(self):
@@ -498,7 +498,7 @@ class ForgotPasswordFormTest(TestCase):
             'username': 'John Doe',
             'email': ''
         }
-        form = ForgotPasswordForm(data=data)
+        form = UsernameAndEmailForm(data=data)
         self.assertFalse(form.is_valid())
 
     def test_unknow_email_forgot_password_form(self):
@@ -506,7 +506,7 @@ class ForgotPasswordFormTest(TestCase):
             'email': 'john.doe@gmail.com',
             'username': ''
         }
-        form = ForgotPasswordForm(data=data)
+        form = UsernameAndEmailForm(data=data)
         self.assertFalse(form.is_valid())
 
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -32,7 +32,7 @@ from zds.member.commons import ProfileCreate, TemporaryReadingOnlySanction, Read
 from zds.member.decorator import can_write_and_read_now
 from zds.member.forms import LoginForm, MiniProfileForm, ProfileForm, RegisterForm, \
     ChangePasswordForm, ChangeUserForm, NewPasswordForm, \
-    PromoteMemberForm, KarmaForm, UsernameAndEmailForm, ForgotPasswordForm
+    PromoteMemberForm, KarmaForm, UsernameAndEmailForm
 from zds.member.models import Profile, TokenForgotPassword, TokenRegister, KarmaNote
 from zds.mp.models import PrivatePost, PrivateTopic
 from zds.tutorialv2.models.models_database import PublishableContent
@@ -706,7 +706,7 @@ def forgot_password(request):
     """If the user forgot his password, he can have a new one."""
 
     if request.method == "POST":
-        form = ForgotPasswordForm(request.POST)
+        form = UsernameAndEmailForm(request.POST)
         if form.is_valid():
 
             # Get data from form
@@ -750,7 +750,7 @@ def forgot_password(request):
         else:
             return render(request, "member/forgot_password/index.html",
                           {"form": form})
-    form = ForgotPasswordForm()
+    form = UsernameAndEmailForm()
     return render(request, "member/forgot_password/index.html", {"form": form})
 
 


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #3912 

### QA

* Créer un compte
* Demander le renvoi d'un courriel depuis la page : membres/validation/ et voir si le courriel est bien envoyé
* Vérifier que le reset d'un mot de passe fonctionne encore