### PR TITLE
Plus de double souscription

### DIFF
--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -211,8 +211,9 @@ class MultipleNotificationsMixin(object):
                                                          content_type__pk=content_notification_type.pk,
                                                          object_id=content.pk, is_read=False))
         # for some reason, it appears that some notification can be subscribed twice.
-        if len(notifications) == 0:
+        if not notifications:
             logging.debug("nothing to mark as read")
+            return
         elif len(notifications) > 1:
             logging.warning("%s notifications were find for %s/%s", len(notifications), content.type, content.title)
             for notif in notifications[1:]:

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -213,7 +213,7 @@ class MultipleNotificationsMixin(object):
         notifications = list(Notification.objects.filter(subscription=self,
                                                          content_type__pk=content_notification_type.pk,
                                                          object_id=content.pk, is_read=False))
-        # for some reason, it appears that some notification can be subscribed twice.
+        # handles cases where a same subscription lead to several notifications
         if not notifications:
             logging.debug("nothing to mark as read")
             return

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-s
 import logging
+from __future__ import unicode_literals
 from smtplib import SMTPException
 
+from django.utils.encoding import python_2_unicode_compatible
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -17,6 +19,7 @@ from zds.notification.managers import NotificationManager, SubscriptionManager, 
 from zds.utils.misc import convert_camel_to_underscore
 
 
+@python_2_unicode_compatible
 class Subscription(models.Model):
     """
     Model used to register the subscription of a user to a set of notifications (regarding a tutorial, a forum, ...)
@@ -36,8 +39,8 @@ class Subscription(models.Model):
     content_object = GenericForeignKey('content_type', 'object_id')
     last_notification = models.ForeignKey(u'Notification', related_name="last_notification", null=True, default=None)
 
-    def __unicode__(self):
-        return _(u'<Abonnement du membre "{0}" aux notifications pour le {1}, #{2}>')\
+    def __str__(self):
+        return _('<Abonnement du membre "{0}" aux notifications pour le {1}, #{2}>')\
             .format(self.user.username, self.content_type, self.object_id)
 
     def activate(self):
@@ -312,6 +315,7 @@ class NewPublicationSubscription(Subscription, MultipleNotificationsMixin):
         return content.title
 
 
+@python_2_unicode_compatible
 class Notification(models.Model):
     """
     A notification
@@ -332,8 +336,8 @@ class Notification(models.Model):
     title = models.CharField('Titre', max_length=200)
     objects = NotificationManager()
 
-    def __unicode__(self):
-        return _(u'Notification du membre "{0}" à propos de : {1} #{2} ({3})')\
+    def __str__(self):
+        return _('Notification du membre "{0}" à propos de : {1} #{2} ({3})')\
             .format(self.subscription.user, self.content_type, self.content_object.pk, self.subscription)
 
     def __copy__(self):

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-s
-import logging
 from __future__ import unicode_literals
+import logging
 from smtplib import SMTPException
 
 from django.utils.encoding import python_2_unicode_compatible

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -217,10 +217,10 @@ class MultipleNotificationsMixin(object):
             logging.warning("%s notifications were find for %s/%s", len(notifications), content.type, content.title)
             for notif in notifications[1:]:
                 notif.delete()
-        else:
-            notification = notifications[0]
-            notification.is_read = True
-            notification.save()
+
+        notification = notifications[0]
+        notification.is_read = True
+        notification.save()
 
 
 class AnswerSubscription(Subscription):

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -335,6 +335,12 @@ class Notification(models.Model):
         return _(u'Notification du membre "{0}" à propos de : {1} #{2} ({3})')\
             .format(self.subscription.user, self.content_type, self.content_object.pk, self.subscription)
 
+    def __copy__(self):
+        return Notification(subscription=self.subscription, pubdate=self.pubdate, content_type=self.content_type,
+                            object_id=self.object_id, content_object=self.content_object,
+                            is_read=self.is_read, is_dead=self.is_dead,
+                            url=self.url, sender=self.sender, title=self.title)
+
     @staticmethod
     def has_read_permission(request):
         return request.user.is_authenticated()

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -104,7 +104,7 @@ def mark_content_reactions_read(sender, **kwargs):
             subscription = NewPublicationSubscription.objects.get_existing(user, author)
             # a subscription has to be handled only if it is active OR if it was triggered from the publication
             # event that creates an "autosubscribe" which is immediately deactivated.
-            if subscription and (subscription.is_active or subscription.user in author):
+            if subscription and (subscription.is_active or subscription.user in authors):
                 subscription.mark_notification_read(content=content)
 
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -220,7 +220,7 @@ def content_published_event(sender, **kwargs):
     :param kwargs:  contains
         - instance: the new content.
         - by_mail: Send or not an email.
-    All authors of the content follow their new content published.
+    All authors of the content follow their newly published content.
     """
     content = kwargs.get('instance')
     by_email = kwargs.get('by_email')
@@ -230,13 +230,13 @@ def content_published_event(sender, **kwargs):
         # no need for condition here, get_or_create_active has its own
         subscription = NewPublicationSubscription.objects.get_or_create_active(user, user)
         subscription.send_notification(content=content, sender=user, send_email=by_email)
-        # this allows to fix the "auto subscribe issue" but can desactivate a manually triggered subscription
+        # this allows to fix the "auto subscribe issue" but can deactivate a manually triggered subscription
         subscription.deactivate()
 
         for subscription in NewPublicationSubscription.objects.get_subscriptions(user):
-            # this condition is here to avoid exponential notification when a user follow one of the authors
-            # while he is himself an author. As the query encapsulated by get_subscription is complex the exclusion
-            # is not ported in sql.
+            # this condition is here to avoid exponential notifications when a user already follows one of the authors
+            # while they are also among the authors. As the query encapsulated by get_subscription is complex the
+            # exclusion is not ported in sql.
             if subscription.user in authors:
                 continue
             by_email = subscription.by_email and subscription.user.profile.email_for_answer

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -104,7 +104,7 @@ def mark_content_reactions_read(sender, **kwargs):
             subscription = NewPublicationSubscription.objects.get_existing(user, author)
             # a subscription has to be handled only if it is active OR if it was triggered from the publication
             # event that creates an "autosubscribe" which is immediately deactivated.
-            if subscription.is_active or subscription.user in author:
+            if subscription and (subscription.is_active or subscription.user in author):
                 subscription.mark_notification_read(content=content)
 
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -228,7 +228,7 @@ def content_published_event(sender, **kwargs):
     for user in authors:
         ContentReactionAnswerSubscription.objects.toggle_follow(content, user, by_email=by_email)
         # no need for condition here, get_or_create_active has its own
-        subscription = NewPublicationSubscription.objects.get_or_create_active(user, user, by_email=False)
+        subscription = NewPublicationSubscription.objects.get_or_create_active(user, user)
         subscription.send_notification(content=content, sender=user, send_email=by_email)
         # this allows to fix the "auto subscribe issue" but can desactivate a manually triggered subscription
         subscription.deactivate()

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -236,12 +236,9 @@ def content_published_event(sender, **kwargs):
         # this allows to fix the "auto subscribe issue" but can deactivate a manually triggered subscription
         subscription.deactivate()
 
-        for subscription in NewPublicationSubscription.objects.get_subscriptions(user):
+        for subscription in NewPublicationSubscription.objects.get_subscriptions(user).exclude(user__in=authors):
             # this condition is here to avoid exponential notifications when a user already follows one of the authors
-            # while they are also among the authors. As the query encapsulated by get_subscription is complex the
-            # exclusion is not ported in sql.
-            if subscription.user in authors:
-                continue
+            # while they are also among the authors.
             by_email = subscription.by_email and subscription.user.profile.email_for_answer
             subscription.send_notification(content=content, sender=user, send_email=by_email)
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -108,7 +108,6 @@ def mark_content_reactions_read(sender, **kwargs):
                 subscription.mark_notification_read(content=content)
 
 
-
 @receiver(content_read, sender=PrivateTopic)
 def mark_pm_reactions_read(sender, **kwargs):
     """

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -99,10 +99,14 @@ def mark_content_reactions_read(sender, **kwargs):
         if subscription:
             subscription.mark_notification_read()
     elif target == PublishableContent:
-        for author in content.authors.all():
-            subscription = NewPublicationSubscription.objects.get_existing(user, author, is_active=True)
-            if subscription:
+        authors = list(content.authors.all())
+        for author in authors:
+            subscription = NewPublicationSubscription.objects.get_existing(user, author)
+            # a subscription has to be handled only if it is active OR if it was triggered from the publication
+            # event that creates an "autosubscribe" which is immediately deactivated.
+            if subscription.is_active or subscription.user in author:
                 subscription.mark_notification_read(content=content)
+
 
 
 @receiver(content_read, sender=PrivateTopic)

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -224,13 +224,21 @@ def content_published_event(sender, **kwargs):
     """
     content = kwargs.get('instance')
     by_email = kwargs.get('by_email')
-
-    for user in content.authors.all():
+    authors = list(content.authors.all())
+    for user in authors:
         ContentReactionAnswerSubscription.objects.toggle_follow(content, user, by_email=by_email)
-        if not NewPublicationSubscription.objects.does_exist(user, user, is_active=True):
-            NewPublicationSubscription.objects.toggle_follow(user, user, by_email=False)
+        # no need for condition here, toogle_follow has its own
+        subscription = NewPublicationSubscription.objects.toggle_follow(user, user, by_email=False)
+        subscription.send_notification(content=content, sender=user, send_email=by_email)
+        # this allows to fix the "auto subscribe issue" but can desactivate a manually triggered subscription
+        subscription.desactivate()
 
         for subscription in NewPublicationSubscription.objects.get_subscriptions(user):
+            # this condition is here to avoid exponential notification when a user follow one of the authors
+            # while he is himself an author. As the query encapsulated by get_subscription is complex the exclusion
+            # is not ported in sql.
+            if subscription.user in authors:
+                continue
             by_email = subscription.by_email and subscription.user.profile.email_for_answer
             subscription.send_notification(content=content, sender=user, send_email=by_email)
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -227,11 +227,11 @@ def content_published_event(sender, **kwargs):
     authors = list(content.authors.all())
     for user in authors:
         ContentReactionAnswerSubscription.objects.toggle_follow(content, user, by_email=by_email)
-        # no need for condition here, toogle_follow has its own
-        subscription = NewPublicationSubscription.objects.toggle_follow(user, user, by_email=False)
+        # no need for condition here, get_or_create_active has its own
+        subscription = NewPublicationSubscription.objects.get_or_create_active(user, user, by_email=False)
         subscription.send_notification(content=content, sender=user, send_email=by_email)
         # this allows to fix the "auto subscribe issue" but can desactivate a manually triggered subscription
-        subscription.desactivate()
+        subscription.deactivate()
 
         for subscription in NewPublicationSubscription.objects.get_subscriptions(user):
             # this condition is here to avoid exponential notification when a user follow one of the authors

--- a/zds/notification/tests.py
+++ b/zds/notification/tests.py
@@ -516,8 +516,7 @@ class NotificationPublishableContentTest(TestCase):
         signals.new_content.send(sender=self.tuto.__class__, instance=self.tuto, by_email=False)
 
         subscription1 = Notification.objects.filter(subscription=subscription, is_read=False).first()
-        subscription2 = copy.deepcopy(subscription1)
-        subscription2.pk = 0
+        subscription2 = copy.copy(subscription1)
         subscription2.save()
         subscription.mark_notification_read(self.tuto)
         subscription1 = Notification.objects.filter(subscription=subscription, is_read=False).first()

--- a/zds/notification/tests.py
+++ b/zds/notification/tests.py
@@ -524,7 +524,7 @@ class NotificationPublishableContentTest(TestCase):
         self.assertEqual(1, Notification.objects.filter(subscription=subscription,
                                                         is_read=True).count())
 
-        
+
 class NotificationPrivateTopicTest(TestCase):
     def setUp(self):
         self.user1 = ProfileFactory().user

--- a/zds/notification/tests.py
+++ b/zds/notification/tests.py
@@ -520,7 +520,7 @@ class NotificationPublishableContentTest(TestCase):
         subscription2.save()
         subscription.mark_notification_read(self.tuto)
         subscription1 = Notification.objects.filter(subscription=subscription, is_read=False).first()
-        self.assertTrue(subscription1.is_read)
+        self.assertIsNone(subscription1)
         self.assertEqual(1, Notification.objects.count(subscription=subscription, is_read=False))
 
 class NotificationPrivateTopicTest(TestCase):

--- a/zds/notification/tests.py
+++ b/zds/notification/tests.py
@@ -18,7 +18,7 @@ from zds.notification import signals
 from zds.notification.models import Notification, TopicAnswerSubscription, ContentReactionAnswerSubscription, \
     PrivateTopicAnswerSubscription, NewTopicSubscription, NewPublicationSubscription
 from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory, ContentReactionFactory, \
-    SubCategoryFactory, PublishedContentFactory
+    SubCategoryFactory
 from zds.tutorialv2.models.models_database import ContentReaction, PublishableContent
 from zds.tutorialv2.publication_utils import publish_content
 from zds.utils import slugify
@@ -521,8 +521,10 @@ class NotificationPublishableContentTest(TestCase):
         subscription.mark_notification_read(self.tuto)
         subscription1 = Notification.objects.filter(subscription=subscription, is_read=False).first()
         self.assertIsNone(subscription1)
-        self.assertEqual(1, Notification.objects.count(subscription=subscription, is_read=False))
+        self.assertEqual(1, Notification.objects.filter(subscription=subscription,
+                                                        is_read=True).count())
 
+        
 class NotificationPrivateTopicTest(TestCase):
     def setUp(self):
         self.user1 = ProfileFactory().user

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -2128,7 +2128,7 @@ class ContentTests(TestCase):
 
         subscription = NewPublicationSubscription.objects.get_existing(user=self.user_author,
                                                                        content_object=self.user_author)
-        # subscription must be desactivated.
+        # subscription must be deactivated.
         self.assertFalse(subscription.is_active)
         self.assertEqual(1, Notification.objects.filter(subscription=subscription, is_read=False).count())
 

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -2128,7 +2128,8 @@ class ContentTests(TestCase):
 
         subscription = NewPublicationSubscription.objects.get_existing(user=self.user_author,
                                                                        content_object=self.user_author)
-        self.assertTrue(subscription.is_active)
+        # subscription must be desactivated.
+        self.assertFalse(subscription.is_active)
         self.assertEqual(1, Notification.objects.filter(subscription=subscription, is_read=False).count())
 
         self.assertEqual(PublishedContent.objects.filter(content=tuto).count(), 1)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug 
| Ticket(s) (_issue(s)_) concerné(s)  | #3918, #3988, #4011 

Le test unitaire arrive.

### QA

* avec user1 créez un tutoriel coécrit avec user2
* avec user 1 suivez user2
* publiez le tuto
* observez qu'il n'y a pas de double souscription

