### PR TITLE
gère au mieux les problèmes de visibilté dans les notifs

### DIFF
--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -3,12 +3,13 @@ from datetime import datetime
 
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
+from django.dispatch.dispatcher import Signal
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext as _
 from django.views.generic.detail import SingleObjectMixin
 
-from zds.forum.models import Forum, Post, TopicRead
+from zds.forum.models import Forum, Post, TopicRead, Topic
 from zds.notification import signals
 from zds.notification.models import TopicAnswerSubscription, Notification, NewTopicSubscription
 from zds.utils.models import Alert
@@ -73,11 +74,12 @@ class TopicEditMixin(object):
             except (KeyError, ValueError, TypeError):
                 raise Http404
             forum = get_object_or_404(Forum, pk=forum_pk)
+            old_forum = topic.forum
             topic.forum = forum
 
             # Save topic to update update_index_date
             topic.save()
-
+            signals.visibility_changed(Topic, instance=topic, old_forum=old_forum)
             signals.edit_content.send(sender=topic.__class__, instance=topic, action='move')
 
             messages.success(request,
@@ -115,6 +117,7 @@ class PostEditMixin(object):
             messages.success(request, _(u'Le message est désormais masqué.'))
             for user in Notification.objects.get_users_for_unread_notification_on(post):
                 signals.content_read.send(sender=post.topic.__class__, instance=post.topic, user=user)
+                signals.visibility_changed(post.__class__, instance=post, old_forum=post.topic.forum)
         else:
             raise PermissionDenied
 

--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -3,13 +3,12 @@ from datetime import datetime
 
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
-from django.dispatch.dispatcher import Signal
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext as _
 from django.views.generic.detail import SingleObjectMixin
 
-from zds.forum.models import Forum, Post, TopicRead, Topic
+from zds.forum.models import Forum, Post, TopicRead
 from zds.notification import signals
 from zds.notification.models import TopicAnswerSubscription, Notification, NewTopicSubscription
 from zds.utils.models import Alert
@@ -79,7 +78,7 @@ class TopicEditMixin(object):
 
             # Save topic to update update_index_date
             topic.save()
-            signals.visibility_changed(Topic, instance=topic, old_forum=old_forum)
+            signals.visibility_changed.send(topic.__class__, instance=topic, old_forum=old_forum)
             signals.edit_content.send(sender=topic.__class__, instance=topic, action='move')
 
             messages.success(request,
@@ -117,7 +116,7 @@ class PostEditMixin(object):
             messages.success(request, _(u'Le message est désormais masqué.'))
             for user in Notification.objects.get_users_for_unread_notification_on(post):
                 signals.content_read.send(sender=post.topic.__class__, instance=post.topic, user=user)
-                signals.visibility_changed(post.__class__, instance=post, old_forum=post.topic.forum)
+                signals.visibility_changed.send(post.__class__, instance=post, old_forum=post.topic.forum)
         else:
             raise PermissionDenied
 

--- a/zds/forum/migrations/0009_cleanup_invisible_notification.py
+++ b/zds/forum/migrations/0009_cleanup_invisible_notification.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from zds.forum.models import mark_read
+
+
+def cleanup(apps, *_):
+    post_class = apps.get_model("forum", "Post")
+    notification_class = apps.get_model("notification", "Notification")
+    for post in post_class.objects.filter(is_visible=False):
+        notification_class.objects.filter(notification_url=post.get_absolute_url()).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forum', '0008_remove_forum_image'),
+    ]
+
+    operations = [
+        migrations.RunPython(cleanup),
+    ]

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -382,6 +382,10 @@ class Topic(models.Model):
 
         return False
 
+    @property
+    def subscribed_object(self):
+        return self
+
 
 class Post(Comment):
     """
@@ -408,6 +412,10 @@ class Post(Comment):
             self.topic.get_absolute_url(),
             page,
             self.pk)
+
+    @property
+    def subscribed_object(self):
+        return self.topic.subscribed_object
 
 
 class TopicRead(models.Model):

--- a/zds/notification/migrations/0013_cleanup_invisible_notification.py
+++ b/zds/notification/migrations/0013_cleanup_invisible_notification.py
@@ -16,7 +16,7 @@ def cleanup(apps, *_):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('forum', '0008_remove_forum_image'),
+        ('notification', '0012_auto_20160703_2255'),
     ]
 
     operations = [

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -331,7 +331,8 @@ def delete_notifications(sender, instance, **kwargs):
 @receiver(visibility_changed, sender=Topic)
 @receiver(visibility_changed, sender=Post)
 def clean_notification_on_restriction(sender, instance, old_forum, **_kwargs):
-    for subscription in Subscription.objects.filter(content_object=instance.subscribed_object):
+    content_type = ContentType.objects.get_for_model(instance.subscribed_object.__class__, for_concrete_model=True)
+    for subscription in Subscription.objects.filter(object_id=instance.subscribed_object.pk, content_type=content_type):
         old_was_visible = old_forum.is_visible_for(subscription.user, instance)
         if old_was_visible and not sender.objects.is_visible_for(instance, subscription.user):
             subscription.deactivate_email()

--- a/zds/notification/signals.py
+++ b/zds/notification/signals.py
@@ -13,3 +13,6 @@ edit_content = Signal(providing_args=['instance', 'action'])
 
 # is sent when a content is read (topic, article or tutorial)
 content_read = Signal(providing_args=['instance', 'user', 'target'])
+
+# is sent when visibility is changed (topic, post)
+visibility_changed = Signal(providing_args=["instance", "subscribed_object", "old_forum"])


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | (ex #3904)

### QA

Une partie des bugs est arrivée avant le passage à la v20, il faudra donc tester sur la v21 si la migration a suffi

Sinon :

- créer un topic avec user1
- avec staff répondre au topic
- avec staff déplacer le topic en zone staff
- vérifier que user1 n'a pas de notification
