### PR TITLE
fix 3227 and adds unittest

### DIFF
--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -152,7 +152,7 @@ class PostEditMixin(object):
         topic_read = TopicRead.objects.filter(topic=post.topic, user=user).first()
         # issue 3227 proves that you can have post.position==1 AND topic_read to None
         # it can happen whether on double click (the event "mark as not read" is therefore sent twice)
-        # or if you have too tabs in your browser.
+        # or if you have two tabs in your browser.
         if topic_read is None and post.position > 1:
             unread = Post.objects.filter(topic=post.topic, position=(post.position - 1)).first()
             topic_read = TopicRead(post=unread, topic=unread.topic, user=user)

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -1271,10 +1271,10 @@ class ManagerTests(TestCase):
 
 class TestMixins(TestCase):
     def test_double_unread_is_handled(self):
-        author = ProfileFactory()
-        viewer = ProfileFactory()
+        author = ProfileFactory().user
+        viewer = ProfileFactory().user
         topic = TopicFactory(author=author, forum=ForumFactory(category=CategoryFactory(), position_in_category=1))
-        post = PostFactory(topic=topic)
+        post = PostFactory(topic=topic, author=author, position=1)
         TopicRead(topic=topic, post=post, user=viewer).save()
         PostEditMixin.perform_unread_message(post, viewer)
         PostEditMixin.perform_unread_message(post, viewer)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | (ex #3227)

### QA

* user1 poste un message
* user2 le lit
* user2 ouvre un nouvel onglet
* user2 appuie sur "marquer comme non lu" dans les deux onglets
* aucune erreur 500 n'apparait.
