### PR TITLE
Affichage du contenu de ses messages masqués

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -92,29 +92,31 @@
                             </a>
                         </li>
                     {% endif %}
-                {% elif perms_change %}
+                {% elif perms_change or message.author == user %}
                     <li>
                         <a href="#show-message-hidden-{{ message.id }}" class="ico-after view">
                             {% trans "Voir" %}
                         </a>
                     </li>
-                    <li>
-                        <a href="#show-message-{{ message.id }}" class="ico-after hide open-modal">
-                            {% trans "Démasquer" %}
-                        </a>
-                        <form action="{{ show_link|safe }}" method="post" id="show-message-{{ message.id }}" class="modal modal-flex">
-                            {% csrf_token %}
-                            <p>
-                                {% blocktrans with editor=message.editor %}
-                                Ce message a été masqué par <strong>{{ editor }}</strong>, êtes vous certains de vouloir le ré-afficher ?
-                                {% endblocktrans %}
-                            </p>
+                    {% if perms_change %}
+                        <li>
+                            <a href="#show-message-{{ message.id }}" class="ico-after hide open-modal">
+                                {% trans "Démasquer" %}
+                            </a>
+                            <form action="{{ show_link|safe }}" method="post" id="show-message-{{ message.id }}" class="modal modal-flex">
+                                {% csrf_token %}
+                                <p>
+                                    {% blocktrans with editor=message.editor %}
+                                    Ce message a été masqué par <strong>{{ editor }}</strong>, êtes vous certains de vouloir le ré-afficher ?
+                                    {% endblocktrans %}
+                                </p>
 
-                            <button type="submit" name="show_message">
-                                {% trans "Confirmer" %}
-                            </button>
-                        </form>
-                    </li>
+                                <button type="submit" name="show_message">
+                                    {% trans "Confirmer" %}
+                                </button>
+                            </form>
+                        </li>
+                    {% endif %}
                 {% endif %}
                 {% if not is_mp %}
                 <li>

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -171,7 +171,7 @@
                 <div itemprop="text">
                     {{ message.text_html|safe }}
                 </div>
-            {% elif perms_change or message.author == user  %}
+            {% elif perms_change or message.author == user %}
                 <div class="message-hidden-content">
                     {{ message.text_html|safe }}
                 </div>

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -171,7 +171,7 @@
                 <div itemprop="text">
                     {{ message.text_html|safe }}
                 </div>
-            {% elif perms_change %}
+            {% elif perms_change or message.author == user  %}
                 <div class="message-hidden-content">
                     {{ message.text_html|safe }}
                 </div>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution

Le but de cette modification est de permettre à l'auteur d'un message de l'afficher même si celui-ci a été masqué (que ce soit par lui-même ou un membre du staff). Cela fait suite à ce sujet : [Montrer le contenu d’origine de ses messages masqués](https://zestedesavoir.com/forums/sujet/7309/montrer-le-contenu-dorigine-de-ses-messages-masques/).

Je précise que je débute complètement dans l'utilisation de GitHub et que cette pull request est ma première, donc excusez-moi si je fais mal les choses. ^^
Je n'ai pas encore installé Zeste de Savoir sur mon ordinateur, mais la modification étant très simple, je l'ai fait depuis l'interface web comme l'avait suggéré Gabbro sur le sujet.
Rectification : j'ai finalement pu installer ZdS sur mon ordinateur et j'ai constaté qu'il manquait un bouton Voir. J'ai édité la PR pour l'ajouter.

### QA

* Créez un message dans un sujet ;
* Masquez-le ;
* Constatez que le message est toujours visible depuis le compte de son auteur.