### PR TITLE
Evite de mettre à jour la date au moment du commentaire

### DIFF
--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -3165,6 +3165,7 @@ class ContentTests(TestCase):
         self.assertEqual(result.status_code, 403)  # get 403 since you're not author
 
         publishable = PublishedContentFactory(author_list=[self.user_author])
+        old_date = publishable.update_date
         self.client.post(
             reverse("content:add-reaction") + u'?pk={}'.format(publishable.pk),
             {
@@ -3172,6 +3173,7 @@ class ContentTests(TestCase):
                 'last_note': '0'
             }, follow=False)
         publishable = PublishableContent.objects.get(pk=publishable.pk)
+        self.assertEqual(old_date, publishable.update_date, "Erreur, le commentaire a entraîné une MAJ de la date!")
         # test antispam
         result = self.client.post(
             reverse("content:add-reaction") + u'?pk={}'.format(publishable.pk),

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -462,7 +462,7 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
 
         if is_new:  # we first need to save the reaction
             self.object.last_note = self.reaction
-            self.object.save()
+            self.object.save(update_date=False)
 
         self.success_url = self.reaction.get_absolute_url()
         return super(SendNoteFormView, self).form_valid(form)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | (ex #3965)

### QA

* Publiez un tutoriel avec user1
* attendais une minute ou deux histoire que le changement soit visible dans l'UI
* Postez un commentaire avec user1 ou tout autre utilisateur
* Allez dans la version brouillon du tutoriel et vérifiez que la date de mise a jour est bien celle de la dernière édition du tuto et non celle du commentaire.
