### PR TITLE
La progression des chapitres inclut les sommaires des parties

### DIFF
--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -973,10 +973,20 @@ class DisplayContainer(LoginRequiredMixin, SingleContentDetailViewMixin):
                 context['has_pagination'] = True
                 context['previous'] = None
                 context['next'] = None
+                if position == 0:
+                    context['previous'] = container.parent
                 if position > 0:
-                    context['previous'] = chapters[position - 1]
+                    previous_chapter = chapters[position - 1]
+                    if previous_chapter.parent == container.parent:
+                        context['previous'] = previous_chapter
+                    else:
+                        context['previous'] = container.parent
                 if position < len(chapters) - 1:
-                    context['next'] = chapters[position + 1]
+                    next_chapter = chapters[position + 1]
+                    if next_chapter.parent == container.parent:
+                        context['next'] = next_chapter
+                    else:
+                        context['next'] = next_chapter.parent
 
         # check whether this tuto support js fiddle
         if self.object.js_support:

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -252,10 +252,20 @@ class DisplayOnlineContainer(SingleOnlineContentDetailViewMixin):
                 context['has_pagination'] = True
                 context['previous'] = None
                 context['next'] = None
+                if position == 0:
+                    context['previous'] = container.parent
                 if position > 0:
-                    context['previous'] = chapters[position - 1]
+                    previous_chapter = chapters[position - 1]
+                    if previous_chapter.parent == container.parent:
+                        context['previous'] = previous_chapter
+                    else:
+                        context['previous'] = container.parent
                 if position < len(chapters) - 1:
-                    context['next'] = chapters[position + 1]
+                    next_chapter = chapters[position + 1]
+                    if next_chapter.parent == container.parent:
+                        context['next'] = next_chapter
+                    else:
+                        context['next'] = next_chapter.parent
 
         return context
 


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | nouvelle fonctionnalité / évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #2883

### QA

- Créer un tutoriel à plusieurs parties.
- Vérifier que quand on est sur le premier chapitre d’une partie, le lien « précédent » mène au sommaire de la partie et que quand on est sur le dernier chapitre d’une partie, le lien « suivant » mène au sommaire de la partie suivante.

C’est la même modification dans les deux cas, mais il faudrait vérifier le cas du tutoriel publié et celui du tutoriel non publié/en bêta.

PS : ne serait-ce pas mieux de faire le lien « suivant » pointer vers la partie du chapitre dans le cas d’un chapitre de fin de partie (cette partie a peut-être une conclusion).