### PR TITLE
Remplacement de réponses par messages dans les MP

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -29,56 +29,56 @@
 
     <section class="home-header">
         <div class="home-wrapper">
-        {% if user.is_authenticated %}
-            <section class="home-description connected">
-                <blockquote><span>{{ quote }}</span></blockquote>
+            {% if user.is_authenticated %}
+                <section class="home-description connected">
+                    <blockquote><span>{{ quote }}</span></blockquote>
 
-                {% if featured_message %}
-                    {% include "featured/includes/featured_message.part.html" %}
-                {% endif %}
-            </section>
-        {% else %}
-            <section class="home-description short" id="description">
-                <blockquote><span>{% trans "Zeste de Savoir, la connaissance" %}</span> <span>{% trans "pour tous et sans pépins" %}</span></blockquote>
-                <a class="home-description-button" href="#description">
-                    {% trans "En savoir plus" %}
-                </a>
-                <a href="#" class="home-description-button close-description">
-                    {% trans "Fermer" %}
-                </a>
-            </section>
-            <section class="home-description">
-                <div class="column">
-                    <h2>{% trans "La connaissance pour tous" %}</h2>
-                    {% blocktrans with site_name=app.site.litteral_name %}
-                        <p>{{site_name}}&nbsp;: un site de <strong>partage de connaissances</strong> où vous trouverez,
-                            <strong>gratuitement</strong> et <strong>sans publicité</strong>&nbsp;:</p>
-                        <ul>
-                            <li>des <a href="{{url_tutorials}}">tutoriels de tous niveaux</a>&nbsp;;</li>
-                            <li>des <a href='{{url_articles}}'>articles</a>&nbsp;;</li>
-                            <li>et des <a href='{{url_forums}}'>forums d'entraide</a>.</li>
-                        </ul>
-                        <p>Tout est animé par la communauté, tous les sujets sont abordés&nbsp;!</p>
-                    {% endblocktrans %}
-                </div>
-                <div class="column">
-                    <h2>{% trans "Partagez vos savoirs…" %}</h2>
-                    {% blocktrans %}
-                        <p><strong>Tous les membres</strong> peuvent écrire et <strong>publier des contenus</strong>.</p>
-                        <p>Pour assurer la qualité, l'équipe du site valide chaque tutoriel et article.</p>
-                    {% endblocktrans %}
-                    <h2>{% trans "… sur une plate-forme libre" %}</h2>
-                        {% blocktrans %}
-                            <p>Le site est géré et financé par une <a href="{{url_association}}">association</a> à but non lucratif.</p>
+                    {% if featured_message %}
+                        {% include "featured/includes/featured_message.part.html" %}
+                    {% endif %}
+                </section>
+            {% else %}
+                <section class="home-description short" id="description">
+                    <blockquote><span>{% trans "Zeste de Savoir, la connaissance" %}</span> <span>{% trans "pour tous et sans pépins" %}</span></blockquote>
+                    <a class="home-description-button" href="#description">
+                        {% trans "En savoir plus" %}
+                    </a>
+                    <a href="#" class="home-description-button close-description">
+                        {% trans "Fermer" %}
+                    </a>
+                </section>
+                <section class="home-description">
+                    <div class="column">
+                        <h2>{% trans "La connaissance pour tous" %}</h2>
+                        {% blocktrans with site_name=app.site.litteral_name %}
+                            <p>{{site_name}}&nbsp;: un site de <strong>partage de connaissances</strong> où vous trouverez,
+                                <strong>gratuitement</strong> et <strong>sans publicité</strong>&nbsp;:</p>
+                            <ul>
+                                <li>des <a href="{{url_tutorials}}">tutoriels de tous niveaux</a>&nbsp;;</li>
+                                <li>des <a href='{{url_articles}}'>articles</a>&nbsp;;</li>
+                                <li>et des <a href='{{url_forums}}'>forums d'entraide</a>.</li>
+                            </ul>
+                            <p>Tout est animé par la communauté, tous les sujets sont abordés&nbsp;!</p>
                         {% endblocktrans %}
-                        {% if app.site.contribute_link %}
-                            {% blocktrans with contribute_link=app.site.contribute_link %}
-                                <p>Chacun peut <a href="{{contribute_link}}">contribuer au code source</a> de la plate-forme, qui est ouvert.</p>
+                    </div>
+                    <div class="column">
+                        <h2>{% trans "Partagez vos savoirs…" %}</h2>
+                        {% blocktrans %}
+                            <p><strong>Tous les membres</strong> peuvent écrire et <strong>publier des contenus</strong>.</p>
+                            <p>Pour assurer la qualité, l'équipe du site valide chaque tutoriel et article.</p>
+                        {% endblocktrans %}
+                        <h2>{% trans "… sur une plate-forme libre" %}</h2>
+                            {% blocktrans %}
+                                <p>Le site est géré et financé par une <a href="{{url_association}}">association</a> à but non lucratif.</p>
                             {% endblocktrans %}
-                        {% endif %}
-                </div>
-            </section>
-        {% endif %}
+                            {% if app.site.contribute_link %}
+                                {% blocktrans with contribute_link=app.site.contribute_link %}
+                                    <p>Chacun peut <a href="{{contribute_link}}">contribuer au code source</a> de la plate-forme, qui est ouvert.</p>
+                                {% endblocktrans %}
+                            {% endif %}
+                    </div>
+                </section>
+            {% endif %}
             {% if app.display_search_bar %}
                  <section class="home-search-box">
                     <form action='{% url "haystack_search" %}' id="search-home">

--- a/templates/home.html
+++ b/templates/home.html
@@ -68,14 +68,14 @@
                             <p>Pour assurer la qualité, l'équipe du site valide chaque tutoriel et article.</p>
                         {% endblocktrans %}
                         <h2>{% trans "… sur une plate-forme libre" %}</h2>
-                            {% blocktrans %}
-                                <p>Le site est géré et financé par une <a href="{{url_association}}">association</a> à but non lucratif.</p>
+                        {% blocktrans %}
+                            <p>Le site est géré et financé par une <a href="{{url_association}}">association</a> à but non lucratif.</p>
+                        {% endblocktrans %}
+                        {% if app.site.contribute_link %}
+                            {% blocktrans with contribute_link=app.site.contribute_link %}
+                                <p>Chacun peut <a href="{{contribute_link}}">contribuer au code source</a> de la plate-forme, qui est ouvert.</p>
                             {% endblocktrans %}
-                            {% if app.site.contribute_link %}
-                                {% blocktrans with contribute_link=app.site.contribute_link %}
-                                    <p>Chacun peut <a href="{{contribute_link}}">contribuer au code source</a> de la plate-forme, qui est ouvert.</p>
-                                {% endblocktrans %}
-                            {% endif %}
+                        {% endif %}
                     </div>
                 </section>
             {% endif %}

--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -58,7 +58,7 @@
                 {% with post_count=topic.get_post_count %}
                     <p class="topic-answers {% if post_count <= 1 %}topic-no-answer{% endif %}">
                         {% blocktrans with plural=post_count|pluralize_fr %}
-                           {{ post_count }} réponse{{ plural }}
+                           {{ post_count }} message{{ plural }}
                         {% endblocktrans %}
                     </p>
                 {% endwith %}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug

Cette pull request remplace "réponses" par "messages" dans la liste des MP. En effet, c'est le nombre de messages qui est affiché et pas le nombre de réponses.

De plus, je corrige une petite erreur d'indentation sur le template de la page d'accueil.

### QA

* Vérifier que "réponses" est bien remplacé par "messages" ;
* Vérifier que le nombre est correct.