### PR TITLE
Correction de l'affichage du pseudo du membre dans la liste des topics

### DIFF
--- a/templates/misc/member_item.part.html
+++ b/templates/misc/member_item.part.html
@@ -16,7 +16,7 @@
             <img src="{{ profile.get_avatar_url|remove_url_protocole }}" alt="" class="avatar" itemprop="image">
         {% endif %}
 
-        <span itemprop="name">{% if member.username %}member.username{% else %}{{ member.user.username }}{% endif %}</span>
+        <span itemprop="name">{% if member.username %}{{ member.username }}{% else %}{{ member.user.username }}{% endif %}</span>
 
         {% if info %}
             <span class="info">({{ info }})</span>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug

Cette pull request corrige un bug lors de l'affichage de la liste des sujets créés par un membre. Le pseudo du membre est maintenant bien affiché.

### QA

* Consulter le profil d'un membre ;
* Vérifier que son pseudo est bien affiché dans les sujets qu'il a créés.