### PR TITLE
Corrige la migration de nettoyage des notifications

### DIFF
--- a/zds/notification/migrations/0013_clean_notifications.py
+++ b/zds/notification/migrations/0013_clean_notifications.py
@@ -4,11 +4,11 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 from zds.notification.models import TopicAnswerSubscription
+from zds.forum.models import Topic
 
 
 def cleanup(apps, *_):
-    topic_class = apps.get_model("forum", "Topic")
-    for topic in topic_class.objects.filter(forum__group__isnull=False).all():
+    for topic in Topic.objects.filter(forum__group__isnull=False).all():
         TopicAnswerSubscription.objects.unfollow_and_mark_read_everybody_at(topic)
 
 


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #3967

### QA

Aucune. C'est le code qui a permis que la migration cesse de planter et fasse le boulot sur la beta alignée prod.