### PR TITLE
Ne pas comptabiliser les messages masqués par leur auteur dans les messages modérés

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -484,7 +484,7 @@
                 <li class="inactive">
                     <span>
                         {% trans "Messages modérés" %}
-                        <span class="count">{{ profile.get_invisible_posts_count }}</span>
+                        <span class="count">{{ profile.get_hidden_by_staff_posts_count }}</span>
                     </span>
                 </li>
                 <li class="inactive">

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -299,8 +299,8 @@ class Profile(models.Model):
     def get_posts(self):
         return Post.objects.filter(author=self.user).all()
 
-    def get_invisible_posts_count(self):
-        return Post.objects.filter(is_visible=False, author=self.user).count()
+    def get_hidden_by_staff_posts_count(self):
+        return Post.objects.filter(is_visible=False, author=self.user).exclude(editor=self.user).count()
 
     # TODO: improve this method's name?
     def get_alerts_posts_count(self):

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -243,13 +243,17 @@ class MemberModelsTest(TestCase):
         self.assertEqual(len(posts), 1)
         self.assertEqual(apost, posts[0])
 
-    def test_get_invisible_posts_count(self):
+    def test_get_hidden_by_staff_posts_count(self):
         # Start with 0
-        self.assertEqual(self.user1.get_invisible_posts_count(), 0)
-        # Post !
-        PostFactory(topic=self.forumtopic, author=self.user1.user, position=1, is_visible=False)
+        self.assertEqual(self.user1.get_hidden_by_staff_posts_count(), 0)
+        # Post and hide it by poster
+        PostFactory(topic=self.forumtopic, author=self.user1.user, position=1, is_visible=False, editor=self.user1.user)
+        # Should be 0
+        self.assertEqual(self.user1.get_hidden_by_staff_posts_count(), 0)
+        # Post and hide it by staff
+        PostFactory(topic=self.forumtopic, author=self.user1.user, position=1, is_visible=False, editor=self.staff.user)
         # Should be 1
-        self.assertEqual(self.user1.get_invisible_posts_count(), 1)
+        self.assertEqual(self.user1.get_hidden_by_staff_posts_count(), 1)
 
     def test_get_alerts_posts_count(self):
         # Start with 0

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -255,6 +255,14 @@ class MemberModelsTest(TestCase):
         # Should be 1
         self.assertEqual(self.user1.get_hidden_by_staff_posts_count(), 1)
 
+    def test_get_hidden_by_staff_posts_count_staff_poster(self):
+        # Start with 0
+        self.assertEqual(self.staff.get_hidden_by_staff_posts_count(), 0)
+        # Post and hide it by poster which is staff
+        PostFactory(topic=self.forumtopic, author=self.staff.user, position=1, is_visible=False, editor=self.staff.user)
+        # Should be 0 because even if poster is staff, he is the poster
+        self.assertEqual(self.staff.get_hidden_by_staff_posts_count(), 0)
+
     def test_get_alerts_posts_count(self):
         # Start with 0
         self.assertEqual(self.user1.get_alerts_posts_count(), 0)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Issue concernée                | #4001

Cette pull request améliore le compteur de messages modérés visible par le staff dans les profils. Seuls les messages n'ayant pas été masqués par leur auteur (autrement dit ceux masqués par le staff) sont comptabilisés.

### QA

* Noter le nombre de messages modérés d'un membre depuis un compte staff ;
* Depuis le compte du membre, poster un message et le masquer ;
* Vérifier depuis un compte staff que le nombre de messages modérés n'a pas changé ;
* Démasquer le message puis le masquer à nouveau avec le compte staff (ou masquer un autre message du membre, peu importe) ;
* Vérifier que le nombre de messages modérés du membre a augmenté de 1.