### PR TITLE
Redirige vers le brouillon à partir de la version publiée

### DIFF
--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -149,6 +149,10 @@
                     {% trans "Ajouter une section" %}
                 </a>
             {%  endif %}
+        {% else %}
+            <a href="{{ content.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
+                {% trans "Version brouillon" %}
+            </a>
         {% endif %}
     {% endif %}
 {% endblock %}

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -150,7 +150,7 @@
                 </a>
             {%  endif %}
         {% else %}
-            <a href="{{ content.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
+            <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
                 {% trans "Version brouillon" %}
             </a>
         {% endif %}

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -107,8 +107,8 @@
         <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Administration">
             <h3>{% blocktrans %}Admin<span class="wide">istration</span>{% endblocktrans %}</h3>
             <ul>
-                <li><a href="{{ container.get_absolute_url }}?version={{ content.sha_public }}" class="ico-after offline blue">
-                    {% trans "Version hors-ligne" %}
+                <li><a href="{{ content.get_absolute_url }}" class="ico-after offline blue">
+                    {% trans "Version brouillon" %}
                 </a></li>
             </ul>
         </div>

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -107,7 +107,7 @@
         <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Administration">
             <h3>{% blocktrans %}Admin<span class="wide">istration</span>{% endblocktrans %}</h3>
             <ul>
-                <li><a href="{{ content.get_absolute_url }}" class="ico-after offline blue">
+                <li><a href="{{ object.get_absolute_url }}" class="ico-after offline blue">
                     {% trans "Version brouillon" %}
                 </a></li>
             </ul>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -179,7 +179,7 @@
             </a>
 
         {% else %}
-            <a href="{{ content.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
+            <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
                 {% trans "Version brouillon" %}
             </a>
         {% endif %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -179,7 +179,7 @@
             </a>
 
         {% else %}
-            <a href="{% url "content:view" content.pk content.slug_repository %}" class="ico-after arrow-right blue new-btn">
+            <a href="{{ content.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
                 {% trans "Version brouillon" %}
             </a>
         {% endif %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -143,8 +143,8 @@
             <h3>{% blocktrans %}Admin<span class="wide">istration</span>{% endblocktrans %}</h3>
             <ul>
                 <li>
-                    <a href="{{ content.get_absolute_url }}?version={{ content.sha_public }}" class="ico-after offline blue">
-                        {% trans "Version hors-ligne" %}
+                    <a href="{{ content.get_absolute_url }}" class="ico-after offline blue">
+                        {% trans "Version brouillon" %}
                     </a>
                 </li>
                 {% if is_staff %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -143,7 +143,7 @@
             <h3>{% blocktrans %}Admin<span class="wide">istration</span>{% endblocktrans %}</h3>
             <ul>
                 <li>
-                    <a href="{{ content.get_absolute_url }}" class="ico-after offline blue">
+                    <a href="{{ object.get_absolute_url }}" class="ico-after offline blue">
                         {% trans "Version brouillon" %}
                     </a>
                 </li>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | nouvelle fonctionnalité / évolution
| Ticket(s) (_issue(s)_) concerné(s)  | (ex #3200)

### QA

- Créer un tutoriel et le publier.
- Aller sur la version publiée, le bouton « Version hors-ligne » devrait maintenant être « Version brouillon. Vérifier que ce bouton mène bien à la version brouillon et pas à la version hors-ligne.
- Vérifier qu’on a aussi ce comportement quand on est dans un chapitre de la version publiée.
- Vérifier ce comportement pour une version du tutoriel qui n’est ni celle publiée, ni le brouillon.

