### PR TITLE
Fix #3237 : prévisualisation biographie

### DIFF
--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -224,7 +224,7 @@
             
             
         var csrfmiddlewaretoken = $form.find("input[name=csrfmiddlewaretoken]").val(),
-            test,
+            text,
             lastPost = $form.find("input[name=last_post]").val();
 
         $.ajax({

--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -217,8 +217,14 @@
      */
     $(".message-bottom").on("click", "[data-ajax-input='preview-message']", function(e){
         var $form = $(this).parents("form:first");
+        if ( $form.find(".preview-source").length )
+            {var text = $form.find(".preview-source").val();}
+        else
+            {var text = $form.find("textarea[name=text]").val();}
+            
+            
         var csrfmiddlewaretoken = $form.find("input[name=csrfmiddlewaretoken]").val(),
-            text = $form.find("textarea[name=text]").val(),
+            test,
             lastPost = $form.find("input[name=last_post]").val();
 
         $.ajax({

--- a/templates/member/settings/profile.html
+++ b/templates/member/settings/profile.html
@@ -25,10 +25,9 @@
     <div class="content-wrapper">
         {% crispy form %}
     </div>
-    
 
     
     {% if form.biographie.value %}
-        {% include "misc/previsualization.part.html" with text=form.biographie.value foo="bar" %}
+        {% include "misc/previsualization.part.html" with text=form.biographie.valuegit %}
     {% endif %}
 {% endblock %}

--- a/templates/member/settings/profile.html
+++ b/templates/member/settings/profile.html
@@ -28,6 +28,6 @@
 
     
     {% if form.biographie.value %}
-        {% include "misc/previsualization.part.html" with text=form.biographie.valuegit %}
+        {% include "misc/previsualization.part.html" with text=form.biographie.value %}
     {% endif %}
 {% endblock %}

--- a/templates/member/settings/profile.html
+++ b/templates/member/settings/profile.html
@@ -25,4 +25,10 @@
     <div class="content-wrapper">
         {% crispy form %}
     </div>
+    
+
+    
+    {% if form.biographie.value %}
+        {% include "misc/previsualization.part.html" with text=form.biographie.value foo="bar" %}
+    {% endif %}
 {% endblock %}

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -265,7 +265,7 @@ class ProfileForm(MiniProfileForm):
             self.fields['options'].initial += 'email_for_answer'
 
         layout = Layout(
-            Field('biography',name='text'),
+            Field('biography'),
             Field('site'),
             Field('avatar_url'),
             HTML(_(u'''<p><a href="{% url 'gallery-list' %}">Choisir un avatar dans une galerie</a><br/>

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -148,7 +148,7 @@ class MiniProfileForm(forms.Form):
     """
     Updates some profile data: biography, website, avatar URL, signature.
     """
-    biography= forms.CharField(
+    biography = forms.CharField(
         label=_('Biographie'),
         required=False,
         widget=forms.Textarea(

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -16,7 +16,7 @@ from crispy_forms.layout import HTML, Layout, \
 from zds.member.models import Profile, KarmaNote
 from zds.member.validators import validate_not_empty, validate_zds_email, validate_zds_username, validate_passwords, \
     validate_zds_password
-from zds.utils.forms import CommonLayoutModalText
+from zds.utils.forms import CommonLayoutModalText, CommonLayoutEditor
 
 # Max password length for the user.
 # Unlike other fields, this is not the length of DB field
@@ -148,13 +148,13 @@ class MiniProfileForm(forms.Form):
     """
     Updates some profile data: biography, website, avatar URL, signature.
     """
-    biography = forms.CharField(
+    biography= forms.CharField(
         label=_('Biographie'),
         required=False,
         widget=forms.Textarea(
             attrs={
                 'placeholder': _(u'Votre biographie au format Markdown.'),
-                'class': 'md-editor'
+                'class': 'md-editor preview-source'
             }
         )
     )
@@ -265,7 +265,7 @@ class ProfileForm(MiniProfileForm):
             self.fields['options'].initial += 'email_for_answer'
 
         layout = Layout(
-            Field('biography'),
+            Field('biography',name='text'),
             Field('site'),
             Field('avatar_url'),
             HTML(_(u'''<p><a href="{% url 'gallery-list' %}">Choisir un avatar dans une galerie</a><br/>
@@ -273,7 +273,7 @@ class ProfileForm(MiniProfileForm):
             Créez une galerie et importez votre avatar si ce n'est pas déjà fait !</p>''')),
             Field('sign'),
             Field('options'),
-            ButtonHolder(StrictButton(_(u'Enregistrer'), type='submit'),)
+            CommonLayoutEditor()
         )
         if initial.get('is_dev'):
             layout.fields.insert(5, Field('github_token'))

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -265,34 +265,14 @@ class MemberModelsTest(TestCase):
         self.assertFalse(self.user1.can_write_now())
         self.user1.user.is_active = True
         self.assertTrue(self.user1.can_write_now())
-        profile_ban_temp = ProfileFactory()
-        profile_ban_temp.can_read = False
-        profile_ban_temp.can_write = False
-        profile_ban_temp.end_ban_read = datetime.now() + timedelta(days=1)
-        profile_ban_temp.save()
-        self.assertFalse(profile_ban_temp.can_read_now())
-        profile_ls_temp = ProfileFactory()
-        profile_ls_temp.can_write = False
-        profile_ls_temp.end_ban_write = datetime.now() + timedelta(days=1)
-        profile_ls_temp.save()
-        self.assertTrue(profile_ls_temp.can_read_now())
+        # TODO Some conditions still need to be tested
 
     def test_can_write_now(self):
         self.user1.user.is_active = False
         self.assertFalse(self.user1.can_write_now())
         self.user1.user.is_active = True
         self.assertTrue(self.user1.can_write_now())
-        profile_ban_temp = ProfileFactory()
-        profile_ban_temp.can_read = False
-        profile_ban_temp.can_write = False
-        profile_ban_temp.end_ban_read = datetime.now() + timedelta(days=1)
-        profile_ban_temp.save()
-        self.assertFalse(profile_ban_temp.can_write_now())
-        profile_ls_temp = ProfileFactory()
-        profile_ls_temp.can_write = False
-        profile_ls_temp.end_ban_write = datetime.now() + timedelta(days=1)
-        profile_ls_temp.save()
-        self.assertFalse(profile_ls_temp.can_write_now())
+        # TODO Some conditions still need to be tested
 
     def test_get_followed_topics(self):
         # Start with 0

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -265,14 +265,34 @@ class MemberModelsTest(TestCase):
         self.assertFalse(self.user1.can_write_now())
         self.user1.user.is_active = True
         self.assertTrue(self.user1.can_write_now())
-        # TODO Some conditions still need to be tested
+        profile_ban_temp = ProfileFactory()
+        profile_ban_temp.can_read = False
+        profile_ban_temp.can_write = False
+        profile_ban_temp.end_ban_read = datetime.now() + timedelta(days=1)
+        profile_ban_temp.save()
+        self.assertFalse(profile_ban_temp.can_read_now())
+        profile_ls_temp = ProfileFactory()
+        profile_ls_temp.can_write = False
+        profile_ls_temp.end_ban_write = datetime.now() + timedelta(days=1)
+        profile_ls_temp.save()
+        self.assertTrue(profile_ls_temp.can_read_now())
 
     def test_can_write_now(self):
         self.user1.user.is_active = False
         self.assertFalse(self.user1.can_write_now())
         self.user1.user.is_active = True
         self.assertTrue(self.user1.can_write_now())
-        # TODO Some conditions still need to be tested
+        profile_ban_temp = ProfileFactory()
+        profile_ban_temp.can_read = False
+        profile_ban_temp.can_write = False
+        profile_ban_temp.end_ban_read = datetime.now() + timedelta(days=1)
+        profile_ban_temp.save()
+        self.assertFalse(profile_ban_temp.can_write_now())
+        profile_ls_temp = ProfileFactory()
+        profile_ls_temp.can_write = False
+        profile_ls_temp.end_ban_write = datetime.now() + timedelta(days=1)
+        profile_ls_temp.save()
+        self.assertFalse(profile_ls_temp.can_write_now())
 
     def test_get_followed_topics(self):
         # Start with 0

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -241,7 +241,7 @@ class MemberTests(TestCase):
             follow=False
         )
         self.assertEqual(result.status_code, 200)
-        
+
     def test_success_preview_biography(self):
 
         response = self.client.post(

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -241,6 +241,19 @@ class MemberTests(TestCase):
             follow=False
         )
         self.assertEqual(result.status_code, 200)
+        
+    def test_success_preview_biography(self):
+
+        response = self.client.post(
+            reverse('update-member'),
+            {
+                'biography': 'It is my life',
+                'preview': '',
+            },
+            follow=True
+        )
+
+        self.assertEqual(200, response.status_code)
 
     def test_login(self):
         """

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -16,7 +16,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q
-from django.http import Http404, HttpResponseBadRequest, HttpResponse, StreamingHttpResponse
+from django.http import Http404, HttpResponseBadRequest, StreamingHttpResponse
 from django.shortcuts import redirect, render, get_object_or_404, render_to_response
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
@@ -119,7 +119,7 @@ class UpdateMember(UpdateView):
 
     def post(self, request, *args, **kwargs):
         form = self.form_class(request.POST)
-        
+
         if "preview" in request.POST:
             if request.is_ajax():
                 print(request.POST)

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -16,8 +16,8 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q
-from django.http import Http404, HttpResponseBadRequest
-from django.shortcuts import redirect, render, get_object_or_404
+from django.http import Http404, HttpResponseBadRequest, HttpResponse, StreamingHttpResponse
+from django.shortcuts import redirect, render, get_object_or_404, render_to_response
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.utils.http import urlunquote
@@ -119,6 +119,12 @@ class UpdateMember(UpdateView):
 
     def post(self, request, *args, **kwargs):
         form = self.form_class(request.POST)
+        
+        if "preview" in request.POST:
+            if request.is_ajax():
+                print(request.POST)
+                content = render_to_response('misc/previsualization.part.html', {'text': request.POST.get('text')})
+                return StreamingHttpResponse(content)
 
         if form.is_valid():
             return self.form_valid(form)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                |  évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #3237 

Ajout de la previsualisation de la biographie. Avant cette PR le champ a previsualiser devait forcement s'appeller text. Aujourd'hui on reste compatible, mais on peut aussi utiliser une classe css pour marquer le champ a previsualiser. Sera utile pour la previsualisation des intros et des conclusions de contenu (a venir). Du coup il faut reconstruire le front.

 
### QA

* lancez `npm run gulp build` pour le front
* Verifier que l'apercu de la biographie fonctionne bien
* Les autres apercu (mp,forum, etc.) doivent toujours fonctionner.
