### PR TITLE
use `caches` instead of the deprecated `get_cache`

### DIFF
--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -13,7 +13,7 @@ from zds.api.pagination import REST_PAGE_SIZE, REST_MAX_PAGE_SIZE, REST_PAGE_SIZ
 from zds.member.factories import ProfileFactory, StaffProfileFactory, ProfileNotSyncFactory
 from zds.member.models import TokenRegister
 from rest_framework_extensions.settings import extensions_api_settings
-from django.core.cache import caches, get_cache
+from django.core.cache import caches
 
 
 class MemberListAPITest(APITestCase):
@@ -1001,7 +1001,7 @@ class PermissionMemberAPITest(APITestCase):
         self.profile = ProfileFactory()
         self.staff = StaffProfileFactory()
 
-        get_cache(extensions_api_settings.DEFAULT_USE_CACHE).clear()
+        caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
 
     def test_has_read_permission_for_anonymous_users(self):
         """

--- a/zds/search/utils.py
+++ b/zds/search/utils.py
@@ -34,7 +34,7 @@ def filter_keyword(html):
 
     :return: list of important words
     """
-    bs = BeautifulSoup(html)
+    bs = BeautifulSoup(html, 'lxml')
 
     keywords = u''
     for tag in bs.findAll(['h1', 'h2', 'h3', 'em', 'strong']):
@@ -49,7 +49,7 @@ def filter_text(html):
     :param html: The text from which words must be extract
     :return: extracted words
     """
-    bs = BeautifulSoup(html)
+    bs = BeautifulSoup(html, 'lxml')
     return u' '.join(bs.findAll(text=True))
 
 


### PR DESCRIPTION
- first commit: fix a Django warning on `get_cache`
- second commit: fix a BeautifulSoup warning on unspecified parser