### PR TITLE
Répare la sidebar & les sourcemaps

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -45,6 +45,7 @@ gulp.task('js', () =>
     gulp.src([
         require.resolve('jquery'),
         require.resolve('cookies-eu-banner'),
+        'assets/js/_custom.modernizr.js',
 
         // Used by other scripts, must be first
         'assets/js/modal.js',

--- a/package.json
+++ b/package.json
@@ -23,26 +23,26 @@
   },
   "homepage": "https://github.com/zestedesavoir/zds-site",
   "dependencies": {
-    "autoprefixer": "6.4.0",
+    "autoprefixer": "6.5.3",
     "cookies-eu-banner": "1.2.7",
-    "cssnano": "3.7.4",
+    "cssnano": "3.8.1",
     "del": "2.2.2",
     "gulp": "3.9.1",
-    "gulp-concat": "2.6.0",
-    "gulp-imagemin": "3.0.3",
-    "gulp-postcss": "6.1.1",
+    "gulp-concat": "2.6.1",
+    "gulp-imagemin": "3.1.1",
+    "gulp-postcss": "6.2.0",
     "gulp-rename": "1.2.2",
     "gulp-sass": "2.3.2",
-    "gulp-sourcemaps": "1.6.0",
+    "gulp-sourcemaps": "1.9.1",
     "gulp-uglify": "2.0.0",
     "gulp.spritesmith": "6.2.1",
-    "jquery": "3.1.0",
-    "normalize.css": "4.2.0"
+    "jquery": "3.1.1",
+    "normalize.css": "5.0.0"
   },
   "devDependencies": {
-    "gulp-jshint": "2.0.1",
+    "gulp-jshint": "2.0.4",
     "gulp-livereload": "3.8.1",
-    "jshint": "2.9.3",
+    "jshint": "2.9.4",
     "jshint-stylish": "2.2.1"
   }
 }


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4020


y'a un bump des dépendances front qui règle un problème de sourcemaps (pas d'issue lié, je l'ai remarqué au passage) ; et en fait, si la sidebar fonctionnait pas, c'est qu'il manquait modernizr, qui rajoute une classe `js` au body au chargement

### QA

* vérifier que la sidebar marche bien sur mobile

