### PR TITLE
v21: Corrige les icônes des alertes des messages de forum

### DIFF
--- a/assets/scss/base/_icons.scss
+++ b/assets/scss/base/_icons.scss
@@ -17,7 +17,7 @@
         @include sprite();
     }
 
-    &.alert {
+    &.alert, &.ico-alert {
         &:after {
             @include sprite-position($alert);
         }

--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -19,7 +19,7 @@
         </p>
     </div>
 {% elif topic.antispam or isantispam %}
-    <div class="alert-box ico-after light">
+    <div class="alert-box ico-after ico-alert light">
         {% trans "Vous venez de poster. Merci de patienter au moins 15 minutes entre deux messages consécutifs afin de limiter le flood" %}.
     </div>
 {% elif topic.alone %}
@@ -38,7 +38,7 @@
     {% endif %}
 
     {% if page_obj.has_next %}
-        <div class="alert-box warning ico-after alert">
+        <div class="alert-box warning ico-after alert light">
             {% trans "<strong>Attention</strong>, vous n'êtes pas sur la dernière page de ce sujet, assurez-vous de l'avoir lu dans son intégralité avant d'y répondre." %}
         </div>
     {% endif %}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | [forum](https://zestedesavoir.com/forums/sujet/7454/v21-principalement-du-bugfix-venez-tester-avec-nous/?page=1#p133021)

### QA

* builder le front
* poster un message sur le forum
* vérifier que l'icône de l'alerte est OK
