### PR TITLE
Empêche un membre non staff d'éditer le profil d'un autre membre

### DIFF
--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -592,7 +592,7 @@ def articles(request):
 @login_required
 def settings_mini_profile(request, user_name):
     """Minimal settings of users for staff."""
-    
+
     if not request.user.has_perm('member.change_profile'):
         raise PermissionDenied
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, logout
-from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User, Group
 from django.template.context_processors import csrf
 from django.core.exceptions import PermissionDenied
@@ -590,9 +590,11 @@ def articles(request):
 
 @can_write_and_read_now
 @login_required
-@permission_required('member.change_profile')
 def settings_mini_profile(request, user_name):
     """Minimal settings of users for staff."""
+    
+    if not request.user.has_perm('member.change_profile'):
+        raise PermissionDenied
 
     # extra information about the current user
     profile = get_object_or_404(Profile, user__username=user_name)

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, logout
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.models import User, Group
 from django.template.context_processors import csrf
 from django.core.exceptions import PermissionDenied
@@ -590,6 +590,7 @@ def articles(request):
 
 @can_write_and_read_now
 @login_required
+@permission_required('member.change_profile')
 def settings_mini_profile(request, user_name):
     """Minimal settings of users for staff."""
 


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug

Cette PR supprime un bug : un membre ne peut plus modifier le profil d'un autre membre sans avoir les droits staff.

### QA

* Vérifier qu'un membre ne peut pas éditer le profil d'un autre membre sans avoir les droits staff : une erreur 403 doit lui être retournée.

