### PR TITLE
Vérifie qu'un membre non staff ne peut pas éditer le profil d'un membre

### DIFF
--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -50,6 +50,7 @@ class MemberTests(TestCase):
             category=self.category1,
             position_in_category=1)
         self.staff = StaffProfileFactory().user
+        self.user = ProfileFactory().user
 
         self.bot = Group(name=settings.ZDS_APP["member"]["bot_group"])
         self.bot.save()
@@ -219,8 +220,16 @@ class MemberTests(TestCase):
         self.assertEqual(result.status_code, 200)
 
     def test_modify_member(self):
+        # we need staff right for update other profile, so a member who is not staff can't access to the page
+        self.client.logout()
+        self.client.login(username=self.user.username, password="hostel77")
 
-        # we need staff right for update other profile
+        result = self.client.get(
+            reverse('member-settings-mini-profile', args=["xkcd"]),
+            follow=False
+        )
+        self.assertEqual(result.status_code, 403)
+
         self.client.logout()
         self.client.login(username=self.staff.username, password="hostel77")
 

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -50,7 +50,6 @@ class MemberTests(TestCase):
             category=self.category1,
             position_in_category=1)
         self.staff = StaffProfileFactory().user
-        self.user = ProfileFactory().user
 
         self.bot = Group(name=settings.ZDS_APP["member"]["bot_group"])
         self.bot.save()
@@ -220,9 +219,11 @@ class MemberTests(TestCase):
         self.assertEqual(result.status_code, 200)
 
     def test_modify_member(self):
+        user = ProfileFactory().user
+
         # we need staff right for update other profile, so a member who is not staff can't access to the page
         self.client.logout()
-        self.client.login(username=self.user.username, password="hostel77")
+        self.client.login(username=user.username, password="hostel77")
 
         result = self.client.get(
             reverse('member-settings-mini-profile', args=["xkcd"]),

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -593,6 +593,9 @@ def articles(request):
 def settings_mini_profile(request, user_name):
     """Minimal settings of users for staff."""
 
+    if not request.user.has_perm('member.change_profile'):
+        raise PermissionDenied
+
     # extra information about the current user
     profile = get_object_or_404(Profile, user__username=user_name)
     if request.method == "POST":


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Pull request concernée  | #4041 

Cette pull request modifie le test de la page mini_profile (permettant au staff de modifier le profil d'un membre) en vérifiant le fait qu'un membre non autorisé reçoit bien une erreur 403.

### QA

* Vérifier que le test `zds.member.tests.tests_views.MemberTests.test_modify_member` fonctionne correctement ;
* Vérifier que le test est invalide si on supprime [cette condition](https://github.com/zestedesavoir/zds-site/blob/prod/zds/member/views.py#L596-L597).