### PR TITLE
Empêche un membre non staff d'en bannir un autre

### DIFF
--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -690,6 +690,35 @@ class MemberTests(TestCase):
         self.assertEqual(ban.text, u'Texte de test pour BAN TEMP')
         self.assertEquals(len(mail.outbox), 6)
 
+    def test_sanctions_with_not_staff_user(self):
+        user = ProfileFactory().user
+
+        # we need staff right for update the sanction of an user, so a member who is not staff can't access to the page
+        self.client.logout()
+        self.client.login(username=user.username, password="hostel77")
+
+        # Test: LS
+        result = self.client.post(
+            reverse(
+                'member-modify-profile', kwargs={
+                    'user_pk': self.staff.id}), {
+                'ls': '', 'ls-text': 'Texte de test pour LS'}, follow=False)
+
+        self.assertEqual(result.status_code, 403)
+
+        # if the user is staff, he can update the sanction of an user
+        self.client.logout()
+        self.client.login(username=self.staff.username, password="hostel77")
+
+        # Test: LS
+        result = self.client.post(
+            reverse(
+                'member-modify-profile', kwargs={
+                    'user_pk': user.id}), {
+                'ls': '', 'ls-text': 'Texte de test pour LS'}, follow=False)
+
+        self.assertEqual(result.status_code, 302)
+
     def test_failed_bot_sanctions(self):
 
         staff = StaffProfileFactory()

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -444,6 +444,9 @@ def unregister(request):
 def modify_profile(request, user_pk):
     """Modifies sanction of a user if there is a POST request."""
 
+    if not request.user.has_perm('member.change_profile'):
+        raise PermissionDenied
+
     profile = get_object_or_404(Profile, user__pk=user_pk)
     if profile.is_private():
         raise PermissionDenied


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction d'une faille de sécurité

*Avant tout, la faille est déjà fixée sur la prod, donc pas d'inquiétude !*

Cette pull request corrige une faille de sécurité qui permettait à un membre de bannir, débannir ou annuler une sanction d'un autre membre sans avoir les droits staff. Un test est également ajouté pour éviter de reproduire cette erreur dans le futur.

Pour reproduire la faille (donc sur une version locale sans le fix), il faut envoyer une requête `POST` vers `/membres/profil/modifier/{pk}/` avec pour paramètres :

- `ban-text` : le motif du bannissement ;
- `csrfmiddlewaretoken` : le token CSRF courant ;
- `ban` : pour indiquer qu'il s'agit d'un bannissement.

### QA

* Vérifier qu'en suivant les instructions ci-dessus sans être staff, on reçoit bien une erreur 403 ;
* Vérifier qu'un membre du staff peut toujours sanctionner un membre.
