### PR TITLE
fix 4063 : persistant notif on unpublish

### DIFF
--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -22,7 +22,7 @@ from zds.notification.models import TopicAnswerSubscription, ContentReactionAnsw
     PingSubscription
 from zds.notification.signals import answer_unread, content_read, new_content, edit_content
 from zds.tutorialv2.models.models_database import PublishableContent, ContentReaction
-
+import zds.tutorialv2.signals
 
 logger = logging.getLogger(__name__)
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
+import logging
+
+from django.db.backends.dummy.base import DatabaseError
+
+import zds
 
 try:
     from functools import wraps
@@ -17,6 +22,9 @@ from zds.notification.models import TopicAnswerSubscription, ContentReactionAnsw
     PingSubscription
 from zds.notification.signals import answer_unread, content_read, new_content, edit_content
 from zds.tutorialv2.models.models_database import PublishableContent, ContentReaction
+
+
+logger = logging.getLogger(__name__)
 
 
 def disable_for_loaddata(signal_handler):
@@ -360,3 +368,27 @@ def delete_notifications(sender, instance, **kwargs):
     """
     Subscription.objects.filter(user=instance).delete()
     Notification.objects.filter(sender=instance).delete()
+
+
+@receiver(zds.tutorialv2.signals.content_unpublished, sender=PublishableContent)
+def cleanup_notification_for_unpublished_content(sender, instance, **_):
+    """
+    Avoid persistant notification if a content is unpublished. A real talk has to be lead to avoid such cross module \
+    dependency.
+
+    :param sender: always PublishableContent
+    :param instance: the unpublished content
+    :param _: the useless kwargs
+    """
+    logger.debug("deal with %s(%s) notifications.", sender, instance)
+    try:
+        notifications = Notification.objects\
+            .filter(content_type=ContentType.objects.get_for_model(instance, True), object_id=instance.pk)
+        for notification in notifications:
+            if notification.subscription.last_notification.pk == notification.pk:
+                notification.subscription.last_notification = None
+                notification.subscription.save()
+            notification.delete()
+        logger.debug("Nothing went wrong.")
+    except DatabaseError:
+        logger.exception()

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -8,6 +8,7 @@ from zds.member.factories import StaffProfileFactory, ProfileFactory
 from zds.notification.models import NewTopicSubscription, Notification, ContentReactionAnswerSubscription, \
     NewPublicationSubscription
 from zds.tutorialv2 import signals
+from zds.notification import signals as notif_signals
 from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory, SubCategoryFactory, \
     PublishedContentFactory
 from zds.tutorialv2.publication_utils import publish_content
@@ -93,7 +94,7 @@ class ContentNotification(TestCase):
         NewPublicationSubscription.objects.get_or_create_active(self.user1, self.user2)
         content = PublishedContentFactory(author_list=[self.user2])
 
-        signals.new_content.send(sender=self.tuto.__class__, instance=content, by_email=False)
+        notif_signals.new_content.send(sender=self.tuto.__class__, instance=content, by_email=False)
         self.assertEqual(1, len(Notification.objects.get_notifications_of(self.user1)))
         unpublish_content(content)
         self.assertEqual(0, len(Notification.objects.get_notifications_of(self.user1)))

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -5,9 +5,7 @@ from zds.forum.factories import CategoryFactory, ForumFactory
 from zds.forum.models import Topic
 from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import StaffProfileFactory, ProfileFactory
-from zds.notification.models import NewTopicSubscription, Notification, ContentReactionAnswerSubscription, \
-    NewPublicationSubscription
-from zds.tutorialv2 import signals
+from zds.notification.models import NewTopicSubscription, Notification, NewPublicationSubscription
 from zds.notification import signals as notif_signals
 from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory, SubCategoryFactory, \
     PublishedContentFactory

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -15,7 +15,6 @@ from django.utils import translation
 from django.utils.translation import ugettext_lazy as _
 from os.path import isdir, dirname
 from zds import settings
-from zds.notification import signals
 from zds.search.models import SearchIndexContent
 from zds.settings import ZDS_APP
 from zds.tutorialv2.signals import content_unpublished
@@ -440,7 +439,7 @@ def unpublish_content(db_object):
 
         db_object.public_version = None
         db_object.save()
-        content_unpublished.send(instance=db_object)
+        content_unpublished.send(sender=db_object.__class__, instance=db_object)
         return True
 
     except (ObjectDoesNotExist, IOError):

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -9,13 +9,16 @@ import zipfile
 from datetime import datetime
 
 from django.core.exceptions import ObjectDoesNotExist
+from django.dispatch.dispatcher import receiver
 from django.template.loader import render_to_string
 from django.utils import translation
 from django.utils.translation import ugettext_lazy as _
 from os.path import isdir, dirname
 from zds import settings
+from zds.notification import signals
 from zds.search.models import SearchIndexContent
 from zds.settings import ZDS_APP
+from zds.tutorialv2.signals import content_unpublished
 from zds.tutorialv2.utils import retrieve_and_update_images_links
 from zds.utils.templatetags.emarkdown import emarkdown
 
@@ -409,7 +412,11 @@ def make_zip_file(published_content):
 
 
 def unpublish_content(db_object):
-    """Remove the given content from the public view
+    """
+    Remove the given content from the public view.
+
+    .. note::
+        This will send content_unpublished event.
 
     :param db_object: Database representation of the content
     :type db_object: PublishableContent
@@ -433,13 +440,19 @@ def unpublish_content(db_object):
 
         db_object.public_version = None
         db_object.save()
-
-        # We just delete all index that correspond to the content
-        SearchIndexContent.objects.filter(publishable_content=db_object).delete()
-
+        content_unpublished.send(instance=db_object)
         return True
 
     except (ObjectDoesNotExist, IOError):
         pass
 
     return False
+
+
+@receiver(content_unpublished)
+def clean_search_on_removed(sender, instance, **_):
+    from zds.tutorialv2.models.models_database import PublishableContent
+    if sender != PublishableContent.__class__:
+        return
+    # We just delete all index that correspond to the content
+    SearchIndexContent.objects.filter(publishable_content=instance).delete()

--- a/zds/tutorialv2/signals.py
+++ b/zds/tutorialv2/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch.dispatcher import Signal
+
+# is sent whenever a content is unpublished
+content_unpublished = Signal(providing_args=['instance'])


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug 
| Ticket(s) (_issue(s)_) concerné(s)  | #4063

### QA

* user2 s'abonne à user1
* user1 publie un tuto
* user3 écrit un commentaire
* user4 répond
* staff dépublie le tuto
* ni user2 ni user3 n'ont de notification.
