### PR TITLE
Dowgrade nomalize.css 5.0.0 -> 4.2.0 (fix #4062)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-uglify": "2.0.0",
     "gulp.spritesmith": "6.2.1",
     "jquery": "3.1.1",
-    "normalize.css": "5.0.0"
+    "normalize.css": "4.2.0"
   },
   "devDependencies": {
     "gulp-jshint": "2.0.4",


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4062

Un changementdans normalize.css (https://github.com/necolas/normalize.css/compare/4.2.0...master#diff-bb3dde41d97f19be8ab7b4780a915d5eR257) que j'avais pas anticipé quand j'ai bump les dépendances (https://github.com/zestedesavoir/zds-site/commit/57417947a8970868a50a7db153eb4f098e3ffd51#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R40) avait tué les interlignes dans l'éditeur.
