### PR TITLE
Permet de marquer ses notifications comme lues

### DIFF
--- a/templates/notification/followed.html
+++ b/templates/notification/followed.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load date %}
+{% load captureas %}
 
 
 {% block title %}
@@ -49,4 +50,26 @@
     </div>
 
     {% include "misc/paginator.html" with position="bottom" %}
+{% endblock %}
+
+
+
+{% block sidebar %}
+    <aside class="sidebar mobile-menu-hide">
+        <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Actions">
+            <h3>{% trans "Actions" %}</h3>
+            <ul>
+                <li>
+                    <a href="#mark-notifications-as-read" class="open-modal ico-after tick green">{% trans 'Tout marquer comme lu' %}</a>
+                        <form action="{% url 'mark-notifications-as-read' %}" method="post" id="mark-notifications-as-read" class="modal modal-flex">
+                            {% csrf_token %}
+                            <p>
+                                {% trans 'Voulez-vous vraiment marquer toutes vos notifications comme lues ?' %}
+                            </p>
+                            <button type="submit">{% trans 'Confirmer' %}</button>
+                    </form>
+                </li>
+            </ul>
+        </div>
+    </aside>
 {% endblock %}

--- a/templates/notification/followed.html
+++ b/templates/notification/followed.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load date %}
-{% load captureas %}
 
 
 {% block title %}

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -769,3 +769,21 @@ class NotificationTest(TestCase):
         self.assertIsNotNone(auto_user_1_sub)
         notifs = list(Notification.objects.get_notifications_of(author1.user))
         self.assertEqual(1, len(notifs))
+
+    def test_mark_notifications_as_read(self):
+        category = CategoryFactory(position=1)
+        forum = ForumFactory(category=category, position_in_category=1)
+        topic = TopicFactory(forum=forum, author=self.user1)
+        PostFactory(topic=topic, author=self.user1, position=1)
+        PostFactory(topic=topic, author=self.user2, position=2)
+
+        notifications = Notification.objects.get_unread_notifications_of(self.user1)
+        self.assertEqual(1, len(notifications))
+
+        result = self.client.post(
+            reverse('mark-notifications-as-read'),
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        notifications = Notification.objects.get_unread_notifications_of(self.user1)
+        self.assertEqual(0, len(notifications))

--- a/zds/notification/urls.py
+++ b/zds/notification/urls.py
@@ -2,8 +2,9 @@
 
 from django.conf.urls import url
 
-from zds.notification.views import NotificationList
+from zds.notification.views import NotificationList, mark_notifications_as_read
 
 urlpatterns = [
     url(r'^$', NotificationList.as_view(), name='notification-list'),
+    url(r'^marquer-comme-lues$', mark_notifications_as_read, name='mark-notifications-as-read'),
 ]

--- a/zds/notification/views.py
+++ b/zds/notification/views.py
@@ -2,6 +2,11 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
 from django.utils.decorators import method_decorator
+from django.contrib import messages
+from django.views.decorators.http import require_POST
+from django.utils.translation import ugettext_lazy as _
+from django.shortcuts import redirect
+from django.core.urlresolvers import reverse
 
 from zds import settings
 from zds.mp.models import PrivateTopic
@@ -28,3 +33,19 @@ class NotificationList(ZdSPagingListView):
             .exclude(subscription__content_type=content_type) \
             .order_by('is_read', '-pubdate') \
             .all()
+
+
+@require_POST
+@login_required
+def mark_notifications_as_read(request):
+    """Mark the notifications of the current user as read"""
+
+    notifications = Notification.objects.get_unread_notifications_of(request.user)
+
+    for notification in notifications:
+        notification.is_read = True
+        notification.save()
+
+    messages.success(request, _(u'Vos notifications ont bien été marquées comme lues.'))
+
+    return redirect(reverse('notification-list'))


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | nouvelle fonctionnalité
| Ticket(s) (_issue(s)_) concerné(s)  | [ce sujet](https://zestedesavoir.com/forums/sujet/7546/petite-suggestion-concernant-les-notifications/)

Cette pull request ajoute une nouvelle fonctionnalité : il est maintenant possible de marquer toutes ses notifications comme lues.

C'est ma première « grosse pull request », donc il y a peut-être des choses que j'ai mal faites. N'hésitez pas à les signaler pour que j'améliore ça.

### QA

* Créer des notifications pour un utilisateur (n'hésitez pas à tester différents biais : forums, contenus, ...) ;
* Vérifier que la nouvelle fonctionnalité fonctionne correctement et marque ces notifications comme lues ;
* Vérifier que rien d'étrange ne semble avoir été introduit sur les notifications ;
* Vérifier que le test `zds.notification.tests.tests_basics.NotificationTest.test_mark_notifications_as_read` fonctionne.