### PR TITLE
Ajout des tooltips manquants (menu dropdown et forum)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -348,7 +348,7 @@
                                     {% with topics=user|interventions_privatetopics %}
                                     {% with notifications=topics.notifications %}
                                     {% with total_notifications=topics.total %}
-                                        <a href="{% url "mp-list" %}" class="ico-link">
+                                        <a href="{% url "mp-list" %}" class="ico-link" title="{% trans 'Messagerie privée' %}">
                                             {% if total_notifications > 0 %}
                                                 <span class="notif-count">{{ total_notifications }}</span>
                                             {% endif %}
@@ -387,7 +387,7 @@
                                 {# NOTIFICATIONS #}
                                 <div>
                                     {% with unread_posts=user|interventions_topics %}
-                                        <a href="{% url 'notification-list' %}" class="ico-link">
+                                        <a href="{% url 'notification-list' %}" class="ico-link" title="{% trans 'Notifications' %}">
                                             {% if unread_posts|length > 0 %}
                                                 <span class="notif-count">{{ unread_posts|length }}</span>
                                             {% endif %}

--- a/templates/forum/includes/topic_row.part.html
+++ b/templates/forum/includes/topic_row.part.html
@@ -9,16 +9,16 @@
     {% endif %}">
     <div class="topic-infos">
         {% if topic.is_sticky %}
-            <span class="ico-after pin blue">[{% trans "Epinglé" %}]</span>
+            <span class="ico-after pin blue" title="{% trans 'Sujet épinglé' %}">[{% trans "Epinglé" %}]</span>
         {% endif %}
         {% if topic.is_solved %}
-            <span class="ico-after tick green">[{% trans "Résolu" %}]</span>
+            <span class="ico-after tick green" title="{% blocktrans %} L'auteur a trouvé une solution à son problème {% endblocktrans %}">[{% trans "Résolu" %}]</span>
         {% endif %}
         {% if topic.is_locked %}
-            <span class="ico-after lock blue">[{% trans "Fermé" %}]</span>
+            <span class="ico-after lock blue title="{% trans 'Sujet fermé' %}">[{% trans "Fermé" %}]</span>
         {% endif %}
         {% if topic.is_followed %}
-            <span class="ico-after star blue">[{% trans "Suivi" %}]</span>
+            <span class="ico-after star blue" title="{% trans 'Sujet suivi' %}">[{% trans "Suivi" %}]</span>
         {% endif %}
     </div>
     {% with profile=topic.author|profile %}

--- a/templates/forum/includes/topic_row.part.html
+++ b/templates/forum/includes/topic_row.part.html
@@ -15,7 +15,7 @@
             <span class="ico-after tick green" title="{% blocktrans %} L'auteur a trouvé une solution à son problème {% endblocktrans %}">[{% trans "Résolu" %}]</span>
         {% endif %}
         {% if topic.is_locked %}
-            <span class="ico-after lock blue title="{% trans 'Sujet fermé' %}">[{% trans "Fermé" %}]</span>
+            <span class="ico-after lock blue" title="{% trans 'Sujet fermé' %}">[{% trans "Fermé" %}]</span>
         {% endif %}
         {% if topic.is_followed %}
             <span class="ico-after star blue" title="{% trans 'Sujet suivi' %}">[{% trans "Suivi" %}]</span>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4074

### QA

* Vérifiez que les tooltips apparaissent bien aux endroit suivants : 

Icones dans le header
- la bulle : Messagerie privée
- la cloche : Notifications

Sur le forum
- la Pin : Sujet mis en avant ou Sujet épinglé (?)
- La check : L'auteur a trouvé une solution à son problème
- Cadenas : Sujet fermé
- Étoile : Sujet suivi