### PR TITLE
Nom du site dans l'aide pour les licences

### DIFF
--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -207,7 +207,7 @@ class ContentForm(ContainerForm):
             .format(
                 settings.ZDS_APP['site']['licenses']['licence_info_title'],
                 settings.ZDS_APP['site']['licenses']['licence_info_link'],
-                settings.ZDS_APP['site']['name']
+                settings.ZDS_APP['site']['litteral_name'],
             )
         ),
         queryset=Licence.objects.order_by('title').all(),


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | formulation

Cette pull request modifie le nom du site affiché dans l'aide pour les licences (sur la page de création d'un contenu). Le paramètre `litteral_name` remplace `name`, ce qui permet me parait plus correct.

### QA

* Accédez à la page de création d'un tutoriel ;
* Vérifier que `ZesteDeSavoir` est remplacé par `Zeste de Savoir`.
