### PR TITLE
Renommage de get_alerts_posts_count en get_active_alerts_count

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -490,7 +490,7 @@
                 <li class="inactive">
                     <span>
                         {% trans "Alertes actives" %}
-                        <span class="count">{{ profile.get_alerts_posts_count }}</span>
+                        <span class="count">{{ profile.get_active_alerts_count }}</span>
                     </span>
                 </li>
             </ul>

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -304,8 +304,7 @@ class Profile(models.Model):
     def get_hidden_by_staff_posts_count(self):
         return Post.objects.filter(is_visible=False, author=self.user).exclude(editor=self.user).count()
 
-    # TODO: improve this method's name?
-    def get_alerts_posts_count(self):
+    def get_active_alerts_count(self):
         """
         :return: The number of currently active alerts created by this user.
         """

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -263,14 +263,14 @@ class MemberModelsTest(TestCase):
         # Should be 0 because even if poster is staff, he is the poster
         self.assertEqual(self.staff.get_hidden_by_staff_posts_count(), 0)
 
-    def test_get_alerts_posts_count(self):
+    def test_get_active_alerts_count(self):
         # Start with 0
-        self.assertEqual(self.user1.get_alerts_posts_count(), 0)
+        self.assertEqual(self.user1.get_active_alerts_count(), 0)
         # Post and Alert it !
         post = PostFactory(topic=self.forumtopic, author=self.user1.user, position=1)
         Alert.objects.create(author=self.user1.user, comment=post, scope='FORUM', pubdate=datetime.now())
         # Should be 1
-        self.assertEqual(self.user1.get_alerts_posts_count(), 1)
+        self.assertEqual(self.user1.get_active_alerts_count(), 1)
 
     def test_can_read_now(self):
         self.user1.user.is_active = False


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution

Cette pull request améliore le nom de la méthode renvoyant le nombre d'alertes actives. `get_alerts_posts_count` est renommé en `get_active_alerts_count`.

### QA

* Vérifier que le nombre d'alertes est correct ;
* Vérifier que le test `zds.member.tests.tests_models.MemberModelsTest.test_get_active_alerts_count` passe toujours.
