### PR TITLE
Titre du module d'alertes dans l'en-tête

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -426,8 +426,8 @@
                                 {% if perms.forum.change_post %}
                                     {% with alerts_list=user|alerts_list %}
                                         <div>
-                                            <a href="{% url "pages-alerts" %}" class="ico-link">
-                                                <span class="notif-text ico ico-alerts">{% trans "Alertes" %}</span>
+                                            <a href="{% url "pages-alerts" %}" class="ico-link" title="{% trans 'Alertes de modération' %}">
+                                                <span class="notif-text ico ico-alerts">{% trans "Alertes de modération" %}</span>
                                                 {% if alerts_list.nb_alerts > 0 %}
                                                     <span class="notif-count">{{ alerts_list.nb_alerts }}</span>
                                                 {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -434,7 +434,7 @@
                                             </a>
 
                                             <div class="dropdown">
-                                                <span class="dropdown-title">{% trans "Alertes Modération" %}</span>
+                                                <span class="dropdown-title">{% trans "Alertes de modération" %}</span>
                                                 <ul class="dropdown-list">
                                                     {% for alert in alerts_list.alerts %}
                                                         <li>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | formulation

Cette (très petite) pull request modifie le titre du cadre d'alertes dans l'en-tête du site. `Alertes Modération` est remplacé par `Alertes de modération`, ce qui est plus correct. ;)

### QA

Pas vraiment nécessaire, mais il suffit de s'assurer que le changement a bien eu lieu en se connectant depuis un compte staff.

EDIT : un `title` a été ajouté sur l'icône, vérifier qu'il s'affiche correctement.