### PR TITLE
Fixe 4106 : plus d'erreur 404 en marquant ses notifications comme lues

### DIFF
--- a/zds/notification/urls.py
+++ b/zds/notification/urls.py
@@ -6,5 +6,5 @@ from zds.notification.views import NotificationList, mark_notifications_as_read
 
 urlpatterns = [
     url(r'^$', NotificationList.as_view(), name='notification-list'),
-    url(r'^marquer-comme-lues$', mark_notifications_as_read, name='mark-notifications-as-read'),
+    url(r'^marquer-comme-lues/$', mark_notifications_as_read, name='mark-notifications-as-read'),
 ]


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4106 

Cette pull request corrige le bug introduit par #4079 et signalé dans #4106. Elle enlève l'erreur 404 en marquant ses notifications comme lues.

### QA

* Vérifier que le marquage des notifications comme lues se déroule correctement.
