### PR TITLE
Améliorations de la page Pseudo et Email

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -6,6 +6,7 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.models import User, Group
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
+from django.shortcuts import get_object_or_404
 
 from captcha.fields import ReCaptchaField
 from crispy_forms.bootstrap import StrictButton
@@ -230,7 +231,6 @@ class ProfileForm(MiniProfileForm):
         label='',
         required=False,
         choices=(
-            ('show_email', _(u'Afficher mon adresse courriel publiquement')),
             ('show_sign', _(u'Afficher les signatures')),
             ('is_hover_enabled', _(u'Cochez pour dérouler les menus au survol')),
             ('allow_temp_visual_changes', _(u'Activer les changements visuels temporaires')),
@@ -248,9 +248,6 @@ class ProfileForm(MiniProfileForm):
         # to get initial value form checkbox show email
         initial = kwargs.get('initial', {})
         self.fields['options'].initial = ''
-
-        if 'show_email' in initial and initial['show_email']:
-            self.fields['options'].initial += 'show_email'
 
         if 'show_sign' in initial and initial['show_sign']:
             self.fields['options'].initial += 'show_sign'
@@ -285,43 +282,69 @@ class ChangeUserForm(forms.Form):
     Update username and email
     """
     username = forms.CharField(
-        label=_(u'Nouveau pseudo'),
+        label=_(u'Mon pseudo'),
         max_length=User._meta.get_field('username').max_length,
         min_length=1,
         required=False,
         widget=forms.TextInput(
             attrs={
-                'placeholder': _(u'Ne mettez rien pour conserver l\'ancien')
+                'placeholder': _(u'Pseudo')
             }
         ),
-        validators=[validate_not_empty, validate_zds_username],
     )
 
     email = forms.EmailField(
-        label=_(u'Nouvelle adresse courriel'),
+        label=_(u'Mon adresse email'),
         max_length=User._meta.get_field('email').max_length,
         required=False,
         widget=forms.TextInput(
             attrs={
-                'placeholder': _(u'Ne mettez rien pour conserver l\'ancienne')
+                'placeholder': _(u'Adresse email')
             }
         ),
-        validators=[validate_not_empty, validate_zds_email],
     )
 
-    def __init__(self, *args, **kwargs):
+    options = forms.MultipleChoiceField(
+        label='',
+        required=False,
+        choices=(
+            ('show_email', _(u'Afficher mon adresse courriel publiquement')),
+        ),
+        widget=forms.CheckboxSelectMultiple,
+    )
+
+    def __init__(self, user, *args, **kwargs):
         super(ChangeUserForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_class = 'content-wrapper'
         self.helper.form_method = 'post'
+        self.previous_mail = user.email
+        self.previous_username = user.username
+        self.fields['options'].initial = ''
+
+        if get_object_or_404(Profile, user__username=user.username).show_email:
+            self.fields['options'].initial += 'show_email'
 
         self.helper.layout = Layout(
-            Field('username'),
-            Field('email'),
+            Field('username', value=user.username),
+            Field('email', value=user.email),
+            Field('options'),
             ButtonHolder(
                 StrictButton(_(u'Enregistrer'), type='submit'),
             ),
         )
+
+    def clean(self):
+        cleaned_data = super(ChangeUserForm, self).clean()
+        username = cleaned_data.get('username')
+        email = cleaned_data.get('email')
+        if username != self.previous_username:
+            validate_not_empty(username)
+            validate_zds_username(username)
+        if email != self.previous_mail:
+            validate_not_empty(email)
+            validate_zds_email(email)
+        return cleaned_data
 
 
 # TODO: Updates the password --> requires a better name

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -6,7 +6,6 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.models import User, Group
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
-from django.shortcuts import get_object_or_404
 
 from captcha.fields import ReCaptchaField
 from crispy_forms.bootstrap import StrictButton
@@ -318,11 +317,11 @@ class ChangeUserForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_class = 'content-wrapper'
         self.helper.form_method = 'post'
-        self.previous_mail = user.email
+        self.previous_email = user.email
         self.previous_username = user.username
         self.fields['options'].initial = ''
 
-        if get_object_or_404(Profile, user__username=user.username).show_email:
+        if user.profile and user.profile.show_email:
             self.fields['options'].initial += 'show_email'
 
         self.helper.layout = Layout(
@@ -336,12 +335,14 @@ class ChangeUserForm(forms.Form):
 
     def clean(self):
         cleaned_data = super(ChangeUserForm, self).clean()
+        cleaned_data['previous_username'] = self.previous_username
+        cleaned_data['previous_email'] = self.previous_email
         username = cleaned_data.get('username')
         email = cleaned_data.get('email')
         if username != self.previous_username:
             validate_not_empty(username)
             validate_zds_username(username)
-        if email != self.previous_mail:
+        if email != self.previous_email:
             validate_not_empty(email)
             validate_zds_email(email)
         return cleaned_data

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -273,99 +273,100 @@ class ChangeUserFormTest(TestCase):
 
     def setUp(self):
         self.user1 = ProfileFactory()
+        self.user2 = ProfileFactory()
 
     def test_valid_change_username_user_form(self):
         data = {
             'username': "MyNewPseudo",
-            'email': ''
+            'email': self.user1.user.email
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertTrue(form.is_valid())
 
     def test_valid_change_email_user_form(self):
         data = {
-            'username': '',
+            'username': self.user1.user.username,
             'email': 'test@gmail.com'
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertTrue(form.is_valid())
 
     def test_already_used_username_user_form(self):
         data = {
-            'username': self.user1.user.username,
-            'email': ''
+            'username': self.user2.user.username,
+            'email': self.user1.user.email
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
     def test_already_used_email_user_form(self):
         data = {
-            'username': '',
-            'email': self.user1.user.email
+            'username': self.user1.user.username,
+            'email': self.user2.user.email
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
     def test_forbidden_email_provider_user_form(self):
         data = {
-            'username': '',
+            'username': self.user1.user.username,
             'email': 'test@yopmail.com'
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
     def test_wrong_email_user_form(self):
         data = {
-            'username': '',
+            'username': self.user1.user.username,
             'email': 'wrong@'
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
         data = {
-            'username': '',
+            'username': self.user1.user.username,
             'email': '@test.com'
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
         data = {
-            'username': '',
+            'username': self.user1.user.username,
             'email': 'wrong@test'
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
         data = {
-            'username': '',
+            'username': self.user1.user.username,
             'email': 'wrong@.com'
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
         data = {
-            'username': '',
+            'username': self.user1.user.username,
             'email': 'wrongtest.com'
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
     def test_username_spaces_register_form(self):
         ProfileFactory()
         data = {
             'username': '  ZeTester  ',
-            'email': ''
+            'email': self.user1.user.email,
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
     def test_username_coma_register_form(self):
         ProfileFactory()
         data = {
             'username': 'Ze,Tester',
-            'email': ''
+            'email': self.user1.user.email,
         }
-        form = ChangeUserForm(data=data)
+        form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
 

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -1057,7 +1057,7 @@ class MemberTests(TestCase):
         self.client.login(username=tester.user.username, password='hostel77')
         data = {
             'username': 'dummy',
-            'email': ''
+            'email': tester.user.email
         }
         result = self.client.post(reverse('update-username-email-member'), data, follow=False)
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -233,18 +233,21 @@ class UpdateUsernameEmailMember(UpdateMember):
 
     def update_profile(self, profile, form):
         profile.show_email = 'show_email' in form.cleaned_data.get('options')
-        if form.data['username']:
+        new_username = form.cleaned_data.get('username')
+        previous_username = form.cleaned_data.get('previous_username')
+        new_email = form.cleaned_data.get('email')
+        previous_email = form.cleaned_data.get('previous_email')
+        if new_username and new_username != previous_username:
             # Add a karma message for the staff
             bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
             KarmaNote(user=profile.user,
                       moderator=bot,
-                      note=_(u"{} s'est renommé {}").format(profile.user.username, form.data['username']),
+                      note=_(u"{} s'est renommé {}").format(profile.user.username, new_username),
                       karma=0).save()
             # Change the pseudo
-            profile.user.username = form.data['username']
-        if form.data['email'] and profile.user.email != form.data["email"]:
-            if form.data['email'].strip() != '':
-                profile.user.email = form.data['email']
+            profile.user.username = new_username
+        if new_email and new_email != previous_email:
+            profile.user.email = new_email
 
     def get_success_url(self):
         profile = self.get_object()


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4073 

### QA

* Vérifier qu'on puisse bien changer son adresse mail sans prendre une adresse mail d'un autre utilisateur, ni une adresse mail vide.
* Vérifier qu'on puisse changer son pseudo sans prendre celui d'un autre utilisateur, ni le pseudo vide.
* Vérifier que la case *Afficher publiquement son mail* fonctionne correctement
