### PR TITLE
Pluriel sur le nombre de publications

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -146,7 +146,7 @@
 
                     <div class="content-item write-tutorial">
                         <div class="write-tutorial-text">
-                            <p>{% blocktrans %}Il y a {{ contents_count }}&nbsp;publications sur&nbsp;Zeste&nbsp;de&nbsp;Savoir.{% endblocktrans %}</p>
+                            <p>{% blocktrans %}Il y a {{ contents_count }}&nbsp;publication{{ contents_count|pluralize }} sur&nbsp;Zeste&nbsp;de&nbsp;Savoir.{% endblocktrans %}</p>
                             <p class="lead">{% trans "Pourquoi pas la vôtre ?" %}</p>
                         </div>
                         <a href="{% url "content:create-tutorial" %}" class="btn btn-write-tutorial">{% trans "Commencer à rédiger" %}</a>

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,6 +8,7 @@
 {% load thumbnail %}
 {% load i18n %}
 {% load captureas %}
+{% load pluralize_fr %}
 
 
 {% block body_class %}home{% endblock %}
@@ -146,7 +147,7 @@
 
                     <div class="content-item write-tutorial">
                         <div class="write-tutorial-text">
-                            <p>{% blocktrans %}Il y a {{ contents_count }}&nbsp;publication{{ contents_count|pluralize }} sur&nbsp;Zeste&nbsp;de&nbsp;Savoir.{% endblocktrans %}</p>
+                            <p>{% blocktrans %}Il y a {{ contents_count }}&nbsp;publication{{ contents_count|pluralize_fr }} sur&nbsp;Zeste&nbsp;de&nbsp;Savoir.{% endblocktrans %}</p>
                             <p class="lead">{% trans "Pourquoi pas la vôtre ?" %}</p>
                         </div>
                         <a href="{% url "content:create-tutorial" %}" class="btn btn-write-tutorial">{% trans "Commencer à rédiger" %}</a>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | orthographe

Cette pull request modifie la boîte avec le nombre de publications sur la page d'accueil pour ne mettre le `s` que s'il y en a au moins deux. Pour le coup, c'est vraiment minime et ça ne servira à rien en production mais c'est mieux pour des raisons de cohérence. ;)

### QA

* Vérifier qu'il n'y a pas de `s` lorsqu'il y a <= 1 publication ;
* Vérifier qu'il y en a un dans le cas contraire.