### PR TITLE
bump: gulp-sourcemaps@2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gulp-postcss": "6.2.0",
     "gulp-rename": "1.2.2",
     "gulp-sass": "2.3.2",
-    "gulp-sourcemaps": "1.9.1",
+    "gulp-sourcemaps": "2.2.2",
     "gulp-uglify": "2.0.0",
     "gulp.spritesmith": "6.2.1",
     "jquery": "3.1.1",


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | -

`gulp-sourcemaps@1.9.1` a été dépublié de npm ; bump vers `@1.9.2` pour fixer travis

### QA

 * Builder le front
 * Vérifier l'état des sourcemaps
