### PR TITLE
Fix 3881 : Ajout des classes d'admin pour certains modèles

### DIFF
--- a/zds/forum/admin.py
+++ b/zds/forum/admin.py
@@ -17,8 +17,12 @@ class TopicReadAdmin(admin.ModelAdmin):
     raw_id_fields = ('topic', 'post', 'user')
 
 
+class PostAdmin(admin.ModelAdmin):
+    raw_id_fields = ('author', 'editor')
+
+
 admin.site.register(Category)
 admin.site.register(Forum)
-admin.site.register(Post)
+admin.site.register(Post, PostAdmin)
 admin.site.register(Topic, TopicAdmin)
 admin.site.register(TopicRead, TopicReadAdmin)

--- a/zds/gallery/admin.py
+++ b/zds/gallery/admin.py
@@ -17,6 +17,7 @@ class ImageAdmin(admin.ModelAdmin):
     """Representation of Image model in the admin interface."""
 
     list_display = ('title', 'gallery', 'legend', 'pubdate', 'update')
+    raw_id_fields = ('gallery',)
 
 
 class UserGalleryAdmin(admin.ModelAdmin):
@@ -24,7 +25,7 @@ class UserGalleryAdmin(admin.ModelAdmin):
     """Representation of UserGallery model in the admin interface."""
 
     list_display = ('user', 'gallery', 'mode')
-
+    raw_id_fields = ('user', 'gallery')
 
 admin.site.register(Gallery, GalleryAdmin)
 admin.site.register(Image, ImageAdmin)

--- a/zds/member/admin.py
+++ b/zds/member/admin.py
@@ -10,6 +10,7 @@ class ProfileAdmin(admin.ModelAdmin):
     list_display = ('user', 'last_ip_address', 'can_read', 'end_ban_read', 'can_write', 'end_ban_write', 'last_visit')
     list_filter = ('can_read', 'can_write')
     search_fields = ['user__username']
+    raw_id_fields = ('user',)
 
 
 class BanAdmin(admin.ModelAdmin):
@@ -17,24 +18,28 @@ class BanAdmin(admin.ModelAdmin):
     list_display = ('user', 'moderator', 'type', 'note', 'pubdate')
     list_filter = ('type',)
     search_fields = ['user__username']
+    raw_id_fields = ('user', 'moderator')
 
 
 class TokenRegisterAdmin(admin.ModelAdmin):
     """Representation of TokenRegister model in the admin interface."""
     list_display = ('user', 'date_end')
     search_fields = ['user__username']
+    raw_id_fields = ('user',)
 
 
 class TokenForgotPasswordAdmin(admin.ModelAdmin):
     """Representation of TokenForgotPassword model in the admin interface."""
     list_display = ('user', 'date_end')
     search_fields = ['user__username']
+    raw_id_fields = ('user',)
 
 
 class KarmaNoteAdmin(admin.ModelAdmin):
     """Representation of KarmaNote model in the admin interface."""
     list_display = ('user', 'moderator', 'note', 'karma', 'pubdate')
     search_fields = ['user__username']
+    raw_id_fields = ('user', 'moderator')
 
 
 admin.site.register(Profile, ProfileAdmin)

--- a/zds/mp/admin.py
+++ b/zds/mp/admin.py
@@ -18,7 +18,7 @@ class PrivateTopicAdmin(admin.ModelAdmin):
     """Representation of PrivateTopic model in the admin interface."""
 
     list_display = ('title', 'subtitle', 'author', 'last_message', 'pubdate')
-    raw_id_fields = ('author', 'participants')
+    raw_id_fields = ('author', 'participants', 'last_message')
 
 
 class PrivateTopicReadAdmin(admin.ModelAdmin):

--- a/zds/mp/admin.py
+++ b/zds/mp/admin.py
@@ -10,6 +10,7 @@ class PrivatePostAdmin(admin.ModelAdmin):
     """Representation of PrivatePost model in the admin interface."""
 
     list_display = ('privatetopic', 'author', 'pubdate', 'update', 'position_in_topic')
+    raw_id_fields = ('privatetopic', 'author')
 
 
 class PrivateTopicAdmin(admin.ModelAdmin):
@@ -17,6 +18,7 @@ class PrivateTopicAdmin(admin.ModelAdmin):
     """Representation of PrivateTopic model in the admin interface."""
 
     list_display = ('title', 'subtitle', 'author', 'last_message', 'pubdate')
+    raw_id_fields = ('author', 'participants')
 
 
 class PrivateTopicReadAdmin(admin.ModelAdmin):
@@ -24,6 +26,7 @@ class PrivateTopicReadAdmin(admin.ModelAdmin):
     """Representation of PrivateTopicRead model in the admin interface."""
 
     list_display = ('privatetopic', 'privatepost', 'user')
+    raw_id_fields = ('privatetopic', 'privatepost', 'user')
 
 
 admin.site.register(PrivatePost, PrivatePostAdmin)

--- a/zds/notification/admin.py
+++ b/zds/notification/admin.py
@@ -4,5 +4,18 @@ from django.contrib import admin
 from zds.notification.models import Notification, Subscription
 
 
-admin.site.register(Notification)
-admin.site.register(Subscription)
+class NotificationAdmin(admin.ModelAdmin):
+
+    """Representation of Notification model in the admin interface."""
+
+    raw_id_fields = ('subscription', 'sender')
+
+
+class SubscriptionAdmin(admin.ModelAdmin):
+
+    """Representation of Subscription model in the admin interface."""
+
+    raw_id_fields = ('user', 'last_notification')
+
+admin.site.register(Notification, NotificationAdmin)
+admin.site.register(Subscription, SubscriptionAdmin)

--- a/zds/pages/admin.py
+++ b/zds/pages/admin.py
@@ -7,6 +7,6 @@ class GroupContactAdmin(admin.ModelAdmin):
 
     """Representation of GroupContact model in the admin interface."""
 
-    raw_id_fields = ('group', 'person_in_charge')
+    raw_id_fields = ('person_in_charge',)
 
 admin.site.register(GroupContact, GroupContactAdmin)

--- a/zds/pages/admin.py
+++ b/zds/pages/admin.py
@@ -3,4 +3,10 @@ from django.contrib import admin
 from zds.pages.models import GroupContact
 
 
-admin.site.register(GroupContact)
+class GroupContactAdmin(admin.ModelAdmin):
+
+    """Representation of GroupContact model in the admin interface."""
+
+    raw_id_fields = ('group', 'person_in_charge')
+
+admin.site.register(GroupContact, GroupContactAdmin)

--- a/zds/tutorialv2/admin.py
+++ b/zds/tutorialv2/admin.py
@@ -5,7 +5,22 @@ from django.contrib import admin
 from zds.tutorialv2.models.models_database import PublishableContent, Validation, ContentReaction, PublishedContent
 
 
-admin.site.register(PublishableContent)
-admin.site.register(PublishedContent)
-admin.site.register(Validation)
-admin.site.register(ContentReaction)
+class PublishableContentnAdmin(admin.ModelAdmin):
+    raw_id_fields = ('authors', 'tags', 'image', 'gallery', 'beta_topic', 'last_note', 'public_version')
+
+
+class PublishedContentAdmin(admin.ModelAdmin):
+    raw_id_fields = ('content', 'authors')
+
+
+class ContentReactionAdmin(admin.ModelAdmin):
+    raw_id_fields = ('author', 'editor')
+
+
+class ValidationAdmin(admin.ModelAdmin):
+    raw_id_fields = ('content', 'validator')
+
+admin.site.register(PublishableContent, PublishableContentnAdmin)
+admin.site.register(PublishedContent, PublishedContentAdmin)
+admin.site.register(Validation, ValidationAdmin)
+admin.site.register(ContentReaction, ContentReactionAdmin)

--- a/zds/utils/admin.py
+++ b/zds/utils/admin.py
@@ -15,7 +15,10 @@ class SubCategoryAdmin(admin.ModelAdmin):
     ordering = ('categorysubcategory__category', 'title')
 
 
-admin.site.register(Alert)
+class AlertAdmin(admin.ModelAdmin):
+    raw_id_fields = ('author', 'comment', 'moderator', 'privatetopic')
+
+admin.site.register(Alert, AlertAdmin)
 admin.site.register(Tag)
 admin.site.register(Licence)
 admin.site.register(Category)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug / évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #3881 

### QA

* Dans l'admin Django vérifiez que les pages citées dans le ticket d'origine ne propose plus une liste déroulante chargeant toutes les entrées de la base, mais un champ d'ID.

J'ai volontairement laissé la liste déroulante pour les champs qui ne contiennent pas beaucoup d'entrées et dont le nombre d'entrée est fixe (ou presque). Par exemple dans les notification le content_type. Ce ticket est là pour régler le problème des clés étrangères chargeant énormément de données : liste d'User, de Post, d'images, etc. 

Bonne QA ! 
