### PR TITLE
Correction de la documentation sur les galeries

### DIFF
--- a/doc/source/back-end/gallery.rst
+++ b/doc/source/back-end/gallery.rst
@@ -46,7 +46,7 @@ Autrement dit,
 + Obtenir le code à insérer dans un champ de texte acceptant le Markdown pour l'image en elle-même, sa miniature ou encore la miniature accompagnée du lien vers l'image en taille réelle.
 
 .. attention::
-    Le titre de l'image n'entre pas en compte dans le nommage de l'image une fois cette dernière téléchargée. Afin de s'assurer l'unicité des noms, nous utilisons un algorithme de hachage pour cela.
+    Le titre de l'image n'entre pas en compte dans le nommage de l'image une fois cette dernière téléchargée. Afin de s'assurer l'unicité des noms, nous utilisons un algorithme de hashage pour cela.
 
 Les utilisateurs et leurs droits
 --------------------------------
@@ -126,4 +126,4 @@ Les images sont stockées dans le dossier renseigné par la variable ``MEDIA_URL
 Outils logiciels utilisés
 =========================
 
-Afin d'assurer une compatibilité maximale de toutes les images des galeries et leur redimensionnement au besoin, le logiciel pyllow est utilisé.
+Afin d'assurer une compatibilité maximale de toutes les images des galeries et leur redimensionnement au besoin, le logiciel `Pyllow` est utilisé.

--- a/doc/source/back-end/gallery.rst
+++ b/doc/source/back-end/gallery.rst
@@ -7,15 +7,15 @@ La liste des galeries de l'utilisateur est accessible via l'url suivante : ``/ga
 Généralités
 ===========
 
-Une galerie rassemble physiquement un certain nombre d'images. Elle peut prendre un titre ainsi qu'un sous-titre.
+Une galerie rassemble un certain nombre d'images. Elle doit prendre un titre et peut également posséder un sous-titre.
 
 Création et remplissage
 -----------------------
 
-On peut créer une nouvelle galerie via l'url ``/galerie/nouveau/``, où il est nécessaire de renseigner ces deux champs.
+On peut créer une nouvelle galerie via l'url ``/galerie/nouveau/``. Le titre de la galerie et un sous-titre facultatif sont demandés.
 
 .. attention::
-   Des galeries sont créées **automatiquement** à la création d'un nouveau `tutoriel <../tutorial/tutorial.html>`_ par un utilisateur et possède alors le même nom que celui-ci.
+   Une galerie est créée **automatiquement** lors de la création d'un nouveau `contenu <contents.html>`_ par un utilisateur. Elle possède alors le même nom que celui-ci.
 
 Il est ensuite possible d'uploader des images via le menu de gauche :
 
@@ -33,7 +33,7 @@ Via celui-ci, on peut importer des archives contenant des images (au format ZIP)
 
 Comme on peut le voir, chaque image doit posséder au minimum un titre et peut posséder une légende, qui sera employée par la suite. Il est donc conseillé de remplir également ce second champ, bien que ce ne soit pas obligatoire. Quant à l'image elle-même, sa taille ne peut pas excéder 1024 Kio.
 
-Une fois l'image uploadée, il est possible d'effectuer différentes actions sur celle-ci sur la page spécifique à celle-ci :
+Une fois l'image uploadée, il est possible d'y effectuer différentes actions sur la page qui lui est spécifique :
 
    .. figure:: ../images/gallery/gestion-image.png
       :align: center
@@ -43,15 +43,15 @@ Une fois l'image uploadée, il est possible d'effectuer différentes actions sur
 Autrement dit,
 
 + En modifier le titre, la légende ou encore l'image en elle-même. À noter que le titre et la légende peuvent être modifiés **sans qu'il ne soit nécessaire** d'uploader une nouvelle image.
-+ Obtenir le code à insérer dans un champ de texte acceptant le markdown pour l'image en elle-même, sa miniature ou encore la miniature accompagnée du lien vers l'image en taille réelle.
++ Obtenir le code à insérer dans un champ de texte acceptant le Markdown pour l'image en elle-même, sa miniature ou encore la miniature accompagnée du lien vers l'image en taille réelle.
 
 .. attention::
-    Le titre de l'image n'entre pas en compte dans le nommage de l'image une fois cette dernière téléchargée. Afin de s'assurer l'unicité des noms, nous utilisons un algorithme de hashage pour cela.
+    Le titre de l'image n'entre pas en compte dans le nommage de l'image une fois cette dernière téléchargée. Afin de s'assurer l'unicité des noms, nous utilisons un algorithme de hachage pour cela.
 
 Les utilisateurs et leurs droits
 --------------------------------
 
-Le créateur de la galerie possède un droit d'écriture, mais peut rajouter à tout moment des utilisateurs dans celle-ci :
+Le créateur de la galerie possède un droit d'écriture, mais peut y ajouter à tout moment des utilisateurs :
 
    .. figure:: ../images/gallery/gestion-auteurs.png
       :align: center
@@ -63,12 +63,12 @@ Lors d'un clic sur "Ajouter un utilisateur", une fenêtre modale s'ouvre :
    .. figure:: ../images/gallery/gestion-auteurs2.png
       :align: center
 
-      Choix de l'utilisateur et sélection de ces droits
+      Choix de l'utilisateur et sélection de ses droits
 
-Il est alors possible de rajouter un nouvel utilisateur dans la galerie. Les droits de celui-ci peuvent-être les suivants :
+Il est alors possible de rajouter un nouvel utilisateur dans la galerie. Les droits de celui-ci peuvent être les suivants :
 
-+ **Lecture** : (``zds.gallery.models.GALLERY_READ``) l'utilisateur a seulement le droit de consulter les images existantes dans la galerie sans pouvoir apporter de modifications;
-+ **Écriture** : (``zds.gallery.models.GALLERY_WRITE``), inclut **Lecture**, l'utilisateur peut modifier ou supprimer des images existantes, en rajouter des nouvelles et changer les attributs de la galerie (y compris ajouter de nouveaux utilisateurs);
++ **Lecture** : (``zds.gallery.models.GALLERY_READ``) l'utilisateur a seulement le droit de consulter les images existantes dans la galerie sans pouvoir apporter de modifications ;
++ **Écriture** : (``zds.gallery.models.GALLERY_WRITE``), inclut **Lecture**, l'utilisateur peut modifier ou supprimer des images existantes, en rajouter des nouvelles et changer les attributs de la galerie (y compris y ajouter de nouveaux utilisateurs);
 
 
 Il n'est actuellement pas possible de modifier les droits d'un utilisateur après son ajout à la galerie.
@@ -84,9 +84,9 @@ Une image peut être supprimée à tout moment en la sélectionnant sur la page 
 
       Suppression d'une ou plusieurs image(s)
 
-Attention qu'aucune confirmation n'est demandée pour la suppression d'une image.
+Attention : aucune confirmation n'est demandée lors de la suppression d'une image.
 
-Une galerie peut être quant à elle supprimée via la page de gestion des galeries (``/galerie/``) en cochant la case de celle-ci et en cliquant sur "supprimer les galeries sélectionnées" dans le menu de gauche :
+Une galerie peut quant à elle être supprimée via la page de gestion des galeries (``/galerie/``) en cochant la case de celle-ci et en cliquant sur "Supprimer les galeries sélectionnées" dans le menu de gauche :
 
    .. figure:: ../images/gallery/sup-galerie.png
       :align: center
@@ -100,7 +100,7 @@ Une modale s'ouvre ensuite, demandant de confirmer le choix :
 
       Confirmation
 
-Une fois cliqué sur "confirmer", la galerie et les images qu'elle contient sont supprimées.
+Une fois cliqué sur "Confirmer", la galerie et les images qu'elle contient sont supprimées.
 
 .. attention::
    Si une galerie est liée à un tutoriel existant, elle ne peut pas être supprimée.
@@ -114,12 +114,10 @@ Chaque auteur possède un droit d'accès en écriture (``GALLERY_WRITE``) sur la
 
 Si un membre possède un droit de lecture seule (``GALLERY_READ``) sur la galerie d'un tutoriel, aucun droit n'est accordé à ce membre quant au tutoriel.
 
-À l'heure actuelle, les articles ne possèdent pas de galerie.
-
 Aspects techniques
 ==================
 
-Chaque galerie (classe ``Gallery``) est stockée en base de données avec son titre, son sous-titre et son *slug* (ainsi que la date de création et de dernière modification). Une galerie est rattachée à l'utilisateur via la classe ``UserGallery``, qui reprend un lien vers l'utilisateur, la galerie, mais également les droits qu'il possède sur cette dernière, sous la forme d'une constante : ``GALLERY_READ`` pour le droit de lecture ou ``GALLERY_WRITE`` pour le droit d'écriture.
+Chaque galerie (classe ``Gallery``) est stockée en base de données avec son titre, son sous-titre et son *slug* (ainsi que la date de création et de dernière modification). Une galerie est associée à l'utilisateur via la classe ``UserGallery``, qui reprend un lien vers l'utilisateur, la galerie, mais également les droits qu'il possède sur cette dernière, sous la forme d'une constante : ``GALLERY_READ`` pour le droit de lecture ou ``GALLERY_WRITE`` pour le droit d'écriture.
 
 Une image (classe ``Image``) est renseignée en base de données avec son titre, sa légende, un lien vers la galerie qui la contient, son *slug* et un lien *physique* vers le fichier image (ainsi que la date de création et de dernière modification).
 
@@ -128,4 +126,4 @@ Les images sont stockées dans le dossier renseigné par la variable ``MEDIA_URL
 Outils logiciels utilisés
 =========================
 
-Afin d'assurer une compatibilité maximale de toutes les images des galeries, leur redimensionnement au besoin... le logiciel pyllow est utilisé.
+Afin d'assurer une compatibilité maximale de toutes les images des galeries et leur redimensionnement au besoin, le logiciel pyllow est utilisé.

--- a/doc/source/back-end/gallery.rst
+++ b/doc/source/back-end/gallery.rst
@@ -46,7 +46,7 @@ Autrement dit,
 + Obtenir le code à insérer dans un champ de texte acceptant le Markdown pour l'image en elle-même, sa miniature ou encore la miniature accompagnée du lien vers l'image en taille réelle.
 
 .. attention::
-    Le titre de l'image n'entre pas en compte dans le nommage de l'image une fois cette dernière téléchargée. Afin de s'assurer l'unicité des noms, nous utilisons un algorithme de hashage pour cela.
+    Le titre de l'image n'entre pas en compte dans le nommage de l'image une fois cette dernière téléchargée. Afin de réduire le risque de rencontrer des conflits de noms de fichiers, ces derniers sont hashés.
 
 Les utilisateurs et leurs droits
 --------------------------------
@@ -126,4 +126,4 @@ Les images sont stockées dans le dossier renseigné par la variable ``MEDIA_URL
 Outils logiciels utilisés
 =========================
 
-Afin d'assurer une compatibilité maximale de toutes les images des galeries et leur redimensionnement au besoin, le logiciel `Pyllow` est utilisé.
+Afin d'assurer une compatibilité maximale de toutes les images des galeries et leur redimensionnement au besoin, le logiciel `Pillow` est utilisé.

--- a/doc/source/back-end/gallery.rst
+++ b/doc/source/back-end/gallery.rst
@@ -126,4 +126,4 @@ Les images sont stockées dans le dossier renseigné par la variable ``MEDIA_URL
 Outils logiciels utilisés
 =========================
 
-Afin d'assurer une compatibilité maximale de toutes les images des galeries et leur redimensionnement au besoin, le logiciel `Pillow` est utilisé.
+Afin d'assurer une compatibilité maximale de toutes les images des galeries et leur redimensionnement au besoin, le logiciel ``Pillow`` est utilisé.


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | orthographe

Voici les corrections sur la documentation concernant les galeries. :)

Note : je corrige également un lien, ainsi qu'une erreur : depuis la ZEP-12, les articles possèdent aussi une galerie liée.

### QA

Relire les corrections en vérifiant qu'elles sont exactes et que je n'ai pas introduit d'autres fautes en les faisant.
