### PR TITLE
[ZEP-13] corrige différentes choses

### DIFF
--- a/assets/scss/components/_alert-box.scss
+++ b/assets/scss/components/_alert-box.scss
@@ -117,6 +117,12 @@
     }
 }
 
+.opinion-alerts {
+    .alert-box-text {
+        float: none;
+    }
+}
+
 @media only screen and #{$media-tablet} {
     .alert-box .alert-box-text {
         display: inline;

--- a/robots.txt
+++ b/robots.txt
@@ -21,3 +21,6 @@ Disallow: /rechercher/
 Disallow: /tutoriels/html/
 Disallow: /tutoriels/md/
 Disallow: /tutoriels/zip/
+Disallow: /tribunes/html/
+Disallow: /tribunes/md/
+Disallow: /tribunes/zip/

--- a/templates/tutorialv2/index.html
+++ b/templates/tutorialv2/index.html
@@ -19,30 +19,30 @@
 {% endblock %}
 
 {% block menu_tutorial %}
-    {% if tutorials %}
+    {% if tutorials != None %}
         current
     {% endif %}
 {% endblock %}
-{% block menu_article %}
-    {% if articles %}
+{% block menu_article%}
+    {% if articles != None  %}
         current
     {% endif %}
 {% endblock %}
 {% block menu_opinion %}
-    {% if opinions %}
+    {% if opinions != None %}
         current
     {% endif %}
 {% endblock %}
 
 
 {% block breadcrumb_base %}
-    {% if tutorials %}
+    {% if tutorials != None %}
         <li><a href="{% url "tutorial:list" %}">{% trans "Tutoriels" %}</a></li>
         <li><a href="{% url "content:find-tutorial" usr.pk %}">{% trans "Tutoriels de" %} {{ usr.username }}</a></li>
-    {% elif articles %}
+    {% elif articles != None %}
         <li><a href="{% url "article:list" %}">{% trans "Articles" %}</a></li>
         <li><a href="{% url "content:find-article" usr.pk %}">{% trans "Articles de" %} {{ usr.username }}</a></li>
-    {% elif opinions %}
+    {% elif opinions != None %}
         <li><a href="{% url "opinion:list" %}">{% trans "Tribunes" %}</a></li>
         <li><a href="{% url "content:find-opinion" usr.pk %}">{% trans "Tribune de" %} {{ usr.username }}</a></li>
     {% endif %}
@@ -54,13 +54,13 @@
     <section class="full-content-wrapper">
         <h2 class="ico-after ico-tutorials">
             {% block headline %}
-                {% if contents %}
+                {% if contents != None %}
                     {% trans "Contenus de" %} {{ usr.username }}
-                {% elif tutorials %}
+                {% elif tutorials != None %}
                     {% trans "Tutoriels de" %} {{ usr.username }}
-                {% elif articles %}
+                {% elif articles != None %}
                     {% trans "Articles de" %} {{ usr.username }}
-                {% elif opinions %}
+                {% elif opinions != None %}
                     {% trans "Tribune de" %} {{ usr.username }}
                 {% endif %}
             {% endblock %}

--- a/templates/tutorialv2/messages/validation_invalid_opinion.md
+++ b/templates/tutorialv2/messages/validation_invalid_opinion.md
@@ -1,0 +1,13 @@
+{% load i18n %}
+
+{% blocktrans with title=content.title|safe admin_name=admin.username|safe admin_url=admin.get_absolute_url message=message_reject|safe %}
+
+Désolé, « [{{ title }}]({{ url }}) » a malheureusement été retiré de la liste des billets choisis par 
+[{{ admin_name }}]({{ admin_url }}) pour la raison suivante :
+
+{{ message }}
+
+N'hésitez surtout pas à contacter cette personne pour lui demander de 
+vous expliquer son choix et de vous conseiller pour remédier à cela.
+
+{% endblocktrans %}

--- a/templates/tutorialv2/messages/validation_revoke.md
+++ b/templates/tutorialv2/messages/validation_revoke.md
@@ -8,8 +8,10 @@ Désolé, « [{{ title }}]({{ url }}) » a malheureusement été dépublié par
 {{ message }}
 
 N'hésitez surtout pas à contacter cette personne pour lui demander de 
-vous expliquer son choix et de vous conseiller pour remédier à cela. Sur ce 
-dernier point, n'oubliez pas que la communauté peut vous aider à travers le 
-système de bêta.
+vous expliquer son choix et de vous conseiller pour remédier à cela. 
 
 {% endblocktrans %}
+
+{% if not content.is_opinion %}
+{% trans "Sur ce dernier point, n'oubliez pas que la communauté peut vous aider à travers le système de bêta." %}
+{% endif %}

--- a/templates/tutorialv2/messages/warn_typo.md
+++ b/templates/tutorialv2/messages/warn_typo.md
@@ -16,7 +16,7 @@
 {% blocktrans with username=user.username|safe title=content.title|safe type=type|safe %}
 Salut !
 
-Il me semble avoir déniché une erreur dans le contenu 
+Il me semble avoir déniché une erreur dans {{ type }}
 « [{{ title }}]({{ content_url }}) ».
 {% endblocktrans %}
 

--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -16,8 +16,6 @@
         {% trans "Articles" %} &bull;
     {% elif request.GET.type == "tuto" %}
         {% trans "Tutoriels" %} &bull;
-    {% elif request.GET.type == "opinion" %}
-        {% trans "Billets" %} &bull;
     {% endif %}
 {% endblock %}
 
@@ -42,8 +40,6 @@
                     / {% trans "Articles" %}
                 {% elif request.GET.type == "tuto" %}
                     / {% trans "Tutoriels" %}
-                {% elif request.GET.type == "opinion" %}
-                    / {% trans "Billets" %}
                 {% endif %}
                 {%  if category %}
                     / {{ category.title }}
@@ -163,11 +159,6 @@
             <li>
                 <a href="{% url "validation:list" %}?type=tuto" class="ico-after view {% if request.GET.type == "tuto" %}selected{% endif %}">
                     {% trans "Tutoriels" %}
-                </a>
-            </li>
-            <li>
-                <a href="{% url "validation:list" %}?type=opinion" class="ico-after view {% if request.GET.type == "opinion" %}selected{% endif %}">
-                    {% trans "Billets" %}
                 </a>
             </li>
             {% if request.GET.type or request.GET.subcategory %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -78,6 +78,31 @@
 
 {% block content %}
 
+    {% if is_staff %}
+        {% for alert in alerts %}
+            <div class="alert-box{% if not alert.solved %} error{% endif %}">
+                {{ alert.pubdate|format_date|capfirst }} {% trans "par" %}
+                {% include "misc/member_item.part.html" with member=alert.author %} :
+                <em class="alert-box-text">{{ alert.text }}</em>
+                {% if alert.solved %}
+                    <span class="close-alert-box close-alert-box-text">
+                        {% trans "Résolu par" %}
+                        {% include "misc/member_item.part.html" with member=alert.moderator %}
+                    </span>
+                {% else %}
+                    <a href="#solve-content-{{ alert.pk }}" class="open-modal close-alert-box close-alert-box-text">{% trans "Résoudre" %}</a>
+                    <form id="solve-content-{{ alert.pk }}" method="post" action="{% url 'content:resolve-content' alert.pk %}" class="modal modal-flex">
+                        <textarea name="text" class="input" placeholder="{% trans "Message à envoyer au membre ayant lancé l'alerte" %}"></textarea>
+                        <input type="hidden" name="alert_pk" value="{{ alert.pk }}">
+
+                        {% csrf_token %}
+                        <button type="submit" name="delete-post" class="button expand alert tiny">{% trans "Résoudre l'alerte" %}</button>
+                    </form>
+                {% endif %}
+            </div>
+        {% endfor %}
+    {% endif %}
+
     {% if content.is_opinion %}
         {% if content.converted_to %}
             {% if content.converted_to.get_absolute_url_online %}
@@ -123,31 +148,6 @@
             {{ content.get_conclusion_online|safe }}
         {% endif %}
 
-    {% endif %}
-
-    {% if is_staff %}
-        {% for alert in alerts %}
-            <div class="alert-box{% if not alert.solved %} error{% endif %}">
-                {{ alert.pubdate|format_date|capfirst }} {% trans "par" %}
-                {% include "misc/member_item.part.html" with member=alert.author %} :
-                <em class="alert-box-text">{{ alert.text }}</em>
-                {% if alert.solved %}
-                    <span class="close-alert-box close-alert-box-text">
-                        {% trans "Résolu par" %}
-                        {% include "misc/member_item.part.html" with member=alert.moderator %}
-                    </span>
-                {% else %}
-                    <a href="#solve-content-{{ alert.pk }}" class="open-modal close-alert-box close-alert-box-text">{% trans "Résoudre" %}</a>
-                    <form id="solve-content-{{ alert.pk }}" method="post" action="{% url 'content:resolve-content' alert.pk %}" class="modal modal-flex">
-                        <textarea name="text" class="input" placeholder="{% trans "Message à envoyer au membre ayant lancé l'alerte" %}"></textarea>
-                        <input type="hidden" name="alert_pk" value="{{ alert.pk }}">
-
-                        {% csrf_token %}
-                        <button type="submit" name="delete-post" class="button expand alert tiny">{% trans "Résoudre l'alerte" %}</button>
-                    </form>
-                {% endif %}
-            </div>
-        {% endfor %}
     {% endif %}
 
     {% include "tutorialv2/includes/article_pager.part.html" with content=content %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -197,7 +197,7 @@
     {% endif %}
     {% endif %}
 
-    {% for author in content.public_version.authors.all %}
+    {% for author in content.authors.all %}
         <li>
             <a href="{% url 'content:find-opinion' author.pk %}" class="ico-after offline blue">
                 {% blocktrans %}
@@ -250,6 +250,14 @@
                                         {% trans "Convertir en article" %}
                                     </a>
                                     {% crispy formConvertOpinion %}
+                                </li>
+                            {% endif %}
+                            {% if content.sha_public == content.sha_picked  %}
+                                <li>
+                                    <a href="#unpick-opinion" class="ico-after open-modal cross blue">
+                                        {% trans "Retirer des billets choisis" %}
+                                    </a>
+                                    {% crispy formUnpickOpinion %}
                                 </li>
                             {% endif %}
                         {% endif %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -9,6 +9,7 @@
 {% load crispy_forms_tags %}
 {% load interventions %}
 {% load pluralize_fr %}
+{% load displayable_authors %}
 
 
 {% block title %}
@@ -197,7 +198,7 @@
     {% endif %}
     {% endif %}
 
-    {% for author in content.authors.all %}
+    {% for author in public_object.authors.all %}
         <li>
             <a href="{% url 'content:find-opinion' author.pk %}" class="ico-after offline blue">
                 {% blocktrans %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -80,17 +80,19 @@
 
     {% if content.is_opinion %}
         {% if content.converted_to %}
-            <div class="alert-box info">
-                {% if content.converted_to.get_absolute_url_online %}
+            {% if content.converted_to.get_absolute_url_online %}
+                <div class="alert-box info">
                     {% blocktrans with url_article=content.converted_to.get_absolute_url_online %}
                         Ce billet a été promu en <a href="{{ url_article }}">article</a>.
                     {% endblocktrans %}
-                {% elif is_staff %}
+                </div>
+            {% elif is_staff %}
+                <div class="alert-box info">
                     {% blocktrans with url_article=content.converted_to.get_absolute_url %}
                         Ce billet a été promu en <a href="{{ url_article }}">article</a> qui est en cours de validation.
                     {% endblocktrans %}
-                {% endif %}
-            </div>
+                </div>
+            {% endif %}
         {% endif %}
     {% endif %}
 

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -78,31 +78,32 @@
 
 
 {% block content %}
+    <div class="opinion-alerts">
+        {% if is_staff %}
+            {% for alert in alerts %}
+                <div class="alert-box{% if not alert.solved %} error{% endif %}">
+                    {{ alert.pubdate|format_date|capfirst }} {% trans "par" %}
+                    {% include "misc/member_item.part.html" with member=alert.author %} :
+                    <em class="alert-box-text">{{ alert.text }}</em>
+                    {% if alert.solved %}
+                        <span class="close-alert-box close-alert-box-text">
+                            {% trans "Résolu par" %}
+                            {% include "misc/member_item.part.html" with member=alert.moderator %}
+                        </span>
+                    {% else %}
+                        <a href="#solve-content-{{ alert.pk }}" class="open-modal close-alert-box close-alert-box-text">{% trans "Résoudre" %}</a>
+                        <form id="solve-content-{{ alert.pk }}" method="post" action="{% url 'content:resolve-content' alert.pk %}" class="modal modal-flex">
+                            <textarea name="text" class="input" placeholder="{% trans "Message à envoyer au membre ayant lancé l'alerte" %}"></textarea>
+                            <input type="hidden" name="alert_pk" value="{{ alert.pk }}">
 
-    {% if is_staff %}
-        {% for alert in alerts %}
-            <div class="alert-box{% if not alert.solved %} error{% endif %}">
-                {{ alert.pubdate|format_date|capfirst }} {% trans "par" %}
-                {% include "misc/member_item.part.html" with member=alert.author %} :
-                <em class="alert-box-text">{{ alert.text }}</em>
-                {% if alert.solved %}
-                    <span class="close-alert-box close-alert-box-text">
-                        {% trans "Résolu par" %}
-                        {% include "misc/member_item.part.html" with member=alert.moderator %}
-                    </span>
-                {% else %}
-                    <a href="#solve-content-{{ alert.pk }}" class="open-modal close-alert-box close-alert-box-text">{% trans "Résoudre" %}</a>
-                    <form id="solve-content-{{ alert.pk }}" method="post" action="{% url 'content:resolve-content' alert.pk %}" class="modal modal-flex">
-                        <textarea name="text" class="input" placeholder="{% trans "Message à envoyer au membre ayant lancé l'alerte" %}"></textarea>
-                        <input type="hidden" name="alert_pk" value="{{ alert.pk }}">
-
-                        {% csrf_token %}
-                        <button type="submit" name="delete-post" class="button expand alert tiny">{% trans "Résoudre l'alerte" %}</button>
-                    </form>
-                {% endif %}
-            </div>
-        {% endfor %}
-    {% endif %}
+                            {% csrf_token %}
+                            <button type="submit" name="delete-post" class="button expand alert tiny">{% trans "Résoudre l'alerte" %}</button>
+                        </form>
+                    {% endif %}
+                </div>
+            {% endfor %}
+        {% endif %}
+    </div>
 
     {% if content.is_opinion %}
         {% if content.converted_to %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -116,7 +116,7 @@
             {% elif is_staff %}
                 <div class="alert-box info">
                     {% blocktrans with url_article=content.converted_to.get_absolute_url %}
-                        Ce billet a été promu en <a href="{{ url_article }}">article</a> qui est en cours de validation.
+                        Ce billet a fait l'objet d'une demande de publication <a href="{{ url_article }}">en tant qu'article</a>. Il est donc présent dans la zone de validation en attente de prise en charge par un validateur.
                     {% endblocktrans %}
                 </div>
             {% endif %}

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -199,10 +199,14 @@ def modify_gallery(request):
             has_v2_content = v2_content is not None
             if has_v2_content:
                 gallery = Gallery.objects.get(pk=g_pk)
+
                 _type = _(u'au tutoriel')
-                if v2_content.type == 'ARTICLE':
-                    _type = _(u"à l'article")
-                error_message = _(u'La galerie « {} » ne peut pas être supprimée car elle est liée {} « {} ».')\
+                if v2_content.is_article:
+                    _type = _(u'à l\'article')
+                elif v2_content.is_opinion:
+                    _type = _(u'à la tribune')
+
+                error_message = _(u"La galerie « {} » ne peut pas être supprimée car elle est liée {} « {} ».")\
                     .format(gallery.title, _type, v2_content.title)
                 messages.error(request, error_message)
             else:

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1158,6 +1158,42 @@ class OpinionValidationForm(forms.Form):
         )
 
 
+class OpinionInvalidationForm(forms.Form):
+
+    version = forms.CharField(widget=forms.HiddenInput())
+
+    text = forms.CharField(
+        label='',
+        required=True,
+        widget=forms.Textarea(
+            attrs={
+                'placeholder': _(u"Pourquoi retirer ce billet de la liste des billets choisis ?"),
+                'rows': '6'
+            }
+        )
+    )
+
+    def __init__(self, content, *args, **kwargs):
+        super(OpinionInvalidationForm, self).__init__(*args, **kwargs)
+
+        # modal form, send back to previous page:
+        self.previous_page_url = content.get_absolute_url_online()
+
+        self.helper = FormHelper()
+        self.helper.form_action = reverse('validation:invalid', kwargs={'pk': content.pk, 'slug': content.slug})
+        self.helper.form_method = 'post'
+        self.helper.form_class = 'modal modal-flex'
+        self.helper.form_id = 'unpick-opinion'
+
+        self.helper.layout = Layout(
+            Field('version'),
+            Field('text'),
+            StrictButton(
+                _(u'Enlever'),
+                type='submit')
+        )
+
+
 class PromoteOpinionToArticleForm(forms.Form):
 
     version = forms.CharField(widget=forms.HiddenInput())

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1005,7 +1005,12 @@ class WarnTypoForm(forms.Form):
             self.previous_page_url = targeted.get_absolute_url_beta()
 
         # add an additional link to send PM if needed
-        type_ = _(u"l'article") if content.type == 'ARTICLE' else _(u'le tutoriel')
+        type_ = _(u'l\'article')
+
+        if content.is_tutorial:
+            type_ = _(u'le tutoriel')
+        elif content.is_opinion:
+            type_ = _(u'le billet')
 
         if targeted.get_tree_depth() == 0:
             pm_title = _(u"J'ai trouvé une faute dans {} « {} ».").format(type_, targeted.title)

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1068,7 +1068,6 @@ class WarnTypoForm(forms.Form):
 
 
 class PublicationForm(forms.Form):
-
     """
     The publication form (used only for content without preliminary validation).
     """
@@ -1136,12 +1135,12 @@ class UnpublicationForm(forms.Form):
         )
 
 
-class OpinionValidationForm(forms.Form):
+class PickOpinionForm(forms.Form):
 
     version = forms.CharField(widget=forms.HiddenInput())
 
     def __init__(self, content, *args, **kwargs):
-        super(OpinionValidationForm, self).__init__(*args, **kwargs)
+        super(PickOpinionForm, self).__init__(*args, **kwargs)
 
         # modal form, send back to previous page:
         self.previous_page_url = content.get_absolute_url_online()
@@ -1163,7 +1162,7 @@ class OpinionValidationForm(forms.Form):
         )
 
 
-class OpinionInvalidationForm(forms.Form):
+class UnpickOpinionForm(forms.Form):
 
     version = forms.CharField(widget=forms.HiddenInput())
 
@@ -1179,7 +1178,7 @@ class OpinionInvalidationForm(forms.Form):
     )
 
     def __init__(self, content, *args, **kwargs):
-        super(OpinionInvalidationForm, self).__init__(*args, **kwargs)
+        super(UnpickOpinionForm, self).__init__(*args, **kwargs)
 
         # modal form, send back to previous page:
         self.previous_page_url = content.get_absolute_url_online()

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1086,7 +1086,7 @@ class PublicationForm(forms.Form):
         super(PublicationForm, self).__init__(*args, **kwargs)
 
         self.helper = FormHelper()
-        self.helper.form_action = reverse('validation:publish', kwargs={'pk': content.pk, 'slug': content.slug})
+        self.helper.form_action = reverse('validation:publish-opinion', kwargs={'pk': content.pk, 'slug': content.slug})
         self.helper.form_method = 'post'
         self.helper.form_class = 'modal modal-flex'
         self.helper.form_id = 'valid-publication'
@@ -1121,7 +1121,9 @@ class UnpublicationForm(forms.Form):
         self.previous_page_url = content.get_absolute_url_online()
 
         self.helper = FormHelper()
-        self.helper.form_action = reverse('validation:unpublish', kwargs={'pk': content.pk, 'slug': content.slug})
+        self.helper.form_action = reverse(
+            'validation:unpublish-opinion', kwargs={'pk': content.pk, 'slug': content.slug})
+
         self.helper.form_method = 'post'
         self.helper.form_class = 'modal modal-flex'
         self.helper.form_id = 'unpublish'
@@ -1146,7 +1148,7 @@ class PickOpinionForm(forms.Form):
         self.previous_page_url = content.get_absolute_url_online()
 
         self.helper = FormHelper()
-        self.helper.form_action = reverse('validation:valid', kwargs={'pk': content.pk, 'slug': content.slug})
+        self.helper.form_action = reverse('validation:pick-opinion', kwargs={'pk': content.pk, 'slug': content.slug})
         self.helper.form_method = 'post'
         self.helper.form_class = 'modal modal-flex'
         self.helper.form_id = 'pick-opinion'
@@ -1184,7 +1186,7 @@ class UnpickOpinionForm(forms.Form):
         self.previous_page_url = content.get_absolute_url_online()
 
         self.helper = FormHelper()
-        self.helper.form_action = reverse('validation:invalid', kwargs={'pk': content.pk, 'slug': content.slug})
+        self.helper.form_action = reverse('validation:unpick-opinion', kwargs={'pk': content.pk, 'slug': content.slug})
         self.helper.form_method = 'post'
         self.helper.form_class = 'modal modal-flex'
         self.helper.form_id = 'unpick-opinion'
@@ -1209,7 +1211,7 @@ class PromoteOpinionToArticleForm(forms.Form):
         self.previous_page_url = content.get_absolute_url_online()
 
         self.helper = FormHelper()
-        self.helper.form_action = reverse('validation:promote', kwargs={'pk': content.pk, 'slug': content.slug})
+        self.helper.form_action = reverse('validation:promote-opinion', kwargs={'pk': content.pk, 'slug': content.slug})
         self.helper.form_method = 'post'
         self.helper.form_class = 'modal modal-flex'
         self.helper.form_id = 'convert-opinion'

--- a/zds/tutorialv2/managers.py
+++ b/zds/tutorialv2/managers.py
@@ -204,7 +204,7 @@ class PublishableContentManager(models.Manager):
                            .select_related('public_version') \
                            .prefetch_related('subcategory') \
                            .prefetch_related('tags') \
-                           .order_by('-public_version__publication_date')[:home_number]
+                           .order_by('-picked_date')[:home_number]
         published = []
         for content in all_contents:
             content.public_version.content = content

--- a/zds/tutorialv2/migrations/0017_auto_20170118_2139.py
+++ b/zds/tutorialv2/migrations/0017_auto_20170118_2139.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tutorialv2', '0016_auto_20161120_1640'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='publishablecontent',
+            name='picked_date',
+            field=models.DateTimeField(default=None, null=True, verbose_name='Date de mise en avant', db_index=True, blank=True),
+        ),
+    ]

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -92,6 +92,8 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
     update_date = models.DateTimeField('Date de mise à jour',
                                        blank=True, null=True)
 
+    picked_date = models.DateTimeField('Date de mise en avant', db_index=True, blank=True, null=True, default=None)
+
     sha_public = models.CharField('Sha1 de la version publique',
                                   blank=True, null=True, max_length=80, db_index=True)
     sha_beta = models.CharField('Sha1 de la version beta publique',

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -326,6 +326,7 @@ class PublishedContentTests(TestCase):
 
         opinion = PublishableContent.objects.get(pk=opinion.pk)
         self.assertIsNone(opinion.sha_picked)
+        self.assertIsNone(opinion.picked_date)
 
         self.assertEqual(
             self.client.login(
@@ -345,6 +346,7 @@ class PublishedContentTests(TestCase):
 
         opinion = PublishableContent.objects.get(pk=opinion.pk)
         self.assertEqual(opinion.sha_picked, opinion_draft.current_version)
+        self.assertIsNotNone(opinion.picked_date)
 
         # invalid with author => 403
         self.assertEqual(

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -55,7 +55,7 @@ class PublishedContentTests(TestCase):
             True)
 
         result = self.client.post(
-            reverse('validation:publish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:publish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_publication,
                 'source': '',
@@ -118,7 +118,7 @@ class PublishedContentTests(TestCase):
             True)
 
         result = self.client.post(
-            reverse('validation:publish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:publish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_publication,
                 'source': '',
@@ -152,7 +152,7 @@ class PublishedContentTests(TestCase):
             True)
 
         result = self.client.post(
-            reverse('validation:publish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:publish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_publication,
                 'source': '',
@@ -190,7 +190,7 @@ class PublishedContentTests(TestCase):
 
         # publish
         result = self.client.post(
-            reverse('validation:publish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:publish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_publication,
                 'source': '',
@@ -201,7 +201,7 @@ class PublishedContentTests(TestCase):
 
         # unpublish
         result = self.client.post(
-            reverse('validation:unpublish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:unpublish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_unpublication,
                 'source': '',
@@ -220,7 +220,7 @@ class PublishedContentTests(TestCase):
 
         # publish
         result = self.client.post(
-            reverse('validation:publish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:publish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_publication,
                 'source': '',
@@ -231,7 +231,7 @@ class PublishedContentTests(TestCase):
 
         # unpublish
         result = self.client.post(
-            reverse('validation:unpublish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:unpublish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_unpublication,
                 'source': '',
@@ -250,7 +250,7 @@ class PublishedContentTests(TestCase):
 
         # publish with author
         result = self.client.post(
-            reverse('validation:publish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:publish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_publication,
                 'source': '',
@@ -267,7 +267,7 @@ class PublishedContentTests(TestCase):
 
         # unpublish
         result = self.client.post(
-            reverse('validation:unpublish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:unpublish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_unpublication,
                 'source': '',
@@ -302,7 +302,7 @@ class PublishedContentTests(TestCase):
 
         # publish
         result = self.client.post(
-            reverse('validation:publish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:publish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_publication,
                 'source': '',
@@ -316,7 +316,7 @@ class PublishedContentTests(TestCase):
         opinion_draft = opinion.load_version()
 
         result = self.client.post(
-            reverse('validation:valid', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:pick-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'source': '',
                 'version': opinion_draft.current_version
@@ -336,7 +336,7 @@ class PublishedContentTests(TestCase):
 
         # valid with staff
         result = self.client.post(
-            reverse('validation:valid', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:pick-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'source': '',
                 'version': opinion_draft.current_version
@@ -356,7 +356,7 @@ class PublishedContentTests(TestCase):
             True)
 
         result = self.client.post(
-            reverse('validation:invalid', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:unpick-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': u'Parce que je veux',
                 'version': opinion_draft.current_version
@@ -375,7 +375,7 @@ class PublishedContentTests(TestCase):
             True)
 
         result = self.client.post(
-            reverse('validation:invalid', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:unpick-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': u'Parce que je peux !',
                 'version': opinion_draft.current_version
@@ -388,7 +388,7 @@ class PublishedContentTests(TestCase):
 
         # double invalidation wont work
         result = self.client.post(
-            reverse('validation:invalid', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:unpick-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': u'Parce que je peux toujours ...',
                 'version': opinion_draft.current_version
@@ -423,7 +423,7 @@ class PublishedContentTests(TestCase):
 
         # publish
         result = self.client.post(
-            reverse('validation:publish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:publish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_publication,
                 'source': '',
@@ -434,7 +434,7 @@ class PublishedContentTests(TestCase):
 
         # valid with author => 403
         result = self.client.post(
-            reverse('validation:promote', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:promote-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'source': '',
                 'version': opinion.load_version().current_version
@@ -450,7 +450,7 @@ class PublishedContentTests(TestCase):
 
         # valid with staff
         result = self.client.post(
-            reverse('validation:promote', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:promote-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'source': '',
                 'version': opinion.load_version().current_version
@@ -481,7 +481,7 @@ class PublishedContentTests(TestCase):
             True)
 
         result = self.client.post(
-            reverse('validation:publish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            reverse('validation:publish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'text': text_publication,
                 'source': '',

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -12,6 +12,7 @@ from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.settings import BASE_DIR
 from zds.tutorialv2.factories import PublishableContentFactory, ExtractFactory, LicenceFactory, PublishedContentFactory
 from zds.tutorialv2.models.models_database import PublishableContent
+from zds.utils.models import Alert
 
 overrided_zds_app = settings.ZDS_APP
 overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
@@ -454,6 +455,90 @@ class PublishedContentTests(TestCase):
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+    def test_opinion_alert(self):
+        """Test content alert"""
+
+        text_publication = u'Aussi tôt dit, aussi tôt fait !'
+
+        opinion = PublishableContentFactory(type='OPINION')
+
+        opinion.authors.add(self.user_author)
+        UserGalleryFactory(gallery=opinion.gallery, user=self.user_author, mode='W')
+        opinion.licence = self.licence
+        opinion.save()
+
+        opinion_draft = opinion.load_version()
+        ExtractFactory(container=opinion_draft, db_object=opinion)
+        ExtractFactory(container=opinion_draft, db_object=opinion)
+
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('validation:publish', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            {
+                'text': text_publication,
+                'source': '',
+                'version': opinion.load_version().current_version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # Alert content
+        random_user = ProfileFactory().user
+
+        self.assertEqual(
+            self.client.login(
+                username=random_user.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('content:alert-content', kwargs={'pk': opinion.pk}),
+            {
+                "signal_text": u'Yeurk !'
+            }, follow=False
+        )
+
+        self.assertEqual(result.status_code, 302)
+        self.assertIsNotNone(Alert.objects.filter(author__pk=random_user.pk, content__pk=opinion.pk).first())
+
+        alert = Alert.objects.filter(author__pk=random_user.pk, content__pk=opinion.pk).first()
+        self.assertFalse(alert.solved)
+
+        result = self.client.post(
+            reverse('content:resolve-content', kwargs={'pk': opinion.pk}),
+            {
+                "alert_pk": alert.pk,
+                "text": u'Je peux ?'
+            }, follow=False
+        )
+        self.assertEqual(result.status_code, 403)  # solving the alert by yourself wont work
+
+        alert = Alert.objects.get(pk=alert.pk)
+        self.assertFalse(alert.solved)
+
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('content:resolve-content', kwargs={'pk': opinion.pk}),
+            {
+                "alert_pk": alert.pk,
+                "text": u'Anéfé!'
+            }, follow=False
+        )
+        self.assertEqual(result.status_code, 302)
+
+        alert = Alert.objects.get(pk=alert.pk)
+        self.assertTrue(alert.solved)
 
     def tearDown(self):
 

--- a/zds/tutorialv2/urls/urls_validations.py
+++ b/zds/tutorialv2/urls/urls_validations.py
@@ -4,7 +4,8 @@ from django.conf.urls import url
 
 from zds.tutorialv2.views.views_validations import AskValidationForContent, ReserveValidation, \
     HistoryOfValidationDisplay, AcceptValidation, RejectValidation, RevokeValidation, CancelValidation, \
-    ValidationListView, Publish, Unpublish, ValidPublication, PromoteOpinionToArticle, ValidationOpinionListView
+    ValidationListView, Publish, Unpublish, ValidOpinion, PromoteOpinionToArticle, ValidationOpinionListView, \
+    InvalidOpinion
 
 urlpatterns = [
     url(r'^historique/(?P<pk>\d+)/(?P<slug>.+)/$', HistoryOfValidationDisplay.as_view(), name='history'),
@@ -23,12 +24,11 @@ urlpatterns = [
     url(r'^revoquer/(?P<pk>\d+)/(?P<slug>.+)/$', RevokeValidation.as_view(), name='revoke'),
 
     # NO VALIDATION BEFORE PUBLICATION
-
-    url(r'^publier/(?P<pk>\d+)/(?P<slug>.+)/$', Publish.as_view(), name='publish'),
-    url(r'^depublier/(?P<pk>\d+)/(?P<slug>.+)/$', Unpublish.as_view(), name='unpublish'),
-    url(r'^valider/(?P<pk>\d+)/(?P<slug>.+)/$', ValidPublication.as_view(), name='valid'),
-    url(r'^promouvoir/(?P<pk>\d+)/(?P<slug>.+)/$', PromoteOpinionToArticle.as_view(), name='promote'),
-
+    url(r'^publier/(?P<pk>\d+)/(?P<slug>.+)/$', Publish.as_view(), name="publish"),
+    url(r'^depublier/(?P<pk>\d+)/(?P<slug>.+)/$', Unpublish.as_view(), name="unpublish"),
+    url(r'^valider/(?P<pk>\d+)/(?P<slug>.+)/$', ValidOpinion.as_view(), name="valid"),
+    url(r'^devalider/(?P<pk>\d+)/(?P<slug>.+)/$', InvalidOpinion.as_view(), name="invalid"),
+    url(r'^promouvoir/(?P<pk>\d+)/(?P<slug>.+)/$', PromoteOpinionToArticle.as_view(), name="promote"),
     # VALIDATION VIEWS FOR STAFF
 
     url(r'^billets/$', ValidationOpinionListView.as_view(), name='list-opinion'),

--- a/zds/tutorialv2/urls/urls_validations.py
+++ b/zds/tutorialv2/urls/urls_validations.py
@@ -4,8 +4,8 @@ from django.conf.urls import url
 
 from zds.tutorialv2.views.views_validations import AskValidationForContent, ReserveValidation, \
     HistoryOfValidationDisplay, AcceptValidation, RejectValidation, RevokeValidation, CancelValidation, \
-    ValidationListView, Publish, Unpublish, ValidOpinion, PromoteOpinionToArticle, ValidationOpinionListView, \
-    InvalidOpinion
+    ValidationListView, PublishOpinion, UnpublishOpinion, PickOpinion, PromoteOpinionToArticle, \
+    ValidationOpinionListView, UnpickOpinion
 
 urlpatterns = [
     url(r'^historique/(?P<pk>\d+)/(?P<slug>.+)/$', HistoryOfValidationDisplay.as_view(), name='history'),
@@ -24,10 +24,10 @@ urlpatterns = [
     url(r'^revoquer/(?P<pk>\d+)/(?P<slug>.+)/$', RevokeValidation.as_view(), name='revoke'),
 
     # NO VALIDATION BEFORE PUBLICATION
-    url(r'^publier/(?P<pk>\d+)/(?P<slug>.+)/$', Publish.as_view(), name="publish"),
-    url(r'^depublier/(?P<pk>\d+)/(?P<slug>.+)/$', Unpublish.as_view(), name="unpublish"),
-    url(r'^valider/(?P<pk>\d+)/(?P<slug>.+)/$', ValidOpinion.as_view(), name="valid"),
-    url(r'^devalider/(?P<pk>\d+)/(?P<slug>.+)/$', InvalidOpinion.as_view(), name="invalid"),
+    url(r'^publier/(?P<pk>\d+)/(?P<slug>.+)/$', PublishOpinion.as_view(), name="publish"),
+    url(r'^depublier/(?P<pk>\d+)/(?P<slug>.+)/$', UnpublishOpinion.as_view(), name="unpublish"),
+    url(r'^valider/(?P<pk>\d+)/(?P<slug>.+)/$', PickOpinion.as_view(), name="valid"),
+    url(r'^devalider/(?P<pk>\d+)/(?P<slug>.+)/$', UnpickOpinion.as_view(), name="invalid"),
     url(r'^promouvoir/(?P<pk>\d+)/(?P<slug>.+)/$', PromoteOpinionToArticle.as_view(), name="promote"),
     # VALIDATION VIEWS FOR STAFF
 

--- a/zds/tutorialv2/urls/urls_validations.py
+++ b/zds/tutorialv2/urls/urls_validations.py
@@ -24,11 +24,13 @@ urlpatterns = [
     url(r'^revoquer/(?P<pk>\d+)/(?P<slug>.+)/$', RevokeValidation.as_view(), name='revoke'),
 
     # NO VALIDATION BEFORE PUBLICATION
-    url(r'^publier/(?P<pk>\d+)/(?P<slug>.+)/$', PublishOpinion.as_view(), name="publish"),
-    url(r'^depublier/(?P<pk>\d+)/(?P<slug>.+)/$', UnpublishOpinion.as_view(), name="unpublish"),
-    url(r'^valider/(?P<pk>\d+)/(?P<slug>.+)/$', PickOpinion.as_view(), name="valid"),
-    url(r'^devalider/(?P<pk>\d+)/(?P<slug>.+)/$', UnpickOpinion.as_view(), name="invalid"),
-    url(r'^promouvoir/(?P<pk>\d+)/(?P<slug>.+)/$', PromoteOpinionToArticle.as_view(), name="promote"),
+
+    url(r'^publier/(?P<pk>\d+)/(?P<slug>.+)/$', PublishOpinion.as_view(), name="publish-opinion"),
+    url(r'^depublier/(?P<pk>\d+)/(?P<slug>.+)/$', UnpublishOpinion.as_view(), name="unpublish-opinion"),
+    url(r'^choisir/(?P<pk>\d+)/(?P<slug>.+)/$', PickOpinion.as_view(), name="pick-opinion"),
+    url(r'^retirer/(?P<pk>\d+)/(?P<slug>.+)/$', UnpickOpinion.as_view(), name="unpick-opinion"),
+    url(r'^promouvoir/(?P<pk>\d+)/(?P<slug>.+)/$', PromoteOpinionToArticle.as_view(), name="promote-opinion"),
+
     # VALIDATION VIEWS FOR STAFF
 
     url(r'^billets/$', ValidationOpinionListView.as_view(), name='list-opinion'),

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -1513,6 +1513,11 @@ class WarnTypo(SingleContentFormViewMixin):
             if form.content.is_opinion:
                 _type = _(u'le billet')
 
+            if form.content.get_tree_depth() == 0:
+                pm_title = _(u'J\'ai trouvé une faute dans {} « {} ».').format(_type, form.content.title)
+            else:
+                pm_title = _(u'J\'ai trouvé une faute dans le chapitre « {} ».').format(form.content.title)
+
             msg = render_to_string(
                 'tutorialv2/messages/warn_typo.md',
                 {
@@ -1525,7 +1530,7 @@ class WarnTypo(SingleContentFormViewMixin):
                 })
 
             # send it :
-            send_mp(user, authors, _(u'Proposition de correction'), form.content.title, msg, leave=False)
+            send_mp(user, authors, pm_title, '', msg, leave=False)
 
             messages.success(self.request, _(u'Merci pour votre proposition de correction.'))
 

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -352,8 +352,10 @@ class DeleteContent(LoggedWithReadWriteHability, SingleContentViewMixin, DeleteV
         object_type = self.object.type.lower()
 
         _type = _(u'ce tutoriel')
-        if self.object.type == 'ARTICLE':
+        if self.object.is_article:
             _type = _(u'cet article')
+        elif self.object.is_opinion:
+            _type = _(u'ce billet')
 
         if self.object.authors.count() > 1:  # if more than one author, just remove author from list
             RemoveAuthorFromContent.remove_author(self.object, self.request.user)
@@ -1505,9 +1507,11 @@ class WarnTypo(SingleContentFormViewMixin):
         else:  # send correction
             text = '\n'.join(['> ' + line for line in form.cleaned_data['text'].split('\n')])
 
-            _type = _(u"l'article")
-            if form.content.type == 'TUTORIAL':
+            _type = _(u'l\'article')
+            if form.content.is_tutorial:
                 _type = _(u'le tutoriel')
+            if form.content.is_opinion:
+                _type = _(u'le billet')
 
             msg = render_to_string(
                 'tutorialv2/messages/warn_typo.md',
@@ -1721,11 +1725,14 @@ class AddAuthorToContent(LoggedWithReadWriteHability, SingleContentFormViewMixin
         return redirect(url, self.request.user)
 
     def form_valid(self, form):
-        _type = self.object.type.lower()
-        if _type == 'tutorial':
+
+        _type = _(u"de l'article")
+
+        if self.object.is_tutorial:
             _type = _(u'du tutoriel')
-        else:
-            _type = _(u"de l'article")
+        elif self.object.is_opinion:
+            _type = _(u'du billet')
+
         bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
         for user in form.cleaned_data['users']:
             if user not in self.object.authors.all() and user != self.request.user:
@@ -1795,8 +1802,10 @@ class RemoveAuthorFromContent(AddAuthorToContent):
         users = form.cleaned_data['users']
 
         _type = _(u'cet article')
-        if self.object.type == 'TUTORIAL':
+        if self.object.is_tutorial:
             _type = _(u'ce tutoriel')
+        elif self.object.is_opinion:
+            _type = _(u'ce billet')
 
         for user in users:
             if RemoveAuthorFromContent.remove_author(self.object, user):

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -694,7 +694,7 @@ class SolveContentAlert(FormView, LoginRequiredMixin):
         alert.solve(request.user, resolve_reason, msg_title, msg_content)
 
         messages.success(self.request, _(u"L'alerte a bien été résolue."))
-        return redirect(content.get_absolute_url())
+        return redirect(content.get_absolute_url_online())
 
 
 class SendNoteAlert(FormView, LoginRequiredMixin):

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -23,7 +23,7 @@ from zds.member.views import get_client_ip
 from zds.notification import signals
 from zds.notification.models import ContentReactionAnswerSubscription, NewPublicationSubscription
 from zds.tutorialv2.forms import RevokeValidationForm, WarnTypoForm, NoteForm, NoteEditForm, UnpublicationForm, \
-    OpinionValidationForm, PromoteOpinionToArticleForm, OpinionInvalidationForm
+    PickOpinionForm, PromoteOpinionToArticleForm, UnpickOpinionForm
 from zds.tutorialv2.mixins import SingleOnlineContentDetailViewMixin, SingleOnlineContentViewMixin, DownloadViewMixin, \
     ContentTypeMixin, SingleOnlineContentFormViewMixin, MustRedirect
 from zds.tutorialv2.models import TYPE_CHOICES_DICT
@@ -111,9 +111,9 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
                     context['next_article'] = all_articles[position + 1]
 
         if self.versioned_object.type == 'OPINION':
-            context['formPickOpinion'] = OpinionValidationForm(
+            context['formPickOpinion'] = PickOpinionForm(
                 self.versioned_object, initial={'version': self.versioned_object.sha_public})
-            context['formUnpickOpinion'] = OpinionInvalidationForm(
+            context['formUnpickOpinion'] = UnpickOpinionForm(
                 self.versioned_object, initial={'version': self.versioned_object.sha_public})
             context['formConvertOpinion'] = PromoteOpinionToArticleForm(
                 self.versioned_object, initial={'version': self.versioned_object.sha_public})

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -23,7 +23,7 @@ from zds.member.views import get_client_ip
 from zds.notification import signals
 from zds.notification.models import ContentReactionAnswerSubscription, NewPublicationSubscription
 from zds.tutorialv2.forms import RevokeValidationForm, WarnTypoForm, NoteForm, NoteEditForm, UnpublicationForm, \
-    OpinionValidationForm, PromoteOpinionToArticleForm
+    OpinionValidationForm, PromoteOpinionToArticleForm, OpinionInvalidationForm
 from zds.tutorialv2.mixins import SingleOnlineContentDetailViewMixin, SingleOnlineContentViewMixin, DownloadViewMixin, \
     ContentTypeMixin, SingleOnlineContentFormViewMixin, MustRedirect
 from zds.tutorialv2.models import TYPE_CHOICES_DICT
@@ -112,6 +112,8 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
 
         if self.versioned_object.type == 'OPINION':
             context['formPickOpinion'] = OpinionValidationForm(
+                self.versioned_object, initial={'version': self.versioned_object.sha_public})
+            context['formUnpickOpinion'] = OpinionInvalidationForm(
                 self.versioned_object, initial={'version': self.versioned_object.sha_public})
             context['formConvertOpinion'] = PromoteOpinionToArticleForm(
                 self.versioned_object, initial={'version': self.versioned_object.sha_public})

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -678,7 +678,7 @@ class SolveContentAlert(FormView, LoginRequiredMixin):
             resolve_reason = request.POST['text']
             authors = alert.content.authors.values_list('username', flat=True)
             authors = ', '.join(authors)
-            msg_title = _(u"Résolution d'alerte : {0}").format(content.title),
+            msg_title = _(u"Résolution d'alerte : {0}").format(content.title)
             msg_content = render_to_string(
                 'tutorialv2/messages/resolve_alert.md', {
                     'content': content,
@@ -741,7 +741,7 @@ class SolveNoteAlert(FormView, LoginRequiredMixin):
         msg_content = ''
         if 'text' in request.POST and request.POST['text']:
             resolve_reason = request.POST['text']
-            msg_title = _(u"Résolution d'alerte : {0}").format(note.related_content.title),
+            msg_title = _(u"Résolution d'alerte : {0}").format(note.related_content.title)
             msg_content = render_to_string(
                 'tutorialv2/messages/resolve_alert.md', {
                     'content': note.related_content,

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -19,7 +19,7 @@ from zds.member.decorator import LoginRequiredMixin, PermissionRequiredMixin, Lo
 from zds.gallery.models import UserGallery
 from zds.notification import signals
 from zds.tutorialv2.forms import AskValidationForm, RejectValidationForm, AcceptValidationForm, RevokeValidationForm, \
-    CancelValidationForm, PublicationForm, OpinionValidationForm, PromoteOpinionToArticleForm, OpinionInvalidationForm
+    CancelValidationForm, PublicationForm, PickOpinionForm, PromoteOpinionToArticleForm, UnpickOpinionForm
 from zds.tutorialv2.mixins import SingleContentFormViewMixin, ModalFormView, \
     SingleOnlineContentFormViewMixin, ValidationBeforeViewMixin, NoValidationBeforeFormViewMixin
 from zds.tutorialv2.models.models_database import Validation, PublishableContent
@@ -540,7 +540,7 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
         return super(RevokeValidation, self).form_valid(form)
 
 
-class Publish(LoggedWithReadWriteHability, NoValidationBeforeFormViewMixin):
+class PublishOpinion(LoggedWithReadWriteHability, NoValidationBeforeFormViewMixin):
     """Publish the content (only content without preliminary validation)"""
 
     form_class = PublicationForm
@@ -554,7 +554,7 @@ class Publish(LoggedWithReadWriteHability, NoValidationBeforeFormViewMixin):
         raise Http404(_(u"Publier un contenu n'est pas possible avec la méthode « GET »."))
 
     def get_form_kwargs(self):
-        kwargs = super(Publish, self).get_form_kwargs()
+        kwargs = super(PublishOpinion, self).get_form_kwargs()
         kwargs['content'] = self.versioned_object
         return kwargs
 
@@ -582,19 +582,18 @@ class Publish(LoggedWithReadWriteHability, NoValidationBeforeFormViewMixin):
             messages.success(self.request, _(u'Le contenu a bien été publié.'))
             self.success_url = published.get_absolute_url_online()
 
-        return super(Publish, self).form_valid(form)
+        return super(PublishOpinion, self).form_valid(form)
 
 
-class Unpublish(LoginRequiredMixin, SingleOnlineContentFormViewMixin, NoValidationBeforeFormViewMixin):
-    """Unpublish a content"""
+class UnpublishOpinion(LoginRequiredMixin, SingleOnlineContentFormViewMixin, NoValidationBeforeFormViewMixin):
+    """Unpublish an opinion"""
 
     form_class = RevokeValidationForm
-    is_public = True
 
     modal_form = True
 
     def get_form_kwargs(self):
-        kwargs = super(Unpublish, self).get_form_kwargs()
+        kwargs = super(UnpublishOpinion, self).get_form_kwargs()
         kwargs['content'] = self.versioned_object
         return kwargs
 
@@ -637,23 +636,23 @@ class Unpublish(LoginRequiredMixin, SingleOnlineContentFormViewMixin, NoValidati
         messages.success(self.request, _(u"Le contenu a bien été dépublié."))
         self.success_url = self.versioned_object.get_absolute_url()
 
-        return super(Unpublish, self).form_valid(form)
+        return super(UnpublishOpinion, self).form_valid(form)
 
 
-class ValidOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
+class PickOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
     """Add the opinion in the picked list """
 
-    form_class = OpinionValidationForm
+    form_class = PickOpinionForm
 
     modal_form = True
     prefetch_all = False
-    permissions = ["tutorialv2.change_validation"]
+    permissions = ['tutorialv2.change_validation']
 
     def get(self, request, *args, **kwargs):
         raise Http404(_(u"Valider un contenu n'est pas possible avec la méthode « GET »."))
 
     def get_form_kwargs(self):
-        kwargs = super(ValidOpinion, self).get_form_kwargs()
+        kwargs = super(PickOpinion, self).get_form_kwargs()
         kwargs['content'] = self.versioned_object
         return kwargs
 
@@ -686,23 +685,23 @@ class ValidOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
 
         messages.success(self.request, _(u'Le contenu a bien été validé.'))
 
-        return super(ValidOpinion, self).form_valid(form)
+        return super(PickOpinion, self).form_valid(form)
 
 
-class InvalidOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
+class UnpickOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
     """Remove opinion from the picked list"""
 
-    form_class = OpinionInvalidationForm
+    form_class = UnpickOpinionForm
 
     modal_form = True
     prefetch_all = False
-    permissions = ["tutorialv2.change_validation"]
+    permissions = ['tutorialv2.change_validation']
 
     def get(self, request, *args, **kwargs):
         raise Http404(_(u"Enlever un billet des billets choisis n'est pas possible avec la méthode « GET »."))
 
     def get_form_kwargs(self):
-        kwargs = super(InvalidOpinion, self).get_form_kwargs()
+        kwargs = super(UnpickOpinion, self).get_form_kwargs()
         kwargs['content'] = self.versioned_object
         return kwargs
 
@@ -743,11 +742,11 @@ class InvalidOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
 
         messages.success(self.request, _(u"Le contenu a bien été enlevé de la liste des billets choisis."))
 
-        return super(InvalidOpinion, self).form_valid(form)
+        return super(UnpickOpinion, self).form_valid(form)
 
 
 class PromoteOpinionToArticle(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
-    """Publish the content"""
+    """Promote an opinion to article"""
 
     form_class = PromoteOpinionToArticleForm
 

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -663,6 +663,7 @@ class PickOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
         self.success_url = versioned.get_absolute_url_online()
 
         db_object.sha_picked = form.cleaned_data['version']
+        db_object.picked_date = datetime.now()
         db_object.save()
 
         msg = render_to_string(

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -641,7 +641,7 @@ class Unpublish(LoginRequiredMixin, SingleOnlineContentFormViewMixin, NoValidati
 
 
 class ValidOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
-    """Publish the content"""
+    """Add the opinion in the picked list """
 
     form_class = OpinionValidationForm
 
@@ -690,7 +690,7 @@ class ValidOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
 
 
 class InvalidOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
-    """Publish the content"""
+    """Remove opinion from the picked list"""
 
     form_class = OpinionInvalidationForm
 

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -19,7 +19,7 @@ from zds.member.decorator import LoginRequiredMixin, PermissionRequiredMixin, Lo
 from zds.gallery.models import UserGallery
 from zds.notification import signals
 from zds.tutorialv2.forms import AskValidationForm, RejectValidationForm, AcceptValidationForm, RevokeValidationForm, \
-    CancelValidationForm, PublicationForm, OpinionValidationForm, PromoteOpinionToArticleForm
+    CancelValidationForm, PublicationForm, OpinionValidationForm, PromoteOpinionToArticleForm, OpinionInvalidationForm
 from zds.tutorialv2.mixins import SingleContentFormViewMixin, ModalFormView, \
     SingleOnlineContentFormViewMixin, ValidationBeforeViewMixin, NoValidationBeforeFormViewMixin
 from zds.tutorialv2.models.models_database import Validation, PublishableContent
@@ -640,7 +640,7 @@ class Unpublish(LoginRequiredMixin, SingleOnlineContentFormViewMixin, NoValidati
         return super(Unpublish, self).form_valid(form)
 
 
-class ValidPublication(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
+class ValidOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
     """Publish the content"""
 
     form_class = OpinionValidationForm
@@ -653,7 +653,7 @@ class ValidPublication(PermissionRequiredMixin, NoValidationBeforeFormViewMixin)
         raise Http404(_(u"Valider un contenu n'est pas possible avec la méthode « GET »."))
 
     def get_form_kwargs(self):
-        kwargs = super(ValidPublication, self).get_form_kwargs()
+        kwargs = super(ValidOpinion, self).get_form_kwargs()
         kwargs['content'] = self.versioned_object
         return kwargs
 
@@ -686,7 +686,64 @@ class ValidPublication(PermissionRequiredMixin, NoValidationBeforeFormViewMixin)
 
         messages.success(self.request, _(u'Le contenu a bien été validé.'))
 
-        return super(ValidPublication, self).form_valid(form)
+        return super(ValidOpinion, self).form_valid(form)
+
+
+class InvalidOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
+    """Publish the content"""
+
+    form_class = OpinionInvalidationForm
+
+    modal_form = True
+    prefetch_all = False
+    permissions = ["tutorialv2.change_validation"]
+
+    def get(self, request, *args, **kwargs):
+        raise Http404(_(u"Enlever un billet des billets choisis n'est pas possible avec la méthode « GET »."))
+
+    def get_form_kwargs(self):
+        kwargs = super(InvalidOpinion, self).get_form_kwargs()
+        kwargs['content'] = self.versioned_object
+        return kwargs
+
+    def form_valid(self, form):
+
+        db_object = self.object
+        versioned = self.versioned_object
+        self.success_url = versioned.get_absolute_url_online()
+
+        if not db_object.sha_picked:
+            raise PermissionDenied("Retirer des billets choisis quelque chose qui n'y est pas")
+
+        if db_object.sha_picked != form.cleaned_data['version']:
+            raise PermissionDenied("Retirer des billets choisis quelque chose qui n'y est pas")
+
+        db_object.sha_picked = None
+        db_object.save()
+
+        msg = render_to_string(
+            'tutorialv2/messages/validation_invalid_opinion.md',
+            {
+                'content': versioned,
+                'url': versioned.get_absolute_url(),
+                'admin': self.request.user,
+                'message_reject': '\n'.join(['> ' + a for a in form.cleaned_data['text'].split('\n')])
+            })
+
+        bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
+        send_mp(
+            bot,
+            versioned.authors.all(),
+            _(u"Billet retiré de la liste des billets choisis"),
+            versioned.title,
+            msg,
+            True,
+            direct=False
+        )
+
+        messages.success(self.request, _(u"Le contenu a bien été enlevé de la liste des billets choisis."))
+
+        return super(InvalidOpinion, self).form_valid(form)
 
 
 class PromoteOpinionToArticle(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug 
| Ticket(s) (_issue(s)_) concerné(s)  | #3993 

Je me suis attaqué à la liste des TODOs de la ZEP-13, l'histoire d'avancer (sauf l'histoire de la 500 que je laisse à @artragis), à savoir:

* Permettre de dévalider un billet (avec des tests et tout)
* Icône superposée au texte "aucun contenu" https://github.com/zestedesavoir/zds-site/pull/3993#issuecomment-270009766
* Bandeau vert vide sur les billets en cours de conversion vers article, contient "Ce billet a été promu" pour le staff https://github.com/zestedesavoir/zds-site/pull/3993#issuecomment-270013869
* Titre du MP résolution d'alerte de billet buggé https://github.com/zestedesavoir/zds-site/pull/3993#issuecomment-270014123
* Et deux ou trois autres machins que j'ai croisé en chemin.

Mais aussi,

+ #4123 : le filtre de validation des billets ne fonctionne pas (et ne fonctionnera plus jamais)
+ #4117 : le robots.txt
+ #4113 : résoudre une alerte redirige vers la version publique.
+ #4124 : le message d'erreur à la suppression d'une galerie. 
+ #4125 : le MP qui mentionnait la bêta pour les billets (maintenant plus)
+ #4116 : message de promotion
+ #4126 : trie les messages par date de choix

Note: je n'arrive pas à reproduire https://github.com/zestedesavoir/zds-site/pull/3993#issuecomment-270012259 (500 quand suppression d'auteur → ça a du être réglé en chemin).