### PR TITLE
Les sujets n'apparaissent plus en double pour les membres de plusieurs groupes

### DIFF
--- a/zds/forum/managers.py
+++ b/zds/forum/managers.py
@@ -63,7 +63,7 @@ class TopicManager(models.Manager):
         """
         queryset = self.filter(author=author) \
                        .prefetch_related('author')
-        queryset = queryset.filter(self.visibility_check_query(user))
+        queryset = queryset.filter(self.visibility_check_query(user)).distinct()
 
         return queryset.order_by('-pubdate').all()[:settings.ZDS_APP['forum']['home_number']]
 
@@ -91,13 +91,13 @@ class TopicManager(models.Manager):
     def get_all_topics_of_a_user(self, current, target):
         queryset = self.filter(author=target)\
                        .prefetch_related('author')
-        queryset = queryset.filter(self.visibility_check_query(current))
+        queryset = queryset.filter(self.visibility_check_query(current)).distinct()
         return queryset.order_by('-pubdate').all()
 
     def get_all_topics_of_a_tag(self, tag, user):
         queryset = self.filter(tags__in=[tag])\
                        .prefetch_related('author', 'last_message', 'tags')
-        queryset = queryset.filter(self.visibility_check_query(user))
+        queryset = queryset.filter(self.visibility_check_query(user)).distinct()
         return queryset.order_by('-last_message__pubdate')
 
 
@@ -129,7 +129,7 @@ class PostManager(InheritanceManager):
                        .prefetch_related('author')
         if not current.has_perm('forum.change_post'):
             queryset = queryset.filter(is_visible=True)
-        queryset = queryset.filter(self.visibility_check_query(current))
+        queryset = queryset.filter(self.visibility_check_query(current)).distinct()
         return queryset.order_by('-pubdate').all()
 
 

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -417,7 +417,6 @@ class FindTopicByTag(FilterMixin, ZdSPagingListView, SingleObjectMixin):
 
     def get_queryset(self):
         self.queryset = Topic.objects.get_all_topics_of_a_tag(self.object, self.request.user)
-        print(self.queryset)
         return super(FindTopicByTag, self).get_queryset()
 
     def filter_queryset(self, queryset, filter_param):

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -417,6 +417,7 @@ class FindTopicByTag(FilterMixin, ZdSPagingListView, SingleObjectMixin):
 
     def get_queryset(self):
         self.queryset = Topic.objects.get_all_topics_of_a_tag(self.object, self.request.user)
+        print(self.queryset)
         return super(FindTopicByTag, self).get_queryset()
 
     def filter_queryset(self, queryset, filter_param):


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4068 

Cette régression avait été engendrée par #3949 (PR d'optimisation).

### QA

* Dans l'admin de Django créez un groupe CA
* Dans l'admin Django associé ce groupe et le groupe staff à un utilisateur
* Dans l'admin Django créez un forum privé avec CA et staff dans la liste des groupes
* Avec votre utilisateur de l'étape 2 se rendre dans le forum créé à l'étape 3
* Créer un topic avec un tag (de votre choix)
* Sur les pages suivantes le topic (ou le post) n’apparait bien qu'une seule fois : 
  - "Messages postés par" : route forums/messages/pk_user
  - "Profil de" : route membres/voir/nom_user
  - "Messages postés par" : route forums/messages/pk_user/
  - Liste des sujets sur le tag de l'étape 5 : route forums/sujets/tag/id_tag/slug_tag/
