### PR TITLE
Fix un test

### DIFF
--- a/zds/forum/tests/tests_feeds.py
+++ b/zds/forum/tests/tests_feeds.py
@@ -279,12 +279,11 @@ class LastPostFeedTest(TestCase):
     def test_get_description(self):
         """ test the return value of description """
 
-        # TODO : Fix this test, bug cause of markdown :(
         emarkdown(self.post3.text)
-        # ref = emarkdown(self.post3.text)
-        # posts = self.postfeed.items(obj={'tag': self.tag2.pk})
-        # ret = self.postfeed.item_description(item=posts[0])
-        # self.assertEqual(ret, ref)
+        ref = emarkdown(self.post3.text)
+        posts = self.postfeed.items(obj={'tag': self.tag2.pk})
+        ret = self.postfeed.item_description(item=posts[0])
+        self.assertEqual(ret, ref)
 
     def test_get_author_name(self):
         """ test the return value of author name """


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | couverture / codebase
| Ticket(s) (_issue(s)_) concerné(s)  | #3897 (partiel)

On retire un todo dans le code et on gagne un test supplémentaire. Comment ? En supprimant les commentaires  ¯\_(ツ)_/¯ . Probablement un soucis réglé du côté de Markdown [depuis ça](https://github.com/zestedesavoir/zds-site/commit/485eac4aa177010affbcf8e46aad431caed6e7f1).

### QA

* Relecture de code + les tests passent

