### PR TITLE
Mise à jour de Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ python-memcached==1.54
 lxml==3.6.0
 factory-boy==2.7.0
 pygeoip==0.3.2
-pillow==3.2.0
+pillow==4.0.0
 gitpython==1.0.1
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.17.zip
 easy-thumbnails==2.3


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | -
| Ticket(s) (_issue(s)_) concerné(s)  | #3898 

Mise à jour de Pillow car d'après Requires.IO on se trouve au niveau Insecure. Pour les curieux le changelog se trouve ici : http://pastebin.com/ZmmPGTJu (ou en passant par requires.io). Zds n'utilise que la fonction open de ce que j'ai pu voir, donc en ce qui nous concerne, il y a : 

```
    Allow pathlib.Path in Image.open on Python 2.7 #2110 [patricksnape]
    Added CMYK mode for opening EPS files #1826 [radarhere]
```


### QA

* Mettre à jour ses dépendances
* L'import d'image depuis une archive ZIP fonctionne toujours
* Lors de l'import d'une archive de tuto avec une archive d'image, les images sont bien liés sur elles ont été préfixées de archive: 

Bonne QA !
