### PR TITLE
Ne supprime pas les notes de karma et les sanctions par un modérateur qui se désinscrit

### DIFF
--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -463,6 +463,12 @@ class MemberTests(TestCase):
         self.assertEqual(Application.objects.count(), 1)
         self.assertEqual(AccessToken.objects.count(), 1)
 
+        # add a karma note and a sanction with this user
+        note = KarmaNote(moderator=user.user, user=user2.user, note='Good!', karma=5)
+        note.save()
+        ban = Ban(moderator=user.user, user=user2.user, type='Ban définitif', note='Test')
+        ban.save()
+
         # login and unregister:
         login_check = self.client.login(
             username=user.user.username,
@@ -565,6 +571,10 @@ class MemberTests(TestCase):
         # check API
         self.assertEqual(Application.objects.count(), 0)
         self.assertEqual(AccessToken.objects.count(), 0)
+
+        # check that the karma note and the sanction were kept
+        self.assertTrue(KarmaNote.objects.filter(pk=note.pk).exists())
+        self.assertTrue(Ban.objects.filter(pk=ban.pk).exists())
 
     def test_forgot_password(self):
         """To test nominal scenario of a lost password."""

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -35,7 +35,7 @@ from zds.member.decorator import can_write_and_read_now
 from zds.member.forms import LoginForm, MiniProfileForm, ProfileForm, RegisterForm, \
     ChangePasswordForm, ChangeUserForm, NewPasswordForm, \
     PromoteMemberForm, KarmaForm, UsernameAndEmailForm
-from zds.member.models import Profile, TokenForgotPassword, TokenRegister, KarmaNote
+from zds.member.models import Profile, TokenForgotPassword, TokenRegister, KarmaNote, Ban
 from zds.mp.models import PrivatePost, PrivateTopic
 from zds.tutorialv2.models.models_database import PublishableContent
 from zds.notification.models import TopicAnswerSubscription, NewPublicationSubscription
@@ -383,6 +383,13 @@ def unregister(request):
     for message in PrivatePost.objects.filter(author=current):
         message.author = anonymous
         message.save()
+    # karma notes and sanctions anonymisation (to keep them)
+    for note in KarmaNote.objects.filter(moderator=current):
+        note.moderator = anonymous
+        note.save()
+    for ban in Ban.objects.filter(moderator=current):
+        ban.moderator = anonymous
+        ban.save()
     # in case current has been moderator in his old day
     for message in Comment.objects.filter(editor=current):
         message.editor = anonymous

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -40,7 +40,7 @@ from zds.mp.models import PrivatePost, PrivateTopic
 from zds.tutorialv2.models.models_database import PublishableContent
 from zds.notification.models import TopicAnswerSubscription, NewPublicationSubscription
 from zds.tutorialv2.models.models_database import PublishedContent
-from zds.utils.models import Comment, CommentVote
+from zds.utils.models import Comment, CommentVote, Alert
 from zds.utils.mps import send_mp
 from zds.utils.paginator import ZdSPagingListView
 from zds.utils.tokens import generate_token
@@ -383,13 +383,19 @@ def unregister(request):
     for message in PrivatePost.objects.filter(author=current):
         message.author = anonymous
         message.save()
-    # karma notes and sanctions anonymisation (to keep them)
+    # karma notes, alerts and sanctions anonymisation (to keep them)
     for note in KarmaNote.objects.filter(moderator=current):
         note.moderator = anonymous
         note.save()
     for ban in Ban.objects.filter(moderator=current):
         ban.moderator = anonymous
         ban.save()
+    for alert in Alert.objects.filter(author=current):
+        alert.author = anonymous
+        alert.save()
+    for alert in Alert.objects.filter(moderator=current):
+        alert.moderator = anonymous
+        alert.save()
     # in case current has been moderator in his old day
     for message in Comment.objects.filter(editor=current):
         message.editor = anonymous


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution

Actuellement, si un modérateur se désinscrit, les notes de karma et les sanctions (je parle de leur archive, c'est-à-dire de l'objet `Ban`, un membre sanctionné le reste) liées à son compte sont supprimées, ce qui est le comportement normal de l'effacement d'un objet dans Django.

Cependant, il serait préférable de garder ces informations en guise d'archive. Cette pull request modifie donc ce comportement pour le même que celui des messages : l'objet n'est pas supprimé mais transmis à l'utilisateur anonyme.

### QA

* Depuis l'admin Django, créer un utilisateur avec les droits staff et le profil associé ;
* Se connecter depuis ce compte, laisser une note de karma sur un membre et le sanctionner ;
* Se désinscrire ;
* Se connecter depuis un compte super-utilisateur (et admin) et vérifier que la note de karma est toujours présente (et qu'elle est liée à l'utilisateur anonyme défini dans `settings.py`) ;
* Dans l'admin Django, vérifier que l'objet `Ban` est toujours présent ;
* Vérifier que le test `zds.member.tests.tests_views.MemberTests.test_unregister` passe toujours.
