### PR TITLE
Corrige le titre du message de résolution d'alerte

### DIFF
--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -638,7 +638,7 @@ class SolveNoteAlert(FormView, LoginRequiredMixin):
         msg_content = ''
         if 'text' in request.POST and request.POST['text']:
             resolve_reason = request.POST['text']
-            msg_title = _(u"Résolution d'alerte : {0}").format(note.related_content.title),
+            msg_title = _(u"Résolution d'alerte : {0}").format(note.related_content.title)
             msg_content = render_to_string(
                 'tutorialv2/messages/resolve_alert.md', {
                     'content': note.related_content,


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4168

Comme promis, voici la pull request corrigeant le titre du message de résolution d'alerte. L'erreur était stupide : il y avait une virgule à la fin de la ligne. :)

### QA

* Créer et publier un contenu (parce que seules les alertes sur les commentaires de contenus sont concernées) ;
* Publier un commentaire et le signaler ;
* Résoudre l'alerte ;
* Vérifier dans votre boîte de MP que le titre du message de résolution est correct.