### PR TITLE
Utilise update pour la désinscription

### DIFF
--- a/zds/notification/views.py
+++ b/zds/notification/views.py
@@ -40,11 +40,7 @@ class NotificationList(ZdSPagingListView):
 def mark_notifications_as_read(request):
     """Mark the notifications of the current user as read"""
 
-    notifications = Notification.objects.get_unread_notifications_of(request.user)
-
-    for notification in notifications:
-        notification.is_read = True
-        notification.save()
+    Notification.objects.get_unread_notifications_of(request.user).update(is_read=True)
 
     messages.success(request, _(u'Vos notifications ont bien été marquées comme lues.'))
 

--- a/zds/utils/migrations/0010_auto_20170203_2100.py
+++ b/zds/utils/migrations/0010_auto_20170203_2100.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('utils', '0009_auto_20161113_2328'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='alert',
+            name='privatetopic',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, verbose_name='Message priv\xe9', blank=True, to='mp.PrivateTopic', null=True),
+        ),
+    ]

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -284,6 +284,7 @@ class Alert(models.Model):
                                       blank=True)
     # PrivateTopic sending the resolve_reason to the alert creator
     privatetopic = models.ForeignKey(PrivateTopic,
+                                     on_delete=models.SET_NULL,
                                      verbose_name=u'Message privé',
                                      db_index=True,
                                      null=True,


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4170

Avec un peu de retard, voici comme promis ma pull request pour résoudre l'issue #4170. La méthode `update` est maintenant utilisée à la place d'une boucle `for` pour modifier/mettre à jour une liste d'objets. La désinscription est la principale page concernée, mais j'en ai aussi profité pour le faire sur le marquage des notifications comme lues.

Je ne suis pas parvenu à gérer tous les cas, notamment celui des sujets privés qui utilise une condition, mais ça devrait déjà alléger largement la désinscription.

J'ai au passage corrigé un petit bug qui était directement lié : si un utilisateur se désinscrivait, ses alertes résolues étaient quand même supprimées. En effet, le message privé de résolution était lui supprimé, celui-ci était lié à l'alerte, il la supprimait. (Même chose au passage quand le membre quittait la conversation.)

### QA

* Vérifier que la désinscription fonctionne toujours correctement (anonymisation des messages, alertes, notes de karma, ...) ;
* Même chose pour le marquage des notifications comme lues.