### PR TITLE
Création d'un historique de sanctions pour le staff

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -603,6 +603,8 @@
                         </form>
                     </li>
                 {% endif %}
+
+                <li><a href="{% url 'member-sanctions-history' usr.pk %}">Historique</a></li>
             </ul>
             {% endif %}
         </div>

--- a/templates/member/sanctions_history.html
+++ b/templates/member/sanctions_history.html
@@ -1,0 +1,54 @@
+{% extends "member/base.html" %}
+{% load i18n %}
+{% load date %}
+
+
+{% block title %}
+    {% trans "Historique des sanctions de" %} {{ usr.username }}
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+        <li><a href="{% url "member-detail" usr.username %}">{{ usr.username }}</a></li>
+        <li>{% trans "Historique des sanctions" %}</li>
+{% endblock %}
+
+
+
+{% block headline %}
+    {% trans "Historique des sanctions de" %} {{ usr.username }}
+{% endblock %}
+
+
+
+{% block content %}
+    {% if sanctions %}
+        <table class="fullwidth">
+            <thead>
+                <th>{% trans "Type" %}</th>
+                <th>{% trans "Explication" %}</th>
+                <th class="wide">{% trans "Modérateur" %}</th>
+                <th class="wide">{% trans "Date" %}</th>
+            </thead>
+            <tbody>
+                {% for sanction in sanctions %}
+                    <tr>
+                        <td>{{ sanction.type }}</td>
+                        <td>
+                            {% if sanction.note %}
+                                {{ sanction.note }}
+                            {% else %}
+                                –
+                            {% endif %}
+                        </td>
+                        <td class="wide"><a href="{% url "member-detail" sanction.moderator.username %}">{{ sanction.moderator.username }}</a></td>
+                        <td class="wide">{{ sanction.pubdate|format_date|capfirst }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p>{{ usr.username }} {% trans "n'a jamais été sanctionné." %}</p>
+    {% endif %}
+{% endblock %}

--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -224,7 +224,7 @@ class ReadingOnlySanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _(u'Lecture Seule')
+        return _(u'Lecture seule définitive')
 
     def get_text(self):
         return self.array_infos.get('ls-text', '')
@@ -246,7 +246,7 @@ class TemporaryReadingOnlySanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _(u'Lecture Seule Temporaire')
+        return _(u'Lecture seule temporaire')
 
     def get_text(self):
         return self.array_infos.get('ls-text', '')
@@ -271,7 +271,7 @@ class DeleteReadingOnlySanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _(u"Autorisation d'écrire")
+        return _(u'Fin de lecture seule')
 
     def get_text(self):
         return self.array_infos.get('unls-text', '')
@@ -293,7 +293,7 @@ class BanSanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _(u'Ban définitif')
+        return _(u'Bannissement définitif')
 
     def get_text(self):
         return self.array_infos.get('ban-text', '')
@@ -315,7 +315,7 @@ class TemporaryBanSanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _(u'Ban Temporaire')
+        return _(u'Bannissement temporaire')
 
     def get_text(self):
         return self.array_infos.get('ban-text', '')
@@ -341,7 +341,7 @@ class DeleteBanSanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _(u'Autorisation de se connecter')
+        return _(u'Fin de bannissement')
 
     def get_text(self):
         return self.array_infos.get('unban-text', '')

--- a/zds/member/urls.py
+++ b/zds/member/urls.py
@@ -5,7 +5,8 @@ from django.conf.urls import url
 from zds.member.views import MemberList, MemberDetail, UpdateMember, UpdateAvatarMember, UpdatePasswordMember, \
     UpdateUsernameEmailMember, RegisterView, SendValidationEmailView, modify_karma, \
     modify_profile, settings_mini_profile, member_from_ip, tutorials, articles, settings_promote, login_view, \
-    logout_view, forgot_password, new_password, activate_account, generate_token_account, unregister, warning_unregister
+    logout_view, forgot_password, new_password, activate_account, generate_token_account, unregister, warning_unregister, \
+    sanctions_history
 
 urlpatterns = [
     # list
@@ -23,6 +24,7 @@ urlpatterns = [
     # moderation
     url(r'^profil/karmatiser/$', modify_karma, name='member-modify-karma'),
     url(r'^profil/modifier/(?P<user_pk>\d+)/$', modify_profile, name='member-modify-profile'),
+    url(r'^profil/historique-sanctions/(?P<user_pk>\d+)/$', sanctions_history, name='member-sanctions-history'),
     url(r'^parametres/mini_profil/(?P<user_name>.+)/$', settings_mini_profile, name='member-settings-mini-profile'),
     url(r'^profil/multi/(?P<ip_address>.+)/$', member_from_ip, name='member-from-ip'),
 

--- a/zds/member/urls.py
+++ b/zds/member/urls.py
@@ -5,8 +5,8 @@ from django.conf.urls import url
 from zds.member.views import MemberList, MemberDetail, UpdateMember, UpdateAvatarMember, UpdatePasswordMember, \
     UpdateUsernameEmailMember, RegisterView, SendValidationEmailView, modify_karma, \
     modify_profile, settings_mini_profile, member_from_ip, tutorials, articles, settings_promote, login_view, \
-    logout_view, forgot_password, new_password, activate_account, generate_token_account, unregister, warning_unregister, \
-    sanctions_history
+    logout_view, forgot_password, new_password, activate_account, generate_token_account, unregister, \
+    warning_unregister, sanctions_history
 
 urlpatterns = [
     # list

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -497,6 +497,23 @@ def modify_profile(request, user_pk):
 
 
 @login_required
+def sanctions_history(request, user_pk):
+    """Display the history of a member sanctions"""
+
+    if not request.user.has_perm('member.change_profile'):
+        raise PermissionDenied
+
+    user = get_object_or_404(User, pk=user_pk)
+
+    sanctions = Ban.objects.filter(user=user).order_by('-pubdate').select_related('moderator')
+
+    return render(request, 'member/sanctions_history.html', {
+        'usr': user,
+        'sanctions': sanctions,
+    })
+
+
+@login_required
 def tutorials(request):
     """Returns all tutorials of the authenticated user."""
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -481,11 +481,9 @@ def modify_profile(request, user_pk):
 
 
 @login_required
+@permission_required('member.change_profile', raise_exception=True)
 def sanctions_history(request, user_pk):
     """Display the history of a member sanctions"""
-
-    if not request.user.has_perm('member.change_profile'):
-        raise PermissionDenied
 
     user = get_object_or_404(User, pk=user_pk)
 


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | nouvelle fonctionnalité

Cette pull request crée un historique de sanctions pour le staff qui permet de voir les actions qui ont été faites et à quelle date. Elle utilise le modèle `Ban` qui a toujours été utilisé pour archiver les sanctions (en effet, il n'est pas utilisé pour vérifier qu'un membre a le droit de se connecter/de poster), mais qui n'était jamais affiché.

### QA

* Avec un compte staff, essayer plusieurs sanctions sur un utilisateur (bannir, débannir, mettre en lecture seule, etc) ;
* Cliquer sur le lien `Historique` dans le sous-menu `Sanctions` et vérifier que les actions effectuées ont bien été répertoriées ;
* Vérifier que cette page n'est accessible qu'aux membres du staff (c'est couvert par les tests de toute façon) ;
* Enfin, vérifier que les tests `zds.member.tests.tests_views.MemberTests` passent toujours.
