### PR TITLE
Utilise permission_required pour la gestion des droits – module member

### DIFF
--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -8,7 +8,7 @@ from oauth2_provider.models import AccessToken
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, logout
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.models import User, Group
 from django.template.context_processors import csrf
 from django.core.exceptions import PermissionDenied
@@ -445,12 +445,10 @@ def unregister(request):
 @require_POST
 @can_write_and_read_now
 @login_required
+@permission_required('member.change_profile', raise_exception=True)
 @transaction.atomic
 def modify_profile(request, user_pk):
     """Modifies sanction of a user if there is a POST request."""
-
-    if not request.user.has_perm('member.change_profile'):
-        raise PermissionDenied
 
     profile = get_object_or_404(Profile, user__pk=user_pk)
     if profile.is_private():
@@ -598,11 +596,9 @@ def articles(request):
 
 @can_write_and_read_now
 @login_required
+@permission_required('member.change_profile', raise_exception=True)
 def settings_mini_profile(request, user_name):
     """Minimal settings of users for staff."""
-
-    if not request.user.has_perm('member.change_profile'):
-        raise PermissionDenied
 
     # extra information about the current user
     profile = get_object_or_404(Profile, user__username=user_name)
@@ -1009,11 +1005,9 @@ def settings_promote(request, user_pk):
 
 
 @login_required
+@permission_required('member.change_profile', raise_exception=True)
 def member_from_ip(request, ip_address):
     """ Get list of user connected from a particular ip """
-
-    if not request.user.has_perm('member.change_profile'):
-        raise PermissionDenied
 
     members = Profile.objects.filter(last_ip_address=ip_address).order_by('-last_visit')
     return render(request, 'member/settings/memberip.html', {
@@ -1023,12 +1017,10 @@ def member_from_ip(request, ip_address):
 
 
 @login_required
+@permission_required('member.change_profile', raise_exception=True)
 @require_POST
 def modify_karma(request):
     """ Add a Karma note to the user profile """
-
-    if not request.user.has_perm('member.change_profile'):
-        raise PermissionDenied
 
     try:
         profile_pk = int(request.POST['profile_pk'])


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | refactorisation
| Ticket(s) (_issue(s)_) concerné(s)  | #4181

Cette pull request modifie le fichier de vues du module `member` pour utiliser le décorateur `permission_required` au lieu d'une condition comme montré dans #4181.

### QA

Vérifier que les pages/actions suivantes ne sont accessibles qu'aux membres du staff :

* sanction d'un membre (pour essayer sans avoir accès au formulaire : #4047)
* modification du profil (je parle de la vue `settings_mini_profile`, pas de la page des paramètres permettant à un membre de changer ses propres paramètres)
* recherche de double-comptes via l'IP
* modification du karma (même principe que pour la sanction d'un membre)

Le comportement attendu est le suivant :

* redirection vers la page de connexion pour un utilisateur non authentifié
* 403 pour un membre n'ayant pas les droits
* accès à la page pour un membre ayant les droits