### PR TITLE
Permet de marquer un contenu comme obsolète

### DIFF
--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -49,6 +49,16 @@
     </h1>
 
     {% include 'tutorialv2/includes/tags_authors.part.html' with content=content online=True %}
+
+    {% if is_obsolete %}
+        <div class="content-wrapper">
+            <div class="alert-box warning">
+                {% blocktrans %}
+                    Ce contenu est obsolète. Il peut contenir des informations intéressantes mais soyez prudent avec celles-ci.
+                {% endblocktrans %}
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}
 
 

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -181,9 +181,9 @@
                             {% csrf_token %}
                             <button type="submit" class="ico-after alert blue">
                                 {% if is_obsolete %}
-                                    {% trans "Marquer non obsolète" %}
+                                    {% trans "Marquer comme non obsolète" %}
                                 {% else %}
-                                    {% trans "Marquer obsolète" %}
+                                    {% trans "Marquer comme obsolète" %}
                                 {% endif %}
                             </button>
                         </form>

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -65,6 +65,16 @@
     {% endif %}
 
     {% include 'tutorialv2/includes/tags_authors.part.html' with content=content online=True %}
+
+    {% if is_obsolete %}
+        <div class="content-wrapper">
+            <div class="alert-box warning">
+                {% blocktrans %}
+                    Ce contenu est obsolète. Il peut contenir des informations intéressantes mais soyez prudent avec celles-ci.
+                {% endblocktrans %}
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}
 
 
@@ -161,17 +171,29 @@
                     </a>
                 </li>
                 {% if is_staff %}
-                <li>
-                    <a href="{% url "validation:history" content.pk content.slug %}" class="ico-after history blue">
-                        {% trans "Historique validation" %}
-                    </a>
-                </li>
-                <li>
-                    <a href="#unpublish" class="ico-after open-modal cross blue">
-                        {% trans "Dépublier" %}
-                    </a>
-                    {% crispy formRevokeValidation %}
-                </li>
+                    <li>
+                        <a href="{% url "validation:history" content.pk content.slug %}" class="ico-after history blue">
+                            {% trans "Historique validation" %}
+                        </a>
+                    </li>
+                    <li>
+                        <form action="{% url 'validation:mark-obsolete' content.pk %}" method="post">
+                            {% csrf_token %}
+                            <button type="submit" class="ico-after alert blue">
+                                {% if is_obsolete %}
+                                    {% trans "Marquer non obsolète" %}
+                                {% else %}
+                                    {% trans "Marquer obsolète" %}
+                                {% endif %}
+                            </button>
+                        </form>
+                    </li>
+                    <li>
+                        <a href="#unpublish" class="ico-after open-modal cross blue">
+                            {% trans "Dépublier" %}
+                        </a>
+                        {% crispy formRevokeValidation %}
+                    </li>
                 {% endif %}
             </ul>
         </div>

--- a/zds/tutorialv2/migrations/0018_publishedcontent_is_obsolete.py
+++ b/zds/tutorialv2/migrations/0018_publishedcontent_is_obsolete.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tutorialv2', '0017_auto_20170204_2239'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='publishedcontent',
+            name='is_obsolete',
+            field=models.BooleanField(default=False, verbose_name='Est obsol\xe8te'),
+        ),
+    ]

--- a/zds/tutorialv2/migrations/0019_auto_20170208_1347.py
+++ b/zds/tutorialv2/migrations/0019_auto_20170208_1347.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tutorialv2', '0018_publishedcontent_is_obsolete'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='publishedcontent',
+            name='is_obsolete',
+        ),
+        migrations.AddField(
+            model_name='publishablecontent',
+            name='is_obsolete',
+            field=models.BooleanField(default=False, verbose_name='Est obsol\xe8te'),
+        ),
+    ]

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -440,6 +440,7 @@ class SingleOnlineContentDetailViewMixin(SingleOnlineContentViewMixin, DetailVie
         context = super(SingleOnlineContentDetailViewMixin, self).get_context_data(**kwargs)
 
         context['content'] = self.versioned_object
+        context['is_obsolete'] = self.object.is_obsolete
         context['public_object'] = self.public_content_object
         context['can_edit'] = self.request.user in self.object.authors.all()
         context['isantispam'] = self.object.antispam(self.request.user)

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -124,6 +124,8 @@ class PublishableContent(models.Model):
 
     must_reindex = models.BooleanField(u'Si le contenu doit-être ré-indexé', default=True)
 
+    is_obsolete = models.BooleanField('Est obsolète', default=False)
+
     public_version = models.ForeignKey(
         'PublishedContent', verbose_name=u'Version publiée', blank=True, null=True, on_delete=models.SET_NULL)
 

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -5627,6 +5627,10 @@ class PublishedContentTests(TestCase):
         result = self.client.get(self.tuto.get_absolute_url_online(), follow=False)
         self.assertEqual(result.status_code, 200)
         self.assertContains(result, _(u'Ce contenu est obsolète.'))
+        # and on a chapter
+        result = self.client.get(self.chapter1.get_absolute_url_online(), follow=False)
+        self.assertEqual(result.status_code, 200)
+        self.assertContains(result, _(u'Ce contenu est obsolète.'))
         # finally, check that this alert can be hidden
         result = self.client.post(
             reverse('validation:mark-obsolete', kwargs={'pk': self.tuto.pk}),

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -12,6 +12,7 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils.translation import ugettext_lazy as _
 
 from zds.forum.factories import ForumFactory, CategoryFactory
 from zds.forum.models import Topic, Post, TopicRead
@@ -5616,7 +5617,7 @@ class PublishedContentTests(TestCase):
         # check that when the content is not marked as obsolete, the alert is not shown
         result = self.client.get(self.tuto.get_absolute_url_online(), follow=False)
         self.assertEqual(result.status_code, 200)
-        self.assertNotContains(result, u'Ce contenu est obsolète.')
+        self.assertNotContains(result, _(u'Ce contenu est obsolète.'))
         # now, let's mark the tutoriel as obsolete
         result = self.client.post(
             reverse('validation:mark-obsolete', kwargs={'pk': self.tuto.pk}),
@@ -5625,7 +5626,7 @@ class PublishedContentTests(TestCase):
         # check that the alert is shown
         result = self.client.get(self.tuto.get_absolute_url_online(), follow=False)
         self.assertEqual(result.status_code, 200)
-        self.assertContains(result, u'Ce contenu est obsolète.')
+        self.assertContains(result, _(u'Ce contenu est obsolète.'))
         # finally, check that this alert can be hidden
         result = self.client.post(
             reverse('validation:mark-obsolete', kwargs={'pk': self.tuto.pk}),
@@ -5633,4 +5634,4 @@ class PublishedContentTests(TestCase):
         self.assertEqual(result.status_code, 302)
         result = self.client.get(self.tuto.get_absolute_url_online(), follow=False)
         self.assertEqual(result.status_code, 200)
-        self.assertNotContains(result, u'Ce contenu est obsolète.')
+        self.assertNotContains(result, _(u'Ce contenu est obsolète.'))

--- a/zds/tutorialv2/urls/urls_validations.py
+++ b/zds/tutorialv2/urls/urls_validations.py
@@ -4,7 +4,7 @@ from django.conf.urls import url
 
 from zds.tutorialv2.views.views_validations import AskValidationForContent, ReserveValidation, \
     HistoryOfValidationDisplay, AcceptValidation, RejectValidation, RevokeValidation, CancelValidation, \
-    ValidationListView
+    ValidationListView, mark_obsolete
 
 urlpatterns = [
     url(r'^proposer/(?P<pk>\d+)/(?P<slug>.+)/$', AskValidationForContent.as_view(), name='ask'),
@@ -17,5 +17,7 @@ urlpatterns = [
 
     url(r'^depublier/(?P<pk>\d+)/(?P<slug>.+)/$', RevokeValidation.as_view(), name='revoke'),
 
-    url(r'^$', ValidationListView.as_view(), name='list')
+    url(r'^$', ValidationListView.as_view(), name='list'),
+
+    url(r'^marquer-obsolete/(?P<pk>\d+)/$', mark_obsolete, name='mark-obsolete'),
 ]

--- a/zds/tutorialv2/urls/urls_validations.py
+++ b/zds/tutorialv2/urls/urls_validations.py
@@ -4,7 +4,7 @@ from django.conf.urls import url
 
 from zds.tutorialv2.views.views_validations import AskValidationForContent, ReserveValidation, \
     HistoryOfValidationDisplay, AcceptValidation, RejectValidation, RevokeValidation, CancelValidation, \
-    ValidationListView, mark_obsolete
+    ValidationListView, MarkObsolete
 
 urlpatterns = [
     url(r'^proposer/(?P<pk>\d+)/(?P<slug>.+)/$', AskValidationForContent.as_view(), name='ask'),
@@ -19,5 +19,5 @@ urlpatterns = [
 
     url(r'^$', ValidationListView.as_view(), name='list'),
 
-    url(r'^marquer-obsolete/(?P<pk>\d+)/$', mark_obsolete, name='mark-obsolete'),
+    url(r'^marquer-obsolete/(?P<pk>\d+)/$', MarkObsolete.as_view(), name='mark-obsolete'),
 ]

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -537,6 +537,6 @@ def mark_obsolete(request, pk):
         messages.info(request, _(u"Le contenu n'est plus marqué comme obsolète."))
     else:
         content.is_obsolete = True
-        messages.info(request, _(u"Le contenu est maintenant marqué comme obsolète."))
+        messages.info(request, _(u'Le contenu est maintenant marqué comme obsolète.'))
     content.save()
     return redirect(content.get_absolute_url_online())

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -523,7 +523,7 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
         return super(RevokeValidation, self).form_valid(form)
 
 
-class MarkObsolete(FormView, LoginRequiredMixin, PermissionRequiredMixin):
+class MarkObsolete(LoginRequiredMixin, PermissionRequiredMixin, FormView):
 
     permissions = ['tutorialv2.change_validation']
 

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -13,6 +13,8 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import ListView, FormView
+from django.contrib.auth.decorators import login_required, permission_required
+from django.views.decorators.http import require_POST
 
 from zds.member.decorator import LoginRequiredMixin, PermissionRequiredMixin, LoggedWithReadWriteHability
 from zds.notification import signals
@@ -425,6 +427,7 @@ class AcceptValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
 
             if form.cleaned_data['is_major'] or not is_update or db_object.pubdate is None:
                 db_object.pubdate = datetime.now()
+                db_object.is_obsolete = False
 
             # close beta if is an article
             if db_object.type == 'ARTICLE':
@@ -520,3 +523,20 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
         self.success_url = self.versioned_object.get_absolute_url() + '?version=' + validation.version
 
         return super(RevokeValidation, self).form_valid(form)
+
+
+@login_required
+@permission_required('tutorialv2.change_validation', raise_exception=True)
+@require_POST
+def mark_obsolete(request, pk):
+    content = get_object_or_404(PublishableContent, pk=pk)
+    if not content.in_public():
+        raise Http404
+    if content.is_obsolete:
+        content.is_obsolete = False
+        messages.info(request, _(u"Le contenu n'est plus marqué comme obsolète."))
+    else:
+        content.is_obsolete = True
+        messages.info(request, _(u"Le contenu est maintenant marqué comme obsolète."))
+    content.save()
+    return redirect(content.get_absolute_url_online())


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | nouvelle fonctionnalité
| Ticket(s) (_issue(s)_) concerné(s)  | #4185 

Ça m'a pris pas mal de temps (surtout pour comprendre le code de `tutorialv2`), mais je pense que le résultat y est ! Cette pull request permet de marquer un contenu comme obsolète, ce qui aura pour effet d'afficher un bandeau le signalant sur toutes ces pages. Cette action, faisable uniquement par le staff, est réversible.

### QA

* Créer un contenu et le publier, vérifier qu'il n'est pas marqué obsolète ;
* Marquer le contenu obsolète, le bandeau doit s'afficher sur toutes ses pages ;
* Le marquer comme non obsolète, le bandeau doit disparaître ;
* Le remarquer comme obsolète, puis le valider à nouveau sans cocher la case `Version majeure`, il doit rester obsolète ;
* Le valider encore une fois, mais cette fois en cochant la case : le bandeau doit disparaître ;
* Enfin, vérifier que le test `zds.tutorialv2.tests.tests_views.PublishedContentTests.test_obsolete` passe.