### PR TITLE
Pysolr enlevé des dépendances

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # Implicit dependencies (optional dependencies of dependencies)
-pysolr==3.4.0
 pygments==2.1.3
 python-social-auth==0.2.19
 elasticsearch==5.1.0

--- a/update.md
+++ b/update.md
@@ -961,7 +961,9 @@ Une fois que tout est indexé,
         systemctl start zds-es-index.timer
         ```
         
-+ Désinstaller Solr.
++ Désinstaller Solr : 
+    * `pp uninstall pysolr django-haystack`
+    * Supprimer la base de données de Solr
 + Supprimer les tables suivantes de MySQL:
 
     * `search_searchindexextract`

--- a/update.md
+++ b/update.md
@@ -962,7 +962,7 @@ Une fois que tout est indexé,
         ```
         
 + Désinstaller Solr : 
-    * `pp uninstall pysolr django-haystack`
+    * `pip uninstall pysolr django-haystack`
     * Supprimer la base de données de Solr
 + Supprimer les tables suivantes de MySQL:
 


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | oubli

`pysolr` avait été conservé par erreur lors du passage à ES. :)

### QA

Rien normalement.