### PR TITLE
[WIP] Empêche les notifications persistantes pour les pings

### DIFF
--- a/zds/notification/managers.py
+++ b/zds/notification/managers.py
@@ -83,11 +83,13 @@ class SubscriptionManager(models.Manager):
                 object_id=content_object.pk,
                 content_type__pk=content_type.pk,
                 user=user)
+            subscription.was_active = subscription.is_active
             if not subscription.is_active:
                 subscription.activate()
         except ObjectDoesNotExist:
             subscription = self.model(user=user, content_object=content_object)
             subscription.save()
+            subscription.was_active = False
 
         return subscription
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -284,7 +284,7 @@ def answer_comment_event(sender, **kwargs):
     assert user is not None
     # avoids creation of a ping if forum is not visible.
     if sender == Post:
-        if not Topic.objects.filter(pk=comment.topic.forum.pk, group__in=list(user.groups.all())).exists():
+        if not Topic.objects.filter(pk=comment.topic.forum.pk, forum__group__in=list(user.groups.all())).exists():
             return
     subscription = PingSubscription.objects.get_or_create_active(user, comment)
     if subscription.was_active:

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -284,11 +284,11 @@ def answer_comment_event(sender, **kwargs):
     assert user is not None
     # avoids creation of a ping if forum is not visible.
     if sender == Post:
-        if Topic.objects.filter(pk=comment.topic.forum.pk, group__in=list(user.groups.all)).first() is None:
+        if Topic.objects.filter(pk=comment.topic.forum.pk, group__in=list(user.groups.all)).exists():
             return
     subscription = PingSubscription.objects.get_or_create_active(user, comment)
     if subscription.was_active:
-        logger.info('subsription %s was active', subscription)
+        logger.info('subscription %s was active', subscription)
         return
     subscription.send_notification(content=comment, sender=comment.author, send_email=False)
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -284,7 +284,7 @@ def answer_comment_event(sender, **kwargs):
     assert user is not None
     # avoids creation of a ping if forum is not visible.
     if sender == Post:
-        if not Topic.objects.filter(pk=comment.topic.forum.pk, group__in=list(user.groups.all)).exists():
+        if not Topic.objects.filter(pk=comment.topic.forum.pk, group__in=list(user.groups.all())).exists():
             return
     subscription = PingSubscription.objects.get_or_create_active(user, comment)
     if subscription.was_active:

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -284,7 +284,7 @@ def answer_comment_event(sender, **kwargs):
     assert user is not None
     # avoids creation of a ping if forum is not visible.
     if sender == Post:
-        if not Topic.objects.filter(pk=comment.topic.forum.pk, forum__group__in=list(user.groups.all())).exists():
+        if not comment.topic.forum.can_read(user):
             return
     subscription = PingSubscription.objects.get_or_create_active(user, comment)
     if subscription.was_active:

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -287,6 +287,9 @@ def answer_comment_event(sender, **kwargs):
         if Topic.objects.filter(pk=comment.topic.forum.pk, group__in=list(user.groups.all)).first() is None:
             return
     subscription = PingSubscription.objects.get_or_create_active(user, comment)
+    if subscription.was_active:
+        logger.info("subsription %s was active", subscription)
+        return
     subscription.send_notification(content=comment, sender=comment.author, send_email=False)
 
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -288,7 +288,7 @@ def answer_comment_event(sender, **kwargs):
             return
     subscription = PingSubscription.objects.get_or_create_active(user, comment)
     if subscription.was_active:
-        logger.info("subsription %s was active", subscription)
+        logger.info('subsription %s was active', subscription)
         return
     subscription.send_notification(content=comment, sender=comment.author, send_email=False)
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -409,4 +409,4 @@ def cleanup_notification_for_unpublished_content(sender, instance, **_):
             notification.delete()
         logger.debug('Nothing went wrong.')
     except DatabaseError:
-        logger.exception("Error while cleaning up database")
+        logger.exception('Error while cleaning up database')

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -284,7 +284,7 @@ def answer_comment_event(sender, **kwargs):
     assert user is not None
     # avoids creation of a ping if forum is not visible.
     if sender == Post:
-        if Topic.objects.filter(pk=comment.topic.forum.pk, group__in=list(user.groups.all)).exists():
+        if not Topic.objects.filter(pk=comment.topic.forum.pk, group__in=list(user.groups.all)).exists():
             return
     subscription = PingSubscription.objects.get_or_create_active(user, comment)
     if subscription.was_active:

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -282,7 +282,10 @@ def answer_comment_event(sender, **kwargs):
 
     assert comment is not None
     assert user is not None
-
+    # avoids creation of a ping if forum is not visible.
+    if sender == Post:
+        if Topic.objects.filter(pk=comment.topic.forum.pk, group__in=list(user.groups.all)).first() is None:
+            return
     subscription = PingSubscription.objects.get_or_create_active(user, comment)
     subscription.send_notification(content=comment, sender=comment.author, send_email=False)
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -178,9 +178,9 @@ def edit_topic_event(sender, **kwargs):
             forum_groups = list(topic.forum.group.all())
             for message in Post.objects.prefetch_related('topic', 'topic__forum').filter(topic=topic):
                 subs = PingSubscription.objects.prefetch_related('last_notification')\
-                                              .filter(content_type=content_type,
-                                                      object_id=message.pk)\
-                                              .filter(~Q(user__groups__in=forum_groups))
+                                               .filter(content_type=content_type,
+                                                       object_id=message.pk)\
+                                               .filter(~Q(user__groups__in=forum_groups))
                 for sub in subs:
                     sub.last_notification.is_read = True
                     sub.last_notification.save()

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -29,9 +29,7 @@ class ForumNotification(TestCase):
         self.category1 = CategoryFactory(position=1)
         self.forum11 = ForumFactory(category=self.category1, position_in_category=1)
         self.forum12 = ForumFactory(category=self.category1, position_in_category=2)
-        self.forum1_staff = ForumFactory(category=self.category1, position_in_category=2)
-        self.forum1_staff.groups.add(Group.objects.filter(name='staff').first())
-        self.forum1_staff.save()
+
         for group in self.staff.groups.all():
             self.forum12.group.add(group)
         self.forum12.save()
@@ -87,18 +85,18 @@ class ForumNotification(TestCase):
 
         self.assertEqual(result.status_code, 302)
         self.assertEqual(1, PingSubscription.objects.filter(is_active=True)
-                                            .count(), "One ping subscription must be created and active")
+                                            .count(), 'One ping subscription must be created and active')
         topic = Topic.objects.get(title='Super sujet')
         data = {
             'move': '',
-            'forum': self.forum1_staff.pk,
+            'forum': self.forum12.pk,
             'topic': topic.pk
         }
         response = self.client.post(reverse('topic-edit'), data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertEqual(1, PingSubscription.objects.filter(is_active=False)
-                         .count(), "No active ping subscription.")
+                         .count(), 'No active ping subscription.')
 
 
 overrided_zds_app = settings.ZDS_APP

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 import os
 import shutil
 
-from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug 
| Ticket(s) (_issue(s)_) concerné(s)  | #4195, #4193

- [ ] fix str function
### QA

    Déplacement vers un forum auquel le pingé n'a pas accès
        Pinger X dans un forum 'public'
        Déplacer le sujet dans un forum non-public
    Créer un ping dans un forum auquel le pingé n'a pas accès
        Pinger X dans un forum non-public
    Créer un ping
        editer sans enlever le ping
        le ping ne doit pas générer deux notification.
