### PR TITLE
Améliore l'historique de modération pour le staff

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -86,21 +86,6 @@
             {% endif %}
         </ul>
 
-        {% if perms.member.change_profile and not profile.is_private %}
-            <div>
-                {% trans "Remarques sur cet utilisateur" %} ({{ profile.karma }}) :
-                <ul>
-                {% if karmanotes.count > 0 %}
-                    {% for note in karmanotes %}
-                        <li><strong>{{ note.karma }}</strong> {{ note.pubdate|format_date:True }} {% trans "par" %} {{ note.moderator.username }} : {{ note.note }}</li>
-                    {% endfor %}
-                {% else %}
-                    <li>{% trans "Cet utilisateur n'a reçu aucune remarque" %}</li>
-                {% endif %}
-                </ul>
-            </div>
-        {% endif %}
-
         {% if profile.sign %}
             <h2 id="signature">{% trans "Signature" %}</h2>
             {{ profile.sign|emarkdown_inline }}
@@ -157,10 +142,40 @@
         </section>
     {% endif %}
 
-    {% if perms.member.change_profile %}
+    {% if perms.member.change_profile and actions %}
         <hr class="clearfix" />
         <section class="full-content-wrapper without-margin article-content">
             <h2 id="historique-moderation">{% trans "Historique de modération" %}</h2>
+            <table class="fullwidth">
+                <thead>
+                    <th>{% trans "Action" %}</th>
+                    <th>{% trans "Explication" %}</th>
+                    <th class="wide">{% trans "Modérateur" %}</th>
+                    <th class="wide">{% trans "Date" %}</th>
+                </thead>
+                <tbody>
+                    {% for action in actions %}
+                        <tr>
+                            <td>
+                                {% if action.karma %}
+                                    {% trans "Modification du karma" %} : {{ action.karma }}
+                                {% else %}
+                                    {{ action.type }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if action.note %}
+                                    {{ action.note }}
+                                {% else %}
+                                    –
+                                {% endif %}
+                            </td>
+                            <td class="wide"><a href="{% url "member-detail" action.moderator.username %}">{{ action.moderator.username }}</a></td>
+                            <td class="wide">{{ action.pubdate|format_date|capfirst }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </section>
     {% endif %}
 
@@ -308,7 +323,7 @@
                     </a>
                 </li>
             {% endif %}
-            {% if perms.member.change_profile %}
+            {% if perms.member.change_profile and actions %}
                 <li>
                     <a href="#historique-moderation">
                         {% trans "Historique de modération" %}
@@ -512,21 +527,23 @@
                 </li>
             </ul>
 
-            <h4>{% trans "Karma" %}</h4>
-            <ul>
-                <li class="inactive">
-                    <span>
-                        {% trans "Valeur actuelle" %}
-                        <span class="count">{{ profile.karma }}</span>
-                    </span>
-                </li>
-                <li>
-                    <a href="#karmatiser-modal" class="open-modal">
-                        {% trans "Ajouter une remarque" %}
-                    </a>
-                    {% crispy karmaform %}
-                </li>
-            </ul>
+            {% if not profile.is_private %}
+                <h4>{% trans "Karma" %}</h4>
+                <ul>
+                    <li class="inactive">
+                        <span>
+                            {% trans "Valeur actuelle" %}
+                            <span class="count">{{ profile.karma }}</span>
+                        </span>
+                    </li>
+                    <li>
+                        <a href="#karmatiser-modal" class="open-modal">
+                            {% trans "Ajouter une remarque" %}
+                        </a>
+                        {% crispy karmaform %}
+                    </li>
+                </ul>
+            {% endif %}
 
             {% if not profile.is_private and usr != user %}
             <h4>{% trans "Sanctions" %}</h4>

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -98,8 +98,6 @@
                     <li>{% trans "Cet utilisateur n'a reçu aucune remarque" %}</li>
                 {% endif %}
                 </ul>
-                <a href="#karmatiser-modal" class="open-modal">{% trans "Ajouter une remarque" %}</a>
-                {% crispy karmaform %}
             </div>
         {% endif %}
 
@@ -156,6 +154,13 @@
             {% else %}
                 {{ profile.biography|emarkdown }}
             {% endif %}
+        </section>
+    {% endif %}
+
+    {% if perms.member.change_profile %}
+        <hr class="clearfix" />
+        <section class="full-content-wrapper without-margin article-content">
+            <h2 id="historique-moderation">{% trans "Historique de modération" %}</h2>
         </section>
     {% endif %}
 
@@ -300,6 +305,13 @@
                 <li>
                     <a href="#biographie">
                         {% trans "Biographie" %}
+                    </a>
+                </li>
+            {% endif %}
+            {% if perms.member.change_profile %}
+                <li>
+                    <a href="#historique-moderation">
+                        {% trans "Historique de modération" %}
                     </a>
                 </li>
             {% endif %}
@@ -497,6 +509,22 @@
                         {% trans "Alertes actives" %}
                         <span class="count">{{ profile.get_active_alerts_count }}</span>
                     </span>
+                </li>
+            </ul>
+
+            <h4>{% trans "Karma" %}</h4>
+            <ul>
+                <li class="inactive">
+                    <span>
+                        {% trans "Valeur actuelle" %}
+                        <span class="count">{{ profile.karma }}</span>
+                    </span>
+                </li>
+                <li>
+                    <a href="#karmatiser-modal" class="open-modal">
+                        {% trans "Ajouter une remarque" %}
+                    </a>
+                    {% crispy karmaform %}
                 </li>
             </ul>
 

--- a/templates/misc/message_user.html
+++ b/templates/misc/message_user.html
@@ -13,7 +13,7 @@
 
         {% if perms.forum.change_post and profile.karma != 0 %}
             <div class="user-metadata">
-                <a href="{{ member.get_absolute_url }}"
+                <a href="{{ member.get_absolute_url }}#historique-moderation"
                    class="user-karma
                           {% if profile.karma < 0 %}
                               negative

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -90,7 +90,7 @@ class MemberTests(TestCase):
             'note': 'warn'
         }, follow=True)
         self.assertEqual(200, r.status_code)
-        self.assertIn('<strong>42</strong>', r.content.decode('utf-8'))
+        self.assertIn('42', r.content.decode('utf-8'))
         # more than 100 karma must unvalidate the karma
         r = self.client.post(reverse('member-modify-karma'), {
             'profile_pk': user.pk,
@@ -98,7 +98,7 @@ class MemberTests(TestCase):
             'note': 'warn'
         }, follow=True)
         self.assertEqual(200, r.status_code)
-        self.assertNotIn('<strong>420</strong>', r.content.decode('utf-8'))
+        self.assertNotIn('420', r.content.decode('utf-8'))
         # empty warning must unvalidate the karma
         r = self.client.post(reverse('member-modify-karma'), {
             'profile_pk': user.pk,
@@ -106,7 +106,7 @@ class MemberTests(TestCase):
             'note': ''
         }, follow=True)
         self.assertEqual(200, r.status_code)
-        self.assertNotIn('<strong>41</strong>', r.content.decode('utf-8'))
+        self.assertNotIn('41', r.content.decode('utf-8'))
 
     def test_list_members(self):
         """
@@ -191,6 +191,9 @@ class MemberTests(TestCase):
             follow=False
         )
         self.assertEqual(result.status_code, 404)
+
+    def test_moderation_history(self):
+        
 
     def test_profile_page_of_weird_member_username(self):
 

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -193,7 +193,50 @@ class MemberTests(TestCase):
         self.assertEqual(result.status_code, 404)
 
     def test_moderation_history(self):
-        
+        user = ProfileFactory().user
+
+        ban = Ban(
+            user=user,
+            moderator=self.staff,
+            type='Lecture Seule Temporaire',
+            note='Test de LS',
+            pubdate=datetime.now(),
+        )
+        ban.save()
+
+        note = KarmaNote(
+            user=user,
+            moderator=self.staff,
+            karma=5,
+            note='Test de karma',
+            pubdate=datetime.now(),
+        )
+        note.save()
+
+        # staff rights are required to view the history, check that
+        self.client.logout()
+        self.client.login(username=user.username, password='hostel77')
+        result = self.client.get(
+            user.profile.get_absolute_url(),
+            follow=False
+        )
+        self.assertNotContains(result, 'Historique de modération')
+
+        self.client.logout()
+        self.client.login(username=self.staff.username, password='hostel77')
+        result = self.client.get(
+            user.profile.get_absolute_url(),
+            follow=False
+        )
+        self.assertContains(result, 'Historique de modération')
+
+        # check that the note and the sanction are in the context
+        self.assertIn(ban, result.context['actions'])
+        self.assertIn(note, result.context['actions'])
+
+        # and are displayed
+        self.assertContains(result, 'Test de LS')
+        self.assertContains(result, 'Test de karma')
 
     def test_profile_page_of_weird_member_username(self):
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -83,16 +83,16 @@ class MemberDetail(DetailView):
             topic.is_followed = topic in followed_topics
         context['articles'] = PublishedContent.objects.last_articles_of_a_member_loaded(usr)
         context['tutorials'] = PublishedContent.objects.last_tutorials_of_a_member_loaded(usr)
-        context['karmaform'] = KarmaForm(profile)
         context['topic_read'] = TopicRead.objects.list_read_topic_pk(self.request.user, context['topics'])
         context['subscriber_count'] = NewPublicationSubscription.objects.get_subscriptions(self.object).count()
         if self.request.user.has_perm('member.change_profile'):
-            sanctions = list(Ban.objects.filter(user=usr).order_by('-pubdate').select_related('moderator'))
-            notes = list(KarmaNote.objects.filter(user=usr).order_by('-pubdate').select_related('moderator'))
+            sanctions = list(Ban.objects.filter(user=usr).select_related('moderator'))
+            notes = list(KarmaNote.objects.filter(user=usr).select_related('moderator'))
             actions = sanctions + notes
             actions.sort(key=lambda e: e.pubdate)
             actions.reverse()
             context['actions'] = actions
+            context['karmaform'] = KarmaForm(profile)
         return context
 
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -89,7 +89,7 @@ class MemberDetail(DetailView):
             sanctions = list(Ban.objects.filter(user=usr).select_related('moderator'))
             notes = list(KarmaNote.objects.filter(user=usr).select_related('moderator'))
             actions = sanctions + notes
-            actions.sort(key=lambda e: e.pubdate)
+            actions.sort(key=lambda action: action.pubdate)
             actions.reverse()
             context['actions'] = actions
             context['karmaform'] = KarmaForm(profile)

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -83,10 +83,16 @@ class MemberDetail(DetailView):
             topic.is_followed = topic in followed_topics
         context['articles'] = PublishedContent.objects.last_articles_of_a_member_loaded(usr)
         context['tutorials'] = PublishedContent.objects.last_tutorials_of_a_member_loaded(usr)
-        context['karmanotes'] = KarmaNote.objects.filter(user=usr).order_by('-pubdate')
         context['karmaform'] = KarmaForm(profile)
         context['topic_read'] = TopicRead.objects.list_read_topic_pk(self.request.user, context['topics'])
         context['subscriber_count'] = NewPublicationSubscription.objects.get_subscriptions(self.object).count()
+        if self.request.user.has_perm('member.change_profile'):
+            sanctions = list(Ban.objects.filter(user=usr).order_by('-pubdate').select_related('moderator'))
+            notes = list(KarmaNote.objects.filter(user=usr).order_by('-pubdate').select_related('moderator'))
+            actions = sanctions + notes
+            actions.sort(key=lambda e: e.pubdate)
+            actions.reverse()
+            context['actions'] = actions
         return context
 
 


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | reprise de #4177 

Cette pull request améliore la gestion du karma et des sanctions en créant un historique commun visible sur le profil d'un membre. Un tableau liste donc les modifications du karma et les sanctions.

### QA

* Sanctionner un membre et ajouter une note de karma ;
* Vérifier que ces deux actions apparaissent sur son profil dans le bon ordre (du plan récent au plus ancien) ;
* Vérifier que la valeur actuelle du karma apparaît bien dans le sous-menu `Modération` et est correcte ;
* Vérifier que l'historique de modération n'apparaît pas sur un membre n'ayant pas été sanctionné et n'ayant aucune note de karma ;
* Vérifier que les tests `zds.member.tests.tests_views` passent toujours.