### PR TITLE
Utilise permission_required pour la gestion des droits : module forum

### DIFF
--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -5,7 +5,7 @@ import json
 import requests
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
@@ -607,6 +607,7 @@ class FindPost(FindTopic):
 
 @can_write_and_read_now
 @login_required
+@permission_required('forum.change_post', raise_exception=True)
 @require_POST
 @transaction.atomic
 def solve_alert(request):
@@ -615,9 +616,6 @@ def solve_alert(request):
     resolver leaves a comment.
     This can only be done by staff.
     """
-
-    if not request.user.has_perm('forum.change_post'):
-        raise PermissionDenied
 
     alert = get_object_or_404(Alert, pk=request.POST['alert_pk'])
     post = Post.objects.get(pk=alert.comment.id)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug / nouvelle fonctionnalité / évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4181 

Le but de cette PR est de clore #4181 en utilisant `permission_required` sur le dernier module à utiliser de permissions : le module `forum`. Cependant, je me suis rendu compte que la plupart des vues sont accessibles soit au staff soit à l'auteur du message, donc que le comportement actuel est le meilleur. Au final, je n'ai vu qu'une vue à corriger qui est `solve_alert`, n'hésitez pas à me dire si j'en ai manqué une quelque part (que ce soit sur ce module ou un autre).

Petite remarque cependant : ça n'a pas sa place dans cette PR, mais le rôle de développeur permet d'envoyer des sujets sur GitHub, au lieu de tester si le membre est dans le groupe, est-ce qu'une permission associée au groupe `dev` ne serait pas plus judicieuse ?

### QA

Code review uniquement.