### PR TITLE
[v22] Correction du pluriel sur le nombre de publications

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -142,7 +142,11 @@
 
                     <div class="content-item write-tutorial">
                         <div class="write-tutorial-text">
-                            <p>{% blocktrans %}Il y a {{ contents_count }}&nbsp;publication{{ contents_count|pluralize_fr }} sur&nbsp;Zeste&nbsp;de&nbsp;Savoir.{% endblocktrans %}</p>
+                            <p>
+                                {% blocktrans with plural=contents_count|pluralize_fr %}
+                                    Il y a {{ contents_count }}&nbsp;publication{{ plural }} sur&nbsp;Zeste&nbsp;de&nbsp;Savoir.
+                                {% endblocktrans %}
+                            </p>
                             <p class="lead">{% trans "Pourquoi pas la vôtre ?" %}</p>
                         </div>
                         <a href="{% url "content:create-tutorial" %}" class="btn btn-write-tutorial">{% trans "Commencer à rédiger" %}</a>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | corrige #4141

Je me suis rendu compte que j'avais mal utilisé `pluralize_fr` en proposant #4141. Du coup, sur la bêta, on a `333 publication` (sans `s`). Voici le correctif.

### QA
 
* Vérifier qu'il est écrit `publication` sur la page d'accueil quand il y a 0 ou 1 publication ;
* Vérifier qu'il est écrit `publications` sinon.