### PR TITLE
Ajoute une alerte sur le nombre de contenus orphelins en validation

### DIFF
--- a/assets/scss/components/_mobile-menu.scss
+++ b/assets/scss/components/_mobile-menu.scss
@@ -298,4 +298,9 @@
             }
         }
     }
+
+
+    .mobile-menu-link .validations-count {
+        display: none;
+    }
 }

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -270,6 +270,7 @@
         height: 60px;
         width: 60px;
         float: right;
+        position: relative;
 
         .username {
             display: none;
@@ -481,6 +482,22 @@
             right: 2.5%;
         }
     }
+
+    .my-account {
+        .validations-count {
+                display: block !important;
+                position: absolute;
+                z-index: 1;
+                top: 50%;
+                right: 50%;
+                margin: -20px -22px 0 0;
+                padding: 0 5px;
+                height: 16px;
+                line-height: 14px;
+                background: #c0392b; //@TODO: Color
+                border-radius: 16px;
+        }
+    }
 }
 
 @media only screen and #{$media-extra-wide} {
@@ -488,4 +505,3 @@
         margin-left: 5%;
     }
 }
-

--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -305,16 +305,16 @@ Récupère la liste des alertes (si l'utilisateur possède les droits pour le fa
 ``waiting_count``
 ---------------
 
-Récupère le nombre de tutoriels ou d'articles dans la zone de validation n'ayant pas été réservés par un validateur.
+Récupère le nombre de contenus, de tutoriels ou d'articles dans la zone de validation n'ayant pas été réservés par un validateur.
 
 .. sourcecode:: html
 
     {% load interventions %}
-    {% with waiting_tutorials_count="TUTORIAL"|waiting_count waiting_articles_count="ARTICLE"|waiting_count %}
+    {% with waiting_all_count=""|waiting_count waiting_tutorials_count="TUTORIAL"|waiting_count waiting_articles_count="ARTICLE"|waiting_count %}
         ...
     {% endwith %}
 
-Le filtre doit être appelé sur ``"TUTORIAL"`` pour récupérer le nombre de tutoriels en attente et sur ``"ARTICLE"`` pour le nombre d'articles.
+Le filtre doit être appelé sur ``"TUTORIAL"`` pour récupérer le nombre de tutoriels en attente et sur ``"ARTICLE"`` pour le nombre d'articles. Pour le nombre de contenus, il faut l'appeler sur une chaîne de caractères vide `""`.
 
 ``humane_delta``
 ----------------

--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -302,6 +302,20 @@ Récupère la liste des alertes (si l'utilisateur possède les droits pour le fa
 - ``alert.pubdate`` donne la date à laquelle l'alerte à été faite ;
 - ``alert.topic`` donne le texte d'alerte.
 
+``waiting_count``
+---------------
+
+Récupère le nombre de tutoriels ou d'articles dans la zone de validation n'ayant pas été réservés par un validateur.
+
+.. sourcecode:: html
+
+    {% load interventions %}
+    {% with waiting_tutorials_count="TUTORIAL"|waiting_count waiting_articles_count="ARTICLE"|waiting_count %}
+        ...
+    {% endwith %}
+
+Le filtre doit être appelé sur ``"TUTORIAL"`` pour récupérer le nombre de tutoriels en attente et sur ``"ARTICLE"`` pour le nombre d'articles.
+
 ``humane_delta``
 ----------------
 

--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -314,7 +314,7 @@ Récupère le nombre de contenus, de tutoriels ou d'articles dans la zone de val
         ...
     {% endwith %}
 
-Le filtre doit être appelé sur ``"TUTORIAL"`` pour récupérer le nombre de tutoriels en attente et sur ``"ARTICLE"`` pour le nombre d'articles. Pour le nombre de contenus, il faut l'appeler sur une chaîne de caractères vide `""`.
+Le filtre doit être appelé sur ``"TUTORIAL"`` pour récupérer le nombre de tutoriels en attente et sur ``"ARTICLE"`` pour le nombre d'articles. Pour le nombre de contenus, il faut l'appeler sur une chaîne de caractères vide ``""``.
 
 ``humane_delta``
 ----------------

--- a/templates/base.html
+++ b/templates/base.html
@@ -515,6 +515,24 @@
                                             <li class="staff-only">
                                                 <a href="{% url "validation:list" %}?type=article">{% trans "Validation des articles" %}</a>
                                             </li>
+                                            {% with waiting_tutorials_count=user|waiting_tutorials_count waiting_articles_count=user|waiting_articles_count %}
+                                                <li>
+                                                    <a href="{% url "validation:list" %}?type=tuto">
+                                                        {% trans "Validation des tutoriels" %}
+                                                        {% if waiting_tutorials_count > 0 %}
+                                                            ({{ waiting_tutorials_count }})
+                                                        {% endif %}
+                                                    </a>
+                                                </li>
+                                                <li>
+                                                    <a href="{% url "validation:list" %}?type=article">
+                                                        {% trans "Validation des articles" %}
+                                                        {% if waiting_articles_count > 0 %}
+                                                            ({{ waiting_articles_count }})
+                                                        {% endif %}
+                                                    </a>
+                                                </li>
+                                            {% endwith %}
                                         {% endif %}
 
                                         {% if perms.featured.change_featuredresource %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -483,6 +483,13 @@
                                            data-active="open-my-account"
                                        {% endif %}
                                     >
+                                        {% if perms.forum.change_post %}
+                                            {% with waiting_all_count=""|waiting_count  %}
+                                                {% if waiting_all_count > 0 %}
+                                                    <span class="validations-count">{{ waiting_all_count }}</span>
+                                                {% endif %}
+                                            {% endwith %}
+                                        {% endif %}
                                         <img src="{{ profile.get_avatar_url|remove_url_protocole }}" alt="" class="avatar">
                                         <span class="username label">{{ user.username }}</span>
                                     </a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -509,14 +509,8 @@
                                         </li>
 
                                         {% if perms.tutorialv2.change_validation %}
-                                            <li class="staff-only">
-                                                <a href="{% url "validation:list" %}?type=tuto">{% trans "Validation des tutoriels" %}</a>
-                                            </li>
-                                            <li class="staff-only">
-                                                <a href="{% url "validation:list" %}?type=article">{% trans "Validation des articles" %}</a>
-                                            </li>
-                                            {% with waiting_tutorials_count=user|waiting_tutorials_count waiting_articles_count=user|waiting_articles_count %}
-                                                <li>
+                                            {% with waiting_tutorials_count="TUTORIAL"|waiting_count waiting_articles_count="ARTICLE"|waiting_count %}
+                                                <li class="staff-only">
                                                     <a href="{% url "validation:list" %}?type=tuto">
                                                         {% trans "Validation des tutoriels" %}
                                                         {% if waiting_tutorials_count > 0 %}
@@ -524,7 +518,7 @@
                                                         {% endif %}
                                                     </a>
                                                 </li>
-                                                <li>
+                                                <li class="staff-only">
                                                     <a href="{% url "validation:list" %}?type=article">
                                                         {% trans "Validation des articles" %}
                                                         {% if waiting_articles_count > 0 %}

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from zds.forum.models import Post, is_read as topic_is_read
 from zds.mp.models import PrivateTopic
+from zds.tutorialv2.models.models_database import Validation
 from zds.notification.models import Notification, TopicAnswerSubscription, ContentReactionAnswerSubscription, \
     NewTopicSubscription, NewPublicationSubscription
 from zds.tutorialv2.models.models_database import ContentReaction
@@ -194,3 +195,19 @@ def alerts_list(user):
                           'text': alert.text})
 
     return {'alerts': total, 'nb_alerts': nb_alerts}
+
+
+@register.filter(name='waiting_tutorials_count')
+def waiting_tutorials_count(user):
+    return Validation.objects.filter(
+        validator__isnull=True,
+        status='PENDING',
+        content__type='TUTORIAL').count()
+
+
+@register.filter(name='waiting_articles_count')
+def waiting_articles_count(user):
+    return Validation.objects.filter(
+        validator__isnull=True,
+        status='PENDING',
+        content__type='ARTICLE').count()

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -200,9 +200,15 @@ def alerts_list(user):
 
 @register.filter(name='waiting_count')
 def waiting_count(content_type):
-    if content_type not in TYPE_CHOICES_DICT:
-        raise template.TemplateSyntaxError("'content_type' must be in 'zds.tutorialv2.models.TYPE_CHOICES_DICT'")
-    return Validation.objects.filter(
+
+    queryset = Validation.objects.filter(
         validator__isnull=True,
-        status='PENDING',
-        content__type=content_type).count()
+        status='PENDING')
+
+    if content_type:
+        if content_type not in TYPE_CHOICES_DICT:
+            raise template.TemplateSyntaxError("'content_type' must be in 'zds.tutorialv2.models.TYPE_CHOICES_DICT'")
+        else:
+            queryset = queryset.filter(content__type=content_type)
+
+    return queryset.count()

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -17,7 +17,6 @@ from zds.utils import get_current_user
 from zds.utils.models import Alert
 from zds import settings
 from zds.tutorialv2.models import TYPE_CHOICES_DICT
->>>>>>> tutorialsv2 => tutorialv2
 
 register = template.Library()
 

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -16,6 +16,7 @@ from zds.tutorialv2.models.models_database import ContentReaction
 from zds.utils import get_current_user
 from zds.utils.models import Alert
 from zds import settings
+from zds.tutorialsv2.models import TYPE_CHOICES_DICT
 
 register = template.Library()
 
@@ -199,6 +200,8 @@ def alerts_list(user):
 
 @register.filter(name='waiting_count')
 def waiting_count(content_type):
+    if not content_type in TYPE_CHOICES_DICT:
+        raise template.TemplateSyntaxError("'content_type' must be in 'zds.tutorialsv2.models.TYPE_CHOICES_DICT'")
     return Validation.objects.filter(
         validator__isnull=True,
         status='PENDING',

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -16,7 +16,8 @@ from zds.tutorialv2.models.models_database import ContentReaction
 from zds.utils import get_current_user
 from zds.utils.models import Alert
 from zds import settings
-from zds.tutorialsv2.models import TYPE_CHOICES_DICT
+from zds.tutorialv2.models import TYPE_CHOICES_DICT
+>>>>>>> tutorialsv2 => tutorialv2
 
 register = template.Library()
 
@@ -201,7 +202,7 @@ def alerts_list(user):
 @register.filter(name='waiting_count')
 def waiting_count(content_type):
     if not content_type in TYPE_CHOICES_DICT:
-        raise template.TemplateSyntaxError("'content_type' must be in 'zds.tutorialsv2.models.TYPE_CHOICES_DICT'")
+        raise template.TemplateSyntaxError("'content_type' must be in 'zds.tutorialv2.models.TYPE_CHOICES_DICT'")
     return Validation.objects.filter(
         validator__isnull=True,
         status='PENDING',

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -197,17 +197,9 @@ def alerts_list(user):
     return {'alerts': total, 'nb_alerts': nb_alerts}
 
 
-@register.filter(name='waiting_tutorials_count')
-def waiting_tutorials_count(user):
+@register.filter(name='waiting_count')
+def waiting_count(content_type):
     return Validation.objects.filter(
         validator__isnull=True,
         status='PENDING',
-        content__type='TUTORIAL').count()
-
-
-@register.filter(name='waiting_articles_count')
-def waiting_articles_count(user):
-    return Validation.objects.filter(
-        validator__isnull=True,
-        status='PENDING',
-        content__type='ARTICLE').count()
+        content__type=content_type).count()

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -201,7 +201,7 @@ def alerts_list(user):
 
 @register.filter(name='waiting_count')
 def waiting_count(content_type):
-    if not content_type in TYPE_CHOICES_DICT:
+    if content_type not in TYPE_CHOICES_DICT:
         raise template.TemplateSyntaxError("'content_type' must be in 'zds.tutorialv2.models.TYPE_CHOICES_DICT'")
     return Validation.objects.filter(
         validator__isnull=True,

--- a/zds/utils/templatetags/tests/tests_interventions.py
+++ b/zds/utils/templatetags/tests/tests_interventions.py
@@ -7,7 +7,9 @@ from django.template import Context, Template
 from django.test import TestCase
 
 from zds.forum.factories import CategoryFactory, ForumFactory, PostFactory, TopicFactory
-from zds.member.factories import ProfileFactory, StaffFactory
+from zds.tutorialv2.models.models_database import Validation
+from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory, SubCategoryFactory
+from zds.member.factories import ProfileFactory, StaffProfileFactory, StaffFactory
 from zds.utils.models import Alert
 from zds.utils.mps import send_message_mp, send_mp
 from zds.utils.templatetags.interventions import alerts_list
@@ -24,8 +26,27 @@ class InterventionsTest(TestCase):
     """
 
     def setUp(self):
+        self.licence = LicenceFactory()
+        self.subcategory = SubCategoryFactory()
+
         self.author = ProfileFactory()
         self.user = ProfileFactory()
+        self.staff = StaffProfileFactory()
+
+        self.tuto = PublishableContentFactory(type='TUTORIAL')
+        self.tuto.authors.add(self.author.user)
+        self.tuto.licence = self.licence
+        self.tuto.subcategory.add(self.subcategory)
+        self.tuto.save()
+
+        self.validation = Validation(
+            content=self.tuto,
+            version=self.tuto.sha_draft,
+            comment_authors='bla',
+            date_proposition=datetime.now(),
+        )
+        self.validation.save()
+
         self.topic = send_mp(author=self.author.user, users=[], title='Title', text='Testing', subtitle='', leave=False)
         self.topic.participants.add(self.user.user)
         send_message_mp(self.user.user, self.topic, 'Testing')
@@ -81,6 +102,29 @@ class InterventionsTest(TestCase):
         response = self.client.post(reverse('homepage'))
         self.assertEqual(200, response.status_code)
         self.assertContains(response, '<span class="notif-count">1</span>', html=True)
+
+    def test_interventions_waiting_contents(self):
+        # Login as staff
+        self.assertTrue(
+            self.client.login(
+                username=self.staff.user.username,
+                password='hostel77'
+            )
+        )
+
+        # check that the number of waiting tutorials is correct
+        response = self.client.post(reverse('homepage'))
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, '(1)')
+
+        # Mark the content as reserved
+        self.validation.status = 'PENDING_V'
+        self.validation.save()
+
+        # and check that the count was removed
+        response = self.client.post(reverse('homepage'))
+        self.assertEqual(200, response.status_code)
+        self.assertNotContains(response, '(1)')
 
     def test_interventions_humane_delta(self):
         tr = Template('{% load interventions %}'


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | nouvelle fonctionnalité
| Ticket(s) (_issue(s)_) concerné(s)  | #4210

Cette PR ajoute au menu d'un membre staff le nombre de contenus orphelins en attente de validation.

### QA

* Reconstruire le front
* Mettre un tutoriel en validation ;
* Vérifier la présence du `(1)` dans le menu ;
* Réserver le tutoriel ;
* Vérifier que le `(1)` a disparu ;
* Idem avec les articles.
