### PR TITLE
Correction de l'historique de modération : cas d'une note nulle

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -157,10 +157,12 @@
                     {% for action in actions %}
                         <tr>
                             <td>
-                                {% if action.karma %}
+                                {% if action.type %}
+                                    {{ action.type }}
+                                {% elif action.karma %}
                                     {% trans "Modification du karma" %} : {{ action.karma }}
                                 {% else %}
-                                    {{ action.type }}
+                                    –
                                 {% endif %}
                             </td>
                             <td>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | correction de #4202 

Je me suis rendu compte que j'avais fait une erreur avec #4202 : pour déterminer si une action était une note de karma ou une sanction, je testais `action.karma`. Sauf que si la note a une valeur nulle (exemple : quand un membre modifie son pseudo), le test était faux et elle était considérée comme une sanction. Le correctif consiste donc à faire le test inverse, c'est-à-dire tester `action.type`, ce qui renverra toujours `True` dans le cas d'une sanction et `False` dans le cas d'une note de karma.

Au passage, si une note de karma a une valeur nulle, j'ai changé le comportement pour afficher `–` au lieu de `Modification du karma : 0` dans la colonne `Action`, ce qui me paraît plus judicieux.

### QA

* Appliquer une sanction à un membre et vérifier qu'elle s'affiche dans la colonne `Action` ;
* Mettre une note de karma non nulle, vérifier qu'il est affiché `Modification du karma : x` ;
* Mettre une note de karma de valeur nulle, vérifier qu'il est affiché `–`.