### PR TITLE
Cohérence dans les labels des paramètres

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -233,7 +233,7 @@ class ProfileForm(MiniProfileForm):
             ('show_sign', _(u'Afficher les signatures')),
             ('is_hover_enabled', _(u'Dérouler les menus au survol')),
             ('allow_temp_visual_changes', _(u'Activer les changements visuels temporaires')),
-            ('email_for_answer', _(u"Recevoir un courriel lors de l'arrivée d'une réponse à un message privé")),
+            ('email_for_answer', _(u"Recevoir un courriel lors d'une réponse à un message privé")),
         ),
         widget=forms.CheckboxSelectMultiple,
     )

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -231,9 +231,9 @@ class ProfileForm(MiniProfileForm):
         required=False,
         choices=(
             ('show_sign', _(u'Afficher les signatures')),
-            ('is_hover_enabled', _(u'Cochez pour dérouler les menus au survol')),
+            ('is_hover_enabled', _(u'Dérouler les menus au survol')),
             ('allow_temp_visual_changes', _(u'Activer les changements visuels temporaires')),
-            ('email_for_answer', _(u'Recevez un courriel lorsque vous recevez une réponse à un message privé')),
+            ('email_for_answer', _(u"Recevoir un courriel lors de l'arrivée d'une réponse à un message privé")),
         ),
         widget=forms.CheckboxSelectMultiple,
     )


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | ~ correction de bug

Une petite PR dont le but est d'améliorer la cohérence dans les labels de la page des paramètres (on y trouvait de l'infinitif et de l'impératif). Tout est maintenant à l'infinitif.

### QA

Code review me paraît suffisant. Sinon, il faut simplement vérifier que les labels ont bien changé sur le formulaire.