### PR TITLE
Améliore le marquage des notifications comme lues

### DIFF
--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -10,7 +10,7 @@ from django.db import IntegrityError
 
 from zds import settings
 from zds.forum.factories import CategoryFactory, ForumFactory, TopicFactory, PostFactory
-from zds.forum.models import Topic
+from zds.forum.models import Topic, is_read
 from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.mp.models import mark_read
@@ -781,8 +781,12 @@ class NotificationTest(TestCase):
         PostFactory(topic=topic, author=self.user1, position=1)
         PostFactory(topic=topic, author=self.user2, position=2)
 
+        self.assertTrue(self.client.login(username=self.user1.username, password='hostel77'))
+
         notifications = Notification.objects.get_unread_notifications_of(self.user1)
         self.assertEqual(1, len(notifications))
+
+        self.assertFalse(is_read(topic, self.user1))
 
         result = self.client.post(
             reverse('mark-notifications-as-read'),
@@ -791,3 +795,5 @@ class NotificationTest(TestCase):
 
         notifications = Notification.objects.get_unread_notifications_of(self.user1)
         self.assertEqual(0, len(notifications))
+
+        self.assertTrue(is_read(topic, self.user1))

--- a/zds/notification/views.py
+++ b/zds/notification/views.py
@@ -12,6 +12,10 @@ from zds import settings
 from zds.mp.models import PrivateTopic
 from zds.notification.models import Notification
 from zds.utils.paginator import ZdSPagingListView
+from zds.forum.models import Post
+from zds.tutorialv2.models.models_database import PublishableContent
+from zds.forum.models import mark_read as mark_topic_read
+from zds.tutorialv2.utils import mark_read as mark_content_read
 
 
 class NotificationList(ZdSPagingListView):
@@ -40,7 +44,17 @@ class NotificationList(ZdSPagingListView):
 def mark_notifications_as_read(request):
     """Mark the notifications of the current user as read"""
 
-    Notification.objects.get_unread_notifications_of(request.user).update(is_read=True)
+    content_type = ContentType.objects.get_for_model(PrivateTopic)
+    notifications = Notification.objects.get_unread_notifications_of(request.user) \
+        .exclude(subscription__content_type=content_type) \
+
+    for notification in notifications:
+        if isinstance(notification.content_object, Post):
+            mark_topic_read(notification.content_object.topic, request.user)
+        if isinstance(notification.content_object, PublishableContent):
+            mark_content_read(notification.content_object.related_content, request.user)
+
+    notifications.update(is_read=True)
 
     messages.success(request, _(u'Vos notifications ont bien été marquées comme lues.'))
 

--- a/zds/notification/views.py
+++ b/zds/notification/views.py
@@ -42,7 +42,12 @@ class NotificationList(ZdSPagingListView):
 @require_POST
 @login_required
 def mark_notifications_as_read(request):
-    """Mark the notifications of the current user as read"""
+    """
+    Mark the notifications of the current user as read.
+    If a notification is linked to a comment, the topic
+    or content associed is also marked as read.
+    Note that notifications for private messages are not concerned.
+    """
 
     content_type = ContentType.objects.get_for_model(PrivateTopic)
     notifications = Notification.objects.get_unread_notifications_of(request.user) \

--- a/zds/notification/views.py
+++ b/zds/notification/views.py
@@ -13,7 +13,7 @@ from zds.mp.models import PrivateTopic
 from zds.notification.models import Notification
 from zds.utils.paginator import ZdSPagingListView
 from zds.forum.models import Post
-from zds.tutorialv2.models.models_database import PublishableContent
+from zds.tutorialv2.models.models_database import ContentReaction
 from zds.forum.models import mark_read as mark_topic_read
 from zds.tutorialv2.utils import mark_read as mark_content_read
 
@@ -51,7 +51,7 @@ def mark_notifications_as_read(request):
     for notification in notifications:
         if isinstance(notification.content_object, Post):
             mark_topic_read(notification.content_object.topic, request.user)
-        if isinstance(notification.content_object, PublishableContent):
+        if isinstance(notification.content_object, ContentReaction):
             mark_content_read(notification.content_object.related_content, request.user)
 
     notifications.update(is_read=True)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4217

Cette pull request améliore le marquage des notifications comme lues en effectuant les deux modifications suivantes :

- les sujets et contenus liés à une notification sont aussi marqués comme lus : il s'agit de la correction du comportement observé dans #4217.
- les notifications de MP ne sont plus concernées : bien qu'il s'agisse de notifications dans la logique du code, elle n'apparaissent pas sur la page des notifications (où se situe le bouton `Tout marquer comme lu`) et les marquer comme lues également me semble assez déroutant.

### QA

* Depuis un compte (disons `user1`), envoyer plusieurs types de notifications à `user2` telles qu'un MP, une réponse à un MP, un commentaire sur un contenu où il est abonné, un post sur un sujet où il est abonné et un sujet sur un forum où il est abonné.
* Depuis `user2`, utiliser la fonction `Tout marquer comme lu`.
* Vérifier qu'il n'y a plus de notification au sens propre du terme qui soit non lue, mais que les MP n'ont pas été concernés.
* Vérifier que le sujet où un post a été écrit n'est plus en gras dans les derniers sujets suivis.