### PR TITLE
Ajout de l'autocomplétion à la création d'un sujet

### DIFF
--- a/assets/js/autocompletion.js
+++ b/assets/js/autocompletion.js
@@ -24,6 +24,10 @@
             this.$form.on("submit", this.handleSubmit.bind(this));
         }
 
+        if(this.options.clickable) {
+          this.$dropdown.css("font-weight","bold");
+        }
+
         this.selected = -1;
 
         this._lastInput = "";
@@ -147,6 +151,10 @@
             this._lastAutocomplete = completion[this.options.fieldname];
             this.selected = -1; // Deselect properly
             this.$input.trigger("input");
+
+            if(this.options.clickable) {
+              window.open(completion.url, "_blank");
+            }
         },
 
         updateCache: function(data) {
@@ -236,6 +244,9 @@
                 $list.append($el);
             }
             this.$dropdown.children().remove();
+            if(this.options.header && $list[0].childElementCount) {
+              this.$dropdown.append("<div class=\"autocomplete-dropdown-header\">" + this.options.header + "</div>")
+            }
             this.$dropdown.append($list);
 
             if (!selected)
@@ -281,7 +292,7 @@
                 "class": "autocomplete-wrapper"
             }),
             $dropdown = $("<div/>", {
-                "class": "autocomplete-dropdown"
+                "class": "autocomplete-dropdown autocomplete-" + input[0].id
             });
 
         return $input.addClass("autocomplete-input")
@@ -307,11 +318,15 @@
     };
 
     $(document).ready(function() {
-        $("[data-autocomplete]").autocomplete();
-        $("#content").on("DOMNodeInserted", "input", function(e) {
+        $("[data-autocomplete]").each(function () {
+          if($(this).data) {
+            $(this).autocomplete();
+          }
+        });
+        /*$("#content").on("DOMNodeInserted", "input", function(e) {
             var $input = $(e.target);
             if ($input.is("[data-autocomplete]"))
                 $input.autocomplete();
-        });
+        });*/
     });
 })(jQuery);

--- a/assets/js/autocompletion.js
+++ b/assets/js/autocompletion.js
@@ -319,9 +319,8 @@
 
     $(document).ready(function() {
         $("[data-autocomplete]").each(function () {
-          if($(this).data) {
-            $(this).autocomplete();
-          }
+          if ($(this).data)
+              $(this).autocomplete();
         });
     });
 })(jQuery);

--- a/assets/js/autocompletion.js
+++ b/assets/js/autocompletion.js
@@ -245,7 +245,7 @@
             }
             this.$dropdown.children().remove();
             if(this.options.header && $list[0].childElementCount) {
-              this.$dropdown.append("<div class=\"autocomplete-dropdown-header\">" + this.options.header + "</div>")
+              this.$dropdown.append("<div class=\"autocomplete-dropdown-header\">" + this.options.header + "</div>");
             }
             this.$dropdown.append($list);
 
@@ -292,7 +292,7 @@
                 "class": "autocomplete-wrapper"
             }),
             $dropdown = $("<div/>", {
-                "class": "autocomplete-dropdown autocomplete-" + input[0].id
+                "class": "autocomplete-dropdown"
             });
 
         return $input.addClass("autocomplete-input")
@@ -323,10 +323,5 @@
             $(this).autocomplete();
           }
         });
-        /*$("#content").on("DOMNodeInserted", "input", function(e) {
-            var $input = $(e.target);
-            if ($input.is("[data-autocomplete]"))
-                $input.autocomplete();
-        });*/
     });
 })(jQuery);

--- a/assets/scss/components/_autocomplete.scss
+++ b/assets/scss/components/_autocomplete.scss
@@ -5,6 +5,19 @@
         position: absolute;
         z-index: 60;
 
+        .autocomplete-dropdown-header {
+          padding: 0;
+          margin: 0;
+          padding-left: 5px;
+          background-color: #EEE;
+          border-right: solid 1px #CCC;
+          border-left: solid 1px #CCC;
+
+          border-bottom-right-radius: 4px;
+          border-bottom-left-radius: 4px;
+          font-weight: normal;
+        }
+
         ul {
             padding: 0;
             margin: 0;

--- a/assets/scss/components/_autocomplete.scss
+++ b/assets/scss/components/_autocomplete.scss
@@ -6,16 +6,16 @@
         z-index: 60;
 
         .autocomplete-dropdown-header {
-          padding: 0;
-          margin: 0;
-          padding-left: 5px;
-          background-color: #EEE;
-          border-right: solid 1px #CCC;
-          border-left: solid 1px #CCC;
+            padding: 0;
+            margin: 0;
+            padding-left: 5px;
+            background-color: #EEE;
+            border-right: solid 1px #CCC;
+            border-left: solid 1px #CCC;
 
-          border-bottom-right-radius: 4px;
-          border-bottom-left-radius: 4px;
-          font-weight: normal;
+            border-bottom-right-radius: 4px;
+            border-bottom-left-radius: 4px;
+            font-weight: normal;
         }
 
         ul {

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import json
 
 from django import forms
 from django.conf import settings
@@ -20,11 +21,13 @@ class TopicForm(forms.Form):
             attrs={
                 'placeholder': _(u'Titre de mon sujet'),
                 'required': 'required',
-                'data-autocomplete': '''{ "type": "simple",
-                                        "header":"Sujets similaires :",
-                                        "fieldname": "title", "url":
-                                        "/rechercher/topics-similaires/?q=%s",
-                                        "clickable":true }'''
+                'data-autocomplete': json.dumps({
+                    'type':'simple',
+                    'fieldname':'title',
+                    'header':str(_(u'Sujets similaires :')),
+                    'url':'/rechercher/sujets-similaires/?q=%s',
+                    'clickable':'true'
+                })
             }
         )
     )

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -20,6 +20,11 @@ class TopicForm(forms.Form):
             attrs={
                 'placeholder': _(u'Titre de mon sujet'),
                 'required': 'required',
+                'data-autocomplete': '''{ "type": "simple",
+                                        "header":"Sujets similaires :",
+                                        "fieldname": "title", "url":
+                                        "/rechercher/topics-similaires/?q=%s",
+                                        "clickable":true }'''
             }
         )
     )
@@ -58,7 +63,7 @@ class TopicForm(forms.Form):
         self.helper.form_method = 'post'
 
         self.helper.layout = Layout(
-            Field('title', autocomplete='off'),
+            Field('title'),
             Field('subtitle', autocomplete='off'),
             Field('tags'),
             CommonLayoutEditor(),

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -22,11 +22,11 @@ class TopicForm(forms.Form):
                 'placeholder': _(u'Titre de mon sujet'),
                 'required': 'required',
                 'data-autocomplete': json.dumps({
-                    'type':'simple',
-                    'fieldname':'title',
-                    'header':str(_(u'Sujets similaires :')),
-                    'url':'/rechercher/sujets-similaires/?q=%s',
-                    'clickable':'true'
+                    'type': 'simple',
+                    'fieldname': 'title',
+                    'header': str(_(u'Sujets similaires :')),
+                    'url': '/rechercher/sujets-similaires/?q=%s',
+                    'clickable': 'true'
                 })
             }
         )

--- a/zds/searchv2/urls.py
+++ b/zds/searchv2/urls.py
@@ -6,6 +6,6 @@ from zds.searchv2.views import SearchView, opensearch, SimilarSubjectsView
 
 urlpatterns = [
     url(r'^$', SearchView.as_view(), name='query'),
-    url(r'^topics-similaires/$', SimilarSubjectsView.as_view(), name='similar'),
+    url(r'^sujets-similaires/$', SimilarSubjectsView.as_view(), name='similar'),
     url(r'^opensearch\.xml$', opensearch, name='opensearch'),
 ]

--- a/zds/searchv2/urls.py
+++ b/zds/searchv2/urls.py
@@ -1,10 +1,11 @@
 # coding: utf-8
 
 from django.conf.urls import url
-from zds.searchv2.views import SearchView, opensearch
+from zds.searchv2.views import SearchView, opensearch, SimilarSubjectsView
 
 
 urlpatterns = [
     url(r'^$', SearchView.as_view(), name='query'),
+    url(r'^topics-similaires/$', SimilarSubjectsView.as_view(), name='similar'),
     url(r'^opensearch\.xml$', opensearch, name='opensearch'),
 ]

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -126,13 +126,17 @@ class SearchView(ZdSPagingListView):
             # find forums the user is allowed to visit
             user = self.request.user
 
-            searched_forums = Forum.objects.filter(group__isnull=True)
+            forums_pub = Forum.objects.filter(group__isnull=True).all()
             if user and user.is_authenticated():
-                private_forums = Forum \
+                forums_private = Forum \
                     .objects \
-                    .filter(group__isnull=False, group__in=user.groups.all())
-                searched_forums = searched_forum | private_forums
-                self.authorized_forums = searched_forums.values_list('pk', flat=True)
+                    .filter(group__isnull=False, group__in=user.groups.all()) \
+                    .all()
+                list_forums = list(forums_pub | forums_private)
+            else:
+                list_forums = list(forums_pub)
+
+            self.authorized_forums = [f.pk for f in list_forums]
 
             search_queryset = Search()
 

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -126,17 +126,13 @@ class SearchView(ZdSPagingListView):
             # find forums the user is allowed to visit
             user = self.request.user
 
-            forums_pub = Forum.objects.filter(groups__isnull=True).all()
+            searched_forums = Forum.objects.filter(group__isnull=True)
             if user and user.is_authenticated():
-                forums_private = Forum \
+                private_forums = Forum \
                     .objects \
-                    .filter(groups__isnull=False, groups__in=user.groups.all()) \
-                    .all()
-                list_forums = list(forums_pub | forums_private)
-            else:
-                list_forums = list(forums_pub)
-
-            self.authorized_forums = [f.pk for f in list_forums]
+                    .filter(group__isnull=False, group__in=user.groups.all())
+                searched_forums = searched_forum | private_forums
+                self.authorized_forums = searched_forums.values_list('pk', flat=True)
 
             search_queryset = Search()
 

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import json
 import operator
 
 from elasticsearch_dsl import Search
@@ -7,14 +8,76 @@ from elasticsearch_dsl.query import Match, MultiMatch, FunctionScore, Term, Term
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.contrib import messages
+from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import render
 from django.core.urlresolvers import reverse
+from django.views.generic import CreateView
+from django.views.generic.detail import SingleObjectMixin
 
 from zds.searchv2.forms import SearchForm
 from zds.searchv2.models import ESIndexManager
 from zds.utils.paginator import ZdSPagingListView
 from zds.forum.models import Forum
+
+
+class SimilarSubjectsView(CreateView, SingleObjectMixin):
+    search_query = None
+    authorized_forums = ''
+    index_manager = None
+
+    def __init__(self, **kwargs):
+        """Overridden because index manager must NOT be initialized elsewhere
+        """
+
+        super(SimilarSubjectsView, self).__init__(**kwargs)
+        self.index_manager = ESIndexManager(**settings.ES_SEARCH_INDEX)
+
+    def get(self, request, *args, **kwargs):
+        if 'q' in request.GET:
+            self.search_query = ''.join(request.GET['q'])
+
+        results = []
+        if self.index_manager.connected_to_es and self.search_query:
+
+            # find forums the user is allowed to visit
+            user = self.request.user
+
+            forums_pub = Forum.objects.filter(group__isnull=True).all()
+            if user and user.is_authenticated():
+                forums_private = Forum \
+                    .objects \
+                    .filter(group__isnull=False, group__in=user.groups.all()) \
+                    .all()
+                list_forums = list(forums_pub | forums_private)
+            else:
+                list_forums = list(forums_pub)
+
+            self.authorized_forums = [f.pk for f in list_forums]
+
+            search_queryset = Search()
+            query = Match(_type='topic') \
+                & Terms(forum_pk=self.authorized_forums) \
+                & MultiMatch(query=self.search_query, fields=['title', 'subtitle', 'tags'])
+
+            functions_score = [
+                {'filter': Match(is_solved=True), 'weight': settings.ZDS_APP['search']['boosts']['topic']['if_solved']},
+                {'filter': Match(is_sticky=True), 'weight': settings.ZDS_APP['search']['boosts']['topic']['if_sticky']},
+                {'filter': Match(is_locked=True), 'weight': settings.ZDS_APP['search']['boosts']['topic']['if_locked']}
+            ]
+
+            scored_query = FunctionScore(query=query, boost_mode='multiply', functions=functions_score)
+            search_queryset = search_queryset.query(scored_query)
+
+            # Build the result
+            cpt = 0
+            for hit in search_queryset.execute():
+                result = {'id': cpt, 'url': str(hit.get_absolute_url), 'title': str(hit.title)}
+                cpt += 1
+                results.append(result)
+
+        data = {'results': results}
+        return HttpResponse(json.dumps(data), content_type='application/json')
 
 
 class SearchView(ZdSPagingListView):

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -67,13 +67,11 @@ class SimilarSubjectsView(CreateView, SingleObjectMixin):
             ]
 
             scored_query = FunctionScore(query=query, boost_mode='multiply', functions=functions_score)
-            search_queryset = search_queryset.query(scored_query)
+            search_queryset = search_queryset.query(scored_query)[:10]
 
             # Build the result
-            cpt = 0
-            for hit in search_queryset.execute():
-                result = {'id': cpt, 'url': str(hit.get_absolute_url), 'title': str(hit.title)}
-                cpt += 1
+            for (index, hit) in enumerate(search_queryset.execute()):
+                result = {'id': index, 'url': str(hit.get_absolute_url), 'title': str(hit.title)}
                 results.append(result)
 
         data = {'results': results}

--- a/zds/utils/templatetags/authorized_forums.py
+++ b/zds/utils/templatetags/authorized_forums.py
@@ -8,11 +8,11 @@ def get_authorized_forums(user):
     :param user: concerned user.
     :return: authorized_forums
     """
-    forums_pub = Forum.objects.filter(group__isnull=True).all()
+    forums_pub = Forum.objects.filter(groups__isnull=True).all()
     if user and user.is_authenticated():
         forums_private = Forum \
             .objects \
-            .filter(group__isnull=False, group__in=user.groups.all()) \
+            .filter(groups__isnull=False, groups__in=user.groups.all()) \
             .all()
         list_forums = list(forums_pub | forums_private)
     else:

--- a/zds/utils/templatetags/authorized_forums.py
+++ b/zds/utils/templatetags/authorized_forums.py
@@ -1,0 +1,21 @@
+from zds.forum.models import Forum
+
+
+def get_authorized_forums(user):
+    """
+    Find forums the user is allowed to visit.
+
+    :param user: concerned user.
+    :return: authorized_forums
+    """
+    forums_pub = Forum.objects.filter(group__isnull=True).all()
+    if user and user.is_authenticated():
+        forums_private = Forum \
+            .objects \
+            .filter(group__isnull=False, group__in=user.groups.all()) \
+            .all()
+        list_forums = list(forums_pub | forums_private)
+    else:
+        list_forums = list(forums_pub)
+
+    return [f.pk for f in list_forums]


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | nouvelle fonctionnalité
| Ticket(s) (_issue(s)_) concerné(s)  | #736 

Hei! I'm back.
~~Du coup, ma PR en cours (manque les tests).~~

~~Bug connu : l'autocomplétion cherche aussi les membres.~~

Note, je ne met pas que les sujets résolus. J'ai hésité, mais perso aller voir un sujet similaire non résolu peut éviter un doublon par exemple.

### QA

* Lancer ElasticSearch
* Se rendre à la création d'un nouveau sujet
* Vérifier qu'on peut bien trouver des sujets similaires et que ça l'ouvre au clic dans un nouvel onglet (exemple *Android ou ios*, *Rédiger sur zestedesavoir*)

* Vérifier qu'on puisse bien créer un sujet même sans elasticsearch

![similar](https://cloud.githubusercontent.com/assets/1888628/23523194/f2b759ac-ff53-11e6-8c10-fa4a3e6aaa84.png)

o/