### PR TITLE
Refonte de l'affichage du badge staff

### DIFF
--- a/zds/member/migrations/0008_profile_show_staff_badge.py
+++ b/zds/member/migrations/0008_profile_show_staff_badge.py
@@ -9,14 +9,15 @@ from zds.member.models import Profile
 
 def forwards_func(apps, schema_editor):
     # Check for each user if the staff badge should be displayed
-    users = User.objects.select_related('profile').all()
+    users = User.objects.all()
     for user in users:
-        try:
-            user_profile = user.profile
-            user_profile.show_staff_badge = user.has_perm('forum.change_post')
-            user_profile.save()
-        except Profile.DoesNotExist:
-            pass
+        if user.has_perm('forum.change_post'):
+            try:
+                user_profile = user.profile
+                user_profile.show_staff_badge = True
+                user_profile.save()
+            except Profile.DoesNotExist:
+                pass
 
 
 class Migration(migrations.Migration):

--- a/zds/member/migrations/0008_profile_show_staff_badge.py
+++ b/zds/member/migrations/0008_profile_show_staff_badge.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from django.contrib.auth.models import User
+from zds.member.models import Profile
+
+
+def forwards_func(apps, schema_editor):
+    # Check for each user if the staff badge should be displayed
+    users = User.objects.select_related('profile').all()
+    for user in users:
+        try:
+            user_profile = user.profile
+            user_profile.show_staff_badge = user.has_perm('forum.change_post')
+            user_profile.save()
+        except Profile.DoesNotExist:
+            pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('member', '0007_auto_20161119_1836'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='show_staff_badge',
+            field=models.BooleanField(default=False, verbose_name='Afficher le badge staff'),
+        ),
+        migrations.RunPython(forwards_func),
+    ]

--- a/zds/member/migrations/0009_profile_show_staff_badge.py
+++ b/zds/member/migrations/0009_profile_show_staff_badge.py
@@ -10,13 +10,16 @@ from django.db.models import Q
 
 def forwards_func(apps, schema_editor):
     # Check for each user if the staff badge should be displayed
-    staff_perm = Permission.objects.get(codename='change_post')
-    staffs = User.objects.filter(
-        Q(groups__permissions=staff_perm) |
-        Q(user_permissions=staff_perm) |
-        Q(is_superuser=True)
-    ).distinct()
-    Profile.objects.filter(user__in=staffs).update(show_staff_badge=True)
+    try:
+        staff_perm = Permission.objects.get(codename='change_post')
+        staffs = User.objects.filter(
+            Q(groups__permissions=staff_perm) |
+            Q(user_permissions=staff_perm) |
+            Q(is_superuser=True)
+        ).distinct()
+        Profile.objects.filter(user__in=staffs).update(show_staff_badge=True)
+    except Permission.DoesNotExist:
+        pass
 
 
 class Migration(migrations.Migration):

--- a/zds/member/migrations/0009_profile_show_staff_badge.py
+++ b/zds/member/migrations/0009_profile_show_staff_badge.py
@@ -23,7 +23,7 @@ def forwards_func(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('member', '0007_auto_20161119_1836'),
+        ('member', '0008_remove_profile_sdz_tutorial'),
     ]
 
     operations = [

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -62,7 +62,6 @@ class Profile(models.Model):
     is_hover_enabled = models.BooleanField('Déroulement au survol ?', default=True)
     allow_temp_visual_changes = models.BooleanField('Activer les changements visuels temporaires', default=True)
     email_for_answer = models.BooleanField('Envoyer pour les réponse MP', default=False)
-    sdz_tutorial = models.TextField('Identifiant des tutos SdZ', blank=True, null=True)
     show_staff_badge = models.BooleanField('Afficher le badge staff', default=False)
     can_read = models.BooleanField('Possibilité de lire', default=True)
     end_ban_read = models.DateTimeField("Fin d'interdiction de lecture", null=True, blank=True)

--- a/zds/utils/templatetags/profile.py
+++ b/zds/utils/templatetags/profile.py
@@ -9,8 +9,6 @@ from zds.member.models import Profile
 
 register = template.Library()
 
-perms = {'forum.change_post': {}}
-
 
 @register.filter('profile')
 def profile(current_user):
@@ -69,13 +67,8 @@ def state(current_user):
             user_state = 'BAN'
         elif not user_profile.can_write_now():
             user_state = 'LS'
-        elif current_user.pk in perms['forum.change_post'] and perms['forum.change_post'][current_user.pk]:
+        elif user_profile.show_staff_badge:
             user_state = 'STAFF'
-        elif current_user.pk not in perms['forum.change_post']:
-            perms['forum.change_post'][current_user.pk] = current_user.has_perm('forum.change_post')
-            user_state = None
-            if perms['forum.change_post'][current_user.pk]:
-                user_state = 'STAFF'
         else:
             user_state = None
     except Profile.DoesNotExist:

--- a/zds/utils/templatetags/tests/test_profile.py
+++ b/zds/utils/templatetags/tests/test_profile.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+
+from zds.utils.templatetags.profile import state
+from zds.member.factories import ProfileFactory
+
+
+class ProfileTest(TestCase):
+    def test_staff_badge(self):
+        user = ProfileFactory()
+
+        self.assertEqual(None, state(user.user))
+
+        result = self.client.get(
+            user.get_absolute_url(),
+            follow=False
+        )
+        self.assertEqual(200, result.status_code)
+        self.assertNotContains(result, 'Staff')
+
+        # Make the user superuser to give him the staff perms
+        user.user.is_superuser = True
+        user.user.save()
+
+        self.assertEqual('STAFF', state(user.user))
+
+        result = self.client.get(
+            user.get_absolute_url(),
+            follow=False
+        )
+        self.assertEqual(200, result.status_code)
+        self.assertContains(result, 'Staff')


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug / évolution / refactorisation
| Ticket(s) (_issue(s)_) concerné(s)  | #2985, #3679

Le but de cette pull request est de refaire l'affichage du badge staff en respectant les deux contraintes suivantes :

- Nommer un membre staff doit afficher son badge immédiatement.
- Aucune requête ne doit avoir lieu pour déterminer si un membre est staff dans un post.

J'ai donc retenu la solution suivante : j'ai créé un attribut `show_staff_badge` sur le modèle `Profile` qui détermine si le badge doit être affiché. Cet attribut est mis à jour automatiquement via un signal lorsqu'un objet `User` est modifié (ce qui est le cas quand on met un membre dans un groupe).

La migration incluse avec la PR s'occupe de renseigner l'attribut pour tous les membres déjà existants.

### QA

* Lancer les migrations (`make migrate` ou `python manage.py migrate` en fonction de l'environnement de développement que vous utilisez).
* Vérifier que les badges s'affichent correctement sur les membres.
* Promouvoir un membre et vérifier que le badge s'affiche immédiatement. Vérifier également l'opération inverse.