### PR TITLE
Améliore la page des alertes

### DIFF
--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -5,13 +5,13 @@
 
 
 {% block title %}
-    {% trans "Liste des alertes en cours" %}
+    {% trans "Liste des alertes" %}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li>{% trans "Liste des alertes en cours" %}</li>
+    <li>{% trans "Liste des alertes" %}</li>
 {% endblock %}
 
 
@@ -23,60 +23,71 @@
 
 
 {% block content_page %}
-    <table class="fullwidth">
-        <thead>
-            <th>{% trans "Type" %}</th>
-            <th>{% trans "Auteur" %}</th>
-            <th class="wide">{% trans "Date" %}</th>
-            <th class="wide">{% trans "Message" %}</th>
-            <th>{% trans "Sur un message de..." %}</th>
-        </thead>
-        <tbody>
-            {% for alert in alerts %}
-                <tr>
-                    <td>{{ alert.get_scope_display }}</td>
-                    <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
-                    <td class="wide">{{ alert.pubdate|format_date|capfirst }}</td>
-                    <td class="wide"><a href="{{ alert.get_comment_subclass.get_absolute_url }}">{{ alert.text }}</a></td>
-                    <td>
-                        {% url "member-detail" alert.comment.author.username as url_member_detail %}
-                        {% blocktrans with author_username=alert.comment.author.username timing=alert.comment.pubdate|format_date %}
-                            <a href="{{ url_member_detail }}">{{ author_username }}</a>, posté le {{ timing }}
-                        {% endblocktrans %}
-                    </td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    {% if alerts %}
+        <table class="fullwidth">
+            <thead>
+                <th>{% trans "Type" %}</th>
+                <th>{% trans "Auteur" %}</th>
+                <th class="wide">{% trans "Date" %}</th>
+                <th class="wide">{% trans "Message" %}</th>
+                <th>{% trans "Sur un message de..." %}</th>
+            </thead>
+            <tbody>
+                {% for alert in alerts %}
+                    <tr>
+                        <td>{{ alert.get_scope_display }}</td>
+                        <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
+                        <td class="wide">{{ alert.pubdate|format_date|capfirst }}</td>
+                        <td class="wide"><a href="{{ alert.get_comment_subclass.get_absolute_url }}">{{ alert.text }}</a></td>
+                        <td>
+                            {% url "member-detail" alert.comment.author.username as url_member_detail %}
+                            {% blocktrans with author_username=alert.comment.author.username timing=alert.comment.pubdate|format_date %}
+                                <a href="{{ url_member_detail }}">{{ author_username }}</a>, posté le {{ timing }}
+                            {% endblocktrans %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <em>{% trans "Aucune alerte en cours." %}</em>
+    {% endif %}
 
     <h1>{% trans "Liste des alertes récemment résolues" %}</h1>
 
-    <table class="fullwidth">
-        <thead>
-            <th>{% trans "Type" %}</th>
-            <th>{% trans "Auteur" %}</th>
-            <th class="wide">{% trans "Date résolution" %}</th>
-            <th class="wide">{% trans "Message" %}</th>
-            <th>{% trans "Résolu par" %}</th>
-        </thead>
-        <tbody>
-            {% for alert in solved %}
-                <tr>
-                    <td>{{ alert.get_scope_display }}</td>
-                    <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
-                    <td class="wide">{{ alert.solved_date|format_date|capfirst }}</td>
-                    <td class="wide">
-                        {% url "member-detail" alert.comment.author.username as url_member_detail %}
-                        <a href="{{ url_member_detail }}">{{ alert.comment.author.username  }}</a> :
-                        <a href="{{ alert.get_comment_subclass.get_absolute_url }}">{{ alert.text }}</a>
-                    </td>
-                    <td class="wide">
-                        {% url "member-detail" alert.moderator.username as url_member_detail %}
-                        <a href="{{ url_member_detail }}">{{ alert.moderator.username }}</a> :
-                        <em>{{ alert.resolve_reason }}</em>
-                    </td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    {% if solved %}
+        <table class="fullwidth">
+            <thead>
+                <th>{% trans "Type" %}</th>
+                <th>{% trans "Auteur" %}</th>
+                <th class="wide">{% trans "Date de résolution" %}</th>
+                <th class="wide">{% trans "Message" %}</th>
+                <th>{% trans "Résolu par" %}</th>
+            </thead>
+            <tbody>
+                {% for alert in solved %}
+                    <tr>
+                        <td>{{ alert.get_scope_display }}</td>
+                        <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
+                        <td class="wide">{{ alert.solved_date|format_date|capfirst }}</td>
+                        <td class="wide">
+                            {% url "member-detail" alert.comment.author.username as url_member_detail %}
+                            <a href="{{ alert.get_comment_subclass.get_absolute_url }}">{{ alert.text }}</a> par
+                            <a href="{{ url_member_detail }}">{{ alert.comment.author.username  }}</a>
+                        </td>
+                        <td>
+                            {% url "member-detail" alert.moderator.username as url_member_detail %}
+                            <a href="{{ url_member_detail }}">{{ alert.moderator.username }}</a>
+                            {% if alert.resolve_reason %}
+                                :
+                                <em>{{ alert.resolve_reason }}</em>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <em>{% trans "Aucune alerte n'a été résolue." %}</em>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution / correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

Cette pull request améliore la page des alertes en apportant les corrections suivantes :

- Un message est affiché au lieu d'un tableau vide s'il n'y a pas d'alertes en cours/résolues.
- Une erreur est corrigé sur mobile : le `td` du modérateur d'une alerte résolue était en `wide`, mais pas le `th`. J'ai enlevé le `wide` étant donné qu'il y avait la place d'afficher les trois colonnes.
- `Date résolution` devient `Date de résolution`.
- Si aucun texte de résolution n'était spécifié, il était indiqué `None` à la place (`admin : None`) dans la colonne `Résolu par` des alertes résolues. Rien n'est maintenant affiché à la place (`admin`).
- `auteur : message` devient `message par auteur` dans la colonne `Message` des alertes résolues. C'est discutable mais je trouve ça plus cohérent.

### QA

- Vérifier que les modifications décrites ont bien été apportées.