### PR TITLE
Corrige la méthode __str__ d'un modèle

### DIFF
--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -481,7 +481,7 @@ class KarmaNote(models.Model):
     pubdate = models.DateTimeField('Date d\'ajout', auto_now_add=True)
 
     def __str__(self):
-        return '{0} - note : {1} ({2}) '.format(self.user.username, self.comment, self.pubdate)
+        return '{0} - note : {1} ({2}) '.format(self.user.username, self.note, self.pubdate)
 
 
 def logout_user(username):


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

Cette PR corrige la méthode `__str__` du modèle `KarmaNote` qui produisait une erreur depuis #3990.

### QA

Vérifier que l'admin Django d'une note de karma s'affiche correctement.