### PR TITLE
Enregistre le numéro d'un ticket GitHub créé

### DIFF
--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -221,44 +221,79 @@
             {% endwith %}
         {% endwith %}
     </li>
-    {% if is_dev %}
-        <li>
-            <a href="#create-issue" class="open-modal ico-after github blue">{% trans 'Envoyer au bugtracker' %}</a>
-            <form action="{% url 'create-issue' topic.pk %}" method="post" id="create-issue" class="modal modal-flex">
-                {% if has_token %}
-                    {% csrf_token %}
-                    <p>
-                        {% trans 'Si vous voulez modifier ce qui sera envoyé sur GitHub, éditez ce formulaire.' %}
-                    </p>
-                    <input type="text" name="title" data-autocomplete="{ 'type': 'single' }" value="{{ topic.title }}">
-                    <textarea name="body" class="textarea" cols="40">
-                        {{ topic.first_post.text }}
-                    </textarea>
-                    {% for tag in tags %}
-                        <label for="tag-{{ tag }}">
-                            {{ tag }}<input type="checkbox" name="tag-{{ tag }}" value="{{ tag }}" id="tag-{{ tag }}">
-                        </label>
-                    {% endfor %}
-                    <button type="submit">{% trans 'Envoyer' %}</button>
-                {% else %}
-                    <p>{% trans "Il semblerait que vous n'ayez pas spécifié un token d'identification GitHub, vous ne pouvez donc pas envoyer ce sujet au bugtracker." %}</p>
-                    {% url 'update-github' as update_github %}
-                    <p>
-                        {% blocktrans %}
-                            Pour y parvenir, pensez simplement à générer un
-                            <a href="https://github.com/settings/tokens">token sur GitHub</a> et à le renseigner dans
-                            <a href="{{ update_github }}">votre profil</a>.
-                        {% endblocktrans %}
-                    </p>
-                {% endif %}
-            </form>
-        </li>
-    {% endif %}
 {% endblock %}
 
 
 
 {% block sidebar_blocks %}
+    {% if is_dev or topic.github_issue %}
+        <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Développement">
+            <h3>{% trans "Développement" %}</h3>
+            <ul>
+                {% if topic.github_issue %}
+                    <li>
+                        <a href="{{ topic|get_github_issue_url }}" class="ico-after github blue">{% trans 'Ticket associé' %}</a>
+                    </li>
+
+                    {% if is_dev %}
+                        <li>
+                            <a href="#unlink-issue" class="open-modal ico-after cross red">{% trans 'Dissocier le ticket' %}</a>
+                        </li>
+                        <form action="{% url 'manage-issue' topic.pk %}" method="post" id="unlink-issue" class="modal modal-flex">
+                            {% csrf_token %}
+                            <p>
+                                {% trans 'Voulez-vous vraiment dissocier ce sujet de son ticket GitHub ?' %}
+                            </p>
+                            <button type="submit" name="unlink">{% trans 'Confirmer' %}</button>
+                        </form>
+                    {% endif %}
+                {% else %}
+                    <li>
+                        <a href="#create-issue" class="open-modal ico-after github blue">{% trans 'Créer un ticket' %}</a>
+                        <form action="{% url 'manage-issue' topic.pk %}" method="post" id="create-issue" class="modal modal-flex">
+                            {% if has_token %}
+                                {% csrf_token %}
+                                <p>
+                                    {% trans 'Si vous voulez modifier ce qui sera envoyé sur GitHub, éditez ce formulaire.' %}
+                                </p>
+                                <input type="text" name="title" value="{{ topic.title }}" required>
+                                <textarea name="body" class="textarea" cols="40" required>{{ topic.first_post.text }}</textarea>
+                                {% for tag in tags %}
+                                    <label for="tag-{{ tag }}">
+                                        {{ tag }}<input type="checkbox" name="tag-{{ tag }}" value="{{ tag }}" id="tag-{{ tag }}">
+                                    </label>
+                                {% endfor %}
+                                <button type="submit" name="create">{% trans 'Envoyer' %}</button>
+                            {% else %}
+                                <p>{% trans "Il semblerait que vous n'ayez pas spécifié un token d'identification GitHub, vous ne pouvez donc pas envoyer pas créer de ticket pour ce sujet." %}</p>
+                                {% url 'update-github' as update_github %}
+                                <p>
+                                    {% blocktrans %}
+                                        Pour y parvenir, pensez simplement à générer un
+                                        <a href="https://github.com/settings/tokens">token sur GitHub</a> et à le renseigner dans
+                                        <a href="{{ update_github }}">votre profil</a>.
+                                    {% endblocktrans %}
+                                </p>
+                            {% endif %}
+                        </form>
+                    </li>
+
+                    <li>
+                        <a href="#link-issue" class="open-modal ico-after arrow-right blue">{% trans 'Associer un ticket' %}</a>
+                        <form action="{% url 'manage-issue' topic.pk %}" method="post" id="link-issue" class="modal modal-flex">
+                            {% csrf_token %}
+                            <p>
+                                {% trans "Quel est le numéro du ticket GitHub que vous souhaitez associer ?" %}
+                            </p>
+                            <input type="number" name="issue" min="1" placeholder="{% trans "Numéro du ticket (sans #)" %}" required>
+                            <button type="submit" name="link">{% trans 'Associer' %}</button>
+                        </form>
+                    </li>
+                {% endif %}
+            </ul>
+        </div>
+    {% endif %}
+
     {% if is_staff %}
         <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Modération">
             <h3>{% trans "Modération" %}</h3>

--- a/zds/forum/admin.py
+++ b/zds/forum/admin.py
@@ -6,7 +6,7 @@ from zds.forum.models import Category, Forum, Post, Topic, TopicRead
 
 
 class TopicAdmin(admin.ModelAdmin):
-    fields = ('title', 'subtitle', 'is_solved', 'is_locked', 'is_sticky', 'forum', 'author',
+    fields = ('title', 'subtitle', 'is_solved', 'is_locked', 'is_sticky', 'github_issue', 'forum', 'author',
               'last_message', 'tags', 'pubdate', 'update_index_date')
     raw_id_fields = ('forum', 'author', 'last_message', 'tags')
     readonly_fields = ('pubdate', 'update_index_date')

--- a/zds/forum/migrations/0013_topic_github_issue.py
+++ b/zds/forum/migrations/0013_topic_github_issue.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forum', '0012_auto_20170204_2239'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='topic',
+            name='github_issue',
+            field=models.PositiveIntegerField(null=True, verbose_name='Ticket GitHub', blank=True),
+        ),
+    ]

--- a/zds/forum/migrations/0014_topic_github_issue.py
+++ b/zds/forum/migrations/0014_topic_github_issue.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('forum', '0012_auto_20170204_2239'),
+        ('forum', '0013_auto_20170327_1349'),
     ]
 
     operations = [

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -209,6 +209,8 @@ class Topic(AbstractESDjangoIndexable):
     is_locked = models.BooleanField('Est verrouillé', default=False, db_index=True)
     is_sticky = models.BooleanField('Est en post-it', default=False, db_index=True)
 
+    github_issue = models.PositiveIntegerField('Ticket GitHub', null=True, blank=True)
+
     tags = models.ManyToManyField(
         Tag,
         verbose_name='Tags du forum',

--- a/zds/forum/urls.py
+++ b/zds/forum/urls.py
@@ -5,7 +5,7 @@ from django.conf.urls import url
 from zds.forum import feeds
 from zds.forum.views import CategoriesForumsListView, CategoryForumsDetailView, ForumTopicsListView, \
     TopicPostsListView, TopicNew, TopicEdit, FindTopic, FindTopicByTag, PostNew, PostEdit, \
-    PostUseful, PostUnread, FindPost, solve_alert, CreateGitHubIssue
+    PostUseful, PostUnread, FindPost, solve_alert, ManageGitHubIssue
 
 urlpatterns = [
 
@@ -25,7 +25,7 @@ urlpatterns = [
     # Viewing a thread
     url(r'^sujet/nouveau/$', TopicNew.as_view(), name='topic-new'),
     url(r'^sujet/editer/$', TopicEdit.as_view(), name='topic-edit'),
-    url(r'^sujet/github/(?P<pk>\d+)/$', CreateGitHubIssue.as_view(), name='create-issue'),
+    url(r'^sujet/github/(?P<pk>\d+)/$', ManageGitHubIssue.as_view(), name='manage-issue'),
     url(r'^sujet/(?P<topic_pk>\d+)/(?P<topic_slug>.+)/$', TopicPostsListView.as_view(), name='topic-posts-list'),
     url(r'^sujets/membre/(?P<user_pk>\d+)/$', FindTopic.as_view(), name='topic-find'),
     url(r'^sujets/tag/(?P<tag_pk>\d+)/(?P<tag_slug>.+)/$', FindTopicByTag.as_view(), name='topic-tag-find'),

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -703,6 +703,6 @@ class ManageGitHubIssue(UpdateView):
 
                     messages.success(request, _('Le ticket a bien été créé.'))
                 except Exception:
-                    messages.error(request, _('Un problème est survenu lors de l\'envoi sur GitHub'))
+                    messages.error(request, _("Un problème est survenu lors de l'envoi sur GitHub."))
 
         return redirect(self.object.get_absolute_url())

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -662,10 +662,12 @@ class ManageGitHubIssue(UpdateView):
         elif 'link' in request.POST:
             try:
                 self.object.github_issue = int(request.POST['issue'])
+                if self.object.github_issue < 1:
+                    raise ValueError
                 self.object.save()
 
                 messages.success(request, _('Le ticket a bien été associé.'))
-            except (KeyError, ValueError, OverflowError):
+            except (KeyError, ValueError, OverflowError, AssertionError):
                 messages.error(request, _('Une erreur est survenue avec le numéro fourni.'))
         else:  # create
             if not request.POST.get('title') or not request.POST.get('body'):

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -667,7 +667,7 @@ class ManageGitHubIssue(UpdateView):
                 self.object.save()
 
                 messages.success(request, _('Le ticket a bien été associé.'))
-            except (KeyError, ValueError, OverflowError, AssertionError):
+            except (KeyError, ValueError, OverflowError):
                 messages.error(request, _('Une erreur est survenue avec le numéro fourni.'))
         else:  # create
             if not request.POST.get('title') or not request.POST.get('body'):

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -14,6 +14,7 @@ from zds.notification.models import Notification, TopicAnswerSubscription, Conte
 from zds.tutorialv2.models.models_database import ContentReaction
 from zds.utils import get_current_user
 from zds.utils.models import Alert
+from zds import settings
 
 register = template.Library()
 
@@ -113,6 +114,17 @@ def followed_topics(user):
                     topics[period[0]] = [topic]
                 break
     return topics
+
+
+@register.filter('get_github_issue_url')
+def get_github_issue_url(topic):
+    if not topic.github_issue:
+        return None
+    else:
+        return '{0}/{1}'.format(
+            settings.ZDS_APP['site']['repository']['bugtracker'],
+            topic.github_issue
+        )
 
 
 def comp(dated_element1, dated_element2):


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | aucun (reprise de #4233)

Cette pull request améliore l'envoi de sujets sur GitHub en retenant le numéro du ticket créé. Ainsi, lorsqu'un ticket est créé, le bouton d'envoi est remplacé par un lien vers celui-ci :

![Ticket déjà associé](https://zestedesavoir.com/media/galleries/3982/bfa0d20a-c918-40b6-ba4b-0fe8b20c1f95.png)

L'envoi est limité au groupe des développeurs (comportement actuel). Le lien ainsi créé est lui visible par tous les membres.

Il est également possible d'associer un ticket déjà existent à un sujet.

### QA

* Avant tout, changez les paramètres `ZDS_APP['site']['repository']['api']` et `ZDS_APP['site']['repository']['bugtracker']` en mettant votre fork pour éviter de créer des issues sur le dépôt de ZdS.
* Connectez-vous avec le compte `dev` (par défaut dans les fixtures si votre installation de ZdS est assez récente) et renseignez votre token GitHub dans les paramètres de votre compte.
* Envoyez un sujet : vérifiez que tout se passe bien et que le lien vers le ticket ainsi créé apparaît.
* Essayez de dissocier le ticket et vérifiez que ça a marché.
* Associez à nouveau le ticket avec l'option `Associer un ticket`. Vérifiez que l'enregistrement réussit.
* Vérifier qu'un utilisateur qui n'est *pas* dans le groupe des développeurs peut voir le lien vers le ticket.