### PR TITLE
Affiche les aides éditoriales lors de la bêta

### DIFF
--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -70,6 +70,26 @@
             </div>
         </div>
     {% endif %}
+
+    {% if helps %}
+        <div class="content-wrapper">
+            <div class="alert-box info">
+                {% if content.authors.count > 1 %}
+                    {% trans "Les auteurs de ce contenu recherchent" %}
+                {% else %}
+                    {% trans "L'auteur de ce contenu recherche" %}
+                {% endif %}
+
+                {% for help in helps.all %}{% if not forloop.first %}{% if forloop.last %}{% trans ' et ' %}{% else %}{% trans ', ' %}{% endif %}{% endif %}un {{ help.title|lower }}{% if forloop.last %}{% trans '.' %}{% endif %}{% endfor %}
+
+                {% if not can_edit %}
+                    {% blocktrans with plural=content.authors.count|pluralize_fr %}
+                        N'hésitez pas le{{ plural }} contacter <a href="{{ pm_link }}">par MP</a> !
+                    {% endblocktrans %}
+                {% endif %}
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}
 
 

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -85,7 +85,7 @@
 
                 {% if not can_edit %}
                     {% blocktrans with plural=content.authors.count|pluralize_fr %}
-                        N'hésitez pas le{{ plural }} contacter <a href="{{ pm_link }}">par MP</a> pour proposer votre aide !
+                        N'hésitez pas à <a href="{{ pm_link }}">le{{ plural }} contacter par MP</a> pour proposer votre aide !
                     {% endblocktrans %}
                 {% endif %}
             </div>

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -5,6 +5,7 @@
 {% load i18n %}
 {% load times %}
 {% load feminize %}
+{% load pluralize_fr %}
 
 {% block title %}
     {{ container.title }} - {{ content.title }}
@@ -71,7 +72,7 @@
         </div>
     {% endif %}
 
-    {% if helps %}
+    {% if helps.count %}
         <div class="content-wrapper">
             <div class="alert-box info">
                 {% if content.authors.count > 1 %}
@@ -84,7 +85,7 @@
 
                 {% if not can_edit %}
                     {% blocktrans with plural=content.authors.count|pluralize_fr %}
-                        N'hésitez pas le{{ plural }} contacter <a href="{{ pm_link }}">par MP</a> !
+                        N'hésitez pas le{{ plural }} contacter <a href="{{ pm_link }}">par MP</a> pour proposer votre aide !
                     {% endblocktrans %}
                 {% endif %}
             </div>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -6,6 +6,7 @@
 {% load i18n %}
 {% load feminize %}
 {% load captureas %}
+{% load pluralize_fr %}
 
 
 {% block title %}
@@ -104,6 +105,26 @@
                 {% endif %}
             </div>
         </div>
+
+        {% if helps %}
+            <div class="content-wrapper">
+                <div class="alert-box info">
+                    {% if content.authors.count > 1 %}
+                        {% trans "Les auteurs de ce contenu recherchent" %}
+                    {% else %}
+                        {% trans "L'auteur de ce contenu recherche" %}
+                    {% endif %}
+
+                    {% for help in helps.all %}{% if not forloop.first %}{% if forloop.last %}{% trans ' et ' %}{% else %}{% trans ', ' %}{% endif %}{% endif %}un {{ help.title|lower }}{% if forloop.last %}{% trans '.' %}{% endif %}{% endfor %}
+
+                    {% if not can_edit %}
+                        {% blocktrans with plural=content.authors.count|pluralize_fr %}
+                            N'hésitez pas le{{ plural }} contacter <a href="{{ pm_link }}">par MP</a> !
+                        {% endblocktrans %}
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
     {% endif %}
 {% endblock %}
 

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -106,7 +106,7 @@
             </div>
         </div>
 
-        {% if helps %}
+        {% if helps.count %}
             <div class="content-wrapper">
                 <div class="alert-box info">
                     {% if content.authors.count > 1 %}
@@ -119,7 +119,7 @@
 
                     {% if not can_edit %}
                         {% blocktrans with plural=content.authors.count|pluralize_fr %}
-                            N'hésitez pas le{{ plural }} contacter <a href="{{ pm_link }}">par MP</a> !
+                            N'hésitez pas le{{ plural }} contacter <a href="{{ pm_link }}">par MP</a> pour proposer votre aide !
                         {% endblocktrans %}
                     {% endif %}
                 </div>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -119,7 +119,7 @@
 
                     {% if not can_edit %}
                         {% blocktrans with plural=content.authors.count|pluralize_fr %}
-                            N'hésitez pas le{{ plural }} contacter <a href="{{ pm_link }}">par MP</a> pour proposer votre aide !
+                            N'hésitez pas à <a href="{{ pm_link }}">le{{ plural }} contacter par MP</a> pour proposer votre aide !
                         {% endblocktrans %}
                     {% endif %}
                 </div>

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -216,6 +216,12 @@ class DisplayBetaContent(DisplayContent):
 
         return obj
 
+    def get_context_data(self, **kwargs):
+        context = super(DisplayBetaContent, self).get_context_data(**kwargs)
+        context['helps'] = self.object.helps
+        context['pm_link'] = self.object.get_absolute_contact_url()
+        return context
+
 
 class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormWithPreview):
     template_name = 'tutorialv2/edit/content.html'
@@ -1015,6 +1021,12 @@ class DisplayBetaContainer(DisplayContainer):
             self.kwargs['slug'] = obj.slug
 
         return obj
+
+    def get_context_data(self, **kwargs):
+        context = super(DisplayBetaContainer, self).get_context_data(**kwargs)
+        context['helps'] = self.object.helps
+        context['pm_link'] = self.object.get_absolute_contact_url()
+        return context
 
 
 class EditContainer(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormWithPreview):


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4251

Cette pull request ajoute une évolution lors de la bêta : les aides éditoriales sont maintenant affichées, comme montré ci-dessous :

![Aides sur la bêta](https://zestedesavoir.com/media/galleries/3982/db08d268-748f-45af-8c3c-4d990a13dc84.png)

### QA

- Créer un tutoriel *sans* aides éditoriales et le mettre en bêta.
- Vérifier que la page s'affiche comme d'habitude.
- Ajouter des aides et vérifier qu'elles s'affichent correctement. Tester avec une, deux et trois aides en vérifiant que la phrase est correcte.
- Vérifier qu'un lien de contact par MP s'affiche lorsque l'on n'est pas auteur.

<!-- À cocher une fois la QA faite. Vous pouvez le faire sur votre pull request si un testeur confirme avoir vérifié le bon fonctionnement de votre PR et avoir relu le code. -->

- [x] Ça fonctionne !
- [x] Code relu et approuvé !