### PR TITLE
Correction orthographique

### DIFF
--- a/templates/forum/index.html
+++ b/templates/forum/index.html
@@ -9,7 +9,7 @@
 
 
 {% block description %}
-    {% trans "Les forums vous permettent de venir poser vos questions aux autres membres mais aussi de vous entraîner ou tout simplement de discuter" %}.
+    {% trans "Les forums vous permettent de venir poser vos questions aux autres membres mais aussi de vous entrainer ou tout simplement de discuter" %}.
 {% endblock %}
 
 
@@ -30,7 +30,7 @@
     <p class="content-wrapper">
         {% blocktrans %}
         Les forums vous permettent de venir poser vos questions aux autres 
-        membres mais aussi de s'entraîner ou <strong>tout simplement de discuter</strong>.
+        membres mais aussi de s'entrainer ou <strong>tout simplement de discuter</strong>.
         Cela fonctionne également dans l'autre sens : vous pouvez ici aider les autres et 
         proposer des exercices au reste de la communauté.
         {% endblocktrans %}

--- a/templates/forum/index.html
+++ b/templates/forum/index.html
@@ -30,7 +30,7 @@
     <p class="content-wrapper">
         {% blocktrans %}
         Les forums vous permettent de venir poser vos questions aux autres 
-        membres mais aussi de s'entrainer ou <strong>tout simplement de discuter</strong>.
+        membres mais aussi de s'entraîner ou <strong>tout simplement de discuter</strong>.
         Cela fonctionne également dans l'autre sens : vous pouvez ici aider les autres et 
         proposer des exercices au reste de la communauté.
         {% endblocktrans %}


### PR DESCRIPTION
Il manquait l'accent circonflexe à *s'entraîner*.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction
| Ticket(s) (_issue(s)_) concerné(s)  | 

### QA
- [x] Ça fonctionne !
- [x] Code relu et approuvé !