### PR TITLE
[ZEP-13] corrige le comportement d'Elasticsearch

### DIFF
--- a/templates/searchv2/includes/publishedcontent.part.html
+++ b/templates/searchv2/includes/publishedcontent.part.html
@@ -30,6 +30,11 @@
                 {% trans "Article publié" %}
             {% elif search_result.content_type == 'TUTORIAL' %}
                 {% trans "Tutoriel publié" %}
+            {% elif search_result.content_type == 'OPINION' %}
+                {% trans "Opinion" %}
+                {% if search_result.picked %}
+                    {% trans "mise en avant" %}
+                {% endif %}
             {% else %}
                 {% trans "Contenu publié" %}
             {% endif %}

--- a/templates/searchv2/includes/publishedcontent.part.html
+++ b/templates/searchv2/includes/publishedcontent.part.html
@@ -31,9 +31,9 @@
             {% elif search_result.content_type == 'TUTORIAL' %}
                 {% trans "Tutoriel publié" %}
             {% elif search_result.content_type == 'OPINION' %}
-                {% trans "Opinion" %}
+                {% trans "Billet" %}
                 {% if search_result.picked %}
-                    {% trans "mise en avant" %}
+                    {% trans "mis en avant" %}
                 {% endif %}
             {% else %}
                 {% trans "Contenu publié" %}

--- a/update.md
+++ b/update.md
@@ -1010,10 +1010,16 @@ Une fois que tout est indexé,
 Tribunes
 --------
 
-Ajouter à la fin de `/etc/munin/plugin-conf.d/zds.conf`
++ Ajouter à la fin de `/etc/munin/plugin-conf.d/zds.conf`
 
 ```
     [zds_total_tribunes]
     env.url http://www.zestedesavoir.com/munin/total_tribunes/
     env.graph_category zds
 ```
+
++ Réindexer les données (un champ a été rajouté):
+
+    ```
+    python manage.py es_manager index_all
+    ```

--- a/zds/searchv2/models.py
+++ b/zds/searchv2/models.py
@@ -246,6 +246,7 @@ def get_django_indexable_objects():
 
 
 class NeedIndex(Exception):
+    """Raised when an action requires an index, but it is not created (yet)."""
     pass
 
 

--- a/zds/searchv2/models.py
+++ b/zds/searchv2/models.py
@@ -234,13 +234,19 @@ def delete_document_in_elasticsearch(instance):
     """
 
     index_manager = ESIndexManager(**settings.ES_SEARCH_INDEX)
-    index_manager.delete_document(instance)
-    index_manager.refresh_index()
+
+    if index_manager.index_exists:
+        index_manager.delete_document(instance)
+        index_manager.refresh_index()
 
 
 def get_django_indexable_objects():
     """Return all indexable objects registered in Django"""
     return [model for model in apps.get_models() if issubclass(model, AbstractESDjangoIndexable)]
+
+
+class NeedIndex(Exception):
+    pass
 
 
 class ESIndexManager(object):
@@ -260,6 +266,7 @@ class ESIndexManager(object):
         """
 
         self.index = name
+        self.index_exists = False
 
         self.number_of_shards = shards
         self.number_of_replicas = replicas
@@ -282,6 +289,9 @@ class ESIndexManager(object):
             else:
                 self.logger.info('connected to ES cluster')
 
+            if self.connected_to_es:
+                self.index_exists = self.es.indices.exists(self.index)
+
     def clear_es_index(self):
         """Clear index
         """
@@ -292,6 +302,8 @@ class ESIndexManager(object):
         if self.es.indices.exists(self.index):
             self.es.indices.delete(self.index)
             self.logger.info('index cleared')
+
+            self.index_exists = False
 
     def reset_es_index(self, models):
         """Delete old index and create an new one (with the same name). Setup the number of shards and replicas.
@@ -327,6 +339,8 @@ class ESIndexManager(object):
             }
         )
 
+        self.index_exists = True
+
         self.logger.info('index created')
 
     def setup_custom_analyzer(self):
@@ -350,6 +364,9 @@ class ESIndexManager(object):
 
         if not self.connected_to_es:
             return
+
+        if not self.index_exists:
+            raise NeedIndex()
 
         self.es.indices.close(self.index)
 
@@ -422,9 +439,6 @@ class ESIndexManager(object):
         :type model: class
         """
 
-        if not self.connected_to_es:
-            return
-
         if issubclass(model, AbstractESDjangoIndexable):  # use a global update with Django
             objs = model.get_es_django_indexable(force_reindexing=True)
             objs.update(es_flagged=True, es_already_indexed=False)
@@ -455,6 +469,9 @@ class ESIndexManager(object):
 
         if not self.connected_to_es:
             return
+
+        if not self.index_exists:
+            raise NeedIndex()
 
         # better safe than sorry
         if model.__name__ == 'FakeChapter':
@@ -568,6 +585,9 @@ class ESIndexManager(object):
         if not self.connected_to_es:
             return
 
+        if not self.index_exists:
+            raise NeedIndex()
+
         self.es.indices.refresh(self.index)
 
     def update_single_document(self, document, doc):
@@ -584,6 +604,9 @@ class ESIndexManager(object):
         if not self.connected_to_es:
             return
 
+        if not self.index_exists:
+            raise NeedIndex()
+
         arguments = {'index': self.index, 'doc_type': document.get_es_document_type(), 'id': document.es_id}
         if self.es.exists(**arguments):
             self.es.update(body={'doc': doc}, **arguments)
@@ -598,6 +621,9 @@ class ESIndexManager(object):
 
         if not self.connected_to_es:
             return
+
+        if not self.index_exists:
+            raise NeedIndex()
 
         arguments = {'index': self.index, 'doc_type': document.get_es_document_type(), 'id': document.es_id}
         if self.es.exists(**arguments):
@@ -621,6 +647,9 @@ class ESIndexManager(object):
         if not self.connected_to_es:
             return
 
+        if not self.index_exists:
+            raise NeedIndex()
+
         response = self.es.delete_by_query(index=self.index, doc_type=doc_type, body={'query': query})
 
         self.logger.info('delete_by_query {}s ({})'.format(doc_type, response['deleted']))
@@ -641,6 +670,9 @@ class ESIndexManager(object):
         if not self.connected_to_es:
             return
 
+        if not self.index_exists:
+            raise NeedIndex()
+
         document = {'text': request}
         tokens = []
         for token in self.es.indices.analyze(index=self.index, body=document)['tokens']:
@@ -659,5 +691,8 @@ class ESIndexManager(object):
 
         if not self.connected_to_es:
             return
+
+        if not self.index_exists:
+            raise NeedIndex()
 
         return request.index(self.index).using(self.es)

--- a/zds/searchv2/tests/tests_utils.py
+++ b/zds/searchv2/tests/tests_utils.py
@@ -91,6 +91,8 @@ class UtilsTests(TestCase):
 
         # 1. test "index-all"
         call_command('es_manager', 'index_all')
+        self.assertTrue(self.index_manager.es.indices.exists(self.index_manager.index))
+        self.index_manager.index_exists = True
 
         topic = Topic.objects.get(pk=topic.pk)
         post = Post.objects.get(pk=post.pk)
@@ -126,7 +128,10 @@ class UtilsTests(TestCase):
 
         # 2. test "clear"
         self.assertTrue(self.index_manager.index in self.index_manager.es.cat.indices())  # index in
+
         call_command('es_manager', 'clear')
+        self.assertFalse(self.index_manager.es.indices.exists(self.index_manager.index))
+        self.index_manager.index_exists = False
 
         # must reset every object
         topic = Topic.objects.get(pk=topic.pk)
@@ -145,6 +150,9 @@ class UtilsTests(TestCase):
 
         # 3. test "setup"
         call_command('es_manager', 'setup')
+        self.assertTrue(self.index_manager.es.indices.exists(self.index_manager.index))
+        self.index_manager.index_exists = True
+
         self.assertTrue(self.index_manager.index in self.index_manager.es.cat.indices())  # index back in ...
 
         s = Search()

--- a/zds/searchv2/tests/tests_views.py
+++ b/zds/searchv2/tests/tests_views.py
@@ -481,6 +481,19 @@ class ViewsTests(TestCase):
 
         settings.ZDS_APP['search']['boosts']['publishedcontent']['if_opinion'] = 1.0
         settings.ZDS_APP['search']['boosts']['publishedcontent']['if_opinion_not_picked'] = 1.0
+        settings.ZDS_APP['search']['boosts']['publishedcontent']['if_medium_or_big_tutorial'] = 2.0
+
+        result = self.client.get(
+            reverse('search:query') + '?q=' + text + '&models=content', follow=False)
+
+        self.assertEqual(result.status_code, 200)
+        response = result.context['object_list'].execute()
+        self.assertEqual(response.hits.total, 5)
+
+        self.assertTrue(response[0].meta.score > response[1].meta.score)
+        self.assertEquals(response[0].meta.id, str(published_tuto.pk))  # obvious
+
+        settings.ZDS_APP['search']['boosts']['publishedcontent']['if_medium_or_big_tutorial'] = 1.0
 
         # 6. Test global boosts
         # NOTE: score are NOT the same for all documents, no matter how hard it tries to, small differences exists

--- a/zds/searchv2/tests/tests_views.py
+++ b/zds/searchv2/tests/tests_views.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import datetime
 
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.query import MatchAll
@@ -284,13 +285,23 @@ class ViewsTests(TestCase):
         article = PublishedContentFactory(type='ARTICLE', title=text)
         published_article = PublishedContent.objects.get(content_pk=article.pk)
 
+        opinion_not_picked = PublishedContentFactory(type='OPINION', title=text)
+        published_opinion_not_picked = PublishedContent.objects.get(content_pk=opinion_not_picked.pk)
+
+        opinion_picked = PublishedContentFactory(type='OPINION', title=text)
+        opinion_picked.sha_picked = opinion_picked.sha_draft
+        opinion_picked.date_picked = datetime.datetime.now()
+        opinion_picked.save()
+
+        published_opinion_picked = PublishedContent.objects.get(content_pk=opinion_picked.pk)
+
         for model in self.indexable:
             if model is FakeChapter:
                 continue
             self.manager.es_bulk_indexing_of_model(model)
         self.manager.refresh_index()
 
-        self.assertEqual(len(self.manager.setup_search(Search().query(MatchAll())).execute()), 8)
+        self.assertEqual(len(self.manager.setup_search(Search().query(MatchAll())).execute()), 10)
 
         # 2. Reset all boosts to 1
         for doc_type in settings.ZDS_APP['search']['boosts']:
@@ -418,10 +429,14 @@ class ViewsTests(TestCase):
 
         self.assertEqual(result.status_code, 200)
         response = result.context['object_list'].execute()
-        self.assertEquals(response.hits.total, 3)
+        self.assertEquals(response.hits.total, 5)
 
         # score are equals without boost:
-        self.assertTrue(response[0].meta.score == response[1].meta.score)
+        self.assertTrue(response[0].meta.score ==
+                        response[1].meta.score ==
+                        response[2].meta.score ==
+                        response[3].meta.score ==
+                        response[4].meta.score)
 
         settings.ZDS_APP['search']['boosts']['publishedcontent']['if_article'] = 2.0
 
@@ -430,7 +445,7 @@ class ViewsTests(TestCase):
 
         self.assertEqual(result.status_code, 200)
         response = result.context['object_list'].execute()
-        self.assertEqual(response.hits.total, 3)
+        self.assertEqual(response.hits.total, 5)
 
         self.assertTrue(response[0].meta.score > response[1].meta.score)
         self.assertEquals(response[0].meta.id, str(published_article.pk))  # obvious
@@ -443,12 +458,29 @@ class ViewsTests(TestCase):
 
         self.assertEqual(result.status_code, 200)
         response = result.context['object_list'].execute()
-        self.assertEqual(response.hits.total, 3)
+        self.assertEqual(response.hits.total, 5)
 
         self.assertTrue(response[0].meta.score > response[1].meta.score)
         self.assertEquals(response[0].meta.id, str(published_tuto.pk))  # obvious
 
         settings.ZDS_APP['search']['boosts']['publishedcontent']['if_tutorial'] = 1.0
+        settings.ZDS_APP['search']['boosts']['publishedcontent']['if_opinion'] = 2.0
+        settings.ZDS_APP['search']['boosts']['publishedcontent']['if_opinion_not_picked'] = 4.0
+        # Note: in "real life", unpicked opinion would get a boost < 1.
+
+        result = self.client.get(
+            reverse('search:query') + '?q=' + text + '&models=content', follow=False)
+
+        self.assertEqual(result.status_code, 200)
+        response = result.context['object_list'].execute()
+        self.assertEqual(response.hits.total, 5)
+
+        self.assertTrue(response[0].meta.score > response[1].meta.score > response[2].meta.score)
+        self.assertEquals(response[0].meta.id, str(published_opinion_not_picked.pk))  # unpicked opinion got first
+        self.assertEquals(response[1].meta.id, str(published_opinion_picked.pk))
+
+        settings.ZDS_APP['search']['boosts']['publishedcontent']['if_opinion'] = 1.0
+        settings.ZDS_APP['search']['boosts']['publishedcontent']['if_opinion_not_picked'] = 1.0
 
         # 6. Test global boosts
         # NOTE: score are NOT the same for all documents, no matter how hard it tries to, small differences exists
@@ -463,7 +495,7 @@ class ViewsTests(TestCase):
 
             self.assertEqual(result.status_code, 200)
             response = result.context['object_list'].execute()
-            self.assertEqual(response.hits.total, 8)
+            self.assertEqual(response.hits.total, 10)
 
             self.assertEqual(response[0].meta.doc_type, model.get_es_document_type())  # obvious
 

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -133,6 +133,14 @@ class SearchView(ZdSPagingListView):
                 'filter': Match(content_type='ARTICLE'),
                 'weight': settings.ZDS_APP['search']['boosts']['publishedcontent']['if_article']
             },
+            {
+                'filter': Match(content_type='OPINION'),
+                'weight': settings.ZDS_APP['search']['boosts']['publishedcontent']['if_opinion']
+            },
+            {
+                'filter': Match(content_type='OPINION') & Match(picked=False),
+                'weight': settings.ZDS_APP['search']['boosts']['publishedcontent']['if_opinion_not_picked']
+            },
         ]
 
         scored_query = FunctionScore(query=query, boost_mode='multiply', functions=functions_score)

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -130,6 +130,10 @@ class SearchView(ZdSPagingListView):
                 'weight': settings.ZDS_APP['search']['boosts']['publishedcontent']['if_tutorial']
             },
             {
+                'filter': Match(content_type='TUTORIAL') & Match(has_chapters=True),
+                'weight': settings.ZDS_APP['search']['boosts']['publishedcontent']['if_medium_or_big_tutorial']
+            },
+            {
                 'filter': Match(content_type='ARTICLE'),
                 'weight': settings.ZDS_APP['search']['boosts']['publishedcontent']['if_article']
             },

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -557,6 +557,8 @@ ZDS_APP = {
                 'global': 3.0,
                 'if_article': 1.0,
                 'if_tutorial': 1.0,
+                'if_opinion': 0.66,
+                'if_opinion_not_picked': 0.5
             },
             'topic': {
                 'global': 2.0,

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -557,6 +557,7 @@ ZDS_APP = {
                 'global': 3.0,
                 'if_article': 1.0,
                 'if_tutorial': 1.0,
+                'if_medium_or_big_tutorial': 1.5,
                 'if_opinion': 0.66,
                 'if_opinion_not_picked': 0.5
             },

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -843,6 +843,7 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
         mapping.field('tags', Text(boost=2.0))
         mapping.field('categories', Text(boost=2.25))
         mapping.field('text', Text())  # for article and mini-tuto, text is directly included into the main object
+        mapping.field('has_chapters', Boolean())  # ... otherwise, it is written
         mapping.field('picked', Boolean())
 
         # not indexed:
@@ -935,6 +936,9 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
 
         if versioned.has_extracts():
             data['text'] = versioned.get_content_online()
+            data['has_chapters'] = False
+        else:
+            data['has_chapters'] = True
 
         data['picked'] = False
 

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -945,7 +945,9 @@ def delete_published_content_in_elasticsearch(sender, instance, **kwargs):
     """
 
     index_manager = ESIndexManager(**settings.ES_SEARCH_INDEX)
-    index_manager.delete_by_query(FakeChapter.get_es_document_type(), ES_Q('match', _routing=instance.es_id))
+
+    if index_manager.index_exists:
+        index_manager.delete_by_query(FakeChapter.get_es_document_type(), ES_Q('match', _routing=instance.es_id))
 
     return delete_document_in_elasticsearch(instance)
 

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -20,7 +20,9 @@ overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'conte
 overrided_zds_app['content']['extra_content_generation_policy'] = 'NONE'
 
 
+@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
+@override_settings(ES_ENABLED=False)
 class PublishedContentTests(TestCase):
     def setUp(self):
         overrided_zds_app['member']['bot_account'] = ProfileFactory().user.username

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -11,7 +11,7 @@ from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.settings import BASE_DIR
 from zds.tutorialv2.factories import PublishableContentFactory, ExtractFactory, LicenceFactory, PublishedContentFactory
-from zds.tutorialv2.models.models_database import PublishableContent
+from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent
 from zds.utils.models import Alert
 
 overrided_zds_app = settings.ZDS_APP
@@ -61,10 +61,16 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_publication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        self.assertEqual(PublishedContent.objects.count(), 1)
+
+        opinion = PublishableContent.objects.get(pk=opinion.pk)
+        self.assertIsNotNone(opinion.public_version)
+        self.assertEqual(opinion.public_version.sha_public, opinion_draft.current_version)
 
     def test_accessible_ui_for_author(self):
         opinion = PublishedContentFactory(author_list=[self.user_author], type='OPINION')
@@ -124,10 +130,16 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_publication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        self.assertEqual(PublishedContent.objects.count(), 1)
+
+        opinion = PublishableContent.objects.get(pk=opinion.pk)
+        self.assertIsNotNone(opinion.public_version)
+        self.assertEqual(opinion.public_version.sha_public, opinion_draft.current_version)
 
     def test_opinion_publication_guest(self):
         """
@@ -158,10 +170,12 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_publication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 403)
+
+        self.assertEqual(PublishedContent.objects.count(), 0)
 
     def test_opinion_unpublication(self):
         """
@@ -196,10 +210,16 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_publication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        self.assertEqual(PublishedContent.objects.count(), 1)
+
+        opinion = PublishableContent.objects.get(pk=opinion.pk)
+        self.assertIsNotNone(opinion.public_version)
+        self.assertEqual(opinion.public_version.sha_public, opinion_draft.current_version)
 
         # unpublish
         result = self.client.post(
@@ -207,10 +227,15 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_unpublication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        self.assertEqual(PublishedContent.objects.count(), 0)
+
+        opinion = PublishableContent.objects.get(pk=opinion.pk)
+        self.assertIsNone(opinion.public_version)
 
         # staff
 
@@ -226,10 +251,16 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_publication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        self.assertEqual(PublishedContent.objects.count(), 1)
+
+        opinion = PublishableContent.objects.get(pk=opinion.pk)
+        self.assertIsNotNone(opinion.public_version)
+        self.assertEqual(opinion.public_version.sha_public, opinion_draft.current_version)
 
         # unpublish
         result = self.client.post(
@@ -237,10 +268,15 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_unpublication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        self.assertEqual(PublishedContent.objects.count(), 0)
+
+        opinion = PublishableContent.objects.get(pk=opinion.pk)
+        self.assertIsNone(opinion.public_version)
 
         # guest => 403
 
@@ -256,10 +292,16 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_publication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        self.assertEqual(PublishedContent.objects.count(), 1)
+
+        opinion = PublishableContent.objects.get(pk=opinion.pk)
+        self.assertIsNotNone(opinion.public_version)
+        self.assertEqual(opinion.public_version.sha_public, opinion_draft.current_version)
 
         self.assertEqual(
             self.client.login(
@@ -273,10 +315,12 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_unpublication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 403)
+
+        self.assertEqual(PublishedContent.objects.count(), 1)
 
     def test_opinion_validation(self):
         """
@@ -308,10 +352,16 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_publication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        self.assertEqual(PublishedContent.objects.count(), 1)
+
+        opinion = PublishableContent.objects.get(pk=opinion.pk)
+        self.assertIsNotNone(opinion.public_version)
+        self.assertEqual(opinion.public_version.sha_public, opinion_draft.current_version)
 
         # valid with author => 403
         opinion = PublishableContent.objects.get(pk=opinion.pk)
@@ -429,17 +479,23 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_publication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        self.assertEqual(PublishedContent.objects.count(), 1)
+
+        opinion = PublishableContent.objects.get(pk=opinion.pk)
+        self.assertIsNotNone(opinion.public_version)
+        self.assertEqual(opinion.public_version.sha_public, opinion_draft.current_version)
 
         # valid with author => 403
         result = self.client.post(
             reverse('validation:promote-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 403)
@@ -455,7 +511,7 @@ class PublishedContentTests(TestCase):
             reverse('validation:promote-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
             {
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -487,10 +543,16 @@ class PublishedContentTests(TestCase):
             {
                 'text': text_publication,
                 'source': '',
-                'version': opinion.load_version().current_version
+                'version': opinion_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
+
+        self.assertEqual(PublishedContent.objects.count(), 1)
+
+        opinion = PublishableContent.objects.get(pk=opinion.pk)
+        self.assertIsNotNone(opinion.public_version)
+        self.assertEqual(opinion.public_version.sha_public, opinion_draft.current_version)
 
         # Alert content
         random_user = ProfileFactory().user

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -671,6 +671,10 @@ class PickOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
         db_object.picked_date = datetime.now()
         db_object.save()
 
+        # mark to reindex to boost correctly in the search
+        self.public_content_object.es_flagged = True
+        self.public_content_object.save()
+
         msg = render_to_string(
             'tutorialv2/messages/validation_opinion.md',
             {
@@ -725,6 +729,10 @@ class UnpickOpinion(PermissionRequiredMixin, NoValidationBeforeFormViewMixin):
 
         db_object.sha_picked = None
         db_object.save()
+
+        # mark to reindex to boost correctly in the search
+        self.public_content_object.es_flagged = True
+        self.public_content_object.save()
 
         msg = render_to_string(
             'tutorialv2/messages/validation_invalid_opinion.md',

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -607,6 +607,9 @@ class UnpublishOpinion(LoginRequiredMixin, SingleOnlineContentFormViewMixin, NoV
         if user not in versioned.authors.all() and not user.has_perm('tutorialv2.change_validation'):
             raise PermissionDenied
 
+        if form.cleaned_data['version'] != self.object.sha_public:
+            raise PermissionDenied
+
         unpublish_content(self.object)
 
         self.object.sha_public = None


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug 
| Ticket(s) (_issue(s)_) concerné(s)  | #3993 #4133 #4231 

### QA

**Cette QA nécessite Elasticsearch** (mais je rappelle que c'est [très facile à installer](http://zds-site.readthedocs.io/fr/latest/install/install-es.html) ;) ).

+ Pour le bug de transaction, si Travis passe, c'est déjà gagné :)
+ Ensuite, créer une tribune A ayant pour titre "banane verte", la publier et lancer l'indexation (`make index-all`). Faire une recherche sur le mot "banane" et vérifier que la tribune apparait bien.
+ Créer une tribune B ayant pour titre "banane jaune".
+ Créer un article C ayant pour titre "banane violette" et le publier, le publier et réindexer (`make index-flagged`). Faire une recherche sur le mot "banane" et vérifier que tout y est (deux tribunes et un article). **Vérifier que l'article apparait bien premier.**
+ Mettre la tribune B ("banane jaune", parce que c'est quand même meilleur) sur la page d'acceil et réindexer (`make index-flagged`).  Faire une recherche sur le mot "banane" et vérifier que "banane jaune" apparait bien en second.
+ Retirer la tribune B de la page d'acceil, mettre la tribune A sur la page d'acceil et réindexer (`make index-flagged`).  Faire une recherche sur le mot "banane" et vérifier que "banane jaune" apparait bien en troisième.
+ Faites vous un milkshake à la banane.

<!-- À cocher une fois la QA faite. Vous pouvez le faire sur votre pull request si un testeur confirme avoir vérifié le bon fonctionnement de votre PR et avoir relu le code. -->

- [ ] Ça fonctionne !
- [ ] Code relu et approuvé !