### PR TITLE
Enlève la coloration sur le nombre d'alertes

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -429,7 +429,7 @@
                                 {# ALERTES MODERATION #}
                                 {% if perms.forum.change_post %}
                                     {% with alerts_list=user|alerts_list %}
-                                        <div class="staff-only">
+                                        <div>
                                             <a href="{% url "pages-alerts" %}" class="ico-link" title="{% trans 'Alertes de modération' %}">
                                                 <span class="notif-text ico ico-alerts">{% trans "Alertes de modération" %}</span>
                                                 {% if alerts_list.nb_alerts > 0 %}
@@ -437,7 +437,7 @@
                                                 {% endif %}
                                             </a>
 
-                                            <div class="dropdown">
+                                            <div class="dropdown staff-only">
                                                 <span class="dropdown-title">{% trans "Alertes de modération" %}</span>
                                                 <ul class="dropdown-list">
                                                     {% for alert in alerts_list.alerts %}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | ~ évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4002 

Je me suis rendu compte en faisant des tests sur les alertes des billets que la classe `staff-only` entraînait la coloration en jaune du nombre d'alertes. Ce nombre étant lui-même sur fond rouge, ce n'est pas hyper esthétique. Cette PR change simplement l'emplacement du `staff-only` pour que le nombre ne soit plus concerné :

![Résultat](https://www.pixenli.com/images/1491/1491311430087268200.png)

### QA

Juste vérifier que la modification a bien été effectuée et que vous avez le même rendu que sur la capture d'écran. :)

- [x] Ça fonctionne !
- [x] Code relu et approuvé !