### PR TITLE
Rend la page « Toutes les alertes » utilisable avec la ZEP-13

### DIFF
--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -71,7 +71,7 @@
                 <th>{% trans "Type" %}</th>
                 <th>{% trans "Auteur" %}</th>
                 <th class="wide">{% trans "Date de résolution" %}</th>
-                <th class="wide">{% trans "Message" %}</th>
+                <th class="wide">{% trans "Contenu signalé" %}</th>
                 <th>{% trans "Résolu par" %}</th>
             </thead>
             <tbody>

--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -29,21 +29,31 @@
                 <th>{% trans "Type" %}</th>
                 <th>{% trans "Auteur" %}</th>
                 <th class="wide">{% trans "Date" %}</th>
-                <th class="wide">{% trans "Message" %}</th>
-                <th>{% trans "Sur un message de..." %}</th>
+                <th class="wide">{% trans "Contenu signalé" %}</th>
+                <th>{% trans "Auteur du message" %}</th>
             </thead>
             <tbody>
                 {% for alert in alerts %}
                     <tr>
-                        <td>{{ alert.get_scope_display }}</td>
+                        <td>{{ alert.get_type }}</td>
                         <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
                         <td class="wide">{{ alert.pubdate|format_date|capfirst }}</td>
-                        <td class="wide"><a href="{{ alert.get_comment_subclass.get_absolute_url }}">{{ alert.text }}</a></td>
+                        <td class="wide">
+                            {% if alert.scope == 'CONTENT' %}
+                                <a href="{{ alert.content.get_absolute_url_online }}">{{ alert.text }}</a>
+                            {% else %}
+                                <a href="{{ alert.get_comment_subclass.get_absolute_url }}">{{ alert.text }}</a>
+                            {% endif %}
+                        </td>
                         <td>
-                            {% url "member-detail" alert.comment.author.username as url_member_detail %}
-                            {% blocktrans with author_username=alert.comment.author.username timing=alert.comment.pubdate|format_date %}
-                                <a href="{{ url_member_detail }}">{{ author_username }}</a>, posté le {{ timing }}
-                            {% endblocktrans %}
+                            {% if alert.scope == 'CONTENT' %}
+                                –
+                            {% else %}
+                                {% url "member-detail" alert.comment.author.username as url_member_detail %}
+                                {% blocktrans with author_username=alert.comment.author.username timing=alert.comment.pubdate|format_date %}
+                                    <a href="{{ url_member_detail }}">{{ author_username }}</a>, posté le {{ timing }}
+                                {% endblocktrans %}
+                            {% endif %}
                         </td>
                     </tr>
                 {% endfor %}
@@ -67,13 +77,17 @@
             <tbody>
                 {% for alert in solved %}
                     <tr>
-                        <td>{{ alert.get_scope_display }}</td>
+                        <td>{{ alert.get_type }}</td>
                         <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
                         <td class="wide">{{ alert.solved_date|format_date|capfirst }}</td>
                         <td class="wide">
-                            {% url "member-detail" alert.comment.author.username as url_member_detail %}
-                            <a href="{{ alert.get_comment_subclass.get_absolute_url }}">{{ alert.text }}</a> par
-                            <a href="{{ url_member_detail }}">{{ alert.comment.author.username  }}</a>
+                            {% if alert.scope == 'CONTENT' %}
+                                <a href="{{ alert.content.get_absolute_url_online }}">{{ alert.text }}</a>
+                            {% else %}
+                                {% url "member-detail" alert.comment.author.username as url_member_detail %}
+                                <a href="{{ alert.get_comment_subclass.get_absolute_url }}">{{ alert.text }}</a> par
+                                <a href="{{ url_member_detail }}">{{ alert.comment.author.username  }}</a>
+                            {% endif %}
                         </td>
                         <td>
                             {% url "member-detail" alert.moderator.username as url_member_detail %}

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -19,7 +19,7 @@ from easy_thumbnails.fields import ThumbnailerImageField
 
 from zds.notification import signals
 from zds.mp.models import PrivateTopic
-from zds.tutorialv2.models import TYPE_CHOICES
+from zds.tutorialv2.models import TYPE_CHOICES, TYPE_CHOICES_DICT
 from zds.utils.mps import send_mp
 from zds.utils import slugify
 from zds.utils.templatetags.emarkdown import get_markdown_instance, render_markdown
@@ -303,6 +303,12 @@ class Alert(models.Model):
                                        db_index=True,
                                        null=True,
                                        blank=True)
+
+    def get_type(self):
+        if self.scope in TYPE_CHOICES_DICT:
+            return _(u'Commentaire')
+        else:
+            return self.get_scope_display()
 
     def solve(self, moderator, resolve_reason='', msg_title='', msg_content=''):
         """Solve alert and send a PrivateTopic to the alert author if a reason is given


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4265 

### QA

Vérifier que la page « Toutes les alertes » s'affiche correctement avec des alertes sur des messages du forum, des commentaires de contenus et des billets. Tester avec des alertes actives et des alertes résolues.

- [x] Ça fonctionne !
- [x] Code relu et approuvé !