### PR TITLE
Reprise de #4275

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ cache:
 
 before_install:
   # see https://docs.travis-ci.com/user/database-setup/#Installing-specific-versions-of-ElasticSearch
-  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.0.deb && sudo dpkg -i --force-confnew elasticsearch-5.2.0.deb && sudo service elasticsearch start
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.0.deb && sudo dpkg -i --force-confnew elasticsearch-5.3.0.deb && sudo service elasticsearch start
 
 before_script:
   # MySQL config

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-coverage==4.0.3
+coverage==4.3.4
 PyYAML==3.12
 django-debug-toolbar==1.5
 flake8==2.5.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 coverage==4.3.4
 PyYAML==3.12
 django-debug-toolbar==1.7
-flake8==2.5.4
+flake8==3.3.0
 flake8_quotes==0.9.0
 autopep8==1.3.1
 sphinx==1.5.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ flake8_quotes==0.8.1
 autopep8==1.3.1
 sphinx==1.4.1
 sphinx_rtd_theme==0.1.9
-fake-factory==0.5.7
+fake-factory==0.7.4
 mock==2.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ flake8==2.5.4
 flake8_quotes==0.9.0
 autopep8==1.3.1
 sphinx==1.5.5
-sphinx_rtd_theme==0.1.9
+sphinx_rtd_theme==0.2.4
 fake-factory==0.7.4
 mock==2.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage==4.3.4
 PyYAML==3.12
-django-debug-toolbar==1.5
+django-debug-toolbar==1.7
 flake8==2.5.4
 flake8_quotes==0.8.1
 autopep8==1.3.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ PyYAML==3.12
 django-debug-toolbar==1.5
 flake8==2.5.4
 flake8_quotes==0.8.1
-autopep8==1.2.2
+autopep8==1.3.1
 sphinx==1.4.1
 sphinx_rtd_theme==0.1.9
 fake-factory==0.5.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 coverage==4.0.3
-PyYAML==3.11
+PyYAML==3.12
 django-debug-toolbar==1.5
 flake8==2.5.4
 flake8_quotes==0.8.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ coverage==4.3.4
 PyYAML==3.12
 django-debug-toolbar==1.7
 flake8==2.5.4
-flake8_quotes==0.8.1
+flake8_quotes==0.9.0
 autopep8==1.3.1
 sphinx==1.4.1
 sphinx_rtd_theme==0.1.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ django-debug-toolbar==1.7
 flake8==2.5.4
 flake8_quotes==0.9.0
 autopep8==1.3.1
-sphinx==1.4.1
+sphinx==1.5.5
 sphinx_rtd_theme==0.1.9
 fake-factory==0.7.4
 mock==2.0.0

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,3 +1,3 @@
-gunicorn==19.4.5
+gunicorn==19.7.1
 MySQL-python==1.2.5
 raven==5.32.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ django-recaptcha==1.0.5
 # Api dependencies
 djangorestframework==3.5.3
 djangorestframework-xml==1.3.0
-django-filter==1.0.1
+django-filter==1.0.2
 django-oauth-toolkit==0.10.0
 drf-extensions==0.3.1
 django-rest-swagger==0.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ django-oauth-toolkit==0.10.0
 drf-extensions==0.3.1
 django-rest-swagger==0.3.6
 django-cors-middleware==1.2.0
-dry-rest-permissions==0.1.6
+dry-rest-permissions==0.1.9
 
 # Zep 12 dependency
 watchdog==0.8.3 # use last non-bc-breaking version

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-crispy-forms==1.6.1
 django-model-utils==2.6.1
 django-munin==0.2.2
 python-memcached==1.58
-lxml==3.6.0
+lxml==3.7.3
 factory-boy==2.7.0
 pygeoip==0.3.2
 pillow==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ python-memcached==1.58
 lxml==3.7.3
 factory-boy==2.7.0
 pygeoip==0.3.2
-pillow==4.0.0
+pillow==4.1.0
 gitpython==1.0.1
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.17.zip
 easy-thumbnails==2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Django==1.8.18
 django-crispy-forms==1.6.1
 django-model-utils==2.5
 django-munin==0.2.2
-python-memcached==1.54
+python-memcached==1.58
 lxml==3.6.0
 factory-boy==2.7.0
 pygeoip==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ django-filter==1.0.2
 django-oauth-toolkit==0.10.0
 drf-extensions==0.3.1
 django-rest-swagger==0.3.6
-django-cors-middleware==1.2.0
+django-cors-middleware==1.3.1
 dry-rest-permissions==0.1.9
 
 # Zep 12 dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ elasticsearch-dsl==5.1.0
 Django==1.8.18
 django-crispy-forms==1.6.1
 django-model-utils==2.5
-django-munin==0.2.1
+django-munin==0.2.2
 python-memcached==1.54
 lxml==3.6.0
 factory-boy==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ beautifulsoup4==4.5.3
 django-recaptcha==1.2.1
 
 # Api dependencies
-djangorestframework==3.5.3
+djangorestframework==3.6.2
 djangorestframework-xml==1.3.0
 django-filter==1.0.2
 django-oauth-toolkit==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.17.zip
 easy-thumbnails==2.3
 CairoSVG==1.0.20
 beautifulsoup4==4.5.3
-django-recaptcha==1.0.5
+django-recaptcha==1.2.1
 
 # Api dependencies
 djangorestframework==3.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pygeoip==0.3.2
 pillow==4.0.0
 gitpython==1.0.1
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.17.zip
-easy-thumbnails==2.3
+easy-thumbnails==2.4.1
 CairoSVG==1.0.20
 beautifulsoup4==4.5.3
 django-recaptcha==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 pygments==2.1.3
 python-social-auth==0.2.19
 elasticsearch==5.3.0
-elasticsearch-dsl==5.1.0
+elasticsearch-dsl==5.2.0
 
 # Explicit dependencies (references in code)
 Django==1.8.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ elasticsearch==5.1.0
 elasticsearch-dsl==5.1.0
 
 # Explicit dependencies (references in code)
-Django==1.8.16
+Django==1.8.18
 django-crispy-forms==1.6.0
 django-model-utils==2.5
 django-munin==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ elasticsearch-dsl==5.1.0
 # Explicit dependencies (references in code)
 Django==1.8.18
 django-crispy-forms==1.6.1
-django-model-utils==2.5
+django-model-utils==2.6.1
 django-munin==0.2.2
 python-memcached==1.58
 lxml==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ gitpython==1.0.1
 https://github.com/zestedesavoir/Python-ZMarkdown/archive/2.6.0-zds.17.zip
 easy-thumbnails==2.3
 CairoSVG==1.0.20
-beautifulsoup4==4.4.1
+beautifulsoup4==4.5.3
 django-recaptcha==1.0.5
 
 # Api dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ django-recaptcha==1.0.5
 djangorestframework==3.5.3
 djangorestframework-xml==1.3.0
 django-filter==1.0.2
-django-oauth-toolkit==0.10.0
+django-oauth-toolkit==0.12.0
 drf-extensions==0.3.1
 django-rest-swagger==0.3.6
 django-cors-middleware==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ elasticsearch-dsl==5.1.0
 
 # Explicit dependencies (references in code)
 Django==1.8.18
-django-crispy-forms==1.6.0
+django-crispy-forms==1.6.1
 django-model-utils==2.5
 django-munin==0.2.1
 python-memcached==1.54

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Implicit dependencies (optional dependencies of dependencies)
-pygments==2.1.3
+pygments==2.2.0
 python-social-auth==0.2.19
 elasticsearch==5.3.0
 elasticsearch-dsl==5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Implicit dependencies (optional dependencies of dependencies)
 pygments==2.1.3
 python-social-auth==0.2.19
-elasticsearch==5.1.0
+elasticsearch==5.3.0
 elasticsearch-dsl==5.1.0
 
 # Explicit dependencies (references in code)

--- a/scripts/release_generator.py
+++ b/scripts/release_generator.py
@@ -140,6 +140,7 @@ def mdarray(tableau):
     ret += '\n'
     return ret
 
+
 ###############################################################
 
 milestones = get_milestones()

--- a/update.md
+++ b/update.md
@@ -1006,9 +1006,8 @@ Une fois que tout est indexé,
     DROP TABLE search_searchindexcontent;
     ```
 
-Actions à faire pour l'upgrade v23
-==================================
-
+Actions à faire pour mettre en prod la version : v23
+====================================================
 
 Tribunes
 --------
@@ -1033,3 +1032,11 @@ A propos de social auth:
 Ne pas oublier de mettre le middleware `'zds.member.utils.ZDSCustomizeSocialAuthExceptionMiddleware'`.
 
 Forcer le paramètre `SOCIAL_AUTH_RAISE_EXCEPTIONS = False`.
+
+
+Mise à jour d'ElasticSearch
+---------------------------
+
+1. `sudo apt update`
+2. `sudo apt upgrade elasticsearch`
+2. `systemctl restart elasticsearch.service`

--- a/zds/gallery/admin.py
+++ b/zds/gallery/admin.py
@@ -27,6 +27,7 @@ class UserGalleryAdmin(admin.ModelAdmin):
     list_display = ('user', 'gallery', 'mode')
     raw_id_fields = ('user', 'gallery')
 
+
 admin.site.register(Gallery, GalleryAdmin)
 admin.site.register(Image, ImageAdmin)
 admin.site.register(UserGallery, UserGalleryAdmin)

--- a/zds/notification/admin.py
+++ b/zds/notification/admin.py
@@ -17,5 +17,6 @@ class SubscriptionAdmin(admin.ModelAdmin):
 
     raw_id_fields = ('user', 'last_notification')
 
+
 admin.site.register(Notification, NotificationAdmin)
 admin.site.register(Subscription, SubscriptionAdmin)

--- a/zds/pages/admin.py
+++ b/zds/pages/admin.py
@@ -9,4 +9,5 @@ class GroupContactAdmin(admin.ModelAdmin):
 
     raw_id_fields = ('person_in_charge',)
 
+
 admin.site.register(GroupContact, GroupContactAdmin)

--- a/zds/searchv2/__init__.py
+++ b/zds/searchv2/__init__.py
@@ -29,5 +29,6 @@ def setup_es_connections():
     except TransportError:
         pass
 
+
 if ENABLED:
     setup_es_connections()

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -643,3 +643,6 @@ if DEBUG:
     INSTALLED_APPS += (
         'debug_toolbar',
     )
+    MIDDLEWARE_CLASSES += (
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    )

--- a/zds/tutorialv2/admin.py
+++ b/zds/tutorialv2/admin.py
@@ -20,6 +20,7 @@ class ContentReactionAdmin(admin.ModelAdmin):
 class ValidationAdmin(admin.ModelAdmin):
     raw_id_fields = ('content', 'validator')
 
+
 admin.site.register(PublishableContent, PublishableContentnAdmin)
 admin.site.register(PublishedContent, PublishedContentAdmin)
 admin.site.register(Validation, ValidationAdmin)

--- a/zds/utils/admin.py
+++ b/zds/utils/admin.py
@@ -18,6 +18,7 @@ class SubCategoryAdmin(admin.ModelAdmin):
 class AlertAdmin(admin.ModelAdmin):
     raw_id_fields = ('author', 'comment', 'moderator', 'privatetopic')
 
+
 admin.site.register(Alert, AlertAdmin)
 admin.site.register(Tag)
 admin.site.register(Licence)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | maintenance
| Ticket(s) (_issue(s)_) concerné(s)  | #4275

J'ai mis à jour les dépendances Python [selon cette liste](https://requires.io/github/zestedesavoir/zds-site/requirements/?branch=dev).

### Dépendances non (complètement) mises à jour

- Django → 1.9 (ou même 1.10 ou 1.11) : parce que ça nécessite pas mal de modifications de code.
- fake-factory : la dernière version n'est pas claire (selon pip ou le site, c'est pas la même)
- raven → 6.0.0 : nécessite probablement une MAJ du serveur
- python-social-auth →0.3 : [nécessite toute une adaptation](https://github.com/omab/python-social-auth/blob/master/MIGRATING_TO_SOCIAL.md)
- python-slugify : non modifié à cause d'une régression connue dans les versions suivantes de django-uuslug

### QA

- Lancez `pip install --upgrade -r requirements.txt -r requirements-dev.txt`
- Lancez `python manage.py migrate`
- Vérifiez que le site marche encore comme prévu

- [x] Ça fonctionne !
- [x] Code relu et approuvé !