### PR TITLE
Fix release_generator.py

### DIFF
--- a/scripts/release_generator.py
+++ b/scripts/release_generator.py
@@ -105,7 +105,7 @@ def parse_issues(req):
 
 def dump_issues(milestone, openissues, closed_bug, closed_evo, closed_unk):
     # output all tables to a file
-    with codecs.open(OUTPUT_PATH, 'w', 'utf-8') as out:
+    with codecs.open(OUTPUT_PATH, 'w+', 'utf-8') as out:
         out.write(u'Rapport pour le jalon **[{}](https://github.com/zestedesavoir/zds-site/milestones/{})** *({})*\n\n'
                   .format(milestone['title'], milestone['title'], milestone['description']))
         out.write(u'{} tickets sont compris dans ce jalon ({} ouverts et {} fermés)\n\n'


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | Correction de bug
| Ticket concerné  | -

Fix un petit bug. Si le fichier markdown n'existait pas, le script plantait.

### QA

- Supprimer un éventuel ancien fichier : `rm scripts/release_summary.md`;
- Lancer le générateur : `python scripts/release_generator.py`. Le fichier markdown doit être créé et complété correctement.

- [ ] Ça fonctionne !
- [ ] Code relu et approuvé !