### PR TITLE
affiche liste des tribunes sur les billets seulement

### DIFF
--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -208,17 +208,17 @@
     </li>
     {% endif %}
     {% endif %}
-
-    {% for author in public_object.authors.all %}
-        <li>
-            <a href="{% url 'content:find-opinion' author.pk %}" class="ico-after offline blue">
-                {% blocktrans %}
-                    Voir la tribune de {{ author }}
-                {% endblocktrans %}
-            </a>
-        </li>
-    {% endfor %}
-
+    {% if public_object.type == 'OPINION' %}
+        {% for author in public_object.authors.all %}
+            <li>
+                <a href="{% url 'content:find-opinion' author.pk %}" class="ico-after offline blue">
+                    {% blocktrans %}
+                        Voir la tribune de {{ author }}
+                    {% endblocktrans %}
+                </a>
+            </li>
+        {% endfor %}
+      {% endif %}
 {% endblock %}
 
 {% block sidebar_blocks %}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | forum

### QA

- Créer un billet avec plusieurs auteurs
- publiez-le
- observez qu'a droite il y a "voir la tribune de" pour chaque auteur
- faite pareil avec un article
- observez que ça n'apparaît pas

