### PR TITLE
[WIP] POC ModelForm

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User, Group
 from django.core.urlresolvers import reverse
+from django.forms import ModelForm
 from django.utils.translation import ugettext_lazy as _
 
 from captcha.fields import ReCaptchaField
@@ -267,27 +268,25 @@ class ProfileForm(MiniProfileForm):
         self.helper.layout = layout
 
 
-class GitHubTokenForm(forms.Form):
+class GitHubTokenForm(ModelForm):
     """
     Updates the GitHub token.
     """
-    github_token = forms.CharField(
-        label='Token GitHub',
-        required=True,
-        widget=forms.TextInput(
-            attrs={
-                'placeholder': _(u'Token qui permet de communiquer avec la plateforme GitHub.'),
-                'autocomplete': 'off'
-            }
-        )
-    )
+    class Meta:
+        # Django 1.9 update, uncomment next line to render field as input and not textarea
+        # field_classes = {'github_token': CharField}
+        fields = ['github_token']
+        model = Profile
 
     def __init__(self, *args, **kwargs):
         super(GitHubTokenForm, self).__init__(*args, **kwargs)
+        self.fields['github_token'].widget.attrs['placeholder'] = _(u'Token qui permet de communiquer avec la plateform'
+                                                                    u'e GitHub.')
+        self.fields['github_token'].widget.attrs['autocomplete'] = 'off'
+
         self.helper = FormHelper()
         self.helper.form_class = 'content-wrapper'
         self.helper.form_method = 'post'
-
         self.helper.layout = Layout(
             Field('github_token'),
             ButtonHolder(


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | x

### QA

Pour modifier des champs liés à un formulaire, il est préférable d'utiliser `django.forms.ModelForm` car ça va "convertir" le champs du modèle en champs de formulaire. Ainsi les attributs comme la taille maximale du champs ou encore l'obligation de remplir ce champs sont automatiquement ajouté au formulaire. C'est une POC sur un seul formulaire, n'hésitez pas à me dire ce que vous en pensez. Je vous laisse un petit lien vers la documentation pour en apprendre plus si besoin (sachez qu'il y a eu des ajouts intéressants dans les versions suivantes de Django) : https://docs.djangoproject.com/fr/1.8/topics/forms/modelforms/

L'énorme avantage c'est qu'en cas de changement du modèle, le formulaire est automatiquement changé et cela évite une double modification du code et donc des bugs potentiels.

- **NE PAS MERGER, POC**

Note :  En ce qui concerne le rendu pour le formulaire GitHubTokenForm, il est de type `textarea` et non pas `input` comme avant. Cela vient du fait que sur le modèle `zds.member.Profile` c'est u n `TextField` et non un `CharField`. La possibilité de forcer le type de champs apparaît avec la version 1.9 de Django, j'ai laissé un commentaire pour y penser. Dans la mesure où cela ne casse aucune fonctionnalité et que ça ne sera visible que pour les devs, je pense que ça ne pose pas de souci particulier.

<!-- À cocher une fois la QA faite. Vous pouvez le faire sur votre pull request si un testeur confirme avoir vérifié le bon fonctionnement de votre PR et avoir relu le code. -->

- [ ] Ça fonctionne !
- [ ] Code relu et approuvé !