### PR TITLE
Fix la sélection des suggestions de sujets similaires

### DIFF
--- a/assets/js/autocompletion.js
+++ b/assets/js/autocompletion.js
@@ -89,16 +89,18 @@
             if (!search || search === this._lastAutocomplete) {
                 this.hideDropdown();
             } else {
-                this.fetchData(search)
-                    .done(function(data) {
-                        self.updateCache(data.results);
-                        self.updateDropdown(self.sortList(data.results, search));
-                    })
-                    .fail(function() {
-                        console.error("[Autocompletition] Something went wrong...");
-                    });
-                this.updateDropdown(this.sortList(this.searchCache(search), search));
-                this.showDropdown();
+                if (!this.options.minLength || search.length >= this.options.minLength) {
+                  this.fetchData(search)
+                  .done(function(data) {
+                    self.updateCache(data.results);
+                    self.updateDropdown(self.sortList(data.results, search));
+                  })
+                  .fail(function() {
+                    console.error("[Autocompletition] Something went wrong...");
+                  });
+                  this.updateDropdown(this.sortList(this.searchCache(search), search));
+                  this.showDropdown();
+                }
             }
         },
 

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -26,7 +26,8 @@ class TopicForm(forms.Form):
                     'fieldname': 'title',
                     'header': str(_(u'Sujets similaires :')),
                     'url': '/rechercher/sujets-similaires/?q=%s',
-                    'clickable': 'true'
+                    'clickable': 'true',
+                    'minLength': 3,
                 })
             }
         )

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -56,8 +56,8 @@ class SimilarSubjectsView(CreateView, SingleObjectMixin):
             search_queryset = search_queryset.query(scored_query)[:10]
 
             # Build the result
-            for (index, hit) in enumerate(search_queryset.execute()):
-                result = {'id': index, 'url': str(hit.get_absolute_url), 'title': str(hit.title)}
+            for hit in search_queryset.execute():
+                result = {'id': hit.pk, 'url': str(hit.get_absolute_url), 'title': str(hit.title)}
                 results.append(result)
 
         data = {'results': results}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4290 

### QA

- Lancer elasticsearch et zestedesavoir
- Se rendre sur la page "Création d'un nouveau sujet"
- Observer que les requêtes type *GET /rechercher/sujets-similaires/?q=* se lancent quand le titre fait 3 caractères au moins.
- Naviguer au clavier entre les suggestions et vérifier que ça ouvre bien la bonne fenetre lorsqu'on appuie sur Entrée. (N'hésitez pas à écrire plusieurs titres différents et cliquer sur plusieurs suggestions)

- [ ] Ça fonctionne !
- [x] Code relu et approuvé !