### PR TITLE
Enlève le compteur de validations sur l'avatar

### DIFF
--- a/assets/scss/components/_mobile-menu.scss
+++ b/assets/scss/components/_mobile-menu.scss
@@ -298,9 +298,4 @@
             }
         }
     }
-
-
-    .mobile-menu-link .validations-count {
-        display: none;
-    }
 }

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -270,7 +270,6 @@
         height: 60px;
         width: 60px;
         float: right;
-        position: relative;
 
         .username {
             display: none;
@@ -480,22 +479,6 @@
 
         .dropdown {
             right: 2.5%;
-        }
-    }
-
-    .my-account {
-        .validations-count {
-                display: block !important;
-                position: absolute;
-                z-index: 1;
-                top: 50%;
-                right: 50%;
-                margin: -20px -22px 0 0;
-                padding: 0 5px;
-                height: 16px;
-                line-height: 14px;
-                background: #c0392b; //@TODO: Color
-                border-radius: 16px;
         }
     }
 }

--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -305,16 +305,16 @@ Récupère la liste des alertes (si l'utilisateur possède les droits pour le fa
 ``waiting_count``
 ---------------
 
-Récupère le nombre de contenus, de tutoriels ou d'articles dans la zone de validation n'ayant pas été réservés par un validateur.
+Récupère le nombre de tutoriels ou d'articles dans la zone de validation n'ayant pas été réservés par un validateur.
 
 .. sourcecode:: html
 
     {% load interventions %}
-    {% with waiting_all_count=""|waiting_count waiting_tutorials_count="TUTORIAL"|waiting_count waiting_articles_count="ARTICLE"|waiting_count %}
+    {% with waiting_tutorials_count="TUTORIAL"|waiting_count waiting_articles_count="ARTICLE"|waiting_count %}
         ...
     {% endwith %}
 
-Le filtre doit être appelé sur ``"TUTORIAL"`` pour récupérer le nombre de tutoriels en attente et sur ``"ARTICLE"`` pour le nombre d'articles. Pour le nombre de contenus, il faut l'appeler sur une chaîne de caractères vide ``""``.
+Le filtre doit être appelé sur ``"TUTORIAL"`` pour récupérer le nombre de tutoriels en attente et sur ``"ARTICLE"`` pour le nombre d'articles.
 
 ``humane_delta``
 ----------------

--- a/templates/base.html
+++ b/templates/base.html
@@ -538,13 +538,6 @@
                                            data-active="open-my-account"
                                        {% endif %}
                                     >
-                                        {% if perms.forum.change_post %}
-                                            {% with waiting_all_count=""|waiting_count  %}
-                                                {% if waiting_all_count > 0 %}
-                                                    <span class="validations-count">{{ waiting_all_count }}</span>
-                                                {% endif %}
-                                            {% endwith %}
-                                        {% endif %}
                                         <img src="{{ profile.get_avatar_url|remove_url_protocole }}" alt="" class="avatar">
                                         <span class="username label">{{ user.username }}</span>
                                     </a>

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -207,15 +207,9 @@ def alerts_list(user):
 
 @register.filter(name='waiting_count')
 def waiting_count(content_type):
-
-    queryset = Validation.objects.filter(
+    if content_type not in TYPE_CHOICES_DICT:
+        raise template.TemplateSyntaxError("'content_type' must be in 'zds.tutorialv2.models.TYPE_CHOICES_DICT'")
+    return Validation.objects.filter(
         validator__isnull=True,
-        status='PENDING')
-
-    if content_type:
-        if content_type not in TYPE_CHOICES_DICT:
-            raise template.TemplateSyntaxError("'content_type' must be in 'zds.tutorialv2.models.TYPE_CHOICES_DICT'")
-        else:
-            queryset = queryset.filter(content__type=content_type)
-
-    return queryset.count()
+        status='PENDING',
+        content__type=content_type).count()

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -207,6 +207,9 @@ def alerts_list(user):
 
 @register.filter(name='waiting_count')
 def waiting_count(content_type):
+    """
+    Gets the number of waiting contents of the specified type (without validator).
+    """
     if content_type not in TYPE_CHOICES_DICT:
         raise template.TemplateSyntaxError("'content_type' must be in 'zds.tutorialv2.models.TYPE_CHOICES_DICT'")
     return Validation.objects.filter(


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | suppression d'une fonctionnalité
| Ticket(s) (_issue(s)_) concerné(s)  | [Sujet de la v23](https://zestedesavoir.com/forums/sujet/8407/v23-en-beta-une-petite-version-de-40-ticket/)

Cette PR supprime le nombre de validations en attente sur l'avatar étant donné que cette fonctionnalité n'a pas plu (notamment car ça fait une alerte qu'on ne peut pas enlever vu qu'il y a toujours du contenu en attente).

Désolé @pierre-24 pour le travail fait là-dessus. :/

### QA

Vérifier que le nombre de contenus a disparu sur l'avatar.

- [x] Ça fonctionne !
- [x] Code relu et approuvé !