### PR TITLE
Corrige les listes du template de pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,9 +5,9 @@
 
 ### QA
 
-- Instruction 1 (ex : lancez `python manage.py migrate` et `npm run gulp build`)
-- Instruction 2
-- etc
+* Instruction 1 (ex : lancez `python manage.py migrate` et `npm run gulp build`)
+* Instruction 2
+* etc
 
 <!-- À cocher une fois la QA faite. Vous pouvez le faire sur votre pull request si un testeur confirme avoir vérifié le bon fonctionnement de votre PR et avoir relu le code. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,11 @@
 | Q                                   | R
 | ----------------------------------- | -------------------------------------------
 | Type de modification                | correction de bug / nouvelle fonctionnalité / évolution
-| Ticket(s) (_issue(s)_) concerné(s)  | (ex #1337)
+| Ticket(s) (_issue(s)_) concerné(s)  | (ex : #1337)
 
 ### QA
 
-* Instruction 1 (ex : lancez `python manage.py migrate` et `npm run gulp build`)
-* Instruction 2
-* etc
-
-<!-- À cocher une fois la QA faite. Vous pouvez le faire sur votre pull request si un testeur confirme avoir vérifié le bon fonctionnement de votre PR et avoir relu le code. -->
-
-- [ ] Ça fonctionne !
-- [ ] Code relu et approuvé !
+- Instruction 1 (exemple : lancez `python manage.py migrate` et `npm run gulp build`)
+- Instruction 2
+- ...
+- Code review


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

Le Markdown de GitHub a tendance à confondre la liste avec les instructions de QA et celle avec les cases à cocher. Cette PR change le signe utilisé (passage de `-` à `*`) sur les instructions de QA pour que GH comprenne qu'il a affaire à deux listes différentes.

### QA

Code review.

- [ ] Code relu et approuvé !