### PR TITLE
Permet de désactiver l'aide Markdown

### DIFF
--- a/assets/js/markdown-help.js
+++ b/assets/js/markdown-help.js
@@ -24,7 +24,7 @@
         "Pour écrire un bout de code au milieu d’une phrase, utilisez la syntaxe <code>`un bout de code`</code>.",
         "Le langage d’un bloc de code peut être spécifié après les <code>```</code> ouvrants. La liste des langages supportés <a href=\"" + linkToPygments + "\">est disponible ici</a>.",
         "Vous pouvez <a href=\"" + linkToMathsTutorial + "\">écrire des formules mathématiques</a> en encadrant ces dernières du signe dollar <code>$</code>."
-        ];    
+    ];
     
     function addDocMD($elem){
         $elem.each(function(){
@@ -38,12 +38,14 @@
     
 
     $(document).ready(function(){
-        addDocMD($(".md-editor"));
-        $("#content").on("DOMNodeInserted", ".md-editor", function(e){
-            var $editor = $(e.target);
-            if($editor.next().hasClass("markdown-help") === false) {
-                addDocMD($editor);
-            }
-        });
+        if ($("body").data("show-markdown-help")) {
+            addDocMD($(".md-editor"));
+            $("#content").on("DOMNodeInserted", ".md-editor", function(e){
+                var $editor = $(e.target);
+                if($editor.next().hasClass("markdown-help") === false) {
+                    addDocMD($editor);
+                }
+            });
+        }
     });
 })(document, jQuery);

--- a/templates/base.html
+++ b/templates/base.html
@@ -122,8 +122,13 @@
 {% endif %}
 
 <body class="{% block body_class %}{% endblock %}{% for vc in visual_changes %} vc-{{ vc }}{% endfor %}"
-      itemscope
-      itemtype="http://schema.org/WebPage"
+    itemscope
+    itemtype="http://schema.org/WebPage"
+    {% if not user.is_authenticated or user.profile.show_markdown_help %}
+        data-show-markdown-help="true"
+    {% else %}
+        data-show-markdown-help="false"
+    {% endif %}
 >
     <!--[if lt IE 9]>
         <p class="chromeframe">Vous utilisez un navigateur <strong>dépassé</strong>. Merci de <a href="http://browsehappy.com/">mettre à jour celui-ci</a> pour améliorer votre expérience.</p>

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -222,7 +222,7 @@ class ProfileForm(MiniProfileForm):
             ('show_sign', _(u'Afficher les signatures')),
             ('is_hover_enabled', _(u'Dérouler les menus au survol')),
             ('allow_temp_visual_changes', _(u'Activer les changements visuels temporaires')),
-            ('show_markdown_help', _(u"Afficher l’aide Markdown dans l’éditeur")),
+            ('show_markdown_help', _(u"Afficher l'aide Markdown dans l'éditeur")),
             ('email_for_answer', _(u"Recevoir un courriel lors d'une réponse à un message privé")),
         ),
         widget=forms.CheckboxSelectMultiple,

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -222,6 +222,7 @@ class ProfileForm(MiniProfileForm):
             ('show_sign', _(u'Afficher les signatures')),
             ('is_hover_enabled', _(u'Dérouler les menus au survol')),
             ('allow_temp_visual_changes', _(u'Activer les changements visuels temporaires')),
+            ('show_markdown_help', _(u"Afficher l’aide Markdown dans l’éditeur")),
             ('email_for_answer', _(u"Recevoir un courriel lors d'une réponse à un message privé")),
         ),
         widget=forms.CheckboxSelectMultiple,
@@ -245,6 +246,9 @@ class ProfileForm(MiniProfileForm):
 
         if 'allow_temp_visual_changes' in initial and initial['allow_temp_visual_changes']:
             self.fields['options'].initial += 'allow_temp_visual_changes'
+
+        if 'show_markdown_help' in initial and initial['show_markdown_help']:
+            self.fields['options'].initial += 'show_markdown_help'
 
         if 'email_for_answer' in initial and initial['email_for_answer']:
             self.fields['options'].initial += 'email_for_answer'

--- a/zds/member/migrations/0010_profile_show_markdown_help.py
+++ b/zds/member/migrations/0010_profile_show_markdown_help.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('member', '0009_profile_show_staff_badge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='show_markdown_help',
+            field=models.BooleanField(default=True, verbose_name='Afficher l\u2019aide Markdown dans l\u2019\xe9diteur'),
+        ),
+    ]

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -61,6 +61,7 @@ class Profile(models.Model):
     # do UI components open by hovering them, or is clicking on them required?
     is_hover_enabled = models.BooleanField('Déroulement au survol ?', default=True)
     allow_temp_visual_changes = models.BooleanField('Activer les changements visuels temporaires', default=True)
+    show_markdown_help = models.BooleanField("Afficher l’aide Markdown dans l’éditeur", default=True)
     email_for_answer = models.BooleanField('Envoyer pour les réponse MP', default=False)
     show_staff_badge = models.BooleanField('Afficher le badge staff', default=False)
     can_read = models.BooleanField('Possibilité de lire', default=True)

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -61,7 +61,7 @@ class Profile(models.Model):
     # do UI components open by hovering them, or is clicking on them required?
     is_hover_enabled = models.BooleanField('Déroulement au survol ?', default=True)
     allow_temp_visual_changes = models.BooleanField('Activer les changements visuels temporaires', default=True)
-    show_markdown_help = models.BooleanField("Afficher l’aide Markdown dans l’éditeur", default=True)
+    show_markdown_help = models.BooleanField("Afficher l'aide Markdown dans l'éditeur", default=True)
     email_for_answer = models.BooleanField('Envoyer pour les réponse MP', default=False)
     show_staff_badge = models.BooleanField('Afficher le badge staff', default=False)
     can_read = models.BooleanField('Possibilité de lire', default=True)

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -1195,6 +1195,20 @@ class MemberTests(TestCase):
         dev = Profile.objects.get(pk=dev.pk)
         self.assertEqual(dev.github_token, '')
 
+    def test_markdown_help_settings(self):
+        user = ProfileFactory().user
+
+        # login and check that the Markdown help is displayed
+        self.client.login(username=user.username, password='hostel77')
+        result = self.client.get(reverse('pages-index'), follow=False)
+        self.assertContains(result, 'data-show-markdown-help="true"')
+
+        # disable Markdown help
+        user.profile.show_markdown_help = False
+        user.profile.save()
+        result = self.client.get(reverse('pages-index'), follow=False)
+        self.assertContains(result, 'data-show-markdown-help="false"')
+
     def tearDown(self):
         if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):
             shutil.rmtree(settings.ZDS_APP['content']['repo_private_path'])

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -119,9 +119,9 @@ class UpdateMember(UpdateView):
             'show_sign': profile.show_sign,
             'is_hover_enabled': profile.is_hover_enabled,
             'allow_temp_visual_changes': profile.allow_temp_visual_changes,
+            'show_markdown_help': profile.show_markdown_help,
             'email_for_answer': profile.email_for_answer,
             'sign': profile.sign,
-            'is_dev': profile.is_dev(),
         })
 
         return form
@@ -152,6 +152,7 @@ class UpdateMember(UpdateView):
         profile.show_sign = 'show_sign' in cleaned_data_options
         profile.is_hover_enabled = 'is_hover_enabled' in cleaned_data_options
         profile.allow_temp_visual_changes = 'allow_temp_visual_changes' in cleaned_data_options
+        profile.show_markdown_help = 'show_markdown_help' in cleaned_data_options
         profile.email_for_answer = 'email_for_answer' in cleaned_data_options
         profile.avatar_url = form.data['avatar_url']
         profile.sign = form.data['sign']


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4334 

### QA

- Reconstruire le front et effectuer les migrations, vider le cache.
- Se connecter sous n'importe quelle compte et vérifier que l'aide Markdown s'affiche.
- Désactiver l'option dans les paramètres du profil et vérifier qu'elle ne s'affiche plus.
- Code review.