### PR TITLE
Affiche la liste des abonnements sur la page des notifications

### DIFF
--- a/templates/notification/followed.html
+++ b/templates/notification/followed.html
@@ -79,7 +79,7 @@
             <h3>{% trans "Abonnements" %}</h3>
             <ul>
                 <li>
-                    <a href="#followed-users" class="open-modal ico-after star blue">{% trans 'Membres suivis' %}</a>
+                    <a href="#followed-users" class="open-modal">{% trans 'Membres suivis' %}</a>
                         <div id="followed-users" class="modal modal-flex" data-modal-close="{% trans 'Fermer' %}">
                             {% if followed_users %}
                                 <table class="fullwidth">
@@ -104,7 +104,7 @@
                 </li>
 
                 <li>
-                    <a href="#followed-forums" class="open-modal ico-after cite blue">{% trans 'Forums suivis' %}</a>
+                    <a href="#followed-forums" class="open-modal">{% trans 'Forums suivis' %}</a>
                         <div id="followed-forums" class="modal modal-flex" data-modal-close="{% trans 'Fermer' %}">
                             {% if followed_forums %}
                                 <table class="fullwidth">
@@ -133,7 +133,7 @@
                 </li>
 
                 <li>
-                    <a href="#followed-tags" class="open-modal ico-after gear blue">{% trans 'Tags suivis' %}</a>
+                    <a href="#followed-tags" class="open-modal">{% trans 'Tags suivis' %}</a>
                         <div id="followed-tags" class="modal modal-flex" data-modal-close="{% trans 'Fermer' %}">
                             {% if followed_tags %}
                                 <table class="fullwidth">

--- a/templates/notification/followed.html
+++ b/templates/notification/followed.html
@@ -74,5 +74,93 @@
                 </li>
             </ul>
         </div>
+
+        <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Abonnements">
+            <h3>{% trans "Abonnements" %}</h3>
+            <ul>
+                <li>
+                    <a href="#followed-users" class="open-modal ico-after star blue">{% trans 'Membres suivis' %}</a>
+                        <div id="followed-users" class="modal modal-flex" data-modal-close="{% trans 'Fermer' %}">
+                            {% if followed_users %}
+                                <table class="fullwidth">
+                                    <thead>
+                                        <th>{% trans "Membre" %}</th>
+                                        <th width="100px">{% trans "Par courriel" %}</th>
+                                    </thead>
+                                    <tbody>
+                                        {% for user in followed_users %}
+                                            <tr>
+                                                <td>{% include "misc/member_item.part.html" with member=user.content_object %}</td>
+                                                <td>{{ user.by_email|yesno:_('Oui,Non') }}</td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            {% else %}
+                                <p>{% trans "Vous ne suivez aucun membre." %}</p>
+                            {% endif %}
+                        </div>
+                    </form>
+                </li>
+
+                <li>
+                    <a href="#followed-forums" class="open-modal ico-after cite blue">{% trans 'Forums suivis' %}</a>
+                        <div id="followed-forums" class="modal modal-flex" data-modal-close="{% trans 'Fermer' %}">
+                            {% if followed_forums %}
+                                <table class="fullwidth">
+                                    <thead>
+                                        <th>{% trans "Forum" %}</th>
+                                        <th width="100px">{% trans "Par courriel" %}</th>
+                                    </thead>
+                                    <tbody>
+                                        {% for forum in followed_forums %}
+                                            <tr>
+                                                <td>
+                                                    <a href="{{ forum.content_object.get_absolute_url }}">
+                                                        {{ forum.content_object.title }}
+                                                    </a>
+                                                </td>
+                                                <td>{{ forum.by_email|yesno:_('Oui,Non') }}</td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            {% else %}
+                                <p>{% trans "Vous ne suivez aucun forum." %}</p>
+                            {% endif %}
+                        </div>
+                    </form>
+                </li>
+
+                <li>
+                    <a href="#followed-tags" class="open-modal ico-after gear blue">{% trans 'Tags suivis' %}</a>
+                        <div id="followed-tags" class="modal modal-flex" data-modal-close="{% trans 'Fermer' %}">
+                            {% if followed_tags %}
+                                <table class="fullwidth">
+                                    <thead>
+                                        <th>{% trans "Tag" %}</th>
+                                        <th width="100px">{% trans "Par courriel" %}</th>
+                                    </thead>
+                                    <tbody>
+                                        {% for tag in followed_tags %}
+                                            <tr>
+                                                <td>
+                                                    <a href="{{ tag.content_object.get_absolute_url }}">
+                                                        {{ tag.content_object.title }}
+                                                    </a>
+                                                </td>
+                                                <td>{{ tag.by_email|yesno:_('Oui,Non') }}</td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            {% else %}
+                                <p>{% trans "Vous ne suivez aucun tag." %}</p>
+                            {% endif %}
+                        </div>
+                    </form>
+                </li>
+            </ul>
+        </div>
     </aside>
 {% endblock %}

--- a/zds/notification/views.py
+++ b/zds/notification/views.py
@@ -7,15 +7,17 @@ from django.views.decorators.http import require_POST
 from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import redirect
 from django.core.urlresolvers import reverse
+from django.contrib.auth.models import User
 
 from zds import settings
 from zds.mp.models import PrivateTopic
-from zds.notification.models import Notification
+from zds.notification.models import Notification, Subscription
 from zds.utils.paginator import ZdSPagingListView
-from zds.forum.models import Post
+from zds.forum.models import Post, Forum
 from zds.tutorialv2.models.models_database import ContentReaction
 from zds.forum.models import mark_read as mark_topic_read
 from zds.tutorialv2.utils import mark_read as mark_content_read
+from zds.utils.models import Tag
 
 
 class NotificationList(ZdSPagingListView):
@@ -37,6 +39,25 @@ class NotificationList(ZdSPagingListView):
             .exclude(subscription__content_type=content_type) \
             .order_by('is_read', '-pubdate') \
             .all()
+
+    def get_context_data(self, **kwargs):
+        user_content_type = ContentType.objects.get_for_model(User)
+        forum_content_type = ContentType.objects.get_for_model(Forum)
+        tag_content_type = ContentType.objects.get_for_model(Tag)
+
+        context = super(NotificationList, self).get_context_data(**kwargs)
+        context['followed_users'] = Subscription.objects \
+            .filter(user=self.request.user, is_active=True, content_type=user_content_type) \
+            .prefetch_related('content_object') \
+            .prefetch_related('content_object__profile')
+        context['followed_forums'] = Subscription.objects \
+            .filter(user=self.request.user, is_active=True, content_type=forum_content_type) \
+            .prefetch_related('content_object') \
+            .prefetch_related('content_object__category')
+        context['followed_tags'] = Subscription.objects \
+            .filter(user=self.request.user, is_active=True, content_type=tag_content_type) \
+            .prefetch_related('content_object')
+        return context
 
 
 @require_POST


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4356 

Cette PR ajoute à la page des notifications des options pour voir la liste des forums, membres et tags auxquels on est abonné dans des pop-ups.

### QA

- S'abonner à un tag, un forum et à un membre et vérifier que ces abonnements s'affichent sur la page des notifications.
- Vérifier que se désabonner supprime bien la ligne.
- Vérifier l'exactitude de l'information "Par courriel".
- Code review