### PR TITLE
Fix #4353: curseur pointeur sur bouton déconnexion + menu mobile

### DIFF
--- a/assets/scss/components/_mobile-menu.scss
+++ b/assets/scss/components/_mobile-menu.scss
@@ -229,6 +229,7 @@
                 float: left;
                 height: 50px;
                 width: 50px;
+                cursor: pointer;
 
                 &:after {
                     display: block;

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -467,6 +467,9 @@
     .logbox .dropdown.my-account-dropdown ul li {
         height: 30px;
         line-height: 30px;
+        button {
+            cursor: pointer;
+        }
     }
 
     .lt-ie9 .dropdown {


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4353 

### QA

- Build le front (`make build-front` ou `make watch-front`)
- Vérifier que le curseur sur le bouton de déconnexion est bien en mode "pointeur"
- Idem pour le bouton de menu sur mobile (voir issue pour capture d'écran, il faut redimensionner la fenêtre du navigateur pour le faire apparaître)