### PR TITLE
Fix #4343: corrige l'affiche des filtres sur les contenus

### DIFF
--- a/templates/tutorialv2/index.html
+++ b/templates/tutorialv2/index.html
@@ -179,16 +179,15 @@
             <h3>Filtrer</h3>
             <ul>
                 {% for current_filter in filters %}
-
-                        {% if tutorials %}
-                            <li><a href="{% url 'content:find-tutorial' usr.pk %}?filter={{ current_filter.key }}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
-                        {% elif articles %}
-                            <li><a href="{% url 'content:find-article' usr.pk %}?filter={{ current_filter.key }}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
-                        {% elif opinions %}
-                            {% if current_filter.key != 'validation' and current_filter.key != 'beta' %}
-                                <li><a href="{% url 'content:find-opinion' usr.pk %}?filter={{ current_filter.key }}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
-                            {% endif %}
+                    {% if tutorials != None %}
+                        <li><a href="{% url 'content:find-tutorial' usr.pk %}?filter={{ current_filter.key }}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
+                    {% elif articles != None %}
+                        <li><a href="{% url 'content:find-article' usr.pk %}?filter={{ current_filter.key }}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
+                    {% elif opinions != None %}
+                        {% if current_filter.key != 'validation' and current_filter.key != 'beta' %}
+                            <li><a href="{% url 'content:find-opinion' usr.pk %}?filter={{ current_filter.key }}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
                         {% endif %}
+                    {% endif %}
                 {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4343

### QA

- Aller sur la page des ses articles/tutoriels/bilelts (Mes articles/Mes tutoriels/Mes billets) et vérifier que les filtres fonctionnent bien comme initialement (voir l'issue #4343 pour leur fonctionnement attendu en images)