### PR TITLE
Fix #3432 : corrige l'absence de date de réservation (validation)

### DIFF
--- a/templates/misc/validation.part.html
+++ b/templates/misc/validation.part.html
@@ -20,6 +20,9 @@
 
         {% if validation.date_reserve %}
             {{ validation.date_reserve|format_date:True }}
+            {% if validation.date_proposition > validation.date_reserve  %}
+                ({% trans 'contenu mis à jour depuis la réservation' %})
+            {% endif %}
             <br>
         {% endif %}
     {% endif %}

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -158,6 +158,7 @@ class AskValidationForContent(LoggedWithReadWriteHability, SingleContentFormView
         validation.version = form.cleaned_data['version']
         if old_validator:
             validation.validator = old_validator
+            validation.date_reserve = old_validation.date_reserve
             validation.status = 'PENDING_V'
         validation.save()
 


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #3432

### QA

**Reproduction du bug AVANT de tester ma PR**

1. user : Créer un contenu (article ou tutoriel)
2. admin : Le réserver
3. admin : Vérifier que la date est bien présente dans la page de validation des tutoriels/articles
4. user : Modifier le contenu
5. user: Mettre à jour la validation
6. admin : Vérifier l'absence de la date de réservation du contenu

**Après la PR**

Refaire la manipulation précédente et vérifier la présence de la date dans le sixième point.