### PR TITLE
Permet de dépublier définitivement depuis la page d'un billet

### DIFF
--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -16,6 +16,7 @@ from zds.tutorialv2.models.models_database import PublishableContent
 from django.utils.translation import ugettext_lazy as _
 from zds.member.models import Profile
 from zds.tutorialv2.utils import slugify_raise_on_invalid, InvalidSlugError
+from zds.utils import get_current_user
 from zds.utils.forms import TagValidator
 
 
@@ -1115,6 +1116,8 @@ class UnpublicationForm(forms.Form):
         )
     )
 
+    permanently = forms.BooleanField(label=_(u'Empêcher de futures republications'))
+
     def __init__(self, content, *args, **kwargs):
         super(UnpublicationForm, self).__init__(*args, **kwargs)
 
@@ -1129,13 +1132,19 @@ class UnpublicationForm(forms.Form):
         self.helper.form_class = 'modal modal-flex'
         self.helper.form_id = 'unpublish'
 
-        self.helper.layout = Layout(
+        layout = Layout(
             CommonLayoutModalText(),
             Field('version'),
             StrictButton(
                 _(u'Dépublier'),
                 type='submit')
         )
+
+        user = get_current_user()
+        if user and user.has_perm('tutorialv2.change_validation'):
+            layout.fields.insert(1, Field('permanently'))
+
+        self.helper.layout = layout
 
 
 class PickOpinionForm(forms.Form):

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -610,6 +610,59 @@ class PublishedContentTests(TestCase):
             follow=False)
         self.assertEqual(result.status_code, 403)  # back
 
+    def test_permanently_unpublish_opinion_from_its_page(self):
+        """
+        Check that it's also possible to
+        permanently unpublish an opinion from its page.
+        """
+
+        # create and publish an opinion with user_author
+        opinion = PublishableContentFactory(type='OPINION')
+
+        opinion.authors.add(self.user_author)
+        UserGalleryFactory(gallery=opinion.gallery, user=self.user_author, mode='W')
+        opinion.licence = self.licence
+        opinion.save()
+
+        opinion_draft = opinion.load_version()
+        ExtractFactory(container=opinion_draft, db_object=opinion)
+        ExtractFactory(container=opinion_draft, db_object=opinion)
+
+        self.assertEqual(
+            self.client.login(
+                username=self.user_author.username,
+                password='hostel77'),
+            True)
+
+        result = self.client.post(
+            reverse('validation:publish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            {
+                'source': '',
+                'version': opinion_draft.current_version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        # login with user_staff
+        self.assertEqual(
+            self.client.login(
+                username=self.user_staff.username,
+                password='hostel77'),
+            True)
+
+        # the option should be available
+        result = self.client.post(
+            reverse('validation:unpublish-opinion', kwargs={'pk': opinion.pk, 'slug': opinion.slug}),
+            {
+                'text': 'Test',
+                'permanently': 'on',
+                'version': opinion_draft.current_version
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302)
+        result = self.client.get(opinion.get_absolute_url())
+        self.assertContains(result, _(u'Billet modéré'))
+
     def test_cancel_pick_operation(self):
         opinion = PublishableContentFactory(type='OPINION')
 

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -623,6 +623,12 @@ class UnpublishOpinion(LoginRequiredMixin, SingleOnlineContentFormViewMixin, NoV
         if form.cleaned_data['version'] != self.object.sha_public:
             raise PermissionDenied
 
+        # if the content is permanently unpublished
+        if user.has_perm('tutorialv2.change_validation') and 'permanently' in self.request.POST:
+            PickListOperation.objects.create(content=self.object, operation='REMOVE_PUB',
+                                             staff_user=user, operation_date=datetime.now(),
+                                             version=self.object.sha_public)
+
         unpublish_content(self.object)
 
         # send PM


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

Cette PR permet de dépublier définitivement un billet depuis le formulaire de dépublication disponible sur la page de celui-ci (il n'est plus nécessaire de passer par `Choix des billets`).

### QA

- Publier un billet avec `user`
- Vérifiez que vous pouvez dépublier le billet avec `user`, mais que l'option pour le faire définitivement n'apparaît pas.
- Se connecter comme `admin` et vérifier que vous pouvez dépublier définitivement.
- Vérifier que l'option fonctionne et qu'il n'est plus possible de publier.
- Code review