### PR TITLE
API Membre, ajout d'un accès rapide pour savoir si un utilisateur existe

### DIFF
--- a/zds/member/api/urls.py
+++ b/zds/member/api/urls.py
@@ -3,10 +3,11 @@
 from django.conf.urls import url
 
 from zds.member.api.views import MemberListAPI, MemberDetailAPI, MemberDetailReadingOnly, MemberDetailBan, \
-    MemberMyDetailAPI
+    MemberMyDetailAPI, MemberExistsAPI
 
 urlpatterns = [
     url(r'^$', MemberListAPI.as_view(), name='list'),
+    url(r'^exists/?$', MemberExistsAPI.as_view(), name='exists'),
     url(r'^mon-profil/?$', MemberMyDetailAPI.as_view(), name='profile'),
     url(r'^(?P<user__id>[0-9]+)/?$', MemberDetailAPI.as_view(), name='detail'),
     url(r'^(?P<user__id>[0-9]+)/lecture-seule/?$', MemberDetailReadingOnly.as_view(), name='read-only'),


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | nouvelle fonctionnalité
| Ticket(s) (_issue(s)_) concerné(s)  | #4382 

### QA

- Lancer zds
- Tester l'existence avec un utilisateur qui existe (ex http://127.0.0.1:8000/api/membres/exists/?search=admin) (retourne une 200 et count = 1)
- Tester l'existence avec un utilisateur qui n'existe pas (retourne une 404 et count = 0)