### PR TITLE
Rend les temps de lecture plus cohérent

### DIFF
--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -147,7 +147,7 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
         context['subscriber_count'] = ContentReactionAnswerSubscription.objects.get_subscriptions(self.object).count()
         # We need reading time expressed in minutes
         try:
-            context['reading_time'] = (self.object.public_version.char_count /
+            context['reading_time'] = (self.versioned_object.get_tree_level() * object.public_version.char_count /
                                        settings.ZDS_APP['content']['sec_per_minute'])
         except ZeroDivisionError as e:
             logger.warning('could not compute reading time : setting sec_per_minute is set to zero (error=%s)', e)

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -147,7 +147,7 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
         context['subscriber_count'] = ContentReactionAnswerSubscription.objects.get_subscriptions(self.object).count()
         # We need reading time expressed in minutes
         try:
-            context['reading_time'] = (self.versioned_object.get_tree_level() * object.public_version.char_count /
+            context['reading_time'] = (self.versioned_object.get_tree_level() * self.object.public_version.char_count /
                                        settings.ZDS_APP['content']['sec_per_minute'])
         except ZeroDivisionError as e:
             logger.warning('could not compute reading time : setting sec_per_minute is set to zero (error=%s)', e)


### PR DESCRIPTION
Depuis l'arrivée du temps de lecture, on a remarqué que si cette estimation
était correcte pour les articles et "mini tuto" elle ne l'était pas pour le reste.

Le plus bel exemple reste le tuto arduino qui est sensé prendre moins de 10h à lire.

Pour ces gros tutos, on aura forcément une marge d'erreur assez élevée, mais on peut quand même mettre des valeurs plus logiques.

J'utilise pour cela une astuce qui dit que si un tuto prend la peine de se hiérarchiser, c'est qu'il faudra d'autant plus de temps
pour comprendre (et donc lire) le tuto.

J'utilise donc la profondeur du contenu pour multiplier l'estimation initiale.

Globalement ça veut dire que l'estimation donnée pour arduino sera de 29h et 15minutes au lieu de 9h45.

