### PR TITLE
Fix #4374 : Corrige le robot.txt pour ne pas indexer l'export des billets

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -21,6 +21,6 @@ Disallow: /rechercher/
 Disallow: /tutoriels/html/
 Disallow: /tutoriels/md/
 Disallow: /tutoriels/zip/
-Disallow: /tribunes/html/
-Disallow: /tribunes/md/
-Disallow: /tribunes/zip/
+Disallow: /billets/html/
+Disallow: /billets/md/
+Disallow: /billets/zip/

--- a/robots.txt
+++ b/robots.txt
@@ -13,6 +13,9 @@ User-agent: *
 Disallow: /articles/html/
 Disallow: /articles/md/
 Disallow: /articles/zip/
+Disallow: /billets/html/
+Disallow: /billets/md/
+Disallow: /billets/zip/
 Disallow: /contenus/
 Disallow: /mp/
 Disallow: /oldarticles/
@@ -21,6 +24,3 @@ Disallow: /rechercher/
 Disallow: /tutoriels/html/
 Disallow: /tutoriels/md/
 Disallow: /tutoriels/zip/
-Disallow: /billets/html/
-Disallow: /billets/md/
-Disallow: /billets/zip/


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4374

### QA

- Vérifier que robot.txt soit bien modifié.

---

Par contre les .epub ne sont pas pris en compte pour les articles, tutoriels et zip. Il faut les bloquer aussi ?