### PR TITLE
Upgrade Elasticsearch à la version 5.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,8 @@ before_install:
     # install elasticsearch
     if [[ "$ZDS_TEST_JOB" == *"zds.searchv2"* ]]; then
       # see https://docs.travis-ci.com/user/database-setup/#Installing-specific-versions-of-ElasticSearch
-      curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.0.deb \
-      && sudo dpkg -i --force-confnew elasticsearch-5.3.0.deb \
+      curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.deb \
+      && sudo dpkg -i --force-confnew elasticsearch-5.5.2.deb \
       && sudo service elasticsearch start
     fi
 
@@ -81,7 +81,6 @@ before_install:
       # MySQL config
       ./scripts/ci_mysql_setup.sh
     fi
-
 
 install:
   - |

--- a/doc/source/install/install-es.rst
+++ b/doc/source/install/install-es.rst
@@ -48,9 +48,9 @@ La procédure d'installation, si vous souhaitez utiliser Elasticsearch sans l'in
 
 .. sourcecode:: bash
 
-    wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.0.zip
-    unzip elasticsearch-5.2.0.zip
-    cd elasticsearch-5.2.0/
+    wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.zip
+    unzip elasticsearch-5.5.2.zip
+    cd elasticsearch-5.5.2/
 
 Pour démarrer Elasticsearch, utilisez
 
@@ -93,9 +93,9 @@ Sous Windows
 
 Elasticsearch requiert **la version 8** de Java, que vous pouvez trouver `sur la page officielle de java <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_. Prenez la version correspondante à votre système d'exploitation.
 
-Téléchargez ensuite Elasticsearch à l'adresse suivante : `https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.0.zip <https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.0.zip>`_, puis extrayez le dossier ``elasticsearch-5.2.0`` du zip à l'aide de votre outil préféré.
+Téléchargez ensuite Elasticsearch à l'adresse suivante : `https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.zip <https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.zip>`_, puis extrayez le dossier ``elasticsearch-5.5.2`` du zip à l'aide de votre outil préféré.
 
-Pour démarer Elasticsearch, ouvrez un *shell* (ou un *powershell*) et rendez-vous dans le dossier ``elasticsearch-5.2.0``.
+Pour démarer Elasticsearch, ouvrez un *shell* (ou un *powershell*) et rendez-vous dans le dossier ``elasticsearch-5.5.2``.
 Exécutez ensuite la commande suivante :
 
 .. sourcecode:: bash
@@ -119,18 +119,19 @@ Vous devriez observer une réponse du même genre que celle-ci :
 .. sourcecode:: none
 
     {
-      "name" : "BSe6-yz",
+      "name" : "p0bcxqN",
       "cluster_name" : "elasticsearch",
-      "cluster_uuid" : "ylUZo_xNR3uAofTV0xT_Gw",
+      "cluster_uuid" : "649S5bMUQOyRzYmQFVPA1A",
       "version" : {
-        "number" : "5.2.0",
-        "build_hash" : "5395e21",
-        "build_date" : "2016-12-06T12:36:15.409Z",
+        "number" : "5.5.2",
+        "build_hash" : "19c13d0",
+        "build_date" : "2017-07-18T20:44:24.823Z",
         "build_snapshot" : false,
-        "lucene_version" : "6.3.0"
+        "lucene_version" : "6.6.0"
       },
       "tagline" : "You Know, for Search"
     }
+
 
 Si ce n'est pas le cas, vérifiez que vous avez démarré Elasticsearch.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Implicit dependencies (optional dependencies of dependencies)
 pygments==2.2.0
 python-social-auth==0.2.19
-elasticsearch==5.3.0
-elasticsearch-dsl==5.2.0
+elasticsearch==5.4.0
+elasticsearch-dsl==5.3.0
 
 # Explicit dependencies (references in code)
 Django==1.10.7

--- a/update.md
+++ b/update.md
@@ -1052,7 +1052,6 @@ Ticket #4313
 
 + Via l'admin Django, ajouter la permission `member.change_bannedemailprovider` aux groupes autorisés à gérer les fournisseurs e-mail bannis.
 
-
 Actions à faire pour mettre en prod la version : v25
 ====================================================
 
@@ -1089,3 +1088,10 @@ Node.js, yarn et npm
 Mettre à jour Node.js à la version v8.x.x.
 
 Installer Yarn à la version v0.27.x ou supérieure. Yarn peut-être installé avec `npm i -g yarn`.
+
+Mise à jour d'ElasticSearch (#420)
+----------------------------------
+
+1. `sudo apt update`
+2. `sudo apt upgrade elasticsearch`
+3. `systemctl restart elasticsearch.service`


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | *néant*

Parce que de temps à autres, il faut le faire. Notez d'ailleurs que la version 5.3 [contient un bug](https://www.elastic.co/blog/multi-data-path-bug-in-elasticsearch-5-3-0) (qui ne nous affecte pas dans l'absolu, mais quand même).

### QA

Installer Elasticsearch selon la procédure habituelle, et vérifier que ça fonctionne bien:

```bash
wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.1.zip
unzip elasticsearch-5.5.1.zip
cd elasticsearch-5.5.1/
./bin/elasticsearch
```

Et puis, dans le dossier de zds,

```bash
make install-back # pour mettre à jour les requirements
make index-all # pour réindexer le machin
```


