### PR TITLE
Fixe la taille du  `+` de la recherche dans le menu mobile

### DIFF
--- a/assets/scss/components/_mobile-menu.scss
+++ b/assets/scss/components/_mobile-menu.scss
@@ -30,15 +30,22 @@
             top: 0;
             left: 0;
             width: 100%;
+            display: flex;
+
+            form {
+                flex: 1;
+            }
 
             input {
                 color: #EEE;
                 background-color: #333;
-                width: 76%;
                 height: 30px;
                 padding: 10px 5%;
                 font-size: 16px;
                 font-size: 1.6rem;
+                width: 100%;
+                height: 100%;
+                box-sizing: border-box;
 
                 &:hover,
                 &:focus {
@@ -47,12 +54,14 @@
                     background-color: #333;
                 }
             }
+
             button {
                 display: none;
             }
+
             .search-more {
                 background-color: #3F3F3F;
-                width: 14%;
+                width: 50px;
                 height: 50px;
                 line-height: 50px;
                 color: #CCC;


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4418

Testé vite fait sur Chrome et FF.
