### PR TITLE
`npm run gulp` survit en cas d’erreur

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -117,7 +117,7 @@ gulp.task('images', ['css:sprite'], () =>
         .pipe(gulp.dest('dist/')));
 
 // Watch for file changes
-gulp.task('watch', ['build'], () => {
+gulp.task('watch-runner', () => {
     gulp.watch('assets/js/*.js', ['js']);
     gulp.watch(['assets/{images,smileys}/**/*', '!assets/images/sprite*.png'], ['images']);
     gulp.watch(['assets/scss/**/*.scss', '!assets/scss/_sprite.scss'], ['css']);
@@ -129,6 +129,30 @@ gulp.task('watch', ['build'], () => {
     );
 
     livereload.listen();
+});
+
+// https://github.com/gulpjs/gulp/issues/259#issuecomment-152177973
+gulp.task('watch', cb => {
+    function spawnGulp(args) {
+        return require('child_process')
+            .spawn(
+                'node_modules/.bin/gulp',
+                args,
+                {stdio: 'inherit'}
+            )
+    }
+
+    function spawnBuild() {
+        return spawnGulp(['build'])
+            .on('close', spawnWatch)
+    }
+
+    function spawnWatch() {
+        return spawnGulp(['watch-runner'])
+            .on('close', spawnWatch)
+    }
+
+    spawnBuild();
 });
 
 // Compiles errors' CSS


### PR DESCRIPTION
Avant, `npm run gulp` crashait bêtement lorsqu’on oubliait un `;` dans le CSS. Pas terrible.

Avec ce patch, il continue d’observer les fichiers. Notez que `npm run build` quitte toujours comme il faut (avec un statut non nul) en cas d’erreur (sinon ça serait pas cool pour la CI).

C’est un peu cochon mais Gulp est assez pété “by design”. Si quelqu’un a une meilleure solution, je suis preneur.

C’est basé là-dessus : https://github.com/gulpjs/gulp/issues/259#issuecomment-152177973

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | none

### QA

Testez `npm run gulp` et `npm run build`, avec et sans erreurs dans les `assets/`.