### PR TITLE
[WIP] Ajoute configuration de développement pour docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/Dockerfile_back
+++ b/Dockerfile_back
@@ -22,6 +22,6 @@ COPY requirements.txt requirements-dev.txt Makefile ./
 
 RUN make install-back
 
-ENV DISPLAY=":99.0" PYTHONIOENCODING="utf-8"
+ENV DISPLAY=":99.0" PYTHONIOENCODING="utf-8" DJANGO_SETTINGS_MODULE="zds.settings.docker_dev"
 
 CMD ["./scripts/docker_dev_entrypoint.sh"]

--- a/Dockerfile_back
+++ b/Dockerfile_back
@@ -1,11 +1,11 @@
-FROM debian:stretch
+FROM python:3-stretch
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
-        git python-dev python-setuptools libxml2-dev python-lxml \
-        libxslt-dev libz-dev python-sqlparse libjpeg62-turbo \
+        git python3-setuptools libxml2-dev python3-lxml \
+        libxslt-dev libz-dev python3-sqlparse libjpeg62-turbo \
         libjpeg62-turbo-dev libfreetype6 libfreetype6-dev \
-        libffi-dev python-pip python-tox build-essential \
+        libffi-dev python-tox build-essential \
         xvfb xauth firefox-esr wget \
     && pip install wheel \
     && wget https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz \
@@ -22,6 +22,6 @@ COPY requirements.txt requirements-dev.txt Makefile ./
 
 RUN make install-back
 
-ENV DISPLAY=":99.0"
+ENV DISPLAY=":99.0" PYTHONIOENCODING="utf-8"
 
 CMD ["./scripts/docker_dev_entrypoint.sh"]

--- a/Dockerfile_back
+++ b/Dockerfile_back
@@ -1,13 +1,19 @@
 FROM debian:stretch
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
         git python-dev python-setuptools libxml2-dev python-lxml \
         libxslt-dev libz-dev python-sqlparse libjpeg62-turbo \
         libjpeg62-turbo-dev libfreetype6 libfreetype6-dev \
         libffi-dev python-pip python-tox build-essential \
+        xvfb xauth firefox-esr wget \
     && pip install wheel \
-    && rm -rf /var/lib/apt/lists/*
+    && wget https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz \
+    && tar -xzf geckodriver-v0.16.1-linux64.tar.gz -C /bin/ \
+    && rm -rf /var/lib/apt/lists/* \
+              /var/cache/* \
+              /usr/share/doc/* \
+              /tmp/*
 
 RUN mkdir -p /zds
 WORKDIR /zds
@@ -15,5 +21,7 @@ WORKDIR /zds
 COPY requirements.txt requirements-dev.txt Makefile ./
 
 RUN make install-back
+
+ENV DISPLAY=":99.0"
 
 CMD ["./scripts/docker_dev_entrypoint.sh"]

--- a/Dockerfile_back
+++ b/Dockerfile_back
@@ -1,0 +1,19 @@
+FROM debian:stretch
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git python-dev python-setuptools libxml2-dev python-lxml \
+        libxslt-dev libz-dev python-sqlparse libjpeg62-turbo \
+        libjpeg62-turbo-dev libfreetype6 libfreetype6-dev \
+        libffi-dev python-pip python-tox build-essential \
+    && pip install wheel \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /zds
+WORKDIR /zds
+
+COPY requirements.txt requirements-dev.txt Makefile ./
+
+RUN make install-back
+
+CMD ["./scripts/docker_dev_entrypoint.sh"]

--- a/Dockerfile_front
+++ b/Dockerfile_front
@@ -1,0 +1,12 @@
+FROM node:8
+
+RUN mkdir -p /zds
+WORKDIR /zds
+
+ENV NODE_ENV=development
+
+COPY package.json ./
+
+RUN npm install
+
+CMD ["npm", "run", "gulp"]

--- a/Dockerfile_front
+++ b/Dockerfile_front
@@ -1,12 +1,12 @@
-FROM node:8
+FROM node:8-slim
 
 RUN mkdir -p /zds
 WORKDIR /zds
 
 ENV NODE_ENV=development
 
-COPY package.json ./
+COPY package.json yarn.lock ./
 
-RUN npm install
+RUN yarn
 
-CMD ["npm", "run", "gulp"]
+CMD ["yarn", "run", "gulp"]

--- a/clem
+++ b/clem
@@ -74,8 +74,7 @@ def test_back():
 
 def test_front():
     cmd = [
-        'npm',
-        'run',
+        'yarn',
         'test',
         '--'
     ] + cli_args.ARG
@@ -147,7 +146,7 @@ def wipe():
 
 
 def lint_front():
-    return run('front', ['npm', 'run', 'lint', '--'] + cli_args.ARG)
+    return run('front', ['yarn', 'run', 'lint', '--'] + cli_args.ARG)
 
 
 def lint_back():

--- a/clem
+++ b/clem
@@ -67,7 +67,7 @@ def test_back():
         'python',
         'manage.py',
         'test',
-        '--settings', 'zds.settings_docker_test',
+        '--settings', 'zds.settings.docker_test',
     ] + cli_args.ARG
 
     return run('back', cmd)
@@ -93,7 +93,6 @@ def fixture():
         'python',
         'manage.py',
         'loaddata',
-        '--settings', 'zds.settings_docker_dev',
     ] + files
 
     return compose(['exec', 'back'] + cmd)
@@ -166,7 +165,6 @@ def es():
         'python',
         'manage.py',
         'es_manager',
-        '--settings', 'zds.settings_docker_dev',
     ] + cli_args.ARG
 
     env = {

--- a/clem
+++ b/clem
@@ -1,0 +1,365 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This script must be compatible with Python 2 and Python 3.
+#
+# Ce script doit être compatible avec Python 2 et Python 3. Étant
+# conçu pour lancer docker-compose et étant exécuté en dehors de
+# Docker, on ne peut pas être certain de la version de Python
+# disponible, vu que docker-compose est aussi compatible avec Python 2
+# et Python 3.
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+
+
+# Quick and dirty global variable. Mutated only once.
+cli_args = None
+
+# Another quick and dirty global variable. Contains the names of the
+# services started by the process of this script (we don't care about
+# already running services).
+#
+# This list is used when a KeyboardInterrupt is received in order to
+# stop and remove freshly started services.
+freshly_started_services = []
+
+
+def compose(args, env=None):
+    """
+    Runs docker-compose with some additional args and environment
+    variables. Waits until the docker-compose process exits.
+
+    Returns the exit status code of the spawned process.
+    """
+    if env is None:
+        env = {}
+    merged_env = os.environ.copy()
+    merged_env.update(env)
+
+    project_name = cli_args.project_name
+    if project_name:
+        args = ['--project-name', project_name] + args
+
+    final_args = ['docker-compose'] + args
+    # Print the command like `sh +x` does. It could be helpful.
+    print('+ ' + ' '.join(final_args))
+
+    p = subprocess.Popen(
+        final_args,
+        env=merged_env,
+    )
+    return p.wait()
+
+
+def run(service, args):
+    global freshly_started_services
+    freshly_started_services += [service]
+    return compose(['run', '--rm', '--no-deps', service] + args)
+
+
+def test_back():
+    cmd = [
+        'python',
+        'manage.py',
+        'test',
+        '--settings', 'zds.settings_docker_test',
+    ] + cli_args.ARG
+
+    return run('back', cmd)
+
+
+def test_front():
+    cmd = [
+        'npm',
+        'run',
+        'test',
+        '--'
+    ] + cli_args.ARG
+
+    return run('front', cmd)
+
+
+def fixture():
+    if not len(cli_args.FILE):
+        files = glob.glob('fixtures/*.yaml')
+    else:
+        files = cli_args.FILE
+
+    cmd = [
+        'python',
+        'manage.py',
+        'loaddata',
+        '--settings', 'zds.settings_docker_dev',
+    ] + files
+
+    return compose(['exec', 'back'] + cmd)
+
+
+def up():
+    global freshly_started_services
+
+    services = [
+        'front',
+        'back',
+    ]
+
+    if cli_args.allow_host:
+        allowed_hosts = ','.join(cli_args.allow_host)
+    else:
+        allowed_hosts = ''
+
+    if cli_args.es:
+        elasticsearch = 'enabled'
+        services += ['elasticsearch']
+    else:
+        elasticsearch = ''
+
+    freshly_started_services += services
+
+    return compose(
+        ['up', '--build', '--no-deps'] + services,
+        {
+            # Use str() to convert from unicode
+            'ZDS_PORT': str(cli_args.port),
+            'ZDS_ADDRESS': str(cli_args.address),
+            'ZDS_ALLOWED_HOSTS': str(allowed_hosts),
+            'ZDS_ELASTICSEARCH': str(elasticsearch),
+        },
+    )
+
+
+def down():
+    return compose(['down'])
+
+
+def rm_freshly_started_services():
+    if len(freshly_started_services):
+        return compose(['rm', '--stop'] + freshly_started_services)
+    return 0
+
+
+def wipe():
+    return run('back', ['rm', 'db/base.db'])
+
+
+def lint_front():
+    return run('front', ['npm', 'run', 'lint', '--'] + cli_args.ARG)
+
+
+def lint_back():
+    return run('back', ['make', 'lint-back'])
+
+
+def lint():
+    status_code = lint_back()
+    if status_code:
+        return status_code
+    return lint_front()
+
+
+def es():
+    cmd = [
+        'python',
+        'manage.py',
+        'es_manager',
+        '--settings', 'zds.settings_docker_dev',
+    ] + cli_args.ARG
+
+    env = {
+        'ZDS_ELASTICSEARCH': 'enabled',
+    }
+
+    return compose(['exec', 'back'] + cmd, env)
+
+
+parser = argparse.ArgumentParser(
+    description='''
+    Utilitaire pour utiliser facilement ZdS avec docker-compose.
+    ''',
+    usage='%(prog)s [options] COMMAND [ARGS...]',
+)
+parser.add_argument(
+    '-p', '--project-name',
+    action='store',
+    help='Spécifie un nom de projet alternatif (nom de dossier par défaut)',
+)
+subparsers = parser.add_subparsers()
+
+
+# Python doesn't support block scoping. Let's create functions.
+
+def create_test_parser():
+    parser = subparsers.add_parser(
+        'test',
+        description='Lance les tests.',
+    )
+
+    test_subparsers = parser.add_subparsers()
+
+    def create_back_parser():
+        back_parser = test_subparsers.add_parser(
+            'back',
+            description='Lance les tests du backend.',
+        )
+        back_parser.add_argument(
+            'ARG',
+            nargs='*',
+            help='Arguments à passer au framework de test sous-jacent.'
+        )
+        back_parser.set_defaults(func=test_back)
+
+    def create_front_parser():
+        front_parser = test_subparsers.add_parser(
+            'front',
+            description='Lance les tests du frontend.',
+        )
+        front_parser.add_argument(
+            'ARG',
+            nargs='*',
+            help='Arguments à passer au framework de test sous-jacent.'
+        )
+        front_parser.set_defaults(func=test_front)
+
+    create_back_parser()
+    create_front_parser()
+
+
+def create_up_parser():
+    parser = subparsers.add_parser(
+        'up',
+        description='Démarre ZdS.',
+    )
+    parser.add_argument(
+        '--es', '--elastic', '--elasticsearch',
+        action='store_true',
+        help='Lancer Elasticsearch (attention, prévoyez un bon Gio ' +
+        'de mémoire vive)',
+    )
+    parser.add_argument(
+        '-a', '--address',
+        action='store',
+        help='L’adresse sur laquelle ZdS sera accessible',
+        default="127.0.0.1",
+    )
+    parser.add_argument(
+        '-p', '--port',
+        action='store',
+        help='Le port sur lequel ZdS sera accessible',
+        default=8000,
+    )
+    parser.add_argument(
+        '--allow-host',
+        metavar='HOSTNAME',
+        action='append',
+        help='Rajoute un hôte à la liste ALLOWED_HOSTS dans la ' +
+        'configuration de Django',
+    )
+    parser.set_defaults(func=up)
+
+
+def create_down_parser():
+    parser = subparsers.add_parser(
+        'down',
+        description='''
+        Arrête ZdS. Normalement, vous n’avez pas trop à vous servir de
+        cette commande sauf pour nettoyer des conteneurs arrêtés.
+        ''',
+    )
+    parser.set_defaults(func=down)
+
+
+def create_fixture_parser():
+    parser = subparsers.add_parser(
+        'fixture',
+        description='Applique des fixtures.',
+    )
+    parser.add_argument(
+        'FILE',
+        nargs='*',
+        help='''
+        Noms de fichier des fixtures (par exemple : fixtures/users.yaml).
+        Par défault, toutes les fixtures sont appliquées.
+        À utiliser pendant que le backend tourne.
+        ''',
+    )
+    parser.set_defaults(func=fixture)
+
+
+def create_wipe_parser():
+    parser = subparsers.add_parser(
+        'wipe',
+        description='Supprime la base de données.',
+    )
+    parser.set_defaults(func=wipe)
+
+
+def create_lint_parser():
+    parser = subparsers.add_parser(
+        'lint',
+        description='Vérifie que vous avez pondu du code sw4g.',
+    )
+
+    lint_subparsers = parser.add_subparsers(dest='lint_cmd')
+
+    def create_front_parser():
+        front_parser = lint_subparsers.add_parser(
+            'front',
+            description='Lint le frontend.',
+        )
+        front_parser.add_argument(
+            'ARG',
+            nargs='*',
+            help='Arguments à passer au linter sous-jacent.'
+        )
+        front_parser.set_defaults(func=lint_front)
+
+    def create_all_parser():
+        all_parser = lint_subparsers.add_parser(
+            'all',
+            description='Lint le frontend et le backend.',
+        )
+        all_parser.set_defaults(func=lint)
+
+    create_front_parser()
+    create_all_parser()
+
+
+def create_es_parser():
+    parser = subparsers.add_parser(
+        'es',
+        description='Lancer des commandes de `manage.py es_manager` ' +
+        '(pour Elasticsearch). À utiliser pendant que le backend et ' +
+        'Elasticsearch tournent.',
+    )
+    parser.add_argument(
+        'ARG',
+        nargs='*',
+        help='Arguments à passer à `manage.py es_manager` ' +
+        '(typiquement `setup`, `clear`, index_flagged` ou `index_all`)',
+    )
+    parser.set_defaults(func=es)
+
+
+create_test_parser()
+create_up_parser()
+create_down_parser()
+create_fixture_parser()
+create_wipe_parser()
+create_lint_parser()
+create_es_parser()
+
+cli_args = parser.parse_args()
+
+try:
+    status_code = cli_args.func()
+except KeyboardInterrupt:
+    try:
+        status_code = rm_freshly_started_services()
+    except KeyboardInterrupt:
+        status_code = 1
+
+sys.exit(status_code or 0)

--- a/clem
+++ b/clem
@@ -63,6 +63,7 @@ def run(service, args):
 
 def test_back():
     cmd = [
+        './scripts/docker_start_xvfb.sh',
         'python',
         'manage.py',
         'test',

--- a/clem
+++ b/clem
@@ -137,7 +137,7 @@ def down():
 
 def rm_freshly_started_services():
     if len(freshly_started_services):
-        return compose(['rm', '--stop'] + freshly_started_services)
+        return compose(['rm', '-f', '--stop'] + freshly_started_services)
     return 0
 
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -6,6 +6,11 @@ Si vous voulez installer et démarrer une instance locale de ZdS, vous devez cli
 
 .. toctree::
    :maxdepth: 2
-   :glob:
 
-   install/*
+   install/docker
+   install/backend-linux-install
+   install/backend-os-x-install
+   install/backend-windows-install
+   install/frontend-install
+   install/install-es
+   install/deploy-in-production

--- a/doc/source/install/docker.rst
+++ b/doc/source/install/docker.rst
@@ -1,0 +1,86 @@
+======
+Docker
+======
+
+Il est possible de faire tourner facilement ZdS avec Docker et
+docker-compose. Notez que c’est encore un peu expérimental.
+
+
+Démarrage rapide
+----------------
+
+`Installez Docker et docker-compose`__ (vous aurez besoin des deux).
+
+.. __: https://docs.docker.com/compose/install/
+
+Clonez le dépot de ZdS avec Git et rendez-vous dans le dossier cloné :
+
+.. code-block:: sh
+
+   $ cd zds-site
+
+Installez et démarrer le site :
+
+.. code-block:: sh
+
+   $ ./clem up
+
+Ce script ``clem`` va se charger de télécharger toutes les
+dépendances, de démarrer les conteneurs Docker et de tout installer
+automatiquement. Ceci peut prendre un certain temps.
+
+À la fin, les migrations sont appliquées et vous pourrez accéder au
+site à l’addresses http://localhost:8000.
+
+Appuyez sur Ctrl+C pour tout arrêter.
+
+
+Commandes principales de ``clem``
+---------------------------------
+
+``./clem --help``
+   Affiche une courte aide et liste les commandes disponibles. Vous
+   pouvez aussi utiliser cette option sur une commande spécifique.
+
+``./clem up``
+   Démarre ZdS. Écoute par défaut sur le port 8000. Vous pouvez
+   utiliser un autre port avec ``--port 1234``.
+
+``./clem test back``
+   Lance les tests du backend. Tous les arguments suivants sont passés
+   au framework de test de Django. Par
+   exemple, ``./clem test back zds.member`` lance uniquement les tests
+   des membres.
+
+``./clem test front``
+   Lance les tests du frontend. Tous les arguments suivants sont aussi
+   passés à Gulp (mais comme il n’y a pas de tests, pour l’instant
+   ce n’est pas très utile).
+
+``./clem fixture``
+   Applique des fixtures. Par défaut, toutes les fixtures sont appliquées
+   mais vous pouvez spécifier un nom de
+   fichier : ``./clem fixture fixtures/users.yaml``.
+   À utiliser pendant que le backend tourne.
+
+``./clem wipe``
+   Supprime la base de données.
+
+``./clem lint back``
+   Lint le backend.
+
+``./clem lint frontend``
+   Lint le frontend.
+
+``./clem lint all``
+   Lint le backend et le frontend.
+
+``./clem es``
+   Lance des commandes de `manage.py es_manager` (pour Elasticsearch).
+   À utiliser pendant que le backend et Elasticsearch tournent.
+
+
+Notez que ces commandes ne sont pas toutes conçues pour être lancées
+en parallèle. Mais en pratique, vous pouvez par exemple lancer
+``./clem up`` dans un terminal et pendant ce temps lancer ``./clem
+test back`` dans un autre.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,27 @@ services:
       - ./tox.ini:/zds/tox.ini:ro
       - ./zds:/zds/zds:ro
     ports:
-      - 8000:8000
+      - "${ZDS_ADDRESS:-127.0.0.1}:${ZDS_PORT:-8000}:8000"
+    environment:
+      # An optional comma-separated list of the hostnames to allow.
+      # Sets Django’s ALLOWED_HOSTS configuration variable.
+      - "ZDS_ALLOWED_HOSTS=${ZDS_ALLOWED_HOSTS}"
+      # Elasticsearch is enabled if this variable is nonempty
+      - "ZDS_ELASTICSEARCH=${ZDS_ELASTICSEARCH}"
+    links:
+      - elasticsearch
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
+    environment:
+      - "http.host=0.0.0.0"
+      - "transport.host=127.0.0.1"
+      - "xpack.security.enabled=false"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    volumes:
+      - elasticsearch:/usr/share/elasticsearch/data
 
 volumes:
   dist:
   db:
+  elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3'
+
+services:
+  front:
+    build:
+      context: .
+      dockerfile: Dockerfile_front
+    volumes:
+      - ./assets:/zds/assets:ro
+      - ./Gulpfile.js:/zds/Gulpfile.js:ro
+      - dist:/zds/dist
+
+  back:
+    build:
+      context: .
+      dockerfile: Dockerfile_back
+    volumes:
+      - db:/zds/db
+      - ./.git:/zds/.git:ro
+      - dist:/zds/dist:ro
+      - ./export-assets:/zds/export-assets:ro
+      - ./fixtures:/zds/fixtures:ro
+      - ./geodata:/zds/geodata:ro
+      - ./manage.py:/zds/manage.py:ro
+      - ./quotes.txt:/zds/quotes.txt:ro
+      - ./scripts:/zds/scripts:ro
+      - ./templates:/zds/templates:ro
+      - ./tox.ini:/zds/tox.ini:ro
+      - ./zds:/zds/zds:ro
+    ports:
+      - 8000:8000
+
+volumes:
+  dist:
+  db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,27 +6,27 @@ services:
       context: .
       dockerfile: Dockerfile_front
     volumes:
-      - ./assets:/zds/assets:ro
-      - ./Gulpfile.js:/zds/Gulpfile.js:ro
-      - dist:/zds/dist
+      - ./assets:/zds/assets:ro,Z
+      - ./Gulpfile.js:/zds/Gulpfile.js:ro,Z
+      - dist:/zds/dist:z
 
   back:
     build:
       context: .
       dockerfile: Dockerfile_back
     volumes:
-      - db:/zds/db
-      - ./.git:/zds/.git:ro
-      - dist:/zds/dist:ro
-      - ./export-assets:/zds/export-assets:ro
-      - ./fixtures:/zds/fixtures:ro
-      - ./geodata:/zds/geodata:ro
-      - ./manage.py:/zds/manage.py:ro
-      - ./quotes.txt:/zds/quotes.txt:ro
-      - ./scripts:/zds/scripts:ro
-      - ./templates:/zds/templates:ro
-      - ./tox.ini:/zds/tox.ini:ro
-      - ./zds:/zds/zds:ro
+      - db:/zds/db:Z
+      - ./.git:/zds/.git:ro,Z
+      - dist:/zds/dist:ro,z
+      - ./export-assets:/zds/export-assets:ro,Z
+      - ./fixtures:/zds/fixtures:ro,Z
+      - ./geodata:/zds/geodata:ro,Z
+      - ./manage.py:/zds/manage.py:ro,Z
+      - ./quotes.txt:/zds/quotes.txt:ro,Z
+      - ./scripts:/zds/scripts:ro,Z
+      - ./templates:/zds/templates:ro,Z
+      - ./tox.ini:/zds/tox.ini:ro,Z
+      - ./zds:/zds/zds:ro,Z
     ports:
       - "${ZDS_ADDRESS:-127.0.0.1}:${ZDS_PORT:-8000}:8000"
     environment:

--- a/scripts/docker_dev_entrypoint.sh
+++ b/scripts/docker_dev_entrypoint.sh
@@ -4,5 +4,5 @@ cd "$(dirname "$0")"
 
 cd ..
 
-python manage.py migrate --settings zds.settings.docker_dev
-exec python manage.py runserver 0.0.0.0:8000 --settings zds.settings.docker_dev
+python manage.py migrate
+exec python manage.py runserver 0.0.0.0:8000

--- a/scripts/docker_dev_entrypoint.sh
+++ b/scripts/docker_dev_entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+cd "$(dirname "$0")"
+
+cd ..
+
+python manage.py migrate --settings zds.settings.docker_dev
+exec python manage.py runserver 0.0.0.0:8000 --settings zds.settings.docker_dev

--- a/scripts/docker_start_xvfb.sh
+++ b/scripts/docker_start_xvfb.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+XVFB_WHD=${XVFB_WHD:-1280x720x16}
+
+Xvfb $DISPLAY -ac -screen 0 $XVFB_WHD -nolisten tcp &
+
+exec $@

--- a/zds/settings/docker.py
+++ b/zds/settings/docker.py
@@ -1,0 +1,27 @@
+from os.path import join
+
+from .abstract_base import *
+
+DB_DIR = join(BASE_DIR, 'db')
+
+# We can't use a Docker volume on a single file. We have to move the
+# database to a separate directory.
+DATABASES['default']['NAME'] = join(DB_DIR, 'base.db')
+MEDIA_ROOT = join(DB_DIR, 'media')
+STATIC_ROOT = join(DB_DIR, 'static')
+STATICFILES_DIRS = (
+    join(BASE_DIR, 'dist'),
+)
+
+ZDS_APP['article']['repo_path'] = join(DB_DIR, 'articles-data')
+
+ZDS_APP['opinions']['repo_path'] = join(DB_DIR, 'opinions-data')
+
+ZDS_APP['tutorial']['repo_path'] = join(DB_DIR, 'tutoriels-private')
+ZDS_APP['tutorial']['repo_public_path'] = join(DB_DIR, 'tutoriels-public')
+
+ZDS_APP['content']['repo_private_path'] = join(DB_DIR, 'contents-private')
+ZDS_APP['content']['repo_public_path'] = join(DB_DIR, 'contents-public')
+# I have no idea wtf is this
+ZDS_APP['content']['extra_content_watchdog_dir'] = join(
+    DB_DIR, 'watchdog-build')

--- a/zds/settings/docker.py
+++ b/zds/settings/docker.py
@@ -1,6 +1,11 @@
+import os
 from os.path import join
 
 from .abstract_base import *
+
+allowed_hosts_string = os.environ.get('ZDS_ALLOWED_HOSTS')
+if allowed_hosts_string:
+    ALLOWED_HOSTS = allowed_hosts_string.split(',')
 
 DB_DIR = join(BASE_DIR, 'db')
 
@@ -22,6 +27,14 @@ ZDS_APP['tutorial']['repo_public_path'] = join(DB_DIR, 'tutoriels-public')
 
 ZDS_APP['content']['repo_private_path'] = join(DB_DIR, 'contents-private')
 ZDS_APP['content']['repo_public_path'] = join(DB_DIR, 'contents-public')
-# I have no idea wtf is this
-ZDS_APP['content']['extra_content_watchdog_dir'] = join(
-    DB_DIR, 'watchdog-build')
+
+# No need to set 'extra_content_watchdog_dir' since
+# 'extra_content_generation_policy' is 'SYNC' by default.
+
+
+if os.environ.get('ZDS_ELASTICSEARCH'):
+    ES_CONNECTIONS = {
+        'default': {
+            'hosts': ['elasticsearch:9200'],
+        }
+    }

--- a/zds/settings/docker_dev.py
+++ b/zds/settings/docker_dev.py
@@ -1,0 +1,2 @@
+from .docker import *
+from .dev import *

--- a/zds/settings/docker_test.py
+++ b/zds/settings/docker_test.py
@@ -1,0 +1,15 @@
+from .test import *
+from .docker import *
+
+# Unlike settings_docker_test.py, we don't change the database
+# location here.  We don't care if the database file is outside of the
+# volume, we don't care about persistence.
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/tmp/django_cache',
+    }
+}
+
+ZDS_APP['site']['secure_url'] = u'http://127.0.0.1:8000'


### PR DESCRIPTION
Les images se basent sur Debian et pas sur Alpine suite à quelques
problèmes de paquets binaires pas distribués pour musl.

Le conteneur du frontend a un accès en lecture seule aux sources, dans
le dossier `assets/`. Il fait tourner uniquement le processus de Gulp,
qui observe tous les fichiers et met à jour un volume monté sur
`dist/` dès le moindre changement.

Ce même volume `dist/` est monté en lecture seule dans le conteneur du
backend, qui fait tourner le processus de Django. Le dossier `zds/`
est également partagé en lecture seule.

La BDD, les fichiers des tutos et ceux des utilisateurs sont dans un
volume nommé, ils persistent.

Il n’y pas de LaTeX.

Il va falloir aussi rajouter un service pour le serveur de zmarkdown par la suite.

-------

Ajoute `clem`, script pour utiliser docker-compose facilement

Je pense que c’est l’idéal pour des gens qui veulent débugger
rapidement un bout de JS sans avoir à lire un tas de documentation
sur comment se servir de Docker.

Ajoute également une petite page de documentation là-dessus.

-----

Notez que j’utilise tout ceci depuis le début, je n’ai d’ailleurs jamais installé ZdS en “dur” sur mon PC. Cette PR a beaucoup évoluée depuis que je l’ai ouverte, il y a maintenant `clem`, de la documentation, des images plus légères et un support d’Elasticsearch.

----

- [ ] Il y a un petit problème quand on arrête `clem` avec un Ctrl+C. Ça s’arrête mais `docker-compose down` reste attaché bizarrement au terminal.

### Contrôle qualité

Vous devez [installer Docker et docker-compose](https://docs.docker.com/compose/install/).

1. Lancer `./clem up` et attendez (longtemps)
2. http://localhost:8000/
3. Il n’y a pas de troisème étape.

Consultez la documentation (ou `clem --help`) et testez le reste (Elasticsearch, fixtures, tests unitaires, …).