### PR TITLE
Makefile : Supprime les options de flake8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ install-back:
 	pip install --upgrade -r requirements.txt -r requirements-dev.txt
 
 lint-back:
-	flake8 --exclude=migrations --max-line-length=120 zds
+	flake8 zds
 
 report-release-back:
 	python scripts/release_generator.py

--- a/doc/source/utils/git-pre-hook.rst
+++ b/doc/source/utils/git-pre-hook.rst
@@ -18,7 +18,7 @@ restera propre et lisible au cours du temps !
 
     #!/bin/sh
 
-    flake8 --exclude=migrations --max-line-length=120 zds
+    flake8 zds
 
     # Store tests result
     RESULT=$?


### PR DESCRIPTION
flake8 va lire ses options depuis le tox.ini :

http://flake8.pycqa.org/en/latest/user/configuration.html

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | aucune

### QA

`make lint-back`