### PR TITLE
[WIP] Remplace `import zds.settings` par `import django.conf`

### DIFF
--- a/zds/featured/managers.py
+++ b/zds/featured/managers.py
@@ -2,8 +2,7 @@
 from datetime import datetime
 
 from django.db import models
-
-from zds import settings
+from django.conf import settings
 
 
 class FeaturedResourceManager(models.Manager):

--- a/zds/featured/views.py
+++ b/zds/featured/views.py
@@ -11,8 +11,8 @@ from django.utils.translation import ugettext as _
 from django.views.generic import CreateView, RedirectView, UpdateView
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.list import MultipleObjectMixin
+from django.conf import settings
 
-from zds import settings
 from zds.featured.forms import FeaturedResourceForm, FeaturedMessageForm
 from zds.featured.models import FeaturedResource, FeaturedMessage
 from zds.utils.paginator import ZdSPagingListView

--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -14,8 +14,7 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
-
-from zds.settings import MEDIA_ROOT, MEDIA_URL
+from django.conf.settings import MEDIA_ROOT, MEDIA_URL
 
 
 # Models settings
@@ -123,7 +122,7 @@ class Image(models.Model):
         :return: Image object URL
         :rtype: str
         """
-        return '{0}/{1}'.format(MEDIA_URL, self.physical)
+        return '{0}/{1}'.format(media.MEDIA_URL, self.physical)
 
     def get_extension(self):
         """Get the extension of an image (used in tests).
@@ -181,7 +180,7 @@ class Gallery(models.Model):
         :return: filesystem path to this gallery root
         :rtype: unicode
         """
-        return os.path.join(MEDIA_ROOT, 'galleries', str(self.pk))
+        return os.path.join(settings.MEDIA_ROOT, 'galleries', str(self.pk))
 
     def get_linked_users(self):
         """Get all the linked users for this gallery whatever their rights

--- a/zds/member/factories.py
+++ b/zds/member/factories.py
@@ -1,10 +1,10 @@
 # coding: utf-8
 
 from django.contrib.auth.models import User, Permission, Group
+from django.conf import settings
 import factory
 
 from zds.member.models import Profile
-from zds import settings
 
 
 class UserFactory(factory.DjangoModelFactory):

--- a/zds/middlewares/setlastvisitmiddleware.py
+++ b/zds/middlewares/setlastvisitmiddleware.py
@@ -1,8 +1,8 @@
 import datetime
 
+from django.conf import settings
 from django.contrib.auth import logout
 
-from zds import settings
 from zds.member.views import get_client_ip
 
 

--- a/zds/middlewares/tests_setlastvisitmiddleware.py
+++ b/zds/middlewares/tests_setlastvisitmiddleware.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 
+from django.conf import settings
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
@@ -9,7 +10,6 @@ from django.shortcuts import get_object_or_404
 
 from zds.member.factories import ProfileFactory
 from zds.member.models import Profile
-from zds import settings
 
 
 overrided_zds_app = settings.ZDS_APP

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -4,6 +4,7 @@ from django.utils.encoding import python_2_unicode_compatible
 import logging
 from smtplib import SMTPException
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -13,7 +14,6 @@ from django.db import models, IntegrityError
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
-from zds import settings
 from zds.forum.models import Topic
 from zds.member.models import Profile
 from zds.notification.managers import NotificationManager, SubscriptionManager, TopicFollowedManager, \

--- a/zds/notification/views.py
+++ b/zds/notification/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
 from django.utils.decorators import method_decorator
@@ -8,7 +9,6 @@ from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import redirect
 from django.core.urlresolvers import reverse
 
-from zds import settings
 from zds.mp.models import PrivateTopic
 from zds.notification.models import Notification
 from zds.utils.paginator import ZdSPagingListView

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -16,13 +16,13 @@ from django.views.generic import ListView, DetailView
 from django.views.generic.edit import FormView
 from django.core.exceptions import PermissionDenied
 from django.views.decorators.http import require_POST
+from django.conf.settings import ZDS_APP, BASE_DIR
 
 from zds.featured.models import FeaturedResource, FeaturedMessage
 from zds.forum.models import Forum, Topic
 from zds.member.decorator import can_write_and_read_now
 from zds.pages.forms import AssocSubscribeForm
 from zds.pages.models import GroupContact
-from zds.settings import BASE_DIR, ZDS_APP
 from zds.searchv2.forms import SearchForm
 from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent
 from zds.utils.forums import create_topic
@@ -36,8 +36,10 @@ def home(request):
     articles = PublishableContent.objects.get_last_articles()
     opinions = PublishableContent.objects.get_last_opinions()
 
+    quotes_file_path = os.path.join(BASE_DIR, 'quotes.txt')
+
     try:
-        with open(os.path.join(BASE_DIR, 'quotes.txt'), 'r') as quotes_file:
+        with open(quotes_file_path, 'r') as quotes_file:
             quote = random.choice(quotes_file.readlines())
     except IOError:
         quote = ZDS_APP['site']['slogan']

--- a/zds/searchv2/forms.py
+++ b/zds/searchv2/forms.py
@@ -5,7 +5,6 @@ import random
 from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-from zds.settings import BASE_DIR
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
@@ -47,8 +46,10 @@ class SearchForm(forms.Form):
         self.helper.form_method = 'get'
         self.helper.form_action = reverse('search:query')
 
+        suggestions_file_path = os.path.join(settings.BASE_DIR, 'suggestions.txt')
+
         try:
-            with open(os.path.join(BASE_DIR, 'suggestions.txt'), 'r') as suggestions_file:
+            with open(suggestions_file_path, 'r') as suggestions_file:
                 suggestions = ', '.join(random.sample(suggestions_file.readlines(), 5)) + u'…'
         except IOError:
             suggestions = _(u'Mathématiques, Droit, UDK, Langues, Python…')

--- a/zds/tutorialv2/feeds.py
+++ b/zds/tutorialv2/feeds.py
@@ -2,11 +2,9 @@
 
 from django.contrib.syndication.views import Feed
 from django.conf import settings
-
 from django.utils.feedgenerator import Atom1Feed
 
 from zds.tutorialv2.models.models_database import PublishedContent
-from zds.settings import ZDS_APP
 
 
 class LastContentFeedRSS(Feed):

--- a/zds/tutorialv2/management/commands/adjust_slugs.py
+++ b/zds/tutorialv2/management/commands/adjust_slugs.py
@@ -3,7 +3,8 @@ import os
 from uuslug import slugify
 
 from django.core.management.base import BaseCommand
-from zds.settings import ZDS_APP
+from django.conf.settings import ZDS_APP
+
 from zds.tutorialv2.models.models_database import PublishableContent
 
 

--- a/zds/tutorialv2/management/commands/generate_pdf.py
+++ b/zds/tutorialv2/management/commands/generate_pdf.py
@@ -2,9 +2,11 @@
 
 import os
 import subprocess
+
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils.translation import ugettext_lazy as _
-from zds import settings
+
 from zds.tutorialv2.models.models_database import PublishedContent
 
 

--- a/zds/tutorialv2/management/commands/migrate_to_zep25.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep25.py
@@ -1,12 +1,12 @@
 # coding: utf-8
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.utils.text import slugify
 
-from zds import settings
 from zds.tutorialv2.models.models_database import PublishableContent
 from zds.utils.models import Category, SubCategory, CategorySubCategory, Tag
 from zds.utils.mps import send_mp

--- a/zds/tutorialv2/management/commands/publication_watchdog.py
+++ b/zds/tutorialv2/management/commands/publication_watchdog.py
@@ -3,14 +3,15 @@ from os.path import dirname, join
 import os
 import time
 
-import shutil
+from codecs import open
 from django.core.management import BaseCommand
+from django.conf import settings
 from pathtools.path import listdir
+import shutil
 from watchdog.observers import Observer
 from watchdog.events import FileCreatedEvent, FileSystemEventHandler, LoggingEventHandler
-from zds import settings
+
 from zds.tutorialv2.publication_utils import generate_exernal_content
-from codecs import open
 
 
 class TutorialIsPublished(FileSystemEventHandler):

--- a/zds/tutorialv2/models/models_versioned.py
+++ b/zds/tutorialv2/models/models_versioned.py
@@ -12,7 +12,6 @@ from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from zds.settings import ZDS_APP
 from zds.tutorialv2.models.mixins import TemplatableContentModelMixin
 from zds.tutorialv2.utils import default_slug_pool, export_content, get_commit_author, InvalidOperationError
 from zds.utils.misc import compute_hash
@@ -217,7 +216,7 @@ class Container:
         :rtype: bool
         """
         if not self.has_extracts():
-            if self.get_tree_depth() < ZDS_APP['content']['max_tree_depth'] - 1:
+            if self.get_tree_depth() < settings.ZDS_APP['content']['max_tree_depth'] - 1:
                 if not self.top_container().type in SINGLE_CONTAINER:
                     return True
         return False
@@ -229,7 +228,7 @@ class Container:
         :rtype: bool
         """
         if not self.has_sub_containers():
-            if self.get_tree_depth() <= ZDS_APP['content']['max_tree_depth']:
+            if self.get_tree_depth() <= settings.ZDS_APP['content']['max_tree_depth']:
                 return True
         return False
 

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -8,13 +8,13 @@ import subprocess
 import zipfile
 from datetime import datetime
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
 from django.utils import translation
 from django.utils.translation import ugettext_lazy as _
 from os.path import isdir, dirname
-from zds import settings
-from zds.settings import ZDS_APP
+
 from zds.tutorialv2.models.models_database import ContentReaction
 from zds.tutorialv2.signals import content_unpublished
 from zds.tutorialv2.utils import retrieve_and_update_images_links
@@ -165,7 +165,7 @@ def generate_exernal_content(base_name, extra_contents_path, md_file_path, pando
     :return:
     """
     excluded = []
-    if not ZDS_APP['content']['build_pdf_when_published'] and not overload_settings:
+    if not settings.ZDS_APP['content']['build_pdf_when_published'] and not overload_settings:
         excluded.append('pdf')
     for __, publicator in PublicatorRegistery.get_all_registered(excluded):
 

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -12,13 +12,13 @@ except ImportError:
 import os
 from PIL import Image as ImagePIL
 from django.contrib.auth.models import User
+from django.conf import settings
 from django.http import Http404
 from django.utils.translation import ugettext_lazy as _
 from git import Repo, Actor
 from lxml import etree
 from uuslug import slugify
 
-from zds import settings
 from zds.notification import signals
 from zds.tutorialv2 import REPLACE_IMAGE_PATTERN, VALID_SLUG
 from zds.tutorialv2.models import CONTENT_TYPE_LIST

--- a/zds/utils/factories.py
+++ b/zds/utils/factories.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from zds.utils.models import HelpWriting
 from zds.utils import slugify
-from zds.settings import BASE_DIR, MEDIA_ROOT
+from django.conf.settings import BASE_DIR, MEDIA_ROOT
 from shutil import copyfile
 from os.path import basename, join
 

--- a/zds/utils/management/commands/load_factory_data.py
+++ b/zds/utils/management/commands/load_factory_data.py
@@ -4,9 +4,9 @@ import glob
 import os
 import yaml
 
+from django.conf.settings import MEDIA_ROOT
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from zds.settings import MEDIA_ROOT
 
 
 @transaction.atomic

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -6,10 +6,11 @@ import time
 
 from datetime import datetime
 from django.core.management.base import BaseCommand
+from django.conf import settings
 from random import randint
 from faker import Factory
-from zds.utils.templatetags.emarkdown import emarkdown
 
+from zds.utils.templatetags.emarkdown import emarkdown
 from zds.forum.factories import CategoryFactory, ForumFactory, TopicFactory, PostFactory
 from zds.gallery.factories import GalleryFactory, UserGalleryFactory, ImageFactory
 from zds.member.factories import StaffProfileFactory, ProfileFactory
@@ -18,7 +19,6 @@ from zds.member.models import Profile
 from zds.forum.models import Forum, Topic, Category as FCategory
 from zds.utils.models import Tag, Category as TCategory, CategorySubCategory, SubCategory, Licence
 from zds.utils import slugify
-from zds import settings
 from django.db import transaction
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, \
     Validation as CValidation, ContentReactionFactory

--- a/zds/utils/management/commands/pdf_generator.py
+++ b/zds/utils/management/commands/pdf_generator.py
@@ -1,8 +1,9 @@
 # coding: utf-8
 
 from django.core.management.base import BaseCommand
+from django.conf import settings
+
 from zds.tutorial.models import Tutorial
-from zds import settings
 import os
 
 

--- a/zds/utils/mixins.py
+++ b/zds/utils/mixins.py
@@ -3,7 +3,8 @@ from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext as _
-from zds import settings
+from django.conf.settings import ZDS_APP
+
 from zds.utils.models import Comment
 
 
@@ -67,5 +68,5 @@ class QuoteMixin(object):
         return _(u'{0}Source:[{1}]({2}{3})').format(
             text,
             post_cite.author.username,
-            settings.ZDS_APP['site']['url'],
+            ZDS_APP['site']['url'],
             post_cite.get_absolute_url())

--- a/zds/utils/paginator.py
+++ b/zds/utils/paginator.py
@@ -4,8 +4,7 @@ from django.views.generic import ListView
 from django.views.generic.list import MultipleObjectMixin
 from django.core.paginator import Paginator, EmptyPage
 from django.http import Http404
-
-from zds.settings import ZDS_APP
+from django.conf.settings import ZDS_APP
 
 
 class ZdSPagingListView(ListView):

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from django import template
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 
 from zds.forum.models import Post, is_read as topic_is_read
 from zds.mp.models import PrivateTopic
@@ -15,7 +16,6 @@ from zds.notification.models import Notification, TopicAnswerSubscription, Conte
 from zds.tutorialv2.models.models_database import ContentReaction, PublishableContent
 from zds.utils import get_current_user
 from zds.utils.models import Alert
-from zds import settings
 from zds.tutorialv2.models import TYPE_CHOICES_DICT
 from zds.member.models import NewEmailProvider
 

--- a/zds/utils/templatetags/remove_url_protocole.py
+++ b/zds/utils/templatetags/remove_url_protocole.py
@@ -1,5 +1,5 @@
 from django import template
-from zds.settings import ZDS_APP
+from django.conf.settings import ZDS_APP
 
 
 register = template.Library()

--- a/zds/utils/templatetags/smileysDef.py
+++ b/zds/utils/templatetags/smileysDef.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import os
-from zds import settings
+from django.conf import settings
 
 SMILEYS_BASE_URL = os.path.join(settings.STATIC_URL, 'smileys')
 


### PR DESCRIPTION
Avant ce commit, lorsque l’on faisait :

    $ manage.py runserver 0.0.0.0:8000 --settings zds.my_custom_settings

`zds.settings` restait `zds.settings` alors que `django.conf` vallait
`zds.my_custom_settings`.

- [x] Remplacement fait sur les sources
- [ ] Remplacement fait sur les tests

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | (ex : #4435)

### QA

Si les tests passent, à priori c’est bon.