### PR TITLE
[betafix] Corrige la pagination du nombre de messages d'un utilisateur

### DIFF
--- a/templates/forum/find/post.html
+++ b/templates/forum/find/post.html
@@ -29,6 +29,17 @@
 
 
 {% block content %}
+
+    {% if hidden_posts_count %}
+        <p class="alert-box info">
+            {% blocktrans count counter=hidden_posts_count %}
+                {{ counter }} message est invisible car dans un sujet inaccessible.
+            {% plural %}
+                {{ counter }} messages sont invisibles car dans un sujet inaccessible.
+            {% endblocktrans %}
+        </p>
+    {% endif %}
+
     {% include "misc/paginator.html" with position="top" %}
 
     {% if posts %}
@@ -75,14 +86,4 @@
     {% endif %}
 
     {% include "misc/paginator.html" with position="bottom" %}
-
-    {% if hidden_messages_count %}
-        <em>
-            {% blocktrans count counter=hidden_messages_count %}
-                Note : {{ counter }} message est invisible car dans un sujet inaccessible.
-            {% plural %}
-                Note : {{ counter }} messages sont invisibles car dans un sujet inaccessible.
-            {% endblocktrans %}
-        </em>
-    {% endif %}
 {% endblock %}

--- a/templates/forum/find/topic.html
+++ b/templates/forum/find/topic.html
@@ -28,6 +28,17 @@
 
 
 {% block content %}
+
+    {% if hidden_topics_count %}
+        <p class="alert-box info">
+            {% blocktrans count counter=hidden_topics_count %}
+                {{ counter }} sujet est invisible car dans un forum inaccessible.
+            {% plural %}
+                {{ counter }} sujets sont invisibles car dans un forum inaccessible.
+            {% endblocktrans %}
+        </p>
+    {% endif %}
+
     {% include "misc/paginator.html" with position="top" %}
 
     {% if topics %}
@@ -72,14 +83,4 @@
     {% endif %}
 
     {% include "misc/paginator.html" with position="bottom" %}
-
-    {% if hidden_topics_count %}
-        <em>
-            {% blocktrans count counter=hidden_topics_count %}
-                Note : {{ counter }} sujet est invisible car dans un forum inaccessible.
-            {% plural %}
-                Note : {{ counter }} sujets sont invisibles car dans un forum inaccessible.
-            {% endblocktrans %}
-        </em>
-    {% endif %}
 {% endblock %}

--- a/zds/forum/managers.py
+++ b/zds/forum/managers.py
@@ -131,16 +131,12 @@ class PostManager(InheritanceManager):
         if not current.has_perm('forum.change_post'):
             queryset = queryset.filter(is_visible=True)
 
-        full_queryset_len = queryset.count()
-        queryset = queryset.filter(self.visibility_check_query(current))
-        hidden_messages_count = full_queryset_len - queryset.count()
+        queryset = queryset\
+            .filter(self.visibility_check_query(current))\
+            .prefetch_related('author')\
+            .order_by('-pubdate')
 
-        queryset = queryset.prefetch_related('author').order_by('-pubdate').all()
-
-        return {
-            'posts': queryset,
-            'hidden_messages_count': hidden_messages_count,
-        }
+        return queryset
 
 
 class TopicReadManager(models.Manager):


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4428 

**Note:** j'ai pas regardé les tests, j'attend Travis :p 

### QA

- Créer un forum caché via l'adminstration, avec accès pour le staff
- Avec `admin`, créer un topic dans ce forum caché et un topic dans un forum pas caché. Répondez également à un troisième puis un 4ième topic.
- `settings.ZDS_APP['forum']['posts_per_page'] = 2`
- Avec `user`, rendez vous sur la page de profil de `admin`. Constatez qu'il y a deux topics et deux messages. Allez voir le détail et constatez qu'il est indiqué qu'un message est inaccessible, et un post inaccessible. Constatez que la pagination fonctionne.
- Avec `admin`, message et topic cachés devraient apparaitre, et l'indication disparaitre
- Code review