### PR TITLE
Corrige l'affichage du tableau sur les petits écrans (#4427)

### DIFF
--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -26,18 +26,18 @@
     {% if alerts %}
         <table class="fullwidth">
             <thead>
-                <th>{% trans "Type" %}</th>
+                <th class="wide">{% trans "Type" %}</th>
                 <th>{% trans "Auteur" %}</th>
-                <th>{% trans "Date" %}</th>
+                <th class="wide">{% trans "Date" %}</th>
                 <th>{% trans "Contenu signalé" %}</th>
                 <th>{% trans "Auteur du message" %}</th>
             </thead>
             <tbody>
                 {% for alert in alerts %}
                     <tr>
-                        <td>{{ alert.get_type }}</td>
+                        <td class="wide">{{ alert.get_type }}</td>
                         <td><a href="{% url 'member-detail' alert.author.username %}">{{ alert.author.username }}</a></td>
-                        <td>{{ alert.pubdate|format_date|capfirst }}</td>
+                        <td class="wide">{{ alert.pubdate|format_date|capfirst }}</td>
                         <td>
                             {% if alert.scope == 'CONTENT' and alert.content.in_public %}
                                 <a href="{{ alert.content.get_absolute_url_online }}">{{ alert.text }}</a>
@@ -71,18 +71,18 @@
     {% if solved %}
         <table class="fullwidth">
             <thead>
-                <th>{% trans "Type" %}</th>
+                <th class="wide">{% trans "Type" %}</th>
                 <th>{% trans "Auteur" %}</th>
-                <th>{% trans "Date de résolution" %}</th>
+                <th class="wide">{% trans "Date de résolution" %}</th>
                 <th>{% trans "Contenu signalé" %}</th>
                 <th>{% trans "Résolu par" %}</th>
             </thead>
             <tbody>
                 {% for alert in solved %}
                     <tr>
-                        <td>{{ alert.get_type }}</td>
+                        <td class="wide">{{ alert.get_type }}</td>
                         <td><a href="{% url 'member-detail' alert.author.username %}">{{ alert.author.username }}</a></td>
-                        <td>{{ alert.solved_date|format_date|capfirst }}</td>
+                        <td class="wide">{{ alert.solved_date|format_date|capfirst }}</td>
                         <td>
                             {% if alert.scope == 'CONTENT' and alert.content.in_public %}
                                 <a href="{{ alert.content.get_absolute_url_online }}">{{ alert.text }}</a>

--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -28,17 +28,17 @@
             <thead>
                 <th>{% trans "Type" %}</th>
                 <th>{% trans "Auteur" %}</th>
-                <th class="wide">{% trans "Date" %}</th>
-                <th class="wide">{% trans "Contenu signalé" %}</th>
+                <th>{% trans "Date" %}</th>
+                <th>{% trans "Contenu signalé" %}</th>
                 <th>{% trans "Auteur du message" %}</th>
             </thead>
             <tbody>
                 {% for alert in alerts %}
                     <tr>
                         <td>{{ alert.get_type }}</td>
-                        <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
-                        <td class="wide">{{ alert.pubdate|format_date|capfirst }}</td>
-                        <td class="wide">
+                        <td><a href="{% url 'member-detail' alert.author.username %}">{{ alert.author.username }}</a></td>
+                        <td>{{ alert.pubdate|format_date|capfirst }}</td>
+                        <td>
                             {% if alert.scope == 'CONTENT' and alert.content.in_public %}
                                 <a href="{{ alert.content.get_absolute_url_online }}">{{ alert.text }}</a>
                             {% elif alert.scope == 'CONTENT' %}
@@ -73,17 +73,17 @@
             <thead>
                 <th>{% trans "Type" %}</th>
                 <th>{% trans "Auteur" %}</th>
-                <th class="wide">{% trans "Date de résolution" %}</th>
-                <th class="wide">{% trans "Contenu signalé" %}</th>
+                <th>{% trans "Date de résolution" %}</th>
+                <th>{% trans "Contenu signalé" %}</th>
                 <th>{% trans "Résolu par" %}</th>
             </thead>
             <tbody>
                 {% for alert in solved %}
                     <tr>
                         <td>{{ alert.get_type }}</td>
-                        <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
-                        <td class="wide">{{ alert.solved_date|format_date|capfirst }}</td>
-                        <td class="wide">
+                        <td><a href="{% url 'member-detail' alert.author.username %}">{{ alert.author.username }}</a></td>
+                        <td>{{ alert.solved_date|format_date|capfirst }}</td>
+                        <td>
                             {% if alert.scope == 'CONTENT' and alert.content.in_public %}
                                 <a href="{{ alert.content.get_absolute_url_online }}">{{ alert.text }}</a>
                             {% elif alert.scope == 'CONTENT' %}

--- a/templates/pages/comment_edits_history.html
+++ b/templates/pages/comment_edits_history.html
@@ -33,14 +33,14 @@
             <thead>
                 <th>{% trans "Date" %}</th>
                 <th>{% trans "Éditeur" %}</th>
-                <th class="wide">{% trans "Version avant édition" %}</th>
+                <th>{% trans "Version avant édition" %}</th>
             </thead>
             <tbody>
                 {% for edit in edits %}
                     <tr>
                         <td>{{ edit.date|format_date|capfirst }}</td>
                         <td>{% include 'misc/member_item.part.html' with member=edit.editor avatar=True %}</td>
-                        <td class="wide">
+                        <td>
                             {% if edit.deleted_by %}
                                 {% trans "Supprimée par" %} {% include 'misc/member_item.part.html' with member=edit.deleted_by avatar=True %} ({{ edit.deleted_at|format_date }})
                             {% else %}

--- a/templates/pages/comment_edits_history.html
+++ b/templates/pages/comment_edits_history.html
@@ -31,14 +31,14 @@
     {% if edits %}
         <table class="fullwidth">
             <thead>
-                <th>{% trans "Date" %}</th>
+                <th class="wide">{% trans "Date" %}</th>
                 <th>{% trans "Éditeur" %}</th>
                 <th>{% trans "Version avant édition" %}</th>
             </thead>
             <tbody>
                 {% for edit in edits %}
                     <tr>
-                        <td>{{ edit.date|format_date|capfirst }}</td>
+                        <td class="wide">{{ edit.date|format_date|capfirst }}</td>
                         <td>{% include 'misc/member_item.part.html' with member=edit.editor avatar=True %}</td>
                         <td>
                             {% if edit.deleted_by %}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4427 

### QA

- Éditer un des messages par défaut dans les fixtures
- Aller sur la page de l'historique d'édition du message ([http://localhost:8000/pages/historique-editions/5/](http://localhost:8000/pages/historique-editions/5/) pour le premier)
- Passer en mode "vue adaptative" et vérifier l'affichage du tableau pour des écrans de petites tailles

- [ ] Code relu et approuvé.
- [ ] Ça fonctionne !

PS : Y a-t-il d'autres pages concernées par ce problème ?