### PR TITLE
Utilise la couleur bleue du site pour les sélections

### DIFF
--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -15,15 +15,43 @@ body {
     width: 100%;
 }
 
-::selection, ::-moz-selection, .taglist li:hover {
+@mixin set-selection {
+    &::selection {
+        @content;
+    }
+
+    &::-moz-selection {
+        @content;
+    }
+}
+
+@mixin normal-selection {
     color: white;
     background: $color-primary;
 }
-.flexpage-header, .write-tutorial, .page-footer, .header-menu, .header-right, .taglist li:not(:hover) {
-    ::selection, ::-moz-selection {
-        /* color: #1C5B78; */
-        color: $color-primary;
-        background: white;
+
+@mixin negative-selection {
+    color: $color-primary;
+    background: white;
+}
+
+@include set-selection {
+    @include normal-selection;
+}
+
+// Elements with a dark background
+.flexpage-header, .write-tutorial, .page-footer, .header-menu, .header-right, .taglist {
+    &, * {
+        @include set-selection {
+            @include negative-selection;
+        }
+    }
+
+    input {
+        // We don't care about buttons and others, there aren't selectable
+        @include set-selection {
+            @include normal-selection;
+        }
     }
 }
 

--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -14,6 +14,19 @@ body {
     min-height: 100%;
     width: 100%;
 }
+
+::selection, ::-moz-selection, .taglist li:hover {
+    color: white;
+    background: $color-primary;
+}
+.flexpage-header, .write-tutorial, .page-footer, .header-menu, .header-right, .taglist li:not(:hover) {
+    ::selection, ::-moz-selection {
+        /* color: #1C5B78; */
+        color: $color-primary;
+        background: white;
+    }
+}
+
 .page-container,
 .main-container {
     min-height: 100%;


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4442 

### QA

- Sélectionner chaque "type" de texte sélectionnable (titre de page, titre de section / partie / tuto, contenu, etc) et vérifier la couleur et le contraste de la sélection. Un texte sur fond bleu devrait être bleu dans une sélection blanche et inversement pour un texte sur fond blanc.

**Un effet de bord étrange a été constaté : la bordure bleue des tags au survol est maintenant présente en bas et à gauche (elle ne devrait être qu'en bas). Quelqu'un aurait-il une idée de la cause ?**

- [ ] Code relu et approuvé.
- [ ] Ça fonctionne !