### PR TITLE
Remplace `import zds.settings` par `from django.conf import settings`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ install:
   - travis_retry pip install tox==2.0.1
 
 script:
+  - ./scripts/no_import_zds_settings.sh
   - tox $TEST_APP
   - |
     # avoid cache update & upload when we didn't explicitely change its content

--- a/scripts/no_import_zds_settings.sh
+++ b/scripts/no_import_zds_settings.sh
@@ -1,0 +1,29 @@
+#!/bin/sh -e
+
+cd "$(dirname "$0")"
+
+cd ../zds
+
+search() {
+    grep -rn zds | grep settings | grep import | grep -v '^settings'
+}
+
+if ! search >/dev/null
+then
+   exit 0
+fi
+
+>&2 cat <<'EOF'
+
+GOTCHA!
+
+Don't import directly `zds.settings`, please import `django.conf`
+instead.
+
+Fix these lines:
+
+EOF
+
+>&2 search
+
+exit 1

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -16,7 +16,6 @@ from elasticsearch_dsl.field import Text, Keyword, Integer, Boolean, Float, Date
 
 from zds.forum.managers import TopicManager, ForumManager, PostManager, TopicReadManager
 from zds.notification import signals
-from zds.settings import ZDS_APP
 from zds.searchv2.models import AbstractESDjangoIndexable, delete_document_in_elasticsearch, ESIndexManager
 from zds.utils import get_current_user, slugify
 from zds.utils.models import Comment, Tag
@@ -311,8 +310,8 @@ class Topic(AbstractESDjangoIndexable):
             try:
                 pk, pos = self.resolve_last_post_pk_and_pos_read_by_user(user)
                 page_nb = 1
-                if pos > ZDS_APP['forum']['posts_per_page']:
-                    page_nb += (pos - 1) // ZDS_APP['forum']['posts_per_page']
+                if pos > settings.ZDS_APP['forum']['posts_per_page']:
+                    page_nb += (pos - 1) // settings.ZDS_APP['forum']['posts_per_page']
                 return '{}?page={}#p{}'.format(
                     self.get_absolute_url(), page_nb, pk)
             except TopicRead.DoesNotExist:

--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -9,13 +9,12 @@ from shutil import rmtree
 from easy_thumbnails.fields import ThumbnailerImageField
 from easy_thumbnails.files import get_thumbnailer
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.db import models
 from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
-
-from zds.settings import MEDIA_ROOT, MEDIA_URL
 
 
 # Models settings
@@ -123,7 +122,7 @@ class Image(models.Model):
         :return: Image object URL
         :rtype: str
         """
-        return '{0}/{1}'.format(MEDIA_URL, self.physical)
+        return '{0}/{1}'.format(settings.MEDIA_URL, self.physical)
 
     def get_extension(self):
         """Get the extension of an image (used in tests).
@@ -181,7 +180,7 @@ class Gallery(models.Model):
         :return: filesystem path to this gallery root
         :rtype: unicode
         """
-        return os.path.join(MEDIA_ROOT, 'galleries', str(self.pk))
+        return os.path.join(settings.MEDIA_ROOT, 'galleries', str(self.pk))
 
     def get_linked_users(self):
         """Get all the linked users for this gallery whatever their rights

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -18,15 +18,14 @@ from zds.member.models import TokenForgotPassword, TokenRegister, Profile
 from zds.tutorialv2.factories import PublishableContentFactory, PublishedContentFactory
 from zds.gallery.factories import GalleryFactory, ImageFactory
 from zds.utils.models import Alert
-from zds.settings import BASE_DIR
 from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 class MemberModelsTest(TestCase):
 

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -14,7 +14,6 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.translation import ugettext_lazy as _
 
-from zds.settings import BASE_DIR
 from zds.notification.models import TopicAnswerSubscription
 from zds.member.factories import ProfileFactory, StaffProfileFactory, NonAsciiProfileFactory, UserFactory, \
     DevProfileFactory
@@ -32,11 +31,11 @@ from zds.utils.models import CommentVote
 from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 class MemberTests(TestCase):
 

--- a/zds/mp/api/tests.py
+++ b/zds/mp/api/tests.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 from collections import OrderedDict
+
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.cache import caches
 from django.core.urlresolvers import reverse
@@ -13,7 +15,6 @@ from zds.member.api.tests import create_oauth2_client, authenticate_client
 from zds.member.factories import ProfileFactory, UserFactory
 from zds.mp.factories import PrivateTopicFactory, PrivatePostFactory
 from zds.mp.models import PrivateTopic
-from zds.settings import ZDS_APP
 
 
 class PrivateTopicListAPITest(APITestCase):
@@ -24,7 +25,7 @@ class PrivateTopicListAPITest(APITestCase):
         authenticate_client(self.client, client_oauth2, self.profile.user.username, 'hostel77')
 
         self.bot_group = Group()
-        self.bot_group.name = ZDS_APP['member']['bot_group']
+        self.bot_group.name = settings.ZDS_APP['member']['bot_group']
         self.bot_group.save()
 
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
@@ -316,7 +317,7 @@ class PrivateTopicListAPITest(APITestCase):
         """
         Tries to create a new private topic with an unreachable user.
         """
-        anonymous_user = UserFactory(username=ZDS_APP['member']['anonymous_account'])
+        anonymous_user = UserFactory(username=settings.ZDS_APP['member']['anonymous_account'])
         anonymous_user.groups.add(self.bot_group)
         anonymous_user.save()
         data = {
@@ -402,7 +403,7 @@ class PrivateTopicDetailAPITest(APITestCase):
         authenticate_client(self.client, client_oauth2, self.profile.user.username, 'hostel77')
 
         self.bot_group = Group()
-        self.bot_group.name = ZDS_APP['member']['bot_group']
+        self.bot_group.name = settings.ZDS_APP['member']['bot_group']
         self.bot_group.save()
 
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
@@ -523,7 +524,7 @@ class PrivateTopicDetailAPITest(APITestCase):
         """
         Tries to update a private topic with an unreachable user.
         """
-        anonymous_user = UserFactory(username=ZDS_APP['member']['anonymous_account'])
+        anonymous_user = UserFactory(username=settings.ZDS_APP['member']['anonymous_account'])
         anonymous_user.groups.add(self.bot_group)
         anonymous_user.save()
         data = {
@@ -1040,7 +1041,7 @@ class PrivateTopicUnreadListAPITest(APITestCase):
         authenticate_client(self.another_client, another_client_oauth2, self.another_profile.user.username, 'hostel77')
 
         self.bot_group = Group()
-        self.bot_group.name = ZDS_APP['member']['bot_group']
+        self.bot_group.name = settings.ZDS_APP['member']['bot_group']
         self.bot_group.save()
 
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()

--- a/zds/mp/tests/tests_forms.py
+++ b/zds/mp/tests/tests_forms.py
@@ -1,12 +1,12 @@
 # coding: utf-8
 
+from django.conf import settings
+from django.contrib.auth.models import Group
 from django.test import TestCase
 
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.mp.forms import PrivateTopicForm, PrivatePostForm
 from zds.mp.factories import PrivateTopicFactory
-from zds.settings import ZDS_APP
-from django.contrib.auth.models import Group
 
 
 class PrivateTopicFormTest(TestCase):
@@ -15,7 +15,7 @@ class PrivateTopicFormTest(TestCase):
         self.profile1 = ProfileFactory()
         self.profile2 = ProfileFactory()
         self.staff1 = StaffProfileFactory()
-        bot = Group(name=ZDS_APP['member']['bot_group'])
+        bot = Group(name=settings.ZDS_APP['member']['bot_group'])
         bot.save()
 
     def test_valid_topic_form(self):

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -9,7 +9,6 @@ from django.core.urlresolvers import reverse
 from zds.member.factories import ProfileFactory, UserFactory
 from zds.mp.factories import PrivateTopicFactory, PrivatePostFactory
 from zds.mp.models import PrivateTopic, PrivatePost
-from zds.settings import ZDS_APP
 from django.contrib.auth.models import Group
 
 
@@ -752,9 +751,9 @@ class LeaveViewTest(TestCase):
         self.profile1 = ProfileFactory()
         self.profile2 = ProfileFactory()
 
-        self.anonymous_account = UserFactory(username=ZDS_APP['member']['anonymous_account'])
+        self.anonymous_account = UserFactory(username=settings.ZDS_APP['member']['anonymous_account'])
         self.bot_group = Group()
-        self.bot_group.name = ZDS_APP['member']['bot_group']
+        self.bot_group.name = settings.ZDS_APP['member']['bot_group']
         self.bot_group.save()
         self.anonymous_account.groups.add(self.bot_group)
         self.anonymous_account.save()
@@ -852,9 +851,9 @@ class AddParticipantViewTest(TestCase):
     def setUp(self):
         self.profile1 = ProfileFactory()
         self.profile2 = ProfileFactory()
-        self.anonymous_account = UserFactory(username=ZDS_APP['member']['anonymous_account'])
+        self.anonymous_account = UserFactory(username=settings.ZDS_APP['member']['anonymous_account'])
         self.bot_group = Group()
-        self.bot_group.name = ZDS_APP['member']['bot_group']
+        self.bot_group.name = settings.ZDS_APP['member']['bot_group']
         self.bot_group.save()
         self.anonymous_account.groups.add(self.bot_group)
         self.anonymous_account.save()

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -1,11 +1,10 @@
 import os
 import shutil
 
-from django.test import TestCase
-from django.core.urlresolvers import reverse
-from django.test.utils import override_settings
 from django.conf import settings
-from zds.settings import BASE_DIR
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
 
 from zds.forum.factories import CategoryFactory, ForumFactory
 from zds.forum.models import Topic
@@ -70,12 +69,12 @@ class ForumNotification(TestCase):
 
 
 overriden_zds_app = deepcopy(settings.ZDS_APP)
-overriden_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overriden_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overriden_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overriden_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 overriden_zds_app['content']['extra_content_generation_policy'] = 'SYNC'
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overriden_zds_app)
 @override_settings(ES_ENABLED=False)
 class ContentNotification(TestCase):

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -4,6 +4,7 @@ import os.path
 import random
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.models import User
@@ -22,7 +23,6 @@ from zds.forum.models import Forum, Topic
 from zds.member.decorator import can_write_and_read_now
 from zds.pages.forms import AssocSubscribeForm
 from zds.pages.models import GroupContact
-from zds.settings import BASE_DIR, ZDS_APP
 from zds.searchv2.forms import SearchForm
 from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent
 from zds.utils.forums import create_topic
@@ -37,10 +37,10 @@ def home(request):
     opinions = PublishableContent.objects.get_last_opinions()
 
     try:
-        with open(os.path.join(BASE_DIR, 'quotes.txt'), 'r') as quotes_file:
+        with open(os.path.join(settings.BASE_DIR, 'quotes.txt'), 'r') as quotes_file:
             quote = random.choice(quotes_file.readlines())
     except IOError:
-        quote = ZDS_APP['site']['slogan']
+        quote = settings.ZDS_APP['site']['slogan']
 
     return render(request, 'home.html', {
         'featured_message': FeaturedMessage.objects.get_last_message(),
@@ -73,8 +73,10 @@ class AssocSubscribeView(FormView):
         user = self.request.user
         data = form.data
 
-        bot = get_object_or_404(User, username=ZDS_APP['member']['bot_account'])
-        forum = get_object_or_404(Forum, pk=ZDS_APP['site']['association']['forum_ca_pk'])
+        site = settings.ZDS_APP['site']
+
+        bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
+        forum = get_object_or_404(Forum, pk=site['association']['forum_ca_pk'])
 
         # create the topic
         title = _(u'Demande d\'adhésion de {}').format(user.username)
@@ -87,7 +89,7 @@ class AssocSubscribeView(FormView):
             'address': data['address'],
             'justification': data['justification'],
             'username': user.username,
-            'profile_url': ZDS_APP['site']['url'] + reverse('member-detail', kwargs={'user_name': user.username}),
+            'profile_url': site['url'] + reverse('member-detail', kwargs={'user_name': user.username}),
 
         }
         text = render_to_string('pages/messages/association_subscribre.md', context)

--- a/zds/searchv2/forms.py
+++ b/zds/searchv2/forms.py
@@ -5,7 +5,6 @@ import random
 from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-from zds.settings import BASE_DIR
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
@@ -48,7 +47,7 @@ class SearchForm(forms.Form):
         self.helper.form_action = reverse('search:query')
 
         try:
-            with open(os.path.join(BASE_DIR, 'suggestions.txt'), 'r') as suggestions_file:
+            with open(os.path.join(settings.BASE_DIR, 'suggestions.txt'), 'r') as suggestions_file:
                 suggestions = ', '.join(random.sample(suggestions_file.readlines(), 5)) + u'…'
         except IOError:
             suggestions = _(u'Mathématiques, Droit, UDK, Langues, Python…')

--- a/zds/searchv2/tests/tests_models.py
+++ b/zds/searchv2/tests/tests_models.py
@@ -9,7 +9,6 @@ from elasticsearch_dsl.query import MatchAll
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from zds.settings import BASE_DIR
 
 from zds.forum.factories import TopicFactory, PostFactory, Topic, Post
 from zds.forum.tests.tests_views import create_category
@@ -21,11 +20,11 @@ from copy import deepcopy
 
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 @override_settings(ES_SEARCH_INDEX={'name': 'zds_search_test', 'shards': 5, 'replicas': 0})
 class ESIndexManagerTests(TestCase):

--- a/zds/searchv2/tests/tests_utils.py
+++ b/zds/searchv2/tests/tests_utils.py
@@ -9,7 +9,6 @@ from elasticsearch_dsl.query import MatchAll
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from zds.settings import BASE_DIR
 from django.core.management import call_command
 
 from zds.member.factories import ProfileFactory, StaffProfileFactory
@@ -21,11 +20,11 @@ from zds.searchv2.models import ESIndexManager
 from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 @override_settings(ES_SEARCH_INDEX={'name': 'zds_search_test', 'shards': 5, 'replicas': 0})
 class UtilsTests(TestCase):

--- a/zds/searchv2/tests/tests_views.py
+++ b/zds/searchv2/tests/tests_views.py
@@ -11,7 +11,6 @@ from elasticsearch_dsl.query import MatchAll
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from zds.settings import BASE_DIR
 from django.core.urlresolvers import reverse
 
 from zds.forum.factories import TopicFactory, PostFactory, Topic, Post, TagFactory
@@ -24,11 +23,11 @@ from zds.tutorialv2.models.models_database import PublishedContent, FakeChapter,
 from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 # 1 shard is not a recommended setting, but since document on different shard may have a different score, it is ok here
 @override_settings(ES_SEARCH_INDEX={'name': 'zds_search_test', 'shards': 1, 'replicas': 0})

--- a/zds/tutorialv2/api/tests.py
+++ b/zds/tutorialv2/api/tests.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from copy import deepcopy
 import os
 import shutil
 
@@ -6,25 +7,24 @@ from django.conf import settings
 from django.core.cache import caches
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
+
 from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 from rest_framework_extensions.settings import extensions_api_settings
 
 from zds.member.factories import ProfileFactory
-from zds.settings import BASE_DIR
 from zds.tutorialv2.factories import ContentReactionFactory, PublishedContentFactory
 from zds.utils.models import CommentVote
-from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 overrided_zds_app['content']['extra_content_generation_policy'] = 'SYNC'
 overrided_zds_app['content']['build_pdf_when_published'] = False
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 class ContentReactionKarmaAPITest(APITestCase):
     def setUp(self):

--- a/zds/tutorialv2/feeds.py
+++ b/zds/tutorialv2/feeds.py
@@ -1,12 +1,10 @@
 # coding: utf-8
 
-from django.contrib.syndication.views import Feed
 from django.conf import settings
-
+from django.contrib.syndication.views import Feed
 from django.utils.feedgenerator import Atom1Feed
 
 from zds.tutorialv2.models.models_database import PublishedContent
-from zds.settings import ZDS_APP
 
 
 class LastContentFeedRSS(Feed):
@@ -23,7 +21,8 @@ class LastContentFeedRSS(Feed):
         :return: The last (typically 5) contents (sorted by publication date).
         If `self.type` is not `None`, the contents will only be of this type.
         """
-        contents = PublishedContent.objects.published_contents(self.content_type)[:ZDS_APP['content']['feed_length']]
+        feed_length = settings.ZDS_APP['content']['feed_length']
+        contents = PublishedContent.objects.published_contents(self.content_type)[:feed_length]
 
         return contents
 

--- a/zds/tutorialv2/management/commands/adjust_slugs.py
+++ b/zds/tutorialv2/management/commands/adjust_slugs.py
@@ -2,8 +2,9 @@
 import os
 from uuslug import slugify
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
-from zds.settings import ZDS_APP
+
 from zds.tutorialv2.models.models_database import PublishableContent
 
 
@@ -18,7 +19,7 @@ class Command(BaseCommand):
             if "'" in c.title:
                 good_slug = slugify(c.title)
                 if c.slug != good_slug:
-                    if os.path.isdir(os.path.join(ZDS_APP['content']['repo_private_path'], good_slug)):
+                    if os.path.isdir(os.path.join(settings.ZDS_APP['content']['repo_private_path'], good_slug)):
                         # this content was created before v16 and is probably broken
                         self.stdout.write(u'Fixing pre-v16 content #{} (« {} ») ... '.format(c.pk, c.title), ending='')
                         c.save()
@@ -26,7 +27,7 @@ class Command(BaseCommand):
                             self.stdout.write(u'[OK]')
                         else:
                             self.stdout.write(u'[KO]')
-                    elif os.path.isdir(os.path.join(ZDS_APP['content']['repo_private_path'], c.slug)):
+                    elif os.path.isdir(os.path.join(settings.ZDS_APP['content']['repo_private_path'], c.slug)):
                         # this content was created during v16 and will be broken if nothing is done
                         self.stdout.write(u'Fixing in-v16 content #{} (« {} ») ... '.format(c.pk, c.title), ending='')
                         try:

--- a/zds/tutorialv2/models/models_versioned.py
+++ b/zds/tutorialv2/models/models_versioned.py
@@ -12,7 +12,6 @@ from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from zds.settings import ZDS_APP
 from zds.tutorialv2.models.mixins import TemplatableContentModelMixin
 from zds.tutorialv2.utils import default_slug_pool, export_content, get_commit_author, InvalidOperationError
 from zds.utils.misc import compute_hash
@@ -217,7 +216,7 @@ class Container:
         :rtype: bool
         """
         if not self.has_extracts():
-            if self.get_tree_depth() < ZDS_APP['content']['max_tree_depth'] - 1:
+            if self.get_tree_depth() < settings.ZDS_APP['content']['max_tree_depth'] - 1:
                 if not self.top_container().type in SINGLE_CONTAINER:
                     return True
         return False
@@ -229,7 +228,7 @@ class Container:
         :rtype: bool
         """
         if not self.has_sub_containers():
-            if self.get_tree_depth() <= ZDS_APP['content']['max_tree_depth']:
+            if self.get_tree_depth() <= settings.ZDS_APP['content']['max_tree_depth']:
                 return True
         return False
 

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -3,18 +3,18 @@ import codecs
 import copy
 import logging
 import os
+from os.path import isdir, dirname
 import shutil
 import subprocess
 import zipfile
 from datetime import datetime
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
 from django.utils import translation
 from django.utils.translation import ugettext_lazy as _
-from os.path import isdir, dirname
-from django.conf import settings
-from zds.settings import ZDS_APP
+
 from zds.tutorialv2.models.models_database import ContentReaction
 from zds.tutorialv2.signals import content_unpublished
 from zds.tutorialv2.utils import retrieve_and_update_images_links
@@ -165,7 +165,7 @@ def generate_exernal_content(base_name, extra_contents_path, md_file_path, pando
     :return:
     """
     excluded = []
-    if not ZDS_APP['content']['build_pdf_when_published'] and not overload_settings:
+    if not settings.ZDS_APP['content']['build_pdf_when_published'] and not overload_settings:
         excluded.append('pdf')
     for __, publicator in PublicatorRegistery.get_all_registered(excluded):
 

--- a/zds/tutorialv2/tests/tests_feeds.py
+++ b/zds/tutorialv2/tests/tests_feeds.py
@@ -11,7 +11,6 @@ from django.contrib.auth.models import Group
 from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.forum.factories import ForumFactory, CategoryFactory
-from zds.settings import BASE_DIR
 from zds.tutorialv2.models.models_database import PublishedContent
 from zds.tutorialv2.feeds import LastTutorialsFeedRSS, LastTutorialsFeedATOM, LastArticlesFeedRSS, LastArticlesFeedATOM
 from zds.tutorialv2.factories import LicenceFactory, SubCategoryFactory, PublishableContentFactory, ContainerFactory, \
@@ -20,11 +19,11 @@ from zds.tutorialv2.publication_utils import publish_content
 from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 class LastTutorialsFeedRSSTest(TestCase):
 

--- a/zds/tutorialv2/tests/tests_lists.py
+++ b/zds/tutorialv2/tests/tests_lists.py
@@ -9,7 +9,6 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
 
-from zds.settings import BASE_DIR
 from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory, \
     SubCategoryFactory, PublishedContentFactory, ValidationFactory
@@ -18,11 +17,11 @@ from zds.forum.factories import ForumFactory, CategoryFactory
 from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 @override_settings(ES_ENABLED=False)
 class ContentTests(TestCase):

--- a/zds/tutorialv2/tests/tests_models.py
+++ b/zds/tutorialv2/tests/tests_models.py
@@ -11,7 +11,6 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from zds.gallery.models import UserGallery
-from zds.settings import BASE_DIR
 
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory, \
@@ -24,11 +23,11 @@ from django.template.defaultfilters import date
 from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 @override_settings(ES_ENABLED=False)
 class ContentTests(TestCase):

--- a/zds/tutorialv2/tests/tests_move.py
+++ b/zds/tutorialv2/tests/tests_move.py
@@ -9,7 +9,6 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
 
-from zds.settings import BASE_DIR
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory, \
     SubCategoryFactory
@@ -20,11 +19,11 @@ from zds.tutorialv2.publication_utils import publish_content
 from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 @override_settings(ES_ENABLED=False)
 class ContentMoveTests(TestCase):

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -11,19 +11,18 @@ from django.utils.translation import ugettext_lazy as _
 
 from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory
-from zds.settings import BASE_DIR
 from zds.tutorialv2.factories import PublishableContentFactory, ExtractFactory, LicenceFactory, PublishedContentFactory
 from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent, PickListOperation
 from zds.utils.models import Alert
 from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 overrided_zds_app['content']['extra_content_generation_policy'] = 'NONE'
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
 @override_settings(ZDS_APP=overrided_zds_app)
 @override_settings(ES_ENABLED=False)
 class PublishedContentTests(TestCase):

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -8,7 +8,6 @@ import datetime
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from zds.settings import BASE_DIR
 from django.core.urlresolvers import reverse
 
 from zds.member.factories import ProfileFactory, StaffProfileFactory
@@ -34,6 +33,8 @@ except ImportError:
         import simplejson as json_reader
     except:
         import json as json_reader
+
+BASE_DIR = settings.BASE_DIR
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
 overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -23,7 +23,6 @@ from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactor
 from zds.mp.models import PrivateTopic, is_privatetopic_unread
 from zds.notification.models import TopicAnswerSubscription, ContentReactionAnswerSubscription, \
     NewPublicationSubscription, Notification, Subscription
-from zds.settings import BASE_DIR
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory, \
     SubCategoryFactory, PublishedContentFactory, tricky_text_content, BetaContentFactory
 from zds.tutorialv2.models.models_database import PublishableContent, Validation, PublishedContent, ContentReaction, \
@@ -33,6 +32,10 @@ from zds.utils.models import HelpWriting, Alert, Tag
 from zds.utils.factories import HelpWritingFactory
 from zds.utils.templatetags.interventions import interventions_topics
 from copy import deepcopy
+
+
+BASE_DIR = settings.BASE_DIR
+
 
 try:
     import ujson as json_reader
@@ -282,7 +285,7 @@ class ContentTests(TestCase):
                 'type': u'TUTORIAL',
                 'licence': self.licence.pk,
                 'subcategory': self.subcategory.pk,
-                'image': open('{}/fixtures/noir_black.png'.format(settings.BASE_DIR))
+                'image': open('{}/fixtures/noir_black.png'.format(BASE_DIR))
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -331,7 +334,7 @@ class ContentTests(TestCase):
                 'licence': new_licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': versioned.compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR))
+                'image': open('{}/fixtures/logo.png'.format(BASE_DIR))
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -1766,7 +1769,7 @@ class ContentTests(TestCase):
                 username=self.user_author.username,
                 password='hostel77'),
             True)
-        archive_path = os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'BadArchive.zip')
+        archive_path = os.path.join(BASE_DIR, 'fixtures', 'tuto', 'BadArchive.zip')
         answer = self.client.post(reverse('content:import',
                                           args=[new_article.pk, new_article.slug]),
                                   {'archive': open(archive_path, 'r'),
@@ -2102,7 +2105,7 @@ class ContentTests(TestCase):
                 'licence': tuto.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': tuto.load_version(tuto.sha_draft).compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR))
+                'image': open('{}/fixtures/logo.png'.format(BASE_DIR))
             },
             follow=False)
 
@@ -5453,7 +5456,7 @@ class PublishedContentTests(TestCase):
                 'licence': self.tuto.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': tuto.load_version().compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR))
+                'image': open('{}/fixtures/logo.png'.format(BASE_DIR))
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -5627,7 +5630,7 @@ class PublishedContentTests(TestCase):
                 'licence': article.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': article.load_version(article.sha_draft).compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR))
+                'image': open('{}/fixtures/logo.png'.format(BASE_DIR))
             },
             follow=False)
         public_count = PublishedContent.objects.count()

--- a/zds/utils/factories.py
+++ b/zds/utils/factories.py
@@ -1,7 +1,9 @@
 # coding: utf-8
+
+from django.conf import settings
+
 from zds.utils.models import HelpWriting
 from zds.utils import slugify
-from zds.settings import BASE_DIR, MEDIA_ROOT
 from shutil import copyfile
 from os.path import basename, join
 
@@ -23,10 +25,10 @@ class HelpWritingFactory(factory.DjangoModelFactory):
         fixture_image_path = kwargs.pop('fixture_image_path', None)
 
         if fixture_image_path is not None:
-            image_path = join(BASE_DIR, 'fixtures', fixture_image_path)
+            image_path = join(settings.BASE_DIR, 'fixtures', fixture_image_path)
 
         if image_path is not None:
-            copyfile(image_path, join(MEDIA_ROOT, basename(image_path)))
+            copyfile(image_path, join(settings.MEDIA_ROOT, basename(image_path)))
             help_writing.image = basename(image_path)
             help_writing.save()
 

--- a/zds/utils/management/commands/load_factory_data.py
+++ b/zds/utils/management/commands/load_factory_data.py
@@ -4,9 +4,9 @@ import glob
 import os
 import yaml
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from zds.settings import MEDIA_ROOT
 
 
 @transaction.atomic
@@ -23,8 +23,8 @@ class Command(BaseCommand):
         files = options.get('files')
 
         # create "media" folder if not existing
-        if not os.path.exists(MEDIA_ROOT):
-            os.mkdir(MEDIA_ROOT)
+        if not os.path.exists(settings.MEDIA_ROOT):
+            os.mkdir(settings.MEDIA_ROOT)
 
         for filename in glob.glob(files):
             stream = open(filename, 'r')

--- a/zds/utils/paginator.py
+++ b/zds/utils/paginator.py
@@ -1,11 +1,10 @@
 # coding: utf-8
 
+from django.conf import settings
 from django.views.generic import ListView
 from django.views.generic.list import MultipleObjectMixin
 from django.core.paginator import Paginator, EmptyPage
 from django.http import Http404
-
-from zds.settings import ZDS_APP
 
 
 class ZdSPagingListView(ListView):
@@ -64,7 +63,7 @@ def paginator_range(current, stop, start=1):
     assert current <= stop
 
     # Basic case when no folding
-    if stop - start <= ZDS_APP['paginator']['folding_limit']:
+    if stop - start <= settings.ZDS_APP['paginator']['folding_limit']:
         return range(start, stop + 1)
 
     # Complex case when folding

--- a/zds/utils/templatetags/remove_url_protocole.py
+++ b/zds/utils/templatetags/remove_url_protocole.py
@@ -1,5 +1,5 @@
 from django import template
-from zds.settings import ZDS_APP
+from django.conf import settings
 
 
 register = template.Library()
@@ -10,8 +10,8 @@ def remove_url_protocole(input_url):
     """
     make every image url pointing to this website protocol independant so that https is not broken
     """
-    if ZDS_APP['site']['dns'] in input_url or ZDS_APP['site']['url'] in input_url:
+    if settings.ZDS_APP['site']['dns'] in input_url or settings.ZDS_APP['site']['url'] in input_url:
         return input_url.replace('http:/', 'https:/')\
-                        .replace('https://' + ZDS_APP['site']['dns'], '')\
-                        .replace(ZDS_APP['site']['url'], '')
+                        .replace('https://' + settings.ZDS_APP['site']['dns'], '')\
+                        .replace(settings.ZDS_APP['site']['url'], '')
     return input_url

--- a/zds/utils/templatetags/tests/test_remove_url_protocole.py
+++ b/zds/utils/templatetags/tests/test_remove_url_protocole.py
@@ -1,13 +1,14 @@
-from zds.settings import ZDS_APP
+from django.conf import settings
 from django.test import TestCase
+
 from zds.utils.templatetags.remove_url_protocole import remove_url_protocole
 
 
 class RemoveUrlProtocolTest(TestCase):
 
     def test_remove_protocole_when_local_url(self):
-        self.assertEqual('/bla.html', remove_url_protocole('http://' + ZDS_APP['site']['dns'] + '/bla.html'))
-        self.assertEqual('/bla.html', remove_url_protocole('https://' + ZDS_APP['site']['dns'] + '/bla.html'))
+        self.assertEqual('/bla.html', remove_url_protocole('http://' + settings.ZDS_APP['site']['dns'] + '/bla.html'))
+        self.assertEqual('/bla.html', remove_url_protocole('https://' + settings.ZDS_APP['site']['dns'] + '/bla.html'))
 
     def test_no_change_when_no_protocole(self):
         self.assertEqual('/bla.html', remove_url_protocole('/bla.html'))

--- a/zds/utils/templatetags/tests/test_top_tags.py
+++ b/zds/utils/templatetags/tests/test_top_tags.py
@@ -10,14 +10,13 @@ from django.conf import settings
 
 from zds.forum.factories import CategoryFactory, ForumFactory, TopicFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory
-from zds.settings import BASE_DIR
 from zds.tutorialv2.factories import PublishedContentFactory
 from zds.utils.templatetags.topbar import top_categories, top_categories_content
 from copy import deepcopy
 
 overrided_zds_app = deepcopy(settings.ZDS_APP)
-overrided_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overrided_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overrided_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
+overrided_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
 overrided_zds_app['content']['build_pdf_when_published'] = False
 
 


### PR DESCRIPTION
Avant ce commit, lorsque l’on faisait :

    $ manage.py runserver 0.0.0.0:8000 --settings zds.my_custom_settings

`zds.settings` restait `zds.settings` alors que `django.conf.settings`
vallait `zds.my_custom_settings`.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4435

### QA

Essayez d’importer `zds.settings` quelque part et lancez `./scripts/no_import_zds_settings.sh` : Si tout se passe bien, vous vous ferez insulter copieusement.