### PR TITLE
[hotfix] Corrige le routing sitemaps pour django 1.10

### DIFF
--- a/zds/urls.py
+++ b/zds/urls.py
@@ -116,7 +116,8 @@ urlpatterns = [
 # SiteMap URLs
 urlpatterns += [
     url(r'^sitemap\.xml$', index_view, {'sitemaps': sitemaps}),
-    url(r'^sitemap-(?P<section>.+)\.xml$', sitemap_view, {'sitemaps': sitemaps}),
+    url(r'^sitemap-(?P<section>.+)\.xml$', sitemap_view, {'sitemaps': sitemaps},
+        name='django.contrib.sitemaps.views.sitemap'),
 ]
 
 if settings.SERVE:


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4462

### QA

- rendez-vous sur localhost:8000/sitemap.xml
- la page ne provoque pas de 500

J'hésite à hotfixer, vous en pensez quoi ?