### PR TITLE
Corrige les marges des .alert-box (toasts)

### DIFF
--- a/assets/scss/components/_alert-box.scss
+++ b/assets/scss/components/_alert-box.scss
@@ -1,6 +1,7 @@
 .alert-box {
     position: relative;
     padding: 8px 30px 8px 15px;
+    margin: 0 0 15px 2%;
     color: #FFF;
     text-shadow: rgba(0, 0, 0, 0.2) 0 0 2px;
     background: #777;


### PR DESCRIPTION
Il n’y avait pas de marge entre les `.alert-box` :

![image](https://user-images.githubusercontent.com/15378830/29003449-3777be90-7ab7-11e7-91b5-4f318d6b1560.png)

Problème introduit par 945998d11e468d8eb3f16253354e5a2b9ad874c5. C’est un revert.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | none

### QA

Pas besoin, c’est comme avant.