### PR TITLE
Rends les boutons du menu principal vraiment flexibles

### DIFF
--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -52,9 +52,10 @@
             display: block;
             flex-grow: 0;
             flex-shrink: 1;
-            flex-basis: 150px;
+            flex-basis: auto;
 
             & > a {
+                padding: 0 2rem;
                 display: block;
                 position: relative;
                 text-align: center;
@@ -134,10 +135,6 @@
             width: 20px;
             height: 9px;
             position: relative;
-
-            @media only screen and #{$media-extra-wide} {
-                width: 28px;
-            }
 
             &:after {
                 content: "";


### PR DESCRIPTION
C’est plus harmonieux :

![image](https://user-images.githubusercontent.com/15378830/29004366-803e3a0a-7ac6-11e7-9a8e-ecd96b9ea0b6.png)

![image](https://user-images.githubusercontent.com/15378830/29004371-92b77322-7ac6-11e7-9008-755b296fed8b.png)

![image](https://user-images.githubusercontent.com/15378830/29004373-98333a2a-7ac6-11e7-8a4a-0149aa645ef6.png)

Le bouton “Bibliothèque” est plus large que les autres.

Tous les crédits sont pour @abdelaz3r.

Testé viteuf sur Chrome, Firefox et IE 11.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | aucun
### QA

Tester sur plein de navigateurs.