### PR TITLE
Ferme les <span> correctement dans base.html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -198,7 +198,7 @@
                         <li>
                             <a href="{% url "publication:list" %}" class="mobile-menu-link {% block menu_publications %}{% endblock %}">
                                 {% trans "Bibliothèque" %}
-                                <span class="arrow" />
+                                <span class="arrow"></span>
                             </a>
 
                                 {% cache 1800 menu_publications user|groups %}
@@ -252,7 +252,7 @@
                         <li>
                             <a href="{% url "opinion:list" %}" class="mobile-menu-link {% block menu_opinion %}{% endblock %}">
                                 {% trans "Tribune" %}
-                                <span class="arrow" />
+                                <span class="arrow"></span>
                             </a>
                             {% cache 1800 menu_opinion user|groups %}
                                 <div class="dropdown header-menu-dropdown">
@@ -305,7 +305,7 @@
                         <li>
                             <a href="{% url "cats-forums-list" %}" class="mobile-menu-link {% block menu_forum %}{% endblock %}">
                                 {% trans "Forum" %}
-                                <span class="arrow" />
+                                <span class="arrow"></span>
                             </a>
                             {% cache 1800 menu_forum user|groups %}
                                 <div class="dropdown header-menu-dropdown">


### PR DESCRIPTION
Parce que Microsoft® Internet Explorer™ 11 n’aime pas ça.

Fix #4488.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4488

### QA

Vérifiez juste le diff, je pense que ce n’est même pas la peine de lancer un navigateur.