### PR TITLE
Permet de modifier la casquette à l'édition d'un message

### DIFF
--- a/templates/misc/hat_choice.html
+++ b/templates/misc/hat_choice.html
@@ -1,13 +1,26 @@
 {% load i18n %}
+{% load set %}
 
 
-{% if user.is_authenticated and user.profile.has_hat %}
-    <label for="hat-choice">{% trans "Poster avec ma caquette :" %}</label>
+{% if edited_message %}
+    {% set edited_message.author as hats_owner %}
+{% else %}
+    {% set user as hats_owner %}
+{% endif %}
+
+{% if hats_owner.profile.has_hat %}
+    <label for="hat-choice">
+        {% if edited_message %}
+            {% trans "Modifier la casquette :" %}
+        {% else %}
+            {% trans "Poster avec ma casquette :" %}
+        {% endif %}
+    </label>
     <select name="hat" id="hat-choice">
         <option value>{% trans "–" %}</option>
-        {% for hat in user.profile.hats.all %}
+        {% for hat in hats_owner.profile.hats.all %}
             <option value="{{ hat.pk }}"
-                {% if request.POST.hat|add:0 == hat.pk %}
+                {% if request.POST.hat|add:0 == hat.pk or not request.POST.hat and edited_message.with_hat == hat.name %}
                     selected
                 {% endif %}
             >
@@ -15,4 +28,8 @@
             </option>
         {% endfor %}
     </select>
+{% elif edited_message.with_hat %}
+    {% blocktrans %}
+        <strong>Attention</strong>, la casquette sera supprimée.
+    {% endblocktrans %}
 {% endif %}

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -68,7 +68,11 @@ class TopicForm(forms.Form):
             CommonLayoutEditor(),
         )
 
-        if 'text' not in self.initial:
+        if 'text' in self.initial:
+            self.helper.layout.append(
+                HTML("{% include 'misc/hat_choice.html' with edited_message=topic.first_post %}")
+            )
+        else:
             self.helper.layout.append(HTML("{% include 'misc/hat_choice.html' %}"))
 
     def clean(self):
@@ -122,7 +126,9 @@ class PostForm(forms.Form):
             Hidden('last_post', '{{ last_post_pk }}'),
         )
 
-        if 'text' not in self.initial:
+        if 'text' in self.initial:
+            self.helper.layout.append(HTML("{% include 'misc/hat_choice.html' with edited_message=post %}"))
+        else:
             self.helper.layout.append(HTML("{% include 'misc/hat_choice.html' %}"))
 
         if topic.antispam(user):

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -1444,14 +1444,15 @@ class PostEditTest(TestCase):
             'last_post': topic.last_message.pk,
             'hat': hat.pk,
         }
-        response = self.client.post(reverse('post-new') + '?sujet={}'.format(topic.pk), data, follow=False)
+        self.client.post(reverse('post-new') + '?sujet={}'.format(topic.pk), data, follow=False)
+        topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(topic.last_message.with_hat, hat.name)  # Hat was used
 
         # test that it's possible to remove the hat
         data = {
             'text': 'A new post!'
         }
-        response = self.client.post(
+        self.client.post(
             reverse('post-edit') + '?message={}'.format(topic.last_message.pk), data, follow=False)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(topic.last_message.with_hat, '')  # Hat was removed
@@ -1461,7 +1462,7 @@ class PostEditTest(TestCase):
             'text': 'A new post!',
             'hat': other_hat.pk,
         }
-        response = self.client.post(
+        self.client.post(
             reverse('post-edit') + '?message={}'.format(topic.last_message.pk), data, follow=False)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(topic.last_message.with_hat, '')  # Hat wasn't used
@@ -1472,7 +1473,7 @@ class PostEditTest(TestCase):
             'text': 'A new post!',
             'hat': other_hat.pk,
         }
-        response = self.client.post(
+        self.client.post(
             reverse('post-edit') + '?message={}'.format(topic.last_message.pk), data, follow=False)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(topic.last_message.with_hat, other_hat.name)  # Now, it works

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -1427,6 +1427,56 @@ class PostEditTest(TestCase):
         response = self.client.get(reverse('topic-edit') + '?topic={}'.format(topic.pk), follow=False)
         self.assertEqual(403, response.status_code)
 
+    def test_hat_edit(self):
+        profile = ProfileFactory()
+        hat, _ = Hat.objects.get_or_create(name__iexact='A hat', defaults={'name': 'A hat'})
+        other_hat, _ = Hat.objects.get_or_create(name__iexact='Another hat', defaults={'name': 'Another hat'})
+        profile.hats.add(hat)
+
+        # add a new thread
+        category, forum = create_category()
+        topic = add_topic_in_a_forum(forum, ProfileFactory())
+
+        # post a message with a hat
+        self.assertTrue(self.client.login(username=profile.user.username, password='hostel77'))
+        data = {
+            'text': 'A new post!',
+            'last_post': topic.last_message.pk,
+            'hat': hat.pk,
+        }
+        response = self.client.post(reverse('post-new') + '?sujet={}'.format(topic.pk), data, follow=False)
+        self.assertEqual(topic.last_message.with_hat, hat.name)  # Hat was used
+
+        # test that it's possible to remove the hat
+        data = {
+            'text': 'A new post!'
+        }
+        response = self.client.post(
+            reverse('post-edit') + '?message={}'.format(topic.last_message.pk), data, follow=False)
+        topic = Topic.objects.get(pk=topic.pk)  # refresh
+        self.assertEqual(topic.last_message.with_hat, '')  # Hat was removed
+
+        # test that it's impossible to use a hat the user hasn't
+        data = {
+            'text': 'A new post!',
+            'hat': other_hat.pk,
+        }
+        response = self.client.post(
+            reverse('post-edit') + '?message={}'.format(topic.last_message.pk), data, follow=False)
+        topic = Topic.objects.get(pk=topic.pk)  # refresh
+        self.assertEqual(topic.last_message.with_hat, '')  # Hat wasn't used
+
+        # but check that it's possible to use a hat the user has
+        profile.hats.add(other_hat)
+        data = {
+            'text': 'A new post!',
+            'hat': other_hat.pk,
+        }
+        response = self.client.post(
+            reverse('post-edit') + '?message={}'.format(topic.last_message.pk), data, follow=False)
+        topic = Topic.objects.get(pk=topic.pk)  # refresh
+        self.assertEqual(topic.last_message.with_hat, other_hat.name)  # Now, it works
+
     def test_creation_archive_on_edit(self):
         profile = ProfileFactory()
         category, forum = create_category()

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -357,7 +357,7 @@ class TopicEdit(UpdateView, SingleObjectMixin, TopicEditMixin):
         return form
 
     def form_valid(self, form):
-        topic = self.perform_edit_info(self.object, self.request.POST, self.request.user)
+        topic = self.perform_edit_info(self.request, self.object, self.request.POST, self.request.user)
         return redirect(topic.get_absolute_url())
 
 
@@ -570,7 +570,7 @@ class PostEdit(UpdateView, SinglePostObjectMixin, PostEditMixin):
         return form
 
     def form_valid(self, form):
-        post = self.perform_edit_post(self.object, self.request.user, self.request.POST.get('text'))
+        post = self.perform_edit_post(self.request, self.object, self.request.user, self.request.POST.get('text'))
         return redirect(post.get_absolute_url())
 
 

--- a/zds/mp/commons.py
+++ b/zds/mp/commons.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 
 from zds.utils.templatetags.emarkdown import emarkdown
+from zds.utils.models import get_hat_from_request
 
 
 class LeavePrivateTopic(object):
@@ -30,9 +31,10 @@ class UpdatePrivatePost(object):
     Updates a private topic.
     """
 
-    def perform_update(self, instance, data):
-        instance.text = data.get('text')
-        instance.text_html = emarkdown(data.get('text'))
+    def perform_update(self, instance, request):
+        instance.with_hat = get_hat_from_request(request, instance.author)
+        instance.text = request.POST.get('text')
+        instance.text_html = emarkdown(request.POST.get('text'))
         instance.update = datetime.now()
         instance.save()
         return instance

--- a/zds/mp/commons.py
+++ b/zds/mp/commons.py
@@ -2,7 +2,6 @@
 from datetime import datetime
 
 from zds.utils.templatetags.emarkdown import emarkdown
-from zds.utils.models import get_hat_from_request
 
 
 class LeavePrivateTopic(object):

--- a/zds/mp/commons.py
+++ b/zds/mp/commons.py
@@ -31,10 +31,10 @@ class UpdatePrivatePost(object):
     Updates a private topic.
     """
 
-    def perform_update(self, instance, request):
-        instance.with_hat = get_hat_from_request(request, instance.author)
-        instance.text = request.POST.get('text')
-        instance.text_html = emarkdown(request.POST.get('text'))
+    def perform_update(self, instance, data, with_hat=''):
+        instance.with_hat = with_hat
+        instance.text = data.get('text')
+        instance.text_html = emarkdown(data.get('text'))
         instance.update = datetime.now()
         instance.save()
         return instance

--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -125,6 +125,7 @@ class PrivatePostForm(forms.Form):
 
         self.helper.layout = Layout(
             CommonLayoutEditor(),
+            HTML("{% include 'misc/hat_choice.html' with edited_message=post %}"),
             Hidden('last_post', '{{ last_post_pk }}'),
         )
 

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -359,6 +359,6 @@ class PrivatePostEdit(UpdateView, UpdatePrivatePost):
 
     def form_valid(self, form):
         self.perform_update(self.current_post, self.request.POST,
-                            with_hat=get_hat_from_request(request, self.current_post.author))
+                            with_hat=get_hat_from_request(self.request, self.current_post.author))
 
         return redirect(self.current_post.get_absolute_url())

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -358,6 +358,6 @@ class PrivatePostEdit(UpdateView, UpdatePrivatePost):
         return form
 
     def form_valid(self, form):
-        self.perform_update(self.current_post, self.request.POST)
+        self.perform_update(self.current_post, self.request)
 
         return redirect(self.current_post.get_absolute_url())

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -358,6 +358,7 @@ class PrivatePostEdit(UpdateView, UpdatePrivatePost):
         return form
 
     def form_valid(self, form):
-        self.perform_update(self.current_post, self.request)
+        self.perform_update(self.current_post, self.request.POST,
+                            with_hat=get_hat_from_request(request, self.current_post.author))
 
         return redirect(self.current_post.get_absolute_url())

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -26,7 +26,7 @@ from zds.pages.models import GroupContact
 from zds.searchv2.forms import SearchForm
 from zds.tutorialv2.models.models_database import PublishableContent, PublishedContent
 from zds.utils.forums import create_topic
-from zds.utils.models import Alert, CommentEdit, Comment
+from zds.utils.models import Alert, CommentEdit, Comment, Hat
 
 
 def home(request):
@@ -230,6 +230,13 @@ def restore_edit(request, edit_pk):
     comment.update = datetime.now()
     comment.editor = request.user
     comment.update_content(edit.original_text)
+    # remove hat if the author hasn't it anymore
+    if comment.with_hat:
+        try:
+            hat = Hat.objects.get(name=comment.with_hat)
+            assert hat in comment.author.profile.hats.all()
+        except (Hat.DoesNotExist, AssertionError):
+            comment.with_hat = ''
     comment.save()
 
     return redirect(comment.get_absolute_url())

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -234,8 +234,9 @@ def restore_edit(request, edit_pk):
     if comment.with_hat:
         try:
             hat = Hat.objects.get(name=comment.with_hat)
-            assert hat in comment.author.profile.hats.all()
-        except (Hat.DoesNotExist, AssertionError):
+            if hat not in comment.author.profile.hats.all():
+                raise ValueError
+        except (Hat.DoesNotExist, ValueError):
             comment.with_hat = ''
     comment.save()
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -517,7 +517,9 @@ class NoteForm(forms.Form):
             Field('last_note') if not last_note else Hidden('last_note', last_note)
         )
 
-        if reaction is None:  # we're not editing an existing comment
+        if reaction is not None:  # we're editing an existing comment
+            self.helper.layout.append(HTML("{% include 'misc/hat_choice.html' with edited_message=reaction %}"))
+        else:
             self.helper.layout.append(HTML("{% include 'misc/hat_choice.html' %}"))
 
         if content.antispam():

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -700,8 +700,11 @@ class UpdateNoteView(SendNoteFormView):
                 # show alert, if any
                 alerts = Alert.objects.filter(comment__pk=self.reaction.pk, solved=False)
                 if alerts.count():
-                    msg_alert = _(u'Attention, en éditant ce message vous résolvez également les alertes suivantes : {}') \
-                        .format(', '.join([u'« {} » (signalé par {})'.format(a.text, a.author.username) for a in alerts]))
+                    msg_alert = _(u'Attention, en éditant ce message vous résolvez également '
+                                  u'les alertes suivantes : {}') \
+                        .format(', '.join(
+                            [u'« {} » (signalé par {})'.format(a.text, a.author.username) for a in alerts]
+                        ))
                     messages.warning(self.request, msg_alert)
 
         return context

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -632,6 +632,7 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
 
             self.reaction.update = datetime.now()
             self.reaction.editor = self.request.user
+            self.reaction.with_hat = get_hat_from_request(self.request, self.reaction.author)
 
         else:
             self.reaction = ContentReaction()
@@ -686,19 +687,22 @@ class UpdateNoteView(SendNoteFormView):
     def get_context_data(self, **kwargs):
         context = super(UpdateNoteView, self).get_context_data(**kwargs)
 
-        if self.reaction and self.reaction.author != self.request.user:
-            messages.add_message(
-                self.request, messages.WARNING,
-                _(u'Vous éditez ce message en tant que modérateur (auteur : {}).'
-                  u' Ne faites pas de bêtise !')
-                .format(self.reaction.author.username))
+        if self.reaction:
+            context['reaction'] = self.reaction
 
-            # show alert, if any
-            alerts = Alert.objects.filter(comment__pk=self.reaction.pk, solved=False)
-            if alerts.count():
-                msg_alert = _(u'Attention, en éditant ce message vous résolvez également les alertes suivantes : {}') \
-                    .format(', '.join([u'« {} » (signalé par {})'.format(a.text, a.author.username) for a in alerts]))
-                messages.warning(self.request, msg_alert)
+            if self.reaction.author != self.request.user:
+                messages.add_message(
+                    self.request, messages.WARNING,
+                    _(u'Vous éditez ce message en tant que modérateur (auteur : {}).'
+                      u' Ne faites pas de bêtise !')
+                    .format(self.reaction.author.username))
+
+                # show alert, if any
+                alerts = Alert.objects.filter(comment__pk=self.reaction.pk, solved=False)
+                if alerts.count():
+                    msg_alert = _(u'Attention, en éditant ce message vous résolvez également les alertes suivantes : {}') \
+                        .format(', '.join([u'« {} » (signalé par {})'.format(a.text, a.author.username) for a in alerts]))
+                    messages.warning(self.request, msg_alert)
 
         return context
 

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -489,12 +489,14 @@ class Hat(models.Model):
         return self.name
 
 
-def get_hat_from_request(request):
+def get_hat_from_request(request, author=None):
+    if author is None:
+        author = request.user
     if not request.POST.get('hat', None):
         return ''
     try:
         hat = Hat.objects.get(pk=int(request.POST.get('hat')))
-        assert hat in request.user.profile.hats.all()
+        assert hat in author.profile.hats.all()
         return hat.name
     except (ValueError, Hat.DoesNotExist, AssertionError):
         logger.warning('User #{0} failed to use hat #{1}.'.format(request.user.pk, request.POST.get('hat')))

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -496,8 +496,9 @@ def get_hat_from_request(request, author=None):
         return ''
     try:
         hat = Hat.objects.get(pk=int(request.POST.get('hat')))
-        assert hat in author.profile.hats.all()
+        if hat not in author.profile.hats.all():
+            raise ValueError
         return hat.name
-    except (ValueError, Hat.DoesNotExist, AssertionError):
+    except (ValueError, Hat.DoesNotExist):
         logger.warning('User #{0} failed to use hat #{1}.'.format(request.user.pk, request.POST.get('hat')))
         return ''


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

### TODO

- [x] Les tests

### QA

- Vérifier que l'on peut modifier la casquette lors de l'édition d'un message de forum, d'un sujet, d'un MP ou d'un commentaire d'un contenu.
- Vérifier que les casquettes disponibles sont celles qu'a l'auteur du message *actuellement*.
- Vérifier que lorsqu'on édite comme staff, les casquettes disponibles restent celles de l'auteur du message.
- Vérifier que restaurer une version depuis l'historique des éditions d'un message entraîne la suppression de la casquette si l'utilisateur ne l'a plus.
- Code review