### PR TITLE
Travis se grouille

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ install:
 
 script:
   - |
-      # lint backend
+    # lint backend
     if [[ "$ZDS_TEST_JOB" == *"zds.gallery"* ]]; then
       ./scripts/no_import_zds_settings.sh \
       && flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ before_install:
   - travis_retry pip install -q coveralls
 
   - |
+    # install elasticsearch
     if [[ "$ZDS_TEST_JOB" == *"zds.searchv2"* ]]; then
       # see https://docs.travis-ci.com/user/database-setup/#Installing-specific-versions-of-ElasticSearch
       curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.0.deb \
@@ -75,6 +76,7 @@ before_install:
     fi
 
   - |
+    # setup mysql
     if [[ "$ZDS_TEST_JOB" == *"zds."* ]]; then
       # MySQL config
       ./scripts/ci_mysql_setup.sh
@@ -83,6 +85,7 @@ before_install:
 
 install:
   - |
+    # install frontend dependencies
     if [[ "$ZDS_TEST_JOB" == *"front"* ]]; then
       nvm install 8 \
       && nvm use 8 \
@@ -91,6 +94,7 @@ install:
     fi
 
   - |
+    # install latex
     if [[ "$ZDS_TEST_JOB" == *"zds.tutorialv2"* ]]; then
       mkdir -p $HOME/bin \
       && ./scripts/install_texlive.sh \
@@ -100,6 +104,7 @@ install:
     fi
 
   - |
+    # install backend dependencies
     if [[ "$ZDS_TEST_JOB" == *"zds."* ]]; then
       pip install -q -rrequirements.txt -rrequirements-dev.txt -rrequirements-prod.txt
     fi
@@ -107,17 +112,20 @@ install:
 
 script:
   - |
+      # lint backend
     if [[ "$ZDS_TEST_JOB" == *"zds.gallery"* ]]; then
       ./scripts/no_import_zds_settings.sh \
       && flake8
     fi
 
   - |
+    # test frontend
     if [[ "$ZDS_TEST_JOB" == *"front"* ]]; then
       yarn test
     fi
 
   - |
+    # test backend
     if [[ "$ZDS_TEST_JOB" == *"zds."* ]]; then
       coverage run --source='.' manage.py \
         test \
@@ -131,11 +139,13 @@ after_success:
   - du -sh $HOME/.texlive 2>/dev/null | true
 
   - |
+    # upload coverage
     if [[ "$ZDS_TEST_JOB" != "none" ]]; then
       coveralls
     fi
 
   - |
+    # upload compiled assets
     COMMIT_MSG=`git rev-list --format=%B --max-count=1 $TRAVIS_COMMIT`
     if [[ "$ZDS_TEST_JOB" == *"front"* ]] && [[ "$TRAVIS_PULL_REQUEST" == false ]] && [[ ! -z "$TRAVIS_TAG" ]] && [[ ! "$TRAVIS_TAG" == *"-build" ]]
     then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,52 @@
 dist: trusty
-sudo: required
-addons:
-  apt:
-    packages:
-    - mysql-server-5.6
-    - mysql-client-core-5.6
-    - mysql-client-5.6
-    - language-pack-fr
-    - unzip
-    - oracle-java8-set-default
-
-git:
-  depth: 1
-
 language: python
+sudo: required
+
 
 python:
   - 2.7
 
-node_js: '8'
+
+addons:
+  apt:
+    packages:
+      - mysql-server-5.6
+      - mysql-client-core-5.6
+      - mysql-client-5.6
+      - language-pack-fr
+      - unzip
+      - oracle-java8-set-default
+
+
+git:
+  depth: 1
+
+
+matrix:
+  fast_finish: true
+
 
 env:
   global:
     - secure: "azmDZZQZzf88zpbkYpLpxI66vpEVyv+kniW0QdWAt4qlys8P5OcO3VJBR5YT85vlvnjN9b6raWQAL1ymee0WmVdTmzXed8XjZv7t9QXVw7pfezxMKlEftVp/4Cu4wtvbew0ViZXNWV2hNXHzEqlhgnoIOq94i0UzZ7grMrI0xm0="
   matrix:
-    - TEST_APP="-e back_mysql -- zds.member zds.mp zds.utils zds.forum zds.gallery zds.pages zds.featured zds.notification zds.searchv2"
-    - TEST_APP="-e back_mysql -- zds.tutorialv2"
-    - TEST_APP="-e front"
+    - ZDS_TEST_JOB="zds.tutorialv2"
+    - ZDS_TEST_JOB="zds.member zds.utils zds.forum"
+    - ZDS_TEST_JOB="front zds.mp zds.gallery zds.pages zds.featured zds.notification zds.searchv2"
+
 
 notifications:
   webhooks:
     urls:
-        - "https://scalar.vector.im/api/neb/services/hooks/dHJhdmlzLWNpLyU0MHNhbmRob3NlJTNBc2FuZGhvc2UuZnIvJTIxd2dlbkt2dHpNY3NYREtiZEhZJTNBbWF0cml4Lm9yZw"
+      - "https://scalar.vector.im/api/neb/services/hooks/dHJhdmlzLWNpLyU0MHNhbmRob3NlJTNBc2FuZGhvc2UuZnIvJTIxd2dlbkt2dHpNY3NYREtiZEhZJTNBbWF0cml4Lm9yZw"
     on_success: change
     on_failure: always
     on_start: never
 
+
 services:
- - memcached
+  - memcached
+
 
 cache:
   apt: true
@@ -46,64 +55,89 @@ cache:
   directories:
     - $HOME/.cabal
     - $HOME/.fonts
-    - $HOME/.nvm
     - $HOME/.pandoc
     - $HOME/.texlive
     - $HOME/bin
+    - node_modules
+
 
 before_install:
-  # see https://docs.travis-ci.com/user/database-setup/#Installing-specific-versions-of-ElasticSearch
-  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.0.deb && sudo dpkg -i --force-confnew elasticsearch-5.3.0.deb && sudo service elasticsearch start
+  - . ./scripts/ci_turbo.sh
 
-before_script:
-  # MySQL config
-  - sudo sed -i'' 's/\[client\]/\[client\]\ndefault-character-set=utf8mb4/' /etc/mysql/my.cnf
-  - sudo sed -i'' 's/\[mysql\]/\[mysql\]\ndefault-character-set=utf8mb4/' /etc/mysql/my.cnf
-  - sudo sed -i'' 's/\[mysqld\]/\[mysqld\]\ninnodb_file_per_table=on\ninnodb_file_format=barracuda\ninnodb_large_prefix=on\ncharacter-set-client-handshake=false\ncharacter-set-server=utf8mb4\ncollation-server=utf8mb4_unicode_ci/' /etc/mysql/my.cnf
-  - sudo /etc/init.d/mysql restart
-  # Travis should fail as soon as possible
-  - mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';"
-  # Avoid "mysql has gone away" errors
-  - mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
-  - mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
-  # Create database with the correct charset and collation
-  - mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"
-  - mv zds/settings_test_travis.py zds/settings_prod.py
+  - travis_retry pip install -q coveralls
+
+  - |
+    if [[ "$ZDS_TEST_JOB" == *"zds.searchv2"* ]]; then
+      # see https://docs.travis-ci.com/user/database-setup/#Installing-specific-versions-of-ElasticSearch
+      curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.0.deb \
+      && sudo dpkg -i --force-confnew elasticsearch-5.3.0.deb \
+      && sudo service elasticsearch start
+    fi
+
+  - |
+    if [[ "$ZDS_TEST_JOB" == *"zds."* ]]; then
+      # MySQL config
+      ./scripts/ci_mysql_setup.sh
+    fi
+
 
 install:
-  - mkdir -p $HOME/bin
-  - ./scripts/install_texlive.sh
   - |
-    # only for front tests
-    if [[ "$TEST_APP" == *"front"* ]]; then
-      node --version
-      npm i -g yarn
-      yarn --silent
+    if [[ "$ZDS_TEST_JOB" == *"front"* ]]; then
+      nvm install 8 \
+      && nvm use 8 \
+      && npm i -g yarn \
+      && yarn --silent
     fi
-  - ./scripts/install_resources.sh
-  - export PATH=$HOME/.texlive/bin/x86_64-linux:$PATH
-  - export PATH=$PATH:$HOME/bin
-  # Python dependencies
-  - travis_retry pip install coveralls
-  - travis_retry pip install tox==2.0.1
+
+  - |
+    if [[ "$ZDS_TEST_JOB" == *"zds.tutorialv2"* ]]; then
+      mkdir -p $HOME/bin \
+      && ./scripts/install_texlive.sh \
+      && ./scripts/install_resources.sh \
+      && export PATH=$HOME/.texlive/bin/x86_64-linux:$PATH \
+      && export PATH=$PATH:$HOME/bin
+    fi
+
+  - |
+    if [[ "$ZDS_TEST_JOB" == *"zds."* ]]; then
+      pip install -q -rrequirements.txt -rrequirements-dev.txt -rrequirements-prod.txt
+    fi
+
 
 script:
-  - ./scripts/no_import_zds_settings.sh
-  - tox $TEST_APP
   - |
-    # avoid cache update & upload when we didn't explicitely change its content
-    if [[ -f "$HOME/.cache_updated" ]]; then
-      echo "Cache updated."
-    else
-      echo "Cache not updated."
-      rm -rf $HOME/.cabal $HOME/.fonts $HOME/.nvm $HOME/.pandoc $HOME/.texlive $HOME/bin
+    if [[ "$ZDS_TEST_JOB" == *"zds.gallery"* ]]; then
+      ./scripts/no_import_zds_settings.sh \
+      && flake8
     fi
 
+  - |
+    if [[ "$ZDS_TEST_JOB" == *"front"* ]]; then
+      yarn test
+    fi
+
+  - |
+    if [[ "$ZDS_TEST_JOB" == *"zds."* ]]; then
+      coverage run --source='.' manage.py \
+        test \
+        --keepdb \
+        --settings zds.settings_test_travis \
+        ${ZDS_TEST_JOB/front/}
+    fi
+
+
 after_success:
-  - coveralls
+  - du -sh $HOME/.texlive 2>/dev/null | true
+
+  - |
+    if [[ "$ZDS_TEST_JOB" != "none" ]]; then
+      coveralls
+    fi
+
   - |
     COMMIT_MSG=`git rev-list --format=%B --max-count=1 $TRAVIS_COMMIT`
-    if [[ "$TEST_APP" == *"front"* ]] && [[ "$TRAVIS_PULL_REQUEST" == false ]] && [[ ! -z "$TRAVIS_TAG" ]] && [[ ! "$TRAVIS_TAG" == *"-build" ]]
+    if [[ "$ZDS_TEST_JOB" == *"front"* ]] && [[ "$TRAVIS_PULL_REQUEST" == false ]] && [[ ! -z "$TRAVIS_TAG" ]] && [[ ! "$TRAVIS_TAG" == *"-build" ]]
     then
       # Adding GitHub OAuth token to login
       echo -e "machine github.com login $BOT_LOGIN\n password $BOT_PASSWORD" > $HOME/.netrc

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,3 +1,4 @@
 gunicorn==19.7.1
 MySQL-python==1.2.5
 raven==5.32.0
+ujson==1.35

--- a/scripts/ci_mysql_setup.sh
+++ b/scripts/ci_mysql_setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+
+sudo sed -i'' 's/\[client\]/\[client\]\ndefault-character-set=utf8mb4/' /etc/mysql/my.cnf
+sudo sed -i'' 's/\[mysql\]/\[mysql\]\ndefault-character-set=utf8mb4/' /etc/mysql/my.cnf
+sudo sed -i'' 's/\[mysqld\]/\[mysqld\]\ninnodb_file_per_table=on\ninnodb_file_format=barracuda\ninnodb_large_prefix=on\ncharacter-set-client-handshake=false\ncharacter-set-server=utf8mb4\ncollation-server=utf8mb4_unicode_ci/' /etc/mysql/my.cnf
+sudo /etc/init.d/mysql restart
+# Travis should fail as soon as possible
+mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';"
+# Avoid "mysql has gone away" errors
+mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
+mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
+# Create database with the correct charset and collation
+mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"

--- a/scripts/ci_turbo.sh
+++ b/scripts/ci_turbo.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+default_branch=dev
+
+git remote set-branches origin $default_branch
+git fetch --unshallow origin $default_branch
+
+if [[ ! -z "$TRAVIS_TAG" ]]
+then
+    exit 0
+fi
+
+changed_files=$(git --no-pager diff --name-only $TRAVIS_COMMIT $(git merge-base $TRAVIS_COMMIT origin/$default_branch))
+echo "changed files:"
+echo $changed_files
+echo
+
+if ! echo "$changed_files" | egrep -v "^assets"
+then
+    # Don't test the backend if only the `/assets/` directory changed
+    if [[ "$ZDS_TEST_JOB" == *"front"* ]]
+    then
+        export ZDS_TEST_JOB="front"
+    else
+        export ZDS_TEST_JOB="none"
+    fi
+
+    echo "skipping backend tests"
+fi

--- a/scripts/install_resources.sh
+++ b/scripts/install_resources.sh
@@ -3,8 +3,6 @@
 if [[ -f "$HOME/.fonts/truetype/SourceCodePro/SourceCodePro-Regular.ttf" ]]; then
   echo "Using cached fonts"
 else
-  # force cache upload after successful build
-  touch $HOME/.cache_updated
   echo "Installing fonts"
   rm -rf $HOME/.fonts
   mkdir -p $HOME/.fonts/truetype
@@ -18,8 +16,6 @@ fc-cache -f -v
 if [[ -f "$HOME/bin/pandoc" && -f "$HOME/.pandoc/templates/default.epub" ]]; then
   echo "Using cached pandoc"
 else
-  # force cache upload after successful build
-  touch $HOME/.cache_updated
   echo "Installing pandoc"
   rm -rf $HOME/.cabal $HOME/.pandoc
   mkdir -p $HOME/.cabal/bin

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -5,8 +5,6 @@ EXTRA_PACKAGES="wallpaper titlesec"
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"
 else
-  # force cache upload after successful build
-  touch $HOME/.cache_updated
   echo "Installing texlive to \$HOME/.texlive"
   rm -rf $HOME/.texlive
   TEXLIVE_PROFILE=${BASH_SOURCE[0]/%install_texlive.sh/texlive.profile}

--- a/tox.ini
+++ b/tox.ini
@@ -10,15 +10,6 @@ setenv =
        PYTHONDONTWRITEBYTECODE = 1
 whitelist_externals=*
 
-[testenv:back_mysql]
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/requirements-dev.txt
-       MySQL-python
-       ujson
-commands =
-       coverage run --source='.' {toxinidir}/manage.py test {posargs}
-       flake8
-
 [testenv:back]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,6 @@ commands = flake8 {posargs}
 [flake8]
 #show-source = True
 max-line-length = 120
-exclude = .tox,.venv,build,dist,doc,migrations,settings_prod.py,settings_test.py,settings_test_local.py,settings_test_travis.py
+exclude = node_modules,.tox,.venv,build,dist,doc,migrations,settings_prod.py,settings_test.py,settings_test_local.py,settings_test_travis.py
 # Ignore N802 (functions in lowercase) because the setUp() function in tests
 ignore = N802

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -23,6 +23,8 @@ from copy import deepcopy
 overridden_zds_app = deepcopy(settings.ZDS_APP)
 overridden_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
 overridden_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
+overridden_zds_app['content']['extra_content_generation_policy'] = 'SYNC'
+overridden_zds_app['content']['build_pdf_when_published'] = False
 
 
 @override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
@@ -191,7 +193,7 @@ class MemberModelsTest(TestCase):
         articles = self.user1.get_public_articles()
         self.assertEqual(len(articles), 0)
         # Should be 1
-        PublishedContentFactory(author_list=[self.user1.user], type='Article')
+        PublishedContentFactory(author_list=[self.user1.user], type='ARTICLE')
         self.assertEqual(len(self.user1.get_public_articles()), 1)
         self.assertEqual(len(self.user1.get_public_tutos()), 0)
 

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -33,6 +33,8 @@ from copy import deepcopy
 overridden_zds_app = deepcopy(settings.ZDS_APP)
 overridden_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
 overridden_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
+overridden_zds_app['content']['extra_content_generation_policy'] = 'SYNC'
+overridden_zds_app['content']['build_pdf_when_published'] = False
 
 
 @override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))

--- a/zds/settings_test_travis.py
+++ b/zds/settings_test_travis.py
@@ -1,3 +1,4 @@
+from zds.settings import *
 from zds.settings_test import *
 
 DATABASES = {

--- a/zds/utils/management/tests.py
+++ b/zds/utils/management/tests.py
@@ -1,5 +1,11 @@
+from copy import deepcopy
+import os
+import shutil
+
 from django.core.management import call_command
 from django.test import TestCase
+from django.test.utils import override_settings
+from django.conf import settings
 
 from django.contrib.auth.models import User, Group, Permission
 from zds.member.models import Profile
@@ -11,7 +17,18 @@ from zds.tutorialv2.models.models_database import PublishableContent, PublishedC
     Validation as CValidation
 from zds.gallery.models import Gallery, UserGallery
 
+BASE_DIR = settings.BASE_DIR
 
+overridden_zds_app = deepcopy(settings.ZDS_APP)
+overridden_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
+overridden_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overridden_zds_app['content']['extra_content_generation_policy'] = 'SYNC'
+overridden_zds_app['content']['build_pdf_when_published'] = False
+
+
+@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(ZDS_APP=overridden_zds_app)
+@override_settings(ES_ENABLED=False)
 class CommandsTestCase(TestCase):
     def test_load_fixtures(self):
 
@@ -63,3 +80,12 @@ class CommandsTestCase(TestCase):
 
         result = self.client.get('/?prof', follow=True)
         self.assertEqual(result.status_code, 200)
+
+    def tearDown(self):
+
+        if os.path.isdir(overridden_zds_app['content']['repo_private_path']):
+            shutil.rmtree(overridden_zds_app['content']['repo_private_path'])
+        if os.path.isdir(overridden_zds_app['content']['repo_public_path']):
+            shutil.rmtree(overridden_zds_app['content']['repo_public_path'])
+        if os.path.isdir(settings.MEDIA_ROOT):
+            shutil.rmtree(settings.MEDIA_ROOT)


### PR DESCRIPTION
Réorganise le .travis.yml et ajoute le script `scripts/ci_turbo.sh` qui
fait sauter les tests du backend quand `dev..$TRAVIS_COMMIT` ne modifie
rien d’autre en dehors du dossier `assets/`.

J’ai simplifié un petit peu les histoires de cache, j’ai l’impression que 
ça marche nettement mieux (en tout cas, les chiffres me le font penser).

J’ai aussi fait en sorte d’éviter d’installer un maximum de dépendances 
inutiles pour un job donné.

La plupart des builds complets (à chaud, avec un cache provenant de
builds précédents) que j’ai lancé avec ce patch ont duré environ 5 ou 
6 minutes, et les builds du frontends uniquement ont duré environ 3 ou
4 minutes. Les builds sans cache provenant de builds précédents sont
plus longs.

J’ai bien fait attention à découper les scripts en petit bouts de façon 
à ce que le temps de chaque étape soit bien mesuré par Travis :

![image](https://user-images.githubusercontent.com/15378830/29070130-299e8cb2-7c3e-11e7-9caf-858269d59917.png)

Contient également un commit de @pierre-24 corrigeant certains
problèmes des tests trop obscurs pour moi.


| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

### QA

Lisez le diff, relacez le build depuis travis-ci.org, amusez-vous à
supprimer le cache, forkez et modifiez le frontend, faites des expériences.