### PR TITLE
[WIP] Restauration du CSS

### DIFF
--- a/assets/js/mobile-menu.js
+++ b/assets/js/mobile-menu.js
@@ -21,10 +21,6 @@
     var appleWebKitVersion = (resultAppleWebKitRegEx === null ? null : parseFloat(regExAppleWebKit.exec(navU)[1]));
     var disableMobileMenu = isAndroidMobile && appleWebKitVersion !== null && appleWebKitVersion < 537;
 
-    if(disableMobileMenu)
-        $("html").removeClass("enable-mobile-menu");
-
-
 
     /**
      * Get prefix to support CSS transform

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -172,8 +172,6 @@
             Modal.current = this;
 
             this.body.find("input:visible, select, textarea").first().focus();
-            if(!$("html").hasClass("enable-mobile-menu"))
-                $("html").addClass("dropdown-active");
         },
 
         /**

--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -1,16 +1,13 @@
 html {
     height: 100%;
     width: 100%;
-    font-size: 62.5%;
     overflow-x: hidden;
     word-wrap: break-word;
 }
 
 body {
     background: $color-body-background;
-    font-size: 14px;
-    font-size: 1.4rem;
-    line-height: 1.7em;
+    line-height: 1.5;
     width: 100%;
     height: 100%;
 }
@@ -123,11 +120,6 @@ nav {
     html,
     body {
         height: 100%;
-    }
-
-    .wrapper {
-        width: 95%;
-        margin: 0 2.5%;
     }
 }
 

--- a/assets/scss/base/_high-pixel-ratio.scss
+++ b/assets/scss/base/_high-pixel-ratio.scss
@@ -46,7 +46,7 @@
        only screen and (min-resolution: 192dpi) and #{$media-mobile-tablet},
        only screen and (min-resolution: 2dppx) and #{$media-mobile-tablet} {
 
-    .enable-mobile-menu .mobile-menu-hide .page-container .mobile-menu-btn:after {
+    .page-container .mobile-menu-btn:after {
         @include sprite-2x();
     }
 

--- a/assets/scss/components/_breadcrumb.scss
+++ b/assets/scss/components/_breadcrumb.scss
@@ -7,7 +7,7 @@
         position: relative;
         display: flex;
         width: calc(100% - 60px * 4);
-        height: 30px;
+        height: 2em;
         padding-left: 2rem;
 
         &:after {
@@ -28,12 +28,13 @@
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
+            display: flex;
+            align-items: center;
 
             li {
                 position: relative;
-                display: inline-block;
-                padding-right: 30px;
-                line-height: 30px;
+                display: flex;
+                align-items: center;
 
                 a {
                     text-decoration: none;
@@ -47,17 +48,14 @@
                 }
 
                 &:not(:last-child):after {
-                    display: block;
-                    position: absolute;
-                    top: 0;
-                    right: 7px;
                     content: " ";
                     height: 30px;
                     width: 15px;
                     @include sprite();
-                    background-repeat: no-repeat;
                     @include sprite-position($ariane);
-                    opacity: .2;
+                    background-repeat: no-repeat;
+                    opacity: 0.2;
+                    margin: 0 1rem;
                 }
             }
         }

--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -20,13 +20,9 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
         .content-description {
             height: 36px; // 2 lines
             white-space: normal;
-            font-size: 14px;
-            font-size: 1.4rem;
-            line-height: 18px;
         }
 
         .content-meta {
-            line-height: 16px;
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
@@ -91,10 +87,10 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
 
         color: $color-secondary;
         text-align: center;
-        line-height: 32px;
         font-weight: bold;
         font-size: 14px;
         font-size: 1.4rem;
+        line-height: 32px;
 
         span {
             position: relative;
@@ -158,9 +154,6 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
 
     .content-description {
         margin: 0;
-        font-size: 15px;
-        font-size: 1.5rem;
-        line-height: 26px;
         height: 26px;
         color: #999;
         margin-bottom: 2px;
@@ -176,9 +169,6 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
 
     .content-meta {
         color: $color-secondary;
-        font-size: 13px;
-        font-size: 1.3rem;
-        line-height: 15px;
 
         &:not(.inline) > * {
             white-space: nowrap;
@@ -220,7 +210,6 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
             a {
                 color: inherit;
                 padding: 0 12px;
-                line-height: 22px;
                 height: 22px;
                 display: block; // to have the click zone matching the parent box
 
@@ -269,22 +258,16 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
 
     &.topic-item {
         .content-info {
-            padding: 14px 20px;
             height: 68px;
         }
 
         .content-title {
-            font-size: 19px;
-            font-size: 1.9rem;
-            line-height: 24px;
+            font-size: 1.2rem;
             color: $color-primary;
         }
 
         .content-description {
             color: #505050;
-            font-size: 16px;
-            font-size: 1.6rem;
-
         }
 
         .member-item {
@@ -294,9 +277,6 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
         }
 
         .content-meta {
-            font-size: 14px;
-            font-size: 1.4rem;
-            line-height: 16px;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;

--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -88,7 +88,6 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
         color: $color-secondary;
         text-align: center;
         font-weight: bold;
-        font-size: 14px;
         font-size: 1.4rem;
         line-height: 32px;
 
@@ -129,7 +128,6 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
     .content-title {
         margin: 0;
 
-        font-size: 17px;
         font-size: 1.7rem;
         font-weight: normal;
         line-height: 20px;

--- a/assets/scss/components/_header-dropdown.scss
+++ b/assets/scss/components/_header-dropdown.scss
@@ -8,8 +8,6 @@
     background-color: $color-header-hover;
     margin: 0;
     padding: 10px 2.5%;
-    font-size: 14px;
-    font-size: 1.4rem;
     border-bottom: 3px solid $color-secondary;
     z-index: 50;
 

--- a/assets/scss/components/_header-search.scss
+++ b/assets/scss/components/_header-search.scss
@@ -12,7 +12,7 @@
             float: left;
             border: none;
             background: rgba(255, 255, 255, .25);
-            height: 40px;
+            height: 100%;
             transition-property: background;
             transition-duration: $transition-duration;
 
@@ -25,7 +25,6 @@
             }
         }
         input {
-            height: 30px;
             padding: 5px 3%;
             width: 70%;
         }
@@ -52,10 +51,10 @@
             }
         }
     }
+
     .search-more {
         display: block;
         float: left;
-        height: 40px;
         font-family: Arial, sans-serif;
         line-height: 40px;
         width: 12%;
@@ -94,11 +93,9 @@
         form {
             input {
                 padding: 6px 10px;
-                height: 30px;
                 width: 60px * 3;
             }
             button {
-                height: 30px;
                 line-height: 30px;
                 width: 30px;
 
@@ -110,7 +107,6 @@
 
         .search-more {
             width: 30px;
-            height: 30px;
             line-height: 30px;
         }
     }

--- a/assets/scss/components/_linkbox.scss
+++ b/assets/scss/components/_linkbox.scss
@@ -21,7 +21,7 @@ $color-linkbox-default: #777;
             position: relative;
             color: white;
             text-decoration: none;
-            
+
             &:after {
                 content: '';
                 position: absolute;
@@ -50,8 +50,7 @@ $color-linkbox-default: #777;
             padding: 10px;
 
             h3 {
-                font-size: 2.2rem;
-                line-height: 32px;
+                font-size: 1.25rem;
                 font-weight: normal;
                 margin: 0; padding: 0;
                 width: 100%;
@@ -65,8 +64,6 @@ $color-linkbox-default: #777;
         .body {
             display: block;
             padding: 10px 10px 5px 10px;
-            font-size: 1.3rem;
-            line-height: 1.7rem;
 
             border-top: solid 1px rgba(0, 0, 0, .25);
 
@@ -82,12 +79,12 @@ $color-linkbox-default: #777;
         .tail {
             display: flex;
             padding: 10px;
-            
+
             border-top: solid 1px rgba(255, 255, 255, .2);
 
             p {
                 margin: 0; padding: 0;
-                line-height: 2.2rem;
+                line-height: 1.5rem;
                 width: 100%;
 
                 overflow: hidden;

--- a/assets/scss/components/_mobile-menu.scss
+++ b/assets/scss/components/_mobile-menu.scss
@@ -1,3 +1,4 @@
+
 .mobile-menu,
 .mobile-menu-btn {
     display: none;
@@ -41,8 +42,6 @@
                 background-color: #333;
                 height: 30px;
                 padding: 10px 5%;
-                font-size: 16px;
-                font-size: 1.6rem;
                 width: 100%;
                 height: 100%;
                 box-sizing: border-box;
@@ -104,13 +103,11 @@
                 display: block;
                 content: attr(data-title);
                 height: 30px;
-                font-size: 14px;
-                font-size: 1.4rem;
                 text-transform: uppercase;
                 padding-bottom: 3px;
                 border-bottom: 2px solid #3F3F3F;
                 font-weight: bold;
-                color: #666;
+                color: #888;
             }
 
             &.mobile-show-ico {
@@ -144,8 +141,6 @@
             line-height: 40px;
             text-decoration: none;
             color: #CCC;
-            font-size: 16px;
-            font-size: 1.6rem;
             text-overflow: ellipsis;
             white-space: nowrap;
             overflow: hidden;
@@ -195,6 +190,7 @@
             }
         }
     }
+
     .js.show-mobile-menu {
         width: 100%;
 
@@ -213,97 +209,36 @@
         }
     }
 
-    // Mobile supports sidebar only
-    .js.enable-mobile-menu {
-        .mobile-menu-hide {
+    .page-container {
+        .mobile-menu-bloc,
+        .mobile-menu-link,
+        .search {
             display: none;
         }
 
-        .page-container {
-            .mobile-menu-bloc,
-            .mobile-menu-link,
-            .search {
-                display: none;
-            }
+        .mobile-menu-btn + .header-logo {
+            margin-left: 0;
+        }
 
-            .mobile-menu-btn + .header-logo {
-                margin-left: 0;
-            }
+        // Adapt menu to smartphone with sidebar
+        .mobile-menu-btn {
+            display: block;
+            float: left;
+            height: 50px;
+            width: 50px;
+            cursor: pointer;
 
-
-            // Adapt menu to smartphone with sidebar
-            .mobile-menu-btn {
+            &:after {
                 display: block;
-                float: left;
-                height: 50px;
-                width: 50px;
-                cursor: pointer;
-
-                &:after {
-                    display: block;
-                    content: " ";
-                    position: absolute;
-                    top: 15px;
-                    left: 13px;
-                    height: 22px;
-                    width: 22px;
-                    @include sprite();
-                    background-repeat: no-repeat;
-                    @include sprite-position($menu);
-                }
-            }
-        }
-    }
-
-    html:not(.enable-mobile-menu) {
-        .header-container {
-            border-bottom: 1px solid #CCC;
-        }
-
-        .page-container {
-            .header-logo {
-                margin-left: 10px;
-            }
-            .header-logo-link {
-                &:after {
-                    left: 55px;
-                    right: 205px;
-                }
-            }
-        }
-
-
-        .logbox {
-            .notifs-links .ico-link,
-            .my-account {
+                content: " ";
                 position: absolute;
-                top: 0;
-                right: 0;
-                height: 50px;
-                width: 50px;
-
-                .avatar {
-                    height: 50px;
-                    width: 50px;
-                }
-            }
-            .notifs-links  {
-                :nth-child(1) .ico-link {
-                    right: 150px;
-                }
-                :nth-child(2) .ico-link {
-                    right: 100px;
-                }
-                :nth-child(3) .ico-link,
-                .ico-link:nth-child(3) {
-                    right: 50px;
-                }
-            }
-
-            &.unlogged {
-                position: absolute;
-                top: 0;
-                right: 0;
+                top: 15px;
+                left: 13px;
+                height: 22px;
+                width: 22px;
+                @include sprite();
+                background-repeat: no-repeat;
+                @include sprite-position($menu);
             }
         }
     }

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -55,7 +55,6 @@
         text-indent: 15px;
         background: $color-primary;
         color: #FFF;
-        font-size: 16px;
         font-size: 1.6rem;
         text-shadow: rgba(0, 0, 0, 0.75) 0 0 3px;
 

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -123,7 +123,7 @@
     }
 }
 
-.enable-mobile-menu .modals-container .modal {
+.modals-container .modal {
     margin: $modal-margin;
     box-shadow: 0 0 5px #000;
     max-width: 100%;
@@ -134,7 +134,7 @@
 }
 
 @media only screen and #{$media-wide} {
-    .enable-mobile-menu .modals-container .modal {
+    .modals-container .modal {
         box-shadow: 0 2px 7px rgba(0, 0, 0, .7);
 
         .modal-title {

--- a/assets/scss/components/_notification-list.scss
+++ b/assets/scss/components/_notification-list.scss
@@ -105,7 +105,6 @@
             display: block;
             margin: 0 !important;
             padding: 0;
-            font-size: 16px;
             font-size: 1.6rem;
             font-weight: normal;
         }

--- a/assets/scss/components/_search-box.scss
+++ b/assets/scss/components/_search-box.scss
@@ -15,16 +15,16 @@
         height: 50px;
     }
 
+    font-size: 1.2rem;
+
     label {
         text-align: right;
         padding: 0 5px;
-        font-size: 2rem;
         font-weight: 300;
         margin-left: 50px;
     }
 
     input {
-        font-size: 2rem;
         border: none;
         font-weight: 300;
         flex: 1;
@@ -144,4 +144,3 @@
         margin: 30px 40px 0;
     }
 }
-

--- a/assets/scss/components/_topic-list.scss
+++ b/assets/scss/components/_topic-list.scss
@@ -161,8 +161,7 @@
             padding: 0;
         }
         .topic-title {
-            font-size: 16px;
-            font-size: 1.6rem;
+            font-size: 1.2rem;
             font-weight: normal;
         }
         .topic-subtitle {

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -261,7 +261,6 @@
                 border-top: 1px solid #D2D5D6;
                 padding: 3px 0 3px 10px;
                 margin: 0 10px 0 0;
-                font-size: 12px;
                 font-size: 1.2rem;
                 color: #999;
                 flex: 1;

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -136,8 +136,6 @@
 
         .message-metadata {
             display: inline-block;
-            font-size: 14px;
-            font-size: 1.4rem;
             margin-left: 5px;
 
             a {
@@ -160,8 +158,6 @@
             }
             .username {
                 color: #484848;
-                font-size: 16px;
-                font-size: 1.6rem;
                 margin-right: 3px;
             }
             .date {

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -3,6 +3,7 @@
     max-width: 500px;
     margin: 20px auto;
 }
+
 .main .content-container {
     .content-wrapper {
         &.article-content,

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -93,7 +93,6 @@
             }
         }
         h2 {
-            font-size: 22px;
             font-size: 2.2rem;
             line-height: 50px;
             margin-bottom: 20px;
@@ -103,22 +102,18 @@
             font-weight: 400;
         }
         h3 {
-            font-size: 20px;
             font-size: 2.0rem;
             margin-bottom: 14px;
         }
         h4 {
-            font-size: 18px;
             font-size: 1.8rem;
             margin-bottom: 12px;
         }
         h5 {
-            font-size: 16px;
             font-size: 1.6rem;
             margin-bottom: 10px;
         }
         h6 {
-            font-size: 15px;
             font-size: 1.5rem;
             margin-bottom: 10px;
         }
@@ -334,7 +329,6 @@
             overflow: auto;
 
             mathjax {
-                font-size: 16px;
                 font-size: 1.6rem;
             }
         }
@@ -353,7 +347,6 @@
         color: $color-primary;
         border-bottom: 1px solid $color-secondary;
         font-weight: normal;
-        font-size: 22px;
         font-size: 2.2rem;
         line-height: 30px;
     }
@@ -406,7 +399,6 @@
             p,
             ol,
             ul:not(.pagination) {
-                font-size: 15px;
                 font-size: 1.5rem;
                 font-size: 1.8ex;
             }

--- a/assets/scss/layout/_footer.scss
+++ b/assets/scss/layout/_footer.scss
@@ -9,8 +9,6 @@
     height: 40px;
     line-height: 40px;
     border-top: 3px solid $color-secondary;
-    font-size: 14px;
-    font-size: 1.4rem;
 
     .wrapper {
         display: flex;

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -48,6 +48,10 @@
         display: flex;
         justify-content: center;
 
+        @media only screen and #{$media-mobile-tablet} {
+            display: none;
+        }
+
         & > li {
             display: block;
             flex-grow: 0;
@@ -60,7 +64,7 @@
                 position: relative;
                 text-align: center;
                 line-height: 60px;
-                font-size: 1.6rem;
+                font-size: 1.2rem;
                 text-transform: uppercase;
                 text-shadow: rgba(0, 0, 0, 0.75) 0 0 3px;
 
@@ -405,8 +409,7 @@
                 text-indent: 0;
                 text-align: left;
                 font-weight: normal;
-                font-size: 17px;
-                font-size: 1.7rem;
+                font-size: 1.2rem;
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 overflow: hidden;
@@ -444,7 +447,6 @@
 
             &.unlogged {
                 font-size: 13px;
-                font-size: 1.3rem;
 
                 a {
                     background-color: rgba(255, 255, 255, .1);

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -4,14 +4,9 @@
 }
 
 .main .content-container {
-    padding-top: 30px;
-
     h1,
     h2 {
-        font-size: 22px;
-        font-size: 2.2rem;
-        line-height: 38px;
-        line-height: 3.8rem;
+        font-size: 1.5rem;
         color: $color-primary;
         font-weight: normal;
         border-bottom: 1px solid $color-secondary;
@@ -63,10 +58,9 @@
         }
 
         .btn {
-            font-size: 16px;
-
-            height: 38px;
-            line-height: 38px;
+            font-size: 1rem;
+            height: 40px;
+            line-height: 40px;
         }
     }
 
@@ -77,9 +71,7 @@
     }
 
     .subtitle {
-        font-size: 18px;
-        font-size: 1.8rem;
-        line-height: 23px;
+        font-size: 1.2rem;
         color: #999;
         margin-top: -15px;
         margin-bottom: 15px;
@@ -144,31 +136,25 @@
 @media only screen and #{$media-mega-wide} {
     .main .content-container {
         .content-wrapper {
-            max-width: 960px;
+            max-width: $max-width;
             margin: 0 auto !important;
         }
     }
 }
 
 @media only screen and #{$media-wide} {
-    body.no-sidebar .main {
-        .content-container {
-            width: 100%;
-        }
-        .sidebar {
-            display: none;
-        }
-    }
-
     .main {
         display: flex;
         flex-direction: row-reverse;
+        justify-content: center;
         margin-left: 0;
-        padding-left: 2.5%;
 
         .content-container {
-            width: 80%;
+            max-width: $max-width;
             margin-right: 0;
+            flex-basis: auto;
+            flex-grow: 1;
+            flex-shrink: 1;
 
             .taglist + .pubdate {
                 margin-top: -40px;
@@ -237,54 +223,10 @@
                 }
             }
         }
-
-        .sidebar {
-            width: 22.5%;
-            border-bottom: none;
-
-            h3,
-            h4,
-            ul li,
-            ol li {
-                padding-left: 11.5%;
-            }
-
-            h3:first-child {
-                margin-top: 31px;
-            }
-
-            h4[data-num] {
-                padding-left: calc(11% + 25px);
-
-                &:before {
-                    left: 11%;
-                }
-            }
-
-            &.sommaire ul li.current {
-                ul,
-                ol {
-                    margin-left: calc(-11% - 10px);
-                    width: calc(111% + 10px);
-                    background: linear-gradient(to bottom, rgba(0, 0, 0, .07), transparent 3px);
-
-                    a {
-                        padding-left: calc(11% + 30px);
-                    }
-                }
-            }
-        }
     }
 }
 
 @media only screen and #{$media-wide} {
-    .content-cols .main {
-        .content-container {
-            width: 79%;
-            margin-left: 1.5%;
-        }
-    }
-
     .full-content-wrapper .tutorial-list article {
         width: 46%;
         float: left;

--- a/assets/scss/layout/_sidebar.scss
+++ b/assets/scss/layout/_sidebar.scss
@@ -3,8 +3,13 @@
     background: $color-sidebar-background;
     border-bottom: 1px solid #FFF;
     color: #424242;
-    width: 105%;
-    margin: 0 0 0 -2.7%;
+
+    @media only screen and #{$media-wide} {
+        flex-basis: 20rem;
+        flex-shrink: 0;
+        flex-grow: 0;
+        border-bottom: none;
+    }
 
     .new-btn {
         display: block;
@@ -13,8 +18,6 @@
         text-decoration: none;
         text-indent: 25px;
         line-height: 40px;
-        font-size: 16px;
-        font-size: 1.6rem;
         position: relative;
         color: lighten($color-primary, 20%);
         transition: all $transition-duration ease;
@@ -36,29 +39,38 @@
 
     h3,
     h4 {
+        font-size: 1.2rem;
         font-weight: normal;
         margin: 0;
         padding: 0;
     }
+
     h3 {
-        font-size: 18px;
-        font-size: 1.8rem;
         line-height: 38px;
         line-height: 3.8rem;
         color: $color-primary;
         border-bottom: 1px solid $color-secondary;
         margin-top: 30px;
     }
+
     h4 {
         padding-top: 20px;
-        font-size: 17px;
-        font-size: 1.7rem;
 
         a {
             text-decoration: none;
             color: #424242;
         }
     }
+
+    @media only screen and #{$media-wide} {
+        h3,
+        h4,
+        ul li,
+        ol li {
+            padding-left: 11.5%;
+        }
+    }
+
     &.accordeon h4 {
         cursor: pointer;
     }
@@ -79,6 +91,20 @@
     h3 + ul,
     h3 + ol {
         margin: 7px 0;
+    }
+
+    @media only screen and #{$media-wide} {
+        h3:first-child {
+            margin-top: 31px;
+        }
+
+        h4[data-num] {
+            padding-left: calc(11% + 25px);
+
+            &:before {
+                left: 11%;
+            }
+        }
     }
 
     ul,
@@ -117,8 +143,6 @@
                 overflow: hidden;
                 height: 30px;
                 line-height: 30px;
-                font-size: 14px;
-                font-size: 1.4rem;
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 border: 0;

--- a/assets/scss/pages/_flexpage.scss
+++ b/assets/scss/pages/_flexpage.scss
@@ -9,10 +9,8 @@ $content-width: 1145px;
         padding: 0;
     }
 
-    #content {
-        width: 100%;
-        margin: 0;
-        padding: 0;
+    .content-container {
+        max-width: initial;
     }
 
     .sub-header{
@@ -43,7 +41,7 @@ $content-width: 1145px;
         }
     }
 
-        .flexpage-title-tool {
+    .flexpage-title-tool {
         padding: 50px;
         font-size: 2rem;
         font-weight: 100;
@@ -91,7 +89,7 @@ $content-width: 1145px;
                 margin: 0 10px 0 0; padding: 0;
 
                 color: inherit;
-                font-size: 6rem;
+                font-size: 3rem;
                 line-height: 50px;
                 border: none;
             }
@@ -147,7 +145,7 @@ $content-width: 1145px;
 
         .aside {
             display: flex;
-            
+
             margin-top: 20px;
             max-width: 600px;
             height: 50px;
@@ -167,6 +165,7 @@ $content-width: 1145px;
                     line-height: 50px;
                     height: 50px;
                     margin: 0; padding: 0 15px;
+                    font-weight: inherit;
 
                     border: none;
                 }

--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -39,7 +39,6 @@
             padding: 0 20px;
 
             h2 {
-                font-size: 18px;
                 font-size: 1.8rem;
                 color: white;
                 margin: 20px 0 10px 0;
@@ -94,7 +93,6 @@
             font-size: 1.4em;
 
             .home-description-button {
-                font-size: 14px;
                 font-size: 1.4rem;
                 line-height: 24px;
                 line-height: 2.4rem;
@@ -112,7 +110,6 @@
     .home-description-button {
         display: inline-block;
         line-height: 2rem;
-        font-size: 1.2rem;
         font-size: 12px;
         color: white;
         text-decoration: none;
@@ -282,7 +279,6 @@
         .home-description {
             .column {
                 h2 {
-                    font-size: 22px;
                     font-size: 2.2rem;
                 }
 

--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -49,7 +49,7 @@
         }
 
         blockquote {
-            font-size: 2.5rem;
+            font-size: 2rem;
             color: white;
             font-weight: 300;
             padding: 0;
@@ -287,9 +287,6 @@
                 }
 
                 p, ul {
-                    line-height: 22px;
-                    font-size: 15px;
-                    font-size: 1.5rem;
                 }
             }
             &.connected {

--- a/assets/scss/pages/_tutorial-help.scss
+++ b/assets/scss/pages/_tutorial-help.scss
@@ -19,8 +19,7 @@
     .tutorial-title {
         margin: 0;
         padding: 0;
-        font-size: 20px;
-        font-size: 2.0rem;
+        font-size: 2rem;
         height: 27px;
         width: 100%;
         overflow: hidden;

--- a/assets/scss/variables/_variables.scss
+++ b/assets/scss/variables/_variables.scss
@@ -1,5 +1,6 @@
 $transition-duration: .15s;
 $modal-margin: 25px;
+$max-width: 960px;
 
 @import "colors";
 @import "typography";

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,7 @@
 
 
 <!DOCTYPE html>
-<html class="enable-mobile-menu" lang="fr">
+<html lang="fr">
 <head>
     <meta charset="utf-8">
 
@@ -607,7 +607,7 @@
 
         <div class="main-container">
             {% block doc_api %}
-                <div class="main wrapper clearfix">
+                <div class="main wrapper">
                     <main class="content-container" role="main" id="content">
                         {% if messages %}
                             {% for message in messages %}

--- a/templates/base_content_page.html
+++ b/templates/base_content_page.html
@@ -20,7 +20,7 @@
 
 
 {% block sidebar %}
-    <aside class="sidebar mobile-menu-hide">
+    <aside class="sidebar">
         {% block sidebar_actions %}{% endblock %}
     </aside>
 {% endblock %}

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -36,7 +36,7 @@
 
 
 {% block sidebar %}
-    <aside class="sidebar mobile-menu-hide">
+    <aside class="sidebar">
         {% captureas returnbtn %}
             {% block return_btn %}{% endblock %}
         {% endcaptureas %}

--- a/templates/gallery/base.html
+++ b/templates/gallery/base.html
@@ -16,7 +16,7 @@
 
 
 {% block sidebar %}
-    <aside class="sidebar mobile-menu-hide">
+    <aside class="sidebar">
         <a href="{% url "gallery-new" %}" class="new-btn ico-after more blue">
             {% trans "Créer une galerie" %}
         </a>

--- a/templates/member/base.html
+++ b/templates/member/base.html
@@ -21,7 +21,7 @@
 
 
 {% block sidebar %}
-    <aside class="sidebar mobile-menu-hide">
+    <aside class="sidebar">
         {% block sidebar_actions %}{% endblock %}
     </aside>
 {% endblock %}

--- a/templates/member/settings/base.html
+++ b/templates/member/settings/base.html
@@ -21,7 +21,7 @@
 
 
 {% block sidebar %}
-    <aside class="sidebar mobile-menu-hide">
+    <aside class="sidebar">
         <div class="mobile-menu-bloc mobile-all-links" data-title="Navigation">
             <h3>{% trans "Navigation" %}</h3>
             <ul>

--- a/templates/mp/base.html
+++ b/templates/mp/base.html
@@ -28,7 +28,7 @@
 
 
 {% block sidebar %}
-    <aside class="sidebar mobile-menu-hide">
+    <aside class="sidebar">
         <a href="{% url 'mp-new' %}" class="new-btn ico-after more blue">
             {% trans "Nouvelle conversation" %}
         </a>

--- a/templates/notification/followed.html
+++ b/templates/notification/followed.html
@@ -58,7 +58,7 @@
 
 
 {% block sidebar %}
-    <aside class="sidebar mobile-menu-hide">
+    <aside class="sidebar">
         <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Actions">
             <h3>{% trans "Actions" %}</h3>
             <ul>

--- a/templates/tutorialv2/base.html
+++ b/templates/tutorialv2/base.html
@@ -66,7 +66,7 @@
 
 
 {% block sidebar %}
-    <aside class="sidebar summary mobile-menu-hide">
+    <aside class="sidebar summary">
         {% block sidebar_new %}{% endblock %}
 
         {% captureas sidebaractions %}


### PR DESCRIPTION
Bon, il y a encore du boulot.

Le CSS actuel est vieux. Trop vieux. La taille de la police est souvent calculée de façon absurde, il y a des clearfix partout, des tailles en `%` et des marges incohérente etc. 

Cette PR vise à : 

 - [x] Faire en sorte que le site s’affiche correctement sur mobile sans JS. Actuellement, si vous enlevez la classe `.js` de l’élément `<body>` et que vous êtes sur un petit écran, ça casse.

 - [x] Retirer des classes inutiles comme `mobile-menu-hide`

 - [ ] Faire en sorte que `1rem` soit égal à la taille de la police par défaut. Actuellement, ce n’est pas le cas et je trouve ça très absurde.

 - [ ] Retirer la plupart des `font-size` en pixels pour quelque chose de plus propre mesuré en `em` et en `rem`.

 - [ ] Terminer de retirer les pourcentages du layout général.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | 

### QA

Vérifier que tout s’affiche comme avant.
