### PR TITLE
Remplace le mot contenu par publication

### DIFF
--- a/templates/tutorialv2/list_page_elements/list_categories.html
+++ b/templates/tutorialv2/list_page_elements/list_categories.html
@@ -14,9 +14,9 @@ exposes categories
             <p>{{ category.description }}</p>
             <p class="right">
                 {% if category.contents_count != 0 %}
-                    {{ category.contents_count }} {% trans 'contenu' %}{{ category.contents_count|pluralize_fr }}
+                    {{ category.contents_count }} {% trans 'publication' %}{{ category.contents_count|pluralize_fr }}
                 {% else %}
-                    {% trans 'Aucun contenu' %}
+                    {% trans 'Aucune publication' %}
                 {% endif %}
             </p>
         </a>

--- a/templates/tutorialv2/list_page_elements/list_of_online_contents.html
+++ b/templates/tutorialv2/list_page_elements/list_of_online_contents.html
@@ -30,7 +30,7 @@ Display a list of content_item.part.html. This template is fully customizable by
         </div>
     {% else %}
         <p>
-            {% trans "Aucun contenu disponible" %}.
+            {% trans "Aucune publication disponible" %}.
         </p>
     {% endif %}
 {% if paginated_bottom %}

--- a/templates/tutorialv2/list_page_elements/list_subcategories.html
+++ b/templates/tutorialv2/list_page_elements/list_subcategories.html
@@ -14,9 +14,9 @@ exposes subcategories
             <a href="{% url 'publication:subcategory' slug_category=category.slug slug=subcategory.slug %}" class="body">
                 <p class="right">
                 {% if subcategory.contents_count %}
-                    {{ subcategory.contents_count }} {% trans 'contenu' %}{{ subcategory.contents_count|pluralize_fr }}
+                    {{ subcategory.contents_count }} {% trans 'publication' %}{{ subcategory.contents_count|pluralize_fr }}
                 {% else %}
-                    {% trans 'Aucun contenu' %}
+                    {% trans 'Aucune publication' %}
                 {% endif %}
                 </p>
             </a>

--- a/templates/tutorialv2/view/base_categories.html
+++ b/templates/tutorialv2/view/base_categories.html
@@ -56,7 +56,7 @@
                         <h1><a href="{% url 'publication:list' %}">{% trans 'Bibliothèque' %}</a></h1>
                         {% if level == 1 %}
                             {% if content_count %}
-                                {{ content_count }} {% trans 'contenu' %}{{ content_count|pluralize_fr }}
+                                {{ content_count }} {% trans 'publication' %}{{ content_count|pluralize_fr }}
                             {% endif %}
                         {% endif %}
                     </div>
@@ -82,7 +82,7 @@
                                 <span class="option">Catégorie : <strong><a href="{% url 'publication:subcategory' slug_category=category.slug slug=subcategory.slug %}">{{subcategory}}</a></strong></span>
                             {% endif %}
                             {% if type %}
-                                <span class="option">Contenu : <strong>{{type}}</strong></span>
+                                <span class="option">Type : <strong>{{type}}</strong></span>
                             {% endif %}
                             {% if tag %}
                                 <span class="option">Tag : <strong>{{tag}}</strong></span>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

Le mot "contenu" est plus un mot appartenant au jargon du développement de ZdS. Cette PR le remplace par "publication" dans les compteurs de la bibliothèque.

### QA

- Code review