### PR TITLE
Image correcte lors de la publication sur Facebook

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -64,7 +64,7 @@
     <meta property="og:url" content="{{app.site.url}}{{ request.path }}">
     <meta property="og:language" content="fr_FR">
     <meta property="og:image" content="https://{{ meta_image }}">
-    <meta property="og:image:url" content="http://{{ meta_image }}">
+    <meta property="og:image:url" content="https://{{ meta_image }}">
     <meta property="og:image:secure_url" content="https://{{ meta_image }}">
     {% block opengraph %}
         <meta property="og:type" content="website">

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,6 +63,7 @@
     <meta property="og:title" content="{{ title|safe }}">
     <meta property="og:url" content="{{app.site.url}}{{ request.path }}">
     <meta property="og:language" content="fr_FR">
+    <meta property="og:image" content="http://{{ meta_image }}">
     <meta property="og:image:url" content="http://{{ meta_image }}">
     <meta property="og:image:secure_url" content="https://{{ meta_image }}">
     {% block opengraph %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,7 +63,7 @@
     <meta property="og:title" content="{{ title|safe }}">
     <meta property="og:url" content="{{app.site.url}}{{ request.path }}">
     <meta property="og:language" content="fr_FR">
-    <meta property="og:image" content="http://{{ meta_image }}">
+    <meta property="og:image" content="https://{{ meta_image }}">
     <meta property="og:image:url" content="http://{{ meta_image }}">
     <meta property="og:image:secure_url" content="https://{{ meta_image }}">
     {% block opengraph %}


### PR DESCRIPTION
Facebook demande que l'attribut og:image soit présent dans la page pour récupérer l'image lors du partage. C'est conforme à la norme [opengraph](http://ogp.me/).

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | https://zestedesavoir.com/forums/sujet/9136/image-illustration-lors-du-partage-dun-article-facebook/

### QA

 - Partager un article, tutoriel ou billet et vérifier que l'image est correcte.
