### PR TITLE
Corrige la gestion des apostrophes dans le MP d'une demande de casquette

### DIFF
--- a/templates/member/messages/hat_request_decision.md
+++ b/templates/member/messages/hat_request_decision.md
@@ -2,12 +2,12 @@
 
 {% trans "Bonjour," %}
 
-{% blocktrans with decision=is_granted|yesno:_("acceptée,refusée") moderator_name=moderator.username|safe moderator_url=moderator.profile.get_absolute_url %}
+{% blocktrans with decision=is_granted|yesno:_("acceptée,refusée") moderator_name=moderator.username|safe moderator_url=moderator.profile.get_absolute_url hat=hat|safe %}
 Vous avez demandé la casquette **{{ hat }}** pour votre compte. Votre demande a été {{ decision }} par [{{ moderator_name }}]({{ moderator_url }}).
 {% endblocktrans %}
 
 {% if comment %}
-> {{ comment }}
+> {{ comment|safe }}
 {% endif %}
 
-{% trans "L'équipe" %} {{ site_name }}
+{% trans "L'équipe" %} {{ site_name|safe }}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

Petite erreur de ma part que j'ai découverte.

### QA

- Demander une casquette avec une apostrophe
- Traiter la demande avec un commentaire contenant une apostrophe
- Vérifier que les deux apostrophes apparaissent bien dans le MP envoyé
- Code review
