### PR TITLE
Empêche un utilisateur sans droits de signaler ses messages masqués

### DIFF
--- a/doc/source/back-end/forum.rst
+++ b/doc/source/back-end/forum.rst
@@ -3,7 +3,7 @@ Les forums
 ==========
 
 Il y a sur Zeste de Savoir un espace communautaire permettant aux membres d'échanger entre eux sur divers sujets. Cet espace est communément appelé « forums ».
-L'URL permettant d'accéder à ce service est simplement : ``/forums``. 
+L'URL permettant d'accéder à ce service est simplement : ``/forums``.
 
 Le découpage des forums
 =======================
@@ -11,30 +11,30 @@ Le découpage des forums
 La modération des forums
 ========================
 
-Sur Zeste de Savoir, une modération des forums, autant sur les sujets que sur les messages qu'ils contiennent, est faite par les membres possèdant un certain rang. Cette dernière permet d'éviter tout débordement ou autre. 
+Sur Zeste de Savoir, une modération des forums, autant sur les sujets que sur les messages qu'ils contiennent, est faite par les membres possèdant un certain rang. Cette dernière permet d'éviter tout débordement ou autre.
 
 La modération des sujets
 ------------------------
 
 Tout d'abord, il y a une posibilité de faire de la modération par sujet. Ici, cette modération s'effectue grâce aux liens se trouvant dans la barre latérale (*sidebar*, zone se trouvant sur le côté gauche de la page).
-  
+
   .. figure:: ../images/forum/modo_forum_sujet.png
      :align:   center
 
 Nous retrouvons ici trois items :
 
 -   **Fermer le sujet** : ici, le but est de fermer le sujet, ce qui empêchera quiconque de poster dedans. Un cadena apparaîtra aussi à côté du sujet sur la liste des sujets de la catégorie et l'encart suivant fera alors son apparition sur le sujet en lui-même :
-    
+
     .. figure:: ../images/forum/sujet_ferme.png
        :align:   center
 
 -   **Marquer en post-it** : le sujet sera mis en post-it sur la catégorie dans laquelle il se trouve. Ce qui fait qu'il surpassera tous les autres sujets, et cela même si une réponse plus récente vient d'être postée dans un autre sujet. Il ne **pourra jamais se retrouver en-dessous des autres**. Lors de la mise en post-it, une épingle apparaît à côté du sujet dans la catégorie où il se trouve.
-  
+
     .. figure:: ../images/forum/post_it.png
        :align:   center
 
 -   **Déplacer le sujet** : cet item permet de faire un déplacement de sujet, au cas où un membre se serait trompé en postant. Cela évite qu'il ait à recréer un sujet et donc un doublon de celui-ci. Le déplacement se fait via une modale :
-    
+
     .. figure:: ../images/forum/deplacement.png
        :align:   center
 
@@ -42,7 +42,7 @@ La modération des messages
 --------------------------
 
 Il est aussi possible d'effectuer la modération plus finement, en ciblant des messages en particulier dans des sujets. Cela se fait grâce aux différents liens qui se trouvent sur les messages :
-  
+
   .. figure:: ../images/forum/modo_message.png
      :align:   center
 
@@ -58,7 +58,7 @@ Ici, les différents choses que vous pouvez faire, sont :
   .. figure:: ../images/forum/edit_modo.png
      :align:   center
 
--   **Signaler** : cela permet d'envoyer une demande d'intervention à l'équipe de modération du site. Ce bouton n'est pas un résultant de votre rang, tous les membres le possèdent.
+-   **Signaler** : cela permet d'envoyer une demande d'intervention à l'équipe de modération du site. Ce bouton n'est pas un résultant de votre rang, tous les membres le possèdent. Cependant, signaler un message masqué n'est pas possible, sauf pour les modérateurs.
 -   **Citer** : permet de citer un message lors de la rédaction d'une réponse. Ce bouton n'est pas un résultant de votre rang.
 
 Les filtres sur les sujets

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -119,22 +119,24 @@
                     {% endif %}
                 {% endif %}
                 {% if not is_mp %}
-                <li>
-                    <a href="#signal-message-{{ message.id }}" class="ico-after alert open-modal">
-                        {% trans "Signaler" %}
-                    </a>
-                    <form action="{{ alert_link|safe }}" method="post" id="signal-message-{{ message.id }}" class="modal modal-flex">
-                        {% csrf_token %}
-                        <label for="signal-message-{{ message.id }}-field">
-                            {% trans "Pour quelle raison signalez-vous ce message" %} ?
-                        </label>
-                        <textarea type="text" name="signal_text" id="signal-message-{{ message.id }}-field" placeholder="Flood, Troll, Hors sujet, …" pattern=".{3,}" required title='{% trans "Minimum 3 caractères pour signaler" %}' rows="4"></textarea>
+                    {% if message.is_visible != False or perms_change %}
+                        <li>
+                            <a href="#signal-message-{{ message.id }}" class="ico-after alert open-modal">
+                                {% trans "Signaler" %}
+                            </a>
+                            <form action="{{ alert_link|safe }}" method="post" id="signal-message-{{ message.id }}" class="modal modal-flex">
+                                {% csrf_token %}
+                                <label for="signal-message-{{ message.id }}-field">
+                                    {% trans "Pour quelle raison signalez-vous ce message" %} ?
+                                </label>
+                                <textarea type="text" name="signal_text" id="signal-message-{{ message.id }}-field" placeholder="Flood, Troll, Hors sujet, …" pattern=".{3,}" required title='{% trans "Minimum 3 caractères pour signaler" %}' rows="4"></textarea>
 
-                        <button type="submit" name="signal_message">
-                            {% trans "Signaler" %}
-                        </button>
-                    </form>
-                </li>
+                                <button type="submit" name="signal_message">
+                                    {% trans "Signaler" %}
+                                </button>
+                            </form>
+                        </li>
+                    {% endif %}
                 {% endif %}
             </ul>
         {% endif %}

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -1649,11 +1649,16 @@ class MessageActionTest(TestCase):
             reverse('post-edit') + '?message={}'.format(topic.last_message.pk), data, follow=False)
         self.assertEqual(302, response.status_code)
 
-        # authenticated, user can still alert both messages
-        self.client.login(username=profile.user.username, password='hostel77')
+        # staff can alert all messages
         response = self.client.get(reverse('topic-posts-list', args=[topic.pk, topic.slug()]))
         alerts = [word for word in response.content.split() if word == 'alert']
         self.assertEqual(len(alerts), 2)
+
+        # authenticated, user can't alert the hidden message
+        self.client.login(username=profile.user.username, password='hostel77')
+        response = self.client.get(reverse('topic-posts-list', args=[topic.pk, topic.slug()]))
+        alerts = [word for word in response.content.split() if word == 'alert']
+        self.assertEqual(len(alerts), 1)
 
     def test_hide(self):
         profile = ProfileFactory()


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4379 

### QA

- Créer un message avec un utilisateur et le masquer.
- Vérifier que les utilisateurs sans droits n'ont pas la possibilité de signaler le message masqué
- Vérifier qu'un modérateur puisse signaler et démasquer le message.
