### PR TITLE
[v25] La page des tags d'une tribune renvoit vers la liste des tribune

### DIFF
--- a/templates/tutorialv2/view/tags.html
+++ b/templates/tutorialv2/view/tags.html
@@ -17,18 +17,33 @@
     <li>{% trans "Liste des tags" %}</li>
 {% endblock %}
 
-
-
 {% block content_out %}
+    {% captureas url_list %}
+        {% if tags_to_display == 'OPINION' %}
+            {% url 'opinion:list' %}
+        {% else %}
+            {% url 'publication:list' %}
+        {% endif %}
+    {% endcaptureas %}
+
     <section class="full-content-wrapper">
         <h2 class="ico-after ico-tags">
-          Tous les tags
+            {% trans 'Tous les tags' %}
+            {% if tags_to_display == 'publications' %}
+                {% trans 'de la bibliothèque' %}
+            {% elif tags_to_display == 'OPINION' %}
+                {% trans 'des billets' %}
+            {% elif tags_to_display == 'ARTICLE' %}
+                {% trans 'des articles' %}
+            {% elif tags_to_display == 'TUTORIAL' %}
+                {% trans 'des tutoriels' %}
+            {% endif %}
         </h2>
 
         <div class="content-tags-list">
             {% for tag in tags %}
                 <div class="content-tag">
-                    <a href="{% url 'publication:list' %}?tag={{ tag.slug }}">
+                    <a href="{{ url_list }}?tag={{ tag.slug }}">
                         <div class="tag-title">{{ tag }}</div>
                         <div class="tag-count">
                             {%  blocktrans with tag_count=tag.num_content plural=tag.num_content|pluralize_fr %}

--- a/templates/tutorialv2/view/tags.html
+++ b/templates/tutorialv2/view/tags.html
@@ -43,7 +43,7 @@
         <div class="content-tags-list">
             {% for tag in tags %}
                 <div class="content-tag">
-                    <a href="{{ url_list }}?tag={{ tag.slug }}">
+                    <a href="{{ url_list }}?tag={% if tags_to_display == 'OPINION' %}{{ tag.title|urlencode }}{% else %}{{ tag.slug }}{% endif %}">
                         <div class="tag-title">{{ tag }}</div>
                         <div class="tag-count">
                             {%  blocktrans with tag_count=tag.num_content plural=tag.num_content|pluralize_fr %}

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -1040,3 +1040,13 @@ class TagsListView(ListView):
             self.displayed_types = [t]
 
         return PublishedContent.objects.get_top_tags(self.displayed_types)
+
+    def get_context_data(self, **kwargs):
+        context = super(TagsListView, self).get_context_data(**kwargs)
+
+        context['tags_to_display'] = 'publications'
+
+        if len(self.displayed_types) == 1:
+            context['tags_to_display'] = self.displayed_types[0]
+
+        return context


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4551

### QA

- Publier un contenu type article/tuto avec un tag quelquonque
- Vérifier que quand on clique sur "tous les tags" dans le dropdown de la bibliothèque, on obtient bien le tag associé au premier contenu. Vérifier que le lien de ce tag renvoit à la bibliothèque. 
- Publier un billet avec un tag aussi (idéalement pas le même)
- Vérifier que dans le dropdown des billets, on tombe bien sur la page listant le tag du billet. Vérifier que quand on clique desus, on tombe bien sur la list des billets.
