### PR TITLE
[v25] affiche les boutons 'plus de xxx' uniquement si nécessaire

### DIFF
--- a/templates/tutorialv2/view/categories.html
+++ b/templates/tutorialv2/view/categories.html
@@ -36,7 +36,7 @@
                 <a href="{% url "tutorial:feed-atom" %}" class="btn btn-grey">Atom</a>
             </h2>
             {% include 'tutorialv2/list_page_elements/list_of_online_contents.html' with public_contents=last_tutorials col_number=1 %}
-            {% if last_tutorials %}
+            {% if last_tutorials and more_tutorials %}
                 <a href="{% url 'publication:list' %}?type=tutorial" class="more-link">Plus de tutoriels</a>
             {% endif %}
         </section>
@@ -48,7 +48,7 @@
                 <a href="{% url "article:feed-atom" %}" class="btn btn-grey">Atom</a>
             </h2>
             {% include 'tutorialv2/list_page_elements/list_of_online_contents.html' with public_contents=last_articles col_number=1 %}
-            {% if last_articles %}
+            {% if last_articles and more_articles %}
                 <a href="{% url 'publication:list' %}?type=article" class="more-link">Plus d'articles</a>
             {% endif %}
         </section>

--- a/templates/tutorialv2/view/category.html
+++ b/templates/tutorialv2/view/category.html
@@ -22,7 +22,7 @@
                 <a href="{% url "tutorial:feed-atom" %}?category={{ category.slug }}" class="btn btn-grey">Atom</a>
             </h2>
             {% include 'tutorialv2/list_page_elements/list_of_online_contents.html' with public_contents=last_tutorials col_number=1 %}
-            {% if last_tutorials %}
+            {% if last_tutorials and more_tutorials %}
                 <a href="{% url 'publication:list' %}?category={{ category.slug }}&amp;type=tutorial" class="more-link">Plus de tutoriels dans {{ category.title | lower }}</a>
             {% endif %}
         </section>
@@ -34,7 +34,7 @@
                 <a href="{% url "article:feed-atom" %}?category={{ category.slug }}" class="btn btn-grey">Atom</a>
             </h2>
             {% include 'tutorialv2/list_page_elements/list_of_online_contents.html' with public_contents=last_articles col_number=1 %}
-            {% if last_tutorials %}
+            {% if last_articles and more_articles %}
                 <a href="{% url 'publication:list' %}?category={{ category.slug }}&amp;type=article" class="more-link">Plus d'articles dans {{ category.title | lower }}</a>
             {% endif %}
         </section>

--- a/templates/tutorialv2/view/subcategory.html
+++ b/templates/tutorialv2/view/subcategory.html
@@ -11,7 +11,7 @@
                 <a href="{% url "tutorial:feed-atom" %}?subcategory={{ subcategory.slug }}" class="btn btn-grey">Atom</a>
             </h2>
             {% include 'tutorialv2/list_page_elements/list_of_online_contents.html' with public_contents=last_tutorials col_number=1 %}
-            {% if last_tutorials %}
+            {% if last_tutorials and more_tutorials %}
                 <a href="{% url 'publication:list' %}?subcategory={{ subcategory.slug }}&amp;type=tutorial" class="more-link">Plus de tutoriels dans {{ subcategory.title | lower }}</a>
             {% endif %}
         </section>
@@ -23,7 +23,7 @@
                     <a href="{% url "article:feed-atom" %}?subcategory={{ subcategory.slug }}" class="btn btn-grey">Atom</a>
                 </h2>
                 {% include 'tutorialv2/list_page_elements/list_of_online_contents.html' with public_contents=last_articles col_number=1 %}
-                {% if last_articles %}
+                {% if last_articles and more_articles %}
                     <a href="{% url 'publication:list' %}?subcategory={{ subcategory.slug }}&amp;type=article" class="more-link">Plus d'articles dans {{ subcategory.title | lower }}</a>
                 {% endif %}
             </section>

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -569,12 +569,15 @@ class ViewPublications(TemplateView):
                 with_previous_item=False)
 
         if self.level < 4:
-            context['last_articles'] = PublishedContent.objects.last_contents(
-                **dict(content_type='ARTICLE', **recent_kwargs)
-            )[:self.max_last_contents]
-            context['last_tutorials'] = PublishedContent.objects.last_contents(
-                **dict(content_type='TUTORIAL', **recent_kwargs)
-            )[:self.max_last_contents]
+            last_articles = PublishedContent.objects.last_contents(
+                **dict(content_type='ARTICLE', **recent_kwargs))
+            context['last_articles'] = last_articles[:self.max_last_contents]
+            context['more_articles'] = last_articles.count() > self.max_last_contents
+
+            last_tutorials = PublishedContent.objects.last_contents(
+                **dict(content_type='TUTORIAL', **recent_kwargs))
+            context['last_tutorials'] = last_tutorials[:self.max_last_contents]
+            context['more_tutorials'] = last_tutorials.count() > self.max_last_contents
 
             context['beta_forum'] = Forum.objects\
                 .prefetch_related('category')\


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4557

### QA

J'espère que j'ai pas trop cassé les performances en faisant ça.

- Publiez trois contenus de même type dans une sous-catégorie donnée, puis un quatrième dans une sous-catégorie différente (et idéalement de catégorie différente).
- Faites en sorte que

```python
ZDS_APP['content']['max_last_publications_level_1'] = ZDS_APP['content']['max_last_publications_level_2'] = ZDS_APP['content']['max_last_publications_level_3'] = 2
```
- Quand vous visitez les pages de niveau 1, 2 ou 3 associées à la sous-catégorie correspondante à vos trois contenus, le bouton "plus de" devrait s'afficher. Lorsque vous visitez les mêmes pages, mais pour la sous-catégorie ou le contenu est seul, ce bouton ne devrait pas s'afficher
- Code review
