### PR TITLE
Les menus déroulants ne se ferment pas lorsque l’on clique dedans

### DIFF
--- a/assets/js/dropdown-menu.js
+++ b/assets/js/dropdown-menu.js
@@ -93,6 +93,11 @@
         var $toggleLink = $container.find("> a");
         var closingTimer;
 
+        $dropdown.on("click", function (event) {
+            // Don't close
+            event.stopPropagation();
+        });
+
         function open() {
             cancelClosingTimer();
 


### PR DESCRIPTION
Cela permet nottament d’ouvrir facilement un ensemble de liens dans un
même menu dans plusieurs onglets différents avec Ctrl+clic.

Avant, lorsque l’on cliquait dans un menu déroulé, l’évènement
remontait le DOM jusqu’au <body> et était considéré comme un clic en
dehors du menu.

Je pense qu’on a peu de raisons de se servir du fait que l’évènement
du clic “remonte” le DOM dans ce cas, du coup j’ai mis un
`.preventDefault()`.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug / évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4575

### QA

Tout tester avec et sans l’option “Dérouler les menus au
survol”. Quand on clique dans un endroit vide d’un menu déroulé, il ne
doit pas se fermer.