### PR TITLE
Utilise des icônes à haute résolution dans l’en-tête

### DIFF
--- a/assets/scss/base/_high-pixel-ratio.scss
+++ b/assets/scss/base/_high-pixel-ratio.scss
@@ -4,10 +4,11 @@
        only screen and (min-device-pixel-ratio: 1.3),
        only screen and (min-resolution: 192dpi),
        only screen and (min-resolution: 2dppx) {
-    .header-logo-link {
-        background-size: 100%;
+
+    .header-container .header-logo-link {
         background-image: url('../images/logo@2x.png');
     }
+
     .ico,
     .ico-after:after,
     .content-item .content-reactions,

--- a/assets/scss/components/_mobile-menu.scss
+++ b/assets/scss/components/_mobile-menu.scss
@@ -247,7 +247,6 @@
                     left: 13px;
                     height: 22px;
                     width: 22px;
-                    @include sprite();
                     background-repeat: no-repeat;
                     @include sprite-position($menu);
                 }

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -1,3 +1,6 @@
+$logo-horizontal-margin: 10px;
+$logo-width: 240px;
+
 .header-container {
     * {
         box-sizing: border-box;
@@ -101,13 +104,10 @@
         display: block;
         margin: 0 auto;
         text-indent: -9999px;
-        width: 100%;
-        max-width: 240px;
+        width: $logo-width + $logo-horizontal-margin;
         height: 60px;
         background: url('../images/logo.png') no-repeat center center;
-
-        // Simulate margins around the picture
-        background-size: 90% auto;
+        background-size: $logo-width auto;
 
         &:hover,
         &:focus {
@@ -472,7 +472,7 @@
 
     .header-logo {
         text-align: left;
-        width: 240px;
+        width: $logo-width + $logo-horizontal-margin;
     }
 
     .dropdown {


### PR DESCRIPTION
J’ai introduit récemment un bug qui faisaient que le logo du site
avait une faible résolution sur les écrans à haute densité. De plus,
sur la production, l’icône du menu “hamburger” est toujours à faible
densité.

Ce patch fait en sorte que les icônes à haute densité sont utilisés
quand il le faut.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucune

### QA

Vérifier que le logo et l’icône du menu “hamburger” sont bien nets sur des écrans à haute résolution (ou alors en zoomant).