### PR TITLE
Centre parfaitement l’en-tête et le pied de page

### DIFF
--- a/assets/scss/layout/_footer.scss
+++ b/assets/scss/layout/_footer.scss
@@ -16,15 +16,29 @@
         display: flex;
     }
 
-    .copyright {
+    .copyright, .links {
         flex-shrink: 1;
+        flex-grow: 1;
+        flex-basis: 0;
         min-width: 0;
+    }
 
+    .copyright {
         margin: 0;
         padding: 0 1rem;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+
+        &,
+        a {
+            color: rgba(white, .5);
+        }
+
+        a:hover,
+        a:focus {
+            color: white;
+        }
     }
 
     ul {
@@ -32,6 +46,10 @@
         margin: 0;
         padding: 0;
         white-space: nowrap;
+
+        &.links {
+            text-align: right;
+        }
 
         &.links li {
             display: inline-block;
@@ -50,7 +68,8 @@
         }
 
         &.social {
-            flex: 1;
+            flex-grow: 0;
+            flex-shrink: 0;
             flex-basis: auto;
             text-align: center;
 
@@ -79,18 +98,6 @@
         }
     }
 
-    .copyright {
-        &,
-        a {
-            color: rgba(255, 255, 255, .5);
-        }
-
-        a:hover,
-        a:focus {
-            color: #FFF;
-        }
-    }
-
     @media only screen and #{$media-mobile-tablet} {
         text-align: center;
         height: auto;
@@ -105,10 +112,17 @@
 
         .copyright, .social {
             border-bottom: 2px solid lighten($color-primary, 4%);
+            flex-basis: auto;
+            flex-shrink: 0;
         }
 
         ul {
             white-space: initial;
+
+            &.links {
+                text-align: inherit;
+            }
+
             li {
                 margin: 0 5px;
             }

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -38,7 +38,7 @@ $logo-width: 240px;
 
     .header-menu {
         height: 60px;
-        flex: 1;
+        flex-basis: auto;
 
         display: flex;
     }
@@ -102,7 +102,7 @@ $logo-width: 240px;
 
     .header-logo-link {
         display: block;
-        margin: 0 auto;
+        margin: 0;
         text-indent: -9999px;
         width: $logo-width + $logo-horizontal-margin;
         height: 60px;
@@ -153,7 +153,9 @@ $logo-width: 240px;
 
 
 .logbox {
-    background: rgba(255, 255, 255, .05);
+    &>div {
+        background: rgba(white, .05);
+    }
 
     .notifs-links {
         display: flex;
@@ -416,6 +418,7 @@ $logo-width: 240px;
 
         header .header-menu {
             height: 30px;
+            flex-grow: 1;
         }
 
         .logbox {
@@ -468,6 +471,11 @@ $logo-width: 240px;
         header {
             background-image: linear-gradient(to right,transparent 20%,rgba(255,255,255,.07) 40%,rgba(255,255,255,.07) 60%,transparent 80%);
         }
+
+        .header-menu {
+            flex-shrink: 0;
+            flex-grow: 0;
+        }
     }
 
     .header-logo {
@@ -491,7 +499,14 @@ $logo-width: 240px;
         top: 90px;
     }
 
+    .header-logo, .header-right {
+        flex-grow: 1;
+        flex-basis: 0;
+    }
+
     .header-right {
         display: flex;
+        flex-shrink: 0;
+        justify-content: flex-end;
     }
 }


### PR DESCRIPTION
Dans le pied de page, les icônes de Facebook, Twitter et Google+ n’étaient
pas toujours vraiment centrés.

Dans l’en-tête, les boutons du menu principal n’étaient pas vraiment centrés.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug / nouvelle fonctionnalité / évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4553
 
### QA

Vérifiez que tout est parfaitement centré (voir #4553).