### PR TITLE
Ordonne les alertes résolues selon leur date de résolution

### DIFF
--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -138,7 +138,7 @@ def cookies(request):
 @permission_required('forum.change_post', raise_exception=True)
 def alerts(request):
     outstanding = Alert.objects.filter(solved=False).order_by('-pubdate')
-    solved = Alert.objects.filter(solved=True).order_by('-pubdate')[:15]
+    solved = Alert.objects.filter(solved=True).order_by('-solved_date')[:15]
 
     return render(request, 'pages/alerts.html', {
         'alerts': outstanding,


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

Actuellement, les alertes "récemment résolues" sont ordonnées selon leur date de création. Cette PR les ordonne selon leur date de résolution, ce qui me semble plus cohérent.

### QA

- Créer une alerte A puis une alerte B.
- Résoudre B puis A.
- Vérifier que A apparaît en haut de la liste avant B.