### PR TITLE
Permet de suivre un sujet dont le premier message est masqué

### DIFF
--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -477,6 +477,29 @@ class TopicEditTest(TestCase):
         self.assertEqual(302, response.status_code)
         self.assertIsNotNone(TopicAnswerSubscription.objects.get_existing(profile.user, topic, is_active=True))
 
+    def test_success_edit_topic_follow_with_hidden_post(self):
+        profile = ProfileFactory()
+        category, forum = create_category()
+        topic = add_topic_in_a_forum(forum, profile)
+
+        first_post = topic.first_post()
+        first_post.is_visible = False
+        first_post.save()
+
+        self.assertTrue(self.client.login(username=profile.user.username, password='hostel77'))
+        data = {
+            'follow': '1'
+        }
+        response = self.client.post(reverse('topic-edit') + '?topic={}'.format(topic.pk), data, follow=False)
+
+        self.assertEqual(302, response.status_code)
+        self.assertIsNotNone(TopicAnswerSubscription.objects.get_existing(profile.user, topic, is_active=False))
+
+        response = self.client.post(reverse('topic-edit') + '?topic={}'.format(topic.pk), data, follow=False)
+
+        self.assertEqual(302, response.status_code)
+        self.assertIsNotNone(TopicAnswerSubscription.objects.get_existing(profile.user, topic, is_active=True))
+
     def test_success_edit_topic_follow_email(self):
         profile = ProfileFactory()
         category, forum = create_category()

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -272,7 +272,8 @@ class TopicEdit(UpdateView, SingleObjectMixin, TopicEditMixin):
         if ('text' in request.POST or request.method == 'GET') \
                 and self.object.author != request.user and not request.user.has_perm('forum.change_topic'):
             raise PermissionDenied
-        if not self.object.first_post().is_visible and not request.user.has_perm('forum.change_topic'):
+        if ('text' in request.POST or request.method == 'GET') \
+                and not self.object.first_post().is_visible and not request.user.has_perm('forum.change_topic'):
             raise PermissionDenied
         if 'page' in request.POST:
             try:


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4548 

### QA

- Se connecter avec un utilisateur sans droits particuliers
- Poster un sujet et en masquer le premier message
- Vérifier qu'on ne peut plus éditer le sujet, mais qu'on peut toujours le suivre (ou ne plus le suivre)
- Code review
