### PR TITLE
Utilise la hauteur de ligne par défaut dans les <textarea>

### DIFF
--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -98,6 +98,7 @@
         width: calc(98% - 2px);
         padding: 10px 1%;
         font-family: $font-monospace;
+        line-height: normal;
     }
 
     input,


### PR DESCRIPTION
La version de normalize.css utilisée règle `line-height: 1.15` sur les
<textarea>. Cela ne marche pas bien avec certaines polices, causant
des chevauchements des sélections entre les lignes.

https://github.com/necolas/normalize.css/blob/7.0.0/normalize.css#L247

Fix #4590.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4590

### QA

Vérifiez que quand vous sélectionnez des choses dans l’éditeur, les lignes ne se chevauchent pas (voir issue).