### PR TITLE
[v25]Empêche de trouver des billets avec une recherche depuis la bibliothèque

### DIFF
--- a/templates/tutorialv2/view/base_categories.html
+++ b/templates/tutorialv2/view/base_categories.html
@@ -107,6 +107,7 @@
                             <label for="id_q" class="control-label">Recherche</label>
                             <input id="id_q" maxlength="150" name="q" required="required" type="search" placeholder="{% trans 'dans' %} {% if subcategory %}{{ subcategory.title|lower }}{% elif category %}{{ category.title|lower }}{% else %}{% trans 'la bibliothèque' %}{% endif %}…">
                             <input type="hidden" name="models" value="content">
+                            <input type="hidden" name="from_library" value="on">
                             {% if category %}
                                 <input type="hidden" name="category" value="{{ category.slug }}">
                                 {% if subcategory %}

--- a/zds/searchv2/forms.py
+++ b/zds/searchv2/forms.py
@@ -39,6 +39,7 @@ class SearchForm(forms.Form):
 
     category = forms.CharField(widget=forms.HiddenInput, required=False)
     subcategory = forms.CharField(widget=forms.HiddenInput, required=False)
+    from_library = forms.CharField(widget=forms.HiddenInput, required=False)
 
     def __init__(self, *args, **kwargs):
 
@@ -62,5 +63,6 @@ class SearchForm(forms.Form):
             Field('q'),
             StrictButton('', type='submit', css_class='ico-after ico-search', title=_(u'Rechercher')),
             Field('category'),
-            Field('subcategory')
+            Field('subcategory'),
+            Field('from_library')
         )

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -127,6 +127,11 @@ class SearchView(ZdSPagingListView):
             if self.search_form.cleaned_data['subcategory']:
                 self.content_subcategory = self.search_form.cleaned_data['subcategory']
 
+            # mark that contents must come from library if required
+            self.from_library = False
+            if self.search_form.cleaned_data['from_library'] == 'on':
+                self.from_library = True
+
             # setting the different querysets (according to the selected models, if any)
             part_querysets = []
             chosen_groups = self.search_form.cleaned_data['models']
@@ -175,6 +180,9 @@ class SearchView(ZdSPagingListView):
             & MultiMatch(
             query=self.search_query,
             fields=['title', 'description', 'categories', 'subcategories', 'tags', 'text'])
+
+        if self.from_library:
+            query &= Match(content_type='TUTORIAL') | Match(content_type='ARTICLE')
 
         if self.content_category:
             query &= Match(categories=self.content_category)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4570 

### QA

- Créer un tuto, un billet et un article avec un mot en commun dans le titre.
- Indexer.
- Vérifier que l'on trouve les trois avec une recherche depuis la page de recherche, mais pas le billet avec une recherche depuis la bibliothèque.
- Code review
