### PR TITLE
Améliore l'interface de modération des billets

### DIFF
--- a/assets/js/tribune-pick.js
+++ b/assets/js/tribune-pick.js
@@ -23,4 +23,20 @@
             $opinionCount.text(parseInt($opinionCount.text(), 10)-1);
         });
     });
+    $(".unpublish-opinion").on("click", function () {
+        var $button = $(this);
+        var csrfmiddlewaretoken = $("input[name='csrfmiddlewaretoken']").val();
+        var data = {
+            csrfmiddlewaretoken: csrfmiddlewaretoken,
+            operation: "REMOVE_PUB",
+        };
+        if (confirm($button.data("confirm"))) {
+            $.post($button.data("url"), data).done(function () {
+                alert($button.data("done"));
+                if (typeof $button.data("redirect-url") !== "undefined" && $button.data("redirect-url")) {
+                    window.location.href = $button.data("redirect-url");
+                }
+            });
+        }
+    });
 })(jQuery);

--- a/templates/base.html
+++ b/templates/base.html
@@ -528,7 +528,7 @@
                                     </li>
 
                                     {% if perms.tutorialv2.change_validation %}
-                                        {% with waiting_tutorials_count="TUTORIAL"|waiting_count waiting_articles_count="ARTICLE"|waiting_count %}
+                                        {% with waiting_tutorials_count="TUTORIAL"|waiting_count waiting_articles_count="ARTICLE"|waiting_count waiting_opinions_count="OPINION"|waiting_count %}
                                             <li class="staff-only">
                                                 <a href="{% url "validation:list" %}?type=tuto">
                                                     {% trans "Validation des tutoriels" %}
@@ -546,8 +546,13 @@
                                                 </a>
                                             </li>
                                             <li class="staff-only">
-                                            <a href="{% url "validation:list-opinion" %}">{% trans "Choix des billets" %}</a>
-                                        </li>
+                                                <a href="{% url "validation:list-opinion" %}">
+                                                    {% trans "Choix des billets" %}
+                                                    {% if waiting_opinions_count > 0 %}
+                                                        ({{ waiting_opinions_count }})
+                                                    {% endif %}
+                                                </a>
+                                            </li>
                                         {% endwith %}
                                     {% endif %}
 

--- a/templates/tutorialv2/messages/validation_unpublish_opinion.md
+++ b/templates/tutorialv2/messages/validation_unpublish_opinion.md
@@ -2,8 +2,8 @@
 
 {% blocktrans with title=content.title|safe moderator_name=moderator.username|safe moderator_url=moderator.get_absolute_url %}
 
-Votre billet « [{{ title }}]({{ url }}) » a été définitivement dépublié par 
-[{{ moderator_name }}]({{ moderator_url }}), probablement car il enfreignait les CGU du site.
+Votre billet « [{{ title }}]({{ url }}) » a été modéré par 
+[{{ moderator_name }}]({{ moderator_url }}), ce qui signifie qu'il a été dépublié et ne peut pas être republié.
 
 N’hésitez pas à contacter cette personne afin d’obtenir plus d’informations sur sa décision.
 {% endblocktrans %}

--- a/templates/tutorialv2/validation/opinions.html
+++ b/templates/tutorialv2/validation/opinions.html
@@ -27,13 +27,6 @@
             {% endblock %}
         </h1>
 
-        {% captureas headlinesub %}
-            {% block headline_sub %}{% endblock %}
-        {% endcaptureas %}
-        {% if headlinesub %}
-            <h2 class="subtitle">{{ headlinesub|safe }}</h2>
-        {% endif %}
-
         {% block content %}
             {% if contents %}
                 <table class="fullwidth">
@@ -63,12 +56,17 @@
                                     <span>{{ content.update_date|format_date:True|capfirst }}</span>
                                 </td>
                                 <td>
-                                    <button type="button" class="btn btn-grey ico-after hide unpick-action" data-url="{% url 'validation:ignore-opinion' content.pk content.slug %}"
-                                            data-operation="NO_PICK">{% trans "Ignorer pour l’instant" %}</button>
                                     <button type="button" class="btn btn-grey ico-after cross red unpick-action" data-url="{% url 'validation:ignore-opinion' content.pk content.slug %}"
-                                            data-operation="REJECT">{% trans "Ignorer définitivement" %}</button>
+                                            data-operation="REMOVE_PUB">{% trans "Modérer" %}</button>
                                     <button type="button" class="btn btn-grey ico-after hide unpick-action" data-url="{% url 'validation:ignore-opinion' content.pk content.slug %}"
-                                            data-operation="REMOVE_PUB">{% trans "Dépublier définitivement" %}</button>
+                                            data-operation="NO_PICK">{% trans "Ignorer cette version" %}</button>
+                                    <button type="button" class="btn btn-grey ico-after cross unpick-action" data-url="{% url 'validation:ignore-opinion' content.pk content.slug %}"
+                                            data-operation="REJECT">{% trans "Ne pas choisir" %}</button>
+                                    <form method="post" action="{% url 'validation:pick-opinion' content.pk content.slug %}">
+                                        {% csrf_token %}
+                                        <input name="version" type="hidden" value="{{ content.sha_public }}" />
+                                        <button type="submit" class="btn btn-grey ico-after tick green">{% trans "Choisir" %}</button>
+                                    </form>
                                 </td>
                                 <td>
                                     {% if content.sha_picked %}
@@ -83,7 +81,7 @@
                 </table>
             {% else %}
                 <p>
-                    {% trans "Aucun billet" %}
+                    {% trans "Aucun billet." %}
                 </p>
             {% endif %}
         {% endblock %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -126,6 +126,14 @@
             </div>
         {% endif %}
     {% endif %}
+
+    {% if not can_publish %}
+        <div class="content-wrapper">
+            <div class="alert-box warning">
+                {% trans "Ce contenu a été modéré. Il ne peut pas faire l'objet d'une nouvelle publication." %}
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}
 
 
@@ -455,7 +463,7 @@
     {% if is_staff %}
 
         <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Validation">
-            <h3>{% trans "Validation" %}</h3>
+            <h3>{{ content.is_opinion|yesno:_("Modération,Validation") }}</h3>
             <ul>
                 {% if not content.is_opinion %}
                     <li>

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -255,20 +255,8 @@
                     {% if content.requires_validation %}
                         <li>
                             <a href="{% url "validation:history" content.pk content.slug %}" class="ico-after history blue">
-                                {% trans "Historique validation" %}
+                                {% trans "Historique de validation" %}
                             </a>
-                        </li>
-                        <li>
-                            <form action="{% url 'validation:mark-obsolete' content.pk %}" method="post">
-                                {% csrf_token %}
-                                <button type="submit" class="ico-after alert blue">
-                                    {% if is_obsolete %}
-                                        {% trans "Marquer comme non obsolète" %}
-                                    {% else %}
-                                        {% trans "Marquer comme obsolète" %}
-                                    {% endif %}
-                                </button>
-                            </form>
                         </li>
                         <li>
                             <a href="#unpublish" class="ico-after open-modal cross blue">
@@ -277,31 +265,29 @@
                             {% crispy formRevokeValidation %}
                         </li>
                     {% else %}
-                        {% if is_staff %}
-                            {% if content.sha_public != content.sha_picked  %}
-                                <li>
-                                    <a href="#pick-opinion" class="ico-after open-modal tick green">
-                                        {% trans "Choisir le billet" %}
-                                    </a>
-                                    {% crispy formPickOpinion %}
-                                </li>
-                            {% endif %}
-                            {% if not content.converted_to %}
-                                <li>
-                                    <a href="#convert-opinion" class="ico-after open-modal tick green">
-                                        {% trans "Convertir en article" %}
-                                    </a>
-                                    {% crispy formConvertOpinion %}
-                                </li>
-                            {% endif %}
-                            {% if content.sha_public == content.sha_picked  %}
-                                <li>
-                                    <a href="#unpick-opinion" class="ico-after open-modal cross blue">
-                                        {% trans "Retirer des billets choisis" %}
-                                    </a>
-                                    {% crispy formUnpickOpinion %}
-                                </li>
-                            {% endif %}
+                        {% if content.sha_public != content.sha_picked  %}
+                            <li>
+                                <a href="#pick-opinion" class="ico-after open-modal tick green">
+                                    {% trans "Choisir le billet" %}
+                                </a>
+                                {% crispy formPickOpinion %}
+                            </li>
+                        {% endif %}
+                        {% if not content.converted_to %}
+                            <li>
+                                <a href="#convert-opinion" class="ico-after open-modal tick green">
+                                    {% trans "Convertir en article" %}
+                                </a>
+                                {% crispy formConvertOpinion %}
+                            </li>
+                        {% endif %}
+                        {% if content.sha_public == content.sha_picked  %}
+                            <li>
+                                <a href="#unpick-opinion" class="ico-after open-modal cross blue">
+                                    {% trans "Retirer des billets choisis" %}
+                                </a>
+                                {% crispy formUnpickOpinion %}
+                            </li>
                         {% endif %}
                         <li>
                             <a href="#unpublish" class="ico-after open-modal cross blue">
@@ -309,7 +295,29 @@
                             </a>
                             {% crispy formUnpublication %}
                         </li>
+                        <li>
+                            <button class="ico-after cross red unpublish-opinion" data-url="{% url 'validation:ignore-opinion' content.pk content.slug %}" data-confirm="{% trans "Voulez-vous vraiment modérer ce billet ? Il sera dépublié et ne pourra pas être republié." %}" data-done="{% trans "Le billet a été modéré." %}" data-redirect-url="{{ object.get_absolute_url }}">
+                                {% trans "Modérer" %}
+                            </button>
+                        </li>
+                        <li>
+                            <a href="{% url "validation:ignore-opinion" content.pk content.slug %}" class="ico-after history blue">
+                                {% trans "Historique de modération" %}
+                            </a>
+                        </li>
                     {% endif %}
+                    <li>
+                        <form action="{% url 'validation:mark-obsolete' content.pk %}" method="post">
+                            {% csrf_token %}
+                            <button type="submit" class="ico-after alert blue">
+                                {% if is_obsolete %}
+                                    {% trans "Marquer comme non obsolète" %}
+                                {% else %}
+                                    {% trans "Marquer comme obsolète" %}
+                                {% endif %}
+                            </button>
+                        </form>
+                    </li>
                 {% endif %}
             </ul>
         </div>


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | évolution
| Ticket(s) (_issue(s)_) concerné(s)  | #4279 notamment

Cette PR améliore l'interface de modération des billets avec les principales demandes qui ont été faites :

- Modérer (dépublier définitivement) un billet depuis la page de celui-ci (et pas depuis l'interface de choix des billets).
- Choisir depuis la liste des billets en attente.
- Affichage du nombre de billets en attente dans le menu utilisateur.

J'ai également modifié certains termes pour qu'ils soient cohérents sur tous le site et soient plus explicites (`Ignorer pour l'instant` et `Ignorer définitivement` deviennent `Ignorer cette version` et `Ne pas choisir`).

### QA

- Vérifier que les modifications décrites ci-dessus fonctionnent.
- Code review
