### PR TITLE
tooltips: Passe des nœuds/strings à setContent

### DIFF
--- a/assets/js/karma.js
+++ b/assets/js/karma.js
@@ -200,15 +200,14 @@
                 var otherLikeCount = data[sign].count - likers.length;
 
                 var currentUser = $("#my-account .username").text();
-                var likeStr = likers.map(function(e) { return e.username === currentUser ? "Vous (" + e.username + ")" : e.username; }).join("<br>");
+                var likes = likers.map(function(e) { return e.username === currentUser ? "Vous (" + e.username + ")" : e.username; });
                 if(otherLikeCount > 0) {
-                    if(likeStr !== "") likeStr += "<br> et " + otherLikeCount + " autre";
-                    else likeStr = otherLikeCount + " vote";
-
-                    if(otherLikeCount !== 1) likeStr += "s";
+                    var otherLikeStr = likes.length > 0 ? "et " + otherLikeCount + " autre" : otherLikeCount + " vote";
+                    if(otherLikeCount !== 1) otherLikeStr += "s";
+                    likes.push(otherLikeStr);
                 }
 
-                this[sign].tooltip.setContent(likeStr);
+                this[sign].tooltip.setContent(likes.map(function(l) { return $("<div>", { text: l }); }));
 
                 // Build list in modal
                 this[sign].listElem.empty();

--- a/assets/js/tooltips.js
+++ b/assets/js/tooltips.js
@@ -11,7 +11,7 @@
      */
     var Tooltip = function(options) {
         this.options = $.extend({ target: null, content: null }, options);
-        if(!Tooltip._initialized) {
+        if (!Tooltip._initialized) {
             this.firstRun();
         }
 
@@ -97,7 +97,7 @@
          * @access private
          */
         mouseover: function() {
-            if(!this.mouseon) this.show();
+            if (!this.mouseon) this.show();
             this.mouseon = true;
             clearTimeout(this.hideTimeout);
         },
@@ -114,8 +114,11 @@
 
         /**
          * Set the content of the tooltip
+         * WARNING: passing HTMLElement(s) will insert them directly into the DOM
+         * without sanitization, beware of XSS. As they are inserted as text,
+         * passing strings is always safe.
          *
-         * @param {string|Array} content - content of the tooltip
+         * @param {string|HTMLElement|Array<string|HTMLElement>} content - content of the tooltip
          */
         setContent: function(content) {
             if (!Array.isArray(content)) content = [content];
@@ -149,7 +152,7 @@
          * Show the tooltip if the content is not empty
          */
         show: function() {
-            if(this.hasContent) {
+            if (this.hasContent) {
                 this.wrapper.show();
                 this.elem.attr("aria-hidden", false);
                 this.recalc(); // Need to recalc on this tick & on next
@@ -163,7 +166,7 @@
          * @access private
          */
         guessOrientation: function() {
-            if(this.target.offset().top - $(window).scrollTop() < this.wrapper.height()) {
+            if (this.target.offset().top - $(window).scrollTop() < this.wrapper.height()) {
                 this.setOrientation("bottom");
             } else {
                 this.setOrientation("top");
@@ -183,9 +186,9 @@
             };
 
             this.guessOrientation();
-            if(this.orientation === "top") {
+            if (this.orientation === "top") {
                 css.top = this.target.offset().top - this.wrapper.outerHeight();
-            } else if(this.orientation === "bottom") {
+            } else if (this.orientation === "bottom") {
                 css.top = this.target.offset().top + this.target.outerHeight();
             } else {
                 css.bottom = this.target.offset().top - this.wrapper.outerHeight() + 8;
@@ -219,8 +222,8 @@
      */
     $.fn.tooltip = function(content) {
         var tooltip = $(this).data("tooltip");
-        if(tooltip) {
-            if(content) tooltip.setContent(content);
+        if (tooltip) {
+            if (content) tooltip.setContent(content);
         } else {
             tooltip = new Tooltip({ target: this, content: content });
             $(this).data("tooltip", tooltip);

--- a/assets/js/tooltips.js
+++ b/assets/js/tooltips.js
@@ -59,6 +59,7 @@
              */
             this.target = $(this.options.target);
 
+            this.hasContent = false;
             this.setOrientation("top");
             this.setContent(this.options.content);
             this.hide();
@@ -114,17 +115,26 @@
         /**
          * Set the content of the tooltip
          *
-         * @param {string} content - HTML content of the tooltip
+         * @param {string|Array} content - content of the tooltip
          */
         setContent: function(content) {
-            this.content = $.trim(content);
-            this.elem.html(this.content);
+            if (!Array.isArray(content)) content = [content];
+            this.elem.empty();
+            this.hasContent = false;
 
-            if(this.content === "") {
-                this.hide();
-            } else if(this.mouseon) {
-                this.show();
+            for (var i = 0; i < content.length; i++) {
+                if (!content[i]) continue;
+                this.hasContent = true;
+
+                if (typeof content[i] === "string") {
+                    this.elem.append(document.createTextNode($.trim(content[i])));
+                } else {
+                    this.elem.append(content[i]);
+                }
             }
+
+            if (!this.hasContent) this.hide();
+            else if (this.mouseon) this.show(); // Recalculate tooltip position
         },
 
         /**
@@ -139,7 +149,7 @@
          * Show the tooltip if the content is not empty
          */
         show: function() {
-            if(this.content !== "") {
+            if(this.hasContent) {
                 this.wrapper.show();
                 this.elem.attr("aria-hidden", false);
                 this.recalc(); // Need to recalc on this tick & on next


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | Je sais plus.

`$().tooltip().setContent()` prend maintenant des chaînes de caractères et des nœuds DOM (un seul élément ou tableau d'éléments) comme paramètre. Ça évite d'injecter de l'HTML unsafe dans les tooltips.

### QA

- Tester les tooltips