### PR TITLE
Corrige des erreurs de typographie

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -28,6 +28,6 @@
 
 {% block content %}
     <p>
-        {% trans "Vous n’avez pas les droits suffisants pour accéder à cette page" %}.
+        {% trans "Vous n’avez pas les droits suffisants pour accéder à cette page." %}
     </p>
 {% endblock %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -28,6 +28,6 @@
 
 {% block content %}
     <p>
-        {% trans "Il semblerait que ce que vous cherchiez ne se trouve plus ici" %}.
+        {% trans "Il semblerait que ce que vous cherchiez ne se trouve plus ici." %}
     </p>
 {% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -37,7 +37,7 @@
     </p>
     <p>
         {% blocktrans with url_bugtracker=app.site.repository.bugtracker %}
-        Si vous êtes curieux, voici une <a href="{{ url_bugtracker }}">liste des sujets ouverts à ce propos</a> sur le bug tracker public de l’association
-        {% endblocktrans %}.
+        Si vous êtes curieux, voici une <a href="{{ url_bugtracker }}">liste des sujets ouverts à ce propos</a> sur le bug tracker public de l’association.
+        {% endblocktrans %}
     </p>
 {% endblock %}

--- a/templates/email/member/confirm_forgot_password.html
+++ b/templates/email/member/confirm_forgot_password.html
@@ -19,6 +19,6 @@
     <hr />
 
     <p>
-    {% trans "Cliquez ou recopiez simplement le lien et complétez le reste du formulaire" %} : <a href="{{ url }}">{{ url }}</a>.
+    {% trans "Cliquez ou recopiez simplement le lien et complétez le reste du formulaire" %} : <a href="{{ url }}">{{ url }}</a>.
     </p>
 {% endblock %}

--- a/templates/email/member/confirm_forgot_password.txt
+++ b/templates/email/member/confirm_forgot_password.txt
@@ -8,9 +8,9 @@
 
 {% trans "ATTENTION" %}
 
-{% trans "Si vous n’avez pas demandé une réinitialisation du mot de passe, IGNOREZ et EFFACEZ ce courriel immédiatement ! Continuez uniquement si vous souhaitez que votre mot de passe soit réinitialisé !" %}
+{% trans "Si vous n’avez pas demandé une réinitialisation du mot de passe, IGNOREZ et EFFACEZ ce courriel immédiatement ! Continuez uniquement si vous souhaitez que votre mot de passe soit réinitialisé !" %}
 
 -----
 
-{% trans "Cliquez ou recopiez simplement le lien et complétez le reste du formulaire" %} : {{ url }}.
+{% trans "Cliquez ou recopiez simplement le lien et complétez le reste du formulaire" %} : {{ url }}.
 {% endblock %}

--- a/templates/email/member/confirm_registration.txt
+++ b/templates/email/member/confirm_registration.txt
@@ -6,12 +6,12 @@
 Vous vous êtes inscrit sur {{ site_name }} ({{ site_url }}) et nous vous en remercions.
 En étant membre de notre communauté, vous aurez la possibilité de rédiger des tutoriels et des articles
 que vous pourrez ensuite publier et ainsi rendre votre savoir accessible au plus grand nombre.
-Vous pourrez également échanger avec les autres membres sur nos forums !
+Vous pourrez également échanger avec les autres membres sur nos forums !
 {% endblocktrans %}
 
 {% blocktrans %}
-Il ne vous reste plus qu’à activer votre profil ! Pour ce faire, visitez le lien ci-dessous : {{ url }}
+Il ne vous reste plus qu’à activer votre profil ! Pour ce faire, visitez le lien ci-dessous : {{ url }}
 {% endblocktrans %}
 
-{% trans "A très bientôt !" %}
+{% trans "A très bientôt !" %}
 {% endblock %}

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -5,7 +5,7 @@
         <p class="copyright">
             {{app.site.literal_name}}
             <span class="version">
-                &bull; {% trans "Version" %} : <a href="{{git_version.url}}">{{git_version.name}}</a>
+                &bull; {% trans "Version :" %} <a href="{{git_version.url}}">{{git_version.name}}</a>
             </span>
         </p>
 

--- a/templates/forum/category/forum.html
+++ b/templates/forum/category/forum.html
@@ -94,7 +94,7 @@
 
     {% if not sticky_topics and not topics %}
         <p>
-            {% trans "Aucun sujet trouvé" %}.
+            {% trans "Aucun sujet trouvé." %}
         </p>
     {% endif %}
 

--- a/templates/forum/find/topic_by_tag.html
+++ b/templates/forum/find/topic_by_tag.html
@@ -6,19 +6,19 @@
 
 
 {% block title %}
-    {% trans "Tag" %} : {{ tag.title }}
+    {% trans "Tag :" %} {{ tag.title }}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li>{% trans "Tag" %} : {{ tag.title }}</li>
+    <li>{% trans "Tag :" %} {{ tag.title }}</li>
 {% endblock %}
 
 
 
 {% block headline %}
-    {% trans "Tag" %} : {{ tag.title }}
+    {% trans "Tag :" %} {{ tag.title }}
 {% endblock %}
 
 {% block feeds_rss %}

--- a/templates/forum/messages/solve_alert_pm.md
+++ b/templates/forum/messages/solve_alert_pm.md
@@ -4,9 +4,9 @@
 Bonjour {{ alert_author }},
 
 Vous recevez ce message car vous avez signalé le message de *{{ post_author }}* dans le sujet [{{ post_title }}]({{ post_url }}).
-Votre alerte a été traitée par **{{ staff_name }}** qui vous a laissé le message suivant :
+Votre alerte a été traitée par **{{ staff_name }}** qui vous a laissé le message suivant :
 
 > {{ staff_message }}
 
-Toute l’équipe de la modération vous remercie !
+Toute l’équipe de la modération vous remercie !
 {% endblocktrans %}

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -67,7 +67,7 @@
             class="alert-box success ico-after tick light {% if not topic.is_solved %}empty{% endif %}"
             data-ajax-output="solve-topic"
         >
-            {% trans "L’auteur de ce sujet a trouvé une solution à son problème" %}.
+            {% trans "L’auteur de ce sujet a trouvé une solution à son problème." %}
         </div>
 
 

--- a/templates/gallery/gallery/details.html
+++ b/templates/gallery/gallery/details.html
@@ -32,7 +32,7 @@
 
 {% block content %}
     <div class="authors">
-        <span class="authors-label">{% trans "Galerie partagée avec" %} : </span>
+        <span class="authors-label">{% trans "Galerie partagée avec" %} : </span>
         <ul>
             {% for u in gallery.get_linked_users %}
                 {% captureas info %}
@@ -97,7 +97,7 @@
         </div>
     {% else %}
         <p>
-            {% trans "Aucune image" %}. <br>
+            {% trans "Aucune image." %} <br>
             {% if gallery_mode.can_write %}
                 {% url "gallery-image-new" gallery.pk as new_img_url %}
                 {% url "gallery-image-import" gallery.pk as import_archive %}

--- a/templates/gallery/image/edit.html
+++ b/templates/gallery/image/edit.html
@@ -29,14 +29,14 @@
 {% block content %}
     <div class="gallery-col-image">
         <p>
-            {% trans "Image" %} :
+            {% trans "Image :" %}
         </p>
         <a href="{{ image.physical.url|remove_url_scheme }}">
             <img src="{{ image.physical.gallery_illu.url|remove_url_scheme }}" alt="{{ image.legend|default:image.title }}">
         </a>
 
         <p>
-            {% trans "Miniature" %} :
+            {% trans "Miniature :" %}
         </p>
         <a href="{{ image.physical.gallery.url|remove_url_scheme }}">
             <img src="{{ image.physical.gallery.url|remove_url_scheme }}" alt="{{ image.legend|default:image.title }}">
@@ -44,7 +44,7 @@
 
         {% if perms.featured.change_featuredresource %}
         <p>
-            {% trans "Lien pour utiliser cette image en une" %} : <br>
+            {% trans "Lien pour utiliser cette image en une :" %}<br>
             <input type="text" value="{{ app.site.url }}{{ image.physical.featured.url }}" readonly onclick="this.select()">
         </p>
         {% endif %}
@@ -56,15 +56,15 @@
         {% endif %}
 
         <p>
-            {% trans "Code markdown pour insérer cette image" %} : <br>
+            {% trans "Code markdown pour insérer cette image :" %}<br>
 
-            {% trans "Taille normale" %} :
+            {% trans "Taille normale : " %}
             <input type="text" value="![{{ image.legend|default:image.title }}]({{ image.physical.url|remove_url_scheme }})" readonly onclick="this.select()"> <br>
 
-            {% trans "Miniature" %} :
+            {% trans "Miniature : " %}
             <input type="text" value="![{{ image.legend|default:image.title }}]({{ image.physical.gallery.url|remove_url_scheme }})" readonly onclick="this.select()"> <br>
 
-            {% trans "Miniature + lien vers taille normale" %} :
+            {% trans "Miniature + lien vers taille normale : " %}
             <input type="text" value="[![{{ image.legend|default:image.title }}]({{ image.physical.gallery.url|remove_url_scheme }})]({{ image.physical.url|remove_url_scheme }})" readonly onclick="this.select()">
         </p>
 

--- a/templates/member/login.html
+++ b/templates/member/login.html
@@ -65,7 +65,7 @@
         <h1>{% trans "Connexion" %}</h1>
 
         <p class="alert-box error">
-            {% trans "Vous êtes déjà connecté" %}.
+            {% trans "Vous êtes déjà connecté." %}
         </p>
     {% endif %}
 {% endblock %}

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -43,7 +43,7 @@
                         {% trans "Inscrit" %} {{ usr.date_joined|format_date:True }}
                     </li>
                     <li>
-                        {% trans "Dernière visite sur le site" %} :
+                        {% trans "Dernière visite sur le site" %} :
                             {% if profile.last_visit %}
                                 {{ profile.last_visit|format_date:True }}
                             {% else %}
@@ -57,7 +57,7 @@
                 {% endif %}
                 {% if perms.member.show_ip %}
                     <li>
-                        {% trans "Dernière IP" %} : <a href="{% url "member-from-ip" profile.last_ip_address %}">{{ profile.last_ip_address }}</a>
+                        {% trans "Dernière IP" %} : <a href="{% url "member-from-ip" profile.last_ip_address %}">{{ profile.last_ip_address }}</a>
                     </li>
                     <li>
                         {{ profile.get_city }}
@@ -73,13 +73,13 @@
         <ul class="member-social">
             {% if profile.show_email and user.is_authenticated %}
                 <li>
-                    {% trans "E-mail" %} : {{ usr.email|obfuscate_mailto }}
+                    {% trans "E-mail" %} : {{ usr.email|obfuscate_mailto }}
                 </li>
             {% endif %}
 
             {% if profile.site %}
                 <li>
-                    {% trans "Site web" %} : <a href="{{ profile.site }}">{{ profile.site }}</a>
+                    {% trans "Site web" %} : <a href="{{ profile.site }}">{{ profile.site }}</a>
                 </li>
             {% endif %}
         </ul>
@@ -122,7 +122,7 @@
                 <form action="{% url 'add-hat' usr.pk %}" method="post" id="add-hat" class="modal modal-flex">
                     {% csrf_token %}
                     <p>
-                        {% blocktrans with username=usr.username %}Vous allez ajouter une casquette à {{ username }} :{% endblocktrans %}
+                        {% blocktrans with username=usr.username %}Vous allez ajouter une casquette à {{ username }} :{% endblocktrans %}
                     </p>
                     <ul>
                         <li>{% trans "Le membre aura la possibilité pour chaque message de poster avec ou sans sa casquette." %}</li>
@@ -212,7 +212,7 @@
                                 {% if action.type %}
                                     {{ action.type }}
                                 {% elif action.karma %}
-                                    {% trans "Modification du karma" %} : {{ action.karma }}
+                                    {% trans "Modification du karma" %} : {{ action.karma }}
                                 {% else %}
                                     –
                                 {% endif %}

--- a/templates/member/register/send_validation_email.html
+++ b/templates/member/register/send_validation_email.html
@@ -35,7 +35,7 @@
         <p>
             {% blocktrans %}
             Vous n’avez pas reçu le mail de confirmation ? Nous pouvons vous le renvoyer, nous avons
-            besoin de l’une des informations suivantes : saisissez votre nom d’utilisateur ou votre adresse de courriel
+            besoin de l’une des informations suivantes : saisissez votre nom d’utilisateur ou votre adresse de courriel
             dans les champs ci-dessous.
             {% endblocktrans %}
         </p>

--- a/templates/member/register/token_success.html
+++ b/templates/member/register/token_success.html
@@ -20,13 +20,13 @@
 
 {% block content_out %}
     <section class="small-content-wrapper">
-        <h2>{% trans "Confirmation d’inscription réussie" %} !</h2>
+        <h2>{% trans "Confirmation d’inscription réussie !" %}</h2>
 
         <p>
-            {% trans "Vous avez confirmé votre courriel sur le site" %}.
+            {% trans "Vous avez confirmé votre courriel sur le site." %}
         </p>
         <p>
-            {% trans "Vous pouvez maintenant vous connecter et partager avec tous les membres" %}.
+            {% trans "Vous pouvez maintenant vous connecter et partager avec tous les membres." %}
             {% crispy form %}
         </p>
     </section>

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -61,7 +61,7 @@
                                         {% csrf_token %}
                                         {% if perms_change %}
                                             <p>
-                                                {% trans "Pour quelle raison souhaitez vous masquer ce message" %} ?
+                                                {% trans "Pour quelle raison souhaitez-vous masquer ce message ?" %}
                                             </p>
                                             <input type="text" name="text_hidden" placeholder="Flood, Troll, Hors sujet, ..." >
                                         {% else %}
@@ -127,7 +127,7 @@
                             <form action="{{ alert_link|safe }}" method="post" id="signal-message-{{ message.id }}" class="modal modal-flex">
                                 {% csrf_token %}
                                 <label for="signal-message-{{ message.id }}-field">
-                                    {% trans "Pour quelle raison signalez-vous ce message" %} ?
+                                    {% trans "Pour quelle raison signalez-vous ce message ?" %}
                                 </label>
                                 <textarea type="text" name="signal_text" id="signal-message-{{ message.id }}-field" placeholder="Flood, Troll, Hors sujet, …" pattern=".{3,}" required title='{% trans "Minimum 3 caractères pour signaler" %}' rows="4"></textarea>
 
@@ -191,7 +191,7 @@
                 <p class="message-hidden">
                     {% trans "Masqué par" %} {{ message.editor }}
                     {% if message.text_hidden %}
-                        : {{ message.text_hidden }}
+                        : {{ message.text_hidden }}
                     {% endif %}
                 </p>
             {% elif message.update %}
@@ -217,7 +217,7 @@
             {% for alert in message.alerts_on_this_comment.all %}
                 <div class="alert-box{% if not alert.solved %} error{% endif %}">
                     {{ alert.pubdate|format_date|capfirst }} {% trans "par" %}
-                    {% include "misc/member_item.part.html" with member=alert.author %} :
+                    {% include "misc/member_item.part.html" with member=alert.author %} :
                     <em class="alert-box-text">{{ alert.text }}</em>
                     {% if alert.solved %}
                         <span class="close-alert-box close-alert-box-text">

--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -4,27 +4,27 @@
 
 {% if topic.is_locked %}
     <div class="alert-box ico-after lock light">
-        {% trans "Ce sujet est verrouillé" %}.
+        {% trans "Ce sujet est verrouillé." %}
     </div>
 {% elif not user.is_authenticated %}
     <div class="alert-box info alert-box-not-closable">
-        {% trans "Vous devez être connecté pour pouvoir poster un message" %}. <br>
+        {% trans "Vous devez être connecté pour pouvoir poster un message." %}<br>
         <a href="{% url "member-login" %}?next={{ request.path }}" class="alert-box-btn alert-box-btn-right">Connexion</a>
     </div>
     <div class="alert-box not-member alert-box-not-closable">
         <h4 class="alert-box-title">Pas encore inscrit ?</h4>
         <p>
-            {% trans "Créez un compte en une minute pour profiter pleinement de toutes les fonctionnalités de Zeste de Savoir. Ici, tout est gratuit et sans publicité" %}. <br>
+            {% trans "Créez un compte en une minute pour profiter pleinement de toutes les fonctionnalités de Zeste de Savoir. Ici, tout est gratuit et sans publicité." %}<br>
             <a href="{% url "register-member" %}" class="alert-box-btn">{% trans "Créer un compte" %}</a>
         </p>
     </div>
 {% elif topic.antispam or is_antispam %}
     <div class="alert-box ico-after ico-alert light">
-        {% trans "Vous venez de poster. Merci de patienter au moins 15 minutes entre deux messages consécutifs afin de limiter le flood" %}.
+        {% trans "Vous venez de poster. Merci de patienter au moins 15 minutes entre deux messages consécutifs afin de limiter le flood." %}
     </div>
 {% elif topic.alone %}
     <div class="alert-box info cross light">
-        {% trans "Vous êtes seul dans cette conversation" %}.
+        {% trans "Vous êtes seul dans cette conversation." %}
     </div>
 {% else %}
     {% if topic.old_post_warning %}

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -39,7 +39,7 @@
             {% else %}
                 <li>
                     <a href="#pagination-{{ position }}" class="open-modal">...</a>
-                    <form action="." method="get" class="modal modal-flex" id="pagination-{{ position }}" data-modal-title='{% trans "Aller à la page" %}...'>
+                    <form action="." method="get" class="modal modal-flex" id="pagination-{{ position }}" data-modal-title='{% trans "Aller à la page…" %}'>
                         {% for key,val in request.GET.iterlists %}
                             {% if key != "page" %}
                                 {% for v in val %}
@@ -48,7 +48,7 @@
                             {% endif %}
                         {% endfor %}
                         <p>
-                            {% trans "Indiquez la page à laquelle vous souhaitez vous rendre" %}.
+                            {% trans "Indiquez la page à laquelle vous souhaitez vous rendre." %}
                         </p>
                         <input type="number" name="page" min="1" max="{{ pages|last }}">
                         <button type="submit">

--- a/templates/misc/paginator.html
+++ b/templates/misc/paginator.html
@@ -35,7 +35,7 @@
             {% else %}
                 <li>
                     <a href="#pagination-{{ position }}" class="open-modal">...</a>
-                    <form action="." method="get" class="modal modal-flex" id="pagination-{{ position }}" data-modal-title='{% trans "Aller à la page" %}...'>
+                    <form action="." method="get" class="modal modal-flex" id="pagination-{{ position }}" data-modal-title='{% trans "Aller à la page…" %}'>
                         {% for key,val in request.GET.iterlists %}
                             {% if key != "page" %}
                                 {% for v in val %}
@@ -44,7 +44,7 @@
                             {% endif %}
                         {% endfor %}
                         <p>
-                            {% trans "Indiquez la page à laquelle vous souhaitez vous rendre" %}.
+                            {% trans "Indiquez la page à laquelle vous souhaitez vous rendre." %}
                         </p>
                         <input type="number" name="page" min="1" max="{{ pages|last }}">
                         <button type="submit">

--- a/templates/misc/validation.part.html
+++ b/templates/misc/validation.part.html
@@ -9,7 +9,7 @@
 
 {% if validation.is_pending %}
     <form action="{{ reservation_url }}" method="post">
-    	{% csrf_token %}
+        {% csrf_token %}
         <button type="submit">
             {% trans "Réserver" %}
         </button>
@@ -21,7 +21,7 @@
         {% if validation.date_reserve %}
             {{ validation.date_reserve|format_date:True }}
             {% if validation.date_proposition > validation.date_reserve  %}
-                ({% trans 'contenu mis à jour depuis la réservation' %})
+                ({% trans "Contenu mis à jour depuis la réservation." %})
             {% endif %}
             <br>
         {% endif %}
@@ -32,7 +32,7 @@
             {% trans "Annuler la réservation" %}
         </a>
         <form action="{{ reservation_url }}" method="post" class="modal modal-flex" id="unreservation-{{ validation.pk }}">
-        	{% csrf_token %}
+            {% csrf_token %}
             <p>
                 {% trans "Actuellement réservé par" %} {% include "misc/member_item.part.html" with member=validation.validator %}. <br>
                 {% blocktrans %}

--- a/templates/mp/post/new.html
+++ b/templates/mp/post/new.html
@@ -19,7 +19,7 @@
 
 
 {% block headline %}
-    {% trans "Répondre au MP" %} : {{topic.title}}
+    {% trans "Répondre au MP" %} : {{topic.title}}
 {% endblock %}
 
 

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -33,7 +33,7 @@
 
 {% block content %}
     <div class="authors">
-        <span class="authors-label">{% trans "Participant" %}{{ topic.participants.all|length|add:"1"|pluralize }} : </span>
+        <span class="authors-label">{% trans "Participant" %}{{ topic.participants.all|length|add:"1"|pluralize }} : </span>
         <ul>
             <li>
                 {% include 'misc/member_item.part.html' with member=topic.author avatar=True %}
@@ -101,7 +101,7 @@
                     </a>
                     <form action="{% url "mp-edit-participant" topic.pk topic.slug %}" method="post" id="add-participant" class="modal modal-flex">
                         <p>
-                            {% trans "Vous allez rajouter un nouveau membre dans la conversation privée" %}.
+                            {% trans "Vous allez rajouter un nouveau membre dans la conversation privée." %}
                         </p>
                         <input
                             type="text" class="input" name="username"
@@ -127,7 +127,7 @@
                 </a>
                 <form action="{% url "mp-delete" topic.pk topic.slug %}" method="post" id="leave-conversation" class="modal modal-flex">
                     <p>
-                        {% trans "Attention, vous vous apprêtez à quitter définitivement cette conversation" %}.
+                        {% trans "Attention, vous vous apprêtez à quitter définitivement cette conversation." %}
                     </p>
 
                     {% csrf_token %}

--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -60,7 +60,7 @@
         <div class="content-col-3">
             <h3>{% trans "Système / Back-end" %}</h3>
             <p>
-                {% trans "Le back-end est propulsé par les outils suivants :" %}
+                {% trans "Le back-end est propulsé par les outils suivants :" %}
             </p>
 
             <h4>{% trans "Site" %}</h4>
@@ -92,7 +92,7 @@
         <div class="content-col-3">
             <h3>{% trans "Front-end" %}</h3>
             <p>
-                {% trans "Le front-end utilise les outils suivants :" %}
+                {% trans "Le front-end utilise les outils suivants :" %}
             </p>
 
             <h4>{% trans "Feuilles de style" %}</h4>

--- a/templates/pages/assoc_subscribe.html
+++ b/templates/pages/assoc_subscribe.html
@@ -32,7 +32,7 @@
     <p>
         {% blocktrans with asso_fee=app.site.association.fee %}
             D'autre part, le financement des activités de l'association, dont bien sûr le site, est intégralement assuré par
-            les cotisations des membres : adhérer vous permet ainsi d'assurer la pérennité du site.
+            les cotisations des membres : adhérer vous permet ainsi d'assurer la pérennité du site.
             La cotisation est de <strong>{{ asso_fee }}</strong> (le montant est révisé tous les ans durant les assemblées générales).
             Si pour une raison quelconque vous ne pouvez pas payer cette cotisation, faites-en nous part, nous pouvons accorder des dérogations exceptionnelles.
         {% endblocktrans %}
@@ -45,13 +45,13 @@
     </p>
     <p>
         {% blocktrans %}
-            Une précision importante : <strong>adhérer à l'association ne vous apporte rien sur le site</strong>. L'adhésion
+            Une précision importante : <strong>adhérer à l'association ne vous apporte rien sur le site</strong>. L'adhésion
             n'est là que pour soutenir le projet, et ne donne droit à aucun pouvoir ou badge supplémentaires. Elle ne donne
             même pas accès à un forum secret, puisque le forum de l'association est public !
         {% endblocktrans %}
     </p>
     <p>
-        {% trans "Enfin, toutes les fonctionnalités du site sont disponibles à tous : aucune n'est conditionnée à l'adhésion à l'association." %}
+        {% trans "Enfin, toutes les fonctionnalités du site sont disponibles à tous : aucune n'est conditionnée à l'adhésion à l'association." %}
     </p>
 
     <h3>{% trans "Formulaire d'adhésion" %}</h3>

--- a/templates/pages/association.html
+++ b/templates/pages/association.html
@@ -53,7 +53,7 @@
         {% endblocktrans %}
     </p>
     <p>
-        {% trans "De même, toutes les fonctionnalités du site sont disponibles à tous : aucune n'est conditionnée à l'adhésion à l'association." %}
+        {% trans "De même, toutes les fonctionnalités du site sont disponibles à tous : aucune n'est conditionnée à l'adhésion à l'association." %}
     </p>
     <p>
         {% trans "Notez que vous devez être inscrit pour pouvoir adhérer." %}

--- a/templates/pages/cookies.html
+++ b/templates/pages/cookies.html
@@ -38,7 +38,7 @@
     </p>
 
     <h3>{% trans "À quoi servent les cookies ?" %}</h3>
-    <p>{% trans "Les cookies se répartissent en deux grands types : les impératifs techniques et la mesure d'audience." %}</p>
+    <p>{% trans "Les cookies se répartissent en deux grands types : les impératifs techniques et la mesure d'audience." %}</p>
     <p>{% blocktrans %}<strong>En aucun cas</strong> les cookies servent à recueillir des renseignements personnels, transmettre des données sensibles ou transmettre des données personnelles à des tiers.{% endblocktrans %}</p>
 
     <h4>{% trans "Cookies techniques" %}</h4>
@@ -47,7 +47,8 @@
     <p>{% blocktrans %}Ces cookies, purement techniques, <strong>sont indispensables au fonctionnement de {{ site_name }}</strong>. Si vous les refusez, les éléments qui en dépendent ne fonctionneront tout simplement pas !{% endblocktrans %}</p>
 
     <h4>{% trans "Cookies d'analyse d'audience" %}</h4>
-    <p>{% blocktrans %}{{ site_name }} analyse son audience. Que signifie ce terme barbare ? Tout simplement que nous étudions la manière dont le site est utilisé :{% endblocktrans %}</p>
+    <p>{% blocktrans %}{{ site_name }} analyse son audience. Que signifie ce terme barbare ? Tout simplement que nous étudions la manière dont le site est utilisé :{% endblocktrans %}</p>
+
     <ul>
         <li>{% trans "Quelles fonctionnalités sont utilisées ?" %}</li>
         <li>{% trans "À quelle fréquence ?" %}</li>
@@ -62,7 +63,7 @@
     <p>{% trans "C'est cette analyse qui peut être désactivée, puisqu'elle n'est pas strictement indispensable au bon fonctionnement du site." %}</p>
 
     <h3>{% trans "Les cookies sur ce site" %}</h3>
-    <p>{% blocktrans %}Pour être tout à fait précis, {{ site_name }} utilise les cookies suivants :{% endblocktrans %}</p>
+    <p>{% blocktrans %}Pour être tout à fait précis, {{ site_name }} utilise les cookies suivants :{% endblocktrans %}</p>
     <h4>{% trans "Cookies techniques" %}</h4>
     <dl>
         <dt><tt>sessionid</tt></dt>
@@ -116,9 +117,10 @@
     <hr>
 
     <h3>{% trans "Une recette de cookies" %}</h3>
-    <p>{% trans "Puisque vous avez réussi à trouver cette page et que vous avez eu le courage de lire jusqu'ici, vous avez bien droit à une récompense : une recette de cookies !" %}</p>
+    <p>{% trans "Puisque vous avez réussi à trouver cette page et que vous avez eu le courage de lire jusqu'ici, vous avez bien droit à une récompense : une recette de cookies !" %}</p>
+
     <h4>{% trans "Ingrédients" %}</h4>
-    <p>{% trans "Pour beaucoup de cookies (parce que le nombre dépend de leur taille) :" %}</p>
+    <p>{% trans "Pour beaucoup de cookies (parce que le nombre dépend de leur taille) :" %}</p>
     <ul>
         <li>{% trans "500 g de farine" %}</li>
         <li>{% trans "500 g de chocolat à pâtisser" %}</li>
@@ -129,8 +131,8 @@
         <li>{% trans "1 pincée de sel" %}</li>
         <li>{% trans "1 sachet de levure" %}</li>
     </ul>
-    <p>{% trans "Préparation : 10 minutes + 15 minutes pour couper le chocolat" %}</p>
-    <p>{% blocktrans %}Cuisson : 10 minutes <strong>par fournée</strong>{% endblocktrans %}</p>
+    <p>{% trans "Préparation : 10 minutes + 15 minutes pour couper le chocolat" %}</p>
+    <p>{% blocktrans %}Cuisson : 10 minutes <strong>par fournée</strong>{% endblocktrans %}</p>
     <h4>{% trans "Préparation" %}</h4>
     <p>{% trans "Avec un grand couteau solide et bien aiguisé, découpez le chocolat en petits morceaux." %}</p>
     <p>{% trans "Mélangez en crème le beurre ramolli et le sucre. Incorporez les &oelig;ufs et la vanille liquide (ou le sucre vanillé)." %}</p>
@@ -141,8 +143,8 @@
     <p>{% trans "Façonnez des cookies pas trop épais par petite cuillerées sur une plaque de cuisson recouverte de papier sulfurisé. Espacez-les parce qu'ils s'étalent à la cuisson." %}</p>
     <p>{% trans "Enfournez-les environ 10 minutes, ils sont cuits lorsqu'ils prennent une belle couleur dorée !" %}</p>
     <h4>{% trans "Conseils divers" %}</h4>
-    <p>{% trans "Si vous avez la flemme de découper le chocolat, vous pouvez utiliser des pépites de chocolat mais en général c'est moins bon. Surtout pas de chocolat à déguster : ces chocolats manquent de sucre pour la pâtisserie !" %}</p>
+    <p>{% trans "Si vous avez la flemme de découper le chocolat, vous pouvez utiliser des pépites de chocolat mais en général c'est moins bon. Surtout pas de chocolat à déguster : ces chocolats manquent de sucre pour la pâtisserie !" %}</p>
     <p>{% trans "Pour découper le chocolat, vous aurez besoin d'un grand couteau solide (donc pas un couteau céramique) et très bien aiguisé. Non, le vôtre n'est pas assez aiguisé. Attaquez la plaque de chocolat côté lisse (carrés sur le dessous), c'est plus simple." %}</p>
-    <p>{% trans "La cuisson parfaite se joue à quelques secondes près (sérieusement), alors surveillez-les bien ! Un SMS de trop, et vous obtenez des cookies en béton. Ce qui serait dommage. Les cookies sont assez mous en sortie de four, c'est normal : ils durcissent en refroidissant." %}</p>
+    <p>{% trans "La cuisson parfaite se joue à quelques secondes près (sérieusement), alors surveillez-les bien ! Un SMS de trop, et vous obtenez des cookies en béton. Ce qui serait dommage. Les cookies sont assez mous en sortie de four, c'est normal : ils durcissent en refroidissant." %}</p>
     <p>{% blocktrans %} On peut faire des cookies à beaucoup de parfums, mais le <em>must</em> reste le cookie au chocolat.{% endblocktrans %}</p>
 {% endblock %}

--- a/templates/pages/eula.html
+++ b/templates/pages/eula.html
@@ -42,7 +42,7 @@
             L'édition du site {{ app.site.dns }} est assurée par l'association française de loi 1901 {{ app.site.literal_name }}, déclarée à la préfecture de Vendée et parue au Journal Officiel le 19 avril 2014.
         </p>
         <p>
-            Vous pouvez joindre l’association via l’adresse courriel : <a href="mailto:{{ app.site.association.email }}">{{ app.site.association.email }}</a>.
+            Vous pouvez joindre l’association via l’adresse courriel : <a href="mailto:{{ app.site.association.email }}">{{ app.site.association.email }}</a>.
         </p>
     {% endif %}
     {% if app.site.hosting %}
@@ -57,12 +57,12 @@
     {% endif %}
     <h3>3. Définitions</h3>
     <ul>
-        <li>Utilisateur : ce terme désigne toute personne qui utilise le site ou l'un des services proposés par le site.</li>
-        <li>Membre : l'utilisateur devient un &laquo; Membre &raquo; dès son inscription sur le site.</li>
-        <li>Contenu de l'utilisateur : ce sont les données transmises par l'utilisateur sur le site.</li>
-        <li>Message : il s'agit d'un contenu publié par un membre qui n'est ni un tutoriel ni un article.</li>
-        <li>Lien hypertexte : ce terme désigne les liens consultables par les visiteurs menant à une autre page du même site ou vers un autre site web.</li>
-        <li>Identifiant et mot de passe : c'est l'ensemble des informations nécessaires à l'identification d'un membre sur le site. L'identifiant et le mot de passe permettent à l'utilisateur d'accéder à des services réservés aux membres du site. Le mot de passe est une information confidentielle. </li>
+        <li>Utilisateur : ce terme désigne toute personne qui utilise le site ou l'un des services proposés par le site.</li>
+        <li>Membre : l'utilisateur devient un &laquo; Membre &raquo; dès son inscription sur le site.</li>
+        <li>Contenu de l'utilisateur : ce sont les données transmises par l'utilisateur sur le site.</li>
+        <li>Message : il s'agit d'un contenu publié par un membre qui n'est ni un tutoriel ni un article.</li>
+        <li>Lien hypertexte : ce terme désigne les liens consultables par les visiteurs menant à une autre page du même site ou vers un autre site web.</li>
+        <li>Identifiant et mot de passe : c'est l'ensemble des informations nécessaires à l'identification d'un membre sur le site. L'identifiant et le mot de passe permettent à l'utilisateur d'accéder à des services réservés aux membres du site. Le mot de passe est une information confidentielle. </li>
     </ul>
 
     <h3>4. Accès au site</h3>
@@ -122,7 +122,7 @@
         Le membre reste titulaire de l’intégralité de ses droits de propriété intellectuelle sur l’ensemble du contenu qu’il publie (articles, billets, tutoriels, de même que le contenu publié sur les forums). Mais par la mise en ligne d’un tutoriel,  ou article, il autorise gratuitement et sans clause d’exclusivité l’éditeur du site à représenter, modifier, adapter et diffuser sa publication sur le site, pour la durée de la propriété intellectuelle. Il autorise notamment l’éditeur du site à utiliser sa publication sur Internet dans le but de faire connaître le site.
     </p>
     <p>
-        L'auteur d'un tutoriel, d'un billet ou d'un article a également la possibilité de mettre sa publication en ligne selon la licence &ldquo;CC&rdquo; (Creative Commons) qui lui convient le mieux parmi les licences CC suivantes :
+        L'auteur d'un tutoriel, d'un billet ou d'un article a également la possibilité de mettre sa publication en ligne selon la licence &ldquo;CC&rdquo; (Creative Commons) qui lui convient le mieux parmi les licences CC suivantes :
     </p>
     <ul>
         <li>Licence CC 0 1.0 - <a href="http://creativecommons.org/publicdomain/zero/1.0/">Lire le résumé explicatif de la licence</a></li>
@@ -152,7 +152,7 @@
         Après inscription, tout membre dispose d'une page de profil personnelle. Ce profil recense l'ensemble de l'activité du membre sur le site (forums, signature, avatar,  articles, billets, tutoriels) à l'exception des informations d'inscription (nom, prénom, adresse courriel, ...) et correspondances (via le système de messagerie privée) privées.
     </p>
     <p>
-        Cette page de profil, accessible à tous les membres, a pour objet de permettre au membre de se présenter. Le membre est libre d'ajouter une photographie le représentant, un avatar et d'autres informations supplémentaires : biographie, formations et emploi, l'adresse des sites et/ou blog et/ou portfolio présentant les travaux du membre, comptes sur les réseaux sociaux et toute autre information au choix du membre.
+        Cette page de profil, accessible à tous les membres, a pour objet de permettre au membre de se présenter. Le membre est libre d'ajouter une photographie le représentant, un avatar et d'autres informations supplémentaires : biographie, formations et emploi, l'adresse des sites et/ou blog et/ou portfolio présentant les travaux du membre, comptes sur les réseaux sociaux et toute autre information au choix du membre.
     </p>
     <p>
         L'éditeur ne peut être tenu responsable des informations données par le membre sur cette page de profil. En effet, le membre doit donc veiller à ne fournir que des informations qu'il souhaite communiquer aux autres membres, le contenu de cette page étant sous sa responsabilité.
@@ -181,7 +181,7 @@
         Toutes les données à caractère personnel transmises par les utilisateurs et membres du site sont recueillies dans le plus strict respect de la législation. Elles ont pour finalité une meilleure utilisation de {{ app.site.dns }} et sont donc utilisées par l'éditeur du site à cette fin.
     </p>
     <p>
-        Lors de son inscription, il est requis de l'utilisateur de fournir des informations le concernant. En particulier, l'adresse électronique pourra être utilisée par le site pour l'administration et la communication d'informations touchant l'ensemble des membres du site (par exemple : une modification importante de la structure du site, l'ajout de fonctionnalités, une modification des présentes conditions, les dernières publications du site (newsletter), etc.).
+        Lors de son inscription, il est requis de l'utilisateur de fournir des informations le concernant. En particulier, l'adresse électronique pourra être utilisée par le site pour l'administration et la communication d'informations touchant l'ensemble des membres du site (par exemple : une modification importante de la structure du site, l'ajout de fonctionnalités, une modification des présentes conditions, les dernières publications du site (newsletter), etc.).
     </p>
     <p>
         Le membre a le choix s'abonner ou non à la newsletter.
@@ -207,7 +207,7 @@
         L'éditeur du site utilise la technologie des marqueurs (cookies) afin d'améliorer la qualité du site et mieux répondre aux attentes des utilisateurs. Le membre prend acte que le site procède à l'installation de cookies sur le disque dur de son ordinateur en vue d'identifier chacune de ses connexions.
     </p>
     <p>
-        De manière générale, les cookies sont sans dommage pour l'ordinateur du membre. Ce dernier est libre d'accepter ou refuser les cookies en configurant son navigateur internet à cet effet. Pour ce faire, le membre peut se rendre sur le site de la Commission Nationale de l'Informatique et des Libertés (CNIL) à l'adresse : <a href="http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/">http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/</a> donnant toutes les informations relatives à une telle configuration. Les cookies sont anonymes et ne sont en aucun cas utilisés pour collecter des données à caractère personnel, mais uniquement à des fins de connexion et statistiques.
+        De manière générale, les cookies sont sans dommage pour l'ordinateur du membre. Ce dernier est libre d'accepter ou refuser les cookies en configurant son navigateur internet à cet effet. Pour ce faire, le membre peut se rendre sur le site de la Commission Nationale de l'Informatique et des Libertés (CNIL) à l'adresse : <a href="http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/">http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/</a> donnant toutes les informations relatives à une telle configuration. Les cookies sont anonymes et ne sont en aucun cas utilisés pour collecter des données à caractère personnel, mais uniquement à des fins de connexion et statistiques.
     </p>
     <p>
         Pour plus de détails, voir <a href="{% url "pages-cookies" %}">la page d'explications sur les cookies</a>.

--- a/templates/tutorialv2/comment/new.html
+++ b/templates/tutorialv2/comment/new.html
@@ -19,7 +19,7 @@
 
 
 {% block headline %}
-    <h1>{% trans "Ajouter un commentaire à" %} : {{ content.title }}</h1>
+    <h1>{% trans "Ajouter un commentaire à :" %} {{ content.title }}</h1>
 {% endblock %}
 
 

--- a/templates/tutorialv2/import/content-new.html
+++ b/templates/tutorialv2/import/content-new.html
@@ -24,7 +24,7 @@
     <div class="alert-box info alert-box-not-closable">
     {%  blocktrans with prefix=app.content.import_image_prefix %}
         Pour importer des images, veuillez spécifier la seconde archive.
-        Pour que vos images soient automatiquement intégrées, ajoutez le préfix « {{ prefix }} » dans l’adresse de vos images. Par exemple : <code>![légende]({{ prefix }}:chemin/vers/image.extension)</code>. Les chemins seront remplacés par les URLs générées par le site.
+        Pour que vos images soient automatiquement intégrées, ajoutez le préfix « {{ prefix }} » dans l’adresse de vos images. Par exemple : <code>![légende]({{ prefix }}:chemin/vers/image.extension)</code>. Les chemins seront remplacés par les URLs générées par le site.
     {% endblocktrans %}
     </div>
 

--- a/templates/tutorialv2/import/content.html
+++ b/templates/tutorialv2/import/content.html
@@ -29,7 +29,7 @@
     <div class="alert-box info alert-box-not-closable">
     {%  blocktrans with prefix=app.content.import_image_prefix %}
         Pour importer des images, veuillez spécifier la seconde archive.
-        Pour que vos images soient automatiquement intégrées, ajoutez le préfix « {{ prefix }} » dans l’adresse de vos images. Par exemple : <code>![légende]({{ prefix }}:chemin/vers/image.extension)</code>. Les chemins seront remplacés par les URLs générées par le site.
+        Pour que vos images soient automatiquement intégrées, ajoutez le préfix « {{ prefix }} » dans l’adresse de vos images. Par exemple : <code>![légende]({{ prefix }}:chemin/vers/image.extension)</code>. Les chemins seront remplacés par les URLs générées par le site.
     {% endblocktrans %}
     </div>
 

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -130,7 +130,7 @@
         </ol>
     {% else %}
         <p class="ico-after warning">
-          {{ "Ce"|feminize:child.get_level_as_string }} {{ child.get_level_as_string|lower }}  {% trans " est actuellement vide" %}.
+          {{ "Ce"|feminize:child.get_level_as_string }} {{ child.get_level_as_string|lower }}  {% trans " est actuellement vide." %}
         </p>
     {% endif %}
 {% endif %}

--- a/templates/tutorialv2/includes/content_item.part.html
+++ b/templates/tutorialv2/includes/content_item.part.html
@@ -45,7 +45,8 @@
     {% endif %}
 {% endcaptureas %}
 
-{# Authors (by X, Y and Z) ; can't have multiple whitespaces because of the title ! #}
+{# Authors (by X, Y and Z); can't have multiple whitespaces because of the title! #}
+
 {% captureas authors_text %}
     {% for author in content|displayable_authors:online %}{% if forloop.first %}{% trans "par" %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %} {% if author == user %}{% trans "vous" %}{% else %}<a href="{{ author.get_absolute_url }}">{{ author.username }}</a>{% endif %}{% endfor %}
 {% endcaptureas %}

--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -31,12 +31,12 @@
 {% if update_date %}
     <span class="pubdate">
     {% if online and update_date == public_object.publication_date %}
-        {% trans "Publié" %} :
+        {% trans "Publié" %} :
         <time datetime="{{ update_date|date:"c" }}" pubdate="pubdate" itemprop="dateModified">
             {{ update_date|format_date }}
         </time>
     {% else %}
-        {% trans "Dernière mise à jour" %} :
+        {% trans "Dernière mise à jour" %} :
         <time datetime="{{ update_date|date:"c" }}" pubdate="pubdate" itemprop="dateModified">
             {{ update_date|format_date }}
         </time>
@@ -48,7 +48,7 @@
 
 <div class="authors">
     <span class="authors-label">
-        {% trans "Auteur" %}{{ publishablecontent|displayable_authors:online|pluralize }} :
+        {% trans "Auteur" %}{{ publishablecontent|displayable_authors:online|pluralize }} :
     </span>
     <ul>
         {% for member in publishablecontent|displayable_authors:online %}
@@ -67,7 +67,7 @@
     </ul>
     <br/>
     <span class="authors-label">
-        {% trans "Catégorie" %}{{ content.subcategory.all|pluralize }} :
+        {% trans "Catégorie" %}{{ content.subcategory.all|pluralize }} :
     </span>
     <ul>
         {% for category in content.subcategory.all %}
@@ -77,7 +77,7 @@
     <br/>
     <span>
         {% if online and reading_time and not is_part_or_chapter %}
-            {% trans "Temps de lecture estimé : " %}{{ reading_time | minute_to_duration:"long"}}
+            {% trans "Temps de lecture estimé : " %}{{ reading_time | minute_to_duration:"long"}}
         {% elif online and not is_part_or_chapter %}
             {% trans "Temps de lecture estimé à moins d’une minute." %}
         {% endif %}

--- a/templates/tutorialv2/index_online_contents.html
+++ b/templates/tutorialv2/index_online_contents.html
@@ -52,11 +52,11 @@
         <h1 class="ico-after ico-{% if current_content_type == "TUTORIAL" %}tutorials{% elif current_content_type == "ARTICLE" %}articles{% elif current_content_type == "OPINION" %}opinions{% else %}articles{% endif %}" itemprop="name">
             {% block headline %}
                 {% if tag %}
-                    {{ verbose_type_name_plural|title }} : {{ tag.title }}
+                    {{ verbose_type_name_plural|title }} : {{ tag.title }}
                 {% elif category %}
-                    {{ verbose_type_name_plural|title }} : {{ category }}
+                    {{ verbose_type_name_plural|title }} : {{ category }}
                 {% elif subcategory %}
-                    {{ verbose_type_name_plural|title }} : {{ subcategory }}
+                    {{ verbose_type_name_plural|title }} : {{ subcategory }}
                 {% else %}
                     {% trans "Tous les" %} {{ verbose_type_name_plural }}
                 {% endif %}

--- a/templates/tutorialv2/list_page_elements/side_bar.html
+++ b/templates/tutorialv2/list_page_elements/side_bar.html
@@ -1,6 +1,6 @@
 {% comment %}
 This template is purely backported from v21/v22. It is just a part of the template refactoring project
-Expected variables are :
+Expected variables are :
     - current_content_type => None if no filter, else can be one of the AVAILABLE_CONTENT_TYPES value (ARTICLE, TUTORIAL, OPINION...)
     - verbose_type_name_plural => basically "contents", "tutorials", "articles"
     - top_categories
@@ -68,7 +68,7 @@ Expected variables are :
             {% for subcat,slug in subcats %}
                 <li>
                     <a href="{{ content_list_url }}?category={{ slug }}" class="mobile-menu-link mobile-menu-sublink">
-                        {{  subcat }}
+                        {{ subcat }}
                     </a>
                 </li>
             {% endfor %}
@@ -96,7 +96,7 @@ Expected variables are :
                         href="{% url "content:feed-rss" %}"
                     {% endif %}
                 class="ico-after rss blue">
-                    {% blocktrans %} Nouveaux {{ verbose_type_name_plural }} (RSS) {% endblocktrans %}
+                    {% blocktrans %}Nouveaux {{ verbose_type_name_plural }} (RSS){% endblocktrans %}
                 </a>
             </li>
             <li>
@@ -111,7 +111,7 @@ Expected variables are :
                         href="{% url "content:feed-atom" %}"
                     {% endif %}
                 class="ico-after rss blue">
-                    {% blocktrans %} Nouveaux {{ verbose_type_name_plural }} (ATOM) {% endblocktrans %}
+                    {% blocktrans %}Nouveaux {{ verbose_type_name_plural }} (ATOM){% endblocktrans %}
                 </a>
             </li>
         </ul>

--- a/templates/tutorialv2/messages/add_author_pm.md
+++ b/templates/tutorialv2/messages/add_author_pm.md
@@ -7,5 +7,5 @@ Vous avez été intégré à la rédaction du contenu « [{{ title }}]({{ url }
 Il a été ajouté à la liste de vos contenus en rédaction 
 [ici]({{ index }}).
 
-Plus rien maintenant ne retient votre plume, alors bon courage !
+Plus rien maintenant ne retient votre plume, alors bon courage !
 {%  endblocktrans %}

--- a/templates/tutorialv2/messages/beta_activate_pm.md
+++ b/templates/tutorialv2/messages/beta_activate_pm.md
@@ -8,6 +8,6 @@ consulter cette version et vous faire ses retours dessus. Elle vous
 permettra ainsi de l’améliorer et de satisfaire aux critères de validation.
 
 Pour cela, un sujet a été créé automatiquement sur le forum et est accessible 
-[ici]({{ url }}). N’hésitez surtout pas à en personnaliser le premier message !
+[ici]({{ url }}). N’hésitez surtout pas à en personnaliser le premier message !
 
 {%  endblocktrans %}

--- a/templates/tutorialv2/messages/beta_activate_topic.md
+++ b/templates/tutorialv2/messages/beta_activate_topic.md
@@ -2,16 +2,16 @@
 {% load date %}
 {% blocktrans with time=content.creation_date|format_date title=content.title|safe type=type|safe %}
 
-Tout le monde se secoue ! :D
+Tout le monde se secoue ! :D
 
 J'ai commencé ({{ time }}) la rédaction d’un {{ type }} au doux nom 
 de « {{ title }} » et j’ai pour objectif de proposer en validation 
 un texte aux petits oignons. Je fais donc appel à votre bonté sans 
 limites pour dénicher le moindre pépin, que ce soit à propos 
 du fond ou de la forme. Vous pourrez consulter la bêta à votre guise à 
-l’adresse suivante :
+l’adresse suivante :
 
--> [À présent, c’est à vous !]({{ url }}) <-
+-> [À présent, c’est à vous !]({{ url }}) <-
 
-Merci !
+Merci !
 {%  endblocktrans %}

--- a/templates/tutorialv2/messages/beta_reactivate.md
+++ b/templates/tutorialv2/messages/beta_reactivate.md
@@ -2,13 +2,13 @@
 
 {% blocktrans with title=content.title|safe type=type|safe %}
 
-Oyez oyez les agrumes !
+Oyez oyez les agrumes !
 
 Je vous annonce avec plaisir la ré-ouverture de la bêta du contenu 
-« {{ title }} » ! Je vous souhaite une agréable lecture à l’adresse 
-suivante :
+« {{ title }} » ! Je vous souhaite une agréable lecture à l’adresse 
+suivante :
 
--> [Je suis de retour !]({{ url }}) <-
+-> [Je suis de retour !]({{ url }}) <-
 
 Merci pour votre participation.
 

--- a/templates/tutorialv2/messages/beta_update.md
+++ b/templates/tutorialv2/messages/beta_update.md
@@ -2,10 +2,10 @@
 
 {% blocktrans with title=content.title|safe %}
 
-Bonjour les agrumes !
+Bonjour les agrumes !
 
 La bêta a été mise à jour et décante sa pulpe 
-à l’adresse suivante :
+à l’adresse suivante :
 
 -> [{{ title}}]({{ url }}) <-
 

--- a/templates/tutorialv2/messages/opinion_promotion.md
+++ b/templates/tutorialv2/messages/opinion_promotion.md
@@ -2,11 +2,11 @@
 
 {% blocktrans with title=content.title|safe %}
 
-Félicitations !
+Félicitations !
 
-Je viens de promouvoir le billet « [{{ title }}]({{ url }}) » en article !
+Je viens de promouvoir le billet « [{{ title }}]({{ url }}) » en article !
 
 Il est en validation et sera examiné prochainement.
 
-À bientôt !
+À bientôt !
 {% endblocktrans %}

--- a/templates/tutorialv2/messages/resolve_alert.md
+++ b/templates/tutorialv2/messages/resolve_alert.md
@@ -5,14 +5,14 @@
 Bonjour {{ name }},
 
 Ce message fait suite à votre alerte concernant les propos de {{ username }}
-dans {{ type_content }} [{{ title }}]({{ url }}) :
+dans {{ type_content }} [{{ title }}]({{ url }}) :
 
 {{ alert_text }}
 
-{{ modo_name }} s’est occupé du signalement et vous a déposé un petit mot :
+{{ modo_name }} s’est occupé du signalement et vous a déposé un petit mot :
 
 {{ message }}
 
-Toute l’équipe de modération vous remercie et vous offre un smoothie !
+Toute l’équipe de modération vous remercie et vous offre un smoothie !
 
 {%  endblocktrans %}

--- a/templates/tutorialv2/messages/validation_change.md
+++ b/templates/tutorialv2/messages/validation_change.md
@@ -7,7 +7,7 @@
 
 {% blocktrans with title=content.title|safe validator=validator|safe %}
 
-Ça pulpe {{ validator }} ?
+Ça pulpe {{ validator }} ?
 
 Je suis là pour t’informer que le contenu « [{{ title }}]({{ url }}) » que tu 
 as réservé a fait l'objet d'une mise à jour puis d'une mise en validation. La 

--- a/templates/tutorialv2/messages/validation_opinion.md
+++ b/templates/tutorialv2/messages/validation_opinion.md
@@ -2,12 +2,12 @@
 
 
 {% blocktrans with title=title|safe validator_name=validator.username|safe validator_url=validator.get_absolute_url message=message_validation|safe %}
-Félicitations !
+Félicitations !
 
-Le billet « [{{ title }}]({{ url }}) » a bien été approuvé par l’équipe du site !
+Le billet « [{{ title }}]({{ url }}) » a bien été approuvé par l’équipe du site !
 {% endblocktrans %}
 
 
 {% blocktrans %}
-Fêtons-donc ça avec un smoothie ! :D
+Fêtons-donc ça avec un smoothie ! :D
 {% endblocktrans %}

--- a/templates/tutorialv2/messages/validation_reserve.md
+++ b/templates/tutorialv2/messages/validation_reserve.md
@@ -2,10 +2,10 @@
 
 {% blocktrans with title=content.title|safe %}
 
-Salut !
+Salut !
 
 Je viens de prendre en charge la validation de ton contenu, « [{{ title }}]({{ url }}) ».
 
-À bientôt !
+À bientôt !
 
 {% endblocktrans %}

--- a/templates/tutorialv2/messages/warn_typo.md
+++ b/templates/tutorialv2/messages/warn_typo.md
@@ -14,7 +14,7 @@
 
 
 {% blocktrans with username=user.username|safe title=content.title|safe type=type|safe %}
-Salut !
+Salut !
 
 Il me semble avoir déniché une erreur dans {{ type }}
 « [{{ title }}]({{ content_url }}) ».

--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -77,7 +77,7 @@
                                     </a>
                                     <br>
                                     {% if validation.content.subcategory.all %}
-                                        {% trans "Catégories" %} : 
+                                        {% trans "Catégories :" %}
                                         {% for subcategory in validation.content.subcategory.all %}
                                             {% if not forloop.first %}
                                                 -

--- a/templates/tutorialv2/view/base_categories.html
+++ b/templates/tutorialv2/view/base_categories.html
@@ -96,16 +96,16 @@
                         <div class="line">
                             <div class="line-item">
                                 {% if category %}
-                                    <span class="has-separator option">Domaine de savoir : <strong><a href="{% url 'publication:category' slug=category.slug %}">{{category}}</a></strong></span>
+                                    <span class="has-separator option">Domaine de savoir : <strong><a href="{% url 'publication:category' slug=category.slug %}">{{category}}</a></strong></span>
                                 {% endif %}
                                 {% if subcategory %}
-                                    <span class="has-separator option">Catégorie : <strong><a href="{% url 'publication:subcategory' slug_category=category.slug slug=subcategory.slug %}">{{subcategory}}</a></strong></span>
+                                    <span class="has-separator option">Catégorie : <strong><a href="{% url 'publication:subcategory' slug_category=category.slug slug=subcategory.slug %}">{{subcategory}}</a></strong></span>
                                 {% endif %}
                                 {% if type %}
-                                    <span class="has-separator option">Type : <strong>{{type}}</strong></span>
+                                    <span class="has-separator option">Type : <strong>{{type}}</strong></span>
                                 {% endif %}
                                 {% if tag %}
-                                    <span class="has-separator option">Tag : <strong>{{tag}}</strong></span>
+                                    <span class="has-separator option">Tag : <strong>{{tag}}</strong></span>
                                 {% endif %}
                             </div>
                         </div>

--- a/templates/tutorialv2/view/category.html
+++ b/templates/tutorialv2/view/category.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% comment %}
-    Structure de la page de second level :
+    Structure de la page de second level :
     - présentation des sous catégories (accessible via {%  for subcategory in subcategories %}
     - liste des 5 derniers tutos en une colonne
     - liste des 5 derniers articles en une colonne

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -102,7 +102,7 @@
         {{ container.get_introduction|emarkdown:is_js }}
     {% elif not content.is_beta %}
         <p class="ico-after warning">
-            {% trans "Il n’y a pas d’introduction" %}.
+            {% trans "Il n’y a pas d’introduction." %}
         </p>
     {% endif %}
 
@@ -122,7 +122,7 @@
         {%  include "tutorialv2/includes/child.part.html" with child=child %}
     {% empty %}
         <p class="ico-after warning">
-            {{ "Ce"|feminize:container.get_level_as_string }} {{ container.get_level_as_string|lower }}  {% trans " est actuellement vide" %}.
+            {{ "Ce"|feminize:container.get_level_as_string }} {{ container.get_level_as_string|lower }}  {% trans " est actuellement vide." %}
         </p>
     {% endfor %}
 
@@ -132,7 +132,7 @@
         {{ container.get_conclusion|emarkdown:is_js }}
     {% elif not content.is_beta %}
         <p class="ico-after warning">
-            {% trans "Il n’y a pas de conclusion" %}.
+            {% trans "Il n’y a pas de conclusion." %}
         </p>
     {% endif %}
 

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -62,7 +62,7 @@
                 {% if validation.comment_authors %}
                     <div class="content-wrapper comment-author">
                         <p>
-                            {% trans "Le message suivant a été laissé à destination des validateurs" %} :
+                            {% trans "Le message suivant a été laissé à destination des validateurs" %} :
                         </p>
 
                         <blockquote>
@@ -134,7 +134,7 @@
         {{ content.get_introduction|emarkdown:is_js }}
     {% elif not content.is_beta %}
         <p class="ico-after warning">
-            {% trans "Il n’y a pas d’introduction" %}.
+            {% trans "Il n’y a pas d’introduction." %}
         </p>
     {% endif %}
 
@@ -154,7 +154,7 @@
         {%  include "tutorialv2/includes/child.part.html" with child=child %}
     {% empty %}
         <p class="ico-after warning">
-            {% trans "Ce contenu est actuellement vide" %}.
+            {% trans "Ce contenu est actuellement vide." %}
         </p>
     {% endfor %}
 
@@ -165,7 +165,7 @@
         {{ content.get_conclusion|emarkdown:is_js }}
     {% elif not content.is_beta %}
         <p class="ico-after warning">
-            {% trans "Il n’y a pas de conclusion" %}.
+            {% trans "Il n’y a pas de conclusion." %}
         </p>
     {% endif %}
 
@@ -581,7 +581,7 @@
                                     {% endblocktrans %}
                                     {%  if need_reason %}
                                         {% blocktrans with username=validation.validator.username %}
-                                            Il est en cours de validation par <strong>{{ username }}</strong>, qui appréciera de savoir pourquoi vous souhaitez le supprimer :
+                                            Il est en cours de validation par <strong>{{ username }}</strong>, qui appréciera de savoir pourquoi vous souhaitez le supprimer :
                                         {% endblocktrans %}
                                     {% endif %}
                                 </p>

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -110,7 +110,7 @@
             {% for alert in alerts %}
                 <div class="alert-box{% if not alert.solved %} error{% endif %}">
                     {{ alert.pubdate|format_date|capfirst }} {% trans "par" %}
-                    {% include "misc/member_item.part.html" with member=alert.author %} :
+                    {% include "misc/member_item.part.html" with member=alert.author %} :
                     <em class="alert-box-text">{{ alert.text }}</em>
                     {% if alert.solved %}
                         <span class="close-alert-box close-alert-box-text">

--- a/templates/tutorialv2/view/subcategory.html
+++ b/templates/tutorialv2/view/subcategory.html
@@ -6,7 +6,7 @@
     <div class="flexpage-column">
         <section>
             <h2 itemprop="name">
-                Derniers tutoriels
+                {% trans "Derniers tutoriels" %}
                 <a href="{% url "tutorial:feed-rss" %}?subcategory={{ subcategory.slug }}" class="btn btn-grey">RSS</a>
                 <a href="{% url "tutorial:feed-atom" %}?subcategory={{ subcategory.slug }}" class="btn btn-grey">Atom</a>
             </h2>
@@ -18,7 +18,7 @@
 
             <section>
                 <h2 itemprop="name">
-                    Derniers articles
+                    {% trans "Derniers articles" %}
                     <a href="{% url "article:feed-rss" %}?subcategory={{ subcategory.slug }}" class="btn btn-grey">RSS</a>
                     <a href="{% url "article:feed-atom" %}?subcategory={{ subcategory.slug }}" class="btn btn-grey">Atom</a>
                 </h2>

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -93,7 +93,7 @@ class MemberTests(TestCase):
             'note': 'warn'
         }, follow=True)
         self.assertEqual(200, r.status_code)
-        self.assertIn('{} : 42'.format(_('Modification du karma')), r.content.decode('utf-8'))
+        self.assertIn('{} : 42'.format(_('Modification du karma')), r.content.decode('utf-8'))
         # more than 100 karma must unvalidate the karma
         r = self.client.post(reverse('member-modify-karma'), {
             'profile_pk': user.pk,
@@ -101,7 +101,7 @@ class MemberTests(TestCase):
             'note': 'warn'
         }, follow=True)
         self.assertEqual(200, r.status_code)
-        self.assertNotIn('{} : 420'.format(_('Modification du karma')), r.content.decode('utf-8'))
+        self.assertNotIn('{} : 420'.format(_('Modification du karma')), r.content.decode('utf-8'))
         # empty warning must unvalidate the karma
         r = self.client.post(reverse('member-modify-karma'), {
             'profile_pk': user.pk,
@@ -109,7 +109,7 @@ class MemberTests(TestCase):
             'note': ''
         }, follow=True)
         self.assertEqual(200, r.status_code)
-        self.assertNotIn('{} : 41'.format(_('Modification du karma')), r.content.decode('utf-8'))
+        self.assertNotIn('{} : 41'.format(_('Modification du karma')), r.content.decode('utf-8'))
 
     def test_list_members(self):
         """


### PR DESCRIPTION
Ce commit remplace les espaces par des espaces insécables quand c'est pertinent (c.a.d. avant les double points, les points d'interrogation, les points d'exclamation et les points-virgules).
Il replace aussi les ponctuations de fin de phrases à l'intérieur des blocs de traduction quand cela est possible.

En conséquence, il peut être nécessaire de vérifier les fichiers de traduction générés avec 'makemessages' (pour les instances qui les utilisent).

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4584 

**J'ai vérifié le diff et le fonctionnement de mon instance locale, mais il est fort possible que des erreurs m'aient échappées.**

### QA

- Vérifier le diff (risque d'être long et fastidieux).
- Vérifier le bon fonctionnement des vues sur une instance locale.
- Vérifier le bon affichage des phrases.