### PR TITLE
changer append_to_get en append_query_params 

### DIFF
--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -8,16 +8,16 @@ Le dossier ``zds/utils/templatetags/`` contient un ensemble de tags et filtres p
 La majorité de ces modules proposent aussi des fonctions proposant les même fonctionnalités depuis le reste du code
 Python.
 
-append_to_get
+append_query_params
 =============
 
-L'élément ``append_to_get`` permet de rajouter des paramètres à la requête ``GET`` courante. Par exemple, sur une page
+L'élément ``append_query_params`` permet de rajouter des paramètres à la requête ``GET`` courante. Par exemple, sur une page
 ``module/toto``, le code de template suivant :
 
 .. sourcecode:: html
 
-    {% load append_to_get %}
-    <a href="{% append_to_get key1=var1,key2=var2 %}">Mon lien</a>
+    {% load append_query_params %}
+    <a href="{% append_query_params key1=var1,key2=var2 %}">Mon lien</a>
 
 produira le code suivant :
 

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -1,5 +1,5 @@
 {% load captureas %}
-{% load append_to_get %}
+{% load append_query_params %}
 {% load i18n %}
 
 
@@ -14,7 +14,7 @@
         {% ifnotequal nb 1 %}
             <li class="prev">
                 {% with prev=nb|add:-1 %}
-                    <a href="{% append_to_get page=prev %}{{ full_anchor }}" class="ico-after arrow-left blue">
+                    <a href="{% append_query_params page=prev %}{{ full_anchor }}" class="ico-after arrow-left blue">
                     <span>
                         {% trans "Précédente" %}
                     </span>
@@ -28,7 +28,7 @@
             {% if page %}
                 <li>
                     <a  {% ifnotequal page nb %}
-                            href="{% append_to_get page=page %}{{ full_anchor }}"
+                            href="{% append_query_params page=page %}{{ full_anchor }}"
                         {% else %}
                             class="current"
                         {% endifnotequal %}
@@ -62,7 +62,7 @@
         {% if pages|last > 0 and pages|last != nb %}
             <li class="next">
                 {% with next=nb|add:1 %}
-                    <a href="{% append_to_get page=next %}{{ full_anchor }}" class="ico-after arrow-right blue">
+                    <a href="{% append_query_params page=next %}{{ full_anchor }}" class="ico-after arrow-right blue">
                         <span>
                         {% trans "Suivante" %}
                         </span>

--- a/templates/misc/paginator.html
+++ b/templates/misc/paginator.html
@@ -1,5 +1,5 @@
 {% load captureas %}
-{% load append_to_get %}
+{% load append_query_params %}
 {% load i18n %}
 
 {% if paginator.num_pages > 1 %}
@@ -12,7 +12,7 @@
     <ul class="pagination pagination-{{ position }}">
         {% if page_obj.has_previous %}
             <li class="prev">
-                <a href="{% append_to_get page=page_obj.previous_page_number %}{{ full_anchor }}" class="ico-after arrow-left blue">
+                <a href="{% append_query_params page=page_obj.previous_page_number %}{{ full_anchor }}" class="ico-after arrow-left blue">
                     <span>
                         {% trans "Précédente" %}
                     </span>
@@ -24,7 +24,7 @@
             {% if page_nb %}
                 <li>
                     <a  {% ifnotequal page_nb page_obj.number %}
-                            href="{% append_to_get page=page_nb %}{{ full_anchor }}"
+                            href="{% append_query_params page=page_nb %}{{ full_anchor }}"
                         {% else %}
                             class="current"
                         {% endifnotequal %}
@@ -57,7 +57,7 @@
 
         {% if page_obj.has_next %}
             <li class="next">
-                <a href="{% append_to_get page=page_obj.next_page_number %}{{ full_anchor }}" class="ico-after arrow-right blue">
+                <a href="{% append_query_params page=page_obj.next_page_number %}{{ full_anchor }}" class="ico-after arrow-right blue">
                     <span>
                         {% trans "Suivante" %}
                     </span>

--- a/templates/tutorialv2/index.html
+++ b/templates/tutorialv2/index.html
@@ -1,5 +1,5 @@
 {% extends "tutorialv2/base.html" %}
-{% load append_to_get %}
+{% load append_query_params %}
 {% load date %}
 {% load i18n %}
 {% load captureas %}
@@ -195,7 +195,7 @@
             <h3>Trier</h3>
             <ul>
                 {% for current_sort in sorts %}
-                    <li><a href="{% append_to_get sort=current_sort.key %}" class="ico-after gear {% if sort == current_sort.key %}selected{% endif %}">{{ current_sort.text }}</a></li>
+                    <li><a href="{% append_query_params sort=current_sort.key %}" class="ico-after gear {% if sort == current_sort.key %}selected{% endif %}">{{ current_sort.text }}</a></li>
                 {% endfor %}
             </ul>
         </div>

--- a/templates/tutorialv2/view/help.html
+++ b/templates/tutorialv2/view/help.html
@@ -4,7 +4,7 @@
 {% load thumbnail %}
 {% load i18n %}
 {% load profile %}
-{% load append_to_get %}
+{% load append_query_params %}
 
 
 
@@ -61,9 +61,9 @@
 
                         <p class="tutorial-authors">
                             {% if content.is_article %}
-                                {% trans "Un" %} <a href="{% append_to_get type="article" %}">{% trans "article" %}</a>
+                                {% trans "Un" %} <a href="{% append_query_params type="article" %}">{% trans "article" %}</a>
                             {% else %}
-                                {% trans "Un" %} <a href="{% append_to_get type="tuto" %}">{% trans "tutoriel" %}</a>
+                                {% trans "Un" %} <a href="{% append_query_params type="tuto" %}">{% trans "tutoriel" %}</a>
                             {% endif %}
 
                             {% for author in content.authors.all %}
@@ -159,7 +159,7 @@
                 <li>
                     <a style="background: url('{{ help.image.help_mini_illu.url }}') no-repeat; padding-left:32px;"
                        class="{% if request.GET.need and request.GET.need == help.slug %}selected{% endif %}"
-                       href="{% append_to_get need=help.slug,page=1 %}">
+                       href="{% append_query_params need=help.slug,page=1 %}">
                         {{ help.title }}
                     </a>
                 </li>
@@ -170,7 +170,7 @@
             {% endfor %}
             {% if request.GET.need %}
                 <li>
-                    <a href="{% append_to_get need="",page=1 %}" class="ico-after cross red ">
+                    <a href="{% append_query_params need="",page=1 %}" class="ico-after cross red ">
                         {% trans "Annuler le filtre" %}
                     </a>
                 </li>
@@ -183,14 +183,14 @@
         <h3>{% trans "Type" %}</h3>
         <ul>
             <li>
-                <a href="{% append_to_get type="article",page=1 %}" class="ico-after view {% if request.GET.type == "article" %}selected{% endif %}">Articles</a>
+                <a href="{% append_query_params type="article",page=1 %}" class="ico-after view {% if request.GET.type == "article" %}selected{% endif %}">Articles</a>
             </li>
             <li>
-                <a href="{% append_to_get type="tuto",page=1 %}" class="ico-after view {% if request.GET.type == "tuto" %}selected{% endif %}">Tutoriels</a>
+                <a href="{% append_query_params type="tuto",page=1 %}" class="ico-after view {% if request.GET.type == "tuto" %}selected{% endif %}">Tutoriels</a>
             </li>
             {% if request.GET.type %}
                 <li>
-                    <a href="{% append_to_get type="",page=1 %}" class="ico-after cross red ">
+                    <a href="{% append_query_params type="",page=1 %}" class="ico-after cross red ">
                         {% trans "Annuler le filtre" %}
                     </a>
                 </li>

--- a/zds/utils/templatetags/append_query_params.py
+++ b/zds/utils/templatetags/append_query_params.py
@@ -93,7 +93,7 @@ class AppendGetNode(template.Node):
 
 @register.tag()
 @easy_tag
-def append_to_get(_, arg_list):
+def append_query_params(_, arg_list):
     """Render an URL appending argument to current GET address.
 
     :param _: Tag name (not used)

--- a/zds/utils/templatetags/tests/tests_append_query_params.py
+++ b/zds/utils/templatetags/tests/tests_append_query_params.py
@@ -4,7 +4,7 @@
 from django.test import TestCase, RequestFactory
 from django.template.base import TemplateSyntaxError, Token, TOKEN_TEXT, Context, VariableDoesNotExist, Template
 
-from zds.utils.templatetags.append_to_get import easy_tag, AppendGetNode
+from zds.utils.templatetags.append_query_params import easy_tag, AppendGetNode
 
 
 class EasyTagTest(TestCase):
@@ -81,14 +81,14 @@ class AppendGetNodeTest(TestCase):
     def test_valid_templatetag(self):
 
         # Test normal call
-        tr = Template('{% load append_to_get %}'
-                      '{% append_to_get key1=var1,key2=var2 %}'
+        tr = Template('{% load append_query_params %}'
+                      '{% append_query_params key1=var1,key2=var2 %}'
                       ).render(self.context)
         self.assertTrue(tr == '/data/test?key1=1&key2=2' or tr == '/data/test?key2=2&key1=1')
 
         # Test call with one argument
-        tr = Template('{% load append_to_get %}'
-                      '{% append_to_get key1=var1 %}'
+        tr = Template('{% load append_query_params %}'
+                      '{% append_query_params key1=var1 %}'
                       ).render(self.context)
         self.assertEqual(tr, '/data/test?key1=1')
 
@@ -96,20 +96,20 @@ class AppendGetNodeTest(TestCase):
         # Test invalid format
 
         # Space separators args :
-        str_tp = ('{% load append_to_get %}'
-                  '{% append_to_get key1=var1 key2=var2 %}')
+        str_tp = ('{% load append_query_params %}'
+                  '{% append_query_params key1=var1 key2=var2 %}')
         self.assertRaises(TemplateSyntaxError, Template, str_tp)
 
         # No values :
-        str_tp = ('{% load append_to_get %}'
-                  '{% append_to_get key1=,key2=var2 %}')
+        str_tp = ('{% load append_query_params %}'
+                  '{% append_query_params key1=,key2=var2 %}')
         self.assertRaises(TemplateSyntaxError, Template, str_tp)
-        str_tp = ('{% load append_to_get %}'
-                  '{% append_to_get key1,key2=var2 %}')
+        str_tp = ('{% load append_query_params %}'
+                  '{% append_query_params key1,key2=var2 %}')
         self.assertRaises(TemplateSyntaxError, Template, str_tp)
 
         # Not resolvable variable
-        tr = Template('{% load append_to_get %}'
-                      '{% append_to_get key1=var3,key2=var2 %}'
+        tr = Template('{% load append_query_params %}'
+                      '{% append_query_params key1=var3,key2=var2 %}'
                       )
         self.assertRaises(VariableDoesNotExist, tr.render, self.context)


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | refactoring / renommer
| Ticket(s) (_issue(s)_) concerné(s)  | #4534

### QA

- "append_to_get" a simplement été renommé en "append_query_params" et deux fichiers renommés