### PR TITLE
Compilation de plusieurs corrections CSS sur la v25

### DIFF
--- a/assets/scss/components/_pagination.scss
+++ b/assets/scss/components/_pagination.scss
@@ -2,7 +2,7 @@
     list-style: none;
     margin: 0;
     padding: 0;
-    border-top: 1px solid #d2d5d6; // @TODO: Color
+    border-top: 1px solid #d2d5d6;
     border-bottom: 1px solid #d2d5d6;
     background: #FBFBFB;
     margin-bottom: 20px !important;

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -55,7 +55,7 @@ $logo-width: 240px;
             flex-basis: auto;
 
             & > a {
-                padding: 0 2rem;
+                padding: 0 2.5rem;
                 display: block;
                 position: relative;
                 text-align: center;
@@ -68,6 +68,18 @@ $logo-width: 240px;
                 &:focus,
                 &.active {
                     background: $color-header-hover;
+
+                    .arrow:after {
+                        border-top: 6px solid #FFF;
+                    }
+                }
+
+                &.has-dropdown {
+                    padding-right: 1.5rem;
+
+                    .arrow {
+                        display: inline-block;
+                    }
                 }
 
                 &.current {
@@ -117,34 +129,22 @@ $logo-width: 240px;
         background: #EEE;
     }
 
-    .has-dropdown {
+    .arrow {
+        display: none;
+        width: 20px;
+        height: 9px;
         position: relative;
 
-        &:hover,
-        &:focus,
-        &.active {
-            .arrow:after {
-                border-top: 6px solid #FFF;
-            }
-        }
-
-        .arrow {
-            display: inline-block;
-            width: 20px;
-            height: 9px;
-            position: relative;
-
-            &:after {
-                content: "";
-                display: block;
-                position: absolute;
-                right: 0;
-                height: 0;
-                width: 0;
-                border: 6px solid transparent;
-                border-top: 6px solid rgba(255, 255, 255, 0.7);
-                border-left: 6px inset transparent;
-            }
+        &:after {
+            content: "";
+            display: block;
+            position: absolute;
+            right: 0;
+            height: 0;
+            width: 0;
+            border: 6px solid transparent;
+            border-top: 6px solid rgba(255, 255, 255, 0.7);
+            border-left: 6px inset transparent;
         }
     }
 }

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -177,8 +177,6 @@ $logo-width: 240px;
                 height: 16px;
                 line-height: 14px;
                 background: #c0392b;
-
-                //@TODO: Color
                 border-radius: 16px;
             }
 
@@ -227,8 +225,6 @@ $logo-width: 240px;
             line-height: 37px;
             text-align: center;
             border-bottom: 1px solid #274a5a;
-
-            // @TODO: Color
             background-color: $color-header-hover;
         }
 
@@ -238,8 +234,6 @@ $logo-width: 240px;
             padding: 0;
             list-style: none;
             background-color: #19526c;
-
-            // @TODO: Color
 
             li {
                 display: block;
@@ -284,8 +278,6 @@ $logo-width: 240px;
                     float: left;
                     margin: 4px 0 0 7px;
                     color: #95D7F5;
-
-                    // @TODO: Color
                     width: 50%;
                     overflow: hidden;
                     text-overflow: ellipsis;
@@ -294,8 +286,6 @@ $logo-width: 240px;
 
                 .date {
                     color: #5196b6;
-
-                    // @TODO: Color
                     float: right;
                     padding: 4px 10px 0 0;
                     transition-property: color;

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -33,13 +33,11 @@ $logo-width: 240px;
                 outline: none;
             }
         }
-
     }
 
     .header-menu {
         height: 60px;
         flex-basis: auto;
-
         display: flex;
     }
 
@@ -47,7 +45,6 @@ $logo-width: 240px;
         margin: 0;
         padding: 0;
         flex: 1;
-
         display: flex;
         justify-content: center;
 
@@ -86,6 +83,7 @@ $logo-width: 240px;
                         border-radius: 2px 2px 0 0;
                         background-color: $color-secondary;
                     }
+
                     &.active:before {
                         height: 0;
                     }
@@ -106,7 +104,7 @@ $logo-width: 240px;
         text-indent: -9999px;
         width: $logo-width + $logo-horizontal-margin;
         height: 60px;
-        background: url('../images/logo.png') no-repeat center center;
+        background: url("../images/logo.png") no-repeat center center;
         background-size: $logo-width auto;
 
         &:hover,
@@ -144,17 +142,16 @@ $logo-width: 240px;
                 height: 0;
                 width: 0;
                 border: 6px solid transparent;
-                border-top: 6px solid rgba(255, 255, 255, .7);
+                border-top: 6px solid rgba(255, 255, 255, 0.7);
                 border-left: 6px inset transparent;
             }
         }
     }
 }
 
-
 .logbox {
-    &>div {
-        background: rgba(white, .05);
+    & > div {
+        background: rgba(white, 0.05);
     }
 
     .notifs-links {
@@ -162,7 +159,6 @@ $logo-width: 240px;
 
         .ico-link {
             flex: 0;
-
             display: block;
             position: relative;
             width: 60px;
@@ -179,9 +175,12 @@ $logo-width: 240px;
                 padding: 0 5px;
                 height: 16px;
                 line-height: 14px;
-                background: #c0392b; //@TODO: Color
+                background: #c0392b;
+
+                //@TODO: Color
                 border-radius: 16px;
             }
+
             .notif-text {
                 display: block;
                 position: absolute;
@@ -195,12 +194,15 @@ $logo-width: 240px;
                 &.ico-messages {
                     @include sprite-position($messages);
                 }
+
                 &.ico-notifs {
                     @include sprite-position($notifications);
                 }
+
                 &.ico-alerts {
                     @include sprite-position($alerts);
                 }
+
                 &.ico-params {
                     @include sprite-position($params);
                 }
@@ -223,7 +225,9 @@ $logo-width: 240px;
             height: 35px;
             line-height: 37px;
             text-align: center;
-            border-bottom: 1px solid #274a5a; // @TODO: Color
+            border-bottom: 1px solid #274a5a;
+
+            // @TODO: Color
             background-color: $color-header-hover;
         }
 
@@ -232,7 +236,9 @@ $logo-width: 240px;
             margin: 0;
             padding: 0;
             list-style: none;
-            background-color: #19526c; // @TODO: Color
+            background-color: #19526c;
+
+            // @TODO: Color
 
             li {
                 display: block;
@@ -251,12 +257,13 @@ $logo-width: 240px;
                         opacity: 1;
                         transition-property: opacity, background-color;
                     }
+
                     &:hover,
                     &:focus {
                         background-color: $color-header-hover;
 
                         .username {
-                            text-shadow: rgba(0, 0, 0, .5) 0 0 5px;
+                            text-shadow: rgba(0, 0, 0, 0.5) 0 0 5px;
                         }
 
                         .date {
@@ -270,29 +277,36 @@ $logo-width: 240px;
                     height: 30px;
                     width: 30px;
                 }
+
                 .username {
                     display: block;
                     float: left;
                     margin: 4px 0 0 7px;
-                    color: #95D7F5; // @TODO: Color
+                    color: #95D7F5;
+
+                    // @TODO: Color
                     width: 50%;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
                 }
+
                 .date {
-                    color: #5196b6; // @TODO: Color
+                    color: #5196b6;
+
+                    // @TODO: Color
                     float: right;
                     padding: 4px 10px 0 0;
                     transition-property: color;
                 }
+
                 .topic {
                     display: block;
                     position: absolute;
                     bottom: 0;
                     left: 0;
                     overflow: hidden;
-                    height: 25px;
+                    height: 31px;
                     padding: 4px 7px 2px;
                     text-overflow: ellipsis;
                     white-space: nowrap;
@@ -310,8 +324,8 @@ $logo-width: 240px;
         }
 
         .dropdown-pm {
-            text-align : left;
-            padding-left : 15px;
+            text-align: left;
+            padding-left: 15px;
 
             .ico-after {
                 float: right;
@@ -322,6 +336,7 @@ $logo-width: 240px;
             .pm-new {
                 &.white:after {
                     @include sprite-position($pm-new-white);
+
                     width: 17px;
                     height: 16px;
                 }
@@ -338,6 +353,7 @@ $logo-width: 240px;
         .username {
             display: none;
         }
+
         .avatar {
             background: $color-header-hover;
         }
@@ -363,7 +379,6 @@ $logo-width: 240px;
             }
         }
     }
-
 
     &.unlogged {
         a {
@@ -391,7 +406,7 @@ $logo-width: 240px;
         }
 
         .header-logo-link {
-            background-image: url('../images/logo-mobile.png') !important;
+            background-image: url("../images/logo-mobile.png") !important;
             background-size: 100%;
             width: 100%;
             height: 100%;
@@ -436,6 +451,7 @@ $logo-width: 240px;
             .dropdown {
                 top: 50px;
             }
+
             .dropdown.my-account-dropdown .dropdown-list {
                 bottom: 0;
 
@@ -450,7 +466,7 @@ $logo-width: 240px;
                 font-size: 1.3rem;
 
                 a {
-                    background-color: rgba(255, 255, 255, .1);
+                    background-color: rgba(255, 255, 255, 0.1);
                     line-height: 30px;
                     height: 30px;
                     margin: 10px 0;
@@ -466,10 +482,10 @@ $logo-width: 240px;
     .header-container {
         z-index: 1;
         position: relative;
-        box-shadow: 0 0 4px rgba(0, 0, 0, .3);
+        box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
 
         header {
-            background-image: linear-gradient(to right,transparent 20%,rgba(255,255,255,.07) 40%,rgba(255,255,255,.07) 60%,transparent 80%);
+            background-image: linear-gradient(to right, transparent 20%, rgba(255, 255, 255, 0.07) 40%, rgba(255, 255, 255, 0.07) 60%, transparent 80%);
         }
 
         .header-menu {
@@ -490,6 +506,7 @@ $logo-width: 240px;
     .logbox .dropdown.my-account-dropdown ul li {
         height: 30px;
         line-height: 30px;
+
         button {
             cursor: pointer;
         }

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -9,7 +9,7 @@ $logo-width: 240px;
     header, .sub-header {
         display: flex;
 
-        @media only screen and #{$media-extra-wide} {
+        @media only screen and #{$media-wide} {
             padding: 0 2rem;
 
             .header-right .dropdown {
@@ -150,7 +150,8 @@ $logo-width: 240px;
 }
 
 .logbox {
-    & > div {
+    & > div,
+    & > a {
         background: rgba(white, 0.05);
     }
 

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -27,12 +27,11 @@
         }
 
         &.ico-after {
-            padding-left: 80px;
+            padding-left: 50px;
 
             &:after {
                 @include sprite-width($articles);
                 @include sprite-height($articles);
-                margin-left: 21px;
             }
         }
         &.ico-articles:after {
@@ -64,10 +63,9 @@
         }
 
         .btn {
-            font-size: 16px;
-
-            height: 38px;
+            font-size: 15px;
             line-height: 38px;
+            height: 38px;
         }
     }
 

--- a/assets/scss/pages/_flexpage.scss
+++ b/assets/scss/pages/_flexpage.scss
@@ -15,7 +15,7 @@ $content-width: 1145px;
         padding: 0;
     }
 
-    .sub-header{
+    .sub-header {
         display: none;
     }
 
@@ -27,8 +27,10 @@ $content-width: 1145px;
     .flexpage-header {
         margin-bottom: 20px;
         border-bottom: solid 1px white;
-        background-color: #19516b; // fallback for older browser
-        background: #19516b radial-gradient(at top, rgba(255,255,255,0.1),rgba(0,0,0,0) 60%);
+
+        // fallback for older browser
+        background-color: #19516b;
+        background: #19516b radial-gradient(at top, rgba(255, 255, 255, 0.1), rgba(0, 0, 0, 0) 60%);
     }
 
     .flexpage-column {
@@ -51,11 +53,12 @@ $content-width: 1145px;
 
         .picto {
             position: absolute;
-            left: 50px; top: 50px;
-            width: 104px; height: 60.04px;
+            left: 50px;
+            top: 50px;
+            width: 104px;
+            height: 60.04px;
             margin: 30.02px 50px 30.02px 0;
-
-            background: rgba(0, 0, 0, .2);
+            background: rgba(0, 0, 0, 0.2);
 
             &:before, &:after {
                 z-index: 0;
@@ -67,19 +70,22 @@ $content-width: 1145px;
             }
 
             &:before {
-                bottom: 100%; left: 0;
-                border-bottom: 30.02px solid rgba(0, 0, 0, .2);
+                bottom: 100%;
+                left: 0;
+                border-bottom: 30.02px solid rgba(0, 0, 0, 0.2);
             }
 
             &:after {
-                top: 100%; left: 0;
+                top: 100%;
+                left: 0;
                 width: 0;
-                border-top: 30.02px solid rgba(0, 0, 0, .2);
+                border-top: 30.02px solid rgba(0, 0, 0, 0.2);
             }
 
             img {
                 position: absolute;
-                top: -20px; left: 2px;
+                top: -20px;
+                left: 2px;
             }
         }
 
@@ -99,13 +105,12 @@ $content-width: 1145px;
 
             h1 {
                 display: block;
-                margin: 0; padding: 0;
-
+                margin: 0;
+                padding: 0;
                 color: inherit;
                 font-size: 5rem;
                 line-height: 50px;
                 border: none;
-
                 overflow: hidden;
                 white-space: nowrap;
                 text-overflow: ellipsis;
@@ -113,9 +118,9 @@ $content-width: 1145px;
 
             h2 {
                 display: inline-block;
-                margin: 0; padding: 0;
+                margin: 0;
+                padding: 0;
                 vertical-align: bottom;
-
                 font-size: inherit;
                 line-height: inherit;
                 color: inherit;
@@ -141,11 +146,11 @@ $content-width: 1145px;
                 &:after {
                     content: '';
                     position: absolute;
-                    top: 12px; left: 0;
-
-                    width: 10px; height: 10px;
+                    top: 12px;
+                    left: 0;
+                    width: 10px;
+                    height: 10px;
                     transform: rotate(45deg);
-
                     border-color: white;
                     border-style: solid;
                     border-width: 2px 2px 0 0;
@@ -156,7 +161,6 @@ $content-width: 1145px;
 
         .aside {
             display: flex;
-
             margin-top: 10px;
             margin-right: 150px;
             height: 50px;
@@ -164,24 +168,28 @@ $content-width: 1145px;
             .search {
                 display: flex;
                 flex-direction: row;
-
                 background: white;
 
                 label {
                     line-height: 50px;
-                    margin: 0; padding: 0 15px;
+                    margin: 0;
+                    padding: 0 15px;
                 }
 
                 input {
                     line-height: 50px;
                     height: 50px;
-                    margin: 0; padding: 0 15px;
-
+                    margin: 0;
+                    padding: 0 15px;
                     border: none;
+                    flex: 1 1 auto;
+                    width: initial !important;
+                    min-width: 0;
                 }
 
                 button {
-                    width: 50px; height: 50px;
+                    width: 50px;
+                    height: 50px;
                     line-height: 50px;
                     background: #fff;
 
@@ -218,7 +226,7 @@ $content-width: 1145px;
         }
 
         .flexpage-title-tool {
-             padding: 15px 25px;
+            padding: 15px 25px;
 
             .picto {
                 display: none;
@@ -226,6 +234,22 @@ $content-width: 1145px;
 
             .aside {
                 max-width: 100%;
+            }
+        }
+    }
+}
+
+@media only screen and #{$media-mobile} {
+    .flexpage {
+        .flexpage-title-tool {
+            padding: 15px 0;
+
+            .aside {
+                margin-right: 0;
+
+                .search label {
+                    padding-right: 5px;
+                }
             }
         }
     }

--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -157,23 +157,9 @@
         }
     }
 
-    .home-heading {
-        height: 40px;
-        padding-left: 50px!important;
-        margin-bottom: 18px!important;
-
-        &.heading-white {
-            color: white;
-            border-bottom-color: white;
-        }
-
-        &.ico-after::after {
-            margin-left: 0!important;
-        }
-
-        .btn {
-            font-size: 15px;
-        }
+    .home-heading.heading-white {
+        color: white;
+        border-bottom-color: white;
     }
 }
 


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4559, autre

Les changements de style dans les fichiers, c'est `prettier`. Désolé si c'est pas très atomique à ce niveau la.

### WIP: Je vais probablement faire d'autres fix au fur et à mesure, voici ce qui est fait pour l'instant:

 - Les menus sont "mieux" alignés (même si c'est subjectif)

<img width="457" alt="image" src="https://user-images.githubusercontent.com/1549952/30515324-9fd7cf14-9b25-11e7-967a-7378cf0a39da.png">

 - Les headers ont été réfactorés pour copier le style de l'accueil partout (padding des icônes, boutons associés au header)

<img width="296" alt="image" src="https://user-images.githubusercontent.com/1549952/30515340-fedca5f2-9b25-11e7-9af7-d694b626a3cf.png">

 - L'alignement des notifications est corrigé

<img width="375" alt="image" src="https://user-images.githubusercontent.com/1549952/30515358-3fff99d6-9b26-11e7-8d89-7ef9c74487f4.png">

 - La taille du champ de recherche sur les flexpage sur mobile (pas parfait mais mieux qu'avant ; bug chelou, voir `FIXME`)

<img width="393" alt="image" src="https://user-images.githubusercontent.com/1549952/30515725-6cc21e10-9b2d-11e7-8cce-2ed455b0ace4.png">

