### PR TITLE
Arrange le style des casquettes

### DIFF
--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -206,11 +206,9 @@
             .with-hat {
                 color: #FFF;
                 background-color: $color-hat;
-                border-radius: 4px;
                 display: inline-block;
                 padding: 0 5px;
-                margin-top: 5px;
-                margin-bottom: 0;
+                margin: 5px 0;
             }
 
             .message-edited,


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

Cette PR survient un peu tard, mais elle corrige deux points de style assez gênants qui ont été remontés sur les casquettes :

- les bords arrondis en inadéquation avec le reste
- l'absence de bordure entre citation et casquette

![Rendu obtenu](https://www.pixenli.com/images/1505/1505652175075821400.png)

### QA

Vérifier que le rendu obtenu correspond à la capture ci-dessus.