### PR TITLE
Forums -> Forum + fix du menu sélectionné

### DIFF
--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -8,13 +8,13 @@
 
 
 {% block title_base %}
-    &bull; {% trans "Forums" %}
+    &bull; {% trans "Forum" %}
 {% endblock %}
 
 
 
 {% block mobile_title %}
-    {% trans "Forums" %}
+    {% trans "Forum" %}
 {% endblock %}
 
 

--- a/templates/tutorialv2/base.html
+++ b/templates/tutorialv2/base.html
@@ -5,29 +5,21 @@
 
 
 {% block title_base %}
-    &bull; {% trans "Contenus" %}
+    &bull; {% trans "Bibliothèque" %}
 {% endblock %}
 
 
 
 {% block mobile_title %}
-    {% trans "Contenus" %}
+    {% trans "Bibliothèque" %}
 {% endblock %}
 
 
-{% block menu_tutorial %}
-    {% if current_content_type == "TUTORIAL" %}
+{% block menu_publications %}
+    {% if current_content_type and current_content_type != "OPINION" %}
         current
     {% endif %}
-    {%  if content and content.type == "TUTORIAL" %}
-        current
-    {% endif %}
-{% endblock %}
-{% block menu_article %}
-    {% if current_content_type == "ARTICLE" %}
-        current
-    {% endif %}
-    {%  if content and content.type == "ARTICLE" %}
+    {%  if content and content.type != "OPINION" %}
         current
     {% endif %}
 {% endblock %}

--- a/templates/tutorialv2/base_online.html
+++ b/templates/tutorialv2/base_online.html
@@ -8,13 +8,8 @@
 {% endblock %}
 
 
-{% block menu_tutorial %}
-    {% if current_content_type == "TUTORIAL" %}
-        current
-    {% endif %}
-{% endblock %}
-{% block menu_article %}
-    {% if current_content_type == "ARTICLE" %}
+{% block menu_publications %}
+    {% if current_content_type and current_content_type != "OPINION" %}
         current
     {% endif %}
 {% endblock %}
@@ -28,7 +23,7 @@
 
 {% block canonical %}
     {% if content.source and content.source != "" %}
-    	<link rel="canonical" href="{{ content.source }}">
+        <link rel="canonical" href="{{ content.source }}">
     {% endif %}
 {% endblock %}
 

--- a/templates/tutorialv2/index.html
+++ b/templates/tutorialv2/index.html
@@ -18,13 +18,8 @@
     {% endif %}
 {% endblock %}
 
-{% block menu_tutorial %}
-    {% if tutorials != None %}
-        current
-    {% endif %}
-{% endblock %}
-{% block menu_article%}
-    {% if articles != None  %}
+{% block menu_publications %}
+    {% if tutorials != None or articles != None %}
         current
     {% endif %}
 {% endblock %}

--- a/templates/tutorialv2/view/base_categories.html
+++ b/templates/tutorialv2/view/base_categories.html
@@ -6,6 +6,17 @@
 {% load set %}
 
 
+{% block title_base %}
+    &bull; {% trans "Bibliothèque" %}
+{% endblock %}
+
+
+
+{% block mobile_title %}
+    {% trans "Bibliothèque" %}
+{% endblock %}
+
+
 {% block title %}
     {% if category %}
         {% if subcategory %}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | #4627 

Sur mobile il était écrit `Forums` dans le header, alors que le `s` avait été supprimé du menu.
Le menu bibliothèque est maintenant systématiquement sélectionné quand on est en train de lire un contenu.