### PR TITLE
Ajoute un tiret entre casquette et lien de suppression

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -96,7 +96,7 @@
                     <li>
                         {{ hat.name }}
                         {% if perms.utils.change_hat %}
-                            <a href="#remove-hat-{{ hat.pk }}" class="open-modal">{% trans "Retirer" %}</a>
+                            – <a href="#remove-hat-{{ hat.pk }}" class="open-modal">{% trans "Retirer" %}</a>
                         {% endif %}
                     </li>
                     {% if perms.utils.change_hat %}


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | ~ correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

Une mini-incohérence que je viens de relever sur la bêta : il y a pas de tiret entre une casquette et son lien `Retirer` sur le profil alors qu'il y a ça dans les paramètres. Un texte et un lien côte à côte, ça fait pas joli.

### QA

- Travis
- Code review
