### PR TITLE
“Aucun élément à la une” ne casse pas sur mobile

### DIFF
--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -141,19 +141,14 @@
         width: 100%;
 
         .no-featured-resource {
-            flex: 1;
             margin: 0;
-            line-height: 0;
             text-align: center;
-            margin-right: 1px;
-            font-size: 20px;
-            background-color: white;
-
-            &::before, &::after {
-                display: block;
-                content: "";
-                padding-top: 10%;
-            }
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #777;
+            padding: 1em;
+            height: 230px;
         }
     }
 


### PR DESCRIPTION
Sur la page d’accueil, la mention “Aucun élément « À la une"
disponible » cassait sur mobile. J’ai simplifié le CSS étant donné que
ce truc n’appparaîtra à priori jamais en production.

Avant : 

![avant](https://user-images.githubusercontent.com/15378830/30663481-17d2b09c-9e4b-11e7-92f5-c3df3f087029.png)

Après : 

![après](https://user-images.githubusercontent.com/15378830/30663434-e9a60fde-9e4a-11e7-85f1-3b4815856ebf.png)

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucun
