### PR TITLE
Met à jour cookies-eu-banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "directories": {
     "doc": "doc"
   },
-  "engines" : {
-    "node" : ">=8.0.0"
+  "engines": {
+    "node": ">=8.0.0"
   },
   "scripts": {
     "gulp": "gulp",
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/zestedesavoir/zds-site",
   "dependencies": {
     "autoprefixer": "7.1.2",
-    "cookies-eu-banner": "1.2.8",
+    "cookies-eu-banner": "^1.2.10",
     "cssnano": "3.10.0",
     "del": "3.0.0",
     "gulp": "3.9.1",

--- a/templates/base.html
+++ b/templates/base.html
@@ -677,17 +677,19 @@
 
 
     {# Google Analytics #}
-    {% if app.site.googleAnalyticsID and app.site.googleTagManagerID %}
-        <script>
-            new CookiesEuBanner(function(){
-                dataLayer = [{'gaTrackingId': '{{ app.site.googleAnalyticsID }}'}];
-                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-                '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-                })(window,document,'script','dataLayer','{{ app.site.googleTagManagerID }}');
-            });
-        </script>
+    {% if debug or app.google_analytics_enabled %}
+    <script>
+        new CookiesEuBanner(function(){
+            {% if app.google_analytics_enabled %}
+            dataLayer = [{'gaTrackingId': '{{ app.site.googleAnalyticsID }}'}];
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','{{ app.site.googleTagManagerID }}');
+            {% endif %}
+        });
+    </script>
     {% endif %}
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -641,9 +641,9 @@ convert-source-map@1.X, convert-source-map@^1.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
-cookies-eu-banner@1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/cookies-eu-banner/-/cookies-eu-banner-1.2.8.tgz#f56da63e3d4cfb865fc4d1fb33395a52df33dbd6"
+cookies-eu-banner@^1.2.10:
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/cookies-eu-banner/-/cookies-eu-banner-1.2.10.tgz#4f97a651644b65ec770f57363b93f3f9af078db0"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"

--- a/zds/utils/context_processor.py
+++ b/zds/utils/context_processor.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from copy import deepcopy
+
 from django.conf import settings
 
 from git import Repo
@@ -30,4 +32,11 @@ def app_settings(request):
     """
     A context processor with all APP settings.
     """
-    return {'app': settings.ZDS_APP}
+    app = deepcopy(settings.ZDS_APP)
+
+    app['google_analytics_enabled'] = 'googleAnalyticsID' in app['site'] and \
+                                      'googleTagManagerID' in app['site']
+
+    return {
+        'app': app,
+    }


### PR DESCRIPTION
Depuis quelques temps, la bannière d’acceptation des cookies ne
fonctionnait plus sur certains navigateurs, dont Google Chrome.

Ceci était dû à un bug de cookie-eu-banner corrigé par ce commit :
https://github.com/Alex-D/Cookies-EU-banner/commit/44eefd6267a26142b8d949ff76552d17b8e46c12

Ce commit fait également en sorte que cookies-eu-banner soit toujours
lancé quand on n’est pas en production (lorsque `DEBUG == True`). Cela
évitera les surprises.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

### QA

Avec Google Chrome, supprimez le cookie `hasConsent` et actualisez. 
Vous deviez voir la banière apparaître une seule fois (elle est implicitement
acceptée, si vous voyez ce que je veut dire).

Toujours avec Chrome, rééssayez ensuite sur https://zestedesavoir.com.
Vous ne devriez pas voir la bannière à cause du bug.
