### PR TITLE
Utilisation du wiki GitHub comme changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,5 @@
 - Instruction 2
 - ...
 - Code review
+
+<!-- Si votre pull request nécessite d'effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu'elles soient ajoutées au changelog lors du merge. --> 

--- a/update.md
+++ b/update.md
@@ -1140,3 +1140,9 @@ Responsables de groupe (#4600)
 ------------------------------
 
 Il faut réassigner les responsables de chaque groupe dans l'admin django post-déploiement.
+
+
+Versions supérieures à la v25
+=============================
+
+Ce fichier n'est plus utilisé après la v25. Il a été remplacé par un *changelog* disponible sur le [wiki GitHub](https://github.com/zestedesavoir/zds-site/wiki).


### PR DESCRIPTION
| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | refactorisation
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

À partir de la v26, il a été décidé d'utiliser le wiki GitHub comme changelog répertoriant les actions lors de la MEP plutôt que le fichier `update.md`. En effet, cela permet de le mettre beaucoup plus facilement à jour après les expériences de mise en bêta. Cette PR :

- ajoute un message à la fin du fichier `update.md` pour préciser qu'il n'est plus utilisé.
- ajoute au template de PR un commentaire invitant à renseigner les actions particulières lors de la MEP afin de ne pas les oublier en mergeant.

### QA

- Code review
