### PR TITLE
Utilise """ pour les chaînes multilignes

### DIFF
--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -60,10 +60,10 @@ class TopicForm(forms.Form):
             Field('title'),
             Field('subtitle', autocomplete='off'),
             Field('tags'),
-            HTML(u'''<div id="topic-suggest" style="display:none;"  url="/rechercher/sujets-similaires/">
+            HTML(u"""<div id="topic-suggest" style="display:none;"  url="/rechercher/sujets-similaires/">
   <label>{0}</label>
   <div id="topic-result-container" data-neither="{1}"></div>
-</div>'''
+</div>"""
                  .format(_(u'Sujets similaires au vôtre :'), _(u'Aucun résultat'))),
             CommonLayoutEditor(),
         )

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -284,13 +284,20 @@ class ProfileForm(MiniProfileForm):
             Field('biography'),
             ButtonHolder(StrictButton(_(u'Aperçu'), type='preview', name='preview',
                                       css_class='btn btn-grey preview-btn'),),
-            HTML('{% if form.biographie.value %}{% include "misc/previsualization.part.html" \
-            with text=form.biographie.value %}{% endif %}'),
+            HTML("""
+                {% if form.biographie.value %}
+                    {% include "misc/previsualization.part.html" with text=form.biographie.value %}
+                {% endif %}
+            """),
             Field('site'),
             Field('avatar_url'),
-            HTML(_(u'''<p><a href="{% url 'gallery-list' %}">Choisir un avatar dans une galerie</a><br/>
-            Naviguez vers l'image voulue et cliquez sur le bouton "<em>Choisir comme avatar</em>".<br/>
-            Créez une galerie et importez votre avatar si ce n'est pas déjà fait !</p>''')),
+            HTML(_(u"""
+                <p>
+                    <a href="{% url 'gallery-list' %}">Choisir un avatar dans une galerie</a><br/>
+                    Naviguez vers l'image voulue et cliquez sur le bouton "<em>Choisir comme avatar</em>".<br/>
+                    Créez une galerie et importez votre avatar si ce n'est pas déjà fait&nbsp;!
+                </p>
+            """)),
             Field('sign'),
             Field('licence'),
             Field('options'),

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -605,15 +605,17 @@ class Command(BaseCommand):
                                help='add new {}.'.format(zds_module.description), action='append_const',
                                const=zds_module)
 
-    help = '''Load fixtures for ZdS
+    help = """
+        Load fixtures for ZdS
 
-Examples:
-    All:
-        python manage.py load_fixtures
-    All with high size:
-        python manage.py load_fixtures size=high
-    Only users with medium size and a different prefix than bare "user":
-        python manage.py load_fixtures --size=medium --member --staff --racine=john'''
+        Examples:
+            All:
+                python manage.py load_fixtures
+            All with high size:
+                python manage.py load_fixtures size=high
+            Only users with medium size and a different prefix than bare "user":
+                python manage.py load_fixtures --size=medium --member --staff --racine=john
+    """
 
     def handle(self, *args, **options):
         size_map = {'low': 1, 'medium': 2, 'high': 3}


### PR DESCRIPTION
Conformité avec la PEP 8 : « For triple-quoted strings, always use
double quote characters to be consistent with the docstring convention
in PEP 257. »

Les versions récentes de flake8 signalent ces erreurs.
