### PR TITLE
[WIP] Le texte de l’éditeur persiste

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ install:
       && mkdir geckodriver \
       && tar -xzf geckodriver-v0.19.0-linux64.tar.gz -C geckodriver \
       && export PATH=$PATH:$PWD/geckodriver \
+      && export XVFB_WHD="1280x720x16" \
       && export DISPLAY=:99.0 \
       && sh -e /etc/init.d/xvfb start \
       && sleep 3 # give xvfb some time to start

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -60,6 +60,7 @@ gulp.task('js', () =>
         'assets/js/compare-commits.js',
         'assets/js/dropdown-menu.js',
         'assets/js/editor.js',
+        'assets/js/editor-persistence.js',
         'assets/js/featured-resource-preview.js',
         'assets/js/form-email-username.js',
         'assets/js/gallery.js',

--- a/assets/js/editor-persistence.js
+++ b/assets/js/editor-persistence.js
@@ -1,0 +1,91 @@
+
+// Stores editor text into window.localStorage with a kind of LRU
+// cache where old entries are automatically deleted.
+(function(document){
+    "use strict";
+
+    var MAX_SAVED_ENTRIES = 32;
+
+    function getSavedEntries() {
+        var source = localStorage.getItem("savedEditorText");
+        return source ? JSON.parse(source) : [];
+    }
+
+    function saveEntries(entries) {
+        localStorage.setItem("savedEditorText", JSON.stringify(entries));
+    }
+
+    // Returns `undefined` if not found.
+    function get(id) {
+        var entries = getSavedEntries();
+        for (var i = 0; i < entries.length; i++) {
+            if (entries[i].id === id) {
+                return entries[i].value;
+            }
+        }
+    }
+
+    function remove(id) {
+        saveEntries(
+            getSavedEntries()
+                .filter(function (entry) {
+                    return entry.id !== id;
+                })
+        );
+    }
+
+    function save(id, value) {
+        remove(id);
+
+        var entry = {id: id, value: value};
+        var entries = [entry].concat(getSavedEntries())
+                             .slice(0, MAX_SAVED_ENTRIES);
+        saveEntries(entries);
+    }
+
+    function toArray(arrayish) {
+        return Array.prototype.slice.call(arrayish);
+    }
+
+    function getFormSubmit(element) {
+        if (!element) {
+            return null;
+        }
+
+        if (element.tagName === "FORM") {
+            return element.querySelector(
+                "button[type=submit], input[type=submit]"
+            );
+        }
+
+        return getFormSubmit(element.parentElement);
+    }
+
+    function setupPersistenceOnEditor(editor) {
+        var name = editor.getAttribute("name") || "";
+        var uniqueId = window.location.pathname + "@" + name;
+
+        var savedText = get(uniqueId);
+        if (savedText && !editor.value) {
+            editor.value = savedText;
+            save(uniqueId, savedText); // Mark it as used.
+        }
+
+        editor.addEventListener("input", function() {
+            // It’s not a big deal, but this event is not fired when
+            // editor buttons are clicked.
+            save(uniqueId, editor.value); // TODO: Throttle?
+        });
+
+        var submit = getFormSubmit(editor);
+        if (submit) {
+            submit.addEventListener("click", function () {
+                remove(uniqueId);
+            });
+        }
+    }
+
+    toArray(document.querySelectorAll(".md-editor"))
+        .forEach(setupPersistenceOnEditor);
+
+})(document);

--- a/zds/member/tests/tests_front.py
+++ b/zds/member/tests/tests_front.py
@@ -1,6 +1,13 @@
+# coding: utf-8
+
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from selenium.webdriver.firefox.webdriver import WebDriver
+from django.core.urlresolvers import reverse
 from django.test import tag
+from selenium.webdriver.firefox.webdriver import WebDriver
+
+from zds.member.factories import ProfileFactory
+from zds.utils.factories import CategoryFactory
+from zds.tutorialv2.factories import PublishableContentFactory, SubCategoryFactory
 
 
 # NOTE In Django 1.11.4 there is a --selenium option for python manage.py test
@@ -18,7 +25,7 @@ class MemberFrontTests(StaticLiveServerTestCase):
         super(MemberFrontTests, cls).tearDownClass()
 
     def test_zestedesavoir_is_present(self):
-        self.selenium.get('%s%s' % (self.live_server_url, '/'))
+        self.selenium.get(self.live_server_url + '/')
         self.assertEqual(
             'Zeste de Savoir',
             self.selenium.find_element_by_css_selector('p.copyright').text[:15]
@@ -26,10 +33,110 @@ class MemberFrontTests(StaticLiveServerTestCase):
         self.assertEqual('Zeste de Savoir', self.selenium.title)
 
     def test_trigger_remember(self):
-        self.selenium.get('%s%s'
-                          % (self.live_server_url, '/membres/connexion/'))
+        self.selenium.get(self.live_server_url + reverse('member-login'))
         is_checked = self.selenium.find_element_by_id('id_remember').is_selected()
         self.selenium.find_element_by_id('id_remember').click()
         self.assertNotEqual(is_checked,
-                            self.selenium.
-                            find_element_by_id('id_remember').is_selected())
+                            self.selenium
+                            .find_element_by_id('id_remember').is_selected())
+
+    def __login(self, profile):
+        """
+        TODO: This is definitely way too slow. Fasten this.
+        """
+        selenium = self.selenium
+        find_element = selenium.find_element_by_css_selector
+
+        selenium.get(self.live_server_url + reverse('member-login'))
+
+        username = find_element('.content-container input#id_username')
+        password = find_element('.content-container input#id_password')
+        username.send_keys(profile.user.username)
+        password.send_keys('hostel77')
+
+        find_element('.content-container button[type=submit]').click()
+
+        # Wait until the user is logged in (this raises if the element
+        # is not found).
+        find_element('.header-container .logbox .my-account .username')
+
+    def test_collaborative_article_edition_and_editor_persistence(self):
+        # TODO: Move this test elsewhere.
+
+        selenium = self.selenium
+        find_element = selenium.find_element_by_css_selector
+
+        author = ProfileFactory()
+
+        article = PublishableContentFactory(type='ARTICLE')
+        article.authors.add(author.user)
+        article.save()
+
+        versioned_article = article.load_version()
+        article.sha_draft = versioned_article.repo_update(
+            'article', '', '', update_slug=False)
+        article.save()
+
+        article_edit_url = reverse('content:edit', args=[
+            article.pk,
+            article.slug,
+        ])
+
+        self.__login(author)
+
+        selenium.get(self.live_server_url + article_edit_url)
+
+        intro = find_element('.md-editor#id_introduction')
+        intro.send_keys('intro')
+
+        selenium.refresh()
+
+        self.assertEqual(
+            'intro',
+            find_element('.md-editor#id_introduction').get_attribute('value'),
+        )
+
+        article.sha_draft = versioned_article.repo_update(
+            'article', 'new intro', '', update_slug=False)
+        article.save()
+
+        selenium.refresh()
+
+        self.assertEqual(
+            'new intro',
+            find_element('.md-editor#id_introduction').get_attribute('value'),
+        )
+
+    def test_the_editor_forgets_its_content_on_form_submission(self):
+        # TODO: Move this test elsewhere.
+
+        selenium = self.selenium
+        find_element = selenium.find_element_by_css_selector
+
+        cat = CategoryFactory()
+        SubCategoryFactory(category=cat)
+
+        author = ProfileFactory()
+
+        self.__login(author)
+
+        new_article_url = self.live_server_url + reverse('content:create-article')
+        selenium.get(new_article_url)
+
+        find_element('#id_title').send_keys('Oulipo')
+
+        intro = find_element('.md-editor#id_introduction')
+        intro.send_keys('Le cadavre exquis boira le vin nouveau.')
+
+        # Choose the first ones, we don't care
+        find_element('#id_licence option').click()
+        find_element('input[type=checkbox][name=subcategory]').click()
+
+        find_element('.content-container button[type=submit]').click()
+
+        selenium.get(new_article_url)
+
+        self.assertEqual(
+            '',
+            find_element('.md-editor#id_introduction').get_attribute('value'),
+        )


### PR DESCRIPTION
Sauvegarde le texte de l’éditeur dans le localStorage.

Les entrées sont écrites en utilisant une sorte de cache LRU de façon
à supprimer automatiquement les plus anciennes.

Ne fonctionne que sur les éditeurs (avec la classe `.md-editor`), ne
fonctionne pas sur tous les `<input type="text">` ou `<textarea>`.

Ne fonctionne pas avec la plupart les boutons de l’éditeur actuel, mais je pense que
c’est un petit détail étant donné que ces boutons n’entraînent pas de modification
significative du texte.

Fix #4237.

Numéro du ticket concerné (optionnel) :  #4237

### Contrôle qualité

  1. Allez sur une page avec un (ou plusieurs) éditeur de texte ;
  2. écrivez du texte dans ces éditeurs ;
  3. naviguez, fermez l’onglet, faites ce que vous voulez ;
  4. retournez sur la page de départ, vous devriez retrouver votre texte.

### À faire

- [x] Oublier lors de la validation d’un formulaire
- [x] Revert le refactoring du template HTML introduit par erreur
