### PR TITLE
Fix sitemaps and atom feeds

### DIFF
--- a/zds/tutorialv2/managers.py
+++ b/zds/tutorialv2/managers.py
@@ -26,7 +26,7 @@ class PublishedContentManager(models.Manager):
         if content_type is not None:
             if not isinstance(content_type, list):
                 content_type = [content_type]
-
+            content_type = list(filter(None, content_type))
             queryset = queryset.filter(content_type__in=list([c.upper() for c in content_type]))
 
         # prefetch:

--- a/zds/tutorialv2/managers.py
+++ b/zds/tutorialv2/managers.py
@@ -26,7 +26,7 @@ class PublishedContentManager(models.Manager):
         if content_type is not None:
             if not isinstance(content_type, list):
                 content_type = [content_type]
-            content_type = list(filter(None, content_type))
+            content_type = filter(None, content_type)
             queryset = queryset.filter(content_type__in=list([c.upper() for c in content_type]))
 
         # prefetch:

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -4,6 +4,7 @@ import logging
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.layout import Layout, ButtonHolder, Field, Div, HTML
 from django.utils.translation import ugettext_lazy as _
+from django.template import defaultfilters
 from zds.utils.models import Tag
 from zds.utils.misc import contains_utf8mb4
 
@@ -110,6 +111,7 @@ class TagValidator(object):
         """
         self.__clean = list(filter(self.validate_length, string_list))
         self.__clean = list(filter(self.validate_utf8mb4, self.__clean))
+        self.__clean = list(filter(self.validate_no_empty_slug, self.__clean))
         return len(string_list) == len(self.__clean)
 
     def validate_utf8mb4(self, tag):
@@ -122,6 +124,19 @@ class TagValidator(object):
         if contains_utf8mb4(tag):
             self.errors.append(_('Le tag {} contient des caractères utf8mb4').format(tag))
             self.logger.warn('%s contains utf8mb4 char', tag)
+            return False
+        return True
+
+    def validate_no_empty_slug(self, tag):
+        """
+        Validate whether the tag slug is good
+
+        :param tag:
+        :return: ``True`` if the tag slug is good
+        """
+        if not defaultfilters.slugify(tag):
+            self.errors.append(_("Le tag {} n'est constitué que de caractères spéciaux et est donc incorrect"))
+            self.logger.warn('%s bad slug', tag)
             return False
         return True
 

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -109,8 +109,9 @@ class TagValidator(object):
         :return: ``True`` if ``v`` is fully valid, ``False`` if at least one error appears. See ``self.errors``
         to get all internationalized error.
         """
-        self.__clean = list(filter(self.validate_length, string_list))
-        self.__clean = list(filter(self.validate_utf8mb4, self.__clean))
+        string_list = list(filter(lambda s: s.strip(), string_list))  # needed to keep only real candidates
+        self.__clean = filter(self.validate_length, string_list)
+        self.__clean = filter(self.validate_utf8mb4, self.__clean)
         self.__clean = list(filter(self.validate_no_empty_slug, self.__clean))
         return len(string_list) == len(self.__clean)
 

--- a/zds/utils/tests/tests_models.py
+++ b/zds/utils/tests/tests_models.py
@@ -71,6 +71,12 @@ class TagsTests(TestCase):
         self.assertEqual(validator.validate_raw_string(tag.title), True)
         self.assertEqual(validator.errors, [])
 
+    def test_validator_with_special_char_only(self):
+
+        validator = TagValidator()
+        self.assertFalse(validator.validate_raw_string('^'))
+        self.assertEqual(len(validator.errors), 1)
+
     def test_validator_with_utf8mb4(self):
 
         raw_string = '🐙☢,bla'


### PR DESCRIPTION
Permet de corriger les deux erreurs suivantes sur sentry

https://sentry.sandhose.fr/zeste-de-savoir/backend-l7/issues/1053/
https://sentry.sandhose.fr/zeste-de-savoir/backend-l7/issues/1053/

Pour cela je corrige un petit bug qui permettait à des slugs d'être vides pour les tags.

# QA

Tenter d'ajouter un tag "incorrect" à un tuto ou un forum.

- exemple "^" ou même "'"