### PR TITLE
an user → a user ; an unique → a unique

### DIFF
--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -139,7 +139,7 @@ class Forum(models.Model):
 
     def can_read(self, user):
         """
-        Checks if an user can read current forum.
+        Checks if a user can read current forum.
         The forum can be read if:
         - The forum has no access restriction (= no group), or
         - the user is in our database and is part of the restricted group which is needed to access this forum
@@ -367,7 +367,7 @@ class Topic(AbstractESDjangoIndexable):
         The user can always post if someone else has posted last.
         If the user is the last poster and there is less than `ZDS_APP['forum']['spam_limit_seconds']` since the last
         post, the anti-spam is active and the user cannot post.
-        :param user: An user. If undefined, the current user is used.
+        :param user: A user. If undefined, the current user is used.
         :return: `True` if the anti-spam is active (user can't post), `False` otherwise.
         """
         if user is None:
@@ -469,7 +469,7 @@ def delete_topic_in_elasticsearch(sender, instance, **kwargs):
 @python_2_unicode_compatible
 class Post(Comment, AbstractESDjangoIndexable):
     """
-    A forum post written by an user.
+    A forum post written by a user.
     A post can be marked as useful: topic's author (or admin) can declare any topic as "useful", and this post is
     displayed as is on front.
     """

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -839,7 +839,7 @@ class FindTopicTest(TestCase):
 
     def test_success_find_topics_of_a_member_private_forum(self):
         """
-        Test that when an user is part of two groups and that those groups can both read a private forum
+        Test that when a user is part of two groups and that those groups can both read a private forum
         only one topic is returned by the query (cf. Issue 4068).
         """
         profile = ProfileFactory()
@@ -887,7 +887,7 @@ class FindTopicByTagTest(TestCase):
 
     def test_success_find_topics_of_a_tag_private_forums(self):
         """
-        Test that when an user is part of two groups and that those groups can both read a private forum
+        Test that when a user is part of two groups and that those groups can both read a private forum
         only one topic is returned by the query (cf. Issue 4068).
         """
         profile = ProfileFactory()
@@ -1836,7 +1836,7 @@ class FindPostTest(TestCase):
 
     def test_success_find_topics_of_a_member_private_forum(self):
         """
-        Test that when an user is part of two groups and that those groups can both read a private forum
+        Test that when a user is part of two groups and that those groups can both read a private forum
         only one post is returned by the query (cf. Issue 4068).
         """
         profile = ProfileFactory()

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -225,7 +225,7 @@ class ModifyGalleryViewTest(TestCase):
         )
         self.assertEqual(404, response.status_code)
 
-        # try to add an user with write permission
+        # try to add a user with write permission
         response = self.client.post(
             reverse('gallery-modify'),
             {
@@ -257,7 +257,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual(1, len(permissions))
         self.assertEqual('R', permissions[0].mode)
 
-        # try to add write permission to an user
+        # try to add write permission to a user
         # who has already an read permission
         response = self.client.post(
             reverse('gallery-modify'),

--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -176,7 +176,7 @@ class MemberListAPITest(APITestCase):
 
     def test_register_new_user_without_username(self):
         """
-        Tries to register a new user in the database without an username.
+        Tries to register a new user in the database without a username.
         """
         data = {
             'email': 'clem@zestedesavoir.com',
@@ -188,7 +188,7 @@ class MemberListAPITest(APITestCase):
 
     def test_register_new_user_with_username_empty(self):
         """
-        Tries to register a new user in the database with an username empty.
+        Tries to register a new user in the database with a username empty.
         """
         data = {
             'username': '',
@@ -356,7 +356,7 @@ class MemberExistsAPITest(APITestCase):
         self.create_multiple_users()
         StaffProfileFactory()
 
-        # get an username
+        # get a username
         response = self.client.get(reverse('api:member:list') + '?search=firmstaff')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         username = response.data['results'][0]['username']

--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -21,7 +21,7 @@ class ProfileCreate(object):
         """
         Creates an inactive profile in the database.
 
-        :param data: Array about an user.
+        :param data: Array about a user.
         :type data: array
         :return: instance of a profile inactive
         :rtype: Profile object
@@ -54,7 +54,7 @@ class TokenGenerator(object):
         """
         Generates a token for member registration.
 
-        :param user: An User object.
+        :param user: A User object.
         :type user: User object
         :return: A token object
         :rtype: Token object

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -427,7 +427,7 @@ def auto_delete_token_on_unregistering(sender, instance, **kwargs):
 @receiver(models.signals.post_save, sender=User)
 def remove_token_github_on_removing_from_dev_group(sender, instance, **kwargs):
     """
-    This signal receiver removes the GitHub token of an user if he's not in the dev group
+    This signal receiver removes the GitHub token of a user if he's not in the dev group
     """
     try:
         profile = instance.profile

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -807,7 +807,7 @@ class MemberTests(TestCase):
     def test_sanctions_with_not_staff_user(self):
         user = ProfileFactory().user
 
-        # we need staff right for update the sanction of an user, so a member who is not staff can't access to the page
+        # we need staff right for update the sanction of a user, so a member who is not staff can't access to the page
         self.client.logout()
         self.client.login(username=user.username, password='hostel77')
 
@@ -820,7 +820,7 @@ class MemberTests(TestCase):
 
         self.assertEqual(result.status_code, 403)
 
-        # if the user is staff, he can update the sanction of an user
+        # if the user is staff, he can update the sanction of a user
         self.client.logout()
         self.client.login(username=self.staff.username, password='hostel77')
 

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -160,9 +160,9 @@ class PrivateTopic(models.Model):
 
     def is_unread(self, user=None):
         """
-        Check if an user has never read the current PrivateTopic.
+        Check if a user has never read the current PrivateTopic.
 
-        :param user: an user as Django User object. If None, the current user is used.
+        :param user: a user as Django User object. If None, the current user is used.
         :type user: User object
         :return: True if the PrivateTopic was never read
         :rtype: bool
@@ -211,7 +211,7 @@ class PrivateTopic(models.Model):
 
 @python_2_unicode_compatible
 class PrivatePost(models.Model):
-    """A private post written by an user."""
+    """A private post written by a user."""
 
     class Meta:
         verbose_name = u'Réponse à un message privé'
@@ -316,11 +316,11 @@ class PrivateTopicRead(models.Model):
 
 def is_privatetopic_unread(privatetopic, user=None):
     """
-    Check if a private topic has been read by an user since it last post was added.
+    Check if a private topic has been read by a user since it last post was added.
 
     :param privatetopic: a PrivateTopic to check
     :type privatetopic: PrivateTopic object
-    :param user: an user as Django User object. If None, the current user is used
+    :param user: a user as Django User object. If None, the current user is used
     :type user: User object
     :return: True if the PrivateTopic was never read
     :rtype: bool
@@ -340,7 +340,7 @@ def mark_read(privatetopic, user=None):
 
     :param privatetopic: a PrivateTopic to check
     :type privatetopic: PrivateTopic object
-    :param user: an user as Django User object. If None, the current user is used
+    :param user: a user as Django User object. If None, the current user is used
     :type user: User object
     :return: nothing is returned
     :rtype: None

--- a/zds/tutorialv2/models/models_versioned.py
+++ b/zds/tutorialv2/models/models_versioned.py
@@ -240,7 +240,7 @@ class Container:
             this function will also raise an Exception if article, because it cannot contain child container
 
         :param container: the new container
-        :param generate_slug: if ``True``, ask the top container an unique slug for this object
+        :param generate_slug: if ``True``, ask the top container a unique slug for this object
         :raises InvalidOperationError: if cannot add container to this one. Please use ``can_add_container`` to check\
         this before calling ``add_container``.
         """
@@ -260,7 +260,7 @@ class Container:
         """Add a child container, but only if no container were previously added
 
         :param extract: the new extract
-        :param generate_slug: if `True`, ask the top container an unique slug for this object
+        :param generate_slug: if `True`, ask the top container a unique slug for this object
         :raise InvalidOperationError: if cannot add extract to this container.
         """
         if self.can_add_extract():

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -115,7 +115,7 @@ def search_extract_or_404(base_content, kwargs_array):
 
 
 def never_read(content, user=None):
-    """Check if a content note feed has been read by an user since its last post was added.
+    """Check if a content note feed has been read by a user since its last post was added.
 
     :param content: the content to check
     :type content: zds.tutorialv2.models.models_database.PublishableContent

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -1799,7 +1799,7 @@ class RemoveAuthorFromContent(AddAuthorToContent):
 
     @staticmethod
     def remove_author(content, user):
-        """Remove an user from the authors and ensure that he is access to the content's gallery is also removed.
+        """Remove a user from the authors and ensure that he is access to the content's gallery is also removed.
         The last author is not removed.
 
         :param content: the content


### PR DESCRIPTION
“u” est considéré comme une consonne dans ce cas.

**Commits propres, veuillez ne pas squash.**
