### PR TITLE
Edge est (vraiment) préférable à IE

### DIFF
--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -94,15 +94,20 @@ textarea {
     resize: vertical;
 }
 
-.chromeframe {
+.old-browser-warning {
     margin: 0;
-    background: #ccc;
+    background: #ddd;
     color: #000;
     padding: 0.2em 0;
     text-align: center;
     position: fixed;
     z-index: 9999;
     width: 100%;
+}
+
+body.old-browser-warning-shown .page-container {
+    position: relative;
+    top: 3rem;
 }
 
 .a11y {

--- a/templates/base.html
+++ b/templates/base.html
@@ -140,9 +140,8 @@
         data-show-markdown-help="false"
     {% endif %}
 >
-    <!--[if lt IE 9]>
-        <p class="chromeframe">Vous utilisez un navigateur <strong>dépassé</strong>. Merci de <a href="http://browsehappy.com/">mettre à jour celui-ci</a> pour améliorer votre expérience.</p>
-    <![endif]-->
+
+    {% include "old_browser_warning.html" %}
 
     <div class="mobile-menu" id="mobile-menu"></div>
 

--- a/templates/old_browser_warning.html
+++ b/templates/old_browser_warning.html
@@ -1,0 +1,27 @@
+
+<div id="old-browser-warning-container"></div>
+
+{# The main JavaScript files may cause parse errors on old browsers in the    #}
+{# future (ES6, ES7, …). It is probably better to keep this script separated. #}
+
+<script>
+
+(function () {
+    var container = document.getElementById("old-browser-warning-container");
+
+    if (window.ActiveXObject || 'ActiveXObject' in window) {
+        var more = document.createElement('A');
+        more.innerText = 'En savoir plus';
+        more.setAttribute('href', 'https://browsehappy.com/?locale=fr');
+
+        var div = document.createElement('DIV');
+        div.className = 'old-browser-warning';
+        div.innerText = 'Le bon fonctionnement du site avec Internet Explorer n’est pas garanti  •  ';
+        div.appendChild(more);
+        container.appendChild(div);
+
+        document.body.classList.add('old-browser-warning-shown');
+    }
+})();
+
+</script>


### PR DESCRIPTION
**Ceci ne veut pas dire qu’on retire vraiment le support d’Internet Explorer.**

Mais bon, en pratique, personne n’a le temps de tester le site sur IE,
et (pire) personne non plus n’a le temps de reporter les bugs sur
IE. Le site marche terriblement mal sur ces navigateurs.

Désormais, une *dickbar*¹ est affiché en haut du site indiquant “Le
bon fonctionnement du site avec Internet Explorer n'est pas garanti”,
avec un lien “En savoir plus” pointant vers https://browsehappy.com.


### Contrôle qualité

La *dickbar* doit apparaître sur IE 11 (ça devrait théoriquement aussi marcher sur IE 10 bien que ce ne soit pas très important). Rien ne doit changer sur les autres navigateurs.

![Capture d’écran avec l’avertissement avec IE](https://user-images.githubusercontent.com/15378830/31897380-7ec224ec-b816-11e7-9edb-d229bc6fda3d.png)

----

1. https://daringfireball.net/linked/2011/03/06/dickbar
