### PR TITLE
Décode quotes.txt en UTF-8

### DIFF
--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -37,7 +37,7 @@ def home(request):
     opinions = PublishableContent.objects.get_last_opinions()
 
     try:
-        with open(os.path.join(settings.BASE_DIR, 'quotes.txt'), 'r') as quotes_file:
+        with open(os.path.join(settings.BASE_DIR, 'quotes.txt'), 'r', encoding='utf-8') as quotes_file:
             quote = random.choice(quotes_file.readlines())
     except OSError:
         quote = settings.ZDS_APP['site']['slogan']


### PR DESCRIPTION
Le codec utilisé par défaut est l’ASCII et ça plantait puisqu’il y a
de l’UTF-8 dans `quotes.txt`.

<!-- Veuillez décrire vos changements à l’emplacement de ce commentaire (inutile dans le cas de tout petits changements). -->

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné (optionnel) :

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

La page d’accueil doit s’afficher correctement. Avant ce patch, vous avez le droit à une belle erreur.