### PR TITLE
Répare Travis qui échouait sur les tests Selenium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ base.db
 /node_modules
 /dist
 /npm-debug.log
+/geckodriver.log
 
 #############
 ## Python

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 
 addons:
-  firefox: "latest"
+  firefox: "56.0"
   apt:
     packages:
       - mysql-server-5.6
@@ -89,9 +89,9 @@ install:
   - |
     # install webdriver for selenium.
     if [[ "$ZDS_TEST_JOB" == *"selenium"* ]]; then
-      wget https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz \
+      wget https://github.com/mozilla/geckodriver/releases/download/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz \
       && mkdir geckodriver \
-      && tar -xzf geckodriver-v0.16.1-linux64.tar.gz -C geckodriver \
+      && tar -xzf geckodriver-v0.19.0-linux64.tar.gz -C geckodriver \
       && export PATH=$PATH:$PWD/geckodriver \
       && export DISPLAY=:99.0 \
       && sh -e /etc/init.d/xvfb start \

--- a/doc/source/utils/selenium.rst
+++ b/doc/source/utils/selenium.rst
@@ -7,30 +7,34 @@ Selenium est utilisé pour réaliser les tests front-end. Il s'agit d'un outil t
 Pour l'utiliser, il suffit au développeur d'installer Selenium et un webdriver.
 
 Les tests front-end
-------------------
+-------------------
 
 Installation du webdriver
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Il est nécessaire d'installer deux choses pour utiliser Selenium avec Django, Selenium (présent dans requirement-dev) et un webdriver. Pour ceci, il suffit d'éxécuter :
+Il est nécessaire d'installer deux choses pour utiliser Selenium avec Django : Selenium (présent dans ``requirements-dev.txt``) et un webdriver. Pour ceci, il suffit d'exécuter :
 
 .. sourcecode:: bash
 
    # Installation du webdriver
-   wget https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz
+   wget https://github.com/mozilla/geckodriver/releases/download/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz
    mkdir geckodriver
-   tar -xzf geckodriver-v0.16.1-linux64.tar.gz -C geckodriver
+   tar -xzf geckodriver-v0.19.0-linux64.tar.gz -C geckodriver
    # Ajout du webdriver dans le PATH
    export PATH=$PATH:$PWD/geckodriver
 
 Pour Mac OS ou Windows, il suffit de lire les instructions à l'adresse suivante : https://github.com/mozilla/geckodriver/
 
+.. attention::
+
+   La version de geckodriver à installer dépend des versions de Selenium et de Firefox ! Par exemple, la version 19.0 de geckodriver fonctionne correctement avec Selenium 3.6.0 et Firefox 55.0 ou 56.0 mais peut ne pas fonctionner avec d'autres versions. En cas de problème lors de l'Installation, ne pas hésiter à demander de l'aide !
+
 Écriture des tests
 ~~~~~~~~~~~~~~~~~~
 
-Il est donc possible d'écrire des tests pour Django directement en utilisant la document de Selenium ici : <http://selenium-python.readthedocs.io/> et le `StaticLiveServerTestCase` de Django (<https://docs.djangoproject.com/en/1.11/ref/contrib/staticfiles/#django.contrib.staticfiles.testing.StaticLiveServerTestCase>).
+Il est donc possible d'écrire des tests pour Django directement en utilisant la document de Selenium ici : <http://selenium-python.readthedocs.io/> et le `StaticLiveServerTestCase` de Django (<https://docs.djangoproject.com/fr/1.11/ref/contrib/staticfiles/#django.contrib.staticfiles.testing.StaticLiveServerTestCase>).
 
-Il est aussi possible d'utiliser l'extension Firefox (<https://addons.mozilla.org/en-US/firefox/addon/selenium-ide/>) et d'exporter le test généré, cependant, il est nécessaire de le réécrire pour prendre en compte Django et Python3. De plus, il est nécessaire d'ajouter un tag à la classe afin de pouvoir lancer les tests Selenium séparément.
+Il est aussi possible d'utiliser l'extension Firefox (<https://addons.mozilla.org/en-US/firefox/addon/selenium-ide/>) et d'exporter le test généré, cependant, il est nécessaire de le réécrire pour prendre en compte Django et Python 3. De plus, il est nécessaire d'ajouter un tag à la classe afin de pouvoir lancer les tests Selenium séparément.
 
 Voici le contenu d'un test :
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ flake8==3.4.1
 flake8_quotes==0.11.0
 autopep8==1.3.2
 sphinx==1.6.3
-selenium==3.5.0
+selenium==3.6.0
 sphinx_rtd_theme==0.2.4
 faker==0.8.3
 mock==2.0.0


### PR DESCRIPTION
Les tests échouaient à cause du passage de Firefox 55 à Firefox 56

- Met à jour Selenium en 3.6.0
- Met à jour geckodriver en 0.19.0
- Fixe la version Firefox de Travis CI en 56.0 (actuellement c'est en "latest", or si la version de Firefox change et qu'elle n'est plus compatible avec les versions de Selenium et geckodriver nos tests échoueront)
- Met à jour la documentation en conséquent

**QA :**
- Avoir une version de Firefox pas trop vieille (fonctionne à minima en 55.0 et 56.0)
- Mettre à jour sa version de geckodriver en suivant la documentation (voir diff)
- Mettre à jour ses paquets Python
- Lancer `make test-front` et voir que ça fonctionne toujours en local
- Attendre que Travis CI finisse et voir que ça fonctionne toujours avec Travis