### PR TITLE
[WIP] Utilise des apostrophes typographiques dans les templates "pages/"

### DIFF
--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -121,6 +121,6 @@
             </tbody>
         </table>
     {% else %}
-        <em>{% trans "Aucune alerte n'a été résolue." %}</em>
+        <em>{% trans "Aucune alerte n’a été résolue." %}</em>
     {% endif %}
 {% endblock %}

--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -91,6 +91,8 @@
                             {% elif alert.scope == 'CONTENT' %}
                                 <em>{% trans 'Sur le contenu : ' %} {{ alert.content.title }}</em> <br/>
                                 {{ alert.text }}
+                            {% endif %}
+                        </td>
                         <td class="wide">{{ alert.get_type }}</td>
                         <td><a href="{% url 'member-detail' alert.author.username %}">{{ alert.author.username }}</a></td>
                         <td class="wide">{{ alert.solved_date|format_date|capfirst }}</td>

--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -82,19 +82,6 @@
                     <tr>
                         <td class="wide">{{ alert.get_type }}</td>
                         <td><a href="{% url 'member-detail' alert.author.username %}">{{ alert.author.username }}</a></td>
-                        <td>{{ alert.get_type }}</td>
-                        <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
-                        <td class="wide">{{ alert.solved_date|format_date|capfirst }}</td>
-                        <td>
-                            {% if alert.scope == 'CONTENT' and alert.content.in_public %}
-                                <a href="{{ alert.content.get_absolute_url_online }}">{{ alert.text }}</a>
-                            {% elif alert.scope == 'CONTENT' %}
-                                <em>{% trans 'Sur le contenu : ' %} {{ alert.content.title }}</em> <br/>
-                                {{ alert.text }}
-                            {% endif %}
-                        </td>
-                        <td class="wide">{{ alert.get_type }}</td>
-                        <td><a href="{% url 'member-detail' alert.author.username %}">{{ alert.author.username }}</a></td>
                         <td class="wide">{{ alert.solved_date|format_date|capfirst }}</td>
                         <td>
                             {% if alert.scope == 'CONTENT' and alert.content.in_public %}

--- a/templates/pages/alerts.html
+++ b/templates/pages/alerts.html
@@ -82,6 +82,17 @@
                     <tr>
                         <td class="wide">{{ alert.get_type }}</td>
                         <td><a href="{% url 'member-detail' alert.author.username %}">{{ alert.author.username }}</a></td>
+                        <td>{{ alert.get_type }}</td>
+                        <td><a href="{% url "member-detail" alert.author.username %}">{{ alert.author.username }}</a></td>
+                        <td class="wide">{{ alert.solved_date|format_date|capfirst }}</td>
+                        <td>
+                            {% if alert.scope == 'CONTENT' and alert.content.in_public %}
+                                <a href="{{ alert.content.get_absolute_url_online }}">{{ alert.text }}</a>
+                            {% elif alert.scope == 'CONTENT' %}
+                                <em>{% trans 'Sur le contenu : ' %} {{ alert.content.title }}</em> <br/>
+                                {{ alert.text }}
+                        <td class="wide">{{ alert.get_type }}</td>
+                        <td><a href="{% url 'member-detail' alert.author.username %}">{{ alert.author.username }}</a></td>
                         <td class="wide">{{ alert.solved_date|format_date|capfirst }}</td>
                         <td>
                             {% if alert.scope == 'CONTENT' and alert.content.in_public %}

--- a/templates/pages/assoc_subscribe.html
+++ b/templates/pages/assoc_subscribe.html
@@ -5,19 +5,19 @@
 
 
 {% block title %}
-    {% blocktrans with asso_name=app.site.association.name %}Adhérer à l'association {{ asso_name }}{% endblocktrans %}
+    {% blocktrans with asso_name=app.site.association.name %}Adhérer à l’association {{ asso_name }}{% endblocktrans %}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li>{% blocktrans with asso_name=app.site.association.name %}Adhérer à l'association {{ asso_name }}{% endblocktrans %}</li>
+    <li>{% blocktrans with asso_name=app.site.association.name %}Adhérer à l’association {{ asso_name }}{% endblocktrans %}</li>
 {% endblock %}
 
 
 
 {% block headline %}
-    <h1>{% blocktrans with asso_name=app.site.association.name %}Adhérer à l'association {{ asso_name }}{% endblocktrans %}</h1>
+    <h1>{% blocktrans with asso_name=app.site.association.name %}Adhérer à l’association {{ asso_name }}{% endblocktrans %}</h1>
 {% endblock %}
 
 
@@ -26,34 +26,34 @@
     <h3>{% trans "Pourquoi adhérer ?" %}</h3>
     <p>
         {% blocktrans with asso_name=app.site.association.name %}
-            Adhérer à l'association {{ asso_name }} permet de nous soutenir de manière concrète et d'officialiser votre engagement.
+            Adhérer à l’association {{ asso_name }} permet de nous soutenir de manière concrète et d’officialiser votre engagement.
         {% endblocktrans %}
     </p>
     <p>
         {% blocktrans with asso_fee=app.site.association.fee %}
-            D'autre part, le financement des activités de l'association, dont bien sûr le site, est intégralement assuré par
-            les cotisations des membres : adhérer vous permet ainsi d'assurer la pérennité du site.
+            D’autre part, le financement des activités de l’association, dont bien sûr le site, est intégralement assuré par
+            les cotisations des membres : adhérer vous permet ainsi d’assurer la pérennité du site.
             La cotisation est de <strong>{{ asso_fee }}</strong> (le montant est révisé tous les ans durant les assemblées générales).
             Si pour une raison quelconque vous ne pouvez pas payer cette cotisation, faites-en nous part, nous pouvons accorder des dérogations exceptionnelles.
         {% endblocktrans %}
     </p>
     <p>
-        {% trans "Notez que l'adhésion est subordonnée au paiement de cette cotisation." %}
+        {% trans "Notez que l’adhésion est subordonnée au paiement de cette cotisation." %}
     </p>
     <p>
-        {% trans "Adhérer permet bien entendu de participer à l'Assemblée Générale annuelle de l'association, qui élit le Conseil d'Administration. Si vous avez des idées pour faire avancer l'association et donc le site, c'est le moment !" %}
+        {% trans "Adhérer permet bien entendu de participer à l’Assemblée Générale annuelle de l’association, qui élit le Conseil d’Administration. Si vous avez des idées pour faire avancer l’association et donc le site, c’est le moment !" %}
     </p>
     <p>
         {% blocktrans %}
-            Une précision importante : <strong>adhérer à l'association ne vous apporte rien sur le site</strong>. L'adhésion
-            n'est là que pour soutenir le projet, et ne donne droit à aucun pouvoir ou badge supplémentaires. Elle ne donne
-            même pas accès à un forum secret, puisque le forum de l'association est public !
+            Une précision importante : <strong>adhérer à l’association ne vous apporte rien sur le site</strong>. L’adhésion
+            n’est là que pour soutenir le projet, et ne donne droit à aucun pouvoir ou badge supplémentaires. Elle ne donne
+            même pas accès à un forum secret, puisque le forum de l’association est public !
         {% endblocktrans %}
     </p>
     <p>
-        {% trans "Enfin, toutes les fonctionnalités du site sont disponibles à tous : aucune n'est conditionnée à l'adhésion à l'association." %}
+        {% trans "Enfin, toutes les fonctionnalités du site sont disponibles à tous : aucune n’est conditionnée à l’adhésion à l’association." %}
     </p>
 
-    <h3>{% trans "Formulaire d'adhésion" %}</h3>
+    <h3>{% trans "Formulaire d’adhésion" %}</h3>
     {% crispy form %}
 {% endblock %}

--- a/templates/pages/association.html
+++ b/templates/pages/association.html
@@ -5,65 +5,65 @@
 
 
 {% block title %}
-    {% blocktrans with asso_name=app.site.association.name %}L'association {{ asso_name }}{% endblocktrans %}
+    {% blocktrans with asso_name=app.site.association.name %}L’association {{ asso_name }}{% endblocktrans %}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li>{% blocktrans with asso_name=app.site.association.name %}L'association {{ asso_name }}{% endblocktrans %}</li>
+    <li>{% blocktrans with asso_name=app.site.association.name %}L’association {{ asso_name }}{% endblocktrans %}</li>
 {% endblock %}
 
 
 
 {% block headline %}
-    <h1>{% blocktrans with asso_name=app.site.association.name %}L'association {{ asso_name }}{% endblocktrans %}</h1>
+    <h1>{% blocktrans with asso_name=app.site.association.name %}L’association {{ asso_name }}{% endblocktrans %}</h1>
 {% endblock %}
 
 
 
 {% block content %}
     {% set app.site.association.name as asso_name %}
-    <h3>{% trans "Présentation de l'association" %}</h3>
+    <h3>{% trans "Présentation de l’association" %}</h3>
     <p>
         {% blocktrans with site_url=app.site.url %}
             {{ asso_name }} est une association loi 1901 (association à but non lucratif) et joue le rôle de structure
             légale du site <a href="{{ site_url }}">{{ site_url }}</a>, dont le but est de promouvoir le partage de connaissances à travers des
             ressources pédagogiques gratuites et de préférence sous licence libre.
             <a href="http://www.journal-officiel.gouv.fr/publications/assoc/pdf/2014/0016/JOAFE_PDF_Unitaire_20140016_01712.pdf">
-                Parue au Journal officiel le 19 avril 2014</a>, l'association a tenu sa première assemblée générale le 15 mars
-            2014, au cours de laquelle ont été élus le bureau et le conseil d'administration en présence des <strong>quatorze</strong> membres fondateurs.
+                Parue au Journal officiel le 19 avril 2014</a>, l’association a tenu sa première assemblée générale le 15 mars
+            2014, au cours de laquelle ont été élus le bureau et le conseil d’administration en présence des <strong>quatorze</strong> membres fondateurs.
         {% endblocktrans %}
     </p>
     <p>
-        {% trans "Ces membres fondateurs sont tous des anciens membres très actifs du feu siteduzero, un site de diffusion de connaissances et d'entraide. À la suite du changement de politique de ce dernier, ils ont décidé de recréer une plateforme sur laquelle ils pourraient à nouveau s'entraider et partager convenablement leurs connaissances et surtout retrouver l'esprit communautaire qu'ils aimaient tant." %}
+        {% trans "Ces membres fondateurs sont tous des anciens membres très actifs du feu siteduzero, un site de diffusion de connaissances et d’entraide. À la suite du changement de politique de ce dernier, ils ont décidé de recréer une plateforme sur laquelle ils pourraient à nouveau s’entraider et partager convenablement leurs connaissances et surtout retrouver l’esprit communautaire qu’ils aimaient tant." %}
     </p>
     <p>
         {% blocktrans %}
-            Voilà l'histoire de {{ asso_name }}.
+            Voilà l’histoire de {{ asso_name }}.
         {% endblocktrans %}
     </p>
 
-    <h3>{% trans "L'association et le site" %}</h3>
+    <h3>{% trans "L’association et le site" %}</h3>
     <p>
         {% blocktrans %}
-            <strong>Adhérer à l'association ne vous apporte rien sur le site</strong>. L'adhésion n'est là que pour soutenir
+            <strong>Adhérer à l’association ne vous apporte rien sur le site</strong>. L’adhésion n’est là que pour soutenir
             le projet, et ne donne droit à aucun pouvoir ou badge supplémentaire. Elle ne donne même pas accès à un forum
-            secret, puisque le forum de l'association est public !
+            secret, puisque le forum de l’association est public !
         {% endblocktrans %}
     </p>
     <p>
-        {% trans "De même, toutes les fonctionnalités du site sont disponibles à tous : aucune n'est conditionnée à l'adhésion à l'association." %}
+        {% trans "De même, toutes les fonctionnalités du site sont disponibles à tous : aucune n’est conditionnée à l’adhésion à l’association." %}
     </p>
     <p>
         {% trans "Notez que vous devez être inscrit pour pouvoir adhérer." %}
     </p>
     <p>
         {% blocktrans %}
-        Les documents officiels et publics de l'association (statuts, règlement intérieur, …) sont disponibles
+        Les documents officiels et publics de l’association (statuts, règlement intérieur, …) sont disponibles
         <a href="https://github.com/zestedesavoir/documents-association">sur le dépôt Git dédié</a>. Vous pouvez même
-        en proposer l'amélioration en soumettant des <em>pull request</em> (l'acceptation ou le refus définitif se fera
-        lors de l'Assemblée Générale).
+        en proposer l’amélioration en soumettant des <em>pull request</em> (l’acceptation ou le refus définitif se fera
+        lors de l’Assemblée Générale).
         {% endblocktrans %}
     </p>
 {% endblock %}

--- a/templates/pages/comment_edits_history.html
+++ b/templates/pages/comment_edits_history.html
@@ -64,6 +64,6 @@
             </tbody>
         </table>
     {% else %}
-        <em>{% trans "Ce message n'a jamais été édité." %}</em>
+        <em>{% trans "Ce message n’a jamais été édité." %}</em>
     {% endif %}
 {% endblock %}

--- a/templates/pages/cookies.html
+++ b/templates/pages/cookies.html
@@ -71,7 +71,7 @@
         <dt><tt>csrftoken</tt></dt>
         <dd>{% blocktrans %}Ce cookie contient une chaîne de caractères aléatoires qui permet de se prémunir des attaques <a href="http://fr.wikipedia.org/wiki/Cross-Site_Request_Forgery">CSRF</a>. Composant indispensable de la sécurité du site, vous ne pourrez rien poster sans ce cookie.{% endblocktrans %}</dd>
         <dt><tt>hasconsent</tt></dt>
-        <dd>{% blocktrans %}Ce cookie indique si vous acceptez l'analyse d'audience. Il peut prendre les valeurs <tt>true</tt> (analyse acceptée) ou <tt>false</tt> (analyse refusée).{% endblocktrans %}</dd>
+        <dd>{% blocktrans %}Ce cookie indique si vous acceptez l’analyse d’audience. Il peut prendre les valeurs <tt>true</tt> (analyse acceptée) ou <tt>false</tt> (analyse refusée).{% endblocktrans %}</dd>
         {% if app.member.old_smileys_allowed %}
             <dt><tt>{{ app.member.old_smileys_cookie_key }}</tt></dt>
             {% url 'update-member' as update_member  %}

--- a/templates/pages/cookies.html
+++ b/templates/pages/cookies.html
@@ -24,50 +24,49 @@
 
 {% block content %}
     {% set app.site.literal_name as site_name %}
-    <h3>{% trans "Qu'est-ce qu'un cookie ?" %}</h3>
+    <h3>{% trans "Qu’est-ce qu’un cookie ?" %}</h3>
     <p>
         {% blocktrans %}
-            Un <strong>cookie</strong> (aussi appelé <strong>témoin de connexion</strong> ou <strong>témoin</strong> au Québec) est un petit bout de texte envoyé par le serveur web au navigateur, et renvoyé à l'identique par le navigateur au serveur.
+            Un <strong>cookie</strong> (aussi appelé <strong>témoin de connexion</strong> ou <strong>témoin</strong> au Québec) est un petit bout de texte envoyé par le serveur web au navigateur, et renvoyé à l’identique par le navigateur au serveur.
         {% endblocktrans %}
     </p>
-    <p>{% trans "Les cookies ne sont ni des logiciels espions ni des virus, puisqu'ils ne sont en réalité que de simples fichiers textes et ne peuvent en aucun cas être exécutés." %}</p>
+    <p>{% trans "Les cookies ne sont ni des logiciels espions ni des virus, puisqu’ils ne sont en réalité que de simples fichiers textes et ne peuvent en aucun cas être exécutés." %}</p>
     <p>
         {% blocktrans %}
-            Pour plus de détails sur ce qu'est un cookie, voyez <a href="http://www.cnil.fr/vos-droits/vos-traces/les-cookies/">le site de la CNIL</a> ou <a href="http://fr.wikipedia.org/wiki/Cookie_%28informatique%29">Wikipédia</a>.
+            Pour plus de détails sur ce qu’est un cookie, voyez <a href="http://www.cnil.fr/vos-droits/vos-traces/les-cookies/">le site de la CNIL</a> ou <a href="http://fr.wikipedia.org/wiki/Cookie_%28informatique%29">Wikipédia</a>.
         {% endblocktrans %}
     </p>
 
     <h3>{% trans "À quoi servent les cookies ?" %}</h3>
-    <p>{% trans "Les cookies se répartissent en deux grands types : les impératifs techniques et la mesure d'audience." %}</p>
+    <p>{% trans "Les cookies se répartissent en deux grands types : les impératifs techniques et la mesure d’audience." %}</p>
     <p>{% blocktrans %}<strong>En aucun cas</strong> les cookies servent à recueillir des renseignements personnels, transmettre des données sensibles ou transmettre des données personnelles à des tiers.{% endblocktrans %}</p>
 
     <h4>{% trans "Cookies techniques" %}</h4>
-    <p>{% blocktrans %}Certaines fonctionnalités du site nécessitent des cookies pour pouvoir être opérationnelles. L'exemple typique est la connexion aux parties privées de {{ site_name }}.{% endblocktrans %}</p>
+    <p>{% blocktrans %}Certaines fonctionnalités du site nécessitent des cookies pour pouvoir être opérationnelles. L’exemple typique est la connexion aux parties privées de {{ site_name }}.{% endblocktrans %}</p>
     <p>{% blocktrans %}La liste complète des cookies techniques utilisés sur {{ site_name }} et leur utilité est détaillée un peu plus bas.{% endblocktrans %}</p>
     <p>{% blocktrans %}Ces cookies, purement techniques, <strong>sont indispensables au fonctionnement de {{ site_name }}</strong>. Si vous les refusez, les éléments qui en dépendent ne fonctionneront tout simplement pas !{% endblocktrans %}</p>
 
-    <h4>{% trans "Cookies d'analyse d'audience" %}</h4>
+    <h4>{% trans "Cookies d’analyse d'audience" %}</h4>
     <p>{% blocktrans %}{{ site_name }} analyse son audience. Que signifie ce terme barbare ? Tout simplement que nous étudions la manière dont le site est utilisé :{% endblocktrans %}</p>
-
     <ul>
         <li>{% trans "Quelles fonctionnalités sont utilisées ?" %}</li>
         <li>{% trans "À quelle fréquence ?" %}</li>
-        <li>{% trans "D'où viennent nos utilisateurs ? (oui, c'est de vous dont je parle !)" %}</li>
+        <li>{% trans "D’où viennent nos utilisateurs ? (oui, c’est de vous dont je parle !)" %}</li>
         <li>{% trans "Comment naviguent-ils dans le site ?" %}</li>
         <li>{% trans "Etc." %}</li>
     </ul>
     <p>{% trans "<em>À quoi cela peut-il bien servir</em>, allez-vous me demander avec sagacité." %}</p>
-    <p>{% blocktrans %}Tout simplement à <strong>améliorer l'expérience utilisateur du site</strong>. Les développeurs, aussi ingénieux soient-ils, ne peuvent <em>jamais</em> deviner l'utilisation <em>réelle</em> qui sera faite du site. Telle ou telle fonctionnalité qui leur paraîtra mineure sera en fait utilisée par une grande majorité, ou telle autre qui leur paraissait cruciale sera ignorée.{% endblocktrans %}</p>
-    <p>{% blocktrans %}Le seul moyen <em>fiable</em> de savoir ce qui est réellement utilisé - et donc ce qu'il faut travailler - est d'analyser l'audience réelle.{% endblocktrans %}</p>
+    <p>{% blocktrans %}Tout simplement à <strong>améliorer l’expérience utilisateur du site</strong>. Les développeurs, aussi ingénieux soient-ils, ne peuvent <em>jamais</em> deviner l’utilisation <em>réelle</em> qui sera faite du site. Telle ou telle fonctionnalité qui leur paraîtra mineure sera en fait utilisée par une grande majorité, ou telle autre qui leur paraissait cruciale sera ignorée.{% endblocktrans %}</p>
+    <p>{% blocktrans %}Le seul moyen <em>fiable</em> de savoir ce qui est réellement utilisé - et donc ce qu’il faut travailler - est d’analyser l’audience réelle.{% endblocktrans %}</p>
     <p>{% trans "Ceci implique de suivre les utilisateurs à travers le site, ce qui se fait grâce à un cookie dédié." %}</p>
-    <p>{% trans "C'est cette analyse qui peut être désactivée, puisqu'elle n'est pas strictement indispensable au bon fonctionnement du site." %}</p>
+    <p>{% trans "C’est cette analyse qui peut être désactivée, puisqu’elle n’est pas strictement indispensable au bon fonctionnement du site." %}</p>
 
     <h3>{% trans "Les cookies sur ce site" %}</h3>
     <p>{% blocktrans %}Pour être tout à fait précis, {{ site_name }} utilise les cookies suivants :{% endblocktrans %}</p>
     <h4>{% trans "Cookies techniques" %}</h4>
     <dl>
         <dt><tt>sessionid</tt></dt>
-        <dd>{% blocktrans %}Ce cookie est un identifiant unique qui permet de faire le lien entre votre session de navigation et les différentes pages que vous visitez. Il permet en particulier de vous connecter à {{ site_name }}. Il ne contient qu'une chaîne de caractères aléatoires.{% endblocktrans %}</dd>
+        <dd>{% blocktrans %}Ce cookie est un identifiant unique qui permet de faire le lien entre votre session de navigation et les différentes pages que vous visitez. Il permet en particulier de vous connecter à {{ site_name }}. Il ne contient qu’une chaîne de caractères aléatoires.{% endblocktrans %}</dd>
         <dt><tt>csrftoken</tt></dt>
         <dd>{% blocktrans %}Ce cookie contient une chaîne de caractères aléatoires qui permet de se prémunir des attaques <a href="http://fr.wikipedia.org/wiki/Cross-Site_Request_Forgery">CSRF</a>. Composant indispensable de la sécurité du site, vous ne pourrez rien poster sans ce cookie.{% endblocktrans %}</dd>
         <dt><tt>hasconsent</tt></dt>
@@ -79,20 +78,20 @@
         {% endif %}
     </dl>
 
-    <h4>{% trans "Cookies d'analyse d'audience" %}</h4>
+    <h4>{% trans "Cookies d’analyse d’audience" %}</h4>
     <dl>
         <dt><tt>_ga</tt>, <tt>__utma</tt>, <tt>__utmb</tt>, <tt>__utmc</tt> et <tt>__utmz</tt></dt>
-        <dd>{% blocktrans %}Ces cookies sont les cookies d'analyse d'audience de <a href="http://www.google.fr/intl/fr/analytics/">Google Analytics</a>. Leur présence et leur contenu exact est géré par Google Analytics.{% endblocktrans %}</dd>
+        <dd>{% blocktrans %}Ces cookies sont les cookies d’analyse d’audience de <a href="http://www.google.fr/intl/fr/analytics/">Google Analytics</a>. Leur présence et leur contenu exact est géré par Google Analytics.{% endblocktrans %}</dd>
     </dl>
 
     <h3>{% trans "Comment refuser les cookies tiers" %}</h3>
     <h4>{% trans "Refus pur et simple des cookies tiers dans le navigateur" %}</h4>
     <p>{% blocktrans %}Vous pouvez bloquer purement et simplement les cookies <strong>tiers</strong> dans votre navigateur, en suivant la procédure décrite <a href="http://www.cnil.fr/vos-droits/vos-traces/les-cookies/conseils-aux-internautes">sur le site de la CNIL dans le Conseil 1</a>.{% endblocktrans %}</p>
-    <p>{% blocktrans %}Cette manœuvre n'empêchera pas {{ site_name }} de fonctionner, puisque les cookies techniques ne sont pas des cookies tiers.{% endblocktrans %}</p>
-    <p>{% trans "Toutefois, devant le manque de finesse de contrôle d'une telle solution, vous pourriez préférer utiliser une solution présentée au paragraphe suivant." %}</p>
+    <p>{% blocktrans %}Cette manœuvre n’empêchera pas {{ site_name }} de fonctionner, puisque les cookies techniques ne sont pas des cookies tiers.{% endblocktrans %}</p>
+    <p>{% trans "Toutefois, devant le manque de finesse de contrôle d’une telle solution, vous pourriez préférer utiliser une solution présentée au paragraphe suivant." %}</p>
 
-    <h4>{% trans "Utilisation d'un logiciel 'anti-espions'" %}</h4>
-    <p>{% blocktrans %}Il existe différents logiciels <em>"anti-espions"</em>, qui empêchent l'installation des cookies d'analyse d'audience, et bien d'autres encore.{% endblocktrans %}</p>
+    <h4>{% trans "Utilisation d’un logiciel 'anti-espions'" %}</h4>
+    <p>{% blocktrans %}Il existe différents logiciels <em>"anti-espions"</em>, qui empêchent l’installation des cookies d’analyse d’audience, et bien d’autres encore.{% endblocktrans %}</p>
     <p>{% blocktrans %}La CNIL <a href="http://www.cnil.fr/vos-droits/vos-traces/les-cookies/conseils-aux-internautes">indique quelles solutions sont disponibles avec votre navigateur</a>, dans son Conseil 2.{% endblocktrans %}</p>
 
     <h3>{% trans "Licence de cette page" %}</h3>
@@ -112,13 +111,12 @@
             {% endblocktrans %}
         </p>
     {% endif %}
-    <p>{% trans "N'oubliez pas d'adapter les cookies réellement utilisés à votre cas si vous reprenez cette page !" %}</p>
+    <p>{% trans "N’oubliez pas d’adapter les cookies réellement utilisés à votre cas si vous reprenez cette page !" %}</p>
 
     <hr>
 
     <h3>{% trans "Une recette de cookies" %}</h3>
-    <p>{% trans "Puisque vous avez réussi à trouver cette page et que vous avez eu le courage de lire jusqu'ici, vous avez bien droit à une récompense : une recette de cookies !" %}</p>
-
+    <p>{% trans "Puisque vous avez réussi à trouver cette page et que vous avez eu le courage de lire jusqu’ici, vous avez bien droit à une récompense : une recette de cookies !" %}</p>
     <h4>{% trans "Ingrédients" %}</h4>
     <p>{% trans "Pour beaucoup de cookies (parce que le nombre dépend de leur taille) :" %}</p>
     <ul>
@@ -140,11 +138,11 @@
     <p>{% trans "Ajoutez les morceaux de chocolat et mélangez avec soin." %}</p>
     <h4>{% trans "Cuisson" %}</h4>
     <p>{% trans "Préchauffez votre four à 200°C / thermostat 6-7 (un peu moins si vous utilisez la chaleur tournante), grille en position basse." %}</p>
-    <p>{% trans "Façonnez des cookies pas trop épais par petite cuillerées sur une plaque de cuisson recouverte de papier sulfurisé. Espacez-les parce qu'ils s'étalent à la cuisson." %}</p>
-    <p>{% trans "Enfournez-les environ 10 minutes, ils sont cuits lorsqu'ils prennent une belle couleur dorée !" %}</p>
+    <p>{% trans "Façonnez des cookies pas trop épais par petite cuillerées sur une plaque de cuisson recouverte de papier sulfurisé. Espacez-les parce qu’ils s’étalent à la cuisson." %}</p>
+    <p>{% trans "Enfournez-les environ 10 minutes, ils sont cuits lorsqu’ils prennent une belle couleur dorée !" %}</p>
     <h4>{% trans "Conseils divers" %}</h4>
-    <p>{% trans "Si vous avez la flemme de découper le chocolat, vous pouvez utiliser des pépites de chocolat mais en général c'est moins bon. Surtout pas de chocolat à déguster : ces chocolats manquent de sucre pour la pâtisserie !" %}</p>
-    <p>{% trans "Pour découper le chocolat, vous aurez besoin d'un grand couteau solide (donc pas un couteau céramique) et très bien aiguisé. Non, le vôtre n'est pas assez aiguisé. Attaquez la plaque de chocolat côté lisse (carrés sur le dessous), c'est plus simple." %}</p>
-    <p>{% trans "La cuisson parfaite se joue à quelques secondes près (sérieusement), alors surveillez-les bien ! Un SMS de trop, et vous obtenez des cookies en béton. Ce qui serait dommage. Les cookies sont assez mous en sortie de four, c'est normal : ils durcissent en refroidissant." %}</p>
-    <p>{% blocktrans %}On peut faire des cookies à beaucoup de parfums, mais le <em>must</em> reste le cookie au chocolat.{% endblocktrans %}</p>
+    <p>{% trans "Si vous avez la flemme de découper le chocolat, vous pouvez utiliser des pépites de chocolat mais en général c’est moins bon. Surtout pas de chocolat à déguster : ces chocolats manquent de sucre pour la pâtisserie !" %}</p>
+    <p>{% trans "Pour découper le chocolat, vous aurez besoin d’un grand couteau solide (donc pas un couteau céramique) et très bien aiguisé. Non, le vôtre n’est pas assez aiguisé. Attaquez la plaque de chocolat côté lisse (carrés sur le dessous), c’est plus simple." %}</p>
+    <p>{% trans "La cuisson parfaite se joue à quelques secondes près (sérieusement), alors surveillez-les bien ! Un SMS de trop, et vous obtenez des cookies en béton. Ce qui serait dommage. Les cookies sont assez mous en sortie de four, c’est normal : ils durcissent en refroidissant." %}</p>
+    <p>{% blocktrans %} On peut faire des cookies à beaucoup de parfums, mais le <em>must</em> reste le cookie au chocolat.{% endblocktrans %}</p>
 {% endblock %}

--- a/templates/pages/eula.html
+++ b/templates/pages/eula.html
@@ -3,19 +3,19 @@
 
 
 {% block title %}
-    Conditions générales d'utilisation
+    Conditions générales d’utilisation
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li>Conditions générales d'utilisation</li>
+    <li>Conditions générales d’utilisation</li>
 {% endblock %}
 
 
 
 {% block headline %}
-    <h1>Conditions générales d'utilisation</h1>
+    <h1>Conditions générales d’utilisation</h1>
 {% endblock %}
 
 
@@ -27,19 +27,19 @@
 
     <h3>1. Objet</h3>
     <p>
-        Les présentes &laquo; conditions générales d'utilisation &raquo; ont pour objet de définir l'encadrement juridique des modalités selon lesquelles{% if app.site.association %} l'association {{ app.site.association.name }},{% else %} la structure{% endif %} éditrice du site, met à la disposition des utilisateurs son site internet {{ app.site.dns }} et les conditions selon lesquelles les utilisateurs accèdent et utilisent ce site.
+        Les présentes &laquo; conditions générales d’utilisation &raquo; ont pour objet de définir l’encadrement juridique des modalités selon lesquelles{% if app.site.association %} l’association {{ app.site.association.name }},{% else %} la structure{% endif %} éditrice du site, met à la disposition des utilisateurs son site internet {{ app.site.dns }} et les conditions selon lesquelles les utilisateurs accèdent et utilisent ce site.
     </p>
     <p>
-        Toute connexion au site {{ app.site.dns }} est soumise au respect des présentes conditions générales d'utilisation. L'accès au site par l'utilisateur entraîne son acceptation des présentes conditions générales d'utilisation et constitue donc un contrat entre l'éditeur et l'utilisateur.
+        Toute connexion au site {{ app.site.dns }} est soumise au respect des présentes conditions générales d’utilisation. L’accès au site par l’utilisateur entraîne son acceptation des présentes conditions générales d’utilisation et constitue donc un contrat entre l’éditeur et l’utilisateur.
     </p>
     <p>
-        En cas de non-acceptation des conditions générales d'utilisation stipulées dans le présent contrat, l'utilisateur se doit de renoncer à l'accès des services proposés par le site.
+        En cas de non-acceptation des conditions générales d’utilisation stipulées dans le présent contrat, l’utilisateur se doit de renoncer à l’accès des services proposés par le site.
     </p>
 
     <h3>2. Mentions légales</h3>
     {% if app.site.association %}
         <p>
-            L'édition du site {{ app.site.dns }} est assurée par l'association française de loi 1901 {{ app.site.literal_name }}, déclarée à la préfecture de Vendée et parue au Journal Officiel le 19 avril 2014.
+            L’édition du site {{ app.site.dns }} est assurée par l’association française de loi 1901 {{ app.site.literal_name }}, déclarée à la préfecture de Vendée et parue au Journal Officiel le 19 avril 2014.
         </p>
         <p>
             Vous pouvez joindre l’association via l’adresse courriel : <a href="mailto:{{ app.site.association.email }}">{{ app.site.association.email }}</a>.
@@ -57,64 +57,73 @@
     {% endif %}
     <h3>3. Définitions</h3>
     <ul>
+<<<<<<< a8eb1160d3039adbc79aaa2d67d5a0cf18393e52
         <li>Utilisateur : ce terme désigne toute personne qui utilise le site ou l'un des services proposés par le site.</li>
         <li>Membre : l'utilisateur devient un &laquo; Membre &raquo; dès son inscription sur le site.</li>
         <li>Contenu de l'utilisateur : ce sont les données transmises par l'utilisateur sur le site.</li>
         <li>Message : il s'agit d'un contenu publié par un membre qui n'est ni un tutoriel ni un article.</li>
         <li>Lien hypertexte : ce terme désigne les liens consultables par les visiteurs menant à une autre page du même site ou vers un autre site web.</li>
         <li>Identifiant et mot de passe : c'est l'ensemble des informations nécessaires à l'identification d'un membre sur le site. L'identifiant et le mot de passe permettent à l'utilisateur d'accéder à des services réservés aux membres du site. Le mot de passe est une information confidentielle. </li>
+=======
+        <li>Utilisateur : ce terme désigne toute personne qui utilise le site ou l’un des services proposés par le site.</li>
+        <li>Membre : l’utilisateur devient un &laquo; Membre &raquo; dès son inscription sur le site.</li>
+        <li>Contenu de l’utilisateur : ce sont les données transmises par l’utilisateur sur le site.</li>
+        <li>Message : il s’agit d’un contenu publié par un membre qui n’est ni un tutoriel ni un article.</li>
+        <li>Lien hypertexte : ce terme désigne les liens consultables par les visiteurs menant à une autre page du même site ou vers un autre site web.</li>
+        <li>Identifiant et mot de passe : c’est l’ensemble des informations nécessaires à l’identification d’un membre sur le site. L’identifiant et le mot de passe permettent à l’utilisateur d’accéder à des services réservés aux membres du site. Le mot de passe est une information confidentielle. </li>
+>>>>>>> Ajoute des apostrophes manquantes
     </ul>
 
     <h3>4. Accès au site</h3>
     <p>
-        Le site est accessible gratuitement à tout utilisateur ayant un accès à Internet. Tous les frais supportés par l'utilisateur pour accéder au service (matériel informatique, logiciels, abonnement Internet, etc.) sont à sa charge.
+        Le site est accessible gratuitement à tout utilisateur ayant un accès à Internet. Tous les frais supportés par l’utilisateur pour accéder au service (matériel informatique, logiciels, abonnement Internet, etc.) sont à sa charge.
     </p>
     <p>
-        L'éditeur met en &oelig;uvre tous les moyens mis à sa disposition pour assurer un accès de qualité à ses services. L'obligation étant de moyens, le site ne s'engage pas à atteindre ce résultat.
+        L’éditeur met en &oelig;uvre tous les moyens mis à sa disposition pour assurer un accès de qualité à ses services. L’obligation étant de moyens, le site ne s’engage pas à atteindre ce résultat.
     </p>
     <p>
-        L'accès au site peut à tout moment faire l'objet d'une interruption à des fins de maintenance, de mise à jour et pour toute autre raison (raisons techniques, force majeure, etc.) sans que l'interruption n'ouvre droit à aucune obligation ni indemnisation.
+        L’accès au site peut à tout moment faire l’objet d’une interruption à des fins de maintenance, de mise à jour et pour toute autre raison (raisons techniques, force majeure, etc.) sans que l’interruption n’ouvre droit à aucune obligation ni indemnisation.
     </p>
     <p>
-        Tout événement d&ucirc; à un cas de force majeure ayant pour conséquence un dysfonctionnement du réseau ou du serveur n'engage pas la responsabilité de l'éditeur.
+        Tout événement d&ucirc; à un cas de force majeure ayant pour conséquence un dysfonctionnement du réseau ou du serveur n’engage pas la responsabilité de l’éditeur.
     </p>
     <p>
-        L'utilisateur non membre n'a pas accès aux services réservés aux membres. En effet, certaines actions sur le site sont réservées aux membres après identification à l'aide de leur identifiant et de leur mot de passe. Elles concernent principalement la rédaction d'articles, de billets ou de tutoriels et la participation active sur les forums.
+        L’utilisateur non membre n’a pas accès aux services réservés aux membres. En effet, certaines actions sur le site sont réservées aux membres après identification à l’aide de leur identifiant et de leur mot de passe. Elles concernent principalement la rédaction d’articles, de billets ou de tutoriels et la participation active sur les forums.
     </p>
     <p>
-        Pour devenir &laquo; Membre &raquo;, l'utilisateur doit créer un compte au moyen du formulaire en ligne prévu à cet effet.
+        Pour devenir &laquo; Membre &raquo;, l’utilisateur doit créer un compte au moyen du formulaire en ligne prévu à cet effet.
     </p>
     <p>
-        Lors de son inscription, le membre choisit un identifiant et un mot de passe lesquels ont un caractère strictement personnel et confidentiel. Le membre est donc tenu de préserver la confidentialité de ces données et à supporter toutes les conséquences pouvant résulter de leur divulgation (qu'elle soit volontaire ou non).
+        Lors de son inscription, le membre choisit un identifiant et un mot de passe lesquels ont un caractère strictement personnel et confidentiel. Le membre est donc tenu de préserver la confidentialité de ces données et à supporter toutes les conséquences pouvant résulter de leur divulgation (qu’elle soit volontaire ou non).
     </p>
     <p>
-        Pour pouvoir accéder aux services réservés aux membres, le membre doit s'identifier à l'aide de son identifiant et de son mot de passe.
+        Pour pouvoir accéder aux services réservés aux membres, le membre doit s’identifier à l’aide de son identifiant et de son mot de passe.
     </p>
     <p>
-        L'éditeur se réserve le droit de refuser l'accès aux services du site, unilatéralement et sans notification préalable, à tout utilisateur ne respectant pas les présentes conditions d'utilisation.
+        L’éditeur se réserve le droit de refuser l’accès aux services du site, unilatéralement et sans notification préalable, à tout utilisateur ne respectant pas les présentes conditions d’utilisation.
     </p>
 
-    <h3>5. Contenu de l'utilisateur</h3>
+    <h3>5. Contenu de l’utilisateur</h3>
     <h4>5.1 Généralités </h4>
     <p>
-        Le site permet aux membres de publier des commentaires, des tutoriels, des articles, des billets, des messages sur les forums, de même que des messages privés entre membres. Le membre est responsable des propos tenus sur les forums et dans les commentaires d'un article, d'un billet ou d'un tutoriel.
+        Le site permet aux membres de publier des commentaires, des tutoriels, des articles, des billets, des messages sur les forums, de même que des messages privés entre membres. Le membre est responsable des propos tenus sur les forums et dans les commentaires d’un article, d’un billet ou d’un tutoriel.
     </p>
     <p>
         Il est interdit aux membres de télécharger, diffuser, transmettre ou d’envoyer sur le site des contenus qui ont un caractère injurieux ou diffamatoire, pornographique, portent atteinte à la vie privée et/ou au droit à l’image d’autrui, incitent à la commission de crimes et délits, incitent à la consommation d’alcool, du tabac ou de médicaments, mettent en péril le bon fonctionnement du site, de ses serveurs et la protection des données de {{ app.site.dns }} ou de ses membres et d’une manière générale, ont un caractère contraire à la législation en vigueur.
     </p>
     <p>
-        Cette interdiction s'applique également aux contenus auxquels donnent accès les liens hypertextes fournis par un membre sur le site.
+        Cette interdiction s’applique également aux contenus auxquels donnent accès les liens hypertextes fournis par un membre sur le site.
     </p>
     <p>
-        Dans ses publications, le membre s'engage de plus à respecter les règles du site. Par ailleurs, le site exerce une modération sur les publications et se réserve le droit de refuser leur mise en ligne, sans avoir à s'en justifier auprès du membre.
+        Dans ses publications, le membre s’engage de plus à respecter les règles du site. Par ailleurs, le site exerce une modération sur les publications et se réserve le droit de refuser leur mise en ligne, sans avoir à s’en justifier auprès du membre.
     </p>
 
     <h4>5.2 Responsabilité des messages publiés par un membre et sanctions en cas de manquement</h4>
     <p>
-        Les membres sont seuls responsables des messages qu'ils publient sur le site. L'éditeur du site ne peut être considéré comme responsable du contenu transmis ou mis en ligne par les membres. Toutefois, les utilisateurs peuvent signaler une publication manifestement contraire aux lois en vigueur, aux règles du site ou aux conditions générales d'utilisation  dans le but d'un acte de modération par l'équipe du site.
+        Les membres sont seuls responsables des messages qu’ils publient sur le site. L’éditeur du site ne peut être considéré comme responsable du contenu transmis ou mis en ligne par les membres. Toutefois, les utilisateurs peuvent signaler une publication manifestement contraire aux lois en vigueur, aux règles du site ou aux conditions générales d’utilisation  dans le but d’un acte de modération par l’équipe du site.
     </p>
     <p>
-        En cas de manquement par un membre des règles du site et/ou des éléments ci-dessus, la modération de {{ app.site.dns }} peut décider de lui bloquer l'accès au site, à titre provisoire ou définitif, ou d'en limiter l'utilisation. Les différentes sanctions applicables sont inscrites dans le règlement du site. Aucune contrepartie ne pourra être exigée.
+        En cas de manquement par un membre des règles du site et/ou des éléments ci-dessus, la modération de {{ app.site.dns }} peut décider de lui bloquer l’accès au site, à titre provisoire ou définitif, ou d’en limiter l’utilisation. Les différentes sanctions applicables sont inscrites dans le règlement du site. Aucune contrepartie ne pourra être exigée.
     </p>
 
     <h4>5.3 Propriété du contenu publié par un membre </h4>
@@ -122,7 +131,11 @@
         Le membre reste titulaire de l’intégralité de ses droits de propriété intellectuelle sur l’ensemble du contenu qu’il publie (articles, billets, tutoriels, de même que le contenu publié sur les forums). Mais par la mise en ligne d’un tutoriel,  ou article, il autorise gratuitement et sans clause d’exclusivité l’éditeur du site à représenter, modifier, adapter et diffuser sa publication sur le site, pour la durée de la propriété intellectuelle. Il autorise notamment l’éditeur du site à utiliser sa publication sur Internet dans le but de faire connaître le site.
     </p>
     <p>
+<<<<<<< a8eb1160d3039adbc79aaa2d67d5a0cf18393e52
         L'auteur d'un tutoriel, d'un billet ou d'un article a également la possibilité de mettre sa publication en ligne selon la licence &ldquo;CC&rdquo; (Creative Commons) qui lui convient le mieux parmi les licences CC suivantes :
+=======
+        L’auteur d’un tutoriel, d’un billet ou d’un article a également la possibilité de mettre sa publication en ligne selon la licence &ldquo;CC&rdquo; (Creative Commons) qui lui convient le mieux parmi les licences CC suivantes :
+>>>>>>> Ajoute des apostrophes manquantes
     </p>
     <ul>
         <li>Licence CC 0 1.0 - <a href="http://creativecommons.org/publicdomain/zero/1.0/">Lire le résumé explicatif de la licence</a></li>
@@ -135,91 +148,99 @@
         <li>Licence CC BY-NC-ND 4.0 - <a href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Lire le résumé explicatif de la licence</a></li>
     </ul>
     <p>
-        La mise en ligne d'un tutoriel ou d'un article est soumise à une validation préalable par l'éditeur du site. L'éditeur du site est libre de refuser la publication d'un tutoriel ou d'un article, sans avoir à s'en justifier auprès du membre et sans qu'aucune contrepartie puisse être exigée.
+        La mise en ligne d’un tutoriel ou d’un article est soumise à une validation préalable par l’éditeur du site. L’éditeur du site est libre de refuser la publication d’un tutoriel ou d’un article, sans avoir à s’en justifier auprès du membre et sans qu’aucune contrepartie puisse être exigée.
     </p>
     <p>
-        La mise en ligne d'un billet est soumise à une validation postérieure par l'éditeur du site. L'éditeur du site est libre de supprimer un billet, sans avoir à s'en justifier auprès du membre et sans qu'aucune contrepartie puisse être exigée.
+        La mise en ligne d’un billet est soumise à une validation postérieure par l’éditeur du site. L’éditeur du site est libre de supprimer un billet, sans avoir à s’en justifier auprès du membre et sans qu’aucune contrepartie puisse être exigée.
     </p>
     <p>
-        L'éditeur du site s'engage à faire figurer le nom du membre et la licence choisie à proximité de chaque utilisation de sa publication.
+        L’éditeur du site s’engage à faire figurer le nom du membre et la licence choisie à proximité de chaque utilisation de sa publication.
     </p>
     <p>
-        En cas de refus de publication, il ne sera fait nul usage par l'éditeur du site de la publication refusée.
+        En cas de refus de publication, il ne sera fait nul usage par l’éditeur du site de la publication refusée.
     </p>
 
-    <h4>5.4 Création d'un profil personnel </h4>
+    <h4>5.4 Création d’un profil personnel </h4>
     <p>
-        Après inscription, tout membre dispose d'une page de profil personnelle. Ce profil recense l'ensemble de l'activité du membre sur le site (forums, signature, avatar,  articles, billets, tutoriels) à l'exception des informations d'inscription (nom, prénom, adresse courriel, ...) et correspondances (via le système de messagerie privée) privées.
+        Après inscription, tout membre dispose d’une page de profil personnelle. Ce profil recense l’ensemble de l’activité du membre sur le site (forums, signature, avatar,  articles, billets, tutoriels) à l’exception des informations d’inscription (nom, prénom, adresse courriel, ...) et correspondances (via le système de messagerie privée) privées.
     </p>
     <p>
+<<<<<<< a8eb1160d3039adbc79aaa2d67d5a0cf18393e52
         Cette page de profil, accessible à tous les membres, a pour objet de permettre au membre de se présenter. Le membre est libre d'ajouter une photographie le représentant, un avatar et d'autres informations supplémentaires : biographie, formations et emploi, l'adresse des sites et/ou blog et/ou portfolio présentant les travaux du membre, comptes sur les réseaux sociaux et toute autre information au choix du membre.
+=======
+        Cette page de profil, accessible à tous les membres, a pour objet de permettre au membre de se présenter. Le membre est libre d’ajouter une photographie le représentant, un avatar et d’autres informations supplémentaires : biographie, formations et emploi, l’adresse des sites et/ou blog et/ou portfolio présentant les travaux du membre, comptes sur les réseaux sociaux et toute autre information au choix du membre.
+>>>>>>> Ajoute des apostrophes manquantes
     </p>
     <p>
-        L'éditeur ne peut être tenu responsable des informations données par le membre sur cette page de profil. En effet, le membre doit donc veiller à ne fournir que des informations qu'il souhaite communiquer aux autres membres, le contenu de cette page étant sous sa responsabilité.
+        L’éditeur ne peut être tenu responsable des informations données par le membre sur cette page de profil. En effet, le membre doit donc veiller à ne fournir que des informations qu’il souhaite communiquer aux autres membres, le contenu de cette page étant sous sa responsabilité.
     </p>
     <p>
-        Le membre s'engage expressément à ne pas publier la photographie ou des informations privées d'une tierce personne. Il s'engage par ailleurs à ne pas usurper l'identité d'un tiers et à respecter scrupuleusement les règles du site, les conditions inscrites dans le présent document ainsi que la législation en vigueur.
+        Le membre s’engage expressément à ne pas publier la photographie ou des informations privées d’une tierce personne. Il s’engage par ailleurs à ne pas usurper l’identité d’un tiers et à respecter scrupuleusement les règles du site, les conditions inscrites dans le présent document ainsi que la législation en vigueur.
     </p>
     <p>
-        Le site est libre d'exercer une modération sur la page de profil d'un membre si celle-ci va à l'encontre des règles du site, des conditions inscrites dans le présent document et/ou de la législation en vigueur.
+        Le site est libre d’exercer une modération sur la page de profil d’un membre si celle-ci va à l’encontre des règles du site, des conditions inscrites dans le présent document et/ou de la législation en vigueur.
     </p>
 
     <h3>6. Données personnelles</h3>
     <h4>6.1  Loi Informatique et Libertés du 6 janvier 1978</h4>
     <p>
-        Conformément à la Loi n<sup>o</sup>78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés, le traitement des données personnelles réalisées sur le site a fait l'objet d'une déclaration auprès de la Commission Nationale Informatique et Liberté (CNIL).
+        Conformément à la Loi n<sup>o</sup>78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, le traitement des données personnelles réalisées sur le site a fait l’objet d’une déclaration auprès de la Commission Nationale Informatique et Liberté (CNIL).
     </p>
     <p>
-        Le traitement des données personnelles de chaque membre se fait conformément à la Loi Informatique et Libertés du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés.
+        Le traitement des données personnelles de chaque membre se fait conformément à la Loi Informatique et Libertés du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés.
     </p>
     <p>
-        L'éditeur du site s'engage à assurer un niveau de protection suffisant des informations fournies dans le but de garantir le respect de la vie privée conformément aux prescriptions légales.
+        L’éditeur du site s’engage à assurer un niveau de protection suffisant des informations fournies dans le but de garantir le respect de la vie privée conformément aux prescriptions légales.
     </p>
 
     <h4>6.2  Utilisation des données enregistrées</h4>
     <p>
-        Toutes les données à caractère personnel transmises par les utilisateurs et membres du site sont recueillies dans le plus strict respect de la législation. Elles ont pour finalité une meilleure utilisation de {{ app.site.dns }} et sont donc utilisées par l'éditeur du site à cette fin.
+        Toutes les données à caractère personnel transmises par les utilisateurs et membres du site sont recueillies dans le plus strict respect de la législation. Elles ont pour finalité une meilleure utilisation de {{ app.site.dns }} et sont donc utilisées par l’éditeur du site à cette fin.
     </p>
     <p>
+<<<<<<< a8eb1160d3039adbc79aaa2d67d5a0cf18393e52
         Lors de son inscription, il est requis de l'utilisateur de fournir des informations le concernant. En particulier, l'adresse électronique pourra être utilisée par le site pour l'administration et la communication d'informations touchant l'ensemble des membres du site (par exemple : une modification importante de la structure du site, l'ajout de fonctionnalités, une modification des présentes conditions, les dernières publications du site (newsletter), etc.).
+=======
+        Lors de son inscription, il est requis de l’utilisateur de fournir des informations le concernant. En particulier, l’adresse électronique pourra être utilisée par le site pour l’administration et la communication d’informations touchant l’ensemble des membres du site (par exemple : une modification importante de la structure du site, l’ajout de fonctionnalités, une modification des présentes conditions, les dernières publications du site (newsletter), etc.).
+>>>>>>> Ajoute des apostrophes manquantes
     </p>
     <p>
-        Le membre a le choix s'abonner ou non à la newsletter.
+        Le membre a le choix s’abonner ou non à la newsletter.
     </p>
     <p>
         Les données concernant les utilisateurs (membres ou non) du site peuvent être également utilisées à des fins statistiques destinées à mesurer la fréquentation du site.
     </p>
     <p>
-        En dehors du cas prévu ci-dessus, les données personnelles ne feront l'objet d'aucune communication à des tiers. Toutefois, elles pourront être divulguées en application d'une loi ou d'un règlement ou en vertu d'une décision d'une autorité réglementaire ou judiciaire compétente.
+        En dehors du cas prévu ci-dessus, les données personnelles ne feront l’objet d’aucune communication à des tiers. Toutefois, elles pourront être divulguées en application d’une loi ou d’un règlement ou en vertu d’une décision d’une autorité réglementaire ou judiciaire compétente.
     </p>
 
     <h4>6.3  Non-acceptation, modification et suppression des données enregistrées</h4>
 
     <p>
-        L'utilisateur est libre de refuser de communiquer les renseignements sollicités pour l'inscription sur le site. Dans ce cas, il ne peut pas en devenir membre.
+        L’utilisateur est libre de refuser de communiquer les renseignements sollicités pour l’inscription sur le site. Dans ce cas, il ne peut pas en devenir membre.
     </p>
     <p>
-        Conformément aux articles 39 et 40 de la Loi n<sup>o</sup>78-17 du 6 janvier 1978, l'utilisateur peut à tout moment accéder aux informations personnelles le concernant détenues par la structure éditrice du site et réaliser leur modification, leur rectification ou leur suppression. Tout utilisateur peut demander que les données soient rectifiées, complétées, mises à jour, ou supprimées. Pour exercer ces droits, tout utilisateur peut se servir du formulaire de contact présent sur le site ou via l'adresse de contact fournie dans les mentions légales du présent document.
+        Conformément aux articles 39 et 40 de la Loi n<sup>o</sup>78-17 du 6 janvier 1978, l’utilisateur peut à tout moment accéder aux informations personnelles le concernant détenues par la structure éditrice du site et réaliser leur modification, leur rectification ou leur suppression. Tout utilisateur peut demander que les données soient rectifiées, complétées, mises à jour, ou supprimées. Pour exercer ces droits, tout utilisateur peut se servir du formulaire de contact présent sur le site ou via l’adresse de contact fournie dans les mentions légales du présent document.
     </p>
 
-    <h4>6.4 Politique relative à l'installation de cookies</h4>
+    <h4>6.4 Politique relative à l’installation de cookies</h4>
     <p>
-        L'éditeur du site utilise la technologie des marqueurs (cookies) afin d'améliorer la qualité du site et mieux répondre aux attentes des utilisateurs. Le membre prend acte que le site procède à l'installation de cookies sur le disque dur de son ordinateur en vue d'identifier chacune de ses connexions.
+        L’éditeur du site utilise la technologie des marqueurs (cookies) afin d’améliorer la qualité du site et mieux répondre aux attentes des utilisateurs. Le membre prend acte que le site procède à l’installation de cookies sur le disque dur de son ordinateur en vue d’identifier chacune de ses connexions.
     </p>
     <p>
-        De manière générale, les cookies sont sans dommage pour l'ordinateur du membre. Ce dernier est libre d'accepter ou refuser les cookies en configurant son navigateur internet à cet effet. Pour ce faire, le membre peut se rendre sur le site de la Commission Nationale de l'Informatique et des Libertés (CNIL) à l'adresse : <a href="http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/">http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/</a> donnant toutes les informations relatives à une telle configuration. Les cookies sont anonymes et ne sont en aucun cas utilisés pour collecter des données à caractère personnel, mais uniquement à des fins de connexion et statistiques.
+        De manière générale, les cookies sont sans dommage pour l’ordinateur du membre. Ce dernier est libre d’accepter ou refuser les cookies en configurant son navigateur internet à cet effet. Pour ce faire, le membre peut se rendre sur le site de la Commission Nationale de l’Informatique et des Libertés (CNIL) à l’adresse : <a href="http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/">http://www.cnil.fr/vos-libertes/vos-traces/les-cookies/</a> donnant toutes les informations relatives à une telle configuration. Les cookies sont anonymes et ne sont en aucun cas utilisés pour collecter des données à caractère personnel, mais uniquement à des fins de connexion et statistiques.
     </p>
     <p>
-        Pour plus de détails, voir <a href="{% url "pages-cookies" %}">la page d'explications sur les cookies</a>.
+        Pour plus de détails, voir <a href="{% url "pages-cookies" %}">la page d’explications sur les cookies</a>.
     </p>
 
 
     <h3>7. Propriété intellectuelle</h3>
     <p>
-        Les marques, illustrations, signes distinctifs et tout autre contenu du site sont la propriété exclusive de l'éditeur du site et font l'objet d'une protection par le Code de la propriété intellectuelle.
+        Les marques, illustrations, signes distinctifs et tout autre contenu du site sont la propriété exclusive de l’éditeur du site et font l’objet d’une protection par le Code de la propriété intellectuelle.
     </p>
     <p>
-        Toute reproduction, publication, copie des différents contenus nécessite au préalable l'autorisation de l'éditeur du site.
+        Toute reproduction, publication, copie des différents contenus nécessite au préalable l’autorisation de l’éditeur du site.
     </p>
     {% if app.site.licenses.logo %}
         <p>
@@ -227,24 +248,24 @@
         </p>
     {% endif %}
     <p>
-        Il n'est concédé aux membres aucun droit de propriété intellectuelle sur le site.
+        Il n’est concédé aux membres aucun droit de propriété intellectuelle sur le site.
     </p>
     <p>
-        Toute exploitation non autorisée de tout ou partie du contenu de l'éditeur du site est susceptible de faire l'objet des poursuites judiciaires.
+        Toute exploitation non autorisée de tout ou partie du contenu de l’éditeur du site est susceptible de faire l’objet des poursuites judiciaires.
     </p>
 
     <h4>7.1 Politique relative au contenu des membres</h4>
     <p>
-        Tout contenu mis en ligne par le membre est de sa seule responsabilité. Le membre s'engage à ne pas mettre en ligne de contenus contraires aux règles du site, aux présentes conditions ou à la législation en vigueur. La responsabilité du site {% if app.site.association %}et de l'association {% endif %}qui l'édite ne pourra être engagée pour une faute commise par un membre.
+        Tout contenu mis en ligne par le membre est de sa seule responsabilité. Le membre s’engage à ne pas mettre en ligne de contenus contraires aux règles du site, aux présentes conditions ou à la législation en vigueur. La responsabilité du site {% if app.site.association %}et de l’association {% endif %}qui l’édite ne pourra être engagée pour une faute commise par un membre.
     </p>
     <p>
-        Tout recours en justice engagé par un tiers lésé sera de la responsabilité du membre et ce dernier s'engage en particulier à prendre en charge le paiement de toutes sommes, quelles qu'elles soient, qui résulteraient d'une action légale d'un tiers, y compris les honoraires d'avocat et frais de justice.
+        Tout recours en justice engagé par un tiers lésé sera de la responsabilité du membre et ce dernier s’engage en particulier à prendre en charge le paiement de toutes sommes, quelles qu’elles soient, qui résulteraient d’une action légale d’un tiers, y compris les honoraires d’avocat et frais de justice.
     </p>
     <p>
-        Le membre reste titulaire de l'intégralité de ses droits de propriété intellectuelle. Il concède cependant des droits à l'éditeur du site (voir titre 5. &ldquo;Contenu de l'utilisateur&rdquo;). Selon la licence choisie, le membre peut également autoriser d'autres utilisations de son &oelig;uvre.
+        Le membre reste titulaire de l’intégralité de ses droits de propriété intellectuelle. Il concède cependant des droits à l’éditeur du site (voir titre 5. &ldquo;Contenu de l’utilisateur&rdquo;). Selon la licence choisie, le membre peut également autoriser d’autres utilisations de son &oelig;uvre.
     </p>
     <p>
-        Le contenu d'un membre peut être à tout moment et pour n'importe quelle raison supprimé ou modifié par le site. Le membre peut ne recevoir aucune justification et notification préalable à la suppression ou à la modification du contenu.
+        Le contenu d’un membre peut être à tout moment et pour n’importe quelle raison supprimé ou modifié par le site. Le membre peut ne recevoir aucune justification et notification préalable à la suppression ou à la modification du contenu.
     </p>
 
     <h4>7.2 Code source du site</h4>
@@ -258,51 +279,51 @@
         </p>
     {% endif %}
 
-    <h4>7.3 Politique de signalement d'abus</h4>
+    <h4>7.3 Politique de signalement d’abus</h4>
     <p>
-        {{ app.site.literal_name }} respecte les droits de propriété intellectuelle d'autrui et demande à ce que les utilisateurs du site agissent de même.
+        {{ app.site.literal_name }} respecte les droits de propriété intellectuelle d’autrui et demande à ce que les utilisateurs du site agissent de même.
     </p>
     <p>
-        Si vous pensez qu'un contenu vous appartenant a été reproduit ou diffusé sans votre autorisation, veuillez nous contacter via le formulaire de contact présent sur le site ou via l'adresse de contact fournie dans les mentions légales du présent document.
+        Si vous pensez qu’un contenu vous appartenant a été reproduit ou diffusé sans votre autorisation, veuillez nous contacter via le formulaire de contact présent sur le site ou via l’adresse de contact fournie dans les mentions légales du présent document.
     </p>
 
     <h3>8. Limitation de responsabilité</h3>
     <p>
-        Les informations présentes sur le site sont fournies en l'état et proviennent de sources réputées fiables. Cependant, l'éditeur du site ne peut garantir l'exactitude ou la pertinence de ces données. En outre, les informations mises à disposition sur ce site le sont uniquement à titre purement pédagogique et informatif.
+        Les informations présentes sur le site sont fournies en l’état et proviennent de sources réputées fiables. Cependant, l’éditeur du site ne peut garantir l’exactitude ou la pertinence de ces données. En outre, les informations mises à disposition sur ce site le sont uniquement à titre purement pédagogique et informatif.
     </p>
     <p>
-        L'utilisateur du site assume l'ensemble des risques découlant de l'utilisation des informations présentes sur le site ou dans les sites joignables au travers des liens hypertextes.
+        L’utilisateur du site assume l’ensemble des risques découlant de l’utilisation des informations présentes sur le site ou dans les sites joignables au travers des liens hypertextes.
     </p>
     <p>
-        Le membre a l'obligation de garder son mot de passe secret. Toute divulgation du mot de passe, quelle que soit sa forme, est interdite. Ce dernier assume les risques liés à l'utilisation de son identifiant et mot de passe. Nous vous encourageons à utiliser pour votre compte des mots de passe forts (mots de passe constitués d'une combinaison de lettres majuscules et minuscules, de chiffres et de caractères spéciaux).
+        Le membre a l’obligation de garder son mot de passe secret. Toute divulgation du mot de passe, quelle que soit sa forme, est interdite. Ce dernier assume les risques liés à l’utilisation de son identifiant et mot de passe. Nous vous encourageons à utiliser pour votre compte des mots de passe forts (mots de passe constitués d’une combinaison de lettres majuscules et minuscules, de chiffres et de caractères spéciaux).
     </p>
     <p>
-        Le site ne saurait être responsable d'un quelconque dommage résultant d'un manquement du membre sur ce qui précède.
+        Le site ne saurait être responsable d’un quelconque dommage résultant d’un manquement du membre sur ce qui précède.
     </p>
     <p>
-        Une garantie optimale de la sécurité et de la confidentialité des données transmises n'est pas assurée par le site. Toutefois, le site s'engage à mettre en &oelig;uvre tous les moyens nécessaires afin de garantir au mieux la sécurité et la confidentialité des données.
+        Une garantie optimale de la sécurité et de la confidentialité des données transmises n’est pas assurée par le site. Toutefois, le site s’engage à mettre en &oelig;uvre tous les moyens nécessaires afin de garantir au mieux la sécurité et la confidentialité des données.
     </p>
     <p>
-        La responsabilité du site ne peut être engagée en cas de force majeure ou du fait imprévisible et insurmontable d'un tiers.
+        La responsabilité du site ne peut être engagée en cas de force majeure ou du fait imprévisible et insurmontable d’un tiers.
     </p>
 
     <h3>9. Liens hypertextes</h3>
     <p>
-        De nombreux liens hypertextes sortants sont présents sur le site, cependant les pages web où mènent ces liens n'engagent en rien la responsabilité du site qui n'a pas le contr&ocirc;le de ces liens.
+        De nombreux liens hypertextes sortants sont présents sur le site, cependant les pages web où mènent ces liens n’engagent en rien la responsabilité du site qui n’a pas le contr&ocirc;le de ces liens.
     </p>
 
     <h3>10. Évolution des présentes conditions</h3>
     <p>
-        L'éditeur se réserve le droit de modifier unilatéralement et à tout moment le contenu des présentes conditions générales d'utilisation.
+        L’éditeur se réserve le droit de modifier unilatéralement et à tout moment le contenu des présentes conditions générales d’utilisation.
     </p>
 
     <h3>11. Durée</h3>
     <p>
-        La durée des présentes conditions générales d'utilisation est indéterminée.
+        La durée des présentes conditions générales d’utilisation est indéterminée.
     </p>
 
     <h3>12. Droit applicable et juridiction compétente</h3>
     <p>
-        La législation française s'applique au présent contrat. Il est fait attribution exclusive de juridiction aux tribunaux compétents de Paris.
+        La législation française s’applique au présent contrat. Il est fait attribution exclusive de juridiction aux tribunaux compétents de Paris.
     </p>
 {% endblock %}

--- a/templates/pages/eula.html
+++ b/templates/pages/eula.html
@@ -57,21 +57,12 @@
     {% endif %}
     <h3>3. Définitions</h3>
     <ul>
-<<<<<<< a8eb1160d3039adbc79aaa2d67d5a0cf18393e52
-        <li>Utilisateur : ce terme désigne toute personne qui utilise le site ou l'un des services proposés par le site.</li>
-        <li>Membre : l'utilisateur devient un &laquo; Membre &raquo; dès son inscription sur le site.</li>
-        <li>Contenu de l'utilisateur : ce sont les données transmises par l'utilisateur sur le site.</li>
-        <li>Message : il s'agit d'un contenu publié par un membre qui n'est ni un tutoriel ni un article.</li>
+        <li>Utilisateur : ce terme désigne toute personne qui utilise le site ou l’un des services proposés par le site.</li>
+        <li>Membre : l’utilisateur devient un &laquo; Membre &raquo; dès son inscription sur le site.</li>
+        <li>Contenu de l’utilisateur : ce sont les données transmises par l’utilisateur sur le site.</li>
+        <li>Message : il s’agit d’un contenu publié par un membre qui n’est ni un tutoriel ni un article.</li>
         <li>Lien hypertexte : ce terme désigne les liens consultables par les visiteurs menant à une autre page du même site ou vers un autre site web.</li>
-        <li>Identifiant et mot de passe : c'est l'ensemble des informations nécessaires à l'identification d'un membre sur le site. L'identifiant et le mot de passe permettent à l'utilisateur d'accéder à des services réservés aux membres du site. Le mot de passe est une information confidentielle. </li>
-=======
-        <li>Utilisateur : ce terme désigne toute personne qui utilise le site ou l’un des services proposés par le site.</li>
-        <li>Membre : l’utilisateur devient un &laquo; Membre &raquo; dès son inscription sur le site.</li>
-        <li>Contenu de l’utilisateur : ce sont les données transmises par l’utilisateur sur le site.</li>
-        <li>Message : il s’agit d’un contenu publié par un membre qui n’est ni un tutoriel ni un article.</li>
-        <li>Lien hypertexte : ce terme désigne les liens consultables par les visiteurs menant à une autre page du même site ou vers un autre site web.</li>
-        <li>Identifiant et mot de passe : c’est l’ensemble des informations nécessaires à l’identification d’un membre sur le site. L’identifiant et le mot de passe permettent à l’utilisateur d’accéder à des services réservés aux membres du site. Le mot de passe est une information confidentielle. </li>
->>>>>>> Ajoute des apostrophes manquantes
+        <li>Identifiant et mot de passe : c’est l’ensemble des informations nécessaires à l’identification d’un membre sur le site. L’identifiant et le mot de passe permettent à l’utilisateur d’accéder à des services réservés aux membres du site. Le mot de passe est une information confidentielle. </li>
     </ul>
 
     <h3>4. Accès au site</h3>
@@ -131,11 +122,7 @@
         Le membre reste titulaire de l’intégralité de ses droits de propriété intellectuelle sur l’ensemble du contenu qu’il publie (articles, billets, tutoriels, de même que le contenu publié sur les forums). Mais par la mise en ligne d’un tutoriel,  ou article, il autorise gratuitement et sans clause d’exclusivité l’éditeur du site à représenter, modifier, adapter et diffuser sa publication sur le site, pour la durée de la propriété intellectuelle. Il autorise notamment l’éditeur du site à utiliser sa publication sur Internet dans le but de faire connaître le site.
     </p>
     <p>
-<<<<<<< a8eb1160d3039adbc79aaa2d67d5a0cf18393e52
-        L'auteur d'un tutoriel, d'un billet ou d'un article a également la possibilité de mettre sa publication en ligne selon la licence &ldquo;CC&rdquo; (Creative Commons) qui lui convient le mieux parmi les licences CC suivantes :
-=======
-        L’auteur d’un tutoriel, d’un billet ou d’un article a également la possibilité de mettre sa publication en ligne selon la licence &ldquo;CC&rdquo; (Creative Commons) qui lui convient le mieux parmi les licences CC suivantes :
->>>>>>> Ajoute des apostrophes manquantes
+        L’auteur d’un tutoriel, d’un billet ou d’un article a également la possibilité de mettre sa publication en ligne selon la licence &ldquo;CC&rdquo; (Creative Commons) qui lui convient le mieux parmi les licences CC suivantes :
     </p>
     <ul>
         <li>Licence CC 0 1.0 - <a href="http://creativecommons.org/publicdomain/zero/1.0/">Lire le résumé explicatif de la licence</a></li>
@@ -165,11 +152,7 @@
         Après inscription, tout membre dispose d’une page de profil personnelle. Ce profil recense l’ensemble de l’activité du membre sur le site (forums, signature, avatar,  articles, billets, tutoriels) à l’exception des informations d’inscription (nom, prénom, adresse courriel, ...) et correspondances (via le système de messagerie privée) privées.
     </p>
     <p>
-<<<<<<< a8eb1160d3039adbc79aaa2d67d5a0cf18393e52
-        Cette page de profil, accessible à tous les membres, a pour objet de permettre au membre de se présenter. Le membre est libre d'ajouter une photographie le représentant, un avatar et d'autres informations supplémentaires : biographie, formations et emploi, l'adresse des sites et/ou blog et/ou portfolio présentant les travaux du membre, comptes sur les réseaux sociaux et toute autre information au choix du membre.
-=======
-        Cette page de profil, accessible à tous les membres, a pour objet de permettre au membre de se présenter. Le membre est libre d’ajouter une photographie le représentant, un avatar et d’autres informations supplémentaires : biographie, formations et emploi, l’adresse des sites et/ou blog et/ou portfolio présentant les travaux du membre, comptes sur les réseaux sociaux et toute autre information au choix du membre.
->>>>>>> Ajoute des apostrophes manquantes
+        Cette page de profil, accessible à tous les membres, a pour objet de permettre au membre de se présenter. Le membre est libre d'ajouter une photographie le représentant, un avatar et d'autres informations supplémentaires : biographie, formations et emploi, l’adresse des sites et/ou blog et/ou portfolio présentant les travaux du membre, comptes sur les réseaux sociaux et toute autre information au choix du membre.
     </p>
     <p>
         L’éditeur ne peut être tenu responsable des informations données par le membre sur cette page de profil. En effet, le membre doit donc veiller à ne fournir que des informations qu’il souhaite communiquer aux autres membres, le contenu de cette page étant sous sa responsabilité.
@@ -198,11 +181,7 @@
         Toutes les données à caractère personnel transmises par les utilisateurs et membres du site sont recueillies dans le plus strict respect de la législation. Elles ont pour finalité une meilleure utilisation de {{ app.site.dns }} et sont donc utilisées par l’éditeur du site à cette fin.
     </p>
     <p>
-<<<<<<< a8eb1160d3039adbc79aaa2d67d5a0cf18393e52
-        Lors de son inscription, il est requis de l'utilisateur de fournir des informations le concernant. En particulier, l'adresse électronique pourra être utilisée par le site pour l'administration et la communication d'informations touchant l'ensemble des membres du site (par exemple : une modification importante de la structure du site, l'ajout de fonctionnalités, une modification des présentes conditions, les dernières publications du site (newsletter), etc.).
-=======
-        Lors de son inscription, il est requis de l’utilisateur de fournir des informations le concernant. En particulier, l’adresse électronique pourra être utilisée par le site pour l’administration et la communication d’informations touchant l’ensemble des membres du site (par exemple : une modification importante de la structure du site, l’ajout de fonctionnalités, une modification des présentes conditions, les dernières publications du site (newsletter), etc.).
->>>>>>> Ajoute des apostrophes manquantes
+        Lors de son inscription, il est requis de l’utilisateur de fournir des informations le concernant. En particulier, l’adresse électronique pourra être utilisée par le site pour l’administration et la communication d’informations touchant l’ensemble des membres du site (par exemple : une modification importante de la structure du site, l’ajout de fonctionnalités, une modification des présentes conditions, les dernières publications du site (newsletter), etc.).
     </p>
     <p>
         Le membre a le choix s’abonner ou non à la newsletter.

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -23,10 +23,10 @@
 
 {% block content %}
     <ul>
-        <li><a href="{% url "pages-eula" %}"><abbr title="{% trans "Conditions générales d'utilisation" %}">{% trans "CGU" %}</abbr></a></li>
+        <li><a href="{% url "pages-eula" %}"><abbr title="{% trans "Conditions générales d’utilisation" %}">{% trans "CGU" %}</abbr></a></li>
         <li><a href="{% url "pages-about" %}">{% trans "À propos" %}</a></li>
         {% if app.site.association %}
-            <li><a href="{% url "pages-association" %}">{% trans "L'association" %}</a></li>
+            <li><a href="{% url "pages-association" %}">{% trans "L’association" %}</a></li>
             {% if user.is_authenticated %}
                 <li><a href="{% url "pages-assoc-subscribe" %}">{% trans "Adhérer" %}</a></li>
             {% endif %}


### PR DESCRIPTION
Utilise des apostrophes typographiques dans les templates (`/pages/*` **uniquement**) à la place des `'`.

Numéro du ticket concerné : #4585 

**Nécessite de mettre à jour les fichiers de traduction pour les instances qui les utilisent.**

### Contrôle qualité

  - Vérifier que l'affichage est correct.
