### PR TITLE
Met à jour le README et la documentation pour Python3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Zeste de Savoir
 
-Site internet communautaire codé à l'aide du framework [Django](https://www.djangoproject.com/) 1.10 et de [Python](https://www.python.org/) 2.7.
+Site internet communautaire codé à l'aide du framework [Django](https://www.djangoproject.com/) 1.10 et de [Python](https://www.python.org/) 3.5.
 
 [Voir l'instance en ligne](https://zestedesavoir.com).
 
@@ -47,8 +47,8 @@ Elles sont reportées essentiellement dans le [*bug tracker*](https://github.com
 Après avoir mis à jour votre dépôt, vous devez exécuter les commandes suivantes (depuis la racine de votre projet) pour mettre à jour les dépendances.
 
 ```console
-pip install --upgrade -r requirements.txt -r requirements-dev.txt
-python manage.py migrate --fake-initial
+pip3 install --upgrade -r requirements.txt -r requirements-dev.txt
+python3 manage.py migrate --fake-initial
 ```
 
 
@@ -57,14 +57,14 @@ python manage.py migrate --fake-initial
 Pour bénéficier de données de test, exécutez les commandes suivantes, dans l'ordre, à la fin des précédentes :
 
 ```console
-python manage.py loaddata fixtures/*.yaml
-python manage.py load_factory_data fixtures/advanced/aide_tuto_media.yaml
+python3 manage.py loaddata fixtures/*.yaml
+python3 manage.py load_factory_data fixtures/advanced/aide_tuto_media.yaml
 ```
 Si vous êtes sur Windows, la première commande ne fonctionnera pas, préférez ceci :
 
 ```console
-python .\manage.py loaddata (dir .\fixtures\*.yaml)
-python .\manage.py load_factory_data .\fixtures\advanced\aide_tuto_media.yaml
+python3 .\manage.py loaddata (dir .\fixtures\*.yaml)
+python3 .\manage.py load_factory_data .\fixtures\advanced\aide_tuto_media.yaml
 ```
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -2,7 +2,7 @@
 Documentation de Zeste De Savoir
 ================================
 
-Zeste de Savoir est un site internet communautaire codé à l'aide du framework Django 1.10 et de Python 2.7
+Zeste de Savoir est un site internet communautaire codé à l'aide du framework Django 1.10 et de Python 3.5.
 
 `Voir l'instance en ligne <https://zestedesavoir.com>`_
 

--- a/doc/source/install/backend-linux-install.rst
+++ b/doc/source/install/backend-linux-install.rst
@@ -16,13 +16,13 @@ Certaines des commandes d'installation (débutant par ``apt-get``) sont données
 ZdS a besoin des dépendances suivantes, installables manuellement ou à l'aide d'un Makefile (voir plus bas) :
 
 - git : ``apt-get install git``
-- python2.7
+- python3.5
 - python-dev : ``apt-get install python-dev``
 - easy_install : ``apt-get install python-setuptools``
-- pip : ``easy_install pip``
+- pip3 : ``apt-get install python3-pip``
 - tox : ``pip install tox``
 - libxml2-dev : ``apt-get install libxml2-dev``
-- python-lxml : ``apt-get install python-lxml``
+- python-lxml : ``apt-get install python3-lxml``
 - libxlst-dev (peut être appelée libxlst1-dev sur certains OS comme Ubuntu)
 - libz-dev (peut être libz1g-dev sur système 64bits)
 - python-sqlparse
@@ -65,8 +65,8 @@ Installation et configuration de `virtualenv`
 
 .. sourcecode:: bash
 
-    pip install --user virtualenv # Ajout du module virtualenv
-    virtualenv zdsenv --python=python2 # Création du répertoire "zdsenv"
+    pip3 install --user virtualenv # Ajout du module virtualenv
+    virtualenv zdsenv --python=python3 # Création du répertoire "zdsenv"
 
 
 **À chaque fois** que vous souhaitez travailler dans votre environnement, activez-le via la commande suivante :

--- a/doc/source/install/backend-windows-install.rst
+++ b/doc/source/install/backend-windows-install.rst
@@ -37,17 +37,17 @@ Prérequis
     - `PowerShell 3.0+ <http://www.microsoft.com/fr-fr/download/details.aspx?id=40855>`_. Uniquement pour les PC tournant sous Windows 7 ou antérieur (installé par défaut avec Windows depuis).
     - `Git <http://git-scm.com/download/win>`_ (Git pour Eclipse ne suffit pas ; associez les .sh).
     - `gettext <https://www.gnu.org/software/gettext/>`_.
-- `Téléchargez et installez Python 2.7 <https://www.python.org/download/releases/2.7/>`_.
+- `Téléchargez et installez Python 3.5 <https://www.python.org/downloads/release/python-352/>`_.
 - Installez setuptools : Démarrez Powershell en mode administrateur et lancez la commande suivante : ``(Invoke-WebRequest https://bootstrap.pypa.io/ez_setup.py).Content | python -``
 - Décompressez l'archive ``setuptools-*XX.X.X*.zip``.
 - Avec la commande ``cd setuptools-XX.X.X``, ouvrez le répertoire possèdant *easy_install.py*.
-- Installez pip et tox : ``python easy_install.py pip tox``.
-- Vous devriez avoir un nouveau répertoire ``C:\Python27\Scripts``, rajoutez le dans le *PATH, la variable d'environnement*.
-- Réinstallez easyinstall : ``python easy_install.py easyinstall``, ça vous permettra de l'utiliser partout, (supprimez l'ancien package).
+- Installez pip et tox : ``python3 easy_install.py pip tox``.
+- Vous devriez avoir un nouveau répertoire ``C:\Python35\Scripts``, rajoutez le dans le *PATH, la variable d'environnement*.
+- Réinstallez easyinstall : ``python3 easy_install.py easyinstall``, ça vous permettra de l'utiliser partout, (supprimez l'ancien package).
 - Redémarrez Powershell (pour recharger *la variable d'environnement PATH*).
 - Installez Virtualenv avec les commandes suivante :
-    - ``pip install virtualenv``
-    - ``pip install virtualenvwrapper-powershell``
+    - ``pip3 install virtualenv``
+    - ``pip3 install virtualenvwrapper-powershell``
 - Clonez le dépot git *via la console git* (et pas via powershell) windows: ``git clone https://github.com/zestedesavoir/zds-site.git``
 - Créez votre workspace dédié à ZdS (mode administrateur obligatoire).
     - se placer dans le dossier du dépôt cloné (``zds-site``)


### PR DESCRIPTION
Met à jour les versions de Python et pip indiquées dans le README et dans la documentation.

Numéro du ticket concerné (optionnel) : Aucun.

### Contrôle qualité

- Bien vérifier que les versions et les commandes sont correctes (ainsi que [le chemin de fichier indiqué ici](https://github.com/rezemika/zds-site/blame/update-doc-readme/doc/source/install/backend-windows-install.rst#L40)).

PS : apparemment `python` et `python3` sont équivalents dans un venv avec Python3. Lequel devrais-je mettre ?