### PR TITLE
Ajoute des champs de traduction dans les modèles de "tutorialv2"

### DIFF
--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -599,7 +599,7 @@ Exemple :
 .. sourcecode:: html
 
     {% joinby fruits %}
-    {% joinby fruits ';' same_final_separator=True %}
+    {% joinby fruits ';' final_separator=';' %}
 
 .. sourcecode:: text
 

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -24,7 +24,7 @@
     <meta name="DC.type" content="text" />
     <meta name="DC.title" content="{{ content.title }}" />
     <meta name="DC.abstract" content="{{ content.type.title }} : {{ content.title }}{% if content.description %} – {{ content.description }}{% endif %}" />
-    <meta name="DC.subject" lang="fr" content="{% joinby content.subcategory.all %}{% if content.tags.all %} – {% joinby content.tags.all separator=' ; ' same_final_separator=True %}{% endif %}" />
+    <meta name="DC.subject" lang="fr" content="{% joinby content.subcategory.all %}{% if content.tags.all %} – {% joinby content.tags.all separator=' ; ' final_separator=' ; ' %}{% endif %}" />
     {% if content.description %}<meta name="DC.description" lang="fr" content="{{ content.description }}" />{% endif %}
     <meta name="DC.date" content="{% if content.pubdate %}{{ content.pubdate|date:'Y/m/d' }}{% else %}{{ content.update_date|date:'Y/m/d' }}{% endif %}" />
     <meta name="DC.format" content="text/html" />

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -20,10 +20,12 @@
 {% block DCMI_cards %}
     <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/" />
     <meta name="DC.publisher" lang="fr" content="{{ app.site.literal_name }}" />
-    <meta name="DC.creator" content="{% joinby publishablecontent|displayable_authors:True %}" />
+    {% for author in publishablecontent|displayable_authors:True %}
+    <meta name="DC.creator" content="{{ author.username }}" />
+    {% endfor %}
     <meta name="DC.type" content="text" />
     <meta name="DC.title" content="{{ content.title }}" />
-    <meta name="DC.abstract" content="{{ content.type.title }} : {{ content.title }}{% if content.description %} – {{ content.description }}{% endif %}" />
+    <meta name="DC.abstract" content="{{ content.title }}{% if content.description %} – {{ content.description }}{% endif %}" />
     <meta name="DC.subject" lang="fr" content="{% joinby content.subcategory.all %}{% if content.tags.all %} – {% joinby content.tags.all separator=' ; ' final_separator=' ; ' %}{% endif %}" />
     {% if content.description %}<meta name="DC.description" lang="fr" content="{{ content.description }}" />{% endif %}
     <meta name="DC.date" content="{% if content.pubdate %}{{ content.pubdate|date:'Y/m/d' }}{% else %}{{ content.update_date|date:'Y/m/d' }}{% endif %}" />

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -11,6 +11,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.dispatch import receiver
 from django.db.models.signals import pre_delete
+from django.utils.translation import ugettext_lazy as _
 
 from elasticsearch_dsl.field import Text, Keyword, Integer, Boolean, Float, Date
 
@@ -34,20 +35,20 @@ class Category(models.Model):
     There is no kind of logic in a Category. It simply here for Forum presentation in a predefined order.
     """
     class Meta:
-        verbose_name = 'Catégorie'
-        verbose_name_plural = 'Catégories'
+        verbose_name = _('Catégorie')
+        verbose_name_plural = _('Catégories')
         ordering = ['position', 'title']
 
-    title = models.CharField('Titre', max_length=80)
-    position = models.IntegerField('Position', default=0)
+    title = models.CharField(_('Titre'), max_length=80)
+    position = models.IntegerField(_('Position'), default=0)
     # Some category slugs are forbidden due to path collisions: Category path is `/forums/<slug>` but some actions on
     # forums have path like `/forums/<action_name>`. Forbidden slugs are all top-level path in forum's `url.py` module.
     # As Categories can only be managed by superadmin, this is purely declarative and there is no control on slug.
     slug = models.SlugField(max_length=80,
                             unique=True,
-                            help_text='Ces slugs vont provoquer des conflits '
+                            help_text=_('Ces slugs vont provoquer des conflits '
                             "d'URL et sont donc interdits : notifications "
-                            'resolution_alerte sujet sujets message messages')
+                            'resolution_alerte sujet sujets message messages'))
 
     def __str__(self):
         """Textual form of a category."""
@@ -79,8 +80,8 @@ class Forum(models.Model):
     A Forum, containing Topics. It can be public or restricted to some groups.
     """
     class Meta:
-        verbose_name = 'Forum'
-        verbose_name_plural = 'Forums'
+        verbose_name = _('Forum')
+        verbose_name_plural = _('Forums')
         ordering = ['position_in_category', 'title']
 
     title = models.CharField('Titre', max_length=80)
@@ -89,11 +90,11 @@ class Forum(models.Model):
     # Groups authorized to read this forum. If no group is defined, the forum is public (and anyone can read it).
     groups = models.ManyToManyField(
         Group,
-        verbose_name='Groupes autorisés (aucun = public)',
+        verbose_name=_('Groupes autorisés (aucun = public)'),
         blank=True)
 
-    category = models.ForeignKey(Category, db_index=True, verbose_name='Catégorie')
-    position_in_category = models.IntegerField('Position dans la catégorie',
+    category = models.ForeignKey(Category, db_index=True, verbose_name=_('Catégorie'))
+    position_in_category = models.IntegerField(_('Position dans la catégorie'),
                                                null=True, blank=True, db_index=True)
 
     slug = models.SlugField(max_length=80, unique=True)
@@ -184,34 +185,34 @@ class Topic(AbstractESDjangoIndexable):
     objects_per_batch = 1000
 
     class Meta:
-        verbose_name = 'Sujet'
-        verbose_name_plural = 'Sujets'
+        verbose_name = _('Sujet')
+        verbose_name_plural = _('Sujets')
 
-    title = models.CharField('Titre', max_length=160)
-    subtitle = models.CharField('Sous-titre', max_length=200, null=True,
+    title = models.CharField(_('Titre'), max_length=160)
+    subtitle = models.CharField(_('Sous-titre'), max_length=200, null=True,
                                 blank=True)
 
-    forum = models.ForeignKey(Forum, verbose_name='Forum', db_index=True)
-    author = models.ForeignKey(User, verbose_name='Auteur',
+    forum = models.ForeignKey(Forum, verbose_name=_('Forum'), db_index=True)
+    author = models.ForeignKey(User, verbose_name=_('Auteur'),
                                related_name='topics', db_index=True)
     last_message = models.ForeignKey('Post', null=True,
                                      related_name='last_message',
-                                     verbose_name='Dernier message')
-    pubdate = models.DateTimeField('Date de création', auto_now_add=True)
+                                     verbose_name=_('Dernier message'))
+    pubdate = models.DateTimeField(_('Date de création'), auto_now_add=True)
     update_index_date = models.DateTimeField(
-        'Date de dernière modification pour la réindexation partielle',
+        _('Date de dernière modification pour la réindexation partielle'),
         auto_now=True,
         db_index=True)
 
-    is_solved = models.BooleanField('Est résolu', default=False, db_index=True)
-    is_locked = models.BooleanField('Est verrouillé', default=False, db_index=True)
-    is_sticky = models.BooleanField('Est en post-it', default=False, db_index=True)
+    is_solved = models.BooleanField(_('Est résolu'), default=False, db_index=True)
+    is_locked = models.BooleanField(_('Est verrouillé'), default=False, db_index=True)
+    is_sticky = models.BooleanField(_('Est en post-it'), default=False, db_index=True)
 
-    github_issue = models.PositiveIntegerField('Ticket GitHub', null=True, blank=True)
+    github_issue = models.PositiveIntegerField(_('Ticket GitHub'), null=True, blank=True)
 
     tags = models.ManyToManyField(
         Tag,
-        verbose_name='Tags du forum',
+        verbose_name=_('Tags du forum'),
         blank=True,
         db_index=True)
 
@@ -477,9 +478,9 @@ class Post(Comment, AbstractESDjangoIndexable):
     """
     objects_per_batch = 2000
 
-    topic = models.ForeignKey(Topic, verbose_name='Sujet', db_index=True)
+    topic = models.ForeignKey(Topic, verbose_name=_('Sujet'), db_index=True)
 
-    is_useful = models.BooleanField('Est utile', default=False)
+    is_useful = models.BooleanField(_('Est utile'), default=False)
     objects = PostManager()
 
     def __str__(self):
@@ -576,8 +577,8 @@ class TopicRead(models.Model):
     Technically it is a simple joint [user, topic, last read post].
     """
     class Meta:
-        verbose_name = 'Sujet lu'
-        verbose_name_plural = 'Sujets lus'
+        verbose_name = _('Sujet lu')
+        verbose_name_plural = _('Sujets lus')
         unique_together = ('topic', 'user')
 
     topic = models.ForeignKey(Topic, db_index=True)

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -31,8 +31,8 @@ class Profile(models.Model):
     """
 
     class Meta:
-        verbose_name = 'Profil'
-        verbose_name_plural = 'Profils'
+        verbose_name = _('Profil')
+        verbose_name_plural = _('Profils')
         permissions = (
             ('moderation', _('Modérer un membre')),
             ('show_ip', _("Afficher les IP d'un membre")),
@@ -42,38 +42,38 @@ class Profile(models.Model):
     # See https://docs.djangoproject.com/en/1.6/topics/auth/customizing/#extending-the-existing-user-model
     user = models.OneToOneField(
         User,
-        verbose_name='Utilisateur',
+        verbose_name=_('Utilisateur'),
         related_name='profile')
 
     last_ip_address = models.CharField(
-        'Adresse IP',
+        _('Adresse IP'),
         max_length=39,
         blank=True,
         null=True)
 
-    site = models.CharField('Site internet', max_length=2000, blank=True)
-    show_email = models.BooleanField('Afficher adresse mail publiquement', default=False)
-    avatar_url = models.CharField('URL de l\'avatar', max_length=2000, null=True, blank=True)
-    biography = models.TextField('Biographie', blank=True)
-    karma = models.IntegerField('Karma', default=0)
-    sign = models.TextField('Signature', max_length=500, blank=True)
+    site = models.CharField(_('Site internet'), max_length=2000, blank=True)
+    show_email = models.BooleanField(_('Afficher adresse mail publiquement'), default=False)
+    avatar_url = models.CharField(_('URL de l\'avatar'), max_length=2000, null=True, blank=True)
+    biography = models.TextField(_('Biographie'), blank=True)
+    karma = models.IntegerField(_('Karma'), default=0)
+    sign = models.TextField(_('Signature'), max_length=500, blank=True)
     licence = models.ForeignKey(Licence,
-                                verbose_name='Licence préférée',
+                                verbose_name=_('Licence préférée'),
                                 blank=True, null=True)
-    github_token = models.TextField('GitHub', blank=True)
-    show_sign = models.BooleanField('Voir les signatures', default=True)
+    github_token = models.TextField(_('GitHub'), blank=True)
+    show_sign = models.BooleanField(_('Voir les signatures'), default=True)
     # do UI components open by hovering them, or is clicking on them required?
-    is_hover_enabled = models.BooleanField('Déroulement au survol&nbsp;?', default=False)
-    allow_temp_visual_changes = models.BooleanField('Activer les changements visuels temporaires', default=True)
-    show_markdown_help = models.BooleanField("Afficher l'aide Markdown dans l'éditeur", default=True)
-    email_for_answer = models.BooleanField('Envoyer pour les réponse MP', default=False)
-    hats = models.ManyToManyField(Hat, verbose_name='Casquettes', db_index=True, blank=True)
-    can_read = models.BooleanField('Possibilité de lire', default=True)
-    end_ban_read = models.DateTimeField("Fin d'interdiction de lecture", null=True, blank=True)
-    can_write = models.BooleanField("Possibilité d'écrire", default=True)
-    end_ban_write = models.DateTimeField("Fin d'interdiction d'écrire", null=True, blank=True)
-    last_visit = models.DateTimeField('Date de dernière visite', null=True, blank=True)
-    use_old_smileys = models.BooleanField('Utilise les anciens smileys&nbsp;?', default=False)
+    is_hover_enabled = models.BooleanField(_('Déroulement au survol&nbsp;?'), default=False)
+    allow_temp_visual_changes = models.BooleanField(_('Activer les changements visuels temporaires'), default=True)
+    show_markdown_help = models.BooleanField(_("Afficher l'aide Markdown dans l'éditeur"), default=True)
+    email_for_answer = models.BooleanField(_('Envoyer pour les réponse MP'), default=False)
+    hats = models.ManyToManyField(Hat, verbose_name=_('Casquettes'), db_index=True, blank=True)
+    can_read = models.BooleanField(_('Possibilité de lire'), default=True)
+    end_ban_read = models.DateTimeField(_("Fin d'interdiction de lecture"), null=True, blank=True)
+    can_write = models.BooleanField(_("Possibilité d'écrire"), default=True)
+    end_ban_write = models.DateTimeField(_("Fin d'interdiction d'écrire"), null=True, blank=True)
+    last_visit = models.DateTimeField(_('Date de dernière visite'), null=True, blank=True)
+    use_old_smileys = models.BooleanField(_('Utilise les anciens smileys&nbsp;?'), default=False)
     _permissions = {}
     _groups = None
 
@@ -484,12 +484,12 @@ class TokenForgotPassword(models.Model):
     This model stores the tokens for the users that have forgot their passwords, with an expiration date.
     """
     class Meta:
-        verbose_name = 'Token de mot de passe oublié'
-        verbose_name_plural = 'Tokens de mots de passe oubliés'
+        verbose_name = _('Token de mot de passe oublié')
+        verbose_name_plural = _('Tokens de mots de passe oubliés')
 
     user = models.ForeignKey(User, verbose_name='Utilisateur', db_index=True)
     token = models.CharField(max_length=100, db_index=True)
-    date_end = models.DateTimeField('Date de fin')
+    date_end = models.DateTimeField(_('Date de fin'))
 
     def get_absolute_url(self):
         """
@@ -509,12 +509,12 @@ class TokenRegister(models.Model):
     This model stores the registration token for each user, with an expiration date.
     """
     class Meta:
-        verbose_name = 'Token d\'inscription'
-        verbose_name_plural = 'Tokens  d\'inscription'
+        verbose_name = _("Token d'inscription")
+        verbose_name_plural = _("Tokens  d'inscription")
 
-    user = models.ForeignKey(User, verbose_name='Utilisateur', db_index=True)
+    user = models.ForeignKey(User, verbose_name=_('Utilisateur'), db_index=True)
     token = models.CharField(max_length=100, db_index=True)
-    date_end = models.DateTimeField('Date de fin')
+    date_end = models.DateTimeField(_('Date de fin'))
 
     def get_absolute_url(self):
         """
@@ -540,14 +540,14 @@ class NewEmailProvider(models.Model):
     """A new-used email provider which should be checked by a staff member."""
 
     class Meta:
-        verbose_name = 'Nouveau fournisseur'
-        verbose_name_plural = 'Nouveaux fournisseurs'
+        verbose_name = _('Nouveau fournisseur')
+        verbose_name_plural = _('Nouveaux fournisseurs')
 
-    provider = models.CharField('Fournisseur', max_length=253, unique=True, db_index=True)
-    use = models.CharField('Utilisation', max_length=11, choices=NEW_PROVIDER_USES)
-    user = models.ForeignKey(User, verbose_name='Utilisateur concerné', on_delete=models.CASCADE,
+    provider = models.CharField(_('Fournisseur'), max_length=253, unique=True, db_index=True)
+    use = models.CharField(_('Utilisation'), max_length=11, choices=NEW_PROVIDER_USES)
+    user = models.ForeignKey(User, verbose_name=_('Utilisateur concerné'), on_delete=models.CASCADE,
                              related_name='new_providers', db_index=True)
-    date = models.DateTimeField("Date de l'alerte", auto_now_add=True, db_index=True,
+    date = models.DateTimeField(_("Date de l'alerte"), auto_now_add=True, db_index=True,
                                 db_column='alert_date')
 
     def __str__(self):
@@ -562,13 +562,13 @@ class BannedEmailProvider(models.Model):
     """
 
     class Meta:
-        verbose_name = 'Fournisseur banni'
-        verbose_name_plural = 'Fournisseurs bannis'
+        verbose_name = _('Fournisseur banni')
+        verbose_name_plural = _('Fournisseurs bannis')
 
-    provider = models.CharField('Fournisseur', max_length=253, unique=True, db_index=True)
-    moderator = models.ForeignKey(User, verbose_name='Modérateur', on_delete=models.CASCADE,
+    provider = models.CharField(_('Fournisseur'), max_length=253, unique=True, db_index=True)
+    moderator = models.ForeignKey(User, verbose_name=_('Modérateur'), on_delete=models.CASCADE,
                                   related_name='banned_providers', db_index=True)
-    date = models.DateTimeField('Date du bannissement', auto_now_add=True, db_index=True,
+    date = models.DateTimeField(_('Date du bannissement'), auto_now_add=True, db_index=True,
                                 db_column='ban_date')
 
     def __str__(self):
@@ -584,14 +584,14 @@ class Ban(models.Model):
     """
 
     class Meta:
-        verbose_name = 'Sanction'
-        verbose_name_plural = 'Sanctions'
+        verbose_name = _('Sanction')
+        verbose_name_plural = _('Sanctions')
 
-    user = models.ForeignKey(User, verbose_name='Sanctionné', db_index=True)
-    moderator = models.ForeignKey(User, verbose_name='Moderateur', related_name='bans', db_index=True)
-    type = models.CharField('Type', max_length=80, db_index=True)
-    note = models.TextField('Explication de la sanction')
-    pubdate = models.DateTimeField('Date de publication', blank=True, null=True, db_index=True)
+    user = models.ForeignKey(User, verbose_name=_('Sanctionné'), db_index=True)
+    moderator = models.ForeignKey(User, verbose_name=_('Moderateur'), related_name='bans', db_index=True)
+    type = models.CharField(_('Type'), max_length=80, db_index=True)
+    note = models.TextField(_('Explication de la sanction'))
+    pubdate = models.DateTimeField(_('Date de publication'), blank=True, null=True, db_index=True)
 
     def __str__(self):
         return '{0} - ban : {1} ({2}) '.format(self.user.username, self.note, self.pubdate)
@@ -609,14 +609,14 @@ class KarmaNote(models.Model):
     - some amount of karma, negative values being… negative
     """
     class Meta:
-        verbose_name = 'Note de karma'
-        verbose_name_plural = 'Notes de karma'
+        verbose_name = _('Note de karma')
+        verbose_name_plural = _('Notes de karma')
 
     user = models.ForeignKey(User, related_name='karmanote_user', db_index=True)
     moderator = models.ForeignKey(User, related_name='karmanote_staff', db_index=True)
-    note = models.CharField('Commentaire', max_length=150)
-    karma = models.IntegerField('Valeur')
-    pubdate = models.DateTimeField('Date d\'ajout', auto_now_add=True)
+    note = models.CharField(_('Commentaire'), max_length=150)
+    karma = models.IntegerField(_('Valeur'))
+    pubdate = models.DateTimeField(_("Date d'ajout"), auto_now_add=True)
 
     def __str__(self):
         return '{0} - note : {1} ({2}) '.format(self.user.username, self.note, self.pubdate)

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db import models
+from django.utils.translation import ugettext_lazy as _
 
 from zds.mp.managers import PrivateTopicManager, PrivatePostManager
 from zds.notification import signals
@@ -20,17 +21,17 @@ class PrivateTopic(models.Model):
     """
 
     class Meta:
-        verbose_name = 'Message privé'
-        verbose_name_plural = 'Messages privés'
+        verbose_name = _('Message privé')
+        verbose_name_plural = _('Messages privés')
 
-    title = models.CharField('Titre', max_length=130)
-    subtitle = models.CharField('Sous-titre', max_length=200, blank=True)
+    title = models.CharField(_('Titre'), max_length=130)
+    subtitle = models.CharField(_('Sous-titre'), max_length=200, blank=True)
     author = models.ForeignKey(User, verbose_name='Auteur', related_name='author', db_index=True)
-    participants = models.ManyToManyField(User, verbose_name='Participants', related_name='participants',
+    participants = models.ManyToManyField(User, verbose_name=_('Participants'), related_name='participants',
                                           db_index=True)
     last_message = models.ForeignKey('PrivatePost', null=True, related_name='last_message',
-                                     verbose_name='Dernier message')
-    pubdate = models.DateTimeField('Date de création', auto_now_add=True, db_index=True)
+                                     verbose_name=_('Dernier message'))
+    pubdate = models.DateTimeField(_('Date de création'), auto_now_add=True, db_index=True)
     objects = PrivateTopicManager()
 
     def __str__(self):
@@ -214,16 +215,16 @@ class PrivatePost(models.Model):
     """A private post written by a user."""
 
     class Meta:
-        verbose_name = 'Réponse à un message privé'
-        verbose_name_plural = 'Réponses à un message privé'
+        verbose_name = _('Réponse à un message privé')
+        verbose_name_plural = _('Réponses à un message privé')
 
-    privatetopic = models.ForeignKey(PrivateTopic, verbose_name='Message privé', db_index=True)
+    privatetopic = models.ForeignKey(PrivateTopic, verbose_name=_('Message privé'), db_index=True)
     author = models.ForeignKey(User, verbose_name='Auteur', related_name='privateposts', db_index=True)
-    text = models.TextField('Texte')
-    text_html = models.TextField('Texte en HTML')
-    pubdate = models.DateTimeField('Date de publication', auto_now_add=True, db_index=True)
-    update = models.DateTimeField('Date d\'édition', null=True, blank=True)
-    position_in_topic = models.IntegerField('Position dans le sujet', db_index=True)
+    text = models.TextField(_('Texte'))
+    text_html = models.TextField(_('Texte en HTML'))
+    pubdate = models.DateTimeField(_('Date de publication'), auto_now_add=True, db_index=True)
+    update = models.DateTimeField(_("Date d'édition"), null=True, blank=True)
+    position_in_topic = models.IntegerField(_('Position dans le sujet'), db_index=True)
     hat = models.ForeignKey('utils.Hat', on_delete=models.SET_NULL, verbose_name='Casquette',
                             related_name='privateposts', blank=True, null=True)
     objects = PrivatePostManager()
@@ -297,8 +298,8 @@ class PrivateTopicRead(models.Model):
     """
 
     class Meta:
-        verbose_name = 'Message privé lu'
-        verbose_name_plural = 'Messages privés lus'
+        verbose_name = _('Message privé lu')
+        verbose_name_plural = _('Messages privés lus')
 
     privatetopic = models.ForeignKey(PrivateTopic, db_index=True)
     privatepost = models.ForeignKey(PrivatePost, db_index=True)

--- a/zds/searchv2/models.py
+++ b/zds/searchv2/models.py
@@ -14,6 +14,7 @@ from elasticsearch_dsl.query import MatchAll
 from elasticsearch_dsl.connections import connections
 
 from django.db import transaction
+from django.utils.translation import ugettext_lazy as _
 
 
 def es_document_mapper(force_reindexing, index, obj):
@@ -165,8 +166,8 @@ class AbstractESDjangoIndexable(AbstractESIndexable, models.Model):
     class Meta:
         abstract = True
 
-    es_flagged = models.BooleanField('Doit être (ré)indexé par ES', default=True, db_index=True)
-    es_already_indexed = models.BooleanField('Déjà indexé par ES', default=False, db_index=True)
+    es_flagged = models.BooleanField(_('Doit être (ré)indexé par ES'), default=True, db_index=True)
+    es_already_indexed = models.BooleanField(_('Déjà indexé par ES'), default=False, db_index=True)
 
     def __init__(self, *args, **kwargs):
         """Override to match ES ``_id`` field and ``pk``"""

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-
 from django.db.models import CASCADE
 from django.utils.encoding import python_2_unicode_compatible
 from datetime import datetime
@@ -68,83 +67,83 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
     - Type, which is either "ARTICLE" "TUTORIAL" or "OPINION"
     """
     class Meta:
-        verbose_name = 'Contenu'
-        verbose_name_plural = 'Contenus'
+        verbose_name = _('Contenu')
+        verbose_name_plural = _('Contenus')
 
     content_type_attribute = 'type'
-    title = models.CharField('Titre', max_length=80)
-    slug = models.CharField('Slug', max_length=80)
-    description = models.CharField('Description', max_length=200)
-    source = models.CharField('Source', max_length=200, blank=True, null=True)
-    authors = models.ManyToManyField(User, verbose_name='Auteurs', db_index=True)
+    title = models.CharField(_('Titre'), max_length=80)
+    slug = models.CharField(_('Slug'), max_length=80)
+    description = models.CharField(_('Description'), max_length=200)
+    source = models.CharField(_('Source'), max_length=200, blank=True, null=True)
+    authors = models.ManyToManyField(User, verbose_name=_('Auteurs'), db_index=True)
     old_pk = models.IntegerField(db_index=True, default=0)
     subcategory = models.ManyToManyField(SubCategory,
-                                         verbose_name='Sous-Catégorie',
+                                         verbose_name=_('Sous-Catégorie'),
                                          blank=True, db_index=True)
 
-    tags = models.ManyToManyField(Tag, verbose_name='Tags du contenu', blank=True, db_index=True)
+    tags = models.ManyToManyField(Tag, verbose_name=_('Tags du contenu'), blank=True, db_index=True)
     # store the thumbnail for tutorial or article
     image = models.ForeignKey(Image,
-                              verbose_name='Image du tutoriel',
+                              verbose_name=_('Image du tutoriel'),
                               blank=True, null=True,
                               on_delete=models.SET_NULL)
 
     # every publishable content has its own gallery to manage images
     gallery = models.ForeignKey(Gallery,
-                                verbose_name="Galerie d'images",
+                                verbose_name=_("Galerie d'images"),
                                 blank=True, null=True, db_index=True)
 
-    creation_date = models.DateTimeField('Date de création')
-    pubdate = models.DateTimeField('Date de publication',
+    creation_date = models.DateTimeField(_('Date de création'))
+    pubdate = models.DateTimeField(_('Date de publication'),
                                    blank=True, null=True, db_index=True)
-    update_date = models.DateTimeField('Date de mise à jour',
+    update_date = models.DateTimeField(_('Date de mise à jour'),
                                        blank=True, null=True)
 
-    picked_date = models.DateTimeField('Date de mise en avant', db_index=True, blank=True, null=True, default=None)
+    picked_date = models.DateTimeField(_('Date de mise en avant'), db_index=True, blank=True, null=True, default=None)
 
-    sha_public = models.CharField('Sha1 de la version publique',
+    sha_public = models.CharField(_('Sha1 de la version publique'),
                                   blank=True, null=True, max_length=80, db_index=True)
-    sha_beta = models.CharField('Sha1 de la version beta publique',
+    sha_beta = models.CharField(_('Sha1 de la version beta publique'),
                                 blank=True, null=True, max_length=80, db_index=True)
-    sha_validation = models.CharField('Sha1 de la version en validation',
+    sha_validation = models.CharField(_('Sha1 de la version en validation'),
                                       blank=True, null=True, max_length=80, db_index=True)
-    sha_draft = models.CharField('Sha1 de la version de rédaction',
+    sha_draft = models.CharField(_('Sha1 de la version de rédaction'),
                                  blank=True, null=True, max_length=80, db_index=True)
-    sha_picked = models.CharField('Sha1 de la version choisie (contenus publiés sans validation)',
+    sha_picked = models.CharField(_('Sha1 de la version choisie (contenus publiés sans validation)'),
                                   blank=True, null=True, max_length=80, db_index=True)
-    beta_topic = models.ForeignKey(Topic, verbose_name='Sujet beta associé', default=None, blank=True, null=True)
+    beta_topic = models.ForeignKey(Topic, verbose_name=_('Sujet beta associé'), default=None, blank=True, null=True)
     licence = models.ForeignKey(Licence,
-                                verbose_name='Licence',
+                                verbose_name=_('Licence'),
                                 blank=True, null=True, db_index=True)
     # as of ZEP 12 this field is no longer the size but the type of content (article/tutorial/opinion)
     type = models.CharField(max_length=10, choices=TYPE_CHOICES, db_index=True)
     # zep03 field
-    helps = models.ManyToManyField(HelpWriting, verbose_name='Aides', blank=True, db_index=True)
+    helps = models.ManyToManyField(HelpWriting, verbose_name=_('Aides'), blank=True, db_index=True)
 
     relative_images_path = models.CharField(
-        'chemin relatif images',
+        _('chemin relatif images'),
         blank=True,
         null=True,
         max_length=200)
 
     last_note = models.ForeignKey('ContentReaction', blank=True, null=True,
                                   related_name='last_note',
-                                  verbose_name='Derniere note')
-    is_locked = models.BooleanField('Est verrouillé', default=False)
-    js_support = models.BooleanField('Support du Javascript', default=False)
+                                  verbose_name=_('Derniere note'))
+    is_locked = models.BooleanField(_('Est verrouillé'), default=False)
+    js_support = models.BooleanField(_('Support du Javascript'), default=False)
 
-    must_reindex = models.BooleanField('Si le contenu doit-être ré-indexé', default=True)
+    must_reindex = models.BooleanField(_('Si le contenu doit-être ré-indexé'), default=True)
 
-    is_obsolete = models.BooleanField('Est obsolète', default=False)
+    is_obsolete = models.BooleanField(_('Est obsolète'), default=False)
 
     public_version = models.ForeignKey(
-        'PublishedContent', verbose_name='Version publiée', blank=True, null=True, on_delete=models.SET_NULL)
+        'PublishedContent', verbose_name=_('Version publiée'), blank=True, null=True, on_delete=models.SET_NULL)
 
     # FK to an opinion which has been converted to article. Useful to keep track of history and
     # to add a canonical link
     converted_to = models.ForeignKey(
         'self',
-        verbose_name='Contenu promu',
+        verbose_name=_('Contenu promu'),
         blank=True,
         null=True,
         on_delete=models.SET_NULL,
@@ -1136,8 +1135,8 @@ class ContentRead(models.Model):
     It remembers the PublishableContent they read and what was the last Note at that time.
     """
     class Meta:
-        verbose_name = 'Contenu lu'
-        verbose_name_plural = 'Contenu lus'
+        verbose_name = _('Contenu lu')
+        verbose_name_plural = _('Contenu lus')
 
     content = models.ForeignKey(PublishableContent, db_index=True)
     note = models.ForeignKey(ContentReaction, db_index=True, null=True)
@@ -1162,24 +1161,24 @@ class Validation(models.Model):
     Content validation.
     """
     class Meta:
-        verbose_name = 'Validation'
-        verbose_name_plural = 'Validations'
+        verbose_name = _('Validation')
+        verbose_name_plural = _('Validations')
 
     content = models.ForeignKey(PublishableContent, null=True, blank=True,
-                                verbose_name='Contenu proposé', db_index=True)
-    version = models.CharField('Sha1 de la version',
+                                verbose_name=_('Contenu proposé'), db_index=True)
+    version = models.CharField(_('Sha1 de la version'),
                                blank=True, null=True, max_length=80, db_index=True)
-    date_proposition = models.DateTimeField('Date de proposition', db_index=True, null=True, blank=True)
-    comment_authors = models.TextField("Commentaire de l'auteur", null=True, blank=True)
+    date_proposition = models.DateTimeField(_('Date de proposition'), db_index=True, null=True, blank=True)
+    comment_authors = models.TextField(_("Commentaire de l'auteur"), null=True, blank=True)
     validator = models.ForeignKey(User,
-                                  verbose_name='Validateur',
+                                  verbose_name=_('Validateur'),
                                   related_name='author_content_validations',
                                   blank=True, null=True, db_index=True)
-    date_reserve = models.DateTimeField('Date de réservation',
+    date_reserve = models.DateTimeField(_('Date de réservation'),
                                         blank=True, null=True)
-    date_validation = models.DateTimeField('Date de validation',
+    date_validation = models.DateTimeField(_('Date de validation'),
                                            blank=True, null=True)
-    comment_validator = models.TextField('Commentaire du validateur',
+    comment_validator = models.TextField(_('Commentaire du validateur'),
                                          blank=True, null=True)
     status = models.CharField(
         max_length=10,
@@ -1233,21 +1232,21 @@ class Validation(models.Model):
 @python_2_unicode_compatible
 class PickListOperation(models.Model):
     class Meta:
-        verbose_name = "Choix d'un billet"
-        verbose_name_plural = 'Choix des billets'
+        verbose_name = _("Choix d'un billet")
+        verbose_name_plural = _('Choix des billets')
 
     content = models.ForeignKey(PublishableContent, null=False, blank=False,
-                                verbose_name='Contenu proposé', db_index=True)
+                                verbose_name=_('Contenu proposé'), db_index=True)
     operation = models.CharField(null=False, blank=False, db_index=True, max_length=len('REMOVE_PUB'),
                                  choices=PICK_OPERATIONS)
-    operation_date = models.DateTimeField(null=False, db_index=True, verbose_name="Date de l'opération")
-    version = models.CharField(null=False, blank=False, max_length=128, verbose_name='Version du billet concernée')
+    operation_date = models.DateTimeField(null=False, db_index=True, verbose_name=_("Date de l'opération"))
+    version = models.CharField(null=False, blank=False, max_length=128, verbose_name=_('Version du billet concernée'))
     staff_user = models.ForeignKey(User, null=False, blank=False, on_delete=CASCADE,
-                                   verbose_name='Modérateur', related_name='pick_operations')
+                                   verbose_name=_('Modérateur'), related_name='pick_operations')
     canceler_user = models.ForeignKey(User, null=True, blank=True, on_delete=CASCADE,
-                                      verbose_name='Modérateur qui a annulé la décision',
+                                      verbose_name=_('Modérateur qui a annulé la décision'),
                                       related_name='canceled_pick_operations')
-    is_effective = models.BooleanField(verbose_name='Choix actif', default=True)
+    is_effective = models.BooleanField(verbose_name=_('Choix actif'), default=True)
 
     def __str__(self):
         return '{} : {}'.format(self.get_operation_display(), self.content)

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -52,12 +52,12 @@ class Category(models.Model):
     """Common category for several concepts of the application."""
 
     class Meta:
-        verbose_name = 'Categorie'
-        verbose_name_plural = 'Categories'
+        verbose_name = _('Categorie')
+        verbose_name_plural = _('Categories')
 
-    title = models.CharField('Titre', unique=True, max_length=80)
-    description = models.TextField('Description')
-    position = models.IntegerField('Position', default=0, db_index=True)
+    title = models.CharField(_('Titre'), unique=True, max_length=80)
+    description = models.TextField(_('Description'))
+    position = models.IntegerField(_('Position'), default=0, db_index=True)
 
     slug = models.SlugField(max_length=80, unique=True)
 
@@ -77,11 +77,11 @@ class SubCategory(models.Model):
     """Common subcategory for several concepts of the application."""
 
     class Meta:
-        verbose_name = 'Sous-categorie'
-        verbose_name_plural = 'Sous-categories'
+        verbose_name = _('Sous-categorie')
+        verbose_name_plural = _('Sous-categories')
 
-    title = models.CharField('Titre', max_length=80, unique=True)
-    subtitle = models.CharField('Sous-titre', max_length=200)
+    title = models.CharField(_('Titre'), max_length=80, unique=True)
+    subtitle = models.CharField(_('Sous-titre'), max_length=200)
 
     image = models.ImageField(upload_to=image_path_category, blank=True, null=True)
 
@@ -119,12 +119,12 @@ class CategorySubCategory(models.Model):
     """ManyToMany between Category and SubCategory but save a boolean to know
     if category is his main category."""
     class Meta:
-        verbose_name = 'Hierarchie catégorie'
-        verbose_name_plural = 'Hierarchies catégories'
+        verbose_name = _('Hierarchie catégorie')
+        verbose_name_plural = _('Hierarchies catégories')
 
-    category = models.ForeignKey(Category, verbose_name='Catégorie', db_index=True)
-    subcategory = models.ForeignKey(SubCategory, verbose_name='Sous-Catégorie', db_index=True)
-    is_main = models.BooleanField('Est la catégorie principale', default=True, db_index=True)
+    category = models.ForeignKey(Category, verbose_name=_('Catégorie'), db_index=True)
+    subcategory = models.ForeignKey(SubCategory, verbose_name=_('Sous-Catégorie'), db_index=True)
+    is_main = models.BooleanField(_('Est la catégorie principale'), default=True, db_index=True)
 
     def __str__(self):
         """Textual Link Form."""
@@ -143,12 +143,12 @@ class Licence(models.Model):
 
     """Publication licence."""
     class Meta:
-        verbose_name = 'Licence'
-        verbose_name_plural = 'Licences'
+        verbose_name = _('Licence')
+        verbose_name_plural = _('Licences')
 
-    code = models.CharField('Code', max_length=20)
-    title = models.CharField('Titre', max_length=80)
-    description = models.TextField('Description')
+    code = models.CharField(_('Code'), max_length=20)
+    title = models.CharField(_('Titre'), max_length=80)
+    description = models.TextField(_('Description'))
 
     def __str__(self):
         """Textual Licence Form."""
@@ -166,13 +166,13 @@ class Hat(models.Model):
     that a moderation message was posted by a staff member.
     """
 
-    name = models.CharField('Casquette', max_length=40, unique=True)
+    name = models.CharField(_('Casquette'), max_length=40, unique=True)
     group = models.ForeignKey(Group, on_delete=models.SET_NULL, verbose_name='Groupe possédant la casquette',
                               related_name='hats', db_index=True, null=True, blank=True)
 
     class Meta:
-        verbose_name = 'Casquette'
-        verbose_name_plural = 'Casquettes'
+        verbose_name = _('Casquette')
+        verbose_name_plural = _('Casquettes')
 
     def __str__(self):
         return self.name
@@ -184,16 +184,16 @@ class HatRequest(models.Model):
     A hat requested by a user.
     """
 
-    user = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name='Utilisateur',
+    user = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name=_('Utilisateur'),
                              related_name='requested_hats')
-    hat = models.CharField('Casquette', max_length=40)
-    reason = models.TextField('Raison de la demande', max_length=3000)
+    hat = models.CharField(_('Casquette'), max_length=40)
+    reason = models.TextField(_('Raison de la demande'), max_length=3000)
     date = models.DateTimeField(auto_now_add=True, db_index=True,
-                                verbose_name='Date de la demande', db_column='request_date')
+                                verbose_name=_('Date de la demande'), db_column='request_date')
 
     class Meta:
-        verbose_name = 'Demande de casquette'
-        verbose_name_plural = 'Demandes de casquettes'
+        verbose_name = _('Demande de casquette')
+        verbose_name_plural = _('Demandes de casquettes')
 
     def __str__(self):
         return 'Hat {0} requested by {1}'.format(
@@ -241,40 +241,40 @@ class Comment(models.Model):
 
     """Comment in forum, articles, tutorial, chapter, etc."""
     class Meta:
-        verbose_name = 'Commentaire'
-        verbose_name_plural = 'Commentaires'
+        verbose_name = _('Commentaire')
+        verbose_name_plural = _('Commentaires')
 
     objects = InheritanceManager()
 
-    author = models.ForeignKey(User, verbose_name='Auteur',
+    author = models.ForeignKey(User, verbose_name=_('Auteur'),
                                related_name='comments', db_index=True)
-    editor = models.ForeignKey(User, verbose_name='Editeur',
+    editor = models.ForeignKey(User, verbose_name=_('Editeur'),
                                related_name='comments-editor+',
                                null=True, blank=True)
-    ip_address = models.CharField('Adresse IP de l\'auteur ', max_length=39)
+    ip_address = models.CharField(_("Adresse IP de l\'auteur"), max_length=39)
 
-    position = models.IntegerField('Position', db_index=True)
+    position = models.IntegerField(_('Position'), db_index=True)
 
-    text = models.TextField('Texte')
-    text_html = models.TextField('Texte en Html')
+    text = models.TextField(_('Texte'))
+    text_html = models.TextField(_('Texte en Html'))
 
-    like = models.IntegerField('Likes', default=0)
-    dislike = models.IntegerField('Dislikes', default=0)
+    like = models.IntegerField(_('Likes'), default=0)
+    dislike = models.IntegerField(_('Dislikes'), default=0)
 
-    pubdate = models.DateTimeField('Date de publication', auto_now_add=True, db_index=True)
-    update = models.DateTimeField('Date d\'édition', null=True, blank=True)
+    pubdate = models.DateTimeField(_('Date de publication'), auto_now_add=True, db_index=True)
+    update = models.DateTimeField(_("Date d'édition"), null=True, blank=True)
     update_index_date = models.DateTimeField(
-        'Date de dernière modification pour la réindexation partielle',
+        _('Date de dernière modification pour la réindexation partielle'),
         auto_now=True,
         db_index=True)
 
-    is_visible = models.BooleanField('Est visible', default=True)
+    is_visible = models.BooleanField(_('Est visible'), default=True)
     text_hidden = models.CharField(
-        'Texte de masquage ',
+        _('Texte de masquage'),
         max_length=80,
         default='')
 
-    hat = models.ForeignKey(Hat, verbose_name='Casquette', on_delete=models.SET_NULL,
+    hat = models.ForeignKey(Hat, verbose_name=_('Casquette'), on_delete=models.SET_NULL,
                             related_name='comments', blank=True, null=True)
 
     def update_content(self, text):
@@ -351,19 +351,19 @@ class CommentEdit(models.Model):
     """Archive for editing a comment."""
 
     class Meta:
-        verbose_name = "Édition d'un message"
-        verbose_name_plural = 'Éditions de messages'
+        verbose_name = _("Édition d'un message")
+        verbose_name_plural = _('Éditions de messages')
 
-    comment = models.ForeignKey(Comment, on_delete=models.CASCADE, verbose_name='Message',
+    comment = models.ForeignKey(Comment, on_delete=models.CASCADE, verbose_name=_('Message'),
                                 related_name='edits', db_index=True)
-    editor = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name='Éditeur',
+    editor = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name=_('Éditeur'),
                                related_name='edits', db_index=True)
     date = models.DateTimeField(auto_now_add=True, db_index=True,
-                                verbose_name="Date de l'édition", db_column='edit_date')
-    original_text = models.TextField("Contenu d'origine", blank=True)
-    deleted_at = models.DateTimeField(db_index=True, verbose_name='Date de suppression',
+                                verbose_name=_("Date de l'édition"), db_column='edit_date')
+    original_text = models.TextField(_("Contenu d'origine"), blank=True)
+    deleted_at = models.DateTimeField(db_index=True, verbose_name=_('Date de suppression'),
                                       blank=True, null=True)
-    deleted_by = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name='Supprimé par',
+    deleted_by = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name=_('Supprimé par'),
                                    related_name='deleted_edits', db_index=True,
                                    null=True, blank=True)
 
@@ -383,44 +383,44 @@ class Alert(models.Model):
     SCOPE_CHOICES_DICT = dict(SCOPE_CHOICES)
 
     author = models.ForeignKey(User,
-                               verbose_name='Auteur',
+                               verbose_name=_('Auteur'),
                                related_name='alerts',
                                db_index=True)
     comment = models.ForeignKey(Comment,
-                                verbose_name='Commentaire',
+                                verbose_name=_('Commentaire'),
                                 related_name='alerts_on_this_comment',
                                 db_index=True,
                                 null=True,
                                 blank=True)
     # use of string definition of pk to avoid circular import.
     content = models.ForeignKey('tutorialv2.PublishableContent',
-                                verbose_name='Contenu',
+                                verbose_name=_('Contenu'),
                                 related_name='alerts_on_this_content',
                                 db_index=True,
                                 null=True,
                                 blank=True)
     scope = models.CharField(max_length=10, choices=SCOPE_CHOICES, db_index=True)
-    text = models.TextField("Texte d'alerte")
-    pubdate = models.DateTimeField('Date de création', db_index=True)
-    solved = models.BooleanField('Est résolue', default=False)
+    text = models.TextField(_("Texte d'alerte"))
+    pubdate = models.DateTimeField(_('Date de création'), db_index=True)
+    solved = models.BooleanField(_('Est résolue'), default=False)
     moderator = models.ForeignKey(User,
-                                  verbose_name='Modérateur',
+                                  verbose_name=_('Modérateur'),
                                   related_name='solved_alerts',
                                   db_index=True,
                                   null=True,
                                   blank=True)
     # sent to the alert creator
-    resolve_reason = models.TextField('Texte de résolution',
+    resolve_reason = models.TextField(_('Texte de résolution'),
                                       null=True,
                                       blank=True)
     # PrivateTopic sending the resolve_reason to the alert creator
     privatetopic = models.ForeignKey(PrivateTopic,
                                      on_delete=models.SET_NULL,
-                                     verbose_name='Message privé',
+                                     verbose_name=_('Message privé'),
                                      db_index=True,
                                      null=True,
                                      blank=True)
-    solved_date = models.DateTimeField('Date de résolution',
+    solved_date = models.DateTimeField(_('Date de résolution'),
                                        db_index=True,
                                        null=True,
                                        blank=True)
@@ -471,8 +471,8 @@ class Alert(models.Model):
         return self.text
 
     class Meta:
-        verbose_name = 'Alerte'
-        verbose_name_plural = 'Alertes'
+        verbose_name = _('Alerte')
+        verbose_name_plural = _('Alertes')
 
 
 @python_2_unicode_compatible
@@ -480,13 +480,13 @@ class CommentVote(models.Model):
 
     """Set of comment votes."""
     class Meta:
-        verbose_name = 'Vote'
-        verbose_name_plural = 'Votes'
+        verbose_name = _('Vote')
+        verbose_name_plural = _('Votes')
         unique_together = ('user', 'comment')
 
     comment = models.ForeignKey(Comment, db_index=True)
     user = models.ForeignKey(User, db_index=True)
-    positive = models.BooleanField('Est un vote positif', default=True)
+    positive = models.BooleanField(_('Est un vote positif'), default=True)
 
     def __str__(self):
         return 'Vote from {} about Comment#{} thumb_up={}'.format(self.user.username, self.comment.pk, self.positive)
@@ -498,11 +498,11 @@ class Tag(models.Model):
     """Set of tags."""
 
     class Meta:
-        verbose_name = 'Tag'
-        verbose_name_plural = 'Tags'
+        verbose_name = _('Tag')
+        verbose_name_plural = _('Tags')
 
-    title = models.CharField('Titre', max_length=30, unique=True, db_index=True)
-    slug = models.SlugField('Slug', max_length=30, unique=True)
+    title = models.CharField(_('Titre'), max_length=30, unique=True, db_index=True)
+    slug = models.SlugField(_('Slug'), max_length=30, unique=True)
 
     def __str__(self):
         """Textual Link Form."""
@@ -532,15 +532,15 @@ class HelpWriting(models.Model):
 
     """Tutorial Help"""
     class Meta:
-        verbose_name = 'Aide à la rédaction'
-        verbose_name_plural = 'Aides à la rédaction'
+        verbose_name = _('Aide à la rédaction')
+        verbose_name_plural = _('Aides à la rédaction')
 
     # A name for this help
-    title = models.CharField('Name', max_length=20, null=False)
+    title = models.CharField(_('Name'), max_length=20, null=False)
     slug = models.SlugField(max_length=20)
 
     # tablelabel: Used for the accessibility "This tutoriel need help for writing"
-    tablelabel = models.CharField('TableLabel', max_length=150, null=False)
+    tablelabel = models.CharField(_('TableLabel'), max_length=150, null=False)
 
     # The image to use to illustrate this role
     image = ThumbnailerImageField(upload_to=image_path_help)

--- a/zds/utils/templatetags/joinby.py
+++ b/zds/utils/templatetags/joinby.py
@@ -18,7 +18,7 @@ def joinby(values, separator=', ', final_separator=_(' et ')):
         return ''
     # Allows to pass a queryset (instead of a list of strings)
     # to the function.
-    values = [str(v) for v in values]
+    values = map(str, values)
     if len(values) == 1:
         return values[0]
     if separator == final_separator:

--- a/zds/utils/templatetags/joinby.py
+++ b/zds/utils/templatetags/joinby.py
@@ -7,22 +7,21 @@ register = template.Library()
 
 
 @register.simple_tag
-def joinby(values, separator=', ', same_final_separator=False):
+def joinby(values, separator=', ', final_separator=_(' et ')):
     """
     Returns a human readable list (of type string) of values separated
-    by a string definable with 'separator' (commas default, excepted
-    the last preceded by "et") from an iterable.
-    Set 'same_final_separator' to True to make the last also preceded
-    by the same separator.
+    by a string definable with 'separator' (commas default) from an
+    iterable. Use 'final_separator' to define another separator
+    for the last value (" et " default).
     """
     if not values:
         return ''
+    # Allows to pass a queryset (instead of a list of strings)
+    # to the function.
+    values = [str(v) for v in values]
     if len(values) == 1:
-        return str(values[0])
-    if same_final_separator:
-        final_sep = separator
+        return values[0]
+    if separator == final_separator:
+        return separator.join(values)
     else:
-        final_sep = _(' et ')
-    return separator.join(map(str, values[:len(values) - 1])) + (
-        final_sep + str(values.last())
-    )
+        return separator.join(values[:-1]) + str(final_separator) + values[-1]

--- a/zds/utils/tests/test_misc.py
+++ b/zds/utils/tests/test_misc.py
@@ -59,6 +59,7 @@ class Misc(TestCase):
             # as we are not in py3 we do not have subTest method. so we use a bare for loop.
             self.assertEquals(remove_url_scheme(element.given), element.expected)
 
+
 class TemplateTagsTest(TestCase):
     def test_joinby(self):
         l = ['apple', 'banana', 'orange', 'clementine']

--- a/zds/utils/tests/test_misc.py
+++ b/zds/utils/tests/test_misc.py
@@ -62,6 +62,9 @@ class Misc(TestCase):
 
 class TemplateTagsTest(TestCase):
     def test_joinby(self):
+        self.assertEqual(joinby([]), '')
+        self.assertEqual(joinby(()), '')
+
         l = ['apple', 'banana', 'orange', 'clementine']
         self.assertEqual(
             joinby(l, final_separator=', '),

--- a/zds/utils/tests/test_misc.py
+++ b/zds/utils/tests/test_misc.py
@@ -9,6 +9,7 @@ from zds.utils.misc import contains_utf8mb4
 from zds.utils.models import Alert
 from zds.utils.templatetags.interventions import alerts_list
 from zds.utils.templatetags.remove_url_scheme import remove_url_scheme
+from zds.utils.templatetags.joinby import joinby
 
 
 class Misc(TestCase):
@@ -54,5 +55,50 @@ class Misc(TestCase):
         }
 
         for element in oracle:
+            # TODO : Now, we are in Py3.
             # as we are not in py3 we do not have subTest method. so we use a bare for loop.
-            self.assertEqual(remove_url_scheme(element.given), element.expected)
+            self.assertEquals(remove_url_scheme(element.given), element.expected)
+
+class TemplateTagsTest(TestCase):
+    def test_joinby(self):
+        l = ['apple', 'banana', 'orange', 'clementine']
+        self.assertEqual(
+            joinby(l, final_separator=', '),
+            'apple, banana, orange, clementine'
+        )
+
+        l = ['apple', 'banana', 'orange', 'clementine']
+        self.assertEqual(
+            joinby(l, final_separator=' and '),
+            'apple, banana, orange and clementine'
+        )
+
+        l = ['apple', 'banana', 'orange', 'clementine']
+        self.assertEqual(
+            joinby(l, separator=';', final_separator=';'),
+            'apple;banana;orange;clementine'
+        )
+
+        l = [1, 2, 3, 4]
+        self.assertEqual(
+            joinby(l, separator=';', final_separator=';'),
+            '1;2;3;4'
+        )
+
+        l = ['Clem']
+        self.assertEqual(
+            joinby(l, final_separator=' and '),
+            'Clem'
+        )
+
+        l = ['Clem', 'Chuck Norris']
+        self.assertEqual(
+            joinby(l, final_separator=' and '),
+            'Clem and Chuck Norris'
+        )
+
+        l = ['Clem', 'Chuck Norris', 'Arnold Schwarzenegger']
+        self.assertEqual(
+            joinby(l, final_separator=' and '),
+            'Clem, Chuck Norris and Arnold Schwarzenegger'
+        )


### PR DESCRIPTION
Cette PR ajoute des champs de traduction dans les modèles de `tutorialv2` qui semblent avoir été oubliés.

Numéro du ticket concerné (optionnel) : Aucun

**Cette PR nécessite de recréer les fichiers de traduction pour les instances qui les utilisent.**

### Contrôle qualité

  - Vérifier qu'il ne reste pas de champs à traduire oubliés ;
  - Vérifier qu'il n'y pas de champs marqués "à traduire" alors qu'ils ne le devraient pas (les champs `related_name` par exemple).
