### PR TITLE
tribunes : trie les billets par date de création

### DIFF
--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -25,7 +25,7 @@ urlpatterns = [
         ContentOfAuthor.as_view(type='ARTICLE', context_object_name='articles'),
         name='find-article'),
     url(r'^tribunes/(?P<pk>\d+)/$',
-        ContentOfAuthor.as_view(type='OPINION', context_object_name='opinions'),
+        ContentOfAuthor.as_view(type='OPINION', context_object_name='opinions', sort='creation'),
         name='find-opinion'),
     url(r'^aides/$', ContentsWithHelps.as_view(), name='helps'),
     url(r'^(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/(?P<container_slug>.+)/$',

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -1926,7 +1926,7 @@ class ContentOfAuthor(ZdSPagingListView):
         # Sort.
         if 'sort' in self.request.GET and self.request.GET['sort'].lower() in self.sorts:
             self.sort = self.request.GET['sort']
-        else:
+        elif not self.sort:
             self.sort = 'abc'
         queryset = self.sorts[self.sort.lower()][0](queryset)
         return queryset


### PR DESCRIPTION
Actuellement les billets visibles sur /contenus/tribunes/ sont triés par
ordre alphabétique. Ils devraient être triés par date.

Numéro du ticket concerné (optionnel) : #4612 

### Contrôle qualité

Vérifier que les billets sur la tribune d'un membre s'affiche bien par dates.