### PR TITLE
`make travis` ne sert à rien

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,3 @@ run:
 	make -j2 watch-front run-back
 
 test: test-back test-front
-
-travis:
-	tox $TEST_APP # set by travis, see .travis.yml


### PR DESCRIPTION
Ça fait très longtemps que Travis n’utilise plus ça. Et puis alors `tox`…
