### PR TITLE
Toujours lire les manifest.json en UTF-8

### DIFF
--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -357,10 +357,16 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
             if sha != public.sha_public:
                 raise NotAPublicVersion
 
-            manifest = open(os.path.join(path, 'manifest.json'), 'r')
-            json = json_reader.loads(manifest.read())
-            versioned = get_content_from_json(
-                json, public.sha_public, slug, public=True, max_title_len=max_title_length, hint_licence=self.licence)
+            with open(os.path.join(path, 'manifest.json'), 'r', encoding='utf-8') as manifest:
+                json = json_reader.loads(manifest.read())
+                versioned = get_content_from_json(
+                    json,
+                    public.sha_public,
+                    slug,
+                    public=True,
+                    max_title_len=max_title_length,
+                    hint_licence=self.licence,
+                )
 
         else:  # draft version, use the repository (slower, but allows manipulation)
             path = self.get_repo_path()


### PR DESCRIPTION
La publication plantait lorque la locale n’était pas réglée sur UTF-8.

Fix #4698.

### Contrôle qualité 

- Mettez une locale (moisie) en US-ASCII
- Allez sur la branche dev.
- Créez un billet avec “bépo” comme titre
- Publiez ! Vous ne devriez pas voir d’erreur.
