### PR TITLE
Retrait des décorateurs python_2_unicode_compatible

### DIFF
--- a/zds/featured/models.py
+++ b/zds/featured/models.py
@@ -1,13 +1,11 @@
 # coding: utf-8
 
-from django.utils.encoding import python_2_unicode_compatible
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from zds.featured.managers import FeaturedResourceManager, FeaturedMessageManager
 
 
-@python_2_unicode_compatible
 class FeaturedResource(models.Model):
     """
         A FeaturedResource is a link to a resource that is featured by the Staff
@@ -40,7 +38,6 @@ class FeaturedResource(models.Model):
         return self.title
 
 
-@python_2_unicode_compatible
 class FeaturedMessage(models.Model):
     """
         The Featured Message is a simple one-line information on the home page.

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from django.utils.encoding import python_2_unicode_compatible
 import logging
 from datetime import datetime, timedelta
 from math import ceil
@@ -27,7 +26,6 @@ def sub_tag(tag):
     return '{0}'.format(start + end)
 
 
-@python_2_unicode_compatible
 class Category(models.Model):
     """
     A Category is a simple container for Forums.
@@ -73,7 +71,6 @@ class Category(models.Model):
         return forums_pub
 
 
-@python_2_unicode_compatible
 class Forum(models.Model):
     """
     A Forum, containing Topics. It can be public or restricted to some groups.
@@ -172,7 +169,6 @@ class Forum(models.Model):
         return self._nb_group > 0
 
 
-@python_2_unicode_compatible
 class Topic(AbstractESDjangoIndexable):
     """
     A Topic is a thread of posts.
@@ -468,7 +464,6 @@ def delete_topic_in_elasticsearch(sender, instance, **kwargs):
     return delete_document_in_elasticsearch(instance)
 
 
-@python_2_unicode_compatible
 class Post(Comment, AbstractESDjangoIndexable):
     """
     A forum post written by a user.
@@ -569,7 +564,6 @@ def delete_post_in_elasticsearch(sender, instance, **kwargs):
     return delete_document_in_elasticsearch(instance)
 
 
-@python_2_unicode_compatible
 class TopicRead(models.Model):
     """
     This model tracks the last post read in a topic by a user.

--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from django.utils.encoding import python_2_unicode_compatible
 import os
 from uuid import uuid4
 from shutil import rmtree
@@ -38,7 +37,6 @@ def image_path(instance, filename):
     return os.path.join('galleries', str(instance.gallery.pk), filename)
 
 
-@python_2_unicode_compatible
 class UserGallery(models.Model):
     """A gallery of images created by a user."""
 
@@ -88,7 +86,6 @@ class UserGallery(models.Model):
         return Image.objects.filter(gallery=self.gallery).order_by('update').all()
 
 
-@python_2_unicode_compatible
 class Image(models.Model):
     """Represent an image in database"""
 
@@ -144,7 +141,6 @@ def auto_delete_file_on_delete(sender, instance, **kwargs):
         thumbmanager.delete(save=False)
 
 
-@python_2_unicode_compatible
 class Gallery(models.Model):
 
     class Meta:

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from django.utils.encoding import python_2_unicode_compatible
 from datetime import datetime
 from hashlib import md5
 from importlib import import_module
@@ -24,7 +23,6 @@ from zds.tutorialv2.models.models_database import PublishableContent, PublishedC
 from zds.utils.models import Alert, Licence, Hat
 
 
-@python_2_unicode_compatible
 class Profile(models.Model):
     """
     A user profile. Complementary data of standard Django `auth.user`.
@@ -476,7 +474,6 @@ def set_old_smileys_cookie(response, profile):
             remove_old_smileys_cookie(response)
 
 
-@python_2_unicode_compatible
 class TokenForgotPassword(models.Model):
     """
     When a user forgot its password, the website sends it an email with a token (embedded in a URL).
@@ -501,7 +498,6 @@ class TokenForgotPassword(models.Model):
         return '{0} - {1}'.format(self.user.username, self.date_end)
 
 
-@python_2_unicode_compatible
 class TokenRegister(models.Model):
     """
     On registration, a token is send by mail to the user. It must use this token (by clicking on a link) to activate its
@@ -535,7 +531,6 @@ def save_profile(backend, user, response, *args, **kwargs):
         profile.save()
 
 
-@python_2_unicode_compatible
 class NewEmailProvider(models.Model):
     """A new-used email provider which should be checked by a staff member."""
 
@@ -554,7 +549,6 @@ class NewEmailProvider(models.Model):
         return 'Alert about the new provider {}'.format(self.provider)
 
 
-@python_2_unicode_compatible
 class BannedEmailProvider(models.Model):
     """
     A email provider which has been banned by a staff member.
@@ -575,7 +569,6 @@ class BannedEmailProvider(models.Model):
         return 'Ban of the {} provider'.format(self.provider)
 
 
-@python_2_unicode_compatible
 class Ban(models.Model):
     """
     This model stores all sanctions (not only bans).
@@ -597,7 +590,6 @@ class Ban(models.Model):
         return '{0} - ban : {1} ({2}) '.format(self.user.username, self.note, self.pubdate)
 
 
-@python_2_unicode_compatible
 class KarmaNote(models.Model):
     """
     Karma notes are a way of annotating members profiles. They are only visible

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -2,7 +2,6 @@
 
 from math import ceil
 
-from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
@@ -13,7 +12,6 @@ from zds.notification import signals
 from zds.utils import get_current_user, slugify
 
 
-@python_2_unicode_compatible
 class PrivateTopic(models.Model):
     """
     Topic private, containing private posts.
@@ -209,7 +207,6 @@ class PrivateTopic(models.Model):
         return PrivateTopic.has_write_permission(request) and self.is_author(request.user)
 
 
-@python_2_unicode_compatible
 class PrivatePost(models.Model):
     """A private post written by a user."""
 
@@ -288,7 +285,6 @@ class PrivatePost(models.Model):
         return PrivateTopic.has_write_permission(request) and self.is_last_message() and self.is_author(request.user)
 
 
-@python_2_unicode_compatible
 class PrivateTopicRead(models.Model):
     """
     Small model which keeps track of the user viewing private topics.

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-s
 
-from django.utils.encoding import python_2_unicode_compatible
 import logging
 from smtplib import SMTPException
 
@@ -24,7 +23,6 @@ from zds.utils.misc import convert_camel_to_underscore
 LOG = logging.getLogger(__name__)
 
 
-@python_2_unicode_compatible
 class Subscription(models.Model):
     """
     Model used to register the subscription of a user to a set of notifications (regarding a tutorial, a forum, ...)
@@ -242,7 +240,6 @@ class MultipleNotificationsMixin(object):
                 LOG.exception('Could not save %s', notification)
 
 
-@python_2_unicode_compatible
 class AnswerSubscription(Subscription):
     """
     Subscription to new answer, either in a topic, a article or a tutorial
@@ -259,7 +256,6 @@ class AnswerSubscription(Subscription):
         return self.content_object.title
 
 
-@python_2_unicode_compatible
 class TopicAnswerSubscription(AnswerSubscription, SingleNotificationMixin):
     """
     Subscription to new answer in a topic
@@ -272,7 +268,6 @@ class TopicAnswerSubscription(AnswerSubscription, SingleNotificationMixin):
             .format(self.user.username, self.object_id)
 
 
-@python_2_unicode_compatible
 class PrivateTopicAnswerSubscription(AnswerSubscription, SingleNotificationMixin):
     """
     Subscription to new answer in a private topic.
@@ -285,7 +280,6 @@ class PrivateTopicAnswerSubscription(AnswerSubscription, SingleNotificationMixin
             .format(self.user.username, self.object_id)
 
 
-@python_2_unicode_compatible
 class ContentReactionAnswerSubscription(AnswerSubscription, SingleNotificationMixin):
     """
     Subscription to new answer in a publishable content.
@@ -298,7 +292,6 @@ class ContentReactionAnswerSubscription(AnswerSubscription, SingleNotificationMi
             .format(self.user.username, self.object_id)
 
 
-@python_2_unicode_compatible
 class NewTopicSubscription(Subscription, MultipleNotificationsMixin):
     """
     Subscription to new topics in a forum or with a tag
@@ -317,7 +310,6 @@ class NewTopicSubscription(Subscription, MultipleNotificationsMixin):
         return topic.title
 
 
-@python_2_unicode_compatible
 class NewPublicationSubscription(Subscription, MultipleNotificationsMixin):
     """
     Subscription to new publications from a user.
@@ -336,7 +328,6 @@ class NewPublicationSubscription(Subscription, MultipleNotificationsMixin):
         return content.title
 
 
-@python_2_unicode_compatible
 class PingSubscription(AnswerSubscription, MultipleNotificationsMixin):
     """
     Subscription to ping of a user
@@ -361,7 +352,6 @@ def ping_url(user=None):
         pass
 
 
-@python_2_unicode_compatible
 class Notification(models.Model):
     """
     A notification
@@ -400,7 +390,6 @@ class Notification(models.Model):
         return Notification.has_read_permission(request) and self.subscription.user == request.user
 
 
-@python_2_unicode_compatible
 class TopicFollowed(models.Model):
     """
     This model tracks which user follows which topic.

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -2,7 +2,6 @@
 
 
 from django.db.models import CASCADE
-from django.utils.encoding import python_2_unicode_compatible
 from datetime import datetime
 
 from zds.tutorialv2.models.mixins import TemplatableContentModelMixin, OnlineLinkableContentMixin
@@ -54,7 +53,6 @@ ALLOWED_TYPES = ['pdf', 'md', 'html', 'epub', 'zip']
 logger = logging.getLogger('zds.tutorialv2')
 
 
-@python_2_unicode_compatible
 class PublishableContent(models.Model, TemplatableContentModelMixin):
     """A publishable content.
 
@@ -581,7 +579,6 @@ def delete_gallery(sender, instance, **kwargs):
         instance.gallery.delete()
 
 
-@python_2_unicode_compatible
 class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, OnlineLinkableContentMixin):
     """A class that contains information on the published version of a content.
 
@@ -1100,7 +1097,6 @@ class FakeChapter(AbstractESIndexable):
         return document
 
 
-@python_2_unicode_compatible
 class ContentReaction(Comment):
     """
     A comment written by any user about a PublishableContent they just read.
@@ -1128,7 +1124,6 @@ class ContentReaction(Comment):
         return self.related_content.title
 
 
-@python_2_unicode_compatible
 class ContentRead(models.Model):
     """
     Small model which keeps track of the user viewing tutorials.
@@ -1156,7 +1151,6 @@ class ContentRead(models.Model):
         return '<Contenu "{}" lu par {}, #{}>'.format(self.content, self.user, self.note.pk)
 
 
-@python_2_unicode_compatible
 class Validation(models.Model):
     """
     Content validation.
@@ -1230,7 +1224,6 @@ class Validation(models.Model):
         return self.status == 'CANCEL'
 
 
-@python_2_unicode_compatible
 class PickListOperation(models.Model):
     class Meta:
         verbose_name = "Choix d'un billet"

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from django.utils.encoding import python_2_unicode_compatible
 from datetime import datetime
 import os
 import string
@@ -47,7 +46,6 @@ def image_path_help(instance, filename):
     return os.path.join('helps/normal', str(instance.pk), filename)
 
 
-@python_2_unicode_compatible
 class Category(models.Model):
     """Common category for several concepts of the application."""
 
@@ -72,7 +70,6 @@ class Category(models.Model):
                 .all()]
 
 
-@python_2_unicode_compatible
 class SubCategory(models.Model):
     """Common subcategory for several concepts of the application."""
 
@@ -113,7 +110,6 @@ class SubCategory(models.Model):
             return None
 
 
-@python_2_unicode_compatible
 class CategorySubCategory(models.Model):
 
     """ManyToMany between Category and SubCategory but save a boolean to know
@@ -138,7 +134,6 @@ class CategorySubCategory(models.Model):
                 self.subcategory.title)
 
 
-@python_2_unicode_compatible
 class Licence(models.Model):
 
     """Publication licence."""
@@ -155,7 +150,6 @@ class Licence(models.Model):
         return self.title
 
 
-@python_2_unicode_compatible
 class Hat(models.Model):
     """
     Hats are labels that users can add to their messages.
@@ -197,7 +191,6 @@ class Hat(models.Model):
         return self.get_users()[:settings.ZDS_APP['member']['users_in_hats_list']]
 
 
-@python_2_unicode_compatible
 class HatRequest(models.Model):
     """
     A hat requested by a user.
@@ -255,7 +248,6 @@ def get_hat_from_settings(key):
     return hat
 
 
-@python_2_unicode_compatible
 class Comment(models.Model):
 
     """Comment in forum, articles, tutorial, chapter, etc."""
@@ -365,7 +357,6 @@ class Comment(models.Model):
         return 'Comment by {}'.format(self.author.username)
 
 
-@python_2_unicode_compatible
 class CommentEdit(models.Model):
     """Archive for editing a comment."""
 
@@ -391,7 +382,6 @@ class CommentEdit(models.Model):
             self.editor.username, self.comment.author.username)
 
 
-@python_2_unicode_compatible
 class Alert(models.Model):
     """Alerts on all kinds of Comments and PublishedContents."""
     SCOPE_CHOICES = (
@@ -494,7 +484,6 @@ class Alert(models.Model):
         verbose_name_plural = 'Alertes'
 
 
-@python_2_unicode_compatible
 class CommentVote(models.Model):
 
     """Set of comment votes."""
@@ -511,7 +500,6 @@ class CommentVote(models.Model):
         return 'Vote from {} about Comment#{} thumb_up={}'.format(self.user.username, self.comment.pk, self.positive)
 
 
-@python_2_unicode_compatible
 class Tag(models.Model):
 
     """Set of tags."""
@@ -546,7 +534,6 @@ class Tag(models.Model):
         return True
 
 
-@python_2_unicode_compatible
 class HelpWriting(models.Model):
 
     """Tutorial Help"""


### PR DESCRIPTION
Simple nettoyage des décorateurs et leur import correspondant

Numéro du ticket concerné: #4701 