### PR TITLE
Ne pas stocker threading.local() dans une variable globale

### DIFF
--- a/zds/utils/__init__.py
+++ b/zds/utils/__init__.py
@@ -1,29 +1,23 @@
 # coding: utf-8
 
+from threading import local
+
 from django.template import defaultfilters
 
 
-try:
-    from threading import local
-except ImportError:
-    from django.utils._threading_local import local
-
-_thread_locals = local()
-
-
 def get_current_user():
-    return getattr(_thread_locals, 'user', None)
+    return getattr(local(), 'user', None)
 
 
 def get_current_request():
-    return getattr(_thread_locals, 'request', None)
+    return getattr(local(), 'request', None)
 
 
 class ThreadLocals(object):
 
     def process_request(self, request):
-        _thread_locals.user = getattr(request, 'user', None)
-        _thread_locals.request = request
+        local().user = getattr(request, 'user', None)
+        local().request = request
 
 
 def slugify(text):


### PR DESCRIPTION
Je crois que ce commit corrige un parfait exemple de comment ne *pas*
utiliser des variables locales à un thread :-)

Quand Django charge et exécute le fichier fichier
`zds/utils/__init__.py`, l’instruction `_thread_locals = local()` est
exécutée et `_thread_locals` contiendra donc les variables locales à
ce thread. Maintenant, le fait est que les requêtes de Django peuvent
très bien être exécutées dans les threads *différents* — et c’est
visiblement le cas dans un environnement de développement (en tout
cas, ça le fait chez moi). Du coup, `_thread_locals` pointait toujours
vers les variables locales du même thread et non du thread actuel — ce
qui revient à utiliser une variable globale. Vous pouvez vérifier
qu’il y a quelque chose qui cloche avec quelques `print()`.

Oh, et ce bug date de PDP :

https://github.com/progdupeupl/pdp_website/blame/master/pdp/utils/__init__.py#L28

### Contrôle qualité

Avant ce patch, vous pouvez vérifier facilement que quelque chose cloche en faisant des `print(locals())` et des `print(_thread_locals)` :upside_down_face: 
