### PR TITLE
Améliore le comportement du bouton "Citer"

### DIFF
--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -194,31 +194,45 @@
         }
     });
 
+    function getLineAt(string, index) {
+        var before = string.slice(0, index).split("\n").slice(-1)[0] || "";
+        var after = string.slice(index).split("\n")[0] || "";
+        return before + after;
+    }
+
+    function insertCitation(editor, citation) {
+        if (editor.selectionStart !== editor.selectionEnd ||
+            getLineAt(editor.value, editor.selectionStart).trim()) {
+            editor.value = editor.value + "\n\n" + citation;
+            return;
+        }
+
+        var before = editor.value.slice(0, editor.selectionStart);
+        var after = editor.value.slice(editor.selectionEnd);
+        editor.value = before + "\n" + citation + "\n" + after;
+    }
+
     /**
      * Cite a message
      */
     $(".message-actions").on("click", "[data-ajax-input='cite-message']", function(e){
-        var $act = $(this),
-            $editor = $(".md-editor");
+        e.stopPropagation();
+        e.preventDefault();
+
+        var $act = $(this);
+        var editor = document.querySelector(".md-editor");
 
         $.ajax({
             url: $act.attr("href"),
             dataType: "json",
             success: function(data){
-                var selStart = $editor[0].selectionStart;
-                var selEnd = $editor[0].selectionEnd;
-                $editor.val($editor.val().slice(0, selStart) + data.text + "\n\n" + $editor.val().slice(selEnd));
-                var caretPos = selEnd + data.text.length + 2;
-                $editor[0].setSelectionRange(caretPos, caretPos);
+                insertCitation(editor, data.text);
             }
         });
 
         // scroll to the textarea and focus the textarea
-        $("html, body").animate({ scrollTop: $editor.offset().top }, 500);
-        $editor.focus();
-
-        e.stopPropagation();
-        e.preventDefault();
+        $("html, body").animate({ scrollTop: $(editor).offset().top }, 500);
+        editor.focus();
     });
 
     /**

--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -205,7 +205,11 @@
             url: $act.attr("href"),
             dataType: "json",
             success: function(data){
-                $editor.val($editor.val() + data.text + "\n\n");
+                var selStart = $editor[0].selectionStart;
+                var selEnd = $editor[0].selectionEnd;
+                $editor.val($editor.val().slice(0, selStart) + data.text + "\n\n" + $editor.val().slice(selEnd));
+                var caretPos = selEnd + data.text.length + 2;
+                $editor[0].setSelectionRange(caretPos, caretPos);
             }
         });
 


### PR DESCRIPTION
L'ancien comportement consistait à insérer la citation à la fin du message, suivie de deux sauts de ligne.

Ce commit fait en sorte que la citation soit maintenant insérée à la position courante du curseur, afin de pouvoir la placer au milieu du message (entre deux paragraphes par exemple).

Numéro du ticket concerné (optionnel) : Aucun

### Contrôle qualité

  - Reconstruire le front ;
  - Vérifier que le bouton "Citer" se comporte correctement dans plusieurs cas de figure (sans le focus, entre deux paragraphes, etc).

**N'hésitez pas à me signaler si vous préférez le comportement actuel. Je fais cette PR surtout parce que j'ai souvent tendance à rédiger une réponse et à vouloir insérer des citations ensuite (qui du coup se rajoutent à la fin du message).**