### PR TITLE
Enlève l'italique sur les commentaires dans le code Markdown

### DIFF
--- a/assets/scss/components/_pygments.scss
+++ b/assets/scss/components/_pygments.scss
@@ -1,12 +1,12 @@
 .codehilite .hll { background-color: #ffffcc }
 .codehilite { background: #f8f8f8; }
-.codehilite .c { color: #408080; font-style: italic } /* Comment */
+.codehilite .c { color: #408080 } /* Comment */
 .codehilite .k { color: #008000; font-weight: bold } /* Keyword */
 .codehilite .o { color: #666666 } /* Operator */
-.codehilite .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.codehilite .cm { color: #408080 } /* Comment.Multiline */
 .codehilite .cp { color: #BC7A00 } /* Comment.Preproc */
-.codehilite .c1 { color: #408080; font-style: italic } /* Comment.Single */
-.codehilite .cs { color: #408080; font-style: italic } /* Comment.Special */
+.codehilite .c1 { color: #408080 } /* Comment.Single */
+.codehilite .cs { color: #408080 } /* Comment.Special */
 .codehilite .gd { color: #A00000 } /* Generic.Deleted */
 .codehilite .ge { font-style: italic } /* Generic.Emph */
 .codehilite .gr { color: #FF0000 } /* Generic.Error */


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #4718 

### Contrôle qualité

- Vérifier que les commentaires ne sont plus en italiques.