### PR TITLE
Simplifie l'installation des dépendances

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,7 +1,6 @@
 strictness: high
 max-line-length: 120
 requirements:
-    - requirements.txt
     - requirements-dev.txt
 ignore-paths:
     - doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ install:
   - |
     # install backend dependencies
     if [[ "$ZDS_TEST_JOB" == *"zds."* ]] || [[ "$ZDS_TEST_JOB" == *"selenium"* ]] || [[ "$ZDS_TEST_JOB" == *"doc"* ]]; then
-      pip install -q -rrequirements.txt -rrequirements-dev.txt -rrequirements-prod.txt
+      pip install -q -r requirements-dev.txt -r requirements-prod.txt
     fi
 
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean-back:
 	find . -name '*.pyc' -exec rm {} \;
 
 install-back:
-	pip install --upgrade -r requirements.txt -r requirements-dev.txt
+	pip install --upgrade -r requirements-dev.txt
 
 lint-back:
 	flake8 zds

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Elles sont reportées essentiellement dans le [*bug tracker*](https://github.com
 Après avoir mis à jour votre dépôt, vous devez exécuter les commandes suivantes (depuis la racine de votre projet) pour mettre à jour les dépendances.
 
 ```console
-pip install --upgrade -r requirements.txt -r requirements-dev.txt
+pip install --upgrade -r requirements-dev.txt
 python manage.py migrate --fake-initial
 ```
 

--- a/doc/source/install/backend-windows-install.rst
+++ b/doc/source/install/backend-windows-install.rst
@@ -62,7 +62,7 @@ Pour redémarrer virtualenv les fois suivantes : exécutez à nouveau le fichier
 
     (zdsenv)PS C:\dev\zestedesavoir\
 
-Lancez par la suite ``pip install -r requirements.txt -r requirements-dev.txt``.
+Lancez par la suite ``pip install --upgrade -r requirements-dev.txt``.
 
 Si l'erreur suivante apparaît :
 
@@ -97,7 +97,7 @@ Suite de l'installation
 
 - Dans la console PowerShell via l'environnement zdsenv installez les dépendances.
     - ``easy_install lxml``
-    - ``pip install -r requirements.txt -r requirements-dev.txt``
+    - ``pip install --upgrade -r requirements-dev.txt``
     - Cairo, disponible `ici <https://www.cairographics.org/download>`_
     - GTK+ (qui contient les DLL de Cairo) disponible `ici <http://downloads.sourceforge.net/gladewin32/gtk-2.12.9-win32-2.exe>`_
     - ``python manage.py migrate``

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+
 coverage==4.4.1
 PyYAML==3.12
 django-debug-toolbar==1.8

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+
 gunicorn==19.7.1
 mysqlclient==1.3.7
 raven==6.2.1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -71,7 +71,6 @@ git checkout -b $1
 
 # Update application data
 source $ENV_PATH/bin/activate
-pip install --upgrade -r requirements.txt
 pip install --upgrade -r requirements-prod.txt
 python manage.py migrate
 python manage.py compilemessages

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,7 @@ setenv =
 whitelist_externals=*
 
 [testenv:back]
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/requirements-dev.txt
+deps = -r{toxinidir}/requirements-dev.txt
 commands = coverage run --source='.' {toxinidir}/manage.py test {posargs}
 
 [testenv:front]


### PR DESCRIPTION
Spécifier que requirements-dev.txt et requirements-prod.txt dépendent de requirements.txt simplifie l'installation et est courant dans le monde Python. C'est notamment [recommandé par le livre "Two Scoops of Django"](https://github.com/twoscoops/django-twoscoops-project/blob/develop/requirements/local.txt).

| Q                             | R
| ----------------------------- | -------------------------------------------
| Correction de bugs ?          | non
| Nouvelle Fonctionnalité ?     | non


### Contrôle qualité

Pour chaque test, avant faire `pip uninstall django`, puis après `pip show django` et s'assurer que c'est la version 1.10.8 qui est installée.

- pip install -r requirements-dev.txt
- pip install -r reqirements-prod.txt
- tox -e back
- make install-back