### PR TITLE
Préfixe les loggers des ESIndexManager par le nom du module

### DIFF
--- a/zds/searchv2/models.py
+++ b/zds/searchv2/models.py
@@ -272,7 +272,9 @@ class ESIndexManager(object):
         self.number_of_shards = shards
         self.number_of_replicas = replicas
 
-        self.logger = logging.getLogger('ESIndexManager:{}'.format(self.index))
+        self.logger = logging.getLogger(
+            '{}.{}:{}'.format(__name__, self.__class__.__name__, self.index)
+        )
 
         self.es = None
         self.connected_to_es = False


### PR DESCRIPTION
C’est important pour différencier les loggers de Django et des autres
bibliothèques de nos loggers.
