### PR TITLE
Améliore le logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,7 @@ watchdog==0.8.3 # use last non-bc-breaking version
 # next versions of this libraries break previous behavior for slug generation from string with single quotes
 django-uuslug==1.0.3
 python-slugify==1.1.4
+
+# Should be in `requirements-dev.txt` but `colorlog` is used in
+# `settings.py`, so…
+colorlog==3.1.0

--- a/zds/settings.py
+++ b/zds/settings.py
@@ -7,6 +7,9 @@ from django.contrib.messages import constants as message_constants
 from django.utils.http import urlquote
 from django.utils.translation import gettext_lazy as _
 
+from colorlog import ColoredFormatter
+
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -276,34 +279,69 @@ CORS_EXPOSE_HEADERS = (
     'link'
 )
 
-# A sample logging configuration. The only tangible logging
-# performed by this configuration is to send an email to
-# the site admins on every HTTP 500 error when DEBUG=False.
-# See http://docs.djangoproject.com/en/dev/topics/logging for
-# more details on how to customize your logging configuration.
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
-        }
-    },
-    'handlers': {
-        'mail_admins': {
-            'level': 'DEBUG',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
-        }
-    },
-    'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'DEBUG',
-            'propagate': True,
+
+    'formatters': {
+        'verbose': {
+            '()': ColoredFormatter,
+            'format': '%(log_color)s %(levelname)s %(reset)s %(bold_black)s%(name)s%(reset)s %(message)s',
+            'log_colors': {
+                'DEBUG': 'fg_white,bg_black',
+                'INFO': 'fg_black,bg_bold_white',
+                'WARNING': 'fg_black,bg_bold_yellow',
+                'ERROR': 'fg_bold_white,bg_bold_red',
+                'CRITICAL': 'fg_bold_white,bg_bold_red',
+            },
         },
-    }
+
+        'django.server': {
+            '()': ColoredFormatter,
+            'format': '%(log_color)s%(message)s',
+            'log_colors': {
+                'INFO': 'bold_black',
+                'WARNING': 'bold_yellow',
+                'ERROR': 'bold_red',
+                'CRITICAL': 'bold_red',
+            },
+        },
+    },
+
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
+
+        'django.server': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'django.server',
+        },
+    },
+
+    'loggers': {
+        'django': {
+            'level': 'INFO',
+            'handlers': ['console'],
+        },
+
+        'django.server': {
+            'level': 'INFO',
+            'handlers': ['django.server'],
+            'propagate': False,
+        },
+
+        'zds': {
+            'level': 'DEBUG',  # Important because the default level is 'WARNING' or something like that
+            'handlers': ['console'],
+        },
+    },
 }
+
 
 CACHES = {
     'default': {

--- a/zds/settings_test.py
+++ b/zds/settings_test.py
@@ -5,3 +5,40 @@ PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',
     'django.contrib.auth.hashers.SHA1PasswordHasher',
 )
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(name)s %(message)s',
+        },
+    },
+
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
+    },
+
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+        },
+
+        'django.request': {
+            'level': 'ERROR',
+            'handlers': [],
+            'propagate': False,
+        },
+
+        'zds': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+        },
+    }
+}


### PR DESCRIPTION
### Logs colorées dans le terminal en local

En local, les logs sont colorées dans le terminal. Les
erreurs s’affichent en rouge, les avertissements en jaune,
etc. Ne prend pas effet lors des tests.

![screenshot from 2017-10-14 15-56-33](https://user-images.githubusercontent.com/15378830/31576306-530359e0-b0f8-11e7-93f2-42a84eb0aacd.png)

---

### Affiche les logs pendant les tests

Rend Django bavard pendant les tests. Avant ce commit, le logging
était désactivé sur Travis, ça rendait la chasse au bugs plutôt pénible.

*(Ce commit est tiré de la brance `zmarkdown-notes`, mais je pense
que c’est bien de le mettre sur la branche `dev` maintenant : C’est pas
vraiment lié à zmarkdown et ça fera toujours moins de choses à review
dans la PR de zmarkdown)*

---

### Contrôle qualité

Vérifiez que les logs soient jolies sur vos machines.

