### PR TITLE
Utilise __name__ pour le nom des loggers

### DIFF
--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -271,7 +271,7 @@ class Topic(AbstractESDjangoIndexable):
                 current_tag, created = Tag.objects.get_or_create(title=tag.lower().strip())
                 self.tags.add(current_tag)
             except ValueError as e:
-                logging.getLogger('zds.forum').warn(e)
+                logging.getLogger(__name__).warn(e)
 
         self.save()
         signals.edit_content.send(sender=self.__class__, instance=self, action='edit_tags_and_title')

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1305,6 +1305,6 @@ def modify_karma(request):
             profile.karma += note.karma
             profile.save()
     except ValueError as e:
-        logging.getLogger('zds.member').warn('ValueError: modifying karma failed because {}'.format(e))
+        logging.getLogger(__name__).warn('ValueError: modifying karma failed because {}'.format(e))
 
     return redirect(reverse('member-detail', args=[profile.user.username]))

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -50,7 +50,7 @@ from zds.utils.tutorials import get_blob
 import logging
 
 ALLOWED_TYPES = ['pdf', 'md', 'html', 'epub', 'zip']
-logger = logging.getLogger('zds.tutorialv2')
+logger = logging.getLogger(__name__)
 
 
 class PublishableContent(models.Model, TemplatableContentModelMixin):

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -251,7 +251,7 @@ class PandocPublicator(Publicator):
         self.pandoc_loc = pandoc_loc
         self.pandoc_pdf_param = pandoc_pdf_param
         self.format = _format
-        self.__logger = logging.getLogger('zds.pandoc-publicator')
+        self.__logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def publish(self, md_file_path, base_name, change_dir='.', pandoc_debug_str='', **kwargs):
         """
@@ -290,7 +290,7 @@ class WatchdogFilePublicator(Publicator):
         self.watched_directory = watched_dir
         if not isdir(self.watched_directory):
             os.mkdir(self.watched_directory)
-        self.__logger = logging.getLogger('zds.watchdog-publicator')
+        self.__logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
     def publish(self, md_file_path, base_name, silently_pass=True, **kwargs):
         if silently_pass:

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -53,6 +53,9 @@ from zds.utils.mps import send_mp
 from zds.utils.paginator import ZdSPagingListView, make_pagination
 
 
+logger = logging.getLogger(__name__)
+
+
 class RedirectOldBetaTuto(RedirectView):
     """
     allows to redirect /tutoriels/beta/old_pk/slug to /contenus/beta/new_pk/slug
@@ -1294,7 +1297,7 @@ class DisplayDiff(LoggedWithReadWriteHability, SingleContentDetailViewMixin):
             # commit_to.diff raises GitErrorCommand if 00..00 SHA for instance
             tdiff = commit_to.diff(commit_from, R=True)
         except (GitCommandError, BadName, BadObject, ValueError) as git_error:
-            logging.getLogger('zds.tutorialv2').warn(git_error)
+            logger.warn(git_error)
             raise Http404('En traitant le contenu {} git a lancé une erreur de type {}:{}'.format(
                 self.object.title,
                 type(git_error),
@@ -1659,12 +1662,10 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
             child = parent.children_dict[child_slug]
             if form.data['moving_method'] == MoveElementForm.MOVE_UP:
                 parent.move_child_up(child_slug)
-                logging.getLogger('zds.tutorialv2').debug('{} was moved up in tutorial id:{}'.format(child_slug,
-                                                                                                     content.pk))
+                logger.debug('{} was moved up in tutorial id:{}'.format(child_slug, content.pk))
             elif form.data['moving_method'] == MoveElementForm.MOVE_DOWN:
                 parent.move_child_down(child_slug)
-                logging.getLogger('zds.tutorialv2').debug('{} was moved down in tutorial id:{}'.format(child_slug,
-                                                                                                       content.pk))
+                logger.debug('{} was moved down in tutorial id:{}'.format(child_slug, content.pk))
             elif form.data['moving_method'][0:len(MoveElementForm.MOVE_AFTER)] == MoveElementForm.MOVE_AFTER:
                 target = form.data['moving_method'][len(MoveElementForm.MOVE_AFTER) + 1:]
                 if not parent.has_child_with_path(target):
@@ -1683,9 +1684,7 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
                     child_slug = target_parent.children[-1].slug
                     parent = target_parent
                 parent.move_child_after(child_slug, target.split('/')[-1])
-                logging.getLogger('zds.tutorialv2').debug('{} was moved after {} in tutorial id:{}'.format(child_slug,
-                                                                                                           target,
-                                                                                                           content.pk))
+                logger.debug('{} was moved after {} in tutorial id:{}'.format(child_slug, target, content.pk))
             elif form.data['moving_method'][0:len(MoveElementForm.MOVE_BEFORE)] == MoveElementForm.MOVE_BEFORE:
                 target = form.data['moving_method'][len(MoveElementForm.MOVE_BEFORE) + 1:]
                 if not parent.has_child_with_path(target):
@@ -1703,9 +1702,7 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
                     child_slug = target_parent.children[-1].slug
                     parent = target_parent
                 parent.move_child_before(child_slug, target.split('/')[-1])
-                logging.getLogger('zds.tutorialv2').debug('{} was moved before {} in tutorial id:{}'.format(child_slug,
-                                                                                                            target,
-                                                                                                            content.pk))
+                logger.debug('{} was moved before {} in tutorial id:{}'.format(child_slug, target, content.pk))
             versioned.slug = content.slug  # we force not to change slug
             versioned.dump_json()
             parent.repo_update(parent.title,
@@ -1726,8 +1723,7 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
             raise Http404("L'arbre spécifié n'est pas valide." + str(e))
         except IndexError:
             messages.warning(self.request, _("L'élément se situe déjà à la place souhaitée."))
-            logging.getLogger('zds.tutorialv2').debug("L'élément {} se situe déjà à la place souhaitée."
-                                                      .format(child_slug))
+            logger.debug("L'élément {} se situe déjà à la place souhaitée".format(child_slug))
         except TypeError:
             messages.error(self.request, _("L'élément ne peut pas être déplacé à cet endroit."))
         if base_container_slug == versioned.slug:

--- a/zds/tutorialv2/views/views_published.py
+++ b/zds/tutorialv2/views/views_published.py
@@ -35,7 +35,7 @@ from zds.utils.models import Alert, CommentVote, Tag, Category, CommentEdit, Sub
 from zds.utils.paginator import make_pagination, ZdSPagingListView
 from zds.utils.templatetags.topbar import top_categories_content
 
-logger = logging.getLogger('zds.tutorialv2')
+logger = logging.getLogger(__name__)
 
 
 class RedirectContentSEO(RedirectView):

--- a/zds/tutorialv2/views/views_validations.py
+++ b/zds/tutorialv2/views/views_validations.py
@@ -31,6 +31,8 @@ from zds.tutorialv2.utils import clone_repo
 from zds.utils.forums import send_post, lock_topic
 from zds.utils.models import SubCategory, get_hat_from_settings
 from zds.utils.mps import send_mp
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -95,9 +97,8 @@ class ValidationListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
             try:
                 validation.versioned_content = validation.content.load_version(sha=validation.content.sha_validation)
             except OSError:  # remember that load_version can raise OSError when path is not correct
-                logging.getLogger('zds.tutorialv2.validation')\
-                       .warn('A validation {} for content {} failed to load'.format(validation.pk,
-                                                                                    validation.content.title))
+                logger.warn('A validation {} for content {} failed to load'.format(validation.pk,
+                                                                                   validation.content.title))
                 removed_ids.append(validation.pk)
         context['validations'] = [_valid for _valid in context['validations'] if _valid.pk not in removed_ids]
         context['category'] = self.subcategory

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -69,7 +69,7 @@ class TagValidator(object):
     """
     def __init__(self):
         self.__errors = []
-        self.logger = logging.getLogger('zds.utils.forms')
+        self.logger = logging.getLogger(__name__)
         self.__clean = []
 
     def validate_raw_string(self, raw_string):

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -29,7 +29,7 @@ from zds.utils.templatetags.emarkdown import get_markdown_instance, render_markd
 from model_utils.managers import InheritanceManager
 
 
-logger = logging.getLogger('zds.utils')
+logger = logging.getLogger(__name__)
 
 
 def image_path_category(instance, filename):


### PR DESCRIPTION
C’est plus verbeux, mais c’est plus uniforme. Je pense que c’est bénéfique.

Notez que certains loggers propres à une classe s’appellent
`zds.nom.du.module.NomDeLaClasse`.

### Contrôle qualité

Regardez le diff.