### PR TITLE
Vilain petit `import zds.settings` bien caché

### DIFF
--- a/zds/urls.py
+++ b/zds/urls.py
@@ -11,7 +11,7 @@ from zds.forum.models import Category, Forum, Topic, Tag
 from zds.pages.views import home as home_view
 from zds.tutorialv2.models.models_database import PublishedContent
 
-from . import settings
+from django.conf import settings
 
 
 # SiteMap data


### PR DESCRIPTION
Ce genre de bêtises empêche de surcharger la configuration.