### PR TITLE
`manage.py runserver` s’arrête quand il reçoit un SIGTERM

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import signal
 
 
 def patch_create_suffix(original):
@@ -18,7 +19,15 @@ def patch_create_suffix(original):
     return patch
 
 
+def sighandler(signum, frame):
+    sys.exit(1)
+
+
 if __name__ == '__main__':
+    # Monkey-patch Django's broken signal handling
+    # http://blog.lotech.org/fix-djangos-runserver-when-run-under-docker-or-pycharm.html
+    signal.signal(signal.SIGTERM, sighandler)
+
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'zds.settings')
 
     if len(sys.argv) > 1 and sys.argv[1] in ['migrate', 'test']:


### PR DESCRIPTION
C’est un problème qui m’agace depuis quelque temps avec Docker. Mais sous Unix,
d’autres gens peuvent le rencontrer avec d’autres technologies.

http://blog.lotech.org/fix-djangos-runserver-when-run-under-docker-or-pycharm.html

En fait, ce n’est pas un problème de ZdS mais de Django. Mais je pense que c’est
suffisament pénible et facile à “corriger” pour justifier un patch de ce genre.

### Contrôle qualité

Sous un *Unix-like*, envoyez un SIGTERM au processus de `python manage.py runserver`.
Il devrait s’arrêter tout de suite.
