### PR TITLE
Affiche directement le markdown d'un message dans son aperçu

### DIFF
--- a/templates/forum/find/post.html
+++ b/templates/forum/find/post.html
@@ -66,7 +66,7 @@
                     </td>
                     <td>
                         {% if post.is_visible %}
-                            {{ post.text|truncatechars:200|emarkdown|striptags }}
+                            {{ post.text|truncatechars:200 }}
                         {% else %}
                             {% if post.text_hidden %}
                                 {% trans "Masqué par" %} {{ post.editor }}

--- a/templates/forum/find/topic.html
+++ b/templates/forum/find/topic.html
@@ -64,7 +64,7 @@
                     </td>
                     <td>
                         {% if topic.first_post.is_visible %}
-                            {{ topic.first_post.text|truncatechars:200|emarkdown|striptags }}
+                            {{ topic.first_post.text|truncatechars:200 }}
                         {% else %}
                             {% if topic.first_post.text_hidden %}
                                 {% trans "Masqué par" %} {{ topic.first_post.editor }}


### PR DESCRIPTION
L'ancien comportement consistait à passer le markdown au filtre "emarkdown" suivi de "striptags". Le rendu ressemblait donc à du plaintext, mais extrait du HTML.

Ce commit modifie ce comportement et affiche directement le markdown pour des raisons de lisibilité. En effet, quand le message commençait par un bloc de code, le rendu ressemblait alors à ceci : '''1 2 3# A simple script. print("Hello world!") exit(0)''' (les "1 2 3" venant des numéros de ligne du bloc de code inséré par emarkdown).

Désormais, le résultat est donc celui-ci : '''```py # A simple script. print("Hello world!") exit(0) ```'''.

La solution de rendre directement le HTML généré par emarkdown (et donc de faire le rendu des blocs de code notamment) n'a pas été retenue pour des questions de lisibilité. Puisque la plupart des membres ayant une expérience de rédaction connaissent le markdown, la solution de l'afficher directement a donc été retenue.

Numéro du ticket concerné (optionnel) : #2076 (#archéologie)

### Contrôle qualité

  - Créer un message commençant par un bloc de code ;
  - Aller sur la liste de ses derniers messages ;
  - Vérifier que le message en question s'affiche correctement / lisiblement.
