### PR TITLE
Enlève l'utilisation des vues génériques d'authentification de Django

### DIFF
--- a/zds/urls.py
+++ b/zds/urls.py
@@ -102,7 +102,6 @@ urlpatterns = [
     url(r'^mise-en-avant/', include('zds.featured.urls')),
     url(r'^notifications/', include('zds.notification.urls')),
     url('', include('social.apps.django_app.urls', namespace='social')),
-    url('', include('django.contrib.auth.urls', namespace='auth')),
 
     url(r'^munin/', include('munin.urls')),
 


### PR DESCRIPTION
Ce commit enlève l'utilisation des vues génériques d'authentification, qui ne sont apparemment pas utilisées mais qui faisaient exister les URLs correspondantes (`/login`, `/logout`, etc) et qui renvoyaient des erreurs 500.

Numéro du ticket concerné (optionnel) : #3226

### Contrôle qualité

  - Vérifier que les vues relatives à l'authentification marchent toujours correctement.
