### PR TITLE
Log des suppressions de contenus et de galeries

### DIFF
--- a/zds/tutorialv2/receivers.py
+++ b/zds/tutorialv2/receivers.py
@@ -2,10 +2,15 @@
 
 
 import datetime
+import logging
+
 from django.dispatch.dispatcher import receiver
 from django.utils.translation import ugettext_lazy as _
+from django.db import models
+
 from zds.tutorialv2.models.models_database import PublishableContent
 from zds.tutorialv2.signals import content_unpublished
+from zds.gallery.models import Gallery
 from zds.utils import get_current_user
 from zds.utils.models import Alert
 
@@ -26,3 +31,25 @@ def cleanup_validation_alerts(sender, instance, **kwargs):
                                                                        resolve_reason=_('Le billet a été dépublié.'),
                                                                        solved_date=datetime.datetime.now(),
                                                                        solved=True)
+
+
+@receiver(models.signals.post_delete, sender=Gallery)
+@receiver(models.signals.post_delete, sender=PublishableContent)
+def log_content_deletion(sender, instance, **kwargs):
+    """
+    When a content or gallery is deleted, this action is logged.
+    """
+
+    logger = logging.getLogger(__name__)
+    current_user = get_current_user()
+
+    if current_user is None:
+        logger.info('%(instance_model)s #%(instance_pk)d (%(instance_slug)s) has been deleted. User not found.',
+                    {'instance_model': type(instance).__name__, 'instance_pk': instance.pk,
+                     'instance_slug': instance.slug})
+    else:
+        logger.info('%(instance_model)s #%(instance_pk)d (%(instance_slug)s) has been deleted '
+                    'by user #%(user_pk)d (%(username)s).', {'instance_model': type(instance).__name__,
+                                                             'instance_pk': instance.pk, 'instance_slug': instance.slug,
+                                                             'user_pk': current_user.pk,
+                                                             'username': current_user.username})


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #4741 #4057

Fix #4741

### Contrôle qualité

- Créer un contenu.
- Le supprimer et vérifier que deux entrées de log apparaissent dans le terminal : la suppression du contenu et celle de la galerie liée.
- Créer une galerie sans contenu et la supprimer, vérifier la présence de l'entrée de log.
