### PR TITLE
Ne charger MathJax que quand il y en a besoin

### DIFF
--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -77,7 +77,7 @@
                 synchText();
             },
             complete: function(){
-              $email.prop("disabled", false);
+                $email.prop("disabled", false);
             }
         });
 
@@ -131,7 +131,7 @@
                 synchText();
             },
             complete: function(){
-              $follow.prop("disabled", false);
+                $follow.prop("disabled", false);
             }
         });
         e.stopPropagation();
@@ -246,11 +246,11 @@
         var $form = $btn.parents("form:first");
         var text = "";
         if ( $form.find(".preview-source").length ) {
-                var $textSource = $btn.parent().prev().find(".preview-source");
-                text = $textSource.val();
-            } else {
-                text = $form.find("textarea[name=text]").val();
-            }
+            var $textSource = $btn.parent().prev().find(".preview-source");
+            text = $textSource.val();
+        } else {
+            text = $form.find("textarea[name=text]").val();
+        }
 
         var csrfmiddlewaretoken = $form.find("input[name=csrfmiddlewaretoken]").val(),
             lastPost = $form.find("input[name=last_post]").val();
@@ -273,8 +273,10 @@
                     $(data).insertAfter($btn);
 
                 /* global MathJax */
-                if (data.indexOf("$") > 0)
+                // MathJax may be unavailable on some pages.
+                if (window.MathJax && data.indexOf("$") > 0) {
                     MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+                }
             }
         });
     });

--- a/templates/base.html
+++ b/templates/base.html
@@ -123,7 +123,8 @@
     <link rel="alternate" type="application/atom+xml" title="Nouveaux billets (ATOM)" href="{% url "opinion:feed-atom" %}">
     {# OpenSearch plugin autodiscovery #}
     <link rel="search" type="application/opensearchdescription+xml" title="{{ app.site.literal_name }}" href="{% url "search:opensearch" %}">
-    {% block extra_link %}{% endblock %}
+
+    {% block head_extra %}{% endblock %}
 </head>
 
 {% if not user.is_authenticated or user.profile.allow_temp_visual_changes %}
@@ -702,23 +703,6 @@
 
 
 
-    {# MathJax #}
-    <script type="text/x-mathjax-config">
-        MathJax.Hub.Config({
-            tex2jax: {
-                inlineMath: [['$', '$']],
-                displayMath: [['$$','$$']],
-                processEscapes: true,
-                processClass: "message-content|article-content",
-                ignoreClass: "page-container"
-            },
-            TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js", "mhchem.js"] },
-            messageStyle: "none",
-        });
-    </script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
-        integrity="sha384-Ra6zh6uYMmH5ydwCqqMoykyf1T/+ZcnOQfFPhDrp2kI4OIxadnhsvvA2vv9A7xYv"
-        crossorigin="anonymous">
-    </script>
+    {% include "mathjax_config.html" %}
 </body>
 </html>

--- a/templates/base_content_page.html
+++ b/templates/base_content_page.html
@@ -2,6 +2,12 @@
 {% load i18n %}
 
 
+{% block head_extra %}
+    {{ block.super }}
+    {% include "mathjax.html" %}
+{% endblock %}
+
+
 {% block content_out %}
     <article class="content-wrapper" {% block article_schema %}{% endblock %}>
         <header>

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -7,6 +7,14 @@
 {% load remove_url_scheme %}
 
 
+
+{% block head_extra %}
+    {{ block.super }}
+    {% include "mathjax.html" %}
+{% endblock %}
+
+
+
 {% block title_base %}
     &bull; {% trans "Forum" %}
 {% endblock %}

--- a/templates/mathjax.html
+++ b/templates/mathjax.html
@@ -1,0 +1,6 @@
+<script type="text/javascript"
+        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+        integrity="sha384-Ra6zh6uYMmH5ydwCqqMoykyf1T/+ZcnOQfFPhDrp2kI4OIxadnhsvvA2vv9A7xYv"
+        crossorigin="anonymous"
+        async>
+</script>

--- a/templates/mathjax_config.html
+++ b/templates/mathjax_config.html
@@ -1,0 +1,13 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+        tex2jax: {
+            inlineMath: [['$', '$']],
+            displayMath: [['$$','$$']],
+            processEscapes: true,
+            processClass: "message-content|article-content",
+            ignoreClass: "page-container"
+        },
+        TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js", "mhchem.js"] },
+        messageStyle: "none",
+    });
+</script>

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -8,6 +8,12 @@
 {% load remove_url_scheme %}
 
 
+{% block head_extra %}
+    {{ block.super }}
+    {% include "mathjax.html" %}
+{% endblock %}
+
+
 {% block title %}
     {{ usr.username }}
 {% endblock %}

--- a/templates/member/settings/base.html
+++ b/templates/member/settings/base.html
@@ -2,6 +2,14 @@
 {% load i18n %}
 
 
+
+{% block head_extra %}
+    {{ block.super }}
+    {% include "mathjax.html" %}
+{% endblock %}
+
+
+
 {% block title_base %}
    &bull; {% trans "Paramètres" %}
 {% endblock %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -50,7 +50,8 @@
 {% endspaceless %}{% endblock %}
 
 
-{% block extra_link %}
+{% block head_extra %}
+    {{ block.super }}
     {% if content.converted_to.get_absolute_url_online %}
         <link rel="canonical" href="{{ content.converted_to.get_absolute_url_online }}" />
     {% endif %}


### PR DESCRIPTION
Actuellement, MathJax est chargé sur toutes les pages du site, ce qui
occasionne notamment une douzaine de requêtes inutiles sur la page
d’accueil. Au moment où j’écris ces lignes, la page d’accueil demande
40 requêtes, sans MathJax ça en fait plus que 28 et une bonne centaine
de Kio de moins à télécharger, ce qui (je pense) n’est pas si
négligeable.

J’ai donc fait en sorte que le <script> de MathJax ne soit inclus dans
la balise <head> que quand il y en a besoin, c’est-à-dire en gros sur
les pages des forums et des publications.

Il reste peut-être quelques rares pages sur lesquelles MathJax n’est
pas disponible et sur lesquelles des maths peuvent être affichées. Si
vous en voyez, signalez-le.

J’ai mis le <script> de MathJax dans la balise <head> avec un attribut
`async` dans l’espoir que son téléchargement puisse commencer le plus
tôt possible sans bloquer le parsing de la page.

Ah aussi, ça n’a pas vraiment de rappord mais le téléchargement de
MathJax se fait en plusieurs (longues) étapes :

- D’abord on télécharge MathJax.js.

- Une fois que MathJax.js est téléchargé, on lui indique la liste des
  plugins à utiliser.

- Une fois que MathJax.js sait quels plugins on demande, il va
  *refaire* des *nouvelles* requêtes HTTP (en rajoutant des balises
  `<script>`) pour aller les chercher.

Ben je sais pas ce que vous en pensez, mais je pense que ce n’est pas
le plus rapide :upside_down_face: 
### Contrôle qualité

Vérifiez qu’il n’y ai pas de page du site **couramment utilisée** sur
laquelle le LaTeX n’est pas rendu (comme je l’ai dit plus haut, les
pages d’édition du profil ça ne compte pas, mais la page de profil ça
compte).

Vérifiez que MathJax n’est pas téléchargé sur la page d’accueil.
