### PR TITLE
Corrections ortho et typographiques sur la recettes des cookies

### DIFF
--- a/templates/pages/cookies.html
+++ b/templates/pages/cookies.html
@@ -88,7 +88,7 @@
     <h3>{% trans "Comment refuser les cookies tiers" %}</h3>
     <h4>{% trans "Refus pur et simple des cookies tiers dans le navigateur" %}</h4>
     <p>{% blocktrans %}Vous pouvez bloquer purement et simplement les cookies <strong>tiers</strong> dans votre navigateur, en suivant la procédure décrite <a href="http://www.cnil.fr/vos-droits/vos-traces/les-cookies/conseils-aux-internautes">sur le site de la CNIL dans le Conseil 1</a>.{% endblocktrans %}</p>
-    <p>{% blocktrans %}Cette man&oelig;uvre n'empêchera pas {{ site_name }} de fonctionner, puisque les cookies techniques ne sont pas des cookies tiers.{% endblocktrans %}</p>
+    <p>{% blocktrans %}Cette manœuvre n'empêchera pas {{ site_name }} de fonctionner, puisque les cookies techniques ne sont pas des cookies tiers.{% endblocktrans %}</p>
     <p>{% trans "Toutefois, devant le manque de finesse de contrôle d'une telle solution, vous pourriez préférer utiliser une solution présentée au paragraphe suivant." %}</p>
 
     <h4>{% trans "Utilisation d'un logiciel 'anti-espions'" %}</h4>
@@ -122,20 +122,20 @@
     <h4>{% trans "Ingrédients" %}</h4>
     <p>{% trans "Pour beaucoup de cookies (parce que le nombre dépend de leur taille) :" %}</p>
     <ul>
-        <li>{% trans "500 g de farine" %}</li>
-        <li>{% trans "500 g de chocolat à pâtisser" %}</li>
-        <li>{% trans "250 g de beurre à température ambiante" %}</li>
-        <li>{% trans "200 g de cassonade, ou à défaut de sucre roux" %}</li>
-        <li>{% trans "2 &oelig;ufs" %}</li>
-        <li>{% trans "2 cuillers à café de vanille liquide ou à défaut 2 sachets de sucre vanillé" %}</li>
-        <li>{% trans "1 pincée de sel" %}</li>
-        <li>{% trans "1 sachet de levure" %}</li>
+        <li>{% trans "500 g de farine ;" %}</li>
+        <li>{% trans "500 g de chocolat à pâtisser ;" %}</li>
+        <li>{% trans "250 g de beurre à température ambiante ;" %}</li>
+        <li>{% trans "200 g de cassonade, ou à défaut de sucre roux ;" %}</li>
+        <li>{% trans "2 œufs ;" %}</li>
+        <li>{% trans "2 cuillères à café de vanille liquide ou à défaut 2 sachets de sucre vanillé ;" %}</li>
+        <li>{% trans "1 pincée de sel ;" %}</li>
+        <li>{% trans "1 sachet de levure." %}</li>
     </ul>
     <p>{% trans "Préparation : 10 minutes + 15 minutes pour couper le chocolat" %}</p>
     <p>{% blocktrans %}Cuisson : 10 minutes <strong>par fournée</strong>{% endblocktrans %}</p>
     <h4>{% trans "Préparation" %}</h4>
     <p>{% trans "Avec un grand couteau solide et bien aiguisé, découpez le chocolat en petits morceaux." %}</p>
-    <p>{% trans "Mélangez en crème le beurre ramolli et le sucre. Incorporez les &oelig;ufs et la vanille liquide (ou le sucre vanillé)." %}</p>
+    <p>{% trans "Mélangez en crème le beurre ramolli et le sucre. Incorporez les œufs et la vanille liquide (ou le sucre vanillé)." %}</p>
     <p>{% trans "Ajoutez la farine et la levure. Mélangez bien." %}</p>
     <p>{% trans "Ajoutez les morceaux de chocolat et mélangez avec soin." %}</p>
     <h4>{% trans "Cuisson" %}</h4>
@@ -146,5 +146,5 @@
     <p>{% trans "Si vous avez la flemme de découper le chocolat, vous pouvez utiliser des pépites de chocolat mais en général c'est moins bon. Surtout pas de chocolat à déguster : ces chocolats manquent de sucre pour la pâtisserie !" %}</p>
     <p>{% trans "Pour découper le chocolat, vous aurez besoin d'un grand couteau solide (donc pas un couteau céramique) et très bien aiguisé. Non, le vôtre n'est pas assez aiguisé. Attaquez la plaque de chocolat côté lisse (carrés sur le dessous), c'est plus simple." %}</p>
     <p>{% trans "La cuisson parfaite se joue à quelques secondes près (sérieusement), alors surveillez-les bien ! Un SMS de trop, et vous obtenez des cookies en béton. Ce qui serait dommage. Les cookies sont assez mous en sortie de four, c'est normal : ils durcissent en refroidissant." %}</p>
-    <p>{% blocktrans %} On peut faire des cookies à beaucoup de parfums, mais le <em>must</em> reste le cookie au chocolat.{% endblocktrans %}</p>
+    <p>{% blocktrans %}On peut faire des cookies à beaucoup de parfums, mais le <em>must</em> reste le cookie au chocolat.{% endblocktrans %}</p>
 {% endblock %}


### PR DESCRIPTION
En m'occupant de la PR #4682, j'ai remarqué qu'il y avait quelques petites coquilles (sans mauvais jeu de mots) dans la recette des cookies au chocolat (dont j'ignorais d'ailleurs l'existence ^^). Vu que ça n'a pas trop de rapport avec cette PR là, je les ai corrigé dans une PR séparée.

Bon, "priorité basse" serait ici un euphémisme...

Numéro du ticket concerné (optionnel) : Aucun

### Contrôle qualité

  - Vérifier que l'orthographe et la typo sont corrects ;
  - Vérifier que les cookies sont bons.
