### PR TITLE
Modifie les gabarits liés à l'inscription et à la connexion

### DIFF
--- a/templates/member/forgot_password/index.html
+++ b/templates/member/forgot_password/index.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 
 
+
 {% block title %}
     {% trans "Mot de passe oublié" %}
 {% endblock %}
@@ -29,7 +30,9 @@
 
     {% if not user.is_authenticated %}
         {% if error %}
-            {{ error }}
+            <p class="alert-box warning">
+                {{ error }}
+            </p>
         {% endif %}
 
         <p>
@@ -63,6 +66,16 @@
 
         {% crispy form %}
     {% else %}
-        <p>{% trans "Vous êtes connecté." %}</p>
+        <p class="alert-box error">
+            {% trans "Vous êtes connecté." %}
+        </p>
     {% endif %}
+{% endblock %}
+
+
+
+{% block sidebar_actions %}
+    <a href="{% url 'member-login' %}" class="new-btn ico-after arrow-left blue">
+        {% trans "Retour" %} <span class="wide">{% trans "à la page de connexion" %}</span>
+    </a>
 {% endblock %}

--- a/templates/member/forgot_password/success.html
+++ b/templates/member/forgot_password/success.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 
+
 {% block title %}
     {% trans "Mot de passe oublié" %}
 {% endblock %}
@@ -25,3 +26,9 @@
         {% trans "Un courriel contenant de plus amples instructions d’activation a été envoyé. Ce courriel se trouve peut-être dans vos spams" %}.
     </p>
 {% endblock %}
+
+
+
+{# No sidebar on this page #}
+{% block body_class %}{% trans "no-sidebar" %}{% endblock %}
+{% block sidebar %}{% endblock %}

--- a/templates/member/new_password/failed.html
+++ b/templates/member/new_password/failed.html
@@ -2,14 +2,15 @@
 {% load i18n %}
 
 
+
 {% block title %}
-    {% trans "Nouveau mot de passe raté" %}
+    {% trans "Échec de la réinitialisation" %}
 {% endblock %}
 
 
 
 {% block headline %}
-    {% trans "Nouveau mot de passe raté" %}
+    {% trans "Échec de la réinitialisation" %}
 {% endblock %}
 
 
@@ -22,9 +23,15 @@
 
 {% block content %}
     <p>
-        {% trans "Votre mot de passe n’a pas pu être modifié. A partir du moment où vous soumettez votre requête pour réinitialiser votre mot de passe, vous n’avez qu’une heure pour la confirmer" %}.
+        {% trans "Votre mot de passe n’a pas pu être modifié. À partir du moment où vous soumettez votre requête pour réinitialiser votre mot de passe, vous n’avez qu’une heure pour la confirmer" %}.
     </p>
     <p>
-        <a href="{% url "member-forgot-password" %}">{% trans "Resoumettre votre demande de réinitialisation" %}</a>.
+        <a href="{% url "member-forgot-password" %}">{% trans "Soumettre à nouveau votre demande de réinitialisation" %}</a>.
     </p>
 {% endblock %}
+
+
+
+{# No sidebar on this page #}
+{% block body_class %}{% trans "no-sidebar" %}{% endblock %}
+{% block sidebar %}{% endblock %}

--- a/templates/member/new_password/index.html
+++ b/templates/member/new_password/index.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 
 
+
 {% block title %}
     {% trans "Nouveau mot de passe" %}
 {% endblock %}
@@ -24,13 +25,23 @@
 {% block content %}
     {% if not user.is_authenticated %}
         {% if error %}
-            {{ error }}
+            <p class="alert-box warning">
+                {{ error }}
+            </p>
         {% endif %}
         <p>
             {% trans "Renseignez votre nouveau mot de passe" %}.
         </p>
         {% crispy form %}
     {% else %}
-        <p>{% trans "Vous êtes connecté." %}</p>
+        <p class="alert-box error">
+            {% trans "Vous êtes connecté." %}
+        </p>
     {% endif %}
 {% endblock %}
+
+
+
+{# No sidebar on this page #}
+{% block body_class %}{% trans "no-sidebar" %}{% endblock %}
+{% block sidebar %}{% endblock %}

--- a/templates/member/new_password/success.html
+++ b/templates/member/new_password/success.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 
+
 {% block title %}
     {% trans "La modification du mot de passe a été effectuée" %}
 {% endblock %}
@@ -25,3 +26,9 @@
         {% trans "Votre mot de passe a bien été modifié, vous pouvez dès maintenant" %} <a href="{% url "member-login" %}">{% trans "vous connecter" %}</a>.
     </p>
 {% endblock %}
+
+
+
+{# No sidebar on this page #}
+{% block body_class %}{% trans "no-sidebar" %}{% endblock %}
+{% block sidebar %}{% endblock %}

--- a/templates/member/register/base.html
+++ b/templates/member/register/base.html
@@ -1,7 +1,0 @@
-{% extends "member/base.html" %}
-{% load i18n %}
-
-
-{# No sidebar on this page #}
-{% block body_class %}no-sidebar{% endblock %}
-{% block sidebar %}{% endblock %}

--- a/templates/member/register/index.html
+++ b/templates/member/register/index.html
@@ -1,6 +1,7 @@
-{% extends "member/register/base.html" %}
+{% extends "member/base.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
+
 
 
 {% block title %}
@@ -13,6 +14,8 @@
     {% trans "Inscription" %}
 {% endblock %}
 
+
+
 {% block breadcrumb %}
     <li>{% trans "Inscription" %}</li>
 {% endblock %}
@@ -23,7 +26,9 @@
     <div class="content-wrapper">
         {% if not user.is_authenticated %}
             {% if error %}
-                {{ error }}
+                <p class="alert-box warning">
+                    {{ error }}
+                </p>
             {% endif %}
 
             <p class="alert-box warning">
@@ -58,7 +63,7 @@
             </div>
         {% else %}
             <div>
-                <p class="alert-box warning">
+                <p class="alert-box error">
                     <strong>
                         {% trans "Vous êtes déjà inscrit." %}
                     </strong>
@@ -67,3 +72,9 @@
         {% endif %}
 </div>
 {% endblock %}
+
+
+
+{# No sidebar on this page #}
+{% block body_class %}no-sidebar{% endblock %}
+{% block sidebar %}{% endblock %}

--- a/templates/member/register/send_validation_email.html
+++ b/templates/member/register/send_validation_email.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 
 
+
 {% block title %}
     {% trans "Envoi du courriel de confirmation" %}
 {% endblock %}
@@ -29,7 +30,9 @@
 
     {% if not user.is_authenticated %}
         {% if error %}
-            {{ error }}
+            <p class="alert-box warning">
+                {{ error }}
+            </p>
         {% endif %}
 
         <p>
@@ -51,6 +54,16 @@
 
         {% crispy form %}
     {% else %}
-        <p>{% trans "Vous êtes connecté" %}</p>
+        <p class="alert-box error">
+            {% trans "Vous êtes déjà connecté." %}
+        </p>
     {% endif %}
+{% endblock %}
+
+
+
+{% block sidebar_actions %}
+    <a href="{% url 'member-login' %}" class="new-btn ico-after arrow-left blue">
+        {% trans "Retour" %} <span class="wide">{% trans "à la page de connexion" %}</span>
+    </a>
 {% endblock %}

--- a/templates/member/register/send_validation_email_success.html
+++ b/templates/member/register/send_validation_email_success.html
@@ -1,4 +1,4 @@
-{% extends "member/register/base.html" %}
+{% extends "member/base.html" %}
 {% load i18n %}
 
 
@@ -25,3 +25,9 @@
         {% trans "Vous allez recevoir un courriel contenant le lien d’activation. Veuillez cliquer sur celui-ci avant toute tentative de connexion." %}.
     </p>
 {% endblock %}
+
+
+
+{# No sidebar on this page #}
+{% block body_class %}{% trans "no-sidebar" %}{% endblock %}
+{% block sidebar %}{% endblock %}

--- a/templates/member/register/success.html
+++ b/templates/member/register/success.html
@@ -1,4 +1,4 @@
-{% extends "member/register/base.html" %}
+{% extends "member/base.html" %}
 {% load i18n %}
 
 
@@ -25,3 +25,9 @@
         {% trans "Votre compte a été créé avec succès. Vous allez recevoir un courriel contenant un lien d’activation. Veuillez cliquer sur celui-ci avant toute tentative de connexion" %}.
     </p>
 {% endblock %}
+
+
+
+{# No sidebar on this page #}
+{% block body_class %}{% trans "no-sidebar" %}{% endblock %}
+{% block sidebar %}{% endblock %}

--- a/templates/member/register/token_already_used.html
+++ b/templates/member/register/token_already_used.html
@@ -1,5 +1,6 @@
-{% extends "member/register/base.html" %}
+{% extends "member/base.html" %}
 {% load i18n %}
+
 
 
 {% block title %}
@@ -28,4 +29,12 @@
             Votre compte a déjà été activé. Si vous avez oublié votre mot de passe, vous pouvez le retrouver <a href="{{url_forgot}}">ici</a>.
         {% endblocktrans %}
     </p>
+{% endblock %}
+
+
+
+{% block sidebar_actions %}
+    <a href="{% url 'member-login' %}" class="new-btn ico-after arrow-left blue">
+        {% trans "Retour" %} <span class="wide">{% trans "à la page de connexion" %}</span>
+    </a>
 {% endblock %}

--- a/templates/member/register/token_failed.html
+++ b/templates/member/register/token_failed.html
@@ -1,4 +1,4 @@
-{% extends "member/register/base.html" %}
+{% extends "member/base.html" %}
 {% load i18n %}
 
 
@@ -29,3 +29,9 @@
         {% endblocktrans %}
     </p>
 {% endblock %}
+
+
+
+{# No sidebar on this page #}
+{% block body_class %}{% trans "no-sidebar" %}{% endblock %}
+{% block sidebar %}{% endblock %}

--- a/templates/member/register/token_success.html
+++ b/templates/member/register/token_success.html
@@ -1,21 +1,20 @@
-{% extends "base.html" %}
+{% extends "member/base.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
+
+
 
 {% block title %}
     {% trans "Confirmation d’inscription réussie" %}
 {% endblock %}
 
 
-{# No sidebar on this page #}
-{% block body_class %}{% trans "no-sidebar" %}{% endblock %}
-{% block sidebar %}{% endblock %}
-
 
 {% block breadcrumb %}
     <li><a href="{% url "register-member" %}">{% trans "Inscription" %}</a></li>
     <li>{% trans "Confirmation" %}</li>
 {% endblock %}
+
 
 
 {% block content_out %}
@@ -30,4 +29,12 @@
             {% crispy form %}
         </p>
     </section>
+{% endblock %}
+
+
+
+{% block sidebar_actions %}
+    <a href="{% url 'member-login' %}" class="new-btn ico-after arrow-left blue">
+        {% trans "Retour" %} <span class="wide">{% trans "à la page de connexion" %}</span>
+    </a>
 {% endblock %}


### PR DESCRIPTION
Modifie les gabarits liés à l'inscription et à la connexion (et corrige #4257 "Sidebar de la page « Mot de passe oublié »)

**QA :** Vérifier que les pages touchées fonctionnent encore et qu'il n'y a pas de bug graphique.