### PR TITLE
Les transitions CSS ne s'appliquent plus sur toutes les propriétés CSS

### DIFF
--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -87,7 +87,7 @@
     button,
     .btn {
         -webkit-appearance: none;
-        transition: all $transition-duration ease;
+        transition: color $transition-duration ease, background $transition-duration ease;
     }
 
     input:not([type=submit]):not([type=reset]):not([type=radio]):not([type=checkbox]) {

--- a/assets/scss/base/_typography.scss
+++ b/assets/scss/base/_typography.scss
@@ -20,7 +20,7 @@ hr {
 a,
 .link {
     color: lighten($color-primary, 20%);
-    transition: all $transition-duration ease;
+    transition: color $transition-duration ease, text-decoration $transition-duration ease;
 
     &:hover {
         color: darken($color-secondary, 15%);

--- a/assets/scss/components/_authors.scss
+++ b/assets/scss/components/_authors.scss
@@ -33,7 +33,7 @@
                 height: 36px;
                 line-height: 36px;
                 padding: 0 8px;
-                transition: all $transition-duration ease;
+                transition: background $transition-duration ease, color $transition-duration ease,;
 
                 &.ico-after {
                     padding-left: 30px;

--- a/assets/scss/components/_header-dropdown.scss
+++ b/assets/scss/components/_header-dropdown.scss
@@ -56,7 +56,7 @@
                     line-height: 25px;
                     color: #95d7f5;
                     overflow: hidden;
-                    transition: all $transition-duration ease;
+                    transition: padding-left $transition-duration ease, background-color $transition-duration ease;
 
                     &:hover,
                     &:focus {
@@ -121,7 +121,7 @@
                 &::-webkit-scrollbar-thumb {
                     background-color: #396a81;
                     border: 1px solid #06354a;
-                    transition: all $transition-duration ease;
+                    transition: background-color $transition-duration ease;
 
                     &:hover {
                         background-color: #5196b6;

--- a/assets/scss/components/_pagination.scss
+++ b/assets/scss/components/_pagination.scss
@@ -20,7 +20,7 @@
             min-width: 45px;
             height: 40px;
             line-height: 40px;
-            transition: all $transition-duration ease;
+            transition: background $transition-duration ease;
 
             &.current {
                 height: 38px;

--- a/assets/scss/components/_tags.scss
+++ b/assets/scss/components/_tags.scss
@@ -15,7 +15,9 @@
             background: $color-header-hover;
             color: #FFF;
             margin-left: 1px;
-            transition: all $transition-duration ease;
+            transition-property: color, background, border;
+            transition-timing-function: ease;
+            transition-duration: $transition-duration;
 
             &:hover,
             &:focus {
@@ -51,7 +53,9 @@
         padding: 8px 15px;
         text-decoration: none;
         background-color: #EEE;
-        transition: all $transition-duration ease;
+        transition-property: color, background, border, outline;
+        transition-timing-function: ease;
+        transition-duration: $transition-duration;
         border: solid 1px #CCC;
 
         &:hover, &:focus {

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -77,7 +77,7 @@
                 line-height: 26px;
                 width: 58px;
                 color: #777;
-                transition: all $transition-duration ease;
+                transition: border $transition-duration ease, background $transition-duration ease;
 
                 &:hover,
                 &:focus {
@@ -149,7 +149,9 @@
                 line-height: 30px;
                 padding: 0 5px;
                 border-bottom: 1px solid #D2D5D6;
-                transition: all $transition-duration ease;
+                transition-property: color, outline, border;
+                transition-timing-function: ease;
+                transition-duration: $transition-duration;
 
                 &:hover,
                 &:focus {
@@ -288,7 +290,7 @@
 
                 a {
                     color: #999;
-                    transition: all $transition-duration ease;
+                    transition: color $transition-duration ease, text-decoration $transition-duration ease;
 
                     &:hover,
                     &:focus {
@@ -428,7 +430,6 @@
                 display: block;
                 float: left;
                 margin-left: 3px;
-                transition: all $transition-duration ease;
 
                 &.ico-after {
                     padding-left: 30px !important;
@@ -437,7 +438,6 @@
                 &:after {
                     top: 7px;
                     left: 7px;
-                    transition: all $transition-duration ease;
                     opacity: .5;
                     margin: 0;
                 }
@@ -462,6 +462,9 @@
                     border-bottom-color: lighten($color-primary, 15%);
                     outline: none;
                     background: none;
+                    transition-property: background, border, outline, opacity;
+                    transition-timing-function: ease;
+                    transition-duration: $transition-duration;
 
                     &:after {
                         opacity: 1;

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -91,7 +91,6 @@ $logo-width: 240px;
                         left: 0;
                         right: 0;
                         height: 2px;
-                        transition: all $transition-duration ease;
                         border-radius: 2px 2px 0 0;
                         background-color: $color-secondary;
                     }

--- a/assets/scss/layout/_sidebar.scss
+++ b/assets/scss/layout/_sidebar.scss
@@ -17,7 +17,7 @@
         font-size: 1.6rem;
         position: relative;
         color: lighten($color-primary, 20%);
-        transition: all $transition-duration ease;
+        transition: background-color $transition-duration ease;
 
         &:first-child {
             margin-top: 31px;
@@ -25,7 +25,7 @@
 
         &:hover,
         &:focus {
-            background: $color-sidebar-hover;
+            background-color: $color-sidebar-hover;
         }
 
         &:after {
@@ -306,7 +306,9 @@
                 a {
                     position: relative;
                     color: $color-primary;
-                    transition: all $transition-duration ease;
+                    transition-property: color, background, margin;
+                    transition-timing-function: ease;
+                    transition-duration: $transition-duration;
 
                     &:hover,
                     &:focus {


### PR DESCRIPTION
Tentative de la solution proposée par @sandhose pour #2649 qui ne fonctionne pas, mais c'est plus propre donc je fais quand même la PR.

**QA :**

- `make build-front`
- Visiter le site et vérifier que les transitions sont toujours les mêmes. (La vraie QA se fera en bêta étant donné que je n'ai pas la liste de toutes les transitions à vérifier.)