### PR TITLE
[WIP] Grand ménage dans les paramètres

### DIFF
--- a/templates/member/settings/base.html
+++ b/templates/member/settings/base.html
@@ -32,7 +32,20 @@
                 {% if user.profile.is_dev %}
                     <li><a href="{% url "update-github" %}">{% trans "Token GitHub" %}</a></li>
                 {% endif %}
-				<li><a href="{% url "member-warning-unregister" %}">{% trans "Se désinscrire" %}</a></li>
+                <li><a href="{% url "member-warning-unregister" %}">{% trans "Se désinscrire" %}</a></li>
+            </ul>
+
+            <h3>{% trans "Nouvelle navigation" %}</h3>
+            <ul>
+                <li><a href="{% url "update-main-settings" %}">{% trans "Paramètres généraux" %}</a></li>
+                <li><a href="{% url "update-profile-settings" %}">{% trans "Modifier mon profil" %}</a></li>
+                <li><a href="{% url "update-account-settings" %}">{% trans "Modifier mon compte" %}</a></li>
+                <li><a href="{% url "update-email-settings" %}">{% trans "Modifier mon courriel" %}</a></li>
+                <li><a href="{% url "hats-settings" %}">{% trans "Gérer mes casquettes" %}</a></li>
+                {% if user.profile.is_dev %}
+                    <li><a href="{% url "update-github" %}">{% trans "Gérer mon token GitHub" %}</a></li>
+                {% endif %}
+                <li><a href="{% url "member-warning-unregister" %}">{% trans "Se désinscrire" %}</a></li>
             </ul>
         </div>
     </aside>

--- a/templates/member/settings/new/account.html
+++ b/templates/member/settings/new/account.html
@@ -1,0 +1,3 @@
+{% extends "member/settings/base.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}

--- a/templates/member/settings/new/account.html
+++ b/templates/member/settings/new/account.html
@@ -1,3 +1,26 @@
 {% extends "member/settings/base.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
+
+
+{% block title %}
+   {% trans "Modifier mon compte" %}
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    <li>{% trans "Modifier mon compte" %}</li>
+{% endblock %}
+
+
+
+{% block headline %}
+    {% trans "Mon compte" %}
+{% endblock %}
+
+
+
+{% block content %}
+    {% crispy form %}
+{% endblock %}

--- a/templates/member/settings/new/email.html
+++ b/templates/member/settings/new/email.html
@@ -1,0 +1,3 @@
+{% extends "member/settings/base.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}

--- a/templates/member/settings/new/email.html
+++ b/templates/member/settings/new/email.html
@@ -1,3 +1,26 @@
 {% extends "member/settings/base.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
+
+
+{% block title %}
+   {% trans "Modifier mon courriel" %}
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    <li>{% trans "Modifier mon courriel" %}</li>
+{% endblock %}
+
+
+
+{% block headline %}
+    {% trans "Mon courriel" %}
+{% endblock %}
+
+
+
+{% block content %}
+    {% crispy form %}
+{% endblock %}

--- a/templates/member/settings/new/main.html
+++ b/templates/member/settings/new/main.html
@@ -1,0 +1,3 @@
+{% extends "member/settings/base.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}

--- a/templates/member/settings/new/main.html
+++ b/templates/member/settings/new/main.html
@@ -1,3 +1,26 @@
 {% extends "member/settings/base.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
+
+
+{% block title %}
+   {% trans "Paramètres généraux" %}
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    <li>{% trans "Paramètres généraux" %}</li>
+{% endblock %}
+
+
+
+{% block headline %}
+    {% trans "Paramètres généraux" %}
+{% endblock %}
+
+
+
+{% block content %}
+    {% crispy form %}
+{% endblock %}

--- a/templates/member/settings/new/profile.html
+++ b/templates/member/settings/new/profile.html
@@ -1,0 +1,3 @@
+{% extends "member/settings/base.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}

--- a/templates/member/settings/new/profile.html
+++ b/templates/member/settings/new/profile.html
@@ -1,3 +1,51 @@
 {% extends "member/settings/base.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
+
+
+{% block title %}
+    {% if user.profile == profile %}
+        {% trans "Modifier mon profil" %}
+    {% else %}
+        {% trans "Modérer le profil de" %} {{ profile.user.username }}
+    {% endif %}
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    <li>
+        {% if user.profile == profile %}
+            {% trans "Modifier mon profil" %}
+        {% else %}
+            {% trans "Modérer le profil de" %} {{ profile.user.username }}
+        {% endif %}
+    </li>
+{% endblock %}
+
+
+
+{% block headline %}
+    {% if user.profile == profile %}
+        {% trans "Modifier mon profil" %}
+    {% else %}
+        {% trans "Modérer le profil de" %} {{ profile.user.username }}
+    {% endif %}
+{% endblock %}
+
+
+
+{% if user.profile != profile %}
+{% block sidebar %}{% endblock sidebar %}
+{% endif %}
+
+
+{% block content %}
+    {% if user.profile != profile %}
+        <p class="alert-box warning">
+            {% trans "Le profil que vous éditez n'est pas le votre, soyez prudent lors de l'édition de celui-ci !" %}
+        </p>
+    {% endif %}
+
+    {% crispy form %}
+{% endblock %}

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -143,7 +143,23 @@ class RegisterForm(forms.Form):
     def throw_error(self, key=None, message=None):
         self._errors[key] = self.error_class([message])
 
+class MainSettingsForm(forms.Form):
+    pass
 
+
+class ProfileSettingsForm(forms.Form):
+    pass
+
+
+class AccountSettingsForm(forms.Form):
+    pass
+
+
+class EmailSettingsForm(forms.Form):
+    pass
+
+
+# TODO; old form to be remove
 class MiniProfileForm(forms.Form):
     """
     Updates some profile data: biography, website, avatar URL, signature.
@@ -208,6 +224,7 @@ class MiniProfileForm(forms.Form):
             ))
 
 
+# TODO; old form to be remove
 class ProfileForm(MiniProfileForm):
     """
     Updates main profile rules:
@@ -304,6 +321,7 @@ class ProfileForm(MiniProfileForm):
         self.helper.layout = layout
 
 
+# TODO; old form to be remove
 class GitHubTokenForm(forms.Form):
     """
     Updates the GitHub token.
@@ -332,6 +350,7 @@ class GitHubTokenForm(forms.Form):
             ))
 
 
+# TODO; old form to be remove
 class ChangeUserForm(forms.Form):
     """
     Update username and email
@@ -404,6 +423,7 @@ class ChangeUserForm(forms.Form):
         return cleaned_data
 
 
+# TODO; old form to be remove
 # TODO: Updates the password --> requires a better name
 class ChangePasswordForm(forms.Form):
 
@@ -462,6 +482,7 @@ class ChangePasswordForm(forms.Form):
         return validate_passwords(cleaned_data, password_label='password_new', username=self.user.username)
 
 
+# TODO; old form to be remove
 class UsernameAndEmailForm(forms.Form):
     username = forms.CharField(
         label=_('Nom d\'utilisateur'),

--- a/zds/member/urls.py
+++ b/zds/member/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
 
     # settings
     url(r'^parametres/$', UpdateMainSettings.as_view(), name='update-main-settings'),
-    url(r'^parametres/(?P<user_name>.+)/$', ModerateProfile.as_view(), name='moderate-profile'),
+    url(r'^parametres/moderer/(?P<user_name>.+)/$', ModerateProfile.as_view(), name='moderate-profile'),
     # TODO: rename this url when removing the old one
     url(r'^parametres/new-profil/$', UpdateProfileSettings.as_view(), name='update-profile-settings'),
     url(r'^parametres/profil/maj_avatar/$', UpdateAvatarMember.as_view(), name='update-avatar-member'),

--- a/zds/member/urls.py
+++ b/zds/member/urls.py
@@ -7,7 +7,8 @@ from zds.member.views import MemberList, MemberDetail, UpdateMember, UpdateGitHu
     generate_token_account, unregister, warning_unregister, BannedEmailProvidersList, NewEmailProvidersList, \
     AddBannedEmailProvider, remove_banned_email_provider, check_new_email_provider, MembersWithProviderList, \
     HatsSettings, RequestedHatsList, HatRequestDetail, add_hat, remove_hat, solve_hat_request, HatsList, HatDetail, \
-    SolvedHatRequestsList
+    SolvedHatRequestsList, \
+    UpdateMainSettings, UpdateProfileSettings, UpdateAccountSettings, UpdateEmailSettings, ModerateProfile
 
 urlpatterns = [
     # list
@@ -16,17 +17,28 @@ urlpatterns = [
     # details
     url(r'^voir/(?P<user_name>.+)/$', MemberDetail.as_view(), name='member-detail'),
 
-    # modification
-    url(r'^parametres/profil/$', UpdateMember.as_view(), name='update-member'),
+    # settings
+    url(r'^parametres/$', UpdateMainSettings.as_view(), name='update-main-settings'),
+    url(r'^parametres/(?P<user_name>.+)/$', ModerateProfile.as_view(), name='moderate-profile'),
+    # TODO: rename this url when removing the old one
+    url(r'^parametres/new-profil/$', UpdateProfileSettings.as_view(), name='update-profile-settings'),
+    url(r'^parametres/profil/maj_avatar/$', UpdateAvatarMember.as_view(), name='update-avatar-member'),
+    # TODO: rename this url when removing the old one
+    url(r'^parametres/new-compte/$', UpdateAccountSettings.as_view(), name='update-account-settings'),
+    url(r'^parametres/courriel/$', UpdateEmailSettings.as_view(), name='update-email-settings'),
     url(r'^parametres/github/$', UpdateGitHubToken.as_view(), name='update-github'),
     url(r'^parametres/github/supprimer/$', remove_github_token, name='remove-github'),
-    url(r'^parametres/profil/maj_avatar/$', UpdateAvatarMember.as_view(), name='update-avatar-member'),
+    url(r'^parametres/casquettes/$', HatsSettings.as_view(), name='hats-settings'),
+
+    # TODO: old settings to be removed
+    url(r'^parametres/profil/$', UpdateMember.as_view(), name='update-member'),
     url(r'^parametres/compte/$', UpdatePasswordMember.as_view(), name='update-password-member'),
     url(r'^parametres/user/$', UpdateUsernameEmailMember.as_view(), name='update-username-email-member'),
 
     # moderation
     url(r'^profil/karmatiser/$', modify_karma, name='member-modify-karma'),
     url(r'^profil/modifier/(?P<user_pk>\d+)/$', modify_profile, name='member-modify-profile'),
+    # TODO: old setting to be removed
     url(r'^parametres/mini_profil/(?P<user_name>.+)/$', settings_mini_profile, name='member-settings-mini-profile'),
     url(r'^profil/multi/(?P<ip_address>.+)/$', member_from_ip, name='member-from-ip'),
 
@@ -47,7 +59,6 @@ urlpatterns = [
     # hats
     url(r'^casquettes/$', HatsList.as_view(), name='hats-list'),
     url(r'^casquettes/(?P<pk>\d+)/$', HatDetail.as_view(), name='hat-detail'),
-    url(r'^parametres/casquettes/$', HatsSettings.as_view(), name='hats-settings'),
     url(r'^casquettes/demandes/$', RequestedHatsList.as_view(), name='requested-hats'),
     url(r'^casquettes/demandes/archives/$', SolvedHatRequestsList.as_view(), name='solved-hat-requests'),
     url(r'^casquettes/demandes/(?P<pk>\d+)/$', HatRequestDetail.as_view(), name='hat-request'),

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -34,7 +34,8 @@ from zds.member.decorator import can_write_and_read_now, LoginRequiredMixin, Per
 from zds.member.forms import LoginForm, MiniProfileForm, ProfileForm, RegisterForm, \
     ChangePasswordForm, ChangeUserForm, NewPasswordForm, \
     PromoteMemberForm, KarmaForm, UsernameAndEmailForm, GitHubTokenForm, \
-    BannedEmailProviderForm, HatRequestForm
+    BannedEmailProviderForm, HatRequestForm, \
+    MainSettingsForm, ProfileSettingsForm, AccountSettingsForm, EmailSettingsForm
 from zds.member.models import Profile, TokenForgotPassword, TokenRegister, KarmaNote, Ban, \
     BannedEmailProvider, NewEmailProvider, set_old_smileys_cookie, remove_old_smileys_cookie
 from zds.mp.models import PrivatePost, PrivateTopic
@@ -98,6 +99,26 @@ class MemberDetail(DetailView):
         return context
 
 
+class UpdateMainSettings(UpdateView):
+    pass
+
+
+class UpdateProfileSettings(UpdateView):
+    pass
+
+
+class ModerateProfile(UpdateProfileSettings):
+    pass
+
+class UpdateAccountSettings(UpdateView):
+    pass
+
+
+class UpdateEmailSettings(UpdateView):
+    pass
+
+
+# TODO; old view to be remove
 class UpdateMember(UpdateView):
     """Update a profile."""
 
@@ -263,6 +284,7 @@ class UpdateAvatarMember(UpdateMember):
         return _('L\'avatar a correctement été mis à jour.')
 
 
+# TODO; old view to be remove
 class UpdatePasswordMember(UpdateMember):
     """Password-related user settings."""
 
@@ -290,6 +312,7 @@ class UpdatePasswordMember(UpdateMember):
         return reverse('update-password-member')
 
 
+# TODO; old view to be remove
 class UpdateUsernameEmailMember(UpdateMember):
     """Settings related to username and email."""
 
@@ -573,6 +596,7 @@ def modify_profile(request, user_pk):
 
 # Settings for public profile
 
+# TODO; old view to be remove
 @can_write_and_read_now
 @login_required
 @permission_required('member.change_profile', raise_exception=True)


### PR DESCRIPTION
Grand ménage dans les paramètres ! **Work In Progress**

Je propose ce découpage :

- Modifier mon profil (page pouvant être modérée par le staff)
  - Avatar
  - Biographie
  - Signature
  - Site web
- Modifier mon compte
  - Pseudo
  - Mot de passe
- Modifier mon courriel
  - Courriel
  - Checkbox avec : 
    - Affichage du courriel
    - Envoi d'un courriel lors d'une réponse à un MP
- Autres paramètres
  - Choix de la licence par défaut pour les contenus
  - Checkbox avec :
    - Changements visuels
    - Menu au survol
    - Aide Markdown
    - Affichage des signatures

Je n'ai pas touché aux pages du token GH ou des casquettes.

![parametres](https://user-images.githubusercontent.com/6664636/33912782-8174e73a-df97-11e7-85b1-836c3fc56828.png)

**WIP :**

- [ ] Créer les nouveaux formulaires, vues et gabarits (en utilisant ModelForm et UpdateView)
- [ ] Supprimer les anciens formulaires, vues et gabarits
- [ ] Adapter le front (modifier les anciens liens)
- [ ] Modifier les tests

**QA :** PAS A JOUR

- Aucune modification du front, ni de la base de donnée donc il suffit de lancer le serveur
- Vérifier que tous les paramètres peuvent être modifiés, sont bien gardés en mémoire et font bien effet comme attendu
- Vérifier qu'on peut ajouter une image comme avatar depuis la galerie
- Vérifier qu'un membre staff peut modérer le profil d'un autre membre (aller sur le profil de ce membre et cliquer sur le lien de la barre latérale)