### PR TITLE
Améliore le templatetag date

### DIFF
--- a/zds/utils/templatetags/date.py
+++ b/zds/utils/templatetags/date.py
@@ -4,7 +4,7 @@ from django import template
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.template.defaultfilters import date
 from django.utils.datetime_safe import datetime
-from django.utils.timezone import get_current_timezone
+from django.utils.timezone import get_default_timezone
 
 register = template.Library()
 
@@ -31,9 +31,9 @@ def date_formatter(value, tooltip, small):
     """
     if not isinstance(value, datetime):
         return value
-    
+
     if getattr(value, 'tzinfo', None):
-        now = datetime.now(get_current_timezone())
+        now = datetime.now(get_default_timezone())
     else:
         now = datetime.now()
     now = now - timedelta(microseconds=now.microsecond)
@@ -74,5 +74,4 @@ def from_elasticsearch_date(value):
         date = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f')
     except ValueError:
         date = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S')
-
     return date

--- a/zds/utils/templatetags/date.py
+++ b/zds/utils/templatetags/date.py
@@ -1,10 +1,10 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django import template
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.template.defaultfilters import date
-from django.utils.datetime_safe import datetime
 from django.utils.timezone import get_default_timezone
+from django.utils.translation import ugettext_lazy as _
 
 register = template.Library()
 
@@ -14,10 +14,10 @@ Define a filter to format date.
 
 # Date formatting constants
 
-__DATE_FMT_FUTUR = 'Dans le futur'
-__ABS_DATE_FMT_SMALL = r'd/m/y à H\hi'       # Small format
-__ABS_DATE_FMT_NORMAL = r'l d F Y à H\hi'    # Normal format
-__ABS_HUMAN_TIME_FMT = '%d %b %Y, %H:%M:%S'
+__DATE_FMT_FUTUR = _('Dans le futur')
+__ABS_DATE_FMT_SMALL = _(r'd/m/y à H\hi')       # Small format
+__ABS_DATE_FMT_NORMAL = _(r'l d F Y à H\hi')    # Normal format
+__ABS_HUMAN_TIME_FMT = _('%d %b %Y, %H:%M:%S')
 
 
 def date_formatter(value, tooltip, small):

--- a/zds/utils/templatetags/date.py
+++ b/zds/utils/templatetags/date.py
@@ -4,7 +4,7 @@ from django import template
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.template.defaultfilters import date
 from django.utils.datetime_safe import datetime
-from django.utils.timezone import LocalTimezone
+from django.utils.timezone import get_current_timezone
 
 register = template.Library()
 
@@ -29,15 +29,11 @@ def date_formatter(value, tooltip, small):
     :param bool small: if `True`, create a shorter string.
     :return:
     """
-    try:
-        value = datetime(value.year, value.month, value.day,
-                         value.hour, value.minute, value.second)
-    except (AttributeError, ValueError):
-        # todo : Check why not raise template.TemplateSyntaxError() ?
+    if not isinstance(value, datetime):
         return value
-
+    
     if getattr(value, 'tzinfo', None):
-        now = datetime.now(LocalTimezone(value))
+        now = datetime.now(get_current_timezone())
     else:
         now = datetime.now()
     now = now - timedelta(microseconds=now.microsecond)


### PR DESCRIPTION
Ce commit améliore le templatetag `date` en évitant la création d'une nouvelle instance de `datetime` et en utilisant la fonction `get_current_timezone()` de Django. J'ai suggéré cette modification pour le ticket #4811, mais vu que ça n'a pas de lien direct avec Django 1.11, j'ai fais une PR séparée.

### Contrôle qualité

- Vérifier que les dates s'affichent toujours correctement.

Edit : mince, je me suis encore planté dans la création de la branche. >_<