### PR TITLE
Fix la notif persistante lors de la dépublication d'un billet

### DIFF
--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 @receiver(m2m_changed, sender=User.groups.through)
-def remove_group_subscription_on_quitting_groups(*, sender, instance, action, pk_set, **_):
+def remove_group_subscription_on_quitting_groups(*, sender, instance, action, pk_set, **__):
     if action not in ('pre_clear', 'pre_remove'):  # only on updating
         return
     if action == 'pre_clear':
@@ -65,52 +65,46 @@ def disable_for_loaddata(signal_handler):
 
 
 @receiver(answer_unread, sender=Topic)
-def unread_topic_event(sender, **kwargs):
+def unread_topic_event(sender, *, user, instance, **__):
     """
-    :param kwargs: contains
-        - instance : the answer being marked as unread
-        - user : user marking the answer as unread
     Sends a notification to the user, without sending an email
-    """
-    answer = kwargs.get('instance')
-    user = kwargs.get('user')
 
-    subscription = TopicAnswerSubscription.objects.get_existing(user, answer.topic, is_active=True)
+    :param instance: the answer being marked as unread
+    :param user: user marking the answer as unread
+
+    """
+    subscription = TopicAnswerSubscription.objects.get_existing(user, instance.topic, is_active=True)
     if subscription:
-        subscription.send_notification(content=answer, sender=answer.author, send_email=False)
+        subscription.send_notification(content=instance, sender=instance.author, send_email=False)
 
 
 @receiver(content_read, sender=Topic)
-def mark_topic_notifications_read(sender, **kwargs):
+def mark_topic_notifications_read(sender, *, instance, user, **__):
     """
-    :param kwargs:  contains
-        - instance : the topic marked as read
-        - user : the user reading the topic
     Marks as read the notifications of the NewTopicSubscriptions and
-    AnswerSubscription of the user to the topic/
-    (This documentation will be okay with the v2 of ZEP-24)
-    """
-    topic = kwargs.get('instance')
-    user = kwargs.get('user')
+    AnswerSubscription of the user to the topic
 
+    :param instance: the topic marked as read
+    :param user: the user reading the topic
+    """
     # Subscription to the topic
-    subscription = TopicAnswerSubscription.objects.get_existing(user, topic, is_active=True)
+    subscription = TopicAnswerSubscription.objects.get_existing(user, instance, is_active=True)
     if subscription:
         subscription.mark_notification_read()
 
     # Subscription to the forum
-    subscription = NewTopicSubscription.objects.get_existing(user, topic.forum, is_active=True)
+    subscription = NewTopicSubscription.objects.get_existing(user, instance.forum, is_active=True)
     if subscription:
-        subscription.mark_notification_read(content=topic)
+        subscription.mark_notification_read(content=instance)
 
     # Subscription to the tags
-    for tag in topic.tags.all():
+    for tag in instance.tags.all():
         subscription = NewTopicSubscription.objects.get_existing(user, tag, is_active=True)
         if subscription:
-            subscription.mark_notification_read(content=topic)
+            subscription.mark_notification_read(content=instance)
 
-    content_type = ContentType.objects.get_for_model(topic)
-    notifications = Notification.objects.filter(subscription__user=user, object_id=topic.pk,
+    content_type = ContentType.objects.get_for_model(instance)
+    notifications = Notification.objects.filter(subscription__user=user, object_id=instance.pk,
                                                 content_type__pk=content_type.pk, is_read=False,
                                                 is_dead=True)
     for notification in notifications:
@@ -120,7 +114,7 @@ def mark_topic_notifications_read(sender, **kwargs):
 
 @receiver(content_read, sender=PublishableContent)
 @receiver(content_unpublished)
-def mark_content_reactions_read(sender, *, instance, user=None, target, **_):
+def mark_content_reactions_read(sender, *, instance, user=None, target, **__):
     """
     Marks as read the notifications of the AnswerSubscription of the user to the publishable content.
 
@@ -151,16 +145,14 @@ def mark_content_reactions_read(sender, *, instance, user=None, target, **_):
 
 
 @receiver(content_read, sender=PrivateTopic)
-def mark_pm_reactions_read(sender, **kwargs):
+def mark_pm_reactions_read(sender, *, user, instance, **__):
     """
-    :param kwargs:  contains
-        - instance : the pm marked as read
-        - user : the user reading the pm
-    Marks as read the notifications of the AnswerSubscription of the user to the private message/
-    (This documentation will be okay with the v2 of ZEP-24)
+    Marks as read the notifications of the AnswerSubscription of the user to the private message
+
+    :param  instance: the pm marked as read
+    :param user: the user reading the pm
     """
-    private_topic = kwargs.get('instance')
-    user = kwargs.get('user')
+    private_topic = instance
 
     subscription = PrivateTopicAnswerSubscription.objects.get_existing(user, private_topic, is_active=True)
     if subscription:
@@ -169,9 +161,8 @@ def mark_pm_reactions_read(sender, **kwargs):
 
 @receiver(content_read, sender=ContentReaction)
 @receiver(content_read, sender=Post)
-def mark_comment_read(sender, **kwargs):
-    comment = kwargs.get('instance')
-    user = kwargs.get('user')
+def mark_comment_read(sender, *, instance, user, **__):
+    comment = instance
 
     subscription = PingSubscription.objects.get_existing(user, comment, is_active=True)
     if subscription:
@@ -179,78 +170,93 @@ def mark_comment_read(sender, **kwargs):
 
 
 @receiver(edit_content, sender=Topic)
-def edit_topic_event(sender, **kwargs):
+def edit_topic_event(sender, *, action, instance, **kwargs):
     """
     :param kwargs: contains
         - instance: the topic edited.
         - action: action of the edit.
     """
-    topic = kwargs.get('instance')
+    topic = instance
     topic_content_type = ContentType.objects.get_for_model(topic)
 
-    if kwargs.get('action') == 'move':
+    if action == 'move':
 
-        # If the topic is moved to a restricted forum, users who cannot read this topic any more unfollow it.
-        # This avoids unreachable notifications.
-        TopicAnswerSubscription.objects.unfollow_and_mark_read_everybody_at(topic)
-        NewTopicSubscription.objects.mark_read_everybody_at(topic)
-        # If the topic is moved to a forum followed by the user, we update the subscription of the notification.
-        # Otherwise, we update the notification as dead.
-        notifications = Notification.objects \
-            .filter(object_id=topic.pk, content_type__pk=topic_content_type.pk, is_read=False).all()
-        for notification in notifications:
+        _handle_private_forum_moving(topic, topic_content_type)
+
+    elif action == 'edit_tags_and_title':
+        topic = instance
+
+        # Update notification as dead if it was triggered by a deleted tag
+        tag_content_type = _handle_deleted_tags(topic, topic_content_type)
+
+        # Add notification of new topic for the subscription on the new tags
+        _handle_added_tags(tag_content_type, topic)
+
+
+def _handle_added_tags(tag_content_type, topic):
+    for tag in topic.tags.all():
+        subscriptions = NewTopicSubscription.objects.filter(
+            object_id=tag.id, content_type__pk=tag_content_type.pk, is_active=True)
+        for subscription in subscriptions:
+            notification = Notification.objects.filter(object_id=topic.id, subscription=subscription)
+            if not notification:
+                if subscription.user != topic.author:
+                    subscription.send_notification(content=topic, sender=topic.author)
+
+
+def _handle_deleted_tags(topic, topic_content_type):
+    tag_content_type = ContentType.objects.get_for_model(Tag)
+    notifications = Notification.objects \
+        .filter(object_id=topic.pk, content_type__pk=topic_content_type.pk, is_read=False).all()
+    for notification in notifications:
+        is_still_valid = notification.subscription.content_type != tag_content_type
+        if not is_still_valid:
+            for tag in topic.tags.all():
+                if tag.id == notification.subscription.object_id:
+                    is_still_valid = True
+                    break
+        if not is_still_valid:
             subscription = NewTopicSubscription.objects \
                 .get_existing(notification.subscription.user, topic.forum, is_active=True)
             if subscription:
                 notification.subscription = subscription
-                notification.save()
-            elif notification.subscription.content_object != notification.content_object.forum:
+            else:
                 notification.is_dead = True
-                notification.save()
+            notification.save()
+    return tag_content_type
 
-    elif kwargs.get('action') == 'edit_tags_and_title':
-        topic = kwargs.get('instance')
 
-        # Update notification as dead if it was triggered by a deleted tag
-        tag_content_type = ContentType.objects.get_for_model(Tag)
-        notifications = Notification.objects \
-            .filter(object_id=topic.pk, content_type__pk=topic_content_type.pk, is_read=False).all()
-        for notification in notifications:
-            is_still_valid = notification.subscription.content_type != tag_content_type
-            if not is_still_valid:
-                for tag in topic.tags.all():
-                    if tag.id == notification.subscription.object_id:
-                        is_still_valid = True
-                        break
-            if not is_still_valid:
-                subscription = NewTopicSubscription.objects \
-                    .get_existing(notification.subscription.user, topic.forum, is_active=True)
-                if subscription:
-                    notification.subscription = subscription
-                else:
-                    notification.is_dead = True
-                notification.save()
-
-        # Add notification of new topic for the subscription on the new tags
-        for tag in topic.tags.all():
-            subscriptions = NewTopicSubscription.objects.filter(
-                object_id=tag.id, content_type__pk=tag_content_type.pk, is_active=True)
-            for subscription in subscriptions:
-                notification = Notification.objects.filter(object_id=topic.id, subscription=subscription)
-                if not notification:
-                    if subscription.user != topic.author:
-                        subscription.send_notification(content=topic, sender=topic.author)
+def _handle_private_forum_moving(topic, topic_content_type):
+    # If the topic is moved to a restricted forum, users who cannot read this topic any more unfollow it.
+    # This avoids unreachable notifications.
+    TopicAnswerSubscription.objects.unfollow_and_mark_read_everybody_at(topic)
+    NewTopicSubscription.objects.mark_read_everybody_at(topic)
+    # If the topic is moved to a forum followed by the user, we update the subscription of the notification.
+    # Otherwise, we update the notification as dead.
+    notifications = Notification.objects \
+        .filter(object_id=topic.pk, content_type__pk=topic_content_type.pk, is_read=False).all()
+    for notification in notifications:
+        subscription = NewTopicSubscription.objects \
+            .get_existing(notification.subscription.user, topic.forum, is_active=True)
+        if subscription:
+            notification.subscription = subscription
+            notification.save()
+        elif notification.subscription.content_object != notification.content_object.forum:
+            notification.is_dead = True
+            notification.save()
 
 
 @receiver(post_save, sender=Topic)
 @disable_for_loaddata
-def new_topic_event(sender, **kwargs):
+def new_topic_event(sender, *, instance, created=True, **__):
     """
-    :param kwargs: contains instance: the new topic.
     Sends a notification to the subscribers of the forum.
+
+    :param instance: the new topic.
+    :param created: a flag set by the event to ensure the save was effective
     """
-    if kwargs.get('created', True):
-        topic = kwargs.get('instance')
+    if created:
+        topic = instance
 
         subscriptions = NewTopicSubscription.objects.get_subscriptions(topic.forum)
         for subscription in subscriptions:
@@ -260,16 +266,16 @@ def new_topic_event(sender, **kwargs):
 
 @receiver(post_save, sender=Post)
 @disable_for_loaddata
-def answer_topic_event(sender, **kwargs):
+def answer_topic_event(sender, *, instance, created=True, **__):
     """
-    :param kwargs:  contains
-        - instance: the new post.
-        - by_mail: Send or not an email.
     Sends TopicAnswerSubscription to the subscribers to the topic and subscribe
     the author to the following answers to the topic.
+
+    :param instance: the new post.
+    :param created: a flag set by the event to ensure the save was effective
     """
-    if kwargs.get('created', True):
-        post = kwargs.get('instance')
+    if created:
+        post = instance
 
         subscription_list = TopicAnswerSubscription.objects.get_subscriptions(post.topic)
         for subscription in subscription_list:
@@ -282,15 +288,17 @@ def answer_topic_event(sender, **kwargs):
 
 @receiver(post_save, sender=ContentReaction)
 @disable_for_loaddata
-def answer_content_reaction_event(sender, **kwargs):
+def answer_content_reaction_event(sender, *, instance, created=True, **__):
     """
-    :param kwargs: contains
-        - instance: the new content reaction.
     Sends ContentReactionAnswerSubscription to the subscribers to the content reaction and
     subscribe the author to the following answers to the publishable content.
+
+    :param instance: the new content reation.
+    :param created: a flag set by the event to ensure the save was effective
+
     """
-    if kwargs.get('created', True):
-        content_reaction = kwargs.get('instance')
+    if created:
+        content_reaction = instance
         publishable_content = content_reaction.related_content
         author = content_reaction.author
 
@@ -305,15 +313,14 @@ def answer_content_reaction_event(sender, **kwargs):
 
 @receiver(new_content, sender=PublishableContent)
 @disable_for_loaddata
-def content_published_event(*_, **kwargs):
+def content_published_event(*__, instance, by_email, **___):
     """
-    :param kwargs:  contains
-        - instance: the new content.
-        - by_mail: Send or not an email.
     All authors of the content follow their newly published content.
+
+    :param instance: the new content.
+    :param by_mail: Send or not an email.
     """
-    content = kwargs.get('instance')
-    by_email = kwargs.get('by_email')
+    content = instance
     authors = list(content.authors.all())
     for user in authors:
         if not ContentReactionAnswerSubscription.objects.get_existing(user, content):
@@ -334,9 +341,9 @@ def content_published_event(*_, **kwargs):
 @receiver(new_content, sender=ContentReaction)
 @receiver(new_content, sender=Post)
 @disable_for_loaddata
-def answer_comment_event(sender, **kwargs):
-    comment = kwargs.get('instance')
-    user = kwargs.get('user')
+def answer_comment_event(sender, *, instance, user, **__):
+    comment = instance
+    user = user
 
     assert comment is not None
     assert user is not None
@@ -347,16 +354,15 @@ def answer_comment_event(sender, **kwargs):
 
 @receiver(new_content, sender=PrivatePost)
 @disable_for_loaddata
-def answer_private_topic_event(sender, **kwargs):
+def answer_private_topic_event(sender, *, instance, by_email, **__):
     """
-    :param kwargs:  contains
-        - instance: the new post.
-        - by_mail: Send or not an email.
     Sends PrivateTopicAnswerSubscription to the subscribers to the topic and subscribe
     the author to the following answers to the topic.
+
+    :param instance: the new post.
+    :param by_mail: Send or not an email.
     """
-    post = kwargs.get('instance')
-    by_email = kwargs.get('by_email')
+    post = instance
 
     if post.position_in_topic == 1:
         # Subscribe the author.
@@ -380,25 +386,24 @@ def answer_private_topic_event(sender, **kwargs):
 
 @receiver(m2m_changed, sender=PrivateTopic.participants.through)
 @disable_for_loaddata
-def add_participant_topic_event(sender, **kwargs):
+def add_participant_topic_event(sender, *, instance, action, reverse, **__):
     """
-    :param kwargs:  contains
-        - sender : the technical class representing the many2many relationship
-        - instance : the technical class representing the many2many relationship
-        - action : "pre_add", "post_add", ... action having sent the signal
-        - reverse : indicates which side of the relation is updated
+    Sends PrivateTopicAnswerSubscription to the subscribers to the private topic.
+
+    :param sender: the technical class representing the many2many relationship
+    :param instance: the technical class representing the many2many relationship
+    :param action: "pre_add", "post_add", ... action having sent the signal
+    :param reverse: indicates which side of the relation is updated
             (from what I understand, forward is from topic to tags, so when the tag side is modified,
             reverse is from tags to topics, so when the topics are modified)
-    Sends PrivateTopicAnswerSubscription to the subscribers to the private topic.
+
     """
 
-    private_topic = kwargs.get('instance')
-    action = kwargs.get('action')
-    relation_reverse = kwargs.get('reverse')
+    private_topic = instance
 
     # This condition is necessary because this receiver is called during the creation of the private topic.
     if private_topic.last_message:
-        if action == 'post_add' and not relation_reverse:
+        if action == 'post_add' and not reverse:
             for participant in private_topic.participants.all():
                 subscription = PrivateTopicAnswerSubscription.objects.get_or_create_active(participant, private_topic)
                 subscription.send_notification(
@@ -406,7 +411,7 @@ def add_participant_topic_event(sender, **kwargs):
                     sender=private_topic.last_message.author,
                     send_email=participant.profile.email_for_answer)
 
-        elif action == 'post_remove' and not relation_reverse:
+        elif action == 'post_remove' and not reverse:
             subscriptions = PrivateTopicAnswerSubscription.objects \
                 .get_subscriptions(content_object=private_topic, is_active=True)
             for subscription in subscriptions:
@@ -417,7 +422,7 @@ def add_participant_topic_event(sender, **kwargs):
 
 
 @receiver(pre_delete, sender=PrivateTopic)
-def delete_private_topic_event(sender, instance, **kwargs):
+def delete_private_topic_event(sender, instance, **__):
     """
     A private topic is deleted when there is nobody in this private topic.
     """
@@ -428,7 +433,7 @@ def delete_private_topic_event(sender, instance, **kwargs):
 
 
 @receiver(pre_delete, sender=User)
-def delete_notifications(sender, instance, **kwargs):
+def delete_notifications(sender, instance, **__):
     """
     Before suppression of a user, Django calls this receiver to
     delete all subscriptions and notifications linked at this member.
@@ -439,14 +444,13 @@ def delete_notifications(sender, instance, **kwargs):
 
 @receiver(zds.tutorialv2.signals.content_unpublished, sender=PublishableContent)
 @receiver(zds.tutorialv2.signals.content_unpublished, sender=ContentReaction)
-def cleanup_notification_for_unpublished_content(sender, instance, **_):
+def cleanup_notification_for_unpublished_content(sender, instance, **__):
     """
     Avoid persistant notification if a content is unpublished. A real talk has to be lead to avoid such cross module \
     dependency.
 
     :param sender: always PublishableContent
     :param instance: the unpublished content
-    :param _: the useless kwargs
     """
     logger.debug('deal with %s(%s) notifications.', sender, instance)
     try:

--- a/zds/tutorialv2/receivers.py
+++ b/zds/tutorialv2/receivers.py
@@ -13,7 +13,7 @@ from zds.utils.models import Alert
 
 
 @receiver(content_unpublished, sender=PublishableContent)
-def cleanup_validation_alerts(sender, instance, *, moderator=None, **_):
+def cleanup_validation_alerts(sender, instance, *, moderator=None, **__):
     """
     When opinions are unpublished (probably permanently), we must be sure all alerts are handled. For now we just \
     resolve them.
@@ -32,7 +32,7 @@ def cleanup_validation_alerts(sender, instance, *, moderator=None, **_):
 
 @receiver(models.signals.post_delete, sender=Gallery)
 @receiver(models.signals.post_delete, sender=PublishableContent)
-def log_content_deletion(sender, instance, **kwargs):
+def log_content_deletion(sender, instance, **__):
     """
     When a content or gallery is deleted, this action is logged.
     """

--- a/zds/tutorialv2/receivers.py
+++ b/zds/tutorialv2/receivers.py
@@ -13,17 +13,17 @@ from zds.utils.models import Alert
 
 
 @receiver(content_unpublished, sender=PublishableContent)
-def cleanup_validation_alerts(sender, instance, **kwargs):
+def cleanup_validation_alerts(sender, instance, *, moderator=None, **_):
     """
     When opinions are unpublished (probably permanently), we must be sure all alerts are handled. For now we just \
     resolve them.
 
     :param sender: sender class
     :param instance: object instance
-    :param kwargs: possibily moderator
+    :param moderator: staff member or author that generated depublication
     """
     if instance.is_opinion:
-        moderator = kwargs.get('moderator', get_current_user())
+        moderator = moderator or get_current_user()
         Alert.objects.filter(scope='CONTENT', content=instance).update(moderator=moderator,
                                                                        resolve_reason=_('Le billet a été dépublié.'),
                                                                        solved_date=datetime.datetime.now(),

--- a/zds/tutorialv2/signals.py
+++ b/zds/tutorialv2/signals.py
@@ -1,4 +1,4 @@
 from django.dispatch.dispatcher import Signal
 
 # is sent whenever a content is unpublished
-content_unpublished = Signal(providing_args=['instance'])
+content_unpublished = Signal(providing_args=['instance', 'target', 'moderator'])

--- a/zds/tutorialv2/views/published.py
+++ b/zds/tutorialv2/views/published.py
@@ -726,7 +726,7 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
 
         if is_new:  # we first need to save the reaction
             self.object.last_note = self.reaction
-            self.object.save(update_date=False)
+            self.object.save(update_date=False, force_slug_update=False)
 
         self.success_url = self.reaction.get_absolute_url()
         return super(SendNoteFormView, self).form_valid(form)


### PR DESCRIPTION
Fix #4319

## QA

1. avec user1 publiez un billet
2. avec user2 visitez le billet et souscrivez aux notifs **de ce billet**
3. avec user1 commentez le billet
4. vérifiez acec user2 il y a une notif **mais ne la lisez pas**
5. avec user1 dépubliez le billet
6. avec user2 vérifiez qu'il n'y a plus de notif