### PR TITLE
Renomme "registery" en "registry"

### DIFF
--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -98,7 +98,7 @@ def publish_content(db_object, versioned, is_major_update=True):
         # ok, now we can really publish the thing !
         generate_exernal_content(base_name, extra_contents_path, md_file_path, pandoc_debug_str)
     elif settings.ZDS_APP['content']['extra_content_generation_policy'] == 'WATCHDOG':
-        PublicatorRegistery.get('watchdog').publish(md_file_path, base_name, silently_pass=False)
+        PublicatorRegistry.get('watchdog').publish(md_file_path, base_name, silently_pass=False)
 
     is_update = False
 
@@ -173,12 +173,12 @@ def generate_exernal_content(base_name, extra_contents_path, md_file_path, pando
     excluded = []
     if not settings.ZDS_APP['content']['build_pdf_when_published'] and not overload_settings:
         excluded.append('pdf')
-    for __, publicator in PublicatorRegistery.get_all_registered(excluded):
+    for __, publicator in PublicatorRegistry.get_all_registered(excluded):
 
         publicator.publish(md_file_path, base_name, change_dir=extra_contents_path, pandoc_debug_str=pandoc_debug_str)
 
 
-class PublicatorRegistery:
+class PublicatorRegistry:
     """
     Register all publicator as a 'human-readable name/publicator' instance key/value list
     """
@@ -245,9 +245,9 @@ class Publicator:
         raise NotImplemented()
 
 
-@PublicatorRegistery.register('pdf', settings.PANDOC_LOC, 'pdf', settings.PANDOC_PDF_PARAM)
-@PublicatorRegistery.register('epub', settings.PANDOC_LOC, 'epub')
-@PublicatorRegistery.register('html', settings.PANDOC_LOC, 'html')
+@PublicatorRegistry.register('pdf', settings.PANDOC_LOC, 'pdf', settings.PANDOC_PDF_PARAM)
+@PublicatorRegistry.register('epub', settings.PANDOC_LOC, 'epub')
+@PublicatorRegistry.register('html', settings.PANDOC_LOC, 'html')
 class PandocPublicator(Publicator):
 
     """
@@ -287,7 +287,7 @@ class PandocPublicator(Publicator):
             self.__logger.info('Finished {} generation'.format(base_name + '.' + self.format))
 
 
-@PublicatorRegistery.register('watchdog', settings.ZDS_APP['content']['extra_content_watchdog_dir'])
+@PublicatorRegistry.register('watchdog', settings.ZDS_APP['content']['extra_content_watchdog_dir'])
 class WatchdogFilePublicator(Publicator):
     """
     Just create a meta data file for watchdog

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -19,7 +19,7 @@ from zds.tutorialv2.utils import get_target_tagged_tree_for_container, \
 from zds.tutorialv2.publication_utils import publish_content, unpublish_content
 from zds.tutorialv2.models.database import PublishableContent, PublishedContent, ContentReaction, ContentRead
 from django.core.management import call_command
-from zds.tutorialv2.publication_utils import Publicator, PublicatorRegistery
+from zds.tutorialv2.publication_utils import Publicator, PublicatorRegistry
 from watchdog.events import FileCreatedEvent
 from zds.tutorialv2.management.commands.publication_watchdog import TutorialIsPublished
 from zds.tutorialv2.tests import TutorialTestMixin
@@ -60,7 +60,7 @@ class UtilsTests(TestCase, TutorialTestMixin):
         self.tuto_draft = self.tuto.load_version()
         self.part1 = ContainerFactory(parent=self.tuto_draft, db_object=self.tuto)
         self.chapter1 = ContainerFactory(parent=self.part1, db_object=self.tuto)
-        self.old_registry = {key: value for key, value in PublicatorRegistery.get_all_registered()}
+        self.old_registry = {key: value for key, value in PublicatorRegistry.get_all_registered()}
 
     def test_get_target_tagged_tree_for_container(self):
         part2 = ContainerFactory(parent=self.tuto_draft, db_object=self.tuto, title='part2')
@@ -534,26 +534,26 @@ class UtilsTests(TestCase, TutorialTestMixin):
 
     def test_watchdog(self):
 
-        PublicatorRegistery.unregister('pdf')
-        PublicatorRegistery.unregister('epub')
-        PublicatorRegistery.unregister('html')
+        PublicatorRegistry.unregister('pdf')
+        PublicatorRegistry.unregister('epub')
+        PublicatorRegistry.unregister('html')
 
         with open('path', 'w') as f:
             f.write('my_content;/path/to/markdown.md')
 
-        @PublicatorRegistery.register('test', '', '')
+        @PublicatorRegistry.register('test', '', '')
         class TestPublicator(Publicator):
             def __init__(self, *__):
                 pass
 
-        PublicatorRegistery.get('test').publish = Mock()
+        PublicatorRegistry.get('test').publish = Mock()
         event = FileCreatedEvent('path')
         handler = TutorialIsPublished()
         handler.prepare_generation = Mock()
         handler.finish_generation = Mock()
         handler.on_created(event)
 
-        self.assertTrue(PublicatorRegistery.get('test').publish.called)
+        self.assertTrue(PublicatorRegistry.get('test').publish.called)
         handler.finish_generation.assert_called_with('/path/to', 'path')
         handler.prepare_generation.assert_called_with('/path/to')
         os.remove('path')
@@ -584,4 +584,4 @@ class UtilsTests(TestCase, TutorialTestMixin):
 
     def tearDown(self):
         super().tearDown()
-        PublicatorRegistery.registry = self.old_registry
+        PublicatorRegistry.registry = self.old_registry

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -26,7 +26,7 @@ from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory
     SubCategoryFactory, PublishedContentFactory, tricky_text_content, BetaContentFactory
 from zds.tutorialv2.models.database import PublishableContent, Validation, PublishedContent, ContentReaction, \
     ContentRead
-from zds.tutorialv2.publication_utils import publish_content, Publicator, PublicatorRegistery
+from zds.tutorialv2.publication_utils import publish_content, Publicator, PublicatorRegistry
 from zds.tutorialv2.tests import TutorialTestMixin
 from zds.utils.models import HelpWriting, Alert, Tag, Hat
 from zds.utils.factories import HelpWritingFactory, CategoryFactory
@@ -44,7 +44,7 @@ overridden_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'cont
 overridden_zds_app['content']['extra_content_generation_policy'] = 'SYNC'
 
 
-@PublicatorRegistery.register('pdf')
+@PublicatorRegistry.register('pdf')
 class FakePDFPublicator(Publicator):
     def publish(self, md_file_path, base_name, **kwargs):
         with open(md_file_path[:-2] + 'pdf', 'w') as f:


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #4810 

### Contrôle qualité

 - Rechercher `registery` dans tout le projet
 - Remarquer qu'il n'y en a plus aucun