### PR TITLE
Correction du balisage dans tutorialv2/view/content.html

### DIFF
--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -281,6 +281,7 @@
                             {% trans "Confirmer" %}
                         </button>
                     </form>
+                </li>
             {% else %}
                 {% if not content.is_beta %}
                     <li>


### PR DESCRIPTION
Closes zestedesavoir/zds-site#4783

J'ai remis le tag `</li>` de fermeture qui manquait.
Il est à nouveau comme lors de sa création : 
https://github.com/zestedesavoir/zds-site/commit/b02c37c12d9ee8816172c498ae13f848b76f0a50#diff-214f7a6c84fd3fab78f2f6cc345d9611R185


Numéro du ticket concerné (optionnel) : #4783 

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

<!-- Écrivez éventuellement ici quelques instructions pour nous aider à vérifier vos changement.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

 - Vérifier que le problème n'existe plus à l'aide de [jinjalint](https://github.com/motet-a/jinjalint)

<!-- Merci ! -->
