### PR TITLE
Refactorise la fonction "login_view()" et rend les messages d'erreurs plus précis

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -55,7 +55,6 @@ class LoginForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        kwargs['data'].pop('next', None)
         super(LoginForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_action = reverse('member-login')

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -54,7 +54,8 @@ class LoginForm(forms.Form):
         required=False,
     )
 
-    def __init__(self, next=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
+        kwargs['data'].pop('next', None)
         super(LoginForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_action = reverse('member-login')

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -341,6 +341,28 @@ class MemberTests(TestCase):
              'remember': 'remember'},
             follow=False)
         self.assertEqual(result.status_code, 200)
+        self.assertContains(result, _(
+                'Le mot de passe saisi est incorrect. '
+                'Cliquez sur le lien « Mot de passe oublié ? » '
+                'si vous ne vous en souvenez plus.'
+            )
+        )
+
+        # login failed with bad username then no redirection
+        # (status_code equals 200 and not 302).
+        result = self.client.post(
+            reverse('member-login'),
+            {'username': 'clem',
+             'password': 'hostel77',
+             'remember': 'remember'},
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+        self.assertContains(result, _(
+                'Ce nom d’utilisateur est inconnu. '
+                'Si vous ne possédez pas de compte, '
+                'vous pouvez vous inscrire.'
+            )
+        )
 
         # login a user. Good password and next parameter then
         # redirection to the "next" page.

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -386,7 +386,7 @@ class MemberTests(TestCase):
              'password': 'hostel77',
              'remember': 'remember'},
             follow=False)
-        self.assertRedirects(result, reverse('gallery-list'))
+        self.assertRedirects(result, reverse('/'))
 
         # check if the login form will redirect if there is
         # a next parameter.

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -386,7 +386,7 @@ class MemberTests(TestCase):
              'password': 'hostel77',
              'remember': 'remember'},
             follow=False)
-        self.assertRedirects(result, reverse('home'))
+        self.assertRedirects(result, reverse('homepage'))
 
         # check if the login form will redirect if there is
         # a next parameter.

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -7,7 +7,7 @@ from oauth2_provider.models import AccessToken, Application
 from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.core import mail
-from django.core.urls import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.translation import ugettext_lazy as _

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -341,7 +341,8 @@ class MemberTests(TestCase):
              'remember': 'remember'},
             follow=False)
         self.assertEqual(result.status_code, 200)
-        self.assertContains(result, _(
+        self.assertContains(
+            result, _(
                 'Le mot de passe saisi est incorrect. '
                 'Cliquez sur le lien « Mot de passe oublié ? » '
                 'si vous ne vous en souvenez plus.'
@@ -357,7 +358,8 @@ class MemberTests(TestCase):
              'remember': 'remember'},
             follow=False)
         self.assertEqual(result.status_code, 200)
-        self.assertContains(result, _(
+        self.assertContains(
+            result, _(
                 'Ce nom d’utilisateur est inconnu. '
                 'Si vous ne possédez pas de compte, '
                 'vous pouvez vous inscrire.'

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -377,6 +377,17 @@ class MemberTests(TestCase):
             follow=False)
         self.assertRedirects(result, reverse('gallery-list'))
 
+        # check the user is redirected to the home page if
+        # the "next" parameter points to a non-existing page.
+        result = self.client.post(
+            reverse('member-login') +
+            '?next=/foobar',
+            {'username': user.user.username,
+             'password': 'hostel77',
+             'remember': 'remember'},
+            follow=False)
+        self.assertRedirects(result, reverse('gallery-list'))
+
         # check if the login form will redirect if there is
         # a next parameter.
         self.client.logout()

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -386,7 +386,7 @@ class MemberTests(TestCase):
              'password': 'hostel77',
              'remember': 'remember'},
             follow=False)
-        self.assertRedirects(result, reverse('/'))
+        self.assertRedirects(result, reverse('home'))
 
         # check if the login form will redirect if there is
         # a next parameter.

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -7,7 +7,7 @@ from oauth2_provider.models import AccessToken, Application
 from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.core.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.translation import ugettext_lazy as _

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -923,9 +923,9 @@ def login_view(request):
         if user is None:
             initial = {'username': username}
             if User.objects.filter(username=username).exists():
-                messages.error(request, _('Mot de passe incorrect.'))
+                messages.error(request, _('Le mot de passe saisi est incorrect. Cliquez sur le lien « Mot de passe oublié ? » si vous ne vous en souvenez plus.'))
             else:
-                messages.error(request, _('Nom d’utilisateur inconnu.'))
+                messages.error(request, _('Ce nom d’utilisateur est inconnu. Si vous ne possédez pas de compte, vous pouvez vous inscrire.'))
 
             form = LoginForm(initial=initial)
             if next_page is not None:

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -941,7 +941,9 @@ def login_view(request):
                     request, _(
                         'Ce nom d’utilisateur est inconnu. '
                         'Si vous ne possédez pas de compte, vous pouvez '
-                        '<a href="{url}">vous inscrire</a>.'.format(url=url)
+                        '<a href="{url}">vous inscrire</a>.'.format(
+                            url=registration_url
+                        )
                     )
                 )
             form = LoginForm(initial=initial)
@@ -997,113 +999,6 @@ def login_view(request):
         'form': form,
         'csrf_tk': csrf_tk
     })
-
-'''
-def login_view(request):
-    """Log user in."""
-
-    csrf_tk = {}
-    csrf_tk.update(csrf(request))
-    error = False
-    initial = {}
-
-    # Redirecting user once logged in?
-
-    if 'next' in request.GET:
-        next_page = request.GET['next']
-    else:
-        next_page = None
-
-    if request.method == 'POST':
-        form = LoginForm(request.POST)
-        if form.is_valid():
-            username = form.cleaned_data['username']
-            password = form.cleaned_data['password']
-            user = authenticate(username=username, password=password)
-            initial = {'username': username}
-
-            if user is None:
-                if User.objects.filter(username=username).exists():
-                    messages.error(
-                        request, _(
-                            'Le mot de passe saisi est incorrect. '
-                            'Cliquez sur le lien « Mot de passe oublié ? » '
-                            'si vous ne vous en souvenez plus.'
-                        )
-                    )
-                else:
-                    messages.error(
-                        request, _(
-                            'Ce nom d’utilisateur est inconnu. '
-                            'Si vous ne possédez pas de compte, vous '
-                            'pouvez vous inscrire.'
-                        )
-                    )
-                form = LoginForm(initial=initial)
-                if next_page is not None:
-                    form.helper.form_action += '?next=' + next_page
-                csrf_tk['error'] = error
-                csrf_tk['form'] = form
-                csrf_tk['next_page'] = next_page
-        return render(request, 'member/login.html', {
-            'form': form,
-            'csrf_tk': csrf_tk
-        })
-
-        profile = get_object_or_404(Profile, user=user)
-        if not user.is_active:
-            messages.error(
-                request,
-                _(
-                    'Vous n\'avez pas encore activé votre compte, '
-                    'vous devez le faire pour pouvoir vous '
-                    'connecter sur le site. Regardez dans vos '
-                    'mails : {}.'
-                ).format(user.email)
-            )
-        else:
-            if not profile.can_read_now():
-                messages.error(
-                    request,
-                    _(
-                        'Vous n\'êtes pas autorisé à vous connecter '
-                        'sur le site, vous avez été banni par un '
-                        'modérateur.'
-                    )
-                )
-            else:
-                login(request, user)
-                request.session['get_token'] = generate_token()
-                if 'remember' not in request.POST:
-                    request.session.set_expiry(0)
-                profile.last_ip_address = get_client_ip(request)
-                profile.save()
-                # Redirect the user if needed.
-                # Set the cookie for Clem smileys.
-                # (For people switching account or clearing cookies
-                # after a browser session.)
-                try:
-                    response = redirect(next_page)
-                    set_old_smileys_cookie(response, profile)
-                    return response
-                except:
-                    response = redirect(reverse('homepage'))
-                    set_old_smileys_cookie(response, profile)
-                    return response
-
-    form = LoginForm(initial=initial)
-    if next_page is not None:
-        form.helper.form_action += '?next=' + next_page
-
-    csrf_tk['error'] = error
-    csrf_tk['form'] = form
-    csrf_tk['next_page'] = next_page
-
-    return render(request, 'member/login.html', {
-        'form': form,
-        'csrf_tk': csrf_tk
-    })
-'''
 
 
 @login_required

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import User, Group
 from django.template.context_processors import csrf
 from django.core.exceptions import PermissionDenied
 from django.core.mail import EmailMultiAlternatives
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy, NoReverseMatch
 from django.db import transaction
 from django.db.models import Q
 from django.http import Http404, HttpResponseBadRequest, StreamingHttpResponse
@@ -23,7 +23,6 @@ from django.utils.translation import string_concat
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, UpdateView, CreateView, FormView
-from django.urls import NoReverseMatch
 
 from zds.forum.models import Topic, TopicRead
 from zds.gallery.forms import ImageAsAvatarForm

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -928,7 +928,8 @@ def login_view(request):
         else:
             profile = get_object_or_404(Profile, user=user)
             if not user.is_active:
-                messages.error(request,
+                messages.error(
+                    request,
                     _(
                         'Vous n\'avez pas encore activé votre compte, '
                         'vous devez le faire pour pouvoir vous '
@@ -938,7 +939,8 @@ def login_view(request):
                 )
             else:
                 if not profile.can_read_now():
-                    messages.error(request,
+                    messages.error(
+                        request,
                         _(
                             'Vous n\'êtes pas autorisé à vous connecter '
                             'sur le site, vous avez été banni par un '

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -902,7 +902,7 @@ def remove_hat(request, user_pk, hat_pk):
 
 def login_view(request):
     """Logs user in."""
-    next_page = request.GET.get('next')
+    next_page = request.GET.get('next', '/')
     csrf_tk = {'next_page': next_page}
     csrf_tk.update(csrf(request))
     error = False

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -923,9 +923,21 @@ def login_view(request):
         if user is None:
             initial = {'username': username}
             if User.objects.filter(username=username).exists():
-                messages.error(request, _('Le mot de passe saisi est incorrect. Cliquez sur le lien « Mot de passe oublié ? » si vous ne vous en souvenez plus.'))
+                messages.error(
+                    request, _(
+                        'Le mot de passe saisi est incorrect. '
+                        'Cliquez sur le lien « Mot de passe oublié ? » '
+                        'si vous ne vous en souvenez plus.'
+                    )
+                )
             else:
-                messages.error(request, _('Ce nom d’utilisateur est inconnu. Si vous ne possédez pas de compte, vous pouvez vous inscrire.'))
+                messages.error(
+                    request, _(
+                        'Ce nom d’utilisateur est inconnu. '
+                        'Si vous ne possédez pas de compte, vous '
+                        'pouvez vous inscrire.'
+                    )
+                )
 
             form = LoginForm(initial=initial)
             if next_page is not None:
@@ -935,12 +947,10 @@ def login_view(request):
             csrf_tk['form'] = form
             csrf_tk['next_page'] = next_page
 
-            return render(request, 'member/login.html',
-                {
-                    'form': form,
-                    'csrf_tk': csrf_tk
-                }
-            )
+            return render(request, 'member/login.html', {
+                'form': form,
+                'csrf_tk': csrf_tk
+            })
 
         profile = get_object_or_404(Profile, user=user)
         if not user.is_active:
@@ -991,12 +1001,10 @@ def login_view(request):
     csrf_tk['form'] = form
     csrf_tk['next_page'] = next_page
 
-    return render(request, 'member/login.html',
-        {
-            'form': form,
-            'csrf_tk': csrf_tk
-        }
-    )
+    return render(request, 'member/login.html', {
+        'form': form,
+        'csrf_tk': csrf_tk
+    })
 
 
 @login_required

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -900,26 +900,33 @@ def remove_hat(request, user_pk, hat_pk):
 
 
 def login_view(request):
-    """Log user in."""
-
+    """Logs user in."""
     csrf_tk = {}
     csrf_tk.update(csrf(request))
     error = False
-    initial = {}
 
-    # Redirecting user once logged in?
+    next_page = request.GET.get('next')
+    csrf_tk['next_page'] = next_page
 
-    if 'next' in request.GET:
-        next_page = request.GET['next']
-    else:
-        next_page = None
+    if request.method != 'POST':
+        form = LoginForm()
+        csrf_tk['error'] = error
+        csrf_tk['form'] = form
+        return render(request, 'member/login.html', {
+            'form': form,
+            'csrf_tk': csrf_tk
+        })
 
-    if request.method == 'POST':
-        form = LoginForm(request.POST)
-        username = request.POST['username']
-        password = request.POST['password']
+    # Now, we are sure that the request is POST.
+    form = LoginForm(request.POST)
+    print('Errors:', repr(form.errors))  # À supprimer.
+    if form.is_valid():
+        print('Valid')  # À supprimer.
+        if next_page is not None:
+            form.helper.form_action += '?next=' + next_page
+        username = form.cleaned_data['username']
+        password = form.cleaned_data['password']
         user = authenticate(username=username, password=password)
-
         if user is None:
             initial = {'username': username}
             if User.objects.filter(username=username).exists():
@@ -938,19 +945,111 @@ def login_view(request):
                         'pouvez vous inscrire.'
                     )
                 )
-
             form = LoginForm(initial=initial)
-            if next_page is not None:
-                form.helper.form_action += '?next=' + next_page
-
             csrf_tk['error'] = error
             csrf_tk['form'] = form
-            csrf_tk['next_page'] = next_page
-
             return render(request, 'member/login.html', {
                 'form': form,
                 'csrf_tk': csrf_tk
             })
+        profile = get_object_or_404(Profile, user=user)
+        if not user.is_active:
+            messages.error(
+                request,
+                _(
+                    'Vous n\'avez pas encore activé votre compte, '
+                    'vous devez le faire pour pouvoir vous '
+                    'connecter sur le site. Regardez dans vos '
+                    'mails : {}.'
+                ).format(user.email)
+            )
+        elif not profile.can_read_now():
+            messages.error(
+                request,
+                _(
+                    'Vous n\'êtes pas autorisé à vous connecter '
+                    'sur le site, vous avez été banni par un '
+                    'modérateur.'
+                )
+            )
+        else:
+            login(request, user)
+            request.session['get_token'] = generate_token()
+            if 'remember' not in request.POST:
+                request.session.set_expiry(0)
+            profile.last_ip_address = get_client_ip(request)
+            profile.save()
+            # Redirect the user if needed.
+            # Set the cookie for Clem smileys.
+            # (For people switching account or clearing cookies
+            # after a browser session.)
+            try:
+                response = redirect(next_page)
+                set_old_smileys_cookie(response, profile)
+                return response
+            except:
+                response = redirect(reverse('homepage'))
+                set_old_smileys_cookie(response, profile)
+                return response
+
+    csrf_tk['error'] = error
+    csrf_tk['form'] = form
+    return render(request, 'member/login.html', {
+        'form': form,
+        'csrf_tk': csrf_tk
+    })
+
+'''
+def login_view(request):
+    """Log user in."""
+
+    csrf_tk = {}
+    csrf_tk.update(csrf(request))
+    error = False
+    initial = {}
+
+    # Redirecting user once logged in?
+
+    if 'next' in request.GET:
+        next_page = request.GET['next']
+    else:
+        next_page = None
+
+    if request.method == 'POST':
+        form = LoginForm(request.POST)
+        if form.is_valid():
+            username = form.cleaned_data['username']
+            password = form.cleaned_data['password']
+            user = authenticate(username=username, password=password)
+            initial = {'username': username}
+
+            if user is None:
+                if User.objects.filter(username=username).exists():
+                    messages.error(
+                        request, _(
+                            'Le mot de passe saisi est incorrect. '
+                            'Cliquez sur le lien « Mot de passe oublié ? » '
+                            'si vous ne vous en souvenez plus.'
+                        )
+                    )
+                else:
+                    messages.error(
+                        request, _(
+                            'Ce nom d’utilisateur est inconnu. '
+                            'Si vous ne possédez pas de compte, vous '
+                            'pouvez vous inscrire.'
+                        )
+                    )
+                form = LoginForm(initial=initial)
+                if next_page is not None:
+                    form.helper.form_action += '?next=' + next_page
+                csrf_tk['error'] = error
+                csrf_tk['form'] = form
+                csrf_tk['next_page'] = next_page
+        return render(request, 'member/login.html', {
+            'form': form,
+            'csrf_tk': csrf_tk
+        })
 
         profile = get_object_or_404(Profile, user=user)
         if not user.is_active:
@@ -1005,6 +1104,7 @@ def login_view(request):
         'form': form,
         'csrf_tk': csrf_tk
     })
+'''
 
 
 @login_required

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -918,7 +918,7 @@ def login_view(request):
         })
 
     # Now, we are sure that the request is POST.
-    form = LoginForm(request.POST)
+    form = LoginForm(data=request.POST)
     print('Errors:', repr(form.errors))  # À supprimer.
     if form.is_valid():
         print('Valid')  # À supprimer.

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -23,6 +23,7 @@ from django.utils.translation import string_concat
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, UpdateView, CreateView, FormView
+from django.urls import NoReverseMatch
 
 from zds.forum.models import Topic, TopicRead
 from zds.gallery.forms import ImageAsAvatarForm
@@ -974,12 +975,10 @@ def login_view(request):
             # after a browser session.)
             try:
                 response = redirect(next_page)
-                set_old_smileys_cookie(response, profile)
-                return response
-            except:
+            except NoReverseMatch:
                 response = redirect(reverse('homepage'))
-                set_old_smileys_cookie(response, profile)
-                return response
+            set_old_smileys_cookie(response, profile)
+            return response
 
     if next_page is not None:
         form.helper.form_action += '?next=' + next_page

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -919,9 +919,7 @@ def login_view(request):
 
     # Now, we are sure that the request is POST.
     form = LoginForm(data=request.POST)
-    print('Errors:', repr(form.errors))  # À supprimer.
     if form.is_valid():
-        print('Valid')  # À supprimer.
         if next_page is not None:
             form.helper.form_action += '?next=' + next_page
         username = form.cleaned_data['username']

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import User, Group
 from django.template.context_processors import csrf
 from django.core.exceptions import PermissionDenied
 from django.core.mail import EmailMultiAlternatives
-from django.urls import reverse, reverse_lazy, NoReverseMatch
+from django.urls import reverse, reverse_lazy, resolve, Resolver404
 from django.db import transaction
 from django.db.models import Q
 from django.http import Http404, HttpResponseBadRequest, StreamingHttpResponse
@@ -973,8 +973,8 @@ def login_view(request):
             # (For people switching account or clearing cookies
             # after a browser session.)
             try:
-                response = redirect(next_page)
-            except NoReverseMatch:
+                response = redirect(resolve(next_page).url_name)
+            except Resolver404:
                 response = redirect(reverse('homepage'))
             set_old_smileys_cookie(response, profile)
             return response

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -938,11 +938,12 @@ def login_view(request):
                     )
                 )
             else:
+                registration_url = reverse('register-member')
                 messages.error(
                     request, _(
                         'Ce nom d’utilisateur est inconnu. '
-                        'Si vous ne possédez pas de compte, vous '
-                        'pouvez vous inscrire.'
+                        'Si vous ne possédez pas de compte, vous pouvez '
+                        '<a href="{url}">vous inscrire</a>.'.format(url=url)
                     )
                 )
             form = LoginForm(initial=initial)

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -909,7 +909,7 @@ def login_view(request):
     if request.method != 'POST':
         form = LoginForm()
     else:
-        form = LoginForm(data=request.POST)
+        form = LoginForm(request.POST)
     if form.is_valid():
         username = form.cleaned_data['username']
         password = form.cleaned_data['password']


### PR DESCRIPTION
Cette modif' a été discutée [sur le forum](https://zestedesavoir.com/forums/sujet/9899/les-identifiants-fournis-ne-sont-pas-valides/) mais le topic semble au point mort. Je propose donc cette PR, à débattre pour savoir si on la garde ou pas. :)

Ce commit change la manière dont la fonction gère les erreurs pour la rendre un peu plus lisible.
Il rend aussi les messages d'erreur plus précis.

Avant, quand les identifiants fournis étaient invalides, seul "Les identifiants fournis ne sont pas valides." était indiqué. Désormais, le message est soit "Nom d’utilisateur inconnu.", soit "Mot de passe incorrect.".

### Contrôle qualité

  - Essayer de se connecter avec :
    - un pseudo et un MDP valides ;
    - un pseudo valide et un mauvais MDP ;
    - un pseudo inconnu.
