### PR TITLE
Trie les notifications de la plus récente à la plus ancienne

### DIFF
--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -143,7 +143,8 @@ def interventions_topics(user):
                              'title': notification.title,
                              'url': notification.url})
 
-    posts_unread.sort(key=lambda post: post['pubdate'].timetuple())
+    # Descending order (newest first, oldest last)
+    posts_unread.sort(key=lambda post: post['pubdate'].timetuple(), reverse=True)
 
     return posts_unread
 


### PR DESCRIPTION
L’ordre a changé suite à un refactoring furtif dans 088f2cfa.

J’aurais bien rajouté un test là-dessus mais je sais pas trop faire.
