### PR TITLE
Corrige le problème d'encodage dans l'historique d'un contenu

### DIFF
--- a/zds/utils/templatetags/htmldiff.py
+++ b/zds/utils/templatetags/htmldiff.py
@@ -10,13 +10,13 @@ register = template.Library()
 
 @register.simple_tag
 def htmldiff(string1, string2):
-    txt1 = str(string1).splitlines()
-    txt2 = str(string2).splitlines()
+    txt1 = string1.decode('utf-8').splitlines()
+    txt2 = string2.decode('utf-8').splitlines()
 
     diff = HtmlDiff(tabsize=4, wrapcolumn=80)
     result = diff.make_table(txt1, txt2, context=True, numlines=2)
 
-    if '<td> No Differences Found </td>' in result:
-        return _('<p>Pas de changements.</p>')
+    if 'No Differences Found' in result:
+        return format_html('<p>{}</p>', _('Pas de changements.'))
     else:
         return format_html('<div class="diff_delta">{}</div>', mark_safe(result))

--- a/zds/utils/templatetags/htmldiff.py
+++ b/zds/utils/templatetags/htmldiff.py
@@ -10,8 +10,17 @@ register = template.Library()
 
 @register.simple_tag
 def htmldiff(string1, string2):
-    txt1 = string1.decode('utf-8').splitlines()
-    txt2 = string2.decode('utf-8').splitlines()
+
+    try:
+        txt1 = string1.decode('utf-8').splitlines()
+    # string1 is an empty SafeText from template
+    except AttributeError:
+        txt1 = string1.splitlines()
+
+    try:
+        txt2 = string2.decode('utf-8').splitlines()
+    except AttributeError:
+        txt2 = string2.splitlines()
 
     diff = HtmlDiff(tabsize=4, wrapcolumn=80)
     result = diff.make_table(txt1, txt2, context=True, numlines=2)

--- a/zds/utils/templatetags/tests/test_htmldiff.py
+++ b/zds/utils/templatetags/tests/test_htmldiff.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+
+from zds.utils.templatetags.htmldiff import htmldiff
+
+
+class HtmlDiffTests(TestCase):
+
+    def test_empty(self):
+        self.assertEquals(htmldiff('essai'.encode(), 'essai'.encode()), '<p>Pas de changements.</p>')
+
+    def test_nominal(self):
+        self.assertIn('Agrume', htmldiff('Agrume'.encode(), ''.encode()))
+
+    def test_encoding(self):
+        # Regression test for issue #4824
+        self.assertIn('Étrange&nbsp;caractère', htmldiff('Étrange caractère'.encode(), ''.encode()))


### PR DESCRIPTION

Numéro du ticket concerné (optionnel) : #4824

- Correction du problème d'encodage décrit dans le ticket. Introduction du bug : [ici](https://github.com/zestedesavoir/zds-site/commit/088f2cfa5e526206e584ad0dfa8740440a22fc37#diff-437007f54928ba703c7c9eb620daf683) + test de non régression
- Correction du templatetag dans le cas des différences non trouvées, la chaînes `<td> No Differences Found </td>` ne pouvait jamais être trouvée dans la réponse car la lib place des espace insécables entre le message et les balises.

### Contrôle qualité

Par exemple :

- Créer un tutorial, l'éditer et introduire des mots contenants des caractères spéciaux (accents, etc.). Dans la visualisation différentielle du contenu, les mots en questions sont bien affichés.
-  Pour l'autre problème (aucune différence entre les contenus), je n'ai pas réussi à trouver un cas de test concrets car nous faisons une vérification en front avant d’appeler le diff. Il faudrait trouver un cas ou notre code pense qu'il y ait une modification, mais que HtmlDiff n'en trouve pas.

