### PR TITLE
Retire les sous catégories vides de la bibliothèque

### DIFF
--- a/zds/tutorialv2/tests/tests_lists.py
+++ b/zds/tutorialv2/tests/tests_lists.py
@@ -92,8 +92,8 @@ class ContentTests(TestCase, TutorialTestMixin):
         resp = self.client.get(reverse('content:find-article', args=[self.user_author.pk]) + '?filter=chuck-norris')
         self.assertEqual(resp.status_code, 404)
 
-    def _create_and_publish_type_in_subcategory(self, type, subcategory):
-        tuto_1 = PublishableContentFactory(type=type, author_list=[self.user_author])
+    def _create_and_publish_type_in_subcategory(self, content_type, subcategory):
+        tuto_1 = PublishableContentFactory(type=content_type, author_list=[self.user_author])
         tuto_1.subcategory.add(subcategory)
         tuto_1.save()
         tuto_1_draft = tuto_1.load_version()

--- a/zds/tutorialv2/tests/tests_lists.py
+++ b/zds/tutorialv2/tests/tests_lists.py
@@ -103,7 +103,8 @@ class ContentTests(TestCase, TutorialTestMixin):
         category_1 = ContentCategoryFactory()
         subcategory_1 = SubCategoryFactory(category=category_1)
         subcategory_2 = SubCategoryFactory(category=category_1)
-        SubCategoryFactory(category=category_1) # Not in context if nothing published inside this subcategory
+        # Not in context if nothing published inside this subcategory
+        SubCategoryFactory(category=category_1)
 
         for _ in range(5):
             self._create_and_publish_type_in_subcategory('TUTORIAL', subcategory_1)

--- a/zds/tutorialv2/views/published.py
+++ b/zds/tutorialv2/views/published.py
@@ -409,19 +409,18 @@ class ViewPublications(TemplateView):
     def categories_with_contents_count(handle_types):
         """Select categories with subcategories and contents count in two queries"""
 
-        queryset_category = (Category.objects.order_by('position')
-                             .filter(categorysubcategory__subcategory__publishablecontent__publishedcontent__must_redirect=False)
-                             .filter(categorysubcategory__subcategory__publishablecontent__type__in=handle_types)
-                             .annotate(contents_count=Count('categorysubcategory__subcategory__publishablecontent__publishedcontent', distinct=True))
-                             ).distinct()
+        queryset_category = Category.objects.order_by('position')\
+            .filter(categorysubcategory__subcategory__publishablecontent__publishedcontent__must_redirect=False)\
+            .filter(categorysubcategory__subcategory__publishablecontent__type__in=handle_types)\
+            .annotate(contents_count=Count('categorysubcategory__subcategory__publishablecontent__publishedcontent',
+                                           distinct=True))\
+            .distinct()
 
-        queryset_subcategory = (CategorySubCategory.objects
-                                .prefetch_related('subcategory', 'category')
-                                .filter(is_main=True)
-                                .order_by('category__id', 'subcategory__title')
-                                .annotate(sub_contents_count=Count('subcategory__publishablecontent__publishedcontent',
-                                                                   distinct=True))
-                                .all())
+        queryset_subcategory = CategorySubCategory.objects.prefetch_related('subcategory', 'category')\
+            .filter(is_main=True)\
+            .order_by('category__id', 'subcategory__title')\
+            .annotate(sub_contents_count=Count('subcategory__publishablecontent__publishedcontent', distinct=True))\
+            .all()
 
         subcategories_sorted = defaultdict(list)
         for category_to_sub_category in queryset_subcategory:


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #4571 

J'ai fait une refacto du code au passage pour retirer tout le SQL. A termes on pourrait peut être factoriser ça avec ce qui est dans la topbar ? 

A voir si on veut appliquer les positions de sous catégories aussi dans cette page (Cf mon autre PR)

### Contrôle qualité

- Lancer votre serveur et créer une sous catégorie qui ne contient pas de contenu
- Cette sous catégorie n’apparaît plus dans la bibliothèque 

