### PR TITLE
Corrige l'affichage des sous-titres des sujets du forum (fix #4828)

### DIFF
--- a/assets/scss/components/_topic-list.scss
+++ b/assets/scss/components/_topic-list.scss
@@ -156,16 +156,17 @@
 
         .topic-title,
         .topic-subtitle {
-            display: inline-block;
             margin: 0 !important;
             padding: 0;
         }
         .topic-title {
+            display: inline-block;
             font-size: 16px;
             font-size: 1.6rem;
             font-weight: normal;
         }
         .topic-subtitle {
+            display: block;
             min-height: 24px;
             line-height: 1.5em;
             color: #777;


### PR DESCRIPTION
Ticket : #4828

QA : 

- Builder le front
- Vérifier que les tags, titres et sous-titres des forums s'affichent correctement en desktop et sur mobile (penser à tester avec des titres et sous-titres courts)