### PR TITLE
Change le nom d'une importation d'erreur

### DIFF
--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 import logging
 
-from django.db.backends.dummy.base import DatabaseError
+from django.db import DatabaseError
 
 import zds
 


### PR DESCRIPTION
Une toute petite modif' pour préparer le terrain pour le passage à Django 1.11 (voir #4811). Voyons ce qu'en pense Travis. :)