### PR TITLE
fix #4834 : le token d'activation n'est pas envoyé à cause d'une erreur de syntaxe

### DIFF
--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -412,7 +412,7 @@ class SendValidationEmailView(FormView, TokenGenerator):
     def form_valid(self, form):
         # Delete old token
         token = TokenRegister.objects.filter(user=self.usr)
-        if token.count >= 1:
+        if token.count() >= 1:
             token.all().delete()
 
         # Generate new token and send email


### PR DESCRIPTION
Ticket concerné #4834

# QA

- lancer le site
- créez un compte
- vérifier dans votre console que le token d'activation a bien été envoyé.