### PR TITLE
Corrige le templatetag 'url' des tags des résultats sur la page de recherche

### DIFF
--- a/templates/searchv2/includes/publishedcontent.part.html
+++ b/templates/searchv2/includes/publishedcontent.part.html
@@ -56,7 +56,7 @@
                 {% if search_result.is_opinion %}
                     <a href="{% url 'opinion:list' %}?tag={{ tag|urlencode }}">{{ tag }}</a>
                 {% else %}
-                    <a href="{% url 'content:list' %}?tag={{ tag|urlencode }}">{{ tag }}</a>
+                    <a href="{% url 'publication:list' %}?tag={{ tag|urlencode }}">{{ tag }}</a>
                 {% endif %}
             </li>
         {% endfor %}


### PR DESCRIPTION
Avant, la balise 'url' renvoyait vers "content:list", qui correspond à l'URL "/contenus/". Or, cette dernière est dépréciée et redirige vers "/bibliotheque/", faisant perdre le paramètre GET du tag.
Ce commit modifie cette balise pour qu'elle renvoie vers 'publication:list', correspondant à l'URL "/bibliotheque/".

Numéro du ticket concerné : #4848 

### Contrôle qualité

  - Faire une recherche sur une instance locale pour un contenu qui possède un tag ;
  - Cliquer sur un des tags de ce contenu ;
  - Vérifier que l'on est bien redirigé vers `/bibliotheque/` et non vers `/contenus/`.
