### PR TITLE
[WIP] La CI affiche moins de logs

### DIFF
--- a/zds/settings/ci_test.py
+++ b/zds/settings/ci_test.py
@@ -18,8 +18,4 @@ DATABASES = {
     }
 }
 
-LOGGING['handlers']['console']['level'] = 'ERROR'
-LOGGING['disable_existing_loggers'] = False
-
-logger = logging.getLogger('console')
-logger.setLevel(logging.ERROR)
+[logger.setLevel(logging.ERROR) for logger in logging.Logger.manager.loggerDict.keys()]

--- a/zds/settings/ci_test.py
+++ b/zds/settings/ci_test.py
@@ -16,3 +16,5 @@ DATABASES = {
         },
     }
 }
+
+LOGGING['handlers']['console']['level'] = 'ERROR'

--- a/zds/settings/ci_test.py
+++ b/zds/settings/ci_test.py
@@ -1,5 +1,6 @@
 from .abstract_base import *
 from .abstract_test import *
+import logging
 
 DATABASES = {
     'default': {
@@ -18,3 +19,7 @@ DATABASES = {
 }
 
 LOGGING['handlers']['console']['level'] = 'ERROR'
+LOGGING['disable_existing_loggers'] = False
+
+logger = logging.getLogger('console')
+logger.setLevel(logging.ERROR)


### PR DESCRIPTION
La CI est actuellement trop verbeuse, il y a des tas de `WARNING` dans les logs alors même que les tests passent. Cette PR change le loglevel pour augmenter le ratio signal/noise.