### PR TITLE
Transforme les templatetags des notifications en un context processor

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -371,121 +371,111 @@
                         <div class="notifs-links">
                             {# MESSAGERIE PRIVEE #}
                             <div>
-                                {% with topics=user|interventions_privatetopics %}
-                                {% with notifications=topics.notifications %}
-                                {% with total_notifications=topics.total %}
-                                    <a href="{% url "mp-list" %}" class="ico-link" title="{% trans 'Messagerie privée' %}">
-                                        {% if total_notifications > 0 %}
-                                            <span class="notif-count">{{ total_notifications }}</span>
+                                <a href="{% url "mp-list" %}" class="ico-link" title="{% trans 'Messagerie privée' %}">
+                                    {% if header_private_topic_notifications.total > 0 %}
+                                        <span class="notif-count">{{ header_private_topic_notifications.total }}</span>
+                                    {% endif %}
+                                    <span class="notif-text ico ico-messages">{% trans "Messagerie privée" %}</span>
+                                </a>
+
+                                <div class="dropdown">
+                                    <span class="dropdown-title dropdown-pm">
+                                        {% trans "Messagerie privée" %}
+                                        <a href="{% url "mp-new" %}" class="ico-after pm-new white" title="{% trans 'Envoyer un nouveau message privé' %}"></a>
+                                   </span>
+
+                                    <ul class="dropdown-list">
+                                        {% for notification in header_private_topic_notifications.list %}
+                                        <li>
+                                            <a href="{{ notification.url }}">
+                                                <img src="{{ notification.sender.profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar">
+                                                <span class="username">{{ notification.sender.username }}</span>
+                                                <span class="date">{{ notification.pubdate|format_date:True|capfirst }}</span>
+                                                <span class="topic">{{ notification.title }}</span>
+                                            </a>
+                                        </li>
+                                        {% endfor %}
+
+                                        {% if header_private_topic_notifications.total == 0 %}
+                                        <li class="dropdown-empty-message">
+                                            {% trans "Aucun nouveau message" %}
+                                        </li>
                                         {% endif %}
-                                        <span class="notif-text ico ico-messages">{% trans "Messagerie privée" %}</span>
+                                    </ul>
+                                    <a href="{% url "mp-list" %}" class="dropdown-link-all">
+                                        {% trans "Toutes les conversations" %}
                                     </a>
-
-                                    <div class="dropdown">
-                                        <span class="dropdown-title dropdown-pm">
-                                            {% trans "Messagerie privée" %}
-                                            <a href="{% url "mp-new" %}" class="ico-after pm-new white" title="{% trans 'Envoyer un nouveau message privé' %}"></a>
-                                       </span>
-
-                                        <ul class="dropdown-list">
-                                            {% for notification in notifications %}
-                                            <li>
-                                                <a href="{{ notification.url }}">
-                                                    <img src="{{ notification.sender.profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar">
-                                                    <span class="username">{{ notification.sender.username }}</span>
-                                                    <span class="date">{{ notification.pubdate|format_date:True|capfirst }}</span>
-                                                    <span class="topic">{{ notification.title }}</span>
-                                                </a>
-                                            </li>
-                                            {% endfor %}
-
-                                            {% if total_notifications == 0 %}
-                                            <li class="dropdown-empty-message">
-                                                {% trans "Aucun nouveau message" %}
-                                            </li>
-                                            {% endif %}
-                                        </ul>
-                                        <a href="{% url "mp-list" %}" class="dropdown-link-all">
-                                            {% trans "Toutes les conversations" %}
-                                        </a>
-                                    </div>
-                                    {% endwith %}
-                                {% endwith %}
-                                {% endwith %}
+                                </div>
                             </div>
 
                             {# NOTIFICATIONS #}
                             <div>
-                                {% with unread_posts=user|interventions_topics %}
-                                    <a href="{% url 'notification-list' %}" class="ico-link" title="{% trans 'Notifications' %}">
-                                        {% if unread_posts|length > 0 %}
-                                            <span class="notif-count">{{ unread_posts|length }}</span>
+                                <a href="{% url 'notification-list' %}" class="ico-link" title="{% trans 'Notifications' %}">
+                                    {% if header_general_notifications.total > 0 %}
+                                        <span class="notif-count">{{ header_general_notifications.total }}</span>
+                                    {% endif %}
+                                    <span class="notif-text ico ico-notifs">{% trans "Notifications" %}</span>
+                                </a>
+
+                                <div class="dropdown">
+                                    <span class="dropdown-title">{% trans "Notifications" %}</span>
+
+                                    <ul class="dropdown-list">
+                                        {% for first_unread in header_general_notifications.list %}
+                                            <li>
+                                                <a href="{{ first_unread.url }}">
+                                                    <img src="{{ first_unread.author.profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar">
+                                                    <span class="username">{{ first_unread.author.username }}</span>
+                                                    <span class="date">{{ first_unread.pubdate|format_date:True|capfirst }}</span>
+                                                    <span class="topic">{{ first_unread.title }}</span>
+                                                </a>
+                                            </li>
+                                        {% endfor %}
+
+                                        {% if header_general_notifications.total == 0 %}
+                                            <li class="dropdown-empty-message">
+                                                {% trans "Aucune notification" %}
+                                            </li>
                                         {% endif %}
-                                        <span class="notif-text ico ico-notifs">{% trans "Notifications" %}</span>
+                                    </ul>
+                                    <a href="{% url 'notification-list' %}" class="dropdown-link-all">
+                                        {% trans "Toutes les notifications" %}
                                     </a>
-
-                                    <div class="dropdown">
-                                        <span class="dropdown-title">{% trans "Notifications" %}</span>
-
-                                        <ul class="dropdown-list">
-                                            {% for first_unread in unread_posts %}
-                                                <li>
-                                                    <a href="{{ first_unread.url }}">
-                                                        <img src="{{ first_unread.author.profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar">
-                                                        <span class="username">{{ first_unread.author.username }}</span>
-                                                        <span class="date">{{ first_unread.pubdate|format_date:True|capfirst }}</span>
-                                                        <span class="topic">{{ first_unread.title }}</span>
-                                                    </a>
-                                                </li>
-                                            {% endfor %}
-
-                                            {% if unread_posts|length == 0 %}
-                                                <li class="dropdown-empty-message">
-                                                    {% trans "Aucune notification" %}
-                                                </li>
-                                            {% endif %}
-                                        </ul>
-                                        <a href="{% url 'notification-list' %}" class="dropdown-link-all">
-                                            {% trans "Toutes les notifications" %}
-                                        </a>
-                                    </div>
-                                {% endwith %}
+                                </div>
                             </div>
 
                             {# ALERTES MODERATION #}
                             {% if perms.forum.change_post %}
-                                {% with alerts_list=user|alerts_list %}
-                                    <div>
-                                        <a href="{% url "pages-alerts" %}" class="ico-link" title="{% trans 'Alertes de modération' %}">
-                                            <span class="notif-text ico ico-alerts">{% trans "Alertes de modération" %}</span>
-                                            {% if alerts_list.nb_alerts > 0 %}
-                                                <span class="notif-count">{{ alerts_list.nb_alerts }}</span>
-                                            {% endif %}
-                                        </a>
+                                <div>
+                                    <a href="{% url "pages-alerts" %}" class="ico-link" title="{% trans 'Alertes de modération' %}">
+                                        <span class="notif-text ico ico-alerts">{% trans "Alertes de modération" %}</span>
+                                        {% if header_alerts.total > 0 %}
+                                            <span class="notif-count">{{ header_alerts.total }}</span>
+                                        {% endif %}
+                                    </a>
 
-                                        <div class="dropdown staff-only">
-                                            <span class="dropdown-title">{% trans "Alertes de modération" %}</span>
-                                            <ul class="dropdown-list">
-                                                {% for alert in alerts_list.alerts %}
-                                                    <li>
-                                                        <a href="{{ alert.url }}">
-                                                            <span class="username">{{ alert.title }}</span>
-                                                            <span class="date">{{ alert.pubdate|format_date:True|capfirst }}</span>
-                                                            <span class="topic">{{ alert.text }}</span>
-                                                        </a>
-                                                    </li>
-                                                {% empty %}
-                                                    <li class="dropdown-empty-message">
-                                                        {% trans "Aucune alerte" %}
-                                                    </li>
-                                                {% endfor %}
-                                            </ul>
-                                            <a href="{% url "pages-alerts" %}" class="dropdown-link-all">
-                                                {% trans "Toutes les alertes" %}
-                                            </a>
-                                        </div>
+                                    <div class="dropdown staff-only">
+                                        <span class="dropdown-title">{% trans "Alertes de modération" %}</span>
+                                        <ul class="dropdown-list">
+                                            {% for alert in header_alerts.list %}
+                                                <li>
+                                                    <a href="{{ alert.url }}">
+                                                        <span class="username">{{ alert.title }}</span>
+                                                        <span class="date">{{ alert.pubdate|format_date:True|capfirst }}</span>
+                                                        <span class="topic">{{ alert.text }}</span>
+                                                    </a>
+                                                </li>
+                                            {% empty %}
+                                                <li class="dropdown-empty-message">
+                                                    {% trans "Aucune alerte" %}
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                        <a href="{% url "pages-alerts" %}" class="dropdown-link-all">
+                                            {% trans "Toutes les alertes" %}
+                                        </a>
                                     </div>
-                                {% endwith %}
+                                </div>
                             {% endif %}
                         </div>
 

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -136,6 +136,7 @@ django_template_engine = {
             # ZDS context processors
             'zds.utils.context_processor.app_settings',
             'zds.utils.context_processor.version',
+            'zds.utils.context_processor.header_notifications'
         ],
     },
 }

--- a/zds/utils/context_processor.py
+++ b/zds/utils/context_processor.py
@@ -4,6 +4,8 @@ from django.conf import settings
 
 from zds import __version__, git_version
 
+from .header_notifications import get_header_notifications
+
 
 def get_version():
     """
@@ -22,6 +24,16 @@ def version(request):
     A context processor to include the app version on all pages.
     """
     return {'zds_version': get_version()}
+
+
+def header_notifications(request):
+    user = request.user
+    results = get_header_notifications(user)
+    if results is None:
+        # Unauthorized
+        return {}
+    # Prefix every key with `header_`
+    return {'header_' + k: v for k, v in results.items()}
 
 
 def app_settings(request):

--- a/zds/utils/header_notifications.py
+++ b/zds/utils/header_notifications.py
@@ -1,0 +1,91 @@
+
+from django.contrib.contenttypes.models import ContentType
+
+from zds.forum.models import Post
+from zds.mp.models import PrivateTopic
+from zds.notification.models import Notification
+from zds.tutorialv2.models.database import ContentReaction, PublishableContent
+from zds.utils.models import Alert
+
+
+def _notifications_to_list(notifications_query):
+    query = (
+        notifications_query
+            .select_related('sender__profile')
+            .order_by('-pubdate')[:10]
+    )
+
+    return [
+        {
+            'pubdate': n.pubdate,
+            'author': n.sender,
+            'title': n.title,
+            'url': n.url
+        } for n in query
+    ]
+
+
+def _get_alert_info(alert):
+    if alert.scope == 'FORUM':
+        post = Post.objects.select_related('topic').get(pk=alert.comment.pk)
+        return post.topic.title, post.get_absolute_url()
+    if alert.scope == 'CONTENT':
+        published = PublishableContent.objects.select_related('public_version').get(pk=alert.content.pk)
+        title = published.public_version.title if published.public_version else published.title,
+        url = published.get_absolute_url_online() if published.public_version else ''
+        return title, url
+    else:
+        comment = ContentReaction.objects.select_related('related_content').get(pk=alert.comment.pk)
+        return comment.related_content.title, comment.get_absolute_url(),
+
+
+def _alert_to_dict(alert):
+    title, url = _get_alert_info(alert)
+    return {
+        'title': title,
+        'url': url,
+        'pubdate': alert.pubdate,
+        'author': alert.author,
+        'text': alert.text
+    }
+
+
+def _alerts_to_list(alerts_query):
+    query = alerts_query \
+        .select_related('author', 'comment', 'content') \
+        .order_by('-pubdate')[:10]
+
+    return [_alert_to_dict(a) for a in query]
+
+
+def get_header_notifications(user):
+    if not user.is_authenticated():
+        return None
+
+    private_topic = ContentType.objects.get_for_model(PrivateTopic)
+
+    notifications = Notification.objects \
+        .filter(subscription__user=user, is_read=False)
+
+    general_notifications = notifications \
+        .exclude(subscription__content_type=private_topic)
+
+    private_notifications = notifications \
+        .filter(subscription__content_type=private_topic)
+
+    alerts = Alert.objects.filter(solved=False)
+
+    return {
+        'general_notifications': {
+            'total': general_notifications.count(),
+            'list': _notifications_to_list(general_notifications),
+        },
+        'private_topic_notifications': {
+            'total': private_notifications.count(),
+            'list': _notifications_to_list(private_notifications),
+        },
+        'alerts': user.has_perm('forum.change_post') and {
+            'total': alerts.count(),
+            'list': _alerts_to_list(alerts),
+        },
+    }

--- a/zds/utils/templatetags/tests/tests_interventions.py
+++ b/zds/utils/templatetags/tests/tests_interventions.py
@@ -1,16 +1,13 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from django.core.urlresolvers import reverse
 from django.template import Context, Template
 from django.test import TestCase
 
-from zds.forum.factories import CategoryFactory, ForumFactory, PostFactory, TopicFactory
 from zds.tutorialv2.models.database import Validation
 from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory, SubCategoryFactory
-from zds.member.factories import ProfileFactory, StaffProfileFactory, StaffFactory
-from zds.utils.models import Alert
+from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.utils.mps import send_message_mp, send_mp
-from zds.utils.templatetags.interventions import alerts_list
 
 
 class InterventionsTest(TestCase):
@@ -149,40 +146,3 @@ class InterventionsTest(TestCase):
                       '{{ date_last_year|humane_delta }}'
                       ).render(self.context)
         self.assertEqual('Plus ancien', tr)
-
-
-class AlertsTest(TestCase):
-    """
-    This class intends to test the templatetag 'alerts_list'
-    """
-
-    def setUp(self):
-        self.staff = StaffFactory()
-        self.dummy_author = ProfileFactory()
-
-        self.category = CategoryFactory(position=1)
-        self.forum = ForumFactory(category=self.category, position_in_category=1)
-        self.topic = TopicFactory(forum=self.forum, author=self.dummy_author.user)
-        self.post = PostFactory(topic=self.topic, author=self.dummy_author.user, position=1)
-
-        self.alerts = []
-        for i in range(20):
-            alert = Alert(author=self.dummy_author.user,
-                          comment=self.post,
-                          scope='FORUM',
-                          text='pouet-{}'.format(i),
-                          pubdate=(datetime.now() + timedelta(minutes=i)))
-            alert.save()
-            self.alerts.append(alert)
-
-    def test_tag(self):
-
-        all_alerts = alerts_list(user=self.staff)
-        self.assertEqual(20, all_alerts['nb_alerts'])
-        self.assertEqual(10, len(all_alerts['alerts']))
-        self.assertEqual(self.alerts[-1].text, all_alerts['alerts'][0]['text'])
-
-        self.alerts[5].delete()
-        all_alerts = alerts_list(user=self.staff)
-        self.assertEqual(19, all_alerts['nb_alerts'])
-        self.assertEqual(10, len(all_alerts['alerts']))

--- a/zds/utils/tests/tests_context_processors.py
+++ b/zds/utils/tests/tests_context_processors.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase
+
+from zds.forum.factories import CategoryFactory, ForumFactory, PostFactory, TopicFactory
+from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.utils.context_processor import header_notifications as notifications_processor
+from zds.utils.models import Alert
+
+
+class AlertsTest(TestCase):
+    def setUp(self):
+        self.staff = StaffProfileFactory()
+        self.dummy_author = ProfileFactory()
+
+        self.category = CategoryFactory(position=1)
+        self.forum = ForumFactory(category=self.category, position_in_category=1)
+        self.topic = TopicFactory(forum=self.forum, author=self.dummy_author.user)
+        self.post = PostFactory(topic=self.topic, author=self.dummy_author.user, position=1)
+
+        self.alerts = []
+        for i in range(20):
+            alert = Alert(author=self.dummy_author.user,
+                          comment=self.post,
+                          scope='FORUM',
+                          text='pouet-{}'.format(i),
+                          pubdate=(datetime.now() + timedelta(minutes=i)))
+            alert.save()
+            self.alerts.append(alert)
+
+    def test_anonymous_user(self):
+        self.assertEqual({}, self.__notifications(AnonymousUser()))
+
+    def test_regular_user(self):
+        self.assertEqual(False, self.__alerts(self.dummy_author.user))
+
+    def test_staff(self):
+        alerts = self.__alerts(self.staff.user)
+        self.assertEqual(20, alerts['total'])
+        self.assertEqual(10, len(alerts['list']))
+        self.assertEqual(self.alerts[-1].text, alerts['list'][0]['text'])
+
+        self.alerts[5].delete()
+        alerts = self.__alerts(self.staff.user)
+        self.assertEqual(19, alerts['total'])
+        self.assertEqual(10, len(alerts['list']))
+
+    def __alerts(self, user):
+        return self.__notifications(user)['header_alerts']
+
+    def __notifications(self, user):
+        class Request(): pass
+        r = Request()
+        r.user = user
+        return notifications_processor(r)


### PR DESCRIPTION
Je ne pense pas que ce soit une bonne pratique de faire des queries vers
la DB dans des templatetags.

Ce commit limite le nombre maximal de notifications affichées dans la
liste déroulante en haut à droite du site. Il n’y en a pas plus de 10
désormais. Toutefois, le nombre de notifications affiché dans le badge
rouge correspond bien au nombre total des notifications.

Le code est quasi le même pour les messages privés, les alertes de
modération et les autres notifications.

J’ai essayé de soigner les queries, il y a d’abord un `SELECT COUNT(*) …`
puis un `SELECT * … LIMIT 10` et c’est tout.

<!-- Veuillez décrire vos changements à l’emplacement de ce commentaire (inutile dans le cas de tout petits changements). -->

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

Vérifiez que ce patch ne change rien aux fonctionnement actuel des notifications et des alertes de modération.

Vérifiez qu’il n’y a pas plus de 10 éléments dans les listes déroulantes.

Vérifiez que le nombre de *queries* nécéssaire pour afficher chaque page diminue un peu avec ce patch. Chez moi, ça passe de 67 à 64 sur la page d’accueil (cache chaud).