### PR TITLE
La CI affiche moins de logs

### DIFF
--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -294,6 +294,11 @@ LOGGING = {
             'handlers': ['console'],
             'level': 'WARNING',
         },
+
+        'root': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+        },
     }
 }
 

--- a/zds/settings/ci_test.py
+++ b/zds/settings/ci_test.py
@@ -16,3 +16,6 @@ DATABASES = {
         },
     }
 }
+
+for logger in LOGGING['loggers'].values():
+    logger['level'] = 'ERROR'


### PR DESCRIPTION
La CI est actuellement trop verbeuse, il y a des tas de `WARNING` dans les logs alors même que les tests passent. Cette PR change le loglevel pour augmenter le ratio signal/noise.

Fait suite à #4854.