### PR TITLE
Corrige le comportement du bouton "Citer"

### DIFF
--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -202,7 +202,7 @@
     }
 
     function insertCitation(editor, citation) {
-        if (editor.value === '') {
+        if (editor.value === "") {
             editor.value = citation + "\n\n";
             return;
         }

--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -202,6 +202,10 @@
     }
 
     function insertCitation(editor, citation) {
+        if (editor.value === '') {
+            editor.value = citation + "\n\n";
+            return;
+        }
         if (editor.selectionStart !== editor.selectionEnd ||
             getLineAt(editor.value, editor.selectionStart).trim()) {
             editor.value = editor.value + "\n\n" + citation;


### PR DESCRIPTION
Depuis #4711, le bouton "Citer" insère une ligne vide suivie de la citation, même quand la boite d'édition est vide. Avant, la citation était ajoutée au début du message et était suivie de deux sauts de lignes.
Ce commit restaure ce comportement quand la boite d'édition est vide.

Numéro du ticket concerné : #4832 

### Contrôle qualité

  - Vérifier que le bouton "Citer" se comporte correctement.
