### PR TITLE
Fix l'alerte persistante  en cas de dépublication de tuto

### DIFF
--- a/doc/source/utils/nettoyage_alerts.rst
+++ b/doc/source/utils/nettoyage_alerts.rst
@@ -1,0 +1,13 @@
+==================================================
+Commande de nettoyage des alertes et notifications
+==================================================
+
+Il peut arriver que le système d'alerte et de notification génère des alertes et/ou notifications persistentes.
+
+Nous faisons en sorte de corriger les bugs pour les nouvelles alertes et notifications mais ces corrections sont rarement
+rétroactives. C'est pourquoi une commande de nettoyage a été mise à disposition.
+
+Elle s'utilise ainsi : ``python manage.py clean_alerts_and_notifications``.
+
+Un paramètre optionnel existe si vous désirez utiliser un autre administrateur que l'utilisateur anonyme/Clem' :
+``--moderator <username>``.

--- a/zds/tutorialv2/api/tests.py
+++ b/zds/tutorialv2/api/tests.py
@@ -1,3 +1,4 @@
+import datetime
 from copy import deepcopy
 import os
 import shutil
@@ -34,7 +35,8 @@ class ContentReactionKarmaAPITest(APITestCase):
 
     def test_failure_reaction_karma_with_client_unauthenticated(self):
         author = ProfileFactory()
-        reaction = ContentReactionFactory(author=author.user, position=1, related_content=self.content)
+        reaction = ContentReactionFactory(author=author.user, position=1, related_content=self.content,
+                                          pubdate=datetime.datetime.now())
 
         response = self.client.put(reverse('api:content:reaction-karma', args=(reaction.pk,)))
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/zds/tutorialv2/factories.py
+++ b/zds/tutorialv2/factories.py
@@ -136,10 +136,8 @@ class ContentReactionFactory(factory.DjangoModelFactory):
         note = super(ContentReactionFactory, cls)._prepare(create, **kwargs)
         note.pubdate = datetime.now()
         note.save()
-        content = kwargs.pop('tutorial', None)
-        if content:
-            content.last_note = note
-            content.save()
+        note.related_content.last_note = note
+        note.related_content.save()
         return note
 
 

--- a/zds/tutorialv2/receivers.py
+++ b/zds/tutorialv2/receivers.py
@@ -5,7 +5,7 @@ from django.dispatch.dispatcher import receiver
 from django.utils.translation import ugettext_lazy as _
 from django.db import models
 
-from zds.tutorialv2.models.database import PublishableContent
+from zds.tutorialv2.models.database import PublishableContent, ContentReaction
 from zds.tutorialv2.signals import content_unpublished
 from zds.gallery.models import Gallery
 from zds.utils import get_current_user
@@ -28,6 +28,12 @@ def cleanup_validation_alerts(sender, instance, *, moderator=None, **__):
                                                                        resolve_reason=_('Le billet a été dépublié.'),
                                                                        solved_date=datetime.datetime.now(),
                                                                        solved=True)
+        reactions = ContentReaction.objects.filter(related_content=instance).values_list('pk', flat=True)
+        Alert.objects.filter(comment__in=reactions).update(moderator=moderator,
+                                                           resolve_reason=_('Le billet a'
+                                                                            ' été dépublié.'),
+                                                           solved_date=datetime.datetime.now(),
+                                                           solved=True)
 
 
 @receiver(models.signals.post_delete, sender=Gallery)

--- a/zds/utils/management/commands/clean_alerts_and_notifications.py
+++ b/zds/utils/management/commands/clean_alerts_and_notifications.py
@@ -1,0 +1,38 @@
+import datetime
+import logging
+
+from django.contrib.auth.models import User
+from django.core.management import BaseCommand
+from django.db import transaction
+from django.conf import settings
+from django.utils.translation import gettext as _
+from zds.utils.models import Alert
+
+
+@transaction.atomic
+class Command(BaseCommand):
+
+    help = 'Clean up useless notifications & alerts.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--moderator', type=str, dest='moderator_name',
+                            default=settings.ZDS_APP['member']['anonymous_account'])
+
+    def handle(self, *args, **options):
+        moderator = User.objects.filter(username=options['moderator_name']).first()
+        if not moderator:
+            logging.error('Could not use this moderator %s', options['moderator_name'])
+            return 1
+        Alert.objects.first(content__isnull=False, content__public_version__isnull=True).update(
+            moderator=moderator,
+            solved=True,
+            solved_date=datetime.datetime.now(),
+            resolve_reason=_('Résolution automatique.')
+        )
+        Alert.objects.filter(scope='CONTENT', comment__related_content__isnull=False,
+                             comment__related_content__public_version__isnull=True)\
+            .update(
+                moderator=moderator,
+                solved=True,
+                solved_date=datetime.datetime.now(),
+                resolve_reason=_('Résolution automatique.'))


### PR DESCRIPTION
Fix #4860

# QA :

- créer un billet
- commenter le billet
- signaler le commentaire
- dépublier le billet

Assurez vous que l'alerte a été résolue.