### PR TITLE
Ajoute sqlparse au requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pygments==2.2.0
 python-social-auth==0.2.19
 elasticsearch==5.4.0
 elasticsearch-dsl==5.3.0
+sqlparse==0.2.4
 
 # Explicit dependencies (references in code)
 Django==1.10.8


### PR DESCRIPTION
sqlparse est nécessaire pour l'installation à cause d'une migration écrite avec du SQL "pur". Pour une certaine raison il est installé dans la doc via les paquets système (et ça c'est mal, si c'est pas nécessaire). J'ai pas viré les bouts de doc qui référencent ça, mais c'est pas gênant non plus.