### PR TITLE
Ajoute une espace insécable entre le titre et le sous-titre d'un MP

### DIFF
--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -35,7 +35,7 @@
                     <div class="topic-description">
                         <a href="{{ topic.get_absolute_url }}" class="topic-title-link navigable-link">
                             {% if topic.is_unread %}<span class="a11y">{% trans "Non-lu" %} :</span>{% endif %}
-                            <span class="topic-title">{{ topic.title }}</span>
+                            <span class="topic-title">{{ topic.title }}</span>&nbsp;
                             <span class="topic-subtitle">{{ topic.subtitle }}</span>
                         </a>
 


### PR DESCRIPTION
Dans la ligne d'un topic, quand le sous-titre est court, celui-ci est placé juste après le titre et en est sépaté par une espace insécable.
Dans la ligne d'un MP, l'espace insécable n'est pas présente et le sous-titre est à "touche-touche" avec le titre, compliquant la lisibilité de la ligne.
Ce commit ajoute donc une espace insécable entre les deux dans le template concerné.

Numéro du ticket concerné : #4869 

### Contrôle qualité

  - Vérifier que les sous-titres des MP sont correctement positionnés quand ils sont courts ou longs.
