### PR TITLE
Utilise 'contextlib.suppress' au lieu d'une fonction faite-maison

### DIFF
--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -1,5 +1,6 @@
 from django.db.models import CASCADE
 from datetime import datetime
+import contextlib
 
 from zds.tutorialv2.models.mixins import TemplatableContentModelMixin, OnlineLinkableContentMixin
 from zds import json_handler
@@ -33,7 +34,6 @@ from zds.tutorialv2.models import TYPE_CHOICES, STATUS_CHOICES, CONTENT_TYPES_RE
 from zds.tutorialv2.utils import get_content_from_json, BadManifestError
 from zds.utils import get_current_user
 from zds.utils.models import SubCategory, Licence, HelpWriting, Comment, Tag
-from zds.utils.misc import ignore
 from zds.searchv2.models import AbstractESDjangoIndexable, AbstractESIndexable, delete_document_in_elasticsearch, \
     ESIndexManager
 from zds.utils.tutorials import get_blob
@@ -638,7 +638,7 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
         :rtype: zds.tutorialv2.models.database.PublicContent
         :raise Http404: if the version is not available
         """
-        with ignore(AttributeError):
+        with contextlib.suppress(AttributeError):
             self.content.count_note = self.count_note
 
         self.versioned_model = self.content.load_version_or_404(sha=self.sha_public, public=self)
@@ -649,7 +649,7 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
         :rtype: zds.tutorialv2.models.database.PublicContent
         :return: the public content
         """
-        with ignore(AttributeError):
+        with contextlib.suppress(AttributeError):
             self.content.count_note = self.count_note
 
         self.versioned_model = self.content.load_version(sha=self.sha_public, public=self)

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -1,6 +1,5 @@
 import hashlib
 import re
-from contextlib import contextmanager
 
 THUMB_MAX_WIDTH = 80
 THUMB_MAX_HEIGHT = 80

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -55,11 +55,3 @@ def contains_utf8mb4(s):
         s = str(s, 'utf-8')
     re_pattern = re.compile('[^\u0000-\uD7FF\uE000-\uFFFF]', re.UNICODE)
     return s != re_pattern.sub('\uFFFD', s)
-
-
-@contextmanager
-def ignore(*exceptions):
-    try:
-        yield
-    except exceptions:
-        pass


### PR DESCRIPTION
Vu que cette fonction n'est utilisée que dans un seul fichier et que la standardlib de Python 3.4 en fourni une qui fait exactement pareil, autant l'utiliser directement. :)

Numéro du ticket concerné : Aucun

### Contrôle qualité

  - Lancer les tests unitaires devrait suffire (je pense).
