### PR TITLE
Simplifie l'URL des tags des sujets du forum

### DIFF
--- a/templates/forum/find/topic_by_tag.html
+++ b/templates/forum/find/topic_by_tag.html
@@ -73,21 +73,21 @@
         <h3>{% trans "Filtres" %}</h3>
         <ul>
             <li>
-                <a href="{% url 'topic-tag-find' tag.pk tag.slug %}?filter=solve"
+                <a href="{% url 'topic-tag-find' tag.slug %}?filter=solve"
                    class="ico-after tick green {% if request.GET.filter == "solve" %}selected{% endif %}"
                 >
                     {% trans "Sujets résolus" %}
                 </a>
             </li>
             <li>
-                <a href="{% url 'topic-tag-find' tag.pk tag.slug %}?filter=unsolve"
+                <a href="{% url 'topic-tag-find' tag.slug %}?filter=unsolve"
                    class="ico-after tick blue {% if request.GET.filter == "unsolve" %}selected{% endif %}"
                 >
                     {% trans "Sujets non résolus" %}
                 </a>
             </li>
             <li>
-                <a href="{% url 'topic-tag-find' tag.pk tag.slug %}?filter=noanswer"
+                <a href="{% url 'topic-tag-find' tag.slug %}?filter=noanswer"
                    class="ico-after view {% if request.GET.filter == "noanswer" %}selected{% endif %}"
                 >
                     {% trans "Sujets sans réponse" %}
@@ -95,7 +95,7 @@
             </li>
             {% if request.GET.filter %}
                 <li>
-                    <a href="{% url 'topic-tag-find' tag.pk tag.slug %}"
+                    <a href="{% url 'topic-tag-find' tag.slug %}"
                        class="ico-after cross blue"
                     >
                         {% trans "Annuler le filtre" %}

--- a/templates/forum/includes/topic_item.part.html
+++ b/templates/forum/includes/topic_item.part.html
@@ -47,7 +47,7 @@
         <ul class="content-tags" itemprop="keywords">
             {% for tag in topic.tags.all|slice:":3" %}
                 <li>
-                    <a href="{% url 'topic-tag-find' tag.pk tag.slug %}" title="Tag {{ tag.title }}">
+                    <a href="{% url 'topic-tag-find' tag.slug %}" title="Tag {{ tag.title }}">
                         {{ tag.title }}
                     </a>
                 </li>

--- a/templates/forum/includes/topic_row.part.html
+++ b/templates/forum/includes/topic_row.part.html
@@ -31,7 +31,7 @@
                 <ul class="topic-tags">
                     {% for tag in topic.tags.all %}
                         <li>
-                            <a href="{% url 'topic-tag-find' tag.pk tag.slug %}" class="topic-tag" title="Tag {{ tag.title }}">
+                            <a href="{% url 'topic-tag-find' tag.slug %}" class="topic-tag" title="Tag {{ tag.title }}">
                                 {{ tag.title }}
                             </a>
                         </li>

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -52,7 +52,7 @@
         <ul class="taglist" itemprop="keywords">
             {% for tag in topic.tags.all %}
                 <li>
-                    <a href="{% url 'topic-tag-find' tag.pk tag.slug %}">
+                    <a href="{% url 'topic-tag-find' tag.slug %}">
                         {{ tag.title }}
                     </a>
                 </li>

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -906,7 +906,7 @@ class FindTopicTest(TestCase):
 
 class FindTopicByTagTest(TestCase):
     def test_failure_find_topics_of_a_tag_not_found(self):
-        response = self.client.get(reverse('topic-tag-find', args=[9999, 'x']), follow=False)
+        response = self.client.get(reverse('topic-tag-find', args=['x']), follow=False)
 
         self.assertEqual(404, response.status_code)
 
@@ -918,7 +918,7 @@ class FindTopicByTagTest(TestCase):
         topic.add_tags([tag.title])
 
         self.assertTrue(self.client.login(username=profile.user.username, password='hostel77'))
-        response = self.client.get(reverse('topic-tag-find', args=[tag.pk, tag.slug]), follow=False)
+        response = self.client.get(reverse('topic-tag-find', args=[tag.slug]), follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context['topics']))
@@ -947,7 +947,7 @@ class FindTopicByTagTest(TestCase):
         topic.add_tags([tag.title])
 
         self.assertTrue(self.client.login(username=profile.user.username, password='hostel77'))
-        response = self.client.get(reverse('topic-tag-find', args=[tag.pk, tag.slug]), follow=False)
+        response = self.client.get(reverse('topic-tag-find', args=[tag.slug]), follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context['topics']))
@@ -962,7 +962,7 @@ class FindTopicByTagTest(TestCase):
         tag = TagFactory()
         topic_solved.add_tags([tag.title])
 
-        response = self.client.get(reverse('topic-tag-find', args=[tag.pk, tag.slug]) + '?filter=solve')
+        response = self.client.get(reverse('topic-tag-find', args=[tag.slug]) + '?filter=solve')
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context['topics']))
@@ -977,7 +977,7 @@ class FindTopicByTagTest(TestCase):
         tag = TagFactory()
         topic_unsolved.add_tags([tag.title])
 
-        response = self.client.get(reverse('topic-tag-find', args=[tag.pk, tag.slug]) + '?filter=unsolve')
+        response = self.client.get(reverse('topic-tag-find', args=[tag.slug]) + '?filter=unsolve')
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context['topics']))
@@ -993,10 +993,25 @@ class FindTopicByTagTest(TestCase):
         topic.add_tags([tag.title])
         another_topic.add_tags([tag.title])
 
-        response = self.client.get(reverse('topic-tag-find', args=[tag.pk, tag.slug]) + '?filter=noanswer')
+        response = self.client.get(reverse('topic-tag-find', args=[tag.slug]) + '?filter=noanswer')
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(2, len(response.context['topics']))
+        self.assertEqual(tag, response.context['tag'])
+
+    def test_redirection(self):
+        profile = ProfileFactory()
+        category, forum = create_category()
+        add_topic_in_a_forum(forum, profile)
+        topic_solved = add_topic_in_a_forum(forum, profile, is_solved=True)
+        tag = TagFactory()
+        topic_solved.add_tags([tag.title])
+
+        response = self.client.get(reverse('old-topic-tag-find', args=[tag.pk, tag.slug]))
+        self.assertEqual(301, response.status_code)
+
+        response = self.client.get(reverse('old-topic-tag-find', args=[tag.pk, tag.slug]), follow=True)
+        self.assertEqual(1, len(response.context['topics']))
         self.assertEqual(tag, response.context['tag'])
 
 

--- a/zds/forum/urls.py
+++ b/zds/forum/urls.py
@@ -2,8 +2,8 @@ from django.conf.urls import url
 
 from zds.forum import feeds
 from zds.forum.views import CategoriesForumsListView, CategoryForumsDetailView, ForumTopicsListView, \
-    TopicPostsListView, TopicNew, TopicEdit, FindTopic, FindTopicByTag, PostNew, PostEdit, PostSignal, \
-    PostUseful, PostUnread, FindPost, solve_alert, ManageGitHubIssue, LastTopicsViewTests
+    TopicPostsListView, TopicNew, TopicEdit, FindTopic, FindTopicByTag, PostNew, PostEdit, \
+    PostSignal, PostUseful, PostUnread, FindPost, solve_alert, ManageGitHubIssue, LastTopicsViewTests
 
 urlpatterns = [
 
@@ -26,7 +26,9 @@ urlpatterns = [
     url(r'^sujet/github/(?P<pk>\d+)/$', ManageGitHubIssue.as_view(), name='manage-issue'),
     url(r'^sujet/(?P<topic_pk>\d+)/(?P<topic_slug>.+)/$', TopicPostsListView.as_view(), name='topic-posts-list'),
     url(r'^sujets/membre/(?P<user_pk>\d+)/$', FindTopic.as_view(), name='topic-find'),
-    url(r'^sujets/tag/(?P<tag_pk>\d+)/(?P<tag_slug>.+)/$', FindTopicByTag.as_view(), name='topic-tag-find'),
+    # The first is kept for URL backward-compatibility.
+    url(r'^sujets/tag/(?P<tag_pk>\d+)/(?P<tag_slug>.+)/$', FindTopicByTag.as_view(), name='old-topic-tag-find'),
+    url(r'^sujets/tag/(?P<tag_slug>.+)/$', FindTopicByTag.as_view(), name='topic-tag-find'),
 
     # Message-related
     url(r'^message/nouveau/$', PostNew.as_view(), name='post-new'),

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -417,6 +417,8 @@ class FindTopicByTag(FilterMixin, ForumEditMixin, ZdSPagingListView, SingleObjec
     object = None
 
     def get(self, request, *args, **kwargs):
+        if self.kwargs.get('tag_pk'):
+            return redirect('topic-tag-find', tag_slug=self.kwargs.get('tag_slug'), permanent=True)
         self.object = self.get_object()
         return super(FindTopicByTag, self).get(request, *args, **kwargs)
 
@@ -450,7 +452,7 @@ class FindTopicByTag(FilterMixin, ForumEditMixin, ZdSPagingListView, SingleObjec
         return context
 
     def get_object(self, queryset=None):
-        return get_object_or_404(Tag, pk=self.kwargs.get('tag_pk'), slug=self.kwargs.get('tag_slug'))
+        return get_object_or_404(Tag, slug=self.kwargs.get('tag_slug'))
 
     def get_queryset(self):
         self.queryset = Topic.objects.get_all_topics_of_a_tag(self.object, self.request.user)

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -624,7 +624,7 @@ class Tag(models.Model):
         return self.title
 
     def get_absolute_url(self):
-        return reverse('topic-tag-find', kwargs={'tag_pk': self.pk, 'tag_slug': self.slug})
+        return reverse('topic-tag-find', kwargs={'tag_slug': self.slug})
 
     def save(self, *args, **kwargs):
         self.title = self.title.strip()


### PR DESCRIPTION
Avant, l'URL d'un tag était de la forme "/forums/sujets/tag/PK/SLUG". La recherche des sujets avec un autre tag ne pouvait donc pas se faire en modifiant l'URL , puisqu'il fallait connaitre sa Public Key.
Désormais, l'URL est simplifiée et est de la forme "/forums/sujets/tag/SLUG", rendant la recherche possible.
L'ancienne URL reste utilisable pour ne pas casser les anciens liens.

Numéro du ticket concerné (optionnel) : Aucun

Que pensez-vous de cette nouvelle URL ? Est-elle pertinente ? Devrais-je la simplifier davantage avec quelque chose comme "/forums/sujets/?tag=SLUG" ou quelque chose comme ça ?

### Contrôle qualité

  - Vérifiez que les URL des tags des sujets sont valides ;
  - Vérifiez la possibilité de chercher un autre tag en modifiant l'URL ;
  - Vérifiez que les anciennes URL sont toujours valides.
