### PR TITLE
Affiche une chaine vide au lieu de "None" quand la conclusion ou l'intro d'un contenu est vide

### DIFF
--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -162,7 +162,7 @@
     {% else %}
 
         {% if content.introduction %}
-            {{ content.get_introduction_online|safe }}
+            {{ content.get_introduction_online|default:""|safe }}
         {% endif %}
 
         {% if not content.has_sub_containers %}
@@ -181,7 +181,7 @@
         <hr />
 
         {% if content.conclusion %}
-            {{ content.get_conclusion_online|safe }}
+            {{ content.get_conclusion_online|default:""|safe }}
         {% endif %}
 
     {% endif %}


### PR DESCRIPTION
Je ne sais pas de quand ça date, mais quand l'introduction ou la conclusion d'un contenu est vide, un "None" est affiché au lieu d'une chaine vide. Cette mini-PR devrait régler ça.

Numéro du ticket concerné (optionnel) : Aucun
