### PR TITLE
Corrige l'indication du temps de lecture estimé quand il est inférieur à une minute

### DIFF
--- a/zds/tutorialv2/views/published.py
+++ b/zds/tutorialv2/views/published.py
@@ -144,8 +144,10 @@ class DisplayOnlineContent(SingleOnlineContentDetailViewMixin):
         context['subscriber_count'] = ContentReactionAnswerSubscription.objects.get_subscriptions(self.object).count()
         # We need reading time expressed in minutes
         try:
-            context['reading_time'] = (self.versioned_object.get_tree_level() * self.object.public_version.char_count /
-                                       settings.ZDS_APP['content']['characters_per_minute'])
+            context['reading_time'] = int(
+                self.versioned_object.get_tree_level() * self.object.public_version.char_count /
+                settings.ZDS_APP['content']['characters_per_minute']
+            )
         except ZeroDivisionError as e:
             logger.warning('could not compute reading time: setting characters_per_minute is set to zero (error=%s)', e)
 


### PR DESCRIPTION
Le temps de lecture estimé est calculé par une division et une multiplication, il s'agit donc d'un float qui peut, quand le contenu est très court, friser le zéro mais sans l'atteindre.
En conséquence, un test booléen dessus renvoyait True, car `bool(0.001) == True`.
Or, l'indication "Temps de lecture estimé à moins d’une minute." devrait être affichée quand le contenu est très court, mais elle était affiché si un test booléen sur le temps de lecture renvoyait False (pour 0 minutes), ce qui ne pouvait se produire que quand le contenu était vide.
Désormais, le calcul est suivi d'une conversion en entier pour éviter ce problème.

Numéro du ticket concerné (optionnel) : Aucun

### Contrôle qualité

  - Vérifiez que le temps de lecture estimé est correct pour un contenu très court (moins d'une minute) ou plus long.
