### PR TITLE
ci: coupe les sorties de compilation dans la CI

### DIFF
--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -279,6 +279,11 @@ LOGGING = {
     },
 
     'loggers': {
+        '': {  # catch all logger
+            'handlers': ['console'],
+            'level': 'WARNING',
+        },
+
         'django': {
             'handlers': ['console'],
             'level': 'WARNING',

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -399,7 +399,13 @@ class ZMarkdownRebberLatexPublicator(Publicator):
         command_process = subprocess.Popen(command,
                                            shell=True, cwd=path.dirname(texfile),
                                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        command_process.communicate()
+        stdout, stderr = command_process.communicate()
+        stdout = stdout.decode('utf-8')
+        stderr = stderr.decode('utf-8')
+        if 'Fatal error occurred' in stdout:
+            logging.debug('stdout:' + '\n'.join(stdout.split()[0:11]))
+        if 'Fatal error occurred' in stderr:
+            logging.debug('stderr:' + '\n'.join(stdout.split()[0:11]))
 
         with contextlib.suppress(ImportError):
             from raven import breadcrumbs
@@ -416,14 +422,14 @@ class ZMarkdownRebberLatexPublicator(Publicator):
                                            shell=True, cwd=path.dirname(texfile),
                                            stdout=subprocess.PIPE,
                                            stderr=subprocess.PIPE)
-        std_out, std_err = command_process.communicate()
+        stdout, stderr = command_process.communicate()
         with contextlib.suppress(ImportError):
             from raven import breadcrumbs
             breadcrumbs.record(message='makeglossaries call',
                                data=command,
                                type='cmd')
         # TODO: check makeglossary exit codes to see if we can enhance error detection
-        if 'fatal' not in std_out.decode('utf-8').lower() and 'fatal' not in std_err.decode('utf-8').lower():
+        if 'fatal' not in stdout.decode('utf-8').lower() and 'fatal' not in stderr.decode('utf-8').lower():
             return True
 
         self.handle_makeglossaries_error(texfile)


### PR DESCRIPTION
Le but est d'attraper stdout/stderr du subprocess latex pour qu'il ne fuite pas dans travis.