### PR TITLE
Rend responsive les vidéos, les équations de maths et les iframes

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -322,3 +322,29 @@ li code {
         padding-left: 25px;
     }
 }
+
+.video-container {
+    margin: 0 auto;
+    max-width: 560px;
+    max-height: 315px;
+
+    .video-wrapper {
+        position: relative;
+        padding-bottom: 56.25%;
+
+        iframe {
+            position:absolute;
+            width: 100%;
+            height: 100%;
+        }
+    }
+}
+
+.inlineMathDouble  .katex {
+    max-width: 100%;
+    overflow-x: auto;
+}
+
+.iframe-wrapper {
+    overflow-x: auto;
+}


### PR DESCRIPTION
Rend responsive les vidéos, les équations de maths et les iframes (normalement il ne reste rien d'autre donc le site est full responsive)

Lié aux tickets : #4390 #2044

**QA :**
- `make build-front`
- Lancer ZMarkdown et le serveur
- Vérifier que les vidéos (Youtube, Dailymotion, Viméo et compagnie), les iframes (JSFiddle et le player de l'INA), les équations de maths `$$`, les tableaux ne dépassent pas des pages sur mobile (ou en redimensionnant son navigateur)