### PR TITLE
Met en cache la signature des utilisateurs

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -4,6 +4,7 @@
 {% load set %}
 {% load i18n %}
 {% load pluralize_fr %}
+{% load cache %}
 
 
 
@@ -242,13 +243,17 @@
                             {% with profile_user=user|profile %}
                                 {% if profile_user.show_sign %}
                                     <div class="signature">
-                                        {{ profile.sign|emarkdown_inline }}
+                                        {% cache 300 message profile.sign %}
+                                            {{ profile.sign|emarkdown_inline }}
+                                        {% endcache %}
                                     </div>
                                 {% endif %}
                             {% endwith %}
                         {% else %}
                             <div class="signature">
-                                {{ profile.sign|emarkdown_inline }}
+                                {% cache 300 message profile.sign %}
+                                    {{ profile.sign|emarkdown_inline }}
+                                {% endcache %}
                             </div>
                         {% endif %}
                     {% endif %}

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -243,7 +243,7 @@
                             {% with profile_user=user|profile %}
                                 {% if profile_user.show_sign %}
                                     <div class="signature">
-                                        {% cache 300 message profile.sign %}
+                                        {% cache 300 profile.user.username profile.sign %}
                                             {{ profile.sign|emarkdown_inline }}
                                         {% endcache %}
                                     </div>
@@ -251,7 +251,7 @@
                             {% endwith %}
                         {% else %}
                             <div class="signature">
-                                {% cache 300 message profile.sign %}
+                                {% cache 300 profile.user.username profile.sign %}
                                     {{ profile.sign|emarkdown_inline }}
                                 {% endcache %}
                             </div>


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #4388 ("Éviter de demander plusieurs fois le parsing de la même signature")

### Contrôle qualité

  - Vérifiez que les signatures sont bien mises en cache ;
  - Vérifiez la durée du cache (300 secondes actuellement).
