### PR TITLE
Ajoute le support des nouvelles classes pour custom-block

### DIFF
--- a/assets/js/spoiler.js
+++ b/assets/js/spoiler.js
@@ -17,7 +17,7 @@
                     class: "spoiler-title ico-after view",
                     href: "#",
                     click: function(e) {
-                        $(this).next(".spoiler").toggle();
+                        $(this).next(".custom-block-spoiler").toggle();
                         e.preventDefault();
                     }
                 }));
@@ -28,9 +28,9 @@
 
     $(document).ready(function() {
         var $content = $("#content");
-        buildSpoilers($content.find(".spoiler"));
+        buildSpoilers($content.find(".custom-block-spoiler"));
         $content.on("DOMNodeInserted", function(e) {
-            var $spoilers = $(e.target).find(".spoiler");
+            var $spoilers = $(e.target).find(".custom-block-spoiler");
             return buildSpoilers($spoilers);
         });
     });

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -82,11 +82,17 @@ h6 {
     &.question,
     &.error,
     &.warning,
-    &.spoiler {
+    &.spoiler,
+    &.custom-block-question,
+    &.custom-block-error,
+    &.custom-block-warning,
+    &.custom-block-information,
+    &.custom-block-neutral,
+    &.custom-block-spoiler {
         margin: 25px 0;
         padding: 7px 15px 7px 45px;
 
-        &.ico-after:after {
+        &:after{
             position: absolute;
             top: 50%;
             left: 23px;
@@ -96,40 +102,43 @@ h6 {
         }
     }
 
-    &.information {
+    &.information,
+    &.custom-block-information {
         background: #daeaee;
-
-        &.ico-after:after {
+        &:after {
             @include sprite-position($information);
         }
     }
 
-    &.question {
+    &.question,
+    &.custom-block-question {
         background: #e2daee;
-
-        &.ico-after:after {
+        &:after{
             @include sprite-position($question);
         }
     }
 
-    &.error {
+    &.error,
+    &.custom-block-error {
         background: #eedada;
 
-        &.ico-after:after {
+        &:after {
             @include sprite-position($error);
         }
     }
 
-    &.warning {
+    &.warning,
+    &.custom-block-warning {
         background: #eee7da;
 
-        &.ico-after:after {
+        &:after {
             @include sprite-position($warning);
         }
     }
 }
 
-.spoiler {
+.spoiler,
+.custom-block-spoiler{
     margin-top: 0;
     padding-left: 15px;
     background: #EEE;
@@ -144,7 +153,7 @@ h6 {
     border-bottom: 1px solid #DDD;
     color: #555;
 
-    &.ico-after:after {
+    &.ico-after:after{
         margin: 8px 0 0 10px;
     }
 

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -135,10 +135,15 @@ h6 {
             @include sprite-position($warning);
         }
     }
+
+    .js .spoiler, .custom-block-spoiler {
+        display: none;
+    }
+
 }
 
 .spoiler,
-.custom-block-spoiler{
+.custom-block-spoiler {
     margin-top: 0;
     padding-left: 15px;
     background: #EEE;

--- a/assets/scss/base/_icons.scss
+++ b/assets/scss/base/_icons.scss
@@ -2,7 +2,8 @@
     background-repeat: no-repeat;
     @include sprite();
 }
-.ico-after {
+.ico-after,
+.custom-block {
     position: relative;
 
     &:after {

--- a/assets/scss/base/_icons.scss
+++ b/assets/scss/base/_icons.scss
@@ -3,7 +3,7 @@
     @include sprite();
 }
 .ico-after,
-.custom-block {
+.custom-block:not(.custom-block-spoiler) {
     position: relative;
 
     &:after {

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -92,10 +92,6 @@
     }
 }
 
-.js .spoiler {
-    display: none;
-}
-
 @media only screen and #{$media-extra-wide} {
     .full-content-wrapper .tutorial-list article {
         width: 29.3%;


### PR DESCRIPTION
Cette PR permet d'ajouter les nouvelles classes de remark-caption tout en gardant la compatibilité avec les anciennes.

Je n'ai pas implémenté le neutral ni les titres dans les blocs.