### PR TITLE
Rotation des logs django en prod

### DIFF
--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -98,19 +98,25 @@ LOGGING = {
     'handlers': {
         'django_log': {
             'level': 'WARNING',
-            'class': 'logging.FileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'maxBytes': 1024 * 1024 * 10,  # rotate when it reaches 10 MB
+            'backupCount': 50,  # only keep the last 50 rotated files, 10M*50 -> 500M
             'filename': '/var/log/zds/logging.django.log',
             'formatter': 'verbose'
         },
         'debug_log': {
             'level': 'DEBUG',
-            'class': 'logging.FileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'maxBytes': 1024 * 1024 * 10,  # rotate when it reaches 10 MB
+            'backupCount': 50,  # only keep the last 50 rotated files, 10M*50 -> 500M
             'filename': '/var/log/zds/debug.django.log',
             'formatter': 'verbose'
         },
         'generator_log': {
             'level': 'WARNING',
-            'class': 'logging.FileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'maxBytes': 1024 * 1024 * 10,  # rotate when it reaches 10 MB
+            'backupCount': 50,  # only keep the last 50 rotated files, 10M*50 -> 500M
             'filename': '/var/log/zds/generator.log',
             'formatter': 'verbose'
         },


### PR DESCRIPTION
En prod on n'a pas de rotation des logs django. On peut la mettre en place dans l'infra ou demander à django de s'en occuper. C'est ce que fait cette PR.

Doc: https://docs.python.org/3/library/logging.handlers.html#rotatingfilehandler