### PR TITLE
Ajoute le CSS pour le custom-block-neutral et les titres de custom-block

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -189,6 +189,60 @@ h6 {
     }
 }
 
+/* Old CSS for custom blocks, for compatibility */
+:not(.alert-box){
+    &.information,
+    &.question,
+    &.error,
+    &.warning,
+    &.spoiler {
+        margin: 25px 0;
+        padding: 7px 15px 7px 45px;
+
+        &.ico-after:after {
+            position: absolute;
+            top: 50%;
+            left: 23px;
+            margin: -11px 0 0 -11px;
+            height: 22px;
+            width: 22px;
+        }
+    }
+    &.information {
+        background: #daeaee;
+
+        &.ico-after:after {
+            @include sprite-position($information);
+        }
+    }
+    &.question {
+        background: #e2daee;
+
+        &.ico-after:after {
+            @include sprite-position($question);
+        }
+    }
+    &.error {
+        background: #eedada;
+
+        &.ico-after:after {
+            @include sprite-position($error);
+        }
+    }
+    &.warning {
+        background: #eee7da;
+
+        &.ico-after:after {
+            @include sprite-position($warning);
+        }
+    }
+}
+.spoiler {
+    margin-top: 0;
+    padding-left: 15px;
+    background: #EEE;
+}
+
 
 
 img {

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -77,78 +77,96 @@ h6 {
     }
 }
 
-:not(.alert-box) {
-    &.information,
-    &.question,
-    &.error,
-    &.warning,
-    &.spoiler,
-    &.custom-block-question,
-    &.custom-block-error,
-    &.custom-block-warning,
-    &.custom-block-information,
-    &.custom-block-neutral,
-    &.custom-block-spoiler {
-        margin: 25px 0;
-        padding: 7px 15px 7px 45px;
 
-        &:after{
-            position: absolute;
-            top: 50%;
-            left: 23px;
-            margin: -11px 0 0 -11px;
-            height: 22px;
-            width: 22px;
-        }
-    }
 
-    &.information,
-    &.custom-block-information {
-        background: #daeaee;
-        &:after {
-            @include sprite-position($information);
-        }
-    }
-
-    &.question,
-    &.custom-block-question {
-        background: #e2daee;
-        &:after{
-            @include sprite-position($question);
-        }
-    }
-
-    &.error,
-    &.custom-block-error {
-        background: #eedada;
-
-        &:after {
-            @include sprite-position($error);
-        }
-    }
-
-    &.warning,
-    &.custom-block-warning {
-        background: #eee7da;
-
-        &:after {
-            @include sprite-position($warning);
-        }
-    }
-
-    .js .spoiler, .custom-block-spoiler {
-        display: none;
-    }
-
+.custom-block {
+    margin: 25px 0;
 }
+.custom-block-body {
+    padding: 7px 15px 7px 45px;
 
-.spoiler,
+    &:after{
+        position: absolute;
+        top: 50%;
+        left: 23px;
+        margin: -11px 0 0 -11px;
+        height: 22px;
+        width: 22px;
+    }
+}
+.custom-block-heading {
+    padding: 3px 15px 3px 15px;
+    font-weight: bold;
+}
+.custom-block-information {
+    background: #daeaee;
+
+    .custom-block-heading {
+        color: white;
+        background: lighten(#1C80B5, 20%);
+    }
+
+    .custom-block-body:after {
+        @include sprite-position($information);
+    }
+}
+.custom-block-question {
+    background: #e2daee;
+
+    .custom-block-heading {
+        color: white;
+        background: lighten(#541BAC, 25%);
+    }
+
+    .custom-block-body:after {
+        @include sprite-position($question);
+    }
+}
+.custom-block-error {
+    background: #eedada;
+
+    .custom-block-heading {
+        color: white;
+        background: lighten(#B51C1C, 20%);
+    }
+
+    .custom-block-body:after {
+        @include sprite-position($error);
+    }
+}
+.custom-block-warning {
+    background: #eee7da;
+
+    .custom-block-heading {
+        color: white;
+        background: lighten(#E6A224, 10%);
+    }
+
+    .custom-block-body:after {
+        @include sprite-position($warning);
+    }
+}
+.custom-block-neutral,
 .custom-block-spoiler {
-    margin-top: 0;
-    padding-left: 15px;
     background: #EEE;
+
+    .custom-block-heading {
+        color: white;
+        background: darken(#EEE, 40%);
+    }
+
+    .custom-block-body {
+        padding-left: 15px;
+
+        &:after {
+            display: none;
+        }
+    }
 }
 
+.js .spoiler, .custom-block-spoiler {
+    display: none;
+}
 .spoiler-title {
     display: block;
     background: #EEE;
@@ -158,7 +176,7 @@ h6 {
     border-bottom: 1px solid #DDD;
     color: #555;
 
-    &.ico-after:after{
+    &.ico-after:after {
         margin: 8px 0 0 10px;
     }
 
@@ -170,6 +188,8 @@ h6 {
         text-decoration: underline;
     }
 }
+
+
 
 img {
     max-width: 100%;

--- a/assets/scss/base/_icons.scss
+++ b/assets/scss/base/_icons.scss
@@ -3,7 +3,7 @@
     @include sprite();
 }
 .ico-after,
-.custom-block:not(.custom-block-spoiler) {
+.custom-block-body {
     position: relative;
 
     &:after {


### PR DESCRIPTION
Ajouts de CSS pour le zmarkdown (#4390) : 

- met le background du bloc neutre en gris (comme pour le bloc secret)
- met le titre en gras avec une bordure colorée en fonction des blocs

Je rappelle que les titres sont optionnels sauf pour le bloc neutre.

![Aperçu des ajouts CSS](https://i.imgur.com/DyH4Ijq.png)