### PR TITLE
Fix #4895 : les user inexistant ne peuvent pas être pingé

### DIFF
--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -38,6 +38,22 @@ class ForumNotification(TestCase):
             self.forum12.groups.add(group)
         self.forum12.save()
 
+    def test_ping_unknown(self):
+        overridden_zds_app['comment']['enable_pings'] = True
+        self.assertTrue(self.client.login(username=self.user2.username, password='hostel77'))
+        result = self.client.post(
+            reverse('topic-new') + '?forum={0}'.format(self.forum11.pk),
+            {
+                'title': 'Super sujet',
+                'subtitle': 'Pour tester les notifs',
+                'text': '@anUnExistingUser is pinged, also a special chars user @{}',
+                'tags': ''
+            },
+            follow=False)
+        self.assertEqual(result.status_code, 302, 'Request must succeed')
+        self.assertEqual(0, PingSubscription.objects.count(),
+                         'As one user is pinged, only one subscription is created.')
+
     def test_no_auto_ping(self):
         overridden_zds_app['comment']['enable_pings'] = True
         self.assertTrue(self.client.login(username=self.user2.username, password='hostel77'))

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -397,7 +397,10 @@ class Comment(models.Model):
         max_ping_count = settings.ZDS_APP['comment']['max_pings']
         first_pings = all_the_pings[:max_ping_count]
         for username in first_pings:
-            signals.new_content.send(sender=self.__class__, instance=self, user=User.objects.get(username=username))
+            pinged_user = User.objects.filter(username=username).first()
+            if not pinged_user:
+                continue
+            signals.new_content.send(sender=self.__class__, instance=self, user=pinged_user)
         unpinged_usernames = set(old_metadata.get('ping', [])) - set(all_the_pings)
         unpinged_users = User.objects.filter(username__in=list(unpinged_usernames))
         for unpinged_user in unpinged_users:


### PR DESCRIPTION
j'ajoute donc un filtre pour n'envoyer la notif de ping qu'à un utilisateur existant