### PR TITLE
Corrige l'affiche du nom du site sur mobile

### DIFF
--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -421,8 +421,7 @@ $logo-width: 240px;
         }
 
         header .header-menu {
-            height: 30px;
-            flex-grow: 1;
+            display: none;
         }
 
         .logbox {


### PR DESCRIPTION
Corrige l'affichage du nom du site sur mobile

[Problème reporté sur le forum](https://zestedesavoir.com/forums/sujet/9938/nom-du-site-coupe-sur-les-petits-ecrans/)