### PR TITLE
CSS pour le ping

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -311,12 +311,14 @@ td code {
 // @ping
 .ping {
     color: inherit;
-    font-weight: bold;
     text-decoration: none;
 
     &:hover,
     &:focus {
         text-decoration: underline;
+    }
+    .ping-username {
+      font-weight: bold;
     }
 }
 


### PR DESCRIPTION
```md
@foo
```
donne
```html
<a href="/membres/voir/foo/" rel="nofollow" class="ping">@<span class="ping-username">foo</span></a>
```

Ce patch affiche [\@**vhf**](/vhf)
