### PR TITLE
Empêche le code source de déborder de la page

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -286,6 +286,9 @@ samp {
   font-style: normal;
   font-size: 14px;
 
+  max-width: 100%;
+  overflow-x: auto;
+
   .hljs-line-numbers {
     counter-reset: line;
     border-right: 1px solid #ddd;
@@ -301,7 +304,6 @@ samp {
     }
   }
   pre {
-    width: 100%;
     margin: 0;
   }
 }


### PR DESCRIPTION
# Avant

![Ça déborde](https://user-images.githubusercontent.com/6664636/37517473-d5c2acd2-2911-11e8-85cf-47c4f98959fb.png)

# Après

![Ça ne déborde plus](https://user-images.githubusercontent.com/6664636/37517497-dfccd9f0-2911-11e8-9702-c31f2c2a9e18.png)
