### PR TITLE
Récupère les CSS de KaTeX et hl.js depuis npm

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -12,7 +12,6 @@ const uglify = require('gulp-uglify');
 const jshint = require('gulp-jshint');
 const autoprefixer = require('autoprefixer');
 const cssnano = require('cssnano');
-const download = require('gulp-download2')
 
 // PostCSS plugins used
 const postcssPlugins = [
@@ -91,12 +90,10 @@ gulp.task('js', () =>
         .pipe(sourcemaps.write('.', { includeContent: true, sourceRoot: '../../' }))
         .pipe(gulp.dest('dist/js/')));
 
-gulp.task('prepare-zmd', ['css:sprite'], () =>
-    download(
-        ["http://jmblog.github.com/color-themes-for-highlightjs/css/themes/tomorrow.css",
-         "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/katex.min.css"]).pipe(
-            gulp.dest('dist/css/')
-        ));
+gulp.task('prepare-zmd', () =>
+    gulp.src(['node_modules/katex/dist/{katex.min.css,fonts/*}'])
+        .pipe(gulp.dest('dist/css/')));
+
 // Compiles the SCSS files to CSS
 gulp.task('css', ['css:sprite'], () =>
     gulp.src(['assets/scss/main.scss', 'assets/scss/zmd.scss'])

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -8,9 +8,10 @@
 @import "sprite";
 
 /*------------------------
-1. Normalize
+1. External dependencies
 ------------------------*/
 @import "normalize.css/normalize";
+@import "highlight.js/styles/tomorrow";
 
 /*------------------------
 2. Base

--- a/assets/scss/zmd.scss
+++ b/assets/scss/zmd.scss
@@ -5,6 +5,7 @@
 // FIXME: high-dpi support for icons?
 @import "variables/variables";
 @import "sprite";
+@import "highlight.js/styles/tomorrow";
 @import "components/alert-box";
 @import "base/icons";
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "gulp-sass": "3.1.0",
     "gulp-sourcemaps": "^2.6.4",
     "gulp-uglify": "3.0.0",
-    "gulp-download2": "1.0.2",
     "gulp.spritesmith": "6.5.1",
+    "highlight.js": "^9.12.0",
     "jquery": "3.2.1",
+    "katex": "^0.9.0",
     "normalize.css": "7.0.0"
   },
   "devDependencies": {

--- a/templates/base.html
+++ b/templates/base.html
@@ -87,7 +87,6 @@
     {# Stylesheets #}
 
 
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/tomorrow.min.css" crossorigin="anonymous">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/katex.min.css" crossorigin="anonymous">
     <link rel="stylesheet" href="{% static "css/main.css" %}">
     {% if not debug %}

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -185,8 +185,7 @@ ZDS_APP = {
         'epub_stylesheets': {
             'toc': Path('toc.css'),
             'full': Path(BASE_DIR) / 'dist' / 'css' / 'zmd.css',
-            'katex': Path(BASE_DIR) / 'dist' / 'css' / 'katex.css',
-            'code': Path(BASE_DIR) / 'dist' / 'css' / 'tomorrow.css'
+            'katex': Path(BASE_DIR) / 'dist' / 'css' / 'katex.min.css'
         }
     },
     'forum': {

--- a/zds/tutorialv2/epub_utils.py
+++ b/zds/tutorialv2/epub_utils.py
@@ -137,7 +137,6 @@ def build_ebook(published_content_entity, working_dir, final_file_path):
     copy_or_create_empty(settings.ZDS_APP['content']['epub_stylesheets']['toc'], style_dir_path, 'toc.css')
     copy_or_create_empty(settings.ZDS_APP['content']['epub_stylesheets']['full'], style_dir_path, 'zmd.css')
     copy_or_create_empty(settings.ZDS_APP['content']['epub_stylesheets']['katex'], style_dir_path, 'katex.css')
-    copy_or_create_empty(settings.ZDS_APP['content']['epub_stylesheets']['code'], style_dir_path, 'code.css')
     style_images_path = Path(settings.BASE_DIR, 'dist', 'images')
     smiley_images_path = Path(settings.BASE_DIR, 'dist', 'smileys')
     if style_images_path.exists():


### PR DESCRIPTION
Plutôt que de télécharger le CSS de KaTeX et le thème highlight.js avec gulp-download, ça récupère les fichiers depuis NPM. J'ai gardé le CDN pour KaTeX (parce qu'il est un peu gros) mais intégré le thème highlight.js au CSS directement histoire d'économiser une requête