### PR TITLE
Corrige la consultation des alertes

### DIFF
--- a/assets/scss/components/_alert-box.scss
+++ b/assets/scss/components/_alert-box.scss
@@ -15,7 +15,7 @@
         float: left;
     }
 
-    .close-alert-box {
+    .close-alert-box, .view-alert-box {
         display: block;
         position: absolute;
         top: 8px;

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -217,7 +217,7 @@
                     <em class="alert-box-text">{{ alert.text }}</em>
 
                     {% if alert.solved %}
-                        <span class="close-alert-box close-alert-box-text">
+                        <span class="view-alert-box close-alert-box-text">
                             {% trans "Résolu par" %}
                             {% include "misc/member_item.part.html" with member=alert.moderator %}
                         </span>


### PR DESCRIPTION
La PR corrige la consultation des alertes qui étaient échappées par le code JS.

Numéro du ticket concerné: #4616

### Contrôle qualité

- Builder le front : `make build-front`
- Lancer zds : `make run-back`
- Créer une alerte sur un message dans le forum, résolvez l'alerte
- (en tant qu'admin) tenter de consulter le profil de celui qui a résolu l'alerte en cliquant sur son pseudo en dessous du message.

Si vous accedez au profil du modérateur de l'alerte, c'est bon.