### PR TITLE
Sauvegarde la version de l'application statiquement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ base.db
 /contents-public
 /media
 /articles-data
+/zds/_version.py
 
 /tutoriels-private-test
 /tutoriels-public-test

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -5,7 +5,12 @@
         <p class="copyright">
             {{app.site.literal_name}}
             <span class="version">
-                &bull; {% trans "Version :" %} <a href="{{git_version.url}}">{{git_version.name}}</a>
+                &bull; {% trans "Version :" %}
+                {% if version.url %}
+                    <a href="{{version.url}}">{{version.name}}</a>
+                {% else %}
+                    {{ version.name }}
+                {% endif %}
             </span>
         </p>
 

--- a/zds/__init__.py
+++ b/zds/__init__.py
@@ -8,3 +8,17 @@ except ImportError:
 import logging
 logging.debug('json is loaded, module is %s', json_handler.__name__)  # this allows to know which one we loaded
 # and avoid pep8 warning.
+
+# Try to load the version informations from `zds/_version.py` and fallback to
+# a default `dev` version.
+#
+# `zds/_version.py` should look like this:
+#
+#   __version__ = 'v27-foo'
+#   git_version = '444c8f11acc921ef97c6971fc30bd91c383a3fea'
+#
+try:
+    from ._version import __version__, git_version
+except ImportError:
+    __version__ = 'dev'
+    git_version = None

--- a/zds/pages/tests.py
+++ b/zds/pages/tests.py
@@ -226,13 +226,13 @@ class PagesGuestTests(TestCase):
         self.assertEqual(result.status_code, 200)
 
     def test_render_template(self):
-        """Test: render_template() works and git_version is in template."""
+        """Test: render_template() works and version is in template."""
 
         result = self.client.get(
             reverse('homepage'),
         )
 
-        self.assertTrue('git_version' in result.context)
+        self.assertTrue('version' in result.context)
 
 
 class CommentEditsHistoryTests(TestCase):

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -135,7 +135,7 @@ django_template_engine = {
             'social.apps.django_app.context_processors.login_redirect',
             # ZDS context processors
             'zds.utils.context_processor.app_settings',
-            'zds.utils.context_processor.git_version',
+            'zds.utils.context_processor.version',
         ],
     },
 }

--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -1,4 +1,4 @@
-from zds.utils.context_processor import get_git_version
+from zds.utils.context_processor import get_version
 
 from .abstract_base import *
 
@@ -80,7 +80,7 @@ django_template_engine['OPTIONS']['loaders'] = [
 # https://docs.getsentry.com/hosted/clients/python/integrations/django/
 RAVEN_CONFIG = {
     'dsn': config['raven']['dsn'],
-    'release': get_git_version()['name'],
+    'release': get_version()['name'],
 }
 
 LOGGING = {

--- a/zds/utils/context_processor.py
+++ b/zds/utils/context_processor.py
@@ -1,49 +1,27 @@
 from copy import deepcopy
 
 from django.conf import settings
-from django.core.cache import cache
 
-from git import Repo
+from zds import __version__, git_version
 
 
-def get_git_version():
+def get_version():
     """
-    Get Git version information.
-
-    Since retrieving the Git version can be rather slow (due to I/O on
-    the filesystem and, most importantly, forced garbage collections
-    triggered by GitPython), you must consider using
-    ``get_cached_git_version()`` (which behaves similarly).
+    Retrieve version informations from `zds/_version.py`.
     """
-    try:
-        repo = Repo(settings.BASE_DIR)
-        branch = repo.active_branch
-        commit = repo.head.commit.hexsha
-        name = '{0}/{1}'.format(branch, commit[:7])
-        return {'name': name, 'url': '{}/tree/{}'.format(settings.ZDS_APP['site']['repository']['url'], commit)}
-    except (KeyError, TypeError):
-        return {'name': '', 'url': ''}
+    if git_version is not None:
+        name = '{0}/{1}'.format(__version__, git_version[:7])
+        url = settings.ZDS_APP['site']['repository']['url']
+        return {'name': name, 'url': '{}/tree/{}'.format(url, git_version)}
+    else:
+        return {'name': __version__, 'url': None}
 
 
-def get_cached_git_version():
+def version(request):
     """
-    Get Git version information.
-
-    Same as ``get_git_version()``, but cached with a simple timeout of
-    one hour.
+    A context processor to include the app version on all pages.
     """
-    version = cache.get('git_version')
-    if version is None:
-        version = get_git_version()
-        cache.set('git_version', version, 60 * 60)
-    return version
-
-
-def git_version(request):
-    """
-    A context processor to include the git version on all pages.
-    """
-    return {'git_version': get_cached_git_version()}
+    return {'version': get_version()}
 
 
 def app_settings(request):


### PR DESCRIPTION
Le fait que la version de l'appli dépende du dépôt git me plaît moyen, et a tendance à casser le déploiement.

Cette PR définie un `zds.__version__` et éventuellement `zds.git_version`, pompé dans le fichier (non-`git`é) `zds/_version.py`. Ce fichier sera généré par ansible/le script de déploiement. Par défaut, si ce fichier n'existe pas, `zds.__version__` est set à `dev`.


### Contrôle qualité

 - vérifier que par défaut, le footer afficher `dev`
 - ajouter un fichier `zds/_version.py` avec ce contenu:
    ```python
    __version__ = 'v27-machin'
    git_version = '444c8f11acc921ef97c6971fc30bd91c383a3fea'
    ```
 - vérifier que le footer affiche `v27-machin/[sha]` avec le bon lien vers le commit