### PR TITLE
Corrige une typo dans la config Elasticsearch prod

### DIFF
--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -189,7 +189,7 @@ SOCIAL_AUTH_PIPELINE = (
 # ZESTE DE SAVOIR SETTINGS
 
 
-ES_SEARCH_INDEX['shards'] = config['elasticsearch'].get('shards', 3),
+ES_SEARCH_INDEX['shards'] = config['elasticsearch'].get('shards', 3)
 
 
 ZDS_APP['site']['association']['email'] = 'communication@zestedesavoir.com'


### PR DESCRIPTION
Y'avait une typo dans la conf. prod, ce qui donnait un tuple. Et c'est la faute à @motet-a :-’