### PR TITLE
Évite les imports cycliques pour la version sentry

### DIFF
--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -1,5 +1,3 @@
-from zds.utils.context_processor import get_version
-
 from .abstract_base import *
 
 # For secrets, prefer `config[key]` over `config.get(key)` in this
@@ -76,11 +74,20 @@ django_template_engine['OPTIONS']['loaders'] = [
     ]),
 ]
 
+
+def _get_version():
+    from zds import __version__, git_version
+    if git_version is None:
+        return __version__
+    else:
+        return '{0}/{1}'.format(__version__, git_version[:7])
+
+
 # Sentry (+ raven, the Python Client)
 # https://docs.getsentry.com/hosted/clients/python/integrations/django/
 RAVEN_CONFIG = {
     'dsn': config['raven']['dsn'],
-    'release': get_version()['name'],
+    'release': _get_version(),
 }
 
 LOGGING = {


### PR DESCRIPTION
Ça marchait pas en beta à cause de ça.