### PR TITLE
Permet de configurer le path du latex_template pour faciliter le dev

### DIFF
--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -186,7 +186,8 @@ ZDS_APP = {
             'toc': Path('toc.css'),
             'full': Path(BASE_DIR) / 'dist' / 'css' / 'zmd.css',
             'katex': Path(BASE_DIR) / 'dist' / 'css' / 'katex.min.css'
-        }
+        },
+        'latex_template_repo': 'NOT_EXISTING_DIR'
     },
     'forum': {
         'posts_per_page': 21,

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -379,7 +379,7 @@ class ZMarkdownRebberLatexPublicator(Publicator):
         )
         if content == '' and messages:
             raise FailureDuringPublication('Markdown was not parsed due to {}'.format(messages))
-        zmd_class_dir_path = Path(os.environ.get('HOME', '~')) / 'texmf' / 'tex' / 'latex'
+        zmd_class_dir_path = Path(settings.ZDS_APP['content']['latex_template_repo'])
         if zmd_class_dir_path.exists() and zmd_class_dir_path.is_dir():
             with contextlib.suppress(FileExistsError):
                 zmd_class_link = base_directory / 'zmdocument.cls'


### PR DESCRIPTION
Ajoute un paramètre pour faciliter le lien avec les éléments de latex.

Pour faciliter le dev, il suffit de cloner le repo dan texmf et même pas besoin de texhash.

Pour la prod, les fichiers seront dans la partie système si on en crois @sandhose.

fix #4939 