### PR TITLE
Ajout d’une précision sur la page de l’association (#4941)

### DIFF
--- a/templates/pages/association.html
+++ b/templates/pages/association.html
@@ -48,8 +48,9 @@
     <p>
         {% blocktrans %}
             <strong>Adhérer à l’association ne vous apporte rien sur le site</strong>. L’adhésion n’est là que pour soutenir
-            le projet, et ne donne droit à aucun pouvoir ou badge supplémentaire. Elle ne donne même pas accès à un forum
-            secret, puisque le forum de l’association est public !
+            le projet, et ne donne droit à aucun pouvoir ou badge supplémentaire. Elle ne donne ni accès à un forum
+            secret, puisque le forum de l’association est public, ni à un poste au sein de l'équipe du site, puisque tout
+            le monde peut prétendre à une responsabilité au sein de l'équipe du site !
         {% endblocktrans %}
     </p>
     <p>


### PR DESCRIPTION
Ajoute une précision sur la page de l'association, pour dire que tout le monde peut prétendre à un rôle dans l'équipe du site, même sans être membre de l'association.

Numéro du ticket concerné: #4941 