### PR TITLE
Fix les chemins d'image pour la génération des epubs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ script:
     if [[ "$ZDS_TEST_JOB" == *"zds."* ]]; then
       python manage.py makemigrations --dry-run --check \
       && coverage run --source='.' manage.py \
-        test \
+        test -v=2\
         --keepdb \
         --settings zds.settings.ci_test \
         --exclude-tag=front \
@@ -162,7 +162,7 @@ script:
     if [[ "$ZDS_TEST_JOB" == *"selenium"* ]]; then
       yarn build
       xvfb-run --server-args="-screen 0 1280x720x8" python manage.py \
-        test \
+        test -v=2\
         --settings zds.settings.ci_test \
         --tag=front \
         --keepdb

--- a/zds/tutorialv2/epub_utils.py
+++ b/zds/tutorialv2/epub_utils.py
@@ -189,13 +189,11 @@ def handle_images(relative_path):
                 final_path = splitted.path
             elif image_url.startswith(settings.MEDIA_URL):
                 final_path = Path(image_url).name
-            elif Path(image_url).is_absolute():
+            elif Path(image_url).is_absolute() and 'images' in image_url:
                 root = Path(image_url)
                 while root.name != 'images':
                     root = root.parent
                 final_path = str(Path(image_url).relative_to(root))
-            if final_path.endswith('svg') or final_path.endswith('gif'):
-                final_path = final_path[:-3] + 'png'
             image_path_in_ebook = relative_path + '/images/' + str(final_path).replace('%20', '_')
             image['src'] = str(image_path_in_ebook)
         ids = {}

--- a/zds/tutorialv2/epub_utils.py
+++ b/zds/tutorialv2/epub_utils.py
@@ -1,11 +1,12 @@
 import contextlib
 import logging
 import shutil
+from collections import namedtuple
 from urllib import parse
 from os import path
 from bs4 import BeautifulSoup
 from pathlib import Path
-from shutil import copytree, copy
+from shutil import copy
 from django.template.loader import render_to_string
 from django.conf import settings
 
@@ -37,6 +38,9 @@ def __traverse_and_identify_images(image_dir):
     }
 
     for image_file_path in image_dir.iterdir():
+        if image_file_path.is_dir():
+            yield from __traverse_and_identify_images(image_file_path)
+            continue
         ext = path.splitext(image_file_path.name)[1]
         identifier = 'image_{}'.format(image_file_path.name).lower().replace('.', '-')
         ebook_image_path = Path('images', image_file_path.name)
@@ -58,10 +62,13 @@ def build_html_chapter_file(published_object, versioned_object, working_dir, roo
     :type published_object: zds.tutorialv2.models.models_database.PublishedContent
     :return: a generator of tuples composed as ``[splitted_html_file_relative_path, chapter-identifier, chapter-title]``
     """
+    DirTuple = namedtuple('DirTuple', ['absolute', 'relative'])
+    img_dir = working_dir.parent / 'images'
     path_to_title_dict = publish_container(published_object, str(working_dir), versioned_object,
                                            template='tutorialv2/export/ebook/chapter.html',
                                            file_ext='xhtml', image_callback=handle_images,
-                                           image_directory=str(working_dir / '..' / 'images'),
+                                           image_directory=DirTuple(str(img_dir.absolute()),
+                                                                    str(img_dir.relative_to(root_dir))),
                                            relative='.')
     for container_path, title in path_to_title_dict.items():
         # TODO: check if a function exists in the std lib to get rid of `root_dir + '/'`
@@ -122,8 +129,9 @@ def build_ebook(published_content_entity, working_dir, final_file_path):
 
     mimetype_conf = __build_mime_type_conf()
     mime_path = Path(working_dir, 'ebook', mimetype_conf['filename'])
-    with contextlib.suppress(FileExistsError):
-        copytree(published_content_entity.content.gallery.get_gallery_path(), str(target_image_dir))
+    with contextlib.suppress(FileExistsError, FileNotFoundError):
+        for img in Path(published_content_entity.content.gallery.get_gallery_path()).iterdir():
+            shutil.copy(str(img), str(target_image_dir))
 
     with mime_path.open(mode='w', encoding='utf-8') as mimefile:
         mimefile.write(mimetype_conf['content'])
@@ -179,13 +187,16 @@ def handle_images(relative_path):
             if image_url.startswith('http://') or image_url.startswith('https://'):
                 splitted = parse.urlsplit(image_url)
                 final_path = splitted.path
-            else:
-                final_path = image_url
-            if not path.splitext(final_path)[1]:
-                final_path += '.png'
+            elif image_url.startswith(settings.MEDIA_URL):
+                final_path = Path(image_url).name
+            elif Path(image_url).is_absolute():
+                root = Path(image_url)
+                while root.name != 'images':
+                    root = root.parent
+                final_path = str(Path(image_url).relative_to(root))
             if final_path.endswith('svg') or final_path.endswith('gif'):
                 final_path = final_path[:-3] + 'png'
-            image_path_in_ebook = relative_path + '/images/' + str(Path(final_path)).replace('%20', '_')
+            image_path_in_ebook = relative_path + '/images/' + str(final_path).replace('%20', '_')
             image['src'] = str(image_path_in_ebook)
         ids = {}
         for element in soup_parser.find_all(name=None, attrs={'id': (lambda s: True)}):

--- a/zds/tutorialv2/factories.py
+++ b/zds/tutorialv2/factories.py
@@ -22,8 +22,11 @@ tricky_text_content = \
     'Image: ![GIF qui existe](http://upload.wikimedia.org/wikipedia/commons/2/27/AnimatedStar.gif)\n\n' \
     'Image: ![GIF qui existe pas](example.com/test.gif)\n\n' \
     'Image: ![Image locale qui existe pas](does-not-exist/test.png)\n\n' \
-    'Image: ![Bonus: image bizarre](https://s.qwant.com/thumbr/?u=http%3A%2F%2Fwww.blogoergosum.com%2Fwp-content%2F' \
-    'uploads%2F2010%2F02%2Fwikipedia-logo.jpg&h=338&w=600)\n\n' \
+    'Image: ![Bonus: image bizarre](https://s2.qwant.com/thumbr/300x0/e/7/' \
+    '56e2a2bdcd656d0b8a29c650116e29e893239089f71adf128d5f06330703b1/1024px-' \
+    'Oh_my_darling.jpg?u=https%3A%2F%2Fupload' \
+    '.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2Fa%2Fa9%2FOh_my_darling.jpg%2F1024px-' \
+    'Oh_my_darling.jpg&q=0&b=0&p=0&a=0)\n\n' \
     'Image: ![Bonus: le serveur existe pas !](http://unknown.image.zds/test.png)\n\n' \
     'Image: ![Bonus: juste du texte](URL invalide)\n\n' \
     '# Et donc ...\n\n'\

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -486,13 +486,14 @@ class ZMarkdownEpubPublicator(Publicator):
         try:
             published_content_entity = self.get_published_content_entity(md_file_path)
             epub_file_path = Path(base_name + '.epub')
+            logger.info('Start generating epub')
             build_ebook(published_content_entity,
                         path.dirname(md_file_path),
                         epub_file_path)
         except (IOError, OSError):
             raise FailureDuringPublication('Error while generating epub file.')
         else:
-            print(epub_file_path)
+            logger.info(epub_file_path)
             epub_path = Path(published_content_entity.get_extra_contents_directory(), Path(epub_file_path.name))
             if epub_path.exists():
                 os.remove(str(epub_path))

--- a/zds/tutorialv2/publish_container.py
+++ b/zds/tutorialv2/publish_container.py
@@ -47,7 +47,8 @@ def publish_container(db_object, base_dir, container, template='tutorialv2/expor
         makedirs(current_dir)
 
     if container.has_extracts():  # the container can be rendered in one template
-        wrapped_image_callback = image_callback(ctx['relative']) if image_callback else image_callback
+        img_relative_path = '..' if ctx['relative'] == '.' else '../' + ctx['relative']
+        wrapped_image_callback = image_callback(img_relative_path) if image_callback else image_callback
         args = {'container': container, 'is_js': is_js}
         args.update(ctx)
         parsed = render_to_string(template, args)

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -116,8 +116,8 @@ def render_markdown(md_input, *, on_error=None, **kwargs):
 
 @register.filter(name='epub_markdown', needs_autoescape=False)
 def epub_markdown(md_input, image_directory):
-    return emarkdown(md_input, output_format='epub', images_download_dir=image_directory,
-                     local_url_to_local_path=[settings.MEDIA_URL + '/galleries/[0-9]+', image_directory])
+    return emarkdown(md_input, output_format='epub', images_download_dir=image_directory.absolute,
+                     local_url_to_local_path=[settings.MEDIA_URL + 'galleries/[0-9]+', image_directory.relative])
 
 
 @register.filter(needs_autoescape=False)

--- a/zmd/yarn.lock
+++ b/zmd/yarn.lock
@@ -1829,9 +1829,9 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-rebber-plugins@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/rebber-plugins/-/rebber-plugins-1.4.0.tgz#5bd971524de45af6696791f5157c7e3a2d2851e0"
+rebber-plugins@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/rebber-plugins/-/rebber-plugins-1.4.1.tgz#53323917f3310aa145293c33c77c181c7de25e3d"
   dependencies:
     has "^1.0.1"
     xtend "^4.0.1"
@@ -1943,9 +1943,9 @@ remark-comments@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/remark-comments/-/remark-comments-1.2.0.tgz#185baf88c290a7c0f87d1b695300975ea31a2d77"
 
-remark-custom-blocks@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/remark-custom-blocks/-/remark-custom-blocks-2.1.1.tgz#7968516a7f52d08b31dd37012e56b9685787fa96"
+remark-custom-blocks@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/remark-custom-blocks/-/remark-custom-blocks-2.2.0.tgz#44a809818537482d3a89a4bcb41c978867653836"
   dependencies:
     space-separated-tokens "^1.1.1"
 
@@ -1963,9 +1963,9 @@ remark-escape-escaped@^0.0.26:
   version "0.0.26"
   resolved "https://registry.yarnpkg.com/remark-escape-escaped/-/remark-escape-escaped-0.0.26.tgz#a161ed16a59c3325698315b4dc768807a9f2b238"
 
-remark-grid-tables@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/remark-grid-tables/-/remark-grid-tables-1.0.12.tgz#25d31901280294eefa5ad88e15be67c1d9abed03"
+remark-grid-tables@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/remark-grid-tables/-/remark-grid-tables-1.0.13.tgz#af9fc7f784c37d788f170125ae2170d5ca3a3ce9"
   dependencies:
     unist-util-visit "^1.1.3"
 
@@ -1996,9 +1996,9 @@ remark-images-download@^2.7.2:
     shortid "^2.2.8"
     unist-util-visit "^1.1.3"
 
-remark-kbd@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/remark-kbd/-/remark-kbd-1.0.10.tgz#262b234d25346ea580bce74f3b03b1ec3d8deae0"
+remark-kbd@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/remark-kbd/-/remark-kbd-1.0.12.tgz#daf7294c48f8c4ed752e0a5e5b59c7fea64de408"
   dependencies:
     is-whitespace-character "^1.0.0"
 
@@ -2034,9 +2034,9 @@ remark-parse@^5.0.0:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
-remark-ping@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/remark-ping/-/remark-ping-2.0.0.tgz#b2f40ece57565188bcdf14c03fba3a02d5aab503"
+remark-ping@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/remark-ping/-/remark-ping-2.1.0.tgz#8148edc1d91a03d3538bc7eaffc57c0a32f54b8b"
   dependencies:
     unist-util-visit "^1.1.3"
 
@@ -2773,9 +2773,9 @@ yamljs@^0.3.0:
     argparse "^1.0.7"
     glob "^7.0.5"
 
-zmarkdown@^5.4.3:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/zmarkdown/-/zmarkdown-5.4.4.tgz#9356bb8b509c03ce067a74a7e6a75f732db2c561"
+zmarkdown@^5.4.4:
+  version "5.4.9"
+  resolved "https://registry.yarnpkg.com/zmarkdown/-/zmarkdown-5.4.9.tgz#c7c244f3553bc2a3c52166384cbefbb382cf567a"
   dependencies:
     body-parser "^1.18.2"
     clone "^2.1.1"
@@ -2786,7 +2786,7 @@ zmarkdown@^5.4.3:
     pmx "^1.5.6"
     raven "^2.1.2"
     rebber "^2.2.2"
-    rebber-plugins "^1.4.0"
+    rebber-plugins "^1.4.1"
     rehype-autolink-headings "^2.0.1"
     rehype-footnotes-title "^0.0.23"
     rehype-highlight "^2.0.1"
@@ -2798,20 +2798,20 @@ zmarkdown@^5.4.3:
     remark-align "^1.2.0"
     remark-captions "^2.0.1"
     remark-comments "^1.2.0"
-    remark-custom-blocks "^2.1.1"
+    remark-custom-blocks "^2.2.0"
     remark-disable-tokenizers "^1.0.14"
     remark-emoticons "^1.1.1"
     remark-escape-escaped "^0.0.26"
-    remark-grid-tables "^1.0.12"
+    remark-grid-tables "^1.0.13"
     remark-heading-shift "^1.0.8"
     remark-heading-trailing-spaces "^0.0.22"
     remark-iframes "^3.0.1"
     remark-images-download "^2.7.2"
-    remark-kbd "^1.0.10"
+    remark-kbd "^1.0.12"
     remark-math "^1.0.1"
     remark-numbered-footnotes "^1.0.5"
     remark-parse "^5.0.0"
-    remark-ping "^2.0.0"
+    remark-ping "^2.1.0"
     remark-rehype "^3.0.0"
     remark-sub-super "^1.0.11"
     textr "^0.3.0"


### PR DESCRIPTION
les epubs n'affichaient pas toutes les images et zmarkdown donnait pas mal de retours pour nous aider

avec ces modifications j'ai de quoi faire.

# QA :

- créer un contenu avec des images externes ainsi que dans la gallerie
- publiez-le
- regardez l'epub => les images doivent être là (testé avec calibre)
- faites un python manage.py generate_epub {id_de_votre_contenu} et testé l'étape précédente
