### PR TITLE
Ajoute un lien pour comparer à la version en validation.

### DIFF
--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -375,6 +375,14 @@
             </li>
         {% endif %}
 
+        {% if content.in_validation %}
+            <li>
+                <a href="{% url "content:diff" content.pk content.slug_repository %}?from={{ validation.version }}&amp;to={% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}" class="ico-after history blue">
+                    {% trans "Comparer avec la version en validation" %}
+                </a>
+            </li>
+        {% endif %}
+
         {# HISTORY #}
         <li>
             <a href="{% url "content:history" content.pk content.slug_repository %}" class="ico-after history blue">


### PR DESCRIPTION
Ajoute un lien pour comparer une version d'un tutoriel à la version en validation s'il y en a une.

Numéro du ticket concerné : #4953.

### Contrôle qualité

- Créer un tutoriel.
- En demander la validation.
- Vérifier qu'il y a bien un lien pour comparer n'importe quelle version du tutoriel à la version en validation et que ce lien fonctionne.