### PR TITLE
Change le thème de la coloration syntaxique pour une version plus lisible

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -11,7 +11,7 @@
 1. External dependencies
 ------------------------*/
 @import "normalize.css/normalize";
-@import "highlight.js/styles/tomorrow";
+@import "highlight.js/styles/idea";
 
 /*------------------------
 2. Base

--- a/assets/scss/zmd.scss
+++ b/assets/scss/zmd.scss
@@ -5,7 +5,7 @@
 // FIXME: high-dpi support for icons?
 @import "variables/variables";
 @import "sprite";
-@import "highlight.js/styles/tomorrow";
+@import "highlight.js/styles/idea";
 @import "components/alert-box";
 @import "base/icons";
 


### PR DESCRIPTION
Cf https://zestedesavoir.com/forums/sujet/10987/la-coloration-de-code-etaient-plus-lisible-avant/?page=1#p183963

### Contrôle qualité

Rebuilder le front et lancer le serveur.
Créer un [message|contenu] avec du code : vérifier que la coloration syntaxique utilisée est lisible (cf le topic lié).