### PR TITLE
[WIP] Ajoute un menu contextuel sur les pseudos et les topics du forum pour copier du Markdown

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -79,6 +79,7 @@ gulp.task('js', () =>
         'assets/js/topic-suggest.js',
         'assets/js/tribune-pick.js',
         'assets/js/zen-mode.js',
+        'assets/js/contextual-menus.js',
     ], { base: '.' })
         .pipe(sourcemaps.init({ loadMaps: true }))
         .pipe(concat('script.js', { newline: ';\r\n' }))

--- a/assets/js/contextual-menus.js
+++ b/assets/js/contextual-menus.js
@@ -1,0 +1,31 @@
+var contextmenuElement;
+
+function pingUser() {
+    copyStringToClipboard("@" + contextmenuElement.explicitOriginalTarget.data);
+}
+
+function markdownLink() {
+    console.log("TTT", contextmenuElement);
+    var text = contextmenuElement.explicitOriginalTarget.data;
+    var url = contextmenuElement.explicitOriginalTarget.parentElement.parentElement.href;
+    console.log("[" + text + "](" + url + ")");
+    copyStringToClipboard("[" + text + "](" + url + ")");
+}
+
+function setContextualMenuElement(e) {
+    //console.log(e);
+    contextmenuElement = e;
+    console.log(contextmenuElement);
+}
+
+// https://techoverflow.net/2018/03/30/copying-strings-to-the-clipboard-using-pure-javascript/
+function copyStringToClipboard(str) {
+    var el = document.createElement("textarea");
+    el.value = str;
+    el.setAttribute("readonly", "");
+    el.style = {display: "none"};
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand("copy");
+    document.body.removeChild(el);
+}

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -11,6 +11,7 @@
 {% block head_extra %}
     {{ block.super }}
     {% include "mathjax.html" %}
+    {% load static %}
 {% endblock %}
 
 
@@ -175,4 +176,11 @@
 
         {% block feeds_rss %} {% endblock %}
     </aside>
+
+    <menu type="context" id="ping-menu">
+        <menuitem label="[ZdS] Ping" onclick="pingUser()"/>
+    </menu>
+    <menu type="context" id="markdown-menu">
+        <menuitem label="[ZdS] Lien Markdown" onclick="markdownLink()"/>
+    </menu>
 {% endblock %}

--- a/templates/forum/includes/topic_row.part.html
+++ b/templates/forum/includes/topic_row.part.html
@@ -38,7 +38,7 @@
                     {% endfor %}
                 </ul>
             {% endif %}
-            <a href="{{ topic.get_absolute_url }}" class="topic-title-link navigable-link" title="{{ topic.title }}. {{ topic.subtitle }}">
+            <a contextmenu="markdown-menu" oncontextmenu="setContextualMenuElement(event);" href="{{ topic.get_absolute_url }}" class="topic-title-link navigable-link" title="{{ topic.title }}. {{ topic.subtitle }}">
                 <h4 class="topic-title" itemprop="itemListElement">{{ topic.title }}</h4>
                 <span class="topic-subtitle">{{ topic.subtitle }}</span>
             </a>

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -145,7 +145,7 @@
         {% endif %}
 
         <div class="message-metadata">
-            <a href="{{ message.author.get_absolute_url }}" class="username" itemprop="author" itemscope itemtype="http://schema.org/Person">
+            <a contextmenu="ping-menu" oncontextmenu="setContextualMenuElement(event);" href="{{ message.author.get_absolute_url }}" class="username" itemprop="author" itemscope itemtype="http://schema.org/Person">
                 <span itemprop="name">{{ message.author.username }}</span>
             </a>
 


### PR DESCRIPTION
Cette PR est un POC qui ajoute un menu contextuel sur les pseudos et les topics des forums pour copier dans le presse-papier, soit le markdown pour pinger l'utilisateur, soit le lien (au format Markdown) vers le topic.

C'est un peu gadget et j'ignore complètement si ça peut être utile et/ou pertinent. C'est juste une idée qui m'est venue il y a quelques jours et je la soumets à discussion, n'hésitez surtout pas à critiquer.

Il ne s'agit ici que d'un *proof of concept*, le code est à améliorer et il ne marche pour l'instant que sur les pseudos dans un topic et sur les titres d'un topic dans un forum.