### PR TITLE
La mise à jour d'un contenu ne conserve pas les anciens auteurs

### DIFF
--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -125,6 +125,7 @@ def publish_content(db_object, versioned, is_major_update=True):
     public_version.save(
         update_fields=['char_count', 'publication_date', 'update_date', 'sha_public'])
 
+    public_version.authors.clear()
     for author in db_object.authors.all():
         public_version.authors.add(author)
 

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -6267,7 +6267,7 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
         tutorial.save()
         tutorial_draft = tutorial.load_version()
 
-        # ask validation 
+        # ask validation
         self.client.login(username=self.user_staff.username, password='hostel77')
         self.client.post(
             reverse('validation:ask', kwargs={'pk': tutorial.pk, 'slug': tutorial.slug}),
@@ -6285,7 +6285,7 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
             {
                 'version': validation.version
             },
-            follow=False)  
+            follow=False)
         self.client.post(
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -6233,6 +6233,12 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
         # ask validation
         self.client.login(username=self.user_author.username, password='hostel77')
         self.client.post(
+            reverse('content:edit', kwargs={'pk': tutorial.pk, 'slug': tutorial.slug}),
+            {
+                'description': 'description'
+            },
+            follow=False)
+        self.client.post(
             reverse('validation:ask', kwargs={'pk': tutorial.pk, 'slug': tutorial.slug}),
             {
                 'text': text_validation,

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -6217,9 +6217,8 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
         self.assertEqual(result.context['previous_content'].pk, user_1_opinion_1.public_version.pk)
         self.assertEqual(result.context['next_content'].pk, user_1_opinion_2.public_version.pk)
 
-
     def test_author_update(self):
-        "Check that the author list of a content is updated when this content is updated."
+        """Check that the author list of a content is updated when this content is updated."""
 
         text_validation = 'Valide moi ce truc, please !'
         text_publication = 'Validation faite !'

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -6226,6 +6226,7 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
 
         tutorial = PublishableContentFactory(type='TUTORIAL')
         tutorial.authors.add(self.user_author)
+        tutorial.authors.add(self.user_guest)
         tutorial.save()
         tutorial_draft = tutorial.load_version()
 
@@ -6252,7 +6253,7 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
             },
             follow=False)
 
-        tutorial.authors.add(self.user_guest)
+        tutorial.authors.remove(self.user_guest)
         tutorial_draft = tutorial.load_version()
 
         # ask second validation
@@ -6278,4 +6279,4 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
             follow=False)
 
         published = PublishedContent.objects.filter(content__pk=tutorial.pk).first()
-        self.assertEqual(published.authors.count(), 2)
+        self.assertEqual(published.authors.count(), 1)

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -6252,5 +6252,5 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
             },
             follow=False)
 
-        published = PublishedContent.objects.filter(content__pk=tutorial.pk).first()
+        published = tutorial.public_version
         self.assertEqual(published.authors.count(), 1)

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -6225,7 +6225,7 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
         text_publication = 'Validation faite !'
 
         tutorial = PublishedContentFactory(
-            type='TUTORIAL', 
+            type='TUTORIAL',
             author_list=[self.user_author, self.user_guest, self.user_staff])
 
         # Remove author to check if it's correct after major update
@@ -6233,7 +6233,7 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
         tutorial.save()
         tutorial_draft = tutorial.load_version()
 
-        # ask validation 
+        # ask validation
         self.client.login(username=self.user_staff.username, password='hostel77')
         self.client.post(
             reverse('validation:ask', kwargs={'pk': tutorial.pk, 'slug': tutorial.slug}),
@@ -6251,7 +6251,7 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
             {
                 'version': validation.version
             },
-            follow=False)  
+            follow=False)
         self.client.post(
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -6224,39 +6224,13 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
         text_validation = 'Valide moi ce truc, please !'
         text_publication = 'Validation faite !'
 
-        tutorial = PublishableContentFactory(type='TUTORIAL')
-        tutorial.authors.add(self.user_author)
-        tutorial.authors.add(self.user_guest)
+        tutorial = PublishedContentFactory(type='TUTORIAL', author_list=[self.user_author, self.user_guest])
         tutorial.save()
-        tutorial_draft = tutorial.load_version()
-
-        # ask validation
-        self.client.login(username=self.user_author.username, password='hostel77')    
-        self.client.post(
-            reverse('validation:ask', kwargs={'pk': turorial.pk, 'slug': tutorial.slug}),
-            {
-                'text': text_validation,
-                'source': '',
-                'version': tutorial_draft.current_version
-            },
-            follow=False)
-
-        # publish the content
-        self.client.login(username=self.user_staff.username,password='hostel77')
-        validation = Validation.objects.filter(content=tutorial).last()        
-        self.client.post(
-            reverse('validation:accept', kwargs={'pk': validation.pk}),
-            {
-                'text': text_publication,
-                'is_major': True,
-                'source': ''
-            },
-            follow=False)
 
         tutorial.authors.remove(self.user_guest)
         tutorial_draft = tutorial.load_version()
 
-        # ask second validation
+        # ask validation
         self.client.login(username=self.user_author.username, password='hostel77')
         self.client.post(
             reverse('validation:ask', kwargs={'pk': tutorial.pk, 'slug': tutorial.slug}),

--- a/zds/tutorialv2/tests/tests_views.py
+++ b/zds/tutorialv2/tests/tests_views.py
@@ -6225,9 +6225,9 @@ class PublishedContentTests(TestCase, TutorialTestMixin):
         text_publication = 'Validation faite !'
 
         tutorial = PublishedContentFactory(type='TUTORIAL', author_list=[self.user_author, self.user_guest])
-        tutorial.save()
 
         tutorial.authors.remove(self.user_guest)
+        tutorial.save()
         tutorial_draft = tutorial.load_version()
 
         # ask validation


### PR DESCRIPTION
Tout est dans le titre, lorsqu'on supprime un auteur d'un tutoriel et qu'on le republie, cet auteur n'apparaît plus dans la liste des auteurs.

Ticket concerné : #4134 

### Contrôle qualité

- Créer un tutoriel.
- Lui ajouter un auteur.
- Le publier et vérifier que l'auteur apparaît dans la liste des auteurs de la version publiée.
- Supprimer cet auteur.
- Republier le tutoriel et vérifier que cet auteur n'apparaît plus dans la liste des auteurs de la version publiée.