### PR TITLE
Restaure l'affichage du nombre de membres inscrits sur la page '/membres/'

### DIFF
--- a/templates/member/index.html
+++ b/templates/member/index.html
@@ -22,9 +22,9 @@
 
 {% block content %}
     <p>
-        {% blocktrans %}
+        {% blocktrans with member_count=paginator.count %}
             Sur cette page vous pourrez trouver la liste des membres
-            inscrits au site (actuellement {{ paginator.count }} membres).
+            inscrits au site (actuellement {{ member_count }} membres).
         {% endblocktrans %}
     </p>
 


### PR DESCRIPTION
Suite au commit 6ac0018, le nombre de membres n'apparait plus sur la page https://zestedesavoir.com/membres/. Cette PR corrige le tag `blocktrans` à l'origine de ce problème.

Numéro du ticket concerné : #4970 

Edit : 5000 ! :tada: