### PR TITLE
Il est à nouveau possible de changer la casse de son pseudo

### DIFF
--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -1150,15 +1150,16 @@ class MemberTests(TestCase):
     def test_pseudo_case_change(self):
         tester = ProfileFactory()
         old_pseudo = tester.user.username
+        new_pseudo = tester.user.username.upper()
         self.client.login(username=tester.user.username, password='hostel77')
 
         data = {
-            'username': 'Dummy',
+            'username': new_pseudo,
             'email': tester.user.email
         }
         self.client.post(reverse('update-username-email-member'), data, follow=False)
 
-        self.assertEqual(tester.user.username, 'Dummy')
+        self.assertEqual(tester.user.username, new_pseudo)
 
     def test_pseudo_change(self):
         tester = ProfileFactory()

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -1156,7 +1156,7 @@ class MemberTests(TestCase):
             'username': 'Dummy',
             'email': tester.user.email
         }
-        result = self.client.post(reverse('update-username-email-member'), data, follow=False)
+        self.client.post(reverse('update-username-email-member'), data, follow=False)
 
         self.assertEqual(tester.user.username, 'Dummy')
 
@@ -1169,7 +1169,7 @@ class MemberTests(TestCase):
             'username': 'dummy-two',
             'email': tester.user.email
         }
-        result = self.client.post(reverse('update-username-email-member'), data, follow=False)
+        self.client.post(reverse('update-username-email-member'), data, follow=False)
 
         self.assertEqual(tester.user.username, 'dummy-two')
 

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -1147,6 +1147,32 @@ class MemberTests(TestCase):
         result = self.client.get(reverse('member-modify-karma'), follow=False)
         self.assertEqual(result.status_code, 405)
 
+    def test_pseudo_case_change(self):
+        tester = ProfileFactory()
+        old_pseudo = tester.user.username
+        self.client.login(username=tester.user.username, password='hostel77')
+
+        data = {
+            'username': 'Dummy',
+            'email': tester.user.email
+        }
+        result = self.client.post(reverse('update-username-email-member'), data, follow=False)
+
+        self.assertEqual(tester.user.username, 'Dummy')
+
+    def test_pseudo_change(self):
+        tester = ProfileFactory()
+        old_pseudo = tester.user.username
+        self.client.login(username=tester.user.username, password='hostel77')
+
+        data = {
+            'username': 'dummy-two',
+            'email': tester.user.email
+        }
+        result = self.client.post(reverse('update-username-email-member'), data, follow=False)
+
+        self.assertEqual(tester.user.username, 'dummy-two')
+
     def test_karma_and_pseudo_change(self):
         """
         To test that a karma note is added when a member change its pseudo

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -86,6 +86,8 @@ def validate_zds_username(value, check_username_available=True):
         msg = _('Le nom d\'utilisateur ne peut pas contenir des caractères utf8mb4')
     elif check_username_available and user_count > 0:
         msg = _('Ce nom d\'utilisateur est déjà utilisé')
+    elif not check_username_available and user_count == 0:
+        msg = _('Ce nom d\'utilisateur n\'existe pas')
     if msg is not None:
         raise ValidationError(msg)
 

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -72,7 +72,6 @@ validate_zds_email = ZdSEmailValidator()
 def validate_zds_username(value, check_username_available=True):
     """
     Check if username is used by another user
-
     :param value: value to validate (str or None)
     :return:
     """

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -69,7 +69,7 @@ class ZdSEmailValidator(EmailValidator):
 validate_zds_email = ZdSEmailValidator()
 
 
-def validate_zds_username(value):
+def validate_zds_username(value, check_username_available=True):
     """
     Check if username is used by another user
 
@@ -78,7 +78,7 @@ def validate_zds_username(value):
     """
     msg = None
     user_count = User.objects.filter(username=value).count()
-    if not user_count:
+    if check_username_available and not user_count:
         return
     if ',' in value:
         msg = _('Le nom d\'utilisateur ne peut contenir de virgules')
@@ -86,7 +86,7 @@ def validate_zds_username(value):
         msg = _('Le nom d\'utilisateur ne peut commencer ou finir par des espaces')
     elif contains_utf8mb4(value):
         msg = _('Le nom d\'utilisateur ne peut pas contenir des caractères utf8mb4')
-    elif user_count > 0:
+    elif check_username_available and user_count > 0:
         msg = _('Ce nom d\'utilisateur est déjà utilisé')
     if msg is not None:
         raise ValidationError(msg)

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -78,8 +78,6 @@ def validate_zds_username(value, check_username_available=True):
     """
     msg = None
     user_count = User.objects.filter(username=value).count()
-    if check_username_available and not user_count:
-        return
     if ',' in value:
         msg = _('Le nom d\'utilisateur ne peut contenir de virgules')
     elif value != value.strip():

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -69,7 +69,7 @@ class ZdSEmailValidator(EmailValidator):
 validate_zds_email = ZdSEmailValidator()
 
 
-def validate_zds_username(value, check_username_available=True):
+def validate_zds_username(value):
     """
     Check if username is used by another user
 
@@ -78,16 +78,16 @@ def validate_zds_username(value, check_username_available=True):
     """
     msg = None
     user_count = User.objects.filter(username=value).count()
+    if not user_count:
+        return
     if ',' in value:
         msg = _('Le nom d\'utilisateur ne peut contenir de virgules')
     elif value != value.strip():
         msg = _('Le nom d\'utilisateur ne peut commencer ou finir par des espaces')
     elif contains_utf8mb4(value):
         msg = _('Le nom d\'utilisateur ne peut pas contenir des caractères utf8mb4')
-    elif check_username_available and user_count > 0:
+    elif user_count > 0:
         msg = _('Ce nom d\'utilisateur est déjà utilisé')
-    elif not check_username_available and user_count == 0:
-        msg = _('Ce nom d\'utilisateur n\'existe pas')
     if msg is not None:
         raise ValidationError(msg)
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -328,7 +328,7 @@ class UpdateUsernameEmailMember(UpdateMember):
         if new_email and new_email != previous_email:
             profile.user.email = new_email
             # Create an alert for the staff if it's a new provider
-            provider = provider = new_email.split('@')[-1].lower()
+            provider = new_email.split('@')[-1].lower()
             if not NewEmailProvider.objects.filter(provider=provider).exists() \
                     and not User.objects.filter(email__iendswith='@{}'.format(provider)) \
                     .exclude(pk=profile.user.pk).exists():


### PR DESCRIPTION
Cette PR corrige un bug qui rendait impossible le fait de changer de pseudo en en changeant uniquement la casse.

`admin` pouvait donc se renommer `superadmin` mais `Admin`. Cette PR corrige ce comportement, et supprime également un paramètre optionnel qui n'était pas utilisé dans le projet. Elle corrige également une double assignation de variable (`provider = provider = ...`) dans un fichier lié.

Numéro du ticket concerné (optionnel) : #4545 
Reprise de la PR #4568.

### Contrôle qualité

- Vérifier qu'on peut changer de pseudo
- Vérifier qu'on peut changer de pseudo pour le même avec une casse différente
