### PR TITLE
Met le langage 'console' en blanc cassé sur fond noir

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -454,3 +454,8 @@ div.align-right {
 div.align-left, figure pre code.hljs {
     text-align: left;
 }
+
+.language-console {
+    color: $color-console-text;
+    background-color: $color-console-bg;
+}

--- a/assets/scss/variables/_colors.scss
+++ b/assets/scss/variables/_colors.scss
@@ -17,3 +17,6 @@ $color-keyboard: #F8F6EA;
 $color-staff-link: $color-secondary;
 $color-hat: #6F6F6F;
 $color-staff-hat: #2B5C73;
+
+$color-console-bg: #000;
+$color-console-text: #333;


### PR DESCRIPTION
# QA 

- buildez le front
- entrez un  message avec 

    \```console
    echo "hello world"
     ```

assurez-vous qu'il s'affiche en blanc sur fond noir