### PR TITLE
Fix #5004 : corrige le rendu du code dans les listes

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -380,7 +380,7 @@ td code {
     color: #A00;
     background: #EEE;
     border: 1px solid #CCC;
-    padding: 0 5px;
+    padding: .5em;
 }
 
 // @ping


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #5004 

### Contrôle qualité

Note : il faut regénérer le CSS (`make build-front`)

Vérifier le rendu avec l'exemple donné dans l'issue. Je en suis pas certain du fix mais ça a l'air de fonctionner. À vérifier le rendu dans les tableaux également, je en suis pas sur qu'il soit parfait mais je n'ai pas trop changé le code à ce niveau.
