### PR TITLE
Fix #4862 : s'assure d'une redirection correcte lors de la connexion

### DIFF
--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -904,6 +904,8 @@ def remove_hat(request, user_pk, hat_pk):
 def login_view(request):
     """Logs user in."""
     next_page = request.GET.get('next', '/')
+    if next_page in [reverse('member-login'), reverse('register-member'), reverse('member-logout')]:
+        next_page = '/'
     csrf_tk = {'next_page': next_page}
     csrf_tk.update(csrf(request))
     error = False


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #4862 

### Contrôle qualité

Essayer de se connecter avec `?next=/membres/conenxion/` dans l'URL. J'ai bloqué la redirection vers : 

- La page de connexion
- La page de déconnexion
- La page d'inscription