### PR TITLE
Corrige la version de django dans la page a propos

### DIFF
--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -66,7 +66,7 @@
             <h4>{% trans "Site" %}</h4>
             <ul>
                 <li><a href="http://www.python.org/">Python 3</a></li>
-                <li><a href="https://www.djangoproject.com/">Django 1.10</a></li>
+                <li><a href="https://www.djangoproject.com/">Django 1.11</a></li>
             </ul>
 
             <h4>HTTP(S) + WSGI</h4>


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #5014 


### Contrôle qualité

Rendez-vous sur la page suivante : http://127.0.0.1:8000/pages/apropos/

Vérifiez bien que vous voyez la version 1.11 de django