### PR TITLE
Affiche la description du groupe sur les détails d'une casquette

### DIFF
--- a/templates/member/hat.html
+++ b/templates/member/hat.html
@@ -1,4 +1,7 @@
 {% extends "member/base.html" %}
+
+
+{% load emarkdown %}
 {% load i18n %}
 
 
@@ -30,6 +33,10 @@
 
 
 {% block content %}
+    {% if groupcontact.description %}
+        <p>{{ groupcontact.description|emarkdown }}</p>
+    {% endif %}
+
     {% if users %}
         <p>{% trans "Les personnes possédant cette casquette sont :" %}</p>
         <div class="authors">

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -25,6 +25,7 @@ from zds.forum.factories import CategoryFactory, ForumFactory, TopicFactory, Pos
 from zds.forum.models import Topic, Post
 from zds.gallery.factories import GalleryFactory, UserGalleryFactory
 from zds.gallery.models import Gallery, UserGallery
+from zds.pages.models import GroupContact
 from zds.utils.models import CommentVote, Hat, HatRequest
 from copy import deepcopy
 
@@ -1732,6 +1733,12 @@ class MemberTests(TestCase):
         result = self.client.get(hat.get_absolute_url())
         self.assertEqual(result.status_code, 200)
         self.assertContains(result, self.staff.username)
+        # if we display this group on the contact page...
+        GroupContact.objects.create(group=Group.objects.get(name='staff'), description='group description', position=1)
+        # the description should be shown on this page too
+        result = self.client.get(hat.get_absolute_url())
+        self.assertEqual(result.status_code, 200)
+        self.assertContains(result, 'group description')
 
     def tearDown(self):
         if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -39,6 +39,7 @@ from zds.member.models import Profile, TokenForgotPassword, TokenRegister, Karma
     BannedEmailProvider, NewEmailProvider, set_old_smileys_cookie, remove_old_smileys_cookie
 from zds.mp.models import PrivatePost, PrivateTopic
 from zds.notification.models import TopicAnswerSubscription, NewPublicationSubscription
+from zds.pages.models import GroupContact
 from zds.tutorialv2.models.database import PublishedContent, PickListOperation
 from zds.utils.models import Comment, CommentVote, Alert, CommentEdit, Hat, HatRequest, get_hat_from_settings, \
     get_hat_to_add
@@ -746,6 +747,10 @@ class HatDetail(DetailView):
                 .filter(user=self.request.user, hat__iexact=hat.name, is_granted__isnull=True).exists()
         if hat.group:
             context['users'] = hat.group.user_set.select_related('profile')
+            try:
+                context['groupcontact'] = hat.group.groupcontact
+            except GroupContact.DoesNotExist:
+                context['groupcontact'] = None  # group not displayed on contact page
         else:
             context['users'] = [p.user for p in hat.profile_set.select_related('user')]
         return context


### PR DESCRIPTION
Petite PR pour me remettre dans le bain. Actuellement, la page des détails d'une casquette donne peu d'informations : son nom et les membres qui la possèdent. Comme certains groupes possèdent déjà une description sur la page contact, cette PR vise à afficher également cette description sur les détails des casquettes directement liées à ces groupes.

### Contrôle qualité

- Vérifier que la page affichant les détails d'une casquette s'affiche correctement.
- Si la casquette est liée à un groupe, et que celui-ci est affiché sur la page de contact (objet `GroupContact`), vérifier que sa description sur la page contact est aussi reportée ici.