### PR TITLE
Vérifie si l'utilisateur a une adresse mail avant de lui envoyer un mail.

### DIFF
--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -87,6 +87,11 @@ class Subscription(models.Model):
                                          settings.ZDS_APP['site']['email_noreply'])
 
         receiver = self.user
+
+        # This can happen when an user subscribes via social networks without providing an e-mail adress
+        if not receiver.email:
+            return
+
         context = {
             'username': receiver.username,
             'title': notification.title,

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -88,7 +88,7 @@ class Subscription(models.Model):
 
         receiver = self.user
 
-        # This can happen when an user subscribes via social networks without providing an e-mail adress
+        # This can happen when a user subscribes via social networks without providing an e-mail address
         if not receiver.email:
             return
 

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.mail import EmailMultiAlternatives
+from django.core.validators import validate_email, ValidationError
 from django.db import models, IntegrityError, transaction
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
@@ -89,7 +90,9 @@ class Subscription(models.Model):
         receiver = self.user
 
         # This can happen when a user subscribes via social networks without providing an e-mail address
-        if not receiver.email:
+        try:
+            validate_email(receiver.email)
+        except ValidationError:
             return
 
         context = {

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -378,10 +378,15 @@ class SubscriptionsTest(TestCase):
         self.userOAuth1 = ProfileFactory(
             email_for_answer=True,
             email_for_new_mp=True).user
+        self.userOAuth2 = ProfileFactory(
+            email_for_answer=True,
+            email_for_new_mp=True).user
 
         self.userOAuth1.email = ''
+        self.userOAuth2.email = 'this is not an email'
 
         self.userOAuth1.save()
+        self.userOAuth2.save()
 
     def test_no_emails_for_those_who_have_none(self):
         """
@@ -395,5 +400,20 @@ class SubscriptionsTest(TestCase):
         self.assertEqual(0, len(mail.outbox))
 
         send_message_mp(self.userOAuth1, topic, '', send_by_mail=True)
+
+        self.assertEqual(1, len(mail.outbox))
+
+    def test_no_emails_for_those_who_have_other_things_in_that_place(self):
+        """
+        Test that we do not try to send e-mails to those who have not registered a valid one.
+        """
+        self.assertEqual(0, len(mail.outbox))
+        topic = send_mp(author=self.userStandard1, users=[self.userOAuth2],
+                        title='Testing', subtitle='', text='',
+                        send_by_mail=True, leave=False)
+
+        self.assertEqual(0, len(mail.outbox))
+
+        send_message_mp(self.userOAuth2, topic, '', send_by_mail=True)
 
         self.assertEqual(1, len(mail.outbox))

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -371,17 +371,16 @@ class ContentNotification(TestCase, TutorialTestMixin):
 @override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
 class SubscriptionsTest(TestCase):
     def setUp(self):
-        self.userStandard1 = ProfileFactory().user
-        self.userOAuth1 = ProfileFactory().user
-
-        self.userStandard1.profile.email_for_answer = True
-        self.userOAuth1.profile.email_for_answer = True
-        self.userStandard1.profile.email_for_new_mp = True
-        self.userOAuth1.profile.email_for_new_mp = True
+        self.userStandard1 = ProfileFactory(
+            email_for_answer=True,
+            email_for_new_mp=True
+        ).user
+        self.userOAuth1 = ProfileFactory(
+            email_for_answer=True,
+            email_for_new_mp=True).user
 
         self.userOAuth1.email = ''
 
-        self.userStandard1.save()
         self.userOAuth1.save()
 
     def test_no_emails_for_those_who_have_none(self):
@@ -389,7 +388,6 @@ class SubscriptionsTest(TestCase):
         Test that we do not try to send e-mails to those who have not registered one.
         """
         self.assertEqual(0, len(mail.outbox))
-
         topic = send_mp(author=self.userStandard1, users=[self.userOAuth1],
                         title='Testing', subtitle='', text='',
                         send_by_mail=True, leave=False)


### PR DESCRIPTION
<!-- Veuillez décrire vos changements à l’emplacement de ce commentaire (inutile dans le cas de tout petits changements). -->
Lors de l'inscription via OAuth (réseaux sociaux), un utilisateur peut être crée sans adresse mail. Ceci cause des erreurs 500 lorsque l'on essaye de lui envoyer une notification par ce moyen.

Cette PR introduit une condition préalable à l'envoi de mails pour éviter ces erreurs.

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné : #4943 

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

- Créez un compte avec une adresse mail vide (allez dans la BDD si besoin)
- Sur ce compte, demandez à recevoir toutes les notifications de MP
- Envoyez un MP à cet utilisateur à l'aide d'un autre compte normal.
- Il ne doit pas y avoir d'erreurs lors de l'envoi du MP.

<!-- Merci ! -->
