### PR TITLE
Fix #5022: les messages masqués ne sont plus considérés comme utiles

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -19,7 +19,7 @@
 <article
     class="topic-message
 
-           {% if message.is_useful %}helpful{% endif %}
+           {% if message.is_useful and message.is_visible %}helpful{% endif %}
            {% if is_repeated_message %}repeated{% endif %}"
 
     {% if comment_schema %}
@@ -173,7 +173,7 @@
                     {% trans "Reprise du dernier message de la page précédente" %}
                 </p>
             {% endif %}
-            <p class="message-helpful tick ico-after green {% if not message.is_useful or is_creator %}hidden{% endif %}"
+            <p class="message-helpful tick ico-after green {% if not message.is_useful or not message.is_visible %}hidden{% endif %}"
                data-ajax-output="mark-message-as-useful">
                 {% trans "Cette réponse a aidé l’auteur du sujet" %}
             </p>

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -1412,6 +1412,25 @@ class PostEditTest(TestCase):
         self.assertEqual(staff.user, post.editor)
         self.assertEqual(text_hidden_expected, post.text_hidden)
 
+    def test_hide_helpful_message(self):
+        profile = ProfileFactory()
+        category, forum = create_category()
+        topic = add_topic_in_a_forum(forum, profile)
+
+        self.assertTrue(self.client.login(username=profile.user.username, password='hostel77'))
+        response = self.client.post(reverse('post-useful') + '?message={}'.format(topic.last_message.pk), follow=False)
+        self.assertEqual(302, response.status_code)
+
+        response = self.client.get(topic.get_absolute_url(), follow=False)
+        self.assertNotContains(response, 'green hidden')
+
+        response = self.client.post(
+            reverse('post-edit') + '?message={}'.format(topic.last_message.pk), {'delete_message': ''}, follow=False)
+        self.assertEqual(302, response.status_code)
+
+        response = self.client.get(topic.get_absolute_url(), follow=False)
+        self.assertContains(response, 'green hidden')
+
     def test_failure_edit_post_show_message_by_user(self):
         another_profile = ProfileFactory()
         category, forum = create_category()


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #5022

### Contrôle qualité

Vérifier que le marquage d'un post comme utile marche toujours, mais qu'un message masqué n'est plus affiché comme utile.