### PR TITLE
Retire le message de contenu modéré sur les tutoriels et articles

### DIFF
--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -127,7 +127,7 @@
         {% endif %}
     {% endif %}
 
-    {% if not can_publish %}
+    {% if not can_publish and content.is_opinion %}
         <div class="content-wrapper">
             <div class="alert-box warning">
                 {% trans "Ce contenu a été modéré. Il ne peut pas faire l'objet d'une nouvelle publication." %}


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #5035 

Fixes #5035

### Contrôle qualité

Vérifier que le message apparaît sur les billets modérés, mais pas sur les tutoriels et articles.