### PR TITLE
Ajout d'attributs rel aux liens de pagination

### DIFF
--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -32,8 +32,14 @@
                         {% else %}
                             class="current"
                         {% endifnotequal %}
-                        {% if page == 1 %}
+                        {% if page|add:-1 == nb %}
+                            rel="next"
+                        {% elif page|add:1 == nb %}
+                            rel="prev"
+                        {% elif page == 1 %}
                             rel="first"
+                        {% elif page_nb == pages|length %}
+                            rel="last"
                         {% endif %}
                     >
                         {{ page }}

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -14,7 +14,7 @@
         {% ifnotequal nb 1 %}
             <li class="prev">
                 {% with prev=nb|add:-1 %}
-                    <a href="{% append_query_params page=prev %}{{ full_anchor }}" class="ico-after arrow-left blue">
+                    <a href="{% append_query_params page=prev %}{{ full_anchor }}" class="ico-after arrow-left blue" rel="prev">
                         <span>
                             {% trans "Précédente" %}
                         </span>
@@ -32,6 +32,9 @@
                         {% else %}
                             class="current"
                         {% endifnotequal %}
+                        {% if page == 1 %}
+                            rel="first"
+                        {% endif %}
                     >
                         {{ page }}
                     </a>
@@ -62,7 +65,7 @@
         {% if pages|last > 0 and pages|last != nb %}
             <li class="next">
                 {% with next=nb|add:1 %}
-                    <a href="{% append_query_params page=next %}{{ full_anchor }}" class="ico-after arrow-right blue">
+                    <a href="{% append_query_params page=next %}{{ full_anchor }}" class="ico-after arrow-right blue" rel="next">
                         <span>
                             {% trans "Suivante" %}
                         </span>

--- a/templates/misc/paginator.html
+++ b/templates/misc/paginator.html
@@ -12,7 +12,7 @@
     <ul class="pagination pagination-{{ position }}">
         {% if page_obj.has_previous %}
             <li class="prev">
-                <a href="{% append_query_params page=page_obj.previous_page_number %}{{ full_anchor }}" class="ico-after arrow-left blue">
+                <a href="{% append_query_params page=page_obj.previous_page_number %}{{ full_anchor }}" class="ico-after arrow-left blue" rel="prev">
                     <span>
                         {% trans "Précédente" %}
                     </span>
@@ -28,6 +28,9 @@
                         {% else %}
                             class="current"
                         {% endifnotequal %}
+                        {% if page_nb == 1 %}
+                            rel="first"
+                        {% endif %}
                     >
                         {{ page_nb }}
                     </a>
@@ -57,7 +60,7 @@
 
         {% if page_obj.has_next %}
             <li class="next">
-                <a href="{% append_query_params page=page_obj.next_page_number %}{{ full_anchor }}" class="ico-after arrow-right blue">
+                <a href="{% append_query_params page=page_obj.next_page_number %}{{ full_anchor }}" class="ico-after arrow-right blue" rel="next">
                     <span>
                         {% trans "Suivante" %}
                     </span>

--- a/templates/misc/paginator.html
+++ b/templates/misc/paginator.html
@@ -28,8 +28,14 @@
                         {% else %}
                             class="current"
                         {% endifnotequal %}
-                        {% if page_nb == 1 %}
+                        {% if page_nb|add:-1 == page_obj.number %}
+                            rel="next"
+                        {% elif page_nb|add:1 == page_obj.number %}
+                            rel="prev"
+                        {% elif page_nb == 1 %}
                             rel="first"
+                        {% elif page_nb == pages|length %}
+                            rel="last"
                         {% endif %}
                     >
                         {{ page_nb }}

--- a/templates/tutorialv2/includes/chapter_pager.part.html
+++ b/templates/tutorialv2/includes/chapter_pager.part.html
@@ -14,6 +14,7 @@
                         href="{{ previous.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
                     {% endif %}
                     class="ico-after arrow-left"
+                    rel="prev"
                 >
                     {{ previous.title }}
                 </a>
@@ -47,6 +48,7 @@
                         href="{{ next.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
                     {% endif %}
                     class="ico-after arrow-right"
+                    rel="next"
                 >
                     {{ next.title }}
                 </a>

--- a/templates/tutorialv2/includes/content_pager.part.html
+++ b/templates/tutorialv2/includes/content_pager.part.html
@@ -3,7 +3,7 @@
     <ul class="pagination pagination-{{ position }} pagination-chapter">
         {% if previous_content %}
             <li class="prev">
-                <a href="{{ previous_content.get_absolute_url_online }}" class="ico-after arrow-left">
+                <a href="{{ previous_content.get_absolute_url_online }}" class="ico-after arrow-left" rel="prev">
                     {{ previous_content.content.title }}
                 </a>
             </li>
@@ -11,7 +11,7 @@
 
         {% if next_content %}
             <li class="next">
-                <a href="{{ next_content.get_absolute_url_online }}" class="ico-after arrow-right" >
+                <a href="{{ next_content.get_absolute_url_online }}" class="ico-after arrow-right" rel="next">
                     {{ next_content.content.title }}
                 </a>
             </li>


### PR DESCRIPTION
Numéro du ticket concerné : #3702 

### Contrôle qualité

- Aller sur une page avec un paginateur (Les MPs sont pratiques car ils n'ont pas de limite anti-flood)
- Vérifier que le lien "Précédent" a l'attribut `rel="prev"`
- Vérifier que le lien "Suivant" a l'attribut `rel="next"`
- Vérifier que le lien "1" a l'attribut `rel="first"`
