### PR TITLE
Ajout d'attributs rel aux tags du forum et des contenus et aux auteurs de contenus.

### DIFF
--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -52,7 +52,7 @@
         <ul class="taglist" itemprop="keywords">
             {% for tag in topic.tags.all %}
                 <li>
-                    <a href="{% url 'topic-tag-find' tag.slug %}">
+                    <a href="{% url 'topic-tag-find' tag.slug %}" rel="tag">
                         {{ tag.title }}
                     </a>
                 </li>

--- a/templates/misc/member_item.part.html
+++ b/templates/misc/member_item.part.html
@@ -10,6 +10,7 @@
            itemtype="http://schema.org/Person"
            {% if author %}
                itemprop="author"
+               rel="author" 
            {% endif %}>
 
             {% if avatar %}

--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -17,7 +17,7 @@
 {% if publishablecontent.tags.all|length > 0 %}
     <ul class="taglist" itemprop="keywords">
         {% for tag in publishablecontent.tags.all %}
-            <li><a href="{{ taglist }}?tag={% if content.is_opinion %}{{ tag.title|urlencode }}{% else %}{{ tag.slug }}{% endif %}">{{ tag.title }}</a></li>
+            <li><a href="{{ taglist }}?tag={% if content.is_opinion %}{{ tag.title|urlencode }}{% else %}{{ tag.slug }}{% endif %}" rel="tag">{{ tag.title }}</a></li>
         {% endfor %}
     </ul>
 {% endif %}


### PR DESCRIPTION
Ajout d'attributs `rel="tag"` aux tags des topics, des tutos, des articles et des billets.
Ajout d'attributs `rel="author"` aux liens vers les auteurs de tutos, articles et billets dans l'en-tête.

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

- Vérifier que les tags ont bien l'attribut `rel="tag"` dans les contenus et les topics, mais pas dans les index.
- Vérifier que les liens vers les auteurs de contenus ont bien l'attribut `rel="author"` sur la (les) page(s) des contenus en question.