### PR TITLE
Retour au preview zmd 'naif'

### DIFF
--- a/assets/js/ajax-actions.js
+++ b/assets/js/ajax-actions.js
@@ -241,71 +241,42 @@
     /**
      * Preview the message
      */
-    var previewTimeout;
-    var previewInput;
-    var previewContent;
-    var previewDelay = 10000;
-    var previewTime;
-    $(".message-bottom [data-ajax-input='preview-message'], .preview-btn").on("mouseover click", function(e){
+    $(".message-bottom [data-ajax-input='preview-message'], .preview-btn").on("click", function(e) {
         e.stopPropagation();
         e.preventDefault();
         var $btn = $(this);
         var $form = $btn.parents("form:first");
-        var isForm = !!$form.find(".preview-source").length;
-        var $insertTarget = isForm ? $btn : $form;
         var text = "";
-        if (isForm) {
-            text = $btn.parent().prev().find(".preview-source").val();
+        if ( $form.find(".preview-source").length ) {
+            var $textSource = $btn.parent().prev().find(".preview-source");
+            text = $textSource.val();
         } else {
             text = $form.find("textarea[name=text]").val();
-        }
-        if (!previewInput) {
-            previewInput = text;
         }
 
         var csrfmiddlewaretoken = $form.find("input[name=csrfmiddlewaretoken]").val(),
             lastPost = $form.find("input[name=last_post]").val();
 
-        if (previewInput === text && e.type === "click" && previewContent && (Date.now() - previewTime) < previewDelay) {
-            return showPreview();
-        }
+        $.ajax({
+            url: $form.attr("action"),
+            type: "POST",
+            data: {
+                "csrfmiddlewaretoken": csrfmiddlewaretoken,
+                "text": text,
+                "last_post": lastPost,
+                "preview": "preview"
+            },
+            success: function(data){
+                $(".previsualisation").remove();
 
-        var later = function() {
-            previewTimeout = null;
-        };
-
-        var callNow = previewInput !== text || !previewTimeout;
-        clearTimeout(previewTimeout);
-        previewTimeout = setTimeout(later, previewDelay);
-
-        if (callNow) {
-            $.ajax({
-                url: $form.attr("action"),
-                type: "POST",
-                data: {
-                    "csrfmiddlewaretoken": csrfmiddlewaretoken,
-                    "text": text,
-                    "last_post": lastPost,
-                    "preview": "preview"
-                }
-            }).done(function(preview){
-                previewContent = preview;
-            }).fail(function(j, textStatus, err) {
-                console.error(err);
-            }).always(function() {
-                previewTime = Date.now();
-                previewInput = text;
-                if (e.type === "click") {
-                    showPreview();
-                }
-            });
-        }
-
-        function showPreview () {
-            $(".previsualisation").remove();
-            $(previewContent).insertAfter($insertTarget);
-        }
+                if (typeof $textSource === "undefined")
+                    $(data).insertAfter($form);
+                else
+                    $(data).insertAfter($btn);
+            }
+        });
     });
+
 
     /*
      * Mark a message useful

--- a/yarn.lock
+++ b/yarn.lock
@@ -3372,9 +3372,9 @@ nan@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
-natives@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
+natives@1.1.3, natives@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
 
 ndarray-fill@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Retour au fonctionnement naïf de la preview. J'ai principalement rebasculé sur la version précédente. Je n'ai pas pu tester, j'ai un problème pour builder les dépendences du back.

Numéro du ticket concerné : #5031

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

1. builder le front
2. lancer le tout
3. ouvrir le network tab des devtools
4. se connecter avec n'importe quel compte
5. dans une zone d'édition, survoler le bouton ne lance pas de preview
6. clicker sur le bouton lance la requête