### PR TITLE
Corrige la règle css des Spoiler qui ne s'active pas (margin-top et padding-left)

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -237,13 +237,13 @@ h6 {
         }
     }
 }
-.spoiler {
-    margin-top: 0;
+
+.spoiler,
+.custom-block-spoiler  {
+    margin-top: 0 ;
     padding-left: 15px;
     background: #EEE;
 }
-
-
 
 img {
     max-width: 100%;


### PR DESCRIPTION
Corrige : #4457

Il faudra vérifier que le margin s'applique aux vieilles balises spoiler. A vérifier et à corriger dans la PR #5026. L'ordre des classes intégrées au JS peut avoir des conséquences.

## Q/A : 

Observer un padding-left qui décale à droite le texte dans le bloc de spoiler. Et constater un écart plus petit entre le contenu et le bouton afficher/masquer. Avant/Après dispo ici : https://github.com/zestedesavoir/zds-site/issues/4457#issuecomment-320470961