### PR TITLE
Améliore l'alignement des popups de l'éditeur :  smileys, caractères spéciaux et code

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -299,6 +299,25 @@
 
                     if (elemPopup = this.getElementsByTagName("div")[0]) {
                         elemPopup.style.display = "block";
+
+                        //>> align
+                        var contentX = document.getElementById("content").offsetWidth,
+                            posLeftSide = elemPopup.offsetParent.offsetLeft + elemPopup.offsetWidth,
+                            isOut = (posLeftSide <= contentX);
+
+                        elemPopup.style.left = (isOut) ? "0" : "inherit";
+                        elemPopup.style.right = (isOut) ? "inherit" : "0";
+
+                        var parentLeft = elemPopup.offsetParent.offsetLeft,
+                            posRightSide = parentLeft - elemPopup.offsetWidth;
+                        if (posRightSide < 0) {
+                            elemPopup.style.right = "inherit";
+                            var left = -parentLeft;
+                            left += Math.max((contentX - elemPopup.offsetWidth) / 2, 0);
+                            elemPopup.style.left = left + "px";
+                        }
+                        //<<
+
                         if(self.currentElemPopup){
                             self.currentElemPopup.style.display = "none";
                         }

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -303,14 +303,14 @@
                         //>> align
                         var contentX = document.getElementById("content").offsetWidth,
                             posLeftSide = elemPopup.offsetParent.offsetLeft + elemPopup.offsetWidth,
-                            isOut = (posLeftSide <= contentX);
+                            isNotOut = (posLeftSide <= contentX);
 
-                        elemPopup.style.left = (isOut) ? "0" : "inherit";
-                        elemPopup.style.right = (isOut) ? "inherit" : "0";
+                        elemPopup.style.left = (isNotOut) ? "0" : "inherit";
+                        elemPopup.style.right = (isNotOut) ? "inherit" : "0";
 
                         var parentLeft = elemPopup.offsetParent.offsetLeft,
                             posRightSide = parentLeft - elemPopup.offsetWidth;
-                        if (posRightSide < 0) {
+                        if (!isNotOut && posRightSide < 0) {
                             elemPopup.style.right = "inherit";
                             var left = -parentLeft;
                             left += Math.max((contentX - elemPopup.offsetWidth) / 2, 0);

--- a/assets/scss/components/_editor.scss
+++ b/assets/scss/components/_editor.scss
@@ -116,6 +116,10 @@ div.zform-popup {
     padding: 2px;
 }
 
+.zform-button-smilies .zform-code-col > span {
+    text-align: center;
+}
+
 
 
 /* 3 cols select code dropdown */


### PR DESCRIPTION
Corrige : #4978 + Alignement auto des popups (smileys, caractères spéciaux et code) pour qu'elles évitent **si possible** de sortir de l'écran.

**Q/A :**

 - Vérifier le centrage des smileys dans la popup ;
 - Vérifier l'alignement auto de la popup : left, right, middle : 

![image](https://user-images.githubusercontent.com/18501150/45058815-1d6dfe00-b09a-11e8-9340-d9fc7564080e.png)
![image](https://user-images.githubusercontent.com/18501150/45058832-2b238380-b09a-11e8-81c9-890f2d2dfabb.png)
