### PR TITLE
fixtures: fix la topbar des forums (environnement de dev)

### DIFF
--- a/fixtures/forums.yaml
+++ b/fixtures/forums.yaml
@@ -3,21 +3,25 @@
     fields:
         title: Site web
         slug: site-web
+        position: 1
 -   model: forum.Category
     pk: 2
     fields:
         title: Programmation
         slug: programmation
+        position: 2
 -   model: forum.Category
     pk: 3
     fields:
         title: Développement Mobile
         slug: developpement-mobile
+        position: 3
 -   model: forum.Category
     pk: 4
     fields:
         title: Communauté
         slug: communaute
+        position: 4
 -   model: forum.Forum
     pk: 1
     fields:


### PR DESCRIPTION
templatetags/topbar.py se base sur l'attribut "position" de la
catégorie pour remplir la topbar. Cet attribut doit donc être
ajouté dans les fixtures.

Issue: #5055

### Contrôle qualité

  - Lancez `make fixtures`
  - Regarder si les forums sont bien tries

