### PR TITLE
reduce code duplication in zds/forum/feeds.py

### DIFF
--- a/zds/forum/feeds.py
+++ b/zds/forum/feeds.py
@@ -22,22 +22,12 @@ class LastPostsFeedRSS(Feed):
 
     def items(self, obj):
         try:
-            if 'forum' in obj and 'tag' in obj:
-                posts = Post.objects.filter(topic__forum__groups__isnull=True,
-                                            topic__forum__pk=int(obj['forum']),
-                                            topic__tags__pk__in=[obj['tag']]) \
-                                    .order_by('-pubdate')[:settings.ZDS_APP['forum']['posts_per_page']]
-            elif 'forum' in obj and 'tag' not in obj:
-                posts = Post.objects.filter(topic__forum__groups__isnull=True,
-                                            topic__forum__pk=int(obj['forum'])) \
-                                    .order_by('-pubdate')[:settings.ZDS_APP['forum']['posts_per_page']]
-            elif 'forum' not in obj and 'tag' in obj:
-                posts = Post.objects.filter(topic__forum__groups__isnull=True,
-                                            topic__tags__pk__in=[obj['tag']]) \
-                                    .order_by('-pubdate')[:settings.ZDS_APP['forum']['posts_per_page']]
-            else:
-                posts = Post.objects.filter(topic__forum__groups__isnull=True)\
-                                    .order_by('-pubdate')[:settings.ZDS_APP['forum']['posts_per_page']]
+            posts = Post.objects.filter(topic__forum__groups__isnull=True)
+            if 'forum' in obj:
+                posts = posts.filter(topic__forum__pk=int(obj['forum']))
+            if 'tag' in obj:
+                posts = posts.filter(topic__tags__pk__in=[obj['tag']])
+            posts = posts.order_by('-pubdate')[:settings.ZDS_APP['forum']['posts_per_page']]
         except (Post.DoesNotExist, ValueError):
             posts = []
         return posts
@@ -81,22 +71,12 @@ class LastTopicsFeedRSS(Feed):
 
     def items(self, obj):
         try:
-            if 'forum' in obj and 'tag' in obj:
-                topics = Topic.objects.filter(forum__groups__isnull=True,
-                                              forum__pk=int(obj['forum']),
-                                              tags__pk__in=[obj['tag']])\
-                    .order_by('-pubdate')[:settings.ZDS_APP['forum']['posts_per_page']]
-            elif 'forum' in obj and 'tag' not in obj:
-                topics = Topic.objects.filter(forum__groups__isnull=True,
-                                              forum__pk=int(obj['forum']))\
-                    .order_by('-pubdate')[:settings.ZDS_APP['forum']['posts_per_page']]
-            elif 'forum' not in obj and 'tag' in obj:
-                topics = Topic.objects.filter(forum__groups__isnull=True,
-                                              tags__pk__in=[obj['tag']])\
-                    .order_by('-pubdate')[:settings.ZDS_APP['forum']['posts_per_page']]
-            if 'forum' not in obj and 'tag' not in obj:
-                topics = Topic.objects.filter(forum__groups__isnull=True)\
-                    .order_by('-pubdate')[:settings.ZDS_APP['forum']['posts_per_page']]
+            topics = Topic.objects.filter(forum__groups__isnull=True)
+            if 'forum' in obj:
+                topics = topics.filter(forum__pk=int(obj['forum']))
+            if 'tag' in obj:
+                topics = topics.filter(tags__pk__in=[obj['tag']])
+            topics = topics.order_by('-pubdate')[:settings.ZDS_APP['forum']['posts_per_page']]
         except (Topic.DoesNotExist, ValueError):
             topics = []
         return topics

--- a/zds/forum/feeds.py
+++ b/zds/forum/feeds.py
@@ -6,19 +6,37 @@ from django.conf import settings
 from .models import Post, Topic
 
 
-class LastPostsFeedRSS(Feed):
+class ItemMixin:
+    def item_pubdate(self, item):
+        return item.pubdate
+
+    def item_author_name(self, item):
+        return item.author.username
+
+    def item_author_link(self, item):
+        return item.author.get_absolute_url()
+
+    def item_link(self, item):
+        return item.get_absolute_url()
+
+
+def request_object(request):
+    obj = {}
+    if 'forum' in request.GET:
+        obj['forum'] = request.GET['forum']
+    if 'tag' in request.GET:
+        obj['tag'] = request.GET['tag']
+    return obj
+
+
+class LastPostsFeedRSS(Feed, ItemMixin):
     title = 'Derniers messages sur {}'.format(settings.ZDS_APP['site']['literal_name'])
     link = '/forums/'
     description = ('Les derniers messages '
                    'parus sur le forum de {}.'.format(settings.ZDS_APP['site']['literal_name']))
 
     def get_object(self, request):
-        obj = {}
-        if 'forum' in request.GET:
-            obj['forum'] = request.GET['forum']
-        if 'tag' in request.GET:
-            obj['tag'] = request.GET['tag']
-        return obj
+        return request_object(request)
 
     def items(self, obj):
         try:
@@ -35,20 +53,8 @@ class LastPostsFeedRSS(Feed):
     def item_title(self, item):
         return '{}, message #{}'.format(item.topic.title, item.pk)
 
-    def item_pubdate(self, item):
-        return item.pubdate
-
     def item_description(self, item):
         return item.text_html
-
-    def item_author_name(self, item):
-        return item.author.username
-
-    def item_author_link(self, item):
-        return item.author.get_absolute_url()
-
-    def item_link(self, item):
-        return item.get_absolute_url()
 
 
 class LastPostsFeedATOM(LastPostsFeedRSS):
@@ -56,18 +62,13 @@ class LastPostsFeedATOM(LastPostsFeedRSS):
     subtitle = LastPostsFeedRSS.description
 
 
-class LastTopicsFeedRSS(Feed):
+class LastTopicsFeedRSS(Feed, ItemMixin):
     title = 'Derniers sujets sur {}'.format(settings.ZDS_APP['site']['literal_name'])
     link = '/forums/'
     description = 'Les derniers sujets créés sur le forum de {}.'.format(settings.ZDS_APP['site']['literal_name'])
 
     def get_object(self, request):
-        obj = {}
-        if 'forum' in request.GET:
-            obj['forum'] = request.GET['forum']
-        if 'tag' in request.GET:
-            obj['tag'] = request.GET['tag']
-        return obj
+        return request_object(request)
 
     def items(self, obj):
         try:
@@ -81,23 +82,11 @@ class LastTopicsFeedRSS(Feed):
             topics = []
         return topics
 
-    def item_pubdate(self, item):
-        return item.pubdate
-
     def item_title(self, item):
         return '{} dans {}'.format(item.title, item.forum.title)
 
     def item_description(self, item):
         return item.subtitle
-
-    def item_author_name(self, item):
-        return item.author.username
-
-    def item_author_link(self, item):
-        return item.author.get_absolute_url()
-
-    def item_link(self, item):
-        return item.get_absolute_url()
 
 
 class LastTopicsFeedATOM(LastTopicsFeedRSS):


### PR DESCRIPTION
C'est juste une petite PR de refactoring de code. Il y a pas mal de redondance dans le code de ZDS et ça me démange régulièrement de faire des PRs de ce genre.

Le problème c'est que je n'ai pas pu tester cette PR parce que je n'ai pas réussi, avec un degré d'efforts raisonnables, à installer le backend à nouveau chez moi (ça avait marché la dernière fois, il y a quelques années). Cf. #5081, mais j'ai eu plein d'ennuis à la con en plus (genre `make install-back` marche une fois sur deux, make ensuite `python migrate.py` foire avec 

```python
ImportError: No module named colorlog
```

J'aimerais faire d'autres PRs de ce genre à l'occasion. Là, j'en envoie une toute petite pour tester et voir comment ça se passe. Je pense qu'il y a plusieurs choix :

- vous vous contentez de relire le code et de vous convaincre que c'est un refactoring qui ne change pas le comportement, et vous avec assez d'intégration continue pour qu'une typo se fasse détecter de toute façon; oui bien,
- l'un d'entre vous a un environnement de dev sur sa machine qui lui permet de tester facilement (moi je ne peux pas); ou bien,
- vous trouver une façon de rendre le site moins chiant à installer (ça ne doit pas prendre plus d'une demi-heure sur une machine; j'ai dépassé rien qu'avec la réinstallation de texlive quand j'ai fait `make install-linux-full` naïvement); ou bien,
- rien de tout cela ne vous convainc, et je pense que je devrai laisser tomber l'idée de faire du refactoring sur la base de code.