### PR TITLE
Refactor forum factories

### DIFF
--- a/zds/forum/api/tests.py
+++ b/zds/forum/api/tests.py
@@ -7,8 +7,7 @@ from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 from rest_framework_extensions.settings import extensions_api_settings
 
-from zds.forum.factories import PostFactory
-from zds.forum.tests.tests_views import create_category, add_topic_in_a_forum
+from zds.forum.factories import PostFactory, create_category_and_forum, create_topic_in_forum
 from zds.member.factories import ProfileFactory
 from zds.utils.models import CommentVote
 
@@ -20,8 +19,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_failure_post_karma_with_client_unauthenticated(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         post = PostFactory(topic=topic, author=profile.user, position=2)
 
         response = self.client.put(reverse('api:forum:post-karma', args=(post.pk,)))
@@ -29,8 +28,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_failure_post_karma_with_sanctioned_user(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
@@ -51,8 +50,8 @@ class ForumPostKarmaAPITest(APITestCase):
         group = Group.objects.create(name='DummyGroup_1')
 
         profile = ProfileFactory()
-        category, forum = create_category(group)
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum(group)
+        topic = create_topic_in_forum(forum, profile)
 
         self.assertTrue(self.client.login(username=profile.user.username, password='hostel77'))
         response = self.client.put(reverse('api:forum:post-karma', args=(topic.last_message.pk,)), {'vote': 'like'})
@@ -60,8 +59,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_success_post_karma_like(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
@@ -72,8 +71,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_success_post_karma_dislike(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
@@ -84,8 +83,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_success_post_karma_neutral(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
@@ -100,8 +99,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_success_post_karma_like_already_disliked(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
@@ -118,8 +117,8 @@ class ForumPostKarmaAPITest(APITestCase):
     def test_get_post_voters(self):
         profile = ProfileFactory()
         profile2 = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
 
         upvoted_answer = PostFactory(topic=topic, author=another_profile.user, position=2)

--- a/zds/forum/factories.py
+++ b/zds/forum/factories.py
@@ -53,3 +53,23 @@ class PostFactory(factory.DjangoModelFactory):
             topic.last_message = post
             topic.save()
         return post
+
+
+def create_category_and_forum(group=None):
+    category = CategoryFactory(position=1)
+    forum = ForumFactory(category=category, position_in_category=1)
+    if group is not None:
+        forum.groups.add(group)
+        forum.save()
+    return category, forum
+
+
+def create_topic_in_forum(forum, profile, is_sticky=False, is_solved=False, is_locked=False):
+    topic = TopicFactory(forum=forum, author=profile.user)
+    topic.is_sticky = is_sticky
+    if is_solved:
+        topic.solved_by = profile.user
+    topic.is_locked = is_locked
+    topic.save()
+    PostFactory(topic=topic, author=profile.user, position=1)
+    return topic

--- a/zds/pages/tests.py
+++ b/zds/pages/tests.py
@@ -5,9 +5,8 @@ from django.test.utils import override_settings
 from django.utils.translation import ugettext_lazy as _
 
 from zds.forum.models import Post
-from zds.forum.factories import CategoryFactory, ForumFactory
+from zds.forum.factories import create_category_and_forum, create_topic_in_forum
 from zds.member.factories import ProfileFactory, StaffProfileFactory
-from zds.forum.tests.tests_views import create_category, add_topic_in_a_forum
 from zds.utils.models import CommentEdit
 from zds.utils.templatetags.emarkdown import render_markdown
 
@@ -71,8 +70,7 @@ class PagesMemberTests(TestCase):
         """
         To test the "subscription to the association" form.
         """
-        forum_category = CategoryFactory(position=1)
-        forum = ForumFactory(category=forum_category, position_in_category=1)
+        _, forum = create_category_and_forum()
 
         # overrides the settings to avoid 404 if forum does not exist
         settings.ZDS_APP['site']['association']['forum_ca_pk'] = forum.pk
@@ -241,8 +239,8 @@ class CommentEditsHistoryTests(TestCase):
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user
 
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, self.user.profile)
+        _, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, self.user.profile)
 
         self.assertTrue(self.client.login(username=self.user.username, password='hostel77'))
         data = {

--- a/zds/searchv2/tests/tests_models.py
+++ b/zds/searchv2/tests/tests_models.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from zds.forum.factories import TopicFactory, PostFactory, Topic, Post
-from zds.forum.tests.tests_views import create_category
+from zds.forum.factories import create_category_and_forum
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.searchv2.models import ESIndexManager
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, publish_content
@@ -22,7 +22,7 @@ class ESIndexManagerTests(TutorialTestMixin, TestCase):
         self.mas = ProfileFactory().user
         settings.ZDS_APP['member']['bot_account'] = self.mas.username
 
-        self.category, self.forum = create_category()
+        self.category, self.forum = create_category_and_forum()
 
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user

--- a/zds/searchv2/tests/tests_utils.py
+++ b/zds/searchv2/tests/tests_utils.py
@@ -10,7 +10,7 @@ from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory
 from zds.tutorialv2.models.database import PublishedContent
 from zds.tutorialv2.publication_utils import publish_content
 from zds.forum.factories import TopicFactory, PostFactory, Topic, Post
-from zds.forum.tests.tests_views import create_category
+from zds.forum.factories import create_category_and_forum
 from zds.searchv2.models import ESIndexManager
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 
@@ -24,7 +24,7 @@ class UtilsTests(TutorialTestMixin, TestCase):
         self.mas = ProfileFactory().user
         settings.ZDS_APP['member']['bot_account'] = self.mas.username
 
-        self.category, self.forum = create_category()
+        self.category, self.forum = create_category_and_forum()
 
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user

--- a/zds/searchv2/tests/tests_views.py
+++ b/zds/searchv2/tests/tests_views.py
@@ -8,8 +8,10 @@ from django.conf import settings
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 
+from django.contrib.auth.models import Group
 from zds.forum.factories import TopicFactory, PostFactory, Topic, Post, TagFactory
-from zds.forum.tests.tests_views import create_category, Group
+from zds.forum.factories import create_category_and_forum
+
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.searchv2.models import ESIndexManager
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, publish_content, \
@@ -27,7 +29,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.mas = ProfileFactory().user
         settings.ZDS_APP['member']['bot_account'] = self.mas.username
 
-        self.category, self.forum = create_category()
+        self.category, self.forum = create_category_and_forum()
 
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user
@@ -214,7 +216,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         text = 'test'
 
         group = Group.objects.create(name='Les illuminatis anonymes de ZdS')
-        _, hidden_forum = create_category(group)
+        _, hidden_forum = create_category_and_forum(group)
 
         self.staff.groups.add(group)
         self.staff.save()
@@ -556,7 +558,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         text = 'test'
 
         group = Group.objects.create(name='Les illuminatis anonymes de ZdS')
-        _, hidden_forum = create_category(group)
+        _, hidden_forum = create_category_and_forum(group)
 
         self.staff.groups.add(group)
         self.staff.save()


### PR DESCRIPTION
Après #5082, je continue à faire un peu de nettoyage de code. J'ai voulu factoriser du code dans `zds/forums/forms`, mais pour cela j'ai commencé par écrire un fichier de tests, et pour cela j'ai eu besoin de code qui existe déjà dans `test_views`, que j'ai transformé en fonctions auxiliaires dans `factories`.

Je n'ai pas pu tester cette PR sur ma machine car je n'ai pas réussi à installer ZDS complètement, donc lancer le serveur ne marche pas chez moi et `tests_views` en dépend. Ceci-dit, l'intégration continue attraperait toute erreur à ce niveau-là -- et j'ai pu tester mon nouveau `test_forms`, à venir dans une autre PR.