### PR TITLE
Refactor forum forms

### DIFF
--- a/zds/forum/api/tests.py
+++ b/zds/forum/api/tests.py
@@ -7,8 +7,7 @@ from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 from rest_framework_extensions.settings import extensions_api_settings
 
-from zds.forum.factories import PostFactory
-from zds.forum.tests.tests_views import create_category, add_topic_in_a_forum
+from zds.forum.factories import PostFactory, create_category_and_forum, create_topic_in_forum
 from zds.member.factories import ProfileFactory
 from zds.utils.models import CommentVote
 
@@ -20,8 +19,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_failure_post_karma_with_client_unauthenticated(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         post = PostFactory(topic=topic, author=profile.user, position=2)
 
         response = self.client.put(reverse('api:forum:post-karma', args=(post.pk,)))
@@ -29,8 +28,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_failure_post_karma_with_sanctioned_user(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
@@ -51,8 +50,8 @@ class ForumPostKarmaAPITest(APITestCase):
         group = Group.objects.create(name='DummyGroup_1')
 
         profile = ProfileFactory()
-        category, forum = create_category(group)
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum(group)
+        topic = create_topic_in_forum(forum, profile)
 
         self.assertTrue(self.client.login(username=profile.user.username, password='hostel77'))
         response = self.client.put(reverse('api:forum:post-karma', args=(topic.last_message.pk,)), {'vote': 'like'})
@@ -60,8 +59,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_success_post_karma_like(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
@@ -72,8 +71,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_success_post_karma_dislike(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
@@ -84,8 +83,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_success_post_karma_neutral(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
@@ -100,8 +99,8 @@ class ForumPostKarmaAPITest(APITestCase):
 
     def test_success_post_karma_like_already_disliked(self):
         profile = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
@@ -118,8 +117,8 @@ class ForumPostKarmaAPITest(APITestCase):
     def test_get_post_voters(self):
         profile = ProfileFactory()
         profile2 = ProfileFactory()
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, profile)
+        category, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
         another_profile = ProfileFactory()
 
         upvoted_answer = PostFactory(topic=topic, author=another_profile.user, position=2)

--- a/zds/forum/factories.py
+++ b/zds/forum/factories.py
@@ -53,3 +53,23 @@ class PostFactory(factory.DjangoModelFactory):
             topic.last_message = post
             topic.save()
         return post
+
+
+def create_category_and_forum(group=None):
+    category = CategoryFactory(position=1)
+    forum = ForumFactory(category=category, position_in_category=1)
+    if group is not None:
+        forum.groups.add(group)
+        forum.save()
+    return category, forum
+
+
+def create_topic_in_forum(forum, profile, is_sticky=False, is_solved=False, is_locked=False):
+    topic = TopicFactory(forum=forum, author=profile.user)
+    topic.is_sticky = is_sticky
+    if is_solved:
+        topic.solved_by = profile.user
+    topic.is_locked = is_locked
+    topic.save()
+    PostFactory(topic=topic, author=profile.user, position=1)
+    return topic

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -7,10 +7,10 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Field, Hidden, HTML
 from crispy_forms.bootstrap import StrictButton
 from zds.forum.models import Forum, Topic
-from zds.utils.forms import CommonLayoutEditor, TagValidator
+from zds.utils.forms import CommonLayoutEditor, TagValidator, FieldValidatorMixin
 
 
-class TopicForm(forms.Form):
+class TopicForm(forms.Form, FieldValidatorMixin):
     title = forms.CharField(
         label=_('Titre'),
         max_length=Topic._meta.get_field('title').max_length,
@@ -77,34 +77,24 @@ class TopicForm(forms.Form):
     def clean(self):
         cleaned_data = super(TopicForm, self).clean()
 
-        title = cleaned_data.get('title')
-        text = cleaned_data.get('text')
+        self.get_non_empty_field_or_error(cleaned_data, 'title',
+                                          lambda: _('Le champ titre ne peut être vide'))
+        text = self.get_non_empty_field_or_error(cleaned_data, 'text',
+                                                 lambda: _('Le champ text ne peut être vide'))
+
+        if text:
+            self.check_text_length_limit(text, settings.ZDS_APP['forum']['max_post_length'],
+                                         lambda: _('Ce message est trop long, '
+                                                   'il ne doit pas dépasser {0} caractères'))
+
         tags = cleaned_data.get('tags')
-
-        if title is not None:
-            if not title.strip():
-                self._errors['title'] = self.error_class(
-                    [_('Le champ titre ne peut être vide')])
-                if 'title' in cleaned_data:
-                    del cleaned_data['title']
-        if text is not None and not text.strip():
-            self._errors['text'] = self.error_class(
-                [_('Le champ text ne peut être vide')])
-            if 'text' in cleaned_data:
-                del cleaned_data['text']
-
-        if text is not None and len(text) > settings.ZDS_APP['forum']['max_post_length']:
-            self._errors['text'] = self.error_class(
-                [_('Ce message est trop long, il ne doit pas dépasser {0} '
-                   'caractères').format(settings.ZDS_APP['forum']['max_post_length'])])
-
         validator = TagValidator()
         if not validator.validate_raw_string(tags):
             self._errors['tags'] = self.error_class(validator.errors)
         return cleaned_data
 
 
-class PostForm(forms.Form):
+class PostForm(forms.Form, FieldValidatorMixin):
     text = forms.CharField(
         label='',
         widget=forms.Textarea(
@@ -149,17 +139,13 @@ class PostForm(forms.Form):
     def clean(self):
         cleaned_data = super(PostForm, self).clean()
 
-        text = cleaned_data.get('text')
+        text = self.get_non_empty_field_or_error(cleaned_data, 'text',
+                                                 lambda: _('Vous devez écrire une réponse !'))
 
-        if text is None or not text.strip():
-            self._errors['text'] = self.error_class(
-                [_('Vous devez écrire une réponse !')])
-
-        elif len(text) > settings.ZDS_APP['forum']['max_post_length']:
-            self._errors['text'] = self.error_class(
-                [_('Ce message est trop long, il ne doit pas dépasser {0} '
-                   'caractères').format(settings.ZDS_APP['forum']['max_post_length'])])
-
+        if text:
+            self.check_text_length_limit(text, settings.ZDS_APP['forum']['max_post_length'],
+                                         lambda: _('Ce message est trop long, '
+                                                   'il ne doit pas dépasser {0} caractères'))
         return cleaned_data
 
 

--- a/zds/forum/tests/tests_forms.py
+++ b/zds/forum/tests/tests_forms.py
@@ -1,0 +1,130 @@
+from django.test import TestCase
+
+from zds.forum.forms import TopicForm, PostForm
+
+from zds.forum.factories import create_category_and_forum, create_topic_in_forum
+from zds.member.factories import ProfileFactory
+from django.conf import settings
+
+text_too_long = (settings.ZDS_APP['forum']['max_post_length'] + 1) * 'a'
+
+
+class TopicFormTest(TestCase):
+
+    def test_valid_topic_form(self):
+        data = {
+            'title': 'Test Topic Title',
+            'subtitle': 'Test Topic Subtitle',
+            'tags': 'test,topic,tags',
+            'text': 'Test Topic Text'
+        }
+        form = TopicForm(data=data)
+
+        self.assertTrue(form.is_valid())
+
+    def test_invalid_topic_form_missing_title(self):
+        """ Test when title is missing """
+        data = {
+            'subtitle': 'Test Topic Subtitle',
+            'tags': 'test,topic,tags',
+            'text': 'Test Topic Text'
+        }
+        form = TopicForm(data=data)
+
+        self.assertFalse(form.is_valid())
+
+    def test_invalid_topic_form_empty_title(self):
+        """ Test when title contains only whitespace """
+        data = {
+            'title': ' ',
+            'subtitle': 'Test Topic Subtitle',
+            'tags': 'test,topic,tags',
+            'text': 'Test Topic Text'
+        }
+        form = TopicForm(data=data)
+
+        self.assertFalse(form.is_valid())
+
+    def test_invalid_topic_form_missing_text(self):
+        """ Test when text is missing """
+        data = {
+            'title': 'Test Topic Title',
+            'subtitle': 'Test Topic Subtitle',
+            'tags': 'test,topic,tags',
+        }
+        form = TopicForm(data=data)
+
+        self.assertFalse(form.is_valid())
+
+    def test_invalid_topic_form_empty_text(self):
+        """ Test when text contains only whitespace """
+        data = {
+            'title': 'Test Topic Title',
+            'subtitle': 'Test Topic Subtitle',
+            'tags': 'test,topic,tags',
+            'text': ' '
+        }
+        form = TopicForm(data=data)
+
+        self.assertFalse(form.is_valid())
+
+    def test_invalid_topic_form_text_too_long(self):
+        """ Test when text runs over the length limit """
+        data = {
+            'title': 'Test Topic Title',
+            'subtitle': 'Test Topic Subtitle',
+            'tags': 'test,topic,tags',
+            'text': text_too_long,
+        }
+        form = TopicForm(data=data)
+
+        self.assertFalse(form.is_valid())
+
+
+class PostFormTest(TestCase):
+
+    def test_valid_post_form(self):
+        profile = ProfileFactory()
+        _, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
+        data = {
+            'text': 'Test Post Text'
+        }
+        form = PostForm(topic, profile.user, data=data)
+
+        self.assertTrue(form.is_valid())
+
+    def test_invalid_post_form_missing_text(self):
+        """ Test when text is missing """
+        profile = ProfileFactory()
+        _, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
+        data = {
+        }
+        form = PostForm(topic, profile.user, data=data)
+
+        self.assertFalse(form.is_valid())
+
+    def test_invalid_post_form_empty_text(self):
+        """ Test when text contains only whitespace """
+        profile = ProfileFactory()
+        _, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
+        data = {
+            'text': ' '
+        }
+        form = PostForm(topic, profile.user, data=data)
+
+        self.assertFalse(form.is_valid())
+
+    def test_invalid_post_form_text_too_long(self):
+        """ Test when text runs over the length limit """
+        profile = ProfileFactory()
+        _, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, profile)
+        data = {
+            'text': text_too_long,
+        }
+        form = PostForm(topic, profile.user, data=data)
+
+        self.assertFalse(form.is_valid())

--- a/zds/forum/tests/tests_forms.py
+++ b/zds/forum/tests/tests_forms.py
@@ -22,6 +22,17 @@ class TopicFormTest(TestCase):
 
         self.assertTrue(form.is_valid())
 
+    def test_valid_topic_form_empty_tags(self):
+        data = {
+            'title': 'Test Topic Title',
+            'subtitle': 'Test Topic Subtitle',
+            'tags': '',
+            'text': 'Test Topic Text'
+        }
+        form = TopicForm(data=data)
+
+        self.assertTrue(form.is_valid())
+
     def test_invalid_topic_form_missing_title(self):
         """ Test when title is missing """
         data = {

--- a/zds/pages/tests.py
+++ b/zds/pages/tests.py
@@ -5,9 +5,8 @@ from django.test.utils import override_settings
 from django.utils.translation import ugettext_lazy as _
 
 from zds.forum.models import Post
-from zds.forum.factories import CategoryFactory, ForumFactory
+from zds.forum.factories import create_category_and_forum, create_topic_in_forum
 from zds.member.factories import ProfileFactory, StaffProfileFactory
-from zds.forum.tests.tests_views import create_category, add_topic_in_a_forum
 from zds.utils.models import CommentEdit
 from zds.utils.templatetags.emarkdown import render_markdown
 
@@ -71,8 +70,7 @@ class PagesMemberTests(TestCase):
         """
         To test the "subscription to the association" form.
         """
-        forum_category = CategoryFactory(position=1)
-        forum = ForumFactory(category=forum_category, position_in_category=1)
+        _, forum = create_category_and_forum()
 
         # overrides the settings to avoid 404 if forum does not exist
         settings.ZDS_APP['site']['association']['forum_ca_pk'] = forum.pk
@@ -241,8 +239,8 @@ class CommentEditsHistoryTests(TestCase):
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user
 
-        category, forum = create_category()
-        topic = add_topic_in_a_forum(forum, self.user.profile)
+        _, forum = create_category_and_forum()
+        topic = create_topic_in_forum(forum, self.user.profile)
 
         self.assertTrue(self.client.login(username=self.user.username, password='hostel77'))
         data = {

--- a/zds/searchv2/tests/tests_models.py
+++ b/zds/searchv2/tests/tests_models.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from zds.forum.factories import TopicFactory, PostFactory, Topic, Post
-from zds.forum.tests.tests_views import create_category
+from zds.forum.factories import create_category_and_forum
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.searchv2.models import ESIndexManager
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, publish_content
@@ -22,7 +22,7 @@ class ESIndexManagerTests(TutorialTestMixin, TestCase):
         self.mas = ProfileFactory().user
         settings.ZDS_APP['member']['bot_account'] = self.mas.username
 
-        self.category, self.forum = create_category()
+        self.category, self.forum = create_category_and_forum()
 
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user

--- a/zds/searchv2/tests/tests_utils.py
+++ b/zds/searchv2/tests/tests_utils.py
@@ -10,7 +10,7 @@ from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory
 from zds.tutorialv2.models.database import PublishedContent
 from zds.tutorialv2.publication_utils import publish_content
 from zds.forum.factories import TopicFactory, PostFactory, Topic, Post
-from zds.forum.tests.tests_views import create_category
+from zds.forum.factories import create_category_and_forum
 from zds.searchv2.models import ESIndexManager
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 
@@ -24,7 +24,7 @@ class UtilsTests(TutorialTestMixin, TestCase):
         self.mas = ProfileFactory().user
         settings.ZDS_APP['member']['bot_account'] = self.mas.username
 
-        self.category, self.forum = create_category()
+        self.category, self.forum = create_category_and_forum()
 
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user

--- a/zds/searchv2/tests/tests_views.py
+++ b/zds/searchv2/tests/tests_views.py
@@ -8,8 +8,10 @@ from django.conf import settings
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 
+from django.contrib.auth.models import Group
 from zds.forum.factories import TopicFactory, PostFactory, Topic, Post, TagFactory
-from zds.forum.tests.tests_views import create_category, Group
+from zds.forum.factories import create_category_and_forum
+
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.searchv2.models import ESIndexManager
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, publish_content, \
@@ -27,7 +29,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.mas = ProfileFactory().user
         settings.ZDS_APP['member']['bot_account'] = self.mas.username
 
-        self.category, self.forum = create_category()
+        self.category, self.forum = create_category_and_forum()
 
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user
@@ -214,7 +216,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         text = 'test'
 
         group = Group.objects.create(name='Les illuminatis anonymes de ZdS')
-        _, hidden_forum = create_category(group)
+        _, hidden_forum = create_category_and_forum(group)
 
         self.staff.groups.add(group)
         self.staff.save()
@@ -556,7 +558,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         text = 'test'
 
         group = Group.objects.create(name='Les illuminatis anonymes de ZdS')
-        _, hidden_forum = create_category(group)
+        _, hidden_forum = create_category_and_forum(group)
 
         self.staff.groups.add(group)
         self.staff.save()

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -143,3 +143,19 @@ class TagValidator(object):
     @property
     def errors(self):
         return self.__errors
+
+
+class FieldValidatorMixin:
+    def get_non_empty_field_or_error(self, cleaned_data, key, error_message):
+        value = cleaned_data.get(key)
+        if value is not None and value.strip():
+            return value
+        else:
+            self._errors[key] = self.error_class([error_message()])
+            if key in cleaned_data:
+                del cleaned_data[key]
+            return None
+
+    def check_text_length_limit(self, text, max_length, message_format):
+        if len(text) > max_length:
+            self._errors['text'] = [message_format().format(max_length)]


### PR DESCRIPTION
Après #5082 qui retirait des redondances de `zds/forum/feeds`, cette PR factorise du code de vérification de champs dans `zds/forum/forms`, en mettant du code utilitaire dans `zds/utils/forms` -- peut-être utilisable en dehors de `zds/forum` à terme ?

Cette PR dépend de #5083 (donc les commits de #5083 sont aussi inclus ici), dont j'ai eu besoin pour écrire un nouveau fichier de test `zds/forum/tests/tests_forms`. Ces tests ne dépendent pas d'avoir une instance du serveur qui tourne, donc j'ai pu tester, et les nouveaux tests passent.