### PR TITLE
Change md export

### DIFF
--- a/templates/tutorialv2/export/content.md
+++ b/templates/tutorialv2/export/content.md
@@ -4,7 +4,6 @@
 {% if content.introduction %}
 {% captureas intro %}{{ content.get_introduction|safe }}{% endcaptureas %}
 {% if intro.strip != '' %}
-# Introduction
 
 {{ intro }}
 {% endif %}
@@ -45,7 +44,8 @@
 {% if content.conclusion %}
 {% captureas conclu %}{{ content.get_conclusion|safe }}{% endcaptureas %}
 {% if conclu.strip != '' %}
-# Conclusion
+
+---------
 
 {{ conclu }}
 {% endif %}

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -847,6 +847,15 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
 
         return self.get_absolute_url_to_extra_content('pdf')
 
+    def get_absolute_url_tex(self):
+        """wrapper around ``self.get_absolute_url_to_extra_content('tex')``
+
+        :return: URL to the tex version of the published content
+        :rtype: str
+        """
+
+        return self.get_absolute_url_to_extra_content('tex')
+
     def get_absolute_url_epub(self):
         """wrapper around ``self.get_absolute_url_to_extra_content('epub')``
 

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -416,8 +416,8 @@ class ZMarkdownRebberLatexPublicator(Publicator):
             latex_file.write(content)
 
         try:
-            self.full_tex_compiler_call(latex_file_path)
-            self.full_tex_compiler_call(latex_file_path)
+            self.full_tex_compiler_call(latex_file_path, draftmode='-draftmode')
+            self.full_tex_compiler_call(latex_file_path, draftmode='-draftmode')
             self.make_glossary(base_name.split('/')[-1], latex_file_path)
             self.full_tex_compiler_call(latex_file_path)
         except FailureDuringPublication:
@@ -428,8 +428,8 @@ class ZMarkdownRebberLatexPublicator(Publicator):
             logging.info('published latex=%s, pdf=%s', published_content_entity.has_type('tex'),
                          published_content_entity.has_type(self.doc_type))
 
-    def full_tex_compiler_call(self, latex_file):
-        success_flag = self.tex_compiler(latex_file)
+    def full_tex_compiler_call(self, latex_file, draftmode: str=''):
+        success_flag = self.tex_compiler(latex_file, draftmode)
         if not success_flag:
             handle_tex_compiler_error(latex_file, self.extension)
 
@@ -438,8 +438,8 @@ class ZMarkdownRebberLatexPublicator(Publicator):
             errors = '\n'.join(filter(line for line in latex_log if 'fatal' in line.lower() or 'error' in line.lower()))
         raise FailureDuringPublication(errors)
 
-    def tex_compiler(self, texfile):
-        command = 'lualatex -shell-escape -interaction=nonstopmode {}'.format(texfile)
+    def tex_compiler(self, texfile, draftmode: str=''):
+        command = 'lualatex -shell-escape -interaction=nonstopmode {} {}'.format(draftmode, texfile)
         command_process = subprocess.Popen(command,
                                            shell=True, cwd=path.dirname(texfile),
                                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -201,7 +201,18 @@ def shift_heading(text, count):
     :return: Filtered text.
     :rtype: str
     """
-    return re.sub(r'(^|\n)(?P<level>#{1,4})(?P<header>.*?)#*(\n|$)', lambda t: sub_hd(t, count), text)
+    text_by_code = re.split('(```|~~~)', text)
+    starting_code = None
+    for i, element in enumerate(text_by_code):
+        if element in ['```', '~~~'] and not starting_code:
+            starting_code = element
+        elif element == starting_code:
+            starting_code = None
+        elif starting_code is None:
+            text_by_code[i] = re.sub(r'(^|\n)(?P<level>#{1,4})(?P<header>.*?)#*(\n|$)',
+                                     lambda t: sub_hd(t, count), text_by_code[i])
+
+    return ''.join(text_by_code)
 
 
 @register.filter('shift_heading_1')

--- a/zds/utils/templatetags/tests/tests_emarkdown.py
+++ b/zds/utils/templatetags/tests/tests_emarkdown.py
@@ -1,5 +1,9 @@
+from textwrap import dedent
+
 from django.test import TestCase
 from django.template import Context, Template
+
+from zds.utils.templatetags.emarkdown import shift_heading
 
 
 class EMarkdownTest(TestCase):
@@ -22,7 +26,7 @@ class EMarkdownTest(TestCase):
         )
         self.assertEqual(tr, expected)
 
-        # Todo: Found a way to force parsing crash or simulate it.
+        # Todo: Find a way to force parsing crash or simulate it.
 
     def test_emarkdown_inline(self):
         # The goal is not to test zmarkdown but test that template tag correctly call it
@@ -36,7 +40,7 @@ class EMarkdownTest(TestCase):
 
         self.assertEqual(tr, expected)
 
-        # Todo: Found a way to force parsing crash or simulate it.
+        # Todo: Find a way to force parsing crash or simulate it.
 
     def test_shift_heading(self):
         tr = Template('{% load emarkdown %}{{ content | shift_heading_1}}').render(self.context)
@@ -56,3 +60,38 @@ class EMarkdownTest(TestCase):
                          '##### Titre **2**\n\n'
                          '###### Titre 3\n\n'
                          '&gt; test', tr)
+
+    def test_special_shift_heading(self):
+        sharp_in_code = dedent("""
+        # title
+        ```
+        # comment
+        ```
+        # another title
+        """)
+        result_sharp_in_code = dedent("""
+        ## title
+        ```
+        # comment
+        ```
+        ## another title
+        """)
+        self.assertEqual(shift_heading(sharp_in_code, 1), result_sharp_in_code)
+
+        sharp_in_code_with_antiquotes = dedent("""
+        # title
+        ~~~
+        ```
+        # comment
+        ~~~
+        # another title
+        """)
+        result_sharp_in_code_with_antiquotes = dedent("""
+        ## title
+        ~~~
+        ```
+        # comment
+        ~~~
+        ## another title
+        """)
+        self.assertEqual(shift_heading(sharp_in_code_with_antiquotes, 1), result_sharp_in_code_with_antiquotes)


### PR DESCRIPTION
Cette PR a pour but de se concentrer sur les exports de contenus, mais à la marge.

Sur le forum, plusieurs bugs ont été détecté : 

- pas d'url latex
- lorsqu'on a des `#` dans des blocs de code, on voit apparaître des `##` devant
- le pdf est long à générer (@pierre-24 j'ai mis un draftmode)
- dans le md (et donc le pdf) l'intro a une partie pour elle seule.

# pour la QA : 

- assurez-vous d'avoir la stack complète (install-full) sinon ni le latex ni le pdf ne seront créés
- créez un tutoriel avec un code C qui a un `# include <wtf.io>` par exemple
- publiez-le

- assurez-vous que dans l'interface le lien de téléchargement latex mène bien audit latex
- téléchargez le mardown (nécessite d'être staff) => assurez vous que `# include` est bine mis comme ça et n'est pas précédé d'autre `#`
