### PR TITLE
Corrige la notification de message privé (fix #5106)

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -226,8 +226,8 @@
                             {% for notification in header_private_topic_notifications.list %}
                                 <li>
                                     <a href="{{ notification.url }}">
-                                        <img src="{{ notification.sender.profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar">
-                                        <span class="username">{{ notification.sender.username }}</span>
+                                        <img src="{{ notification.author.profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar">
+                                        <span class="username">{{ notification.author.username }}</span>
                                         <span class="date">{{ notification.pubdate|format_date:True|capfirst }}</span>
                                         <span class="topic">{{ notification.title }}</span>
                                     </a>


### PR DESCRIPTION
Corrige #5106 

J'ai regardé l'historique de modification du gabarit et il n'a pas été touché depuis un certain temps. Je ne comprends pas pourquoi le problème est arrivé d'un coup avec la v27.3, c'est très mystérieux... J'ai essayé de mettre `author` à place de `sender` car c'est ce qui est utilisé pour les autres notifications (forum, commentaire, ping) et ça a fonctionné.

**QA :**

- Lancer le serveur
- Vérifier que sur les notifications de nouveau message privé, le pseudo et l'avatar s'affichent bien