### PR TITLE
Corrige les filtres de la recherche (fix #5107)

### DIFF
--- a/templates/searchv2/search.html
+++ b/templates/searchv2/search.html
@@ -27,16 +27,7 @@
                 {% for radio in form.models %}
                     <li>
 
-                        <input id="{{ radio.id_for_label }}"
-                               form="search-form"
-                               name="models"
-                               type="checkbox"
-                               value="{{ radio.choice_value }}"
-
-                               {% if radio.choice_value in form.cleaned_data.models %}
-                                   checked
-                               {% endif %}
-                                >
+                        {{ radio.tag }}
 
                         <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
                     </li>

--- a/zds/searchv2/forms.py
+++ b/zds/searchv2/forms.py
@@ -31,7 +31,12 @@ class SearchForm(forms.Form):
 
     models = forms.MultipleChoiceField(
         label='',
-        widget=forms.CheckboxSelectMultiple,
+        widget=forms.CheckboxSelectMultiple(
+            attrs={
+                'class': 'search-filters',
+                'form': 'search-form'
+            }
+        ),
         required=False,
         choices=choices
     )


### PR DESCRIPTION
Corrige #5107 

Je ne sais pas pourquoi `radio.choice_value` ne retourne plus rien tout d'un coup, malgré plusieurs heures de recherches... Le mystère reste entier ! Mais bon, c'est bloquant et j'ai un correctif qui fonctionne donc on va s'en contenter pour l'instant :)

**QA :** 

- Lancer ElasticSearch avec `./.local/elasticsearch/bin/elasticsearch` (il faut au préalable l'avoir installé avec `make install-linux-full`)
- Lancer le serveur
- Vérifier que la recherche ne met pas d'erreur 403 quand on sélectionne les filtres
- Vérifier que les filtres fonctionnent correctement