### PR TITLE
Corrige "Aller à la page" dans la pagination (fix #5108)

### DIFF
--- a/templates/misc/paginator.html
+++ b/templates/misc/paginator.html
@@ -46,11 +46,9 @@
                 <li>
                     <a href="#pagination-{{ position }}" class="open-modal">...</a>
                     <form action="." method="get" class="modal modal-flex" id="pagination-{{ position }}" data-modal-title='{% trans "Aller à la page…" %}'>
-                        {% for key,val in request.GET.iterlists %}
+                        {% for key,val in request.GET.items %}
                             {% if key != "page" %}
-                                {% for v in val %}
-                                    <input type="hidden" name="{{ key }}" value="{{ v }}">
-                                {% endfor %}
+                                    <input type="hidden" name="{{ key }}" value="{{ val }}">
                             {% endif %}
                         {% endfor %}
                         <p>


### PR DESCRIPTION
Corrige #5108 

- Remplace `iterlists` par `items` => je suppose que ça fonctionnait avec une ancienne version de Django mais que le nom a changé depuis
- On n'itère pas sur `val` => **je ne sais pas si ça avait une utilité ou pas, il se peut que ça crée des problèmes sur une autre page**

**QA :**
- Lancer le serveur
- Aller sur la bibliothèque, puis "Voir tous les tutoriels"
- Dans la pagination, cliquer sur "..." pour aller à une page intermédiaire
- Vérifier qu'on retombe bien sur la liste des tutoriels et non pas sur la page principale de la Bibliothèque

Astuce si vous n'avez pas beaucoup de tutoriels pour faire afficher la pagination : `ZDS_APP['content']['content_per_page'] = 1`