### PR TITLE
Améliore le Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,8 +138,7 @@ script:
   - |
     # test and build frontend
     if [[ "$ZDS_TEST_JOB" == *"front"* ]]; then
-      yarn test \
-      && yarn build # we need to upload the assets later
+      yarn run lint && yarn run build # we need to upload the assets later
     fi
   - |
     # test backend
@@ -162,7 +161,7 @@ script:
   - |
     # selenium tests
     if [[ "$ZDS_TEST_JOB" == *"selenium"* ]]; then
-      yarn build
+      yarn run build
       xvfb-run --server-args="-screen 0 1280x720x8" python manage.py \
         test -v=2\
         --settings zds.settings.ci_test \
@@ -171,7 +170,7 @@ script:
     fi
 
   - |
-    # test and build frontend
+    # build documentation
     if [[ "$ZDS_TEST_JOB" == *"doc"* ]]; then
       make --directory doc html
     fi

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -184,6 +184,5 @@ gulp.task('errors', () =>
         .pipe(sourcemaps.write('.', { includeContent: true, sourceRoot: '../scss/' }))
         .pipe(gulp.dest('errors/css/')));
 
-gulp.task('test', ['js:lint']);
 gulp.task('build', ['prepare-zmd', 'css', 'js', 'images']);
-gulp.task('default', ['watch', 'test']);
+gulp.task('default', ['watch', 'js:lint']);

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,3 @@
-.PHONY: fixtures doc
-
-all: help
-
-# install
-## linux
 install-linux:
 	./scripts/install_zds.sh +base
 
@@ -14,8 +8,6 @@ install-macos:
 	brew install gettext cairo --without-x11 py2cairo node && \
 	pip3 install virtualenv virtualenvwrapper
 
-# dev back
-## django
 generate-pdf:
 	python manage.py generate_pdf
 
@@ -34,7 +26,6 @@ index-all:
 index-flagged:
 	python manage.py es_manager index_flagged
 
-## back-utils
 clean-back:
 	find . -name '*.pyc' -exec rm {} \;
 
@@ -57,11 +48,8 @@ test-back: clean-back zmd-start
 	python manage.py test --settings zds.settings.test --exclude-tag=front
 	make zmd-stop
 
-# elasticsearch
 run-elastic:
 	elasticsearch || echo 'No elasticsearch installed (you can add it locally with `./scripts/install_zds.sh +elasticsearch`)'
-
-# zmd
 
 zmd-install:
 	cd zmd && npm -g install pm2 && npm install --production
@@ -74,10 +62,6 @@ zmd-stop:
 
 zmd-check:
 	@curl -s http://localhost:27272 || echo 'Use `make zmd-start` to start zmarkdown server'
-
-
-# front
-## front-utils
 
 build-front:
 	yarn run build
@@ -94,8 +78,6 @@ lint-front:
 watch-front:
 	yarn run gulp
 
-# generic utils
-
 clean: clean-back clean-front
 
 wipe:
@@ -103,10 +85,12 @@ wipe:
 	rm -rf contents-private/*
 	rm -rf contents-public/*
 
+.PHONY: doc
 doc:
 	cd doc && \
 	make html
 
+.PHONY: fixtures
 fixtures:
 	python manage.py loaddata fixtures/*.yaml
 	python manage.py load_factory_data fixtures/advanced/aide_tuto_media.yaml
@@ -114,43 +98,19 @@ fixtures:
 restart_db: wipe migrate fixtures
 	python manage.py load_fixtures --size=low --all
 
-help:
-	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  build-front       to build frontend code"
-	@echo "  doc               to generate the html documentation"
-	@echo "  fixtures          to load every fixtures"
-	@echo "  generate-pdf      to regenerate all PDFs"
-	@echo "  index-all         to setup and (re)index all things for search"
-	@echo "  index-flagged     to index flagged things for search"
-	@echo "  help              to get this help"
-	@echo "  install-back      to install backend dependencies"
-	@echo "  install-front     to install frontend dependencies"
-	@echo "  install-debian    to install debian dependencies"
-	@echo "  install-ubuntu    to install ubuntu dependencies"
-	@echo "  install-fedora    to install fedora dependencies"
-	@echo "  install-archlinux to install archlinux dependencies"
-	@echo "  install-macos       to install os x dependencies"
-	@echo "  lint-back         to lint backend code (flake8)"
-	@echo "  lint-front        to lint frontend code (jshint)"
-	@echo "  clean-back        to clean *.pyc"
-	@echo "  clean-front       to clean frontend builds"
-	@echo "  clean             to clean everything"
-	@echo "  wipe              to clean data (database and contents)"
-	@echo "  watch-front       to watch frontend code"
-	@echo "  migrate           to migrate the project"
-	@echo "  report-release-back  to generate release report"
-	@echo "  run               to run the project locally"
-	@echo "  run-back          to only run the backend"
-	@echo "  run-elastic       to run elasticsearch"
-	@echo "  shell             to get django shell"
-	@echo "  test              to run django tests"
-	@echo "Open this Makefile to see what each target does."
-	@echo "When a target uses an env variable (eg. $$(VAR)), you can do"
-	@echo "  make VAR=my_var cible"
-
 lint: lint-back lint-front
 
 run:
 	make -j2 watch-front run-back
 
 test: test-back test-front
+
+# inspired from https://gist.github.com/sjparkinson/f0413d429b12877ecb087c6fc30c1f0a
+
+.DEFAULT_GOAL := help
+help:
+	@echo "Use 'make [command]' to run one of these commands:"
+	@echo ""
+	@fgrep --no-filename "##" ${MAKEFILE_LIST} | head -n '-1' | sed 's/\:.*\#/\: \#/g' | column -s ':#' -t -c 2
+	@echo ""
+	@echo "Open this Makefile to see what each command does."

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@ install-linux:
 install-linux-full:
 	./scripts/install_zds.sh +full
 
-install-macos:
-	brew install gettext cairo --without-x11 py2cairo node && \
-	pip3 install virtualenv virtualenvwrapper
-
 generate-pdf:
 	python manage.py generate_pdf
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-install-linux:
+install-linux: ## Install the minimal components needed
 	./scripts/install_zds.sh +base
 
-install-linux-full:
+install-linux-full: ## Install all the components needed
 	./scripts/install_zds.sh +full
 
-generate-pdf:
+generate-pdf: ## Generate PDFs of published contents
 	python manage.py generate_pdf
 
 migrate-db: ## Create or update database schema
@@ -41,16 +41,16 @@ test-back: clean-back zmd-start ## Run backend unit tests
 run-elasticsearch: ## Run the Elastic Search server
 	elasticsearch || echo 'No Elastic Search installed (you can add it locally with `./scripts/install_zds.sh +elasticsearch`)'
 
-zmd-install:
+zmd-install: ## Install the Node.js packages for zmarkdown
 	cd zmd && npm -g install pm2 && npm install --production
 
-zmd-start:
+zmd-start: ## Start the zmarkdown server
 	cd zmd/node_modules/zmarkdown && npm run server
 
-zmd-stop:
+zmd-stop: ## Stop the zmarkdown server
 	pm2 kill
 
-zmd-check:
+zmd-check: ## Check if the zmarkdown server is running
 	@curl -s http://localhost:27272 || echo 'Use `make zmd-start` to start zmarkdown server'
 
 build-front: ## Build the frontend assets (CSS, JS, images)
@@ -68,7 +68,7 @@ lint-front: ## Lint the frontend's Javascript
 watch-front: ## Build the frontend assets when they are modified
 	yarn run watch --speed
 
-clean: clean-back clean-front
+clean: clean-back clean-front ## Clean everything (`clean-back` & `clean-front`)
 
 wipe-db: ## Remove the database and the contents directories
 	rm base.db
@@ -87,17 +87,17 @@ generate-fixtures: ## Generate fixtures (users, tutorials, articles, opinions, t
 
 new-db: wipe-db migrate-db generate-fixtures ## Create a new full database (`wipe-db` & `migrate-db` & `generate-fixtures`)
 
-lint: lint-back lint-front
+lint: lint-back lint-front ## Lint everything (`lint-back` & `lint-front`)
 
-run:
+run: ## Run the backend server and watch the frontend (`watch-front` in parallel with `run-back`)
 	make -j2 watch-front run-back
 
-test: test-back test-back-selenium
+test: test-back test-back-selenium ## Test everything (`test-back` & `test-back-selenium`)
 
 # inspired from https://gist.github.com/sjparkinson/f0413d429b12877ecb087c6fc30c1f0a
 
 .DEFAULT_GOAL := help
-help:
+help: ## Show this help
 	@echo "Use 'make [command]' to run one of these commands:"
 	@echo ""
 	@fgrep --no-filename "##" ${MAKEFILE_LIST} | head -n '-1' | sed 's/\:.*\#/\: \#/g' | column -s ':#' -t -c 2

--- a/Makefile
+++ b/Makefile
@@ -16,25 +16,25 @@ index-all: ## Index the database in a new Elastic Search index
 index-flagged: ## Index the database in the current Elastic Search index
 	python manage.py es_manager index_flagged
 
-clean-back:
+clean-back: ## Remove Python bytecode files (*.pyc)
 	find . -name '*.pyc' -exec rm {} \;
 
-install-back:
+install-back: ## Install the Python packages for the backend
 	pip3 install --upgrade -r requirements-dev.txt
 
-lint-back:
+lint-back: ## Lint Python code
 	flake8 zds
 
 generate-release-summary: ## Generate a release summary from Github's issues and PRs
 	@python scripts/generate_release_summary.py
 
-run-back: zmd-check
+run-back: zmd-check ## Run the backend server
 	python manage.py runserver
 
-test-front:
+test-back-selenium: ## Run backend Selenium tests
 	python manage.py test --settings zds.settings.test --tag=front
 
-test-back: clean-back zmd-start
+test-back: clean-back zmd-start ## Run backend unit tests
 	python manage.py test --settings zds.settings.test --exclude-tag=front
 	make zmd-stop
 
@@ -92,7 +92,7 @@ lint: lint-back lint-front
 run:
 	make -j2 watch-front run-back
 
-test: test-back test-front
+test: test-back test-back-selenium
 
 # inspired from https://gist.github.com/sjparkinson/f0413d429b12877ecb087c6fc30c1f0a
 

--- a/Makefile
+++ b/Makefile
@@ -53,20 +53,20 @@ zmd-stop:
 zmd-check:
 	@curl -s http://localhost:27272 || echo 'Use `make zmd-start` to start zmarkdown server'
 
-build-front:
+build-front: ## Build the frontend assets (CSS, JS, images)
 	yarn run build
 
-clean-front:
+clean-front: ## Clean the frontend builds
 	yarn run clean
 
-install-front:
-	yarn
+install-front: ## Install the Node.js packages for the frontend
+	yarn install
 
-lint-front:
+lint-front: ## Lint the frontend's Javascript
 	yarn run lint
 
-watch-front:
-	yarn run gulp
+watch-front: ## Build the frontend assets when they are modified
+	yarn run watch --speed
 
 clean: clean-back clean-front
 

--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,10 @@ wipe-db: ## Remove the database and the contents directories
 	rm -rf contents-private/*
 	rm -rf contents-public/*
 
-.PHONY: doc
-doc:
-	cd doc && \
-	make html
+generate-doc: ## Generate the project's documentation
+	cd doc && make html
+	@echo ""
+	@echo "Open 'doc/build/html/index.html' to read the documentation'"
 
 generate-fixtures: ## Generate fixtures (users, tutorials, articles, opinions, topics...)
 	python manage.py loaddata fixtures/*.yaml

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ generate-pdf:
 migrate-db: ## Create or update database schema
 	python manage.py migrate
 
-index-all:
+index-all: ## Index the database in a new Elastic Search index
 	python manage.py es_manager index_all
 
-index-flagged:
+index-flagged: ## Index the database in the current Elastic Search index
 	python manage.py es_manager index_flagged
 
 clean-back:
@@ -38,8 +38,8 @@ test-back: clean-back zmd-start
 	python manage.py test --settings zds.settings.test --exclude-tag=front
 	make zmd-stop
 
-run-elastic:
-	elasticsearch || echo 'No elasticsearch installed (you can add it locally with `./scripts/install_zds.sh +elasticsearch`)'
+run-elasticsearch: ## Run the Elastic Search server
+	elasticsearch || echo 'No Elastic Search installed (you can add it locally with `./scripts/install_zds.sh +elasticsearch`)'
 
 zmd-install:
 	cd zmd && npm -g install pm2 && npm install --production

--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,64 @@
+## ~ General
+
 install-linux: ## Install the minimal components needed
 	./scripts/install_zds.sh +base
 
 install-linux-full: ## Install all the components needed
 	./scripts/install_zds.sh +full
 
-generate-pdf: ## Generate PDFs of published contents
-	python manage.py generate_pdf
+new-db: wipe-db migrate-db generate-fixtures ## Create a new full database (`wipe-db` & `migrate-db` & `generate-fixtures`)
 
-migrate-db: ## Create or update database schema
-	python manage.py migrate
+run: ## Run the backend server and watch the frontend (`watch-front` in parallel with `run-back`)
+	make -j2 watch-front run-back
 
-index-all: ## Index the database in a new Elastic Search index
-	python manage.py es_manager index_all
+lint: lint-back lint-front ## Lint everything (`lint-back` & `lint-front`)
 
-index-flagged: ## Index the database in the current Elastic Search index
-	python manage.py es_manager index_flagged
+test: test-back test-back-selenium ## Test everything (`test-back` & `test-back-selenium`)
 
-clean-back: ## Remove Python bytecode files (*.pyc)
-	find . -name '*.pyc' -exec rm {} \;
+clean: clean-back clean-front ## Clean everything (`clean-back` & `clean-front`)
+
+##
+## ~ Backend
 
 install-back: ## Install the Python packages for the backend
 	pip3 install --upgrade -r requirements-dev.txt
 
-lint-back: ## Lint Python code
-	flake8 zds
-
-generate-release-summary: ## Generate a release summary from Github's issues and PRs
-	@python scripts/generate_release_summary.py
-
 run-back: zmd-check ## Run the backend server
 	python manage.py runserver
 
-test-back-selenium: ## Run backend Selenium tests
-	python manage.py test --settings zds.settings.test --tag=front
+lint-back: ## Lint Python code
+	flake8 zds
 
 test-back: clean-back zmd-start ## Run backend unit tests
 	python manage.py test --settings zds.settings.test --exclude-tag=front
 	make zmd-stop
 
-run-elasticsearch: ## Run the Elastic Search server
-	elasticsearch || echo 'No Elastic Search installed (you can add it locally with `./scripts/install_zds.sh +elasticsearch`)'
+test-back-selenium: ## Run backend Selenium tests
+	python manage.py test --settings zds.settings.test --tag=front
+
+clean-back: ## Remove Python bytecode files (*.pyc)
+	find . -name '*.pyc' -exec rm {} \;
+
+##
+## ~ Frontend
+
+install-front: ## Install the Node.js packages for the frontend
+	yarn install
+
+build-front: ## Build the frontend assets (CSS, JS, images)
+	yarn run build
+
+watch-front: ## Build the frontend assets when they are modified
+	yarn run watch --speed
+
+lint-front: ## Lint the frontend's Javascript
+	yarn run lint
+
+clean-front: ## Clean the frontend builds
+	yarn run clean
+
+##
+## ~ zmarkdown
 
 zmd-install: ## Install the Node.js packages for zmarkdown
 	cd zmd && npm -g install pm2 && npm install --production
@@ -47,52 +66,56 @@ zmd-install: ## Install the Node.js packages for zmarkdown
 zmd-start: ## Start the zmarkdown server
 	cd zmd/node_modules/zmarkdown && npm run server
 
-zmd-stop: ## Stop the zmarkdown server
-	pm2 kill
-
 zmd-check: ## Check if the zmarkdown server is running
 	@curl -s http://localhost:27272 || echo 'Use `make zmd-start` to start zmarkdown server'
 
-build-front: ## Build the frontend assets (CSS, JS, images)
-	yarn run build
+zmd-stop: ## Stop the zmarkdown server
+	pm2 kill
 
-clean-front: ## Clean the frontend builds
-	yarn run clean
+##
+## ~ Elastic Search
 
-install-front: ## Install the Node.js packages for the frontend
-	yarn install
+run-elasticsearch: ## Run the Elastic Search server
+	elasticsearch || echo 'No Elastic Search installed (you can add it locally with `./scripts/install_zds.sh +elasticsearch`)'
 
-lint-front: ## Lint the frontend's Javascript
-	yarn run lint
+index-all: ## Index the database in a new Elastic Search index
+	python manage.py es_manager index_all
 
-watch-front: ## Build the frontend assets when they are modified
-	yarn run watch --speed
+index-flagged: ## Index the database in the current Elastic Search index
+	python manage.py es_manager index_flagged
 
-clean: clean-back clean-front ## Clean everything (`clean-back` & `clean-front`)
+##
+## ~ PDF
 
-wipe-db: ## Remove the database and the contents directories
-	rm base.db
-	rm -rf contents-private/*
-	rm -rf contents-public/*
+generate-pdf: ## Generate PDFs of published contents
+	python manage.py generate_pdf
 
-generate-doc: ## Generate the project's documentation
-	cd doc && make html
-	@echo ""
-	@echo "Open 'doc/build/html/index.html' to read the documentation'"
+##
+## ~ Database
+
+migrate-db: ## Create or update database schema
+	python manage.py migrate
 
 generate-fixtures: ## Generate fixtures (users, tutorials, articles, opinions, topics...)
 	python manage.py loaddata fixtures/*.yaml
 	python manage.py load_factory_data fixtures/advanced/aide_tuto_media.yaml
 	python manage.py load_fixtures --size=low --all
 
-new-db: wipe-db migrate-db generate-fixtures ## Create a new full database (`wipe-db` & `migrate-db` & `generate-fixtures`)
+wipe-db: ## Remove the database and the contents directories
+	rm base.db
+	rm -rf contents-private/*
+	rm -rf contents-public/*
 
-lint: lint-back lint-front ## Lint everything (`lint-back` & `lint-front`)
+##
+## ~ Tools
 
-run: ## Run the backend server and watch the frontend (`watch-front` in parallel with `run-back`)
-	make -j2 watch-front run-back
+generate-doc: ## Generate the project's documentation
+	cd doc && make html
+	@echo ""
+	@echo "Open 'doc/build/html/index.html' to read the documentation'"
 
-test: test-back test-back-selenium ## Test everything (`test-back` & `test-back-selenium`)
+generate-release-summary: ## Generate a release summary from Github's issues and PRs
+	@python scripts/generate_release_summary.py
 
 # inspired from https://gist.github.com/sjparkinson/f0413d429b12877ecb087c6fc30c1f0a
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test-back: clean-back zmd-start ## Run backend unit tests
 	make zmd-stop
 
 test-back-selenium: ## Run backend Selenium tests
-	python manage.py test --settings zds.settings.test --tag=front
+	xvfb-run --server-args="-screen 0 1280x720x8" python manage.py test --settings zds.settings.test --tag=front
 
 clean-back: ## Remove Python bytecode files (*.pyc)
 	find . -name '*.pyc' -exec rm {} \;

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install-linux-full:
 generate-pdf:
 	python manage.py generate_pdf
 
-migrate:
+migrate-db: ## Create or update database schema
 	python manage.py migrate
 
 index-all:
@@ -70,7 +70,7 @@ watch-front:
 
 clean: clean-back clean-front
 
-wipe:
+wipe-db: ## Remove the database and the contents directories
 	rm base.db
 	rm -rf contents-private/*
 	rm -rf contents-public/*
@@ -80,13 +80,12 @@ doc:
 	cd doc && \
 	make html
 
-.PHONY: fixtures
-fixtures:
+generate-fixtures: ## Generate fixtures (users, tutorials, articles, opinions, topics...)
 	python manage.py loaddata fixtures/*.yaml
 	python manage.py load_factory_data fixtures/advanced/aide_tuto_media.yaml
-
-restart_db: wipe migrate fixtures
 	python manage.py load_fixtures --size=low --all
+
+new-db: wipe-db migrate-db generate-fixtures ## Create a new full database (`wipe-db` & `migrate-db` & `generate-fixtures`)
 
 lint: lint-back lint-front
 

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ install-back:
 lint-back:
 	flake8 zds
 
-report-release-back:
-	python scripts/release_generator.py
+generate-release-summary: ## Generate a release summary from Github's issues and PRs
+	@python scripts/generate_release_summary.py
 
 run-back: zmd-check
 	python manage.py runserver

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,6 @@ generate-pdf:
 migrate:
 	python manage.py migrate
 
-reset:
-	python manage.py reset
-
-shell:
-	python manage.py shell
-
 index-all:
 	python manage.py es_manager index_all
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ La procédure d'installation [est détaillée ici](http://docs.zestedesavoir.com
 Pour bénéficier de données de test, exécutez la commande suivante:
 
 ```console
-make fixtures
+make generate-fixtures
 ```
 
 Si vous êtes sur Windows, préférez ceci :

--- a/doc/source/install/extra-install-frontend.rst
+++ b/doc/source/install/extra-install-frontend.rst
@@ -121,8 +121,8 @@ que vous devez corriger.
 .. note::
    L'outil d'intégration continue que nous utilisons, Travis CI, fait cette vérification à la création de chaque *pull
    request* et sortira la liste des erreurs et des avertissements. Pour éviter d'attendre qu'il ait fini, il est plus
-   pratique pour vous (et nous) que vous lanciez cette commande en amont avec ``make lint-front`` ou ``yarn run test`` (ou
-   ``yarn test``).
+   pratique pour vous (et nous) que vous lanciez cette commande en amont avec ``make lint-front`` ou ``yarn run lint`` (ou
+   ``yarn lint``).
 
 Coder plus simplement avec ``watch``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -108,7 +108,7 @@ Strictement équivalent au commande suivantes:
 .. sourcecode:: bash
 
     make install-back # Dépendances Python
-    make migrate # Cf. "migrate" de Django
+    make migrate-db # Cf. "migrate" de Django
 
 Composant ``front``
 ===================
@@ -145,7 +145,7 @@ Strictement équivalent à la commande suivantes:
 
 .. sourcecode:: bash
 
-    make fixtures
+    make generate-fixtures
 
 Plus d'info sur cette fonctionalité `sur la page dédiée <../utils/fixture_loaders.html>`_.
 

--- a/doc/source/install/install-osx.rst
+++ b/doc/source/install/install-osx.rst
@@ -97,16 +97,15 @@ On crée d'abord la base de donnée, puis le `jeu de données utile au dévellop
 
 .. sourcecode:: bash
 
-    make migrate
-    make fixtures
+    make migrate-db
+    make generate-fixtures
 
 On peut finalement lancer zmarkdown, puis ZdS:
 
 .. sourcecode:: bash
 
-    make zmd-run
+    make zmd-start
     make run-back
-
 
 
 Aller plus loin

--- a/doc/source/install/install-osx.rst
+++ b/doc/source/install/install-osx.rst
@@ -2,6 +2,10 @@
 Installation sous macOS
 =======================
 
+.. Attention::
+
+    Cette partie de la documentation n'est probablement pas à jour faute de contributeur utilisant MacOS. Il se peut que l'installation et les tests unitaires fonctionnent correctement, partiellement ou pas du tout. Bref, en cas de problème n'hésitez pas à venir demander de l'aide sur le `forum des Devs' de Zeste de Savoir <https://zestedesavoir.com/forums/communaute/dev-zone/>`_ !
+
 Pour installer une version locale de ZdS sur macOS, veuillez suivre les instructions suivantes.
 Si une commande ne passe pas, essayez de savoir pourquoi avant de continuer.
 
@@ -34,7 +38,8 @@ Pré-requis
 
 .. sourcecode:: bash
 
-  make install-macos
+  brew install gettext cairo --without-x11 py2cairo node && \
+  pip3 install virtualenv virtualenvwrapper
 
 Une fois les pré-requis terminés, vous pouvez vous lancer dans l'installaton de l'environnement de zds.
 

--- a/package.json
+++ b/package.json
@@ -10,10 +10,9 @@
   },
   "scripts": {
     "gulp": "gulp",
-    "lint": "gulp js:lint",
-    "travis": "gulp test && gulp build",
-    "test": "gulp test",
     "build": "gulp build",
+    "watch": "gulp watch",
+    "lint": "gulp js:lint",
     "clean": "gulp clean"
   },
   "repository": {

--- a/scripts/generate_release_summary.py
+++ b/scripts/generate_release_summary.py
@@ -120,6 +120,7 @@ def dump_issues(milestone, openissues, closed_bug, closed_evo, closed_unk):
         out.write(mdarray(closed_evo))
         out.write('## Non défini\n\n')
         out.write(mdarray(closed_unk))
+    print('==> Vous pouvez trouver le rapport dans', OUTPUT_PATH)
 
 
 def mdarray(tableau):

--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -252,7 +252,7 @@ fi
 if  ! $(_in "-back" $@) && ( $(_in "+back" $@) || $(_in "+base" $@) || $(_in "+full" $@) ); then
     info "* [+back] install back dependencies & migration"
     make install-back
-    make migrate # migration are required for the instance to run properly anyway
+    make migrate-db # migration are required for the instance to run properly anyway
 fi
 
 # install front
@@ -275,6 +275,6 @@ fi
 # fixtures
 if  ! $(_in "-data" $@) && ( $(_in "+data" $@) || $(_in "+base" $@) || $(_in "+full" $@) ); then
     info "* [+data] fixtures"
-    make fixtures
+    make generate-fixtures
 fi
 info "Done. You can now run instance with \`source $ZDS_VENV/bin/activate\`, and then, \`make zmd-start && make run-back\`"


### PR DESCRIPTION
Améliore le Makefile (voir la liste des commits pour avoir tous les détails)

fix #5081

- `make help` est généré automatiquement à partir des commentaires de chaque commande du Makefile
- `make reset` et `make shell` sont supprimées
- `make doc` et `make report-release-back` sont renommées
- Des commandes sont légèrement modifiées
- La structure du Makefile est revue pour regrouper les commandes et les afficher proprement avec `make help`
- Modifie les commandes dans le `.travis.yml` et le `script/zds_install.sh`
- Modifie les commandes dans la documentation et dans le README.md
- Ajoute `xvfb` dans `make test-back-selenium`

Je ne pense pas changer les commandes `lint-back` et `lint-front` dans cette PR car elle est déjà assez grosse comme ça je trouve.

**QA :**

- Vérifier que les commandes fonctionnent bien (je pense que c'est impossible de toutes les tester, donc de la relecture et Travis CI devrait suffire)
- Vérifier que les noms des commandes sont bien choisis
- Vérifier que les commentaires des commandes sont dans un anglais correct et compréhensible

**Aperçu de `make help` :**

```
$ make help
Use 'make [command]' to run one of these commands:

 ~ General
install-linux                 Install the minimal components needed
install-linux-full            Install all the components needed
new-db                        Create a new full database (`wipe-db` & `migrate-db` & `generate-fixtures`)
run                           Run the backend server and watch the frontend (`watch-front` in parallel with `run-back`)
lint                          Lint everything (`lint-back` & `lint-front`)
test                          Test everything (`test-back` & `test-back-selenium`)
clean                         Clean everything (`clean-back` & `clean-front`)

 ~ Backend
install-back                  Install the Python packages for the backend
run-back                      Run the backend server
lint-back                     Lint Python code
test-back                     Run backend unit tests
test-back-selenium            Run backend Selenium tests
clean-back                    Remove Python bytecode files (*.pyc)

 ~ Frontend
install-front                 Install the Node.js packages for the frontend
build-front                   Build the frontend assets (CSS, JS, images)
watch-front                   Build the frontend assets when they are modified
lint-front                    Lint the frontend's Javascript
clean-front                   Clean the frontend builds

 ~ zmarkdown
zmd-install                   Install the Node.js packages for zmarkdown
zmd-start                     Start the zmarkdown server
zmd-check                     Check if the zmarkdown server is running
zmd-stop                      Stop the zmarkdown server

 ~ Elastic Search
run-elasticsearch             Run the Elastic Search server
index-all                     Index the database in a new Elastic Search index
index-flagged                 Index the database in the current Elastic Search index

 ~ PDF
generate-pdf                  Generate PDFs of published contents

 ~ Database
migrate-db                    Create or update database schema
generate-fixtures             Generate fixtures (users, tutorials, articles, opinions, topics...)
wipe-db                       Remove the database and the contents directories

 ~ Tools
generate-doc                  Generate the project's documentation
generate-release-summary      Generate a release summary from Github's issues and PRs
help                          Show this help

Open this Makefile to see what each command does.
```