### PR TITLE
Améliore le bandeau sur l'utilisation des cookies (fix #5074)

### DIFF
--- a/assets/scss/components/_cookies-banner.scss
+++ b/assets/scss/components/_cookies-banner.scss
@@ -1,85 +1,49 @@
 #cookies-eu-banner {
-    padding: 0 3%;
-    background: #062E41;
+    padding: 5px 25px;
+    background: #062e41;
     display: none;
 
-    div,
-    #cookies-eu-reject {
-        display: inline-block;
-        margin: 0;
-        padding: 7px 0;
-        color: #EEE;
-        line-height: 23px;
-    }
-    #cookies-eu-reject {
-        background: none;
-        border: none;
-        text-decoration: underline;
-
-        &:hover,
-        &:focus {
-            text-decoration: none;
-        }
+    p {
+        margin: 5px 0;
+        color: #eee;
     }
 
     #cookies-eu-more,
-    #cookies-eu-accept {
-        display: inline-block;
-        margin-top: 3px;
-        padding: 4px 15px;
-        text-decoration: none;
-        transition: background $transition-duration, color $transition-duration;
+    #cookies-eu-accept,
+    #cookies-eu-reject {
+        padding: 6px 15px;
+        margin: 5px 0;
+
+        transition-property: background, color;
+        transition-duration: $transition-duration;
     }
+
     #cookies-eu-more {
-        margin-left: 15px;
-        color: #EEE;
+        text-decoration: none;
+
+        color: #eee;
         background: $color-primary;
 
         &:hover,
         &:focus {
             color: $color-primary;
-            background: #EEE;
+            background: #eee;
         }
     }
-    #cookies-eu-accept {
+
+    #cookies-eu-accept,
+    #cookies-eu-reject {
         border: none;
+        line-height: 1.295;
+        margin-left: 5px;
+
         color: $color-primary;
-        background: #EEE;
+        background: #eee;
 
         &:hover,
         &:focus {
             color: #EEE;
             background: $color-primary;
-        }
-    }
-}
-
-@media only screen and #{$media-mobile} {
-    #cookies-eu-banner {
-        position: absolute;
-        top: 50px;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        z-index: 10;
-
-        div {
-            margin-top: 40px;
-            padding: 0 5px;
-        }
-
-        #cookies-eu-more,
-        #cookies-eu-accept {
-            display: block;
-            width: 100%;
-            height: 40px;
-            padding: 0 !important;
-            margin: 15px 0 0 0 !important;
-            text-align: center;
-        }
-        #cookies-eu-more {
-            margin-top: 40px !important;
-            line-height: 40px;
         }
     }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -162,12 +162,12 @@
         </ul>
 
         <div id="cookies-eu-banner">
-            <div>
-                {% trans "Ce site utilise Google Analytics. En poursuivant votre navigation sur ce site, vous nous autorisez à déposer des cookies à des fins de mesure d’audience. Pour s’opposer à ce dépôt vous pouvez cliquer" %}
-                <button id="cookies-eu-reject">{% trans "ici" %}</button>.
-            </div>
+            <p>
+                {% trans "Nous souhaitons déposer des cookies à des fins de mesure d'audience avec Google Analytics. Vous êtes libre d'accepter ou de refuser. En poursuivant votre navigation sur ce site sans exprimer votre choix, vous autorisez la mesure d'audience." %}
+            </p>
             <a href="/pages/cookies" id="cookies-eu-more">{% trans "En savoir plus" %}</a>
-            <button id="cookies-eu-accept">{% trans "OK" %}</button>
+            <button id="cookies-eu-accept">{% trans "Accepter" %}</button>
+            <button id="cookies-eu-reject">{% trans "Refuser" %}</button>
         </div>
 
         <div class="header-container">


### PR DESCRIPTION
Améliore le bandeau d'utilisation des cookies (ticket #5074)

- Il y a deux boutons "Accepter" et "Refuser" pour donner vraiment la possibilité d'un choix
- Le texte est plus explicite sur les choix possibles et sur ce qu'il se passe si l'utilisateur ne clique pas sur un des boutons
- Sur mobile, l'affichage est le même que sur ordinateur pour que l'utilisateur puisse cliquer sur "En savoir plus" et lire la page des cookies sans être gêné par le bandeau

**QA :**

- `make build-front`
- Bien penser à vider ses cookies et désactiver le Do Not Track pour que la barre s'affiche
- Tester sur ordinateur et sur mobile

**Aperçu :**

![Aperçu sur ordinateur](https://user-images.githubusercontent.com/6664636/49371298-5187a800-f6f7-11e8-96f7-8e65b70e1783.png)

![Aperçu sur mobile](https://user-images.githubusercontent.com/6664636/49371343-7845de80-f6f7-11e8-82ec-01d1e52175e5.png)
