### PR TITLE
Supprime une propriété CSS causant des problèmes (fix #5124)

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -138,7 +138,6 @@
             ul:not(.pagination) {
                 font-size: 15px;
                 font-size: 1.5rem;
-                font-size: 1.8ex;
             }
         }
 


### PR DESCRIPTION
Corrige le bug très bloquant apparu avec Chrome 71 #5124 

**QA :**

- Générer les fichiers CSS avec `make build-front`
- Lancer le serveur avec `make run-back`
- Vérifier que l'ordinateur et le téléphone sont sur le même réseau WIFI
- Ajouter `ALLOWED_HOSTS = ('adresse IP de l'ordinateur',)` à `zds/settings/abstract_base/django.py` pour pouvoir se connecter depuis le téléphone
- Sur le téléphone, ouvrir Google Chrome v71 puis aller sur un contenu
- Vérifier que le contenu s'affiche avec le texte à la bonne taille (comparer avec un contenu de zestedesavoir.com)