### PR TITLE
Améliore le support de make install-linux avec `/etc/issue`

### DIFF
--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -42,7 +42,8 @@ fi
 # os-specific package install
 if  ! $(_in "-packages" $@) && ( $(_in "+packages" $@) || $(_in "+base" $@) || $(_in "+full" $@) ); then
     echo "* [+packages] installing packages (require sudo)"
-    version=$(cat /proc/version)
+    version="$(cat /proc/version) $(cat /etc/issue)"
+    version=${version,,}
     if [[ "$version" =~ "ubuntu" ]]; then
 		REALPATH="realpath"
 		release=$(lsb_release -c)


### PR DESCRIPTION
Fix #5127 et ajoute le support à l'ancienne commande `make install-debian` car la nouvelle commande `make install-linux` ne fonctionne pas chez moi.