### PR TITLE
Corrige un possible malentendu en lisant la phrase

### DIFF
--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -41,7 +41,7 @@ fi
 
 # os-specific package install
 if  ! $(_in "-packages" $@) && ( $(_in "+packages" $@) || $(_in "+base" $@) || $(_in "+full" $@) ); then
-    echo "* [+packages] installing packages (require sudo)"
+    echo "* [+packages] installing packages (this subcommand will be run as super-user)"
     version=$(cat /proc/version)
     if [[ "$version" =~ "ubuntu" ]]; then
 		REALPATH="realpath"


### PR DESCRIPTION
Corrige un possible malentendu en lisant la phrase et permet d'éviter de comprendre qu'il faut lancer le make en sudo.

Q/A : 

Vérifier que le mot soit présent.