### PR TITLE
core: update katex @ 0.10.0 to fit with new css

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gulp.spritesmith": "6.5.1",
     "highlight.js": "^9.12.0",
     "jquery": "3.2.1",
-    "katex": "^0.9.0",
+    "katex": "^0.10.0",
     "moment": "^2.20.1",
     "normalize.css": "7.0.0"
   },

--- a/templates/base.html
+++ b/templates/base.html
@@ -81,7 +81,7 @@
 
 
     {# Stylesheets #}
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/katex.min.css" crossorigin="anonymous">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.0/katex.min.css" crossorigin="anonymous">
     <link rel="stylesheet" href="{% static "css/main.css" %}">
     {% if not debug %}
         {% block canonical %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -81,7 +81,7 @@
 
 
     {# Stylesheets #}
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.0/katex.min.css" crossorigin="anonymous">
+    <link rel="stylesheet" href="{% static "css/katex.min.css" %}">
     <link rel="stylesheet" href="{% static "css/main.css" %}">
     {% if not debug %}
         {% block canonical %}{% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,6 +769,10 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.16.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+
 commander@~2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
@@ -2949,11 +2953,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-katex@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.9.0.tgz#26a7d082c21d53725422d2d71da9b2d8455fbd4a"
+katex@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.10.0.tgz#da562e5d0d5cc3aa602e27af8a9b8710bfbce765"
   dependencies:
-    match-at "^0.1.1"
+    commander "^2.16.0"
 
 kind-of@^1.1.0:
   version "1.1.0"
@@ -3280,10 +3284,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-match-at@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/match-at/-/match-at-0.1.1.tgz#25d040d291777704d5e6556bbb79230ec2de0540"
-
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -3469,7 +3469,7 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-natives@1.1.3, natives@^1.1.0:
+natives@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
 


### PR DESCRIPTION
port dans master de la branche 27.4

fix #5111 

# QA

ajoutez des maths contenant une fraction `$\frac{1}{2} = rationel désaltérant$`

assurez-vous que l'affichage est bon
