### PR TITLE
 Améliorer la proportion du texte sur mobile 

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -136,8 +136,8 @@
             p,
             ol,
             ul:not(.pagination) {
-                font-size: 15px;
-                font-size: 1.5rem;
+                font-size: 14px;
+                font-size: 1.4rem;
             }
         }
 


### PR DESCRIPTION
Améliorer la proportion du texte sur mobile suite au fix #5124 .

Rendu attendu sur firefox mobile :
[Firefox rendu actuel sur la prod de zds](https://user-images.githubusercontent.com/18501150/49686940-343e4980-fafc-11e8-9855-7c39b8ba70cc.png)

Rendu obtenu : 

 - [Firefox mobile fix](https://user-images.githubusercontent.com/18501150/49686952-4b7d3700-fafc-11e8-8592-d041f7969f78.png)
 - [Chrome mobile fix](https://user-images.githubusercontent.com/18501150/49686935-2983b480-fafc-11e8-91be-f68193634176.png)
