### PR TITLE
Corrige l'affichage des blocs de code dans les listes (fix #5004)

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -374,13 +374,15 @@ kbd {
 }
 
 // Code inline
-p code,
-li code,
-td code {
-    color: #A00;
-    background: #EEE;
-    border: 1px solid #CCC;
-    padding: 0 5px;
+p,
+li,
+td {
+    code:not(.hljs) {
+        color: #A00;
+        background: #EEE;
+        border: 1px solid #CCC;
+        padding: 0 5px;
+    }
 }
 
 // @ping


### PR DESCRIPTION
Corrige l'affichage des blocs de code dans les listes (#5004)

**QA :**

- `make build-front`
- Vérifier que ce code s'affiche correctement : 

~~~md
* truc
* ```
  foo bar
  ```
* plop
*     truc
      ure truc
* truc
* `paf`
* ggg
~~~

**Avant**

![image](https://user-images.githubusercontent.com/6664636/49731429-970a1f00-fc7b-11e8-86fc-e1b03994ddee.png)

**Après**

![image](https://user-images.githubusercontent.com/6664636/49731444-a38e7780-fc7b-11e8-81e1-fc4fc5f2912c.png)

