### PR TITLE
La légende n'est plus ignorée lors de l'upload d'une image (fix #5118)

### DIFF
--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -313,7 +313,7 @@ class NewImage(ImageFromGalleryContextViewMixin, ImageCreateMixin, LoggedWithRea
         self.perform_create(
             form.cleaned_data.get('title'),
             self.request.FILES.get('physical'),
-            form.cleaned_data.get('title'))
+            form.cleaned_data.get('legend'))
 
         self.success_url = reverse(
             'gallery-image-edit',


### PR DESCRIPTION
La légende n'est plus ignorée lors de l'upload d'une image (fix #5118)

**QA :**

- Dans une galerie, créer une nouvelle image avec un titre et une légende
- Vérifier que la légende a bien été enregistrée