### PR TITLE
Revert "Respect des nouvelles norme d'import SASS"

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -4,93 +4,93 @@
  * @file main.scss
  */
 
-@import url("variables/variables");
-@import url("sprite");
+@import "variables/variables";
+@import "sprite";
 
 /*------------------------
 1. External dependencies
 ------------------------*/
-@import url("normalize.css/normalize");
-@import url("highlight.js/styles/idea");
+@import "normalize.css/normalize";
+@import "highlight.js/styles/idea";
 
 /*------------------------
 2. Base
 ------------------------*/
-@import url("base/base");
-@import url("base/tables");
-@import url("base/forms");
+@import "base/base";
+@import "base/tables";
+@import "base/forms";
 
 /*------------------------
 3. Typography
 ------------------------*/
-@import url("base/typography");
+@import "base/typography";
 
 /*------------------------
 4. Icons
 ------------------------*/
-@import url("base/icons");
+@import "base/icons";
 
 /*------------------------
 5. Helpers
 ------------------------*/
-@import url("base/helpers");
+@import "base/helpers";
 
 /*------------------------
 6. Header
 ------------------------*/
-@import url("layout/header");
-@import url("components/header-dropdown");
-@import url("components/header-search");
-@import url("components/accessibility-bar");
-@import url("components/cookies-banner");
+@import "layout/header";
+@import "components/header-dropdown";
+@import "components/header-search";
+@import "components/accessibility-bar";
+@import "components/cookies-banner";
 
 /*------------------------
 7. Layout
 ------------------------*/
-@import url("layout/sidebar");
-@import url("layout/main");
-@import url("layout/content");
-@import url("layout/footer");
+@import "layout/sidebar";
+@import "layout/main";
+@import "layout/content";
+@import "layout/footer";
 
 /*------------------------
 8. Components
 ------------------------*/
-@import url("components/alert-box");
-@import url("components/authors");
-@import url("components/autocomplete");
-@import url("components/breadcrumb");
-@import url("components/content-item");
-@import url("components/editor");
-@import url("components/featured-item");
-@import url("components/markdown-help");
-@import url("components/mobile-menu");
-@import url("components/modals");
-@import url("components/pagination");
-@import url("components/pygments");
-@import url("components/search-box");
-@import url("components/tags");
-@import url("components/tooltips");
-@import url("components/topic-list");
-@import url("components/notification-list");
-@import url("components/topic-message");
-@import url("components/topic-new");
-@import url("components/user-profile");
-@import url("components/linkbox");
-@import url("components/more-link");
+@import "components/alert-box";
+@import "components/authors";
+@import "components/autocomplete";
+@import "components/breadcrumb";
+@import "components/content-item";
+@import "components/editor";
+@import "components/featured-item";
+@import "components/markdown-help";
+@import "components/mobile-menu";
+@import "components/modals";
+@import "components/pagination";
+@import "components/pygments";
+@import "components/search-box";
+@import "components/tags";
+@import "components/tooltips";
+@import "components/topic-list";
+@import "components/notification-list";
+@import "components/topic-message";
+@import "components/topic-new";
+@import "components/user-profile";
+@import "components/linkbox";
+@import "components/more-link";
 
 /*------------------------
 9. Pages
 ------------------------*/
-@import url("pages/flexpage");
-@import url("pages/home");
-@import url("pages/gallery");
-@import url("pages/api");
-@import url("pages/search");
-@import url("pages/stats");
-@import url("pages/tutorial-help");
-@import url("pages/tutorial-history");
+@import "pages/flexpage";
+@import "pages/home";
+@import "pages/gallery";
+@import "pages/api";
+@import "pages/search";
+@import "pages/stats";
+@import "pages/tutorial-help";
+@import "pages/tutorial-history";
 
 /*-------------------------
 10. High pixel ratio (retina)
 -------------------------*/
-@import url("base/high-pixel-ratio");
+@import "base/high-pixel-ratio";

--- a/assets/scss/zmd.scss
+++ b/assets/scss/zmd.scss
@@ -3,15 +3,15 @@
  */
 
 // FIXME: high-dpi support for icons?
-@import url("variables/variables");
-@import url("sprite");
-@import url("highlight.js/styles/idea");
-@import url("components/alert-box");
-@import url("base/icons");
+@import "variables/variables";
+@import "sprite";
+@import "highlight.js/styles/idea";
+@import "components/alert-box";
+@import "base/icons";
 
 .zmarkdown {
     color: #424242;
 
-    @import url("base/content");
-    @import url("base/tables");
+    @import "base/content";
+    @import "base/tables";
 }


### PR DESCRIPTION
Cette PR cassait le CSS du site et il se trouve qu'elle n'est en fait pas nécessaire, voir https://github.com/zestedesavoir/zds-site/issues/5059#issuecomment-446196564