### PR TITLE
Simplifie l'ajout et l'édition dans les tutos

### DIFF
--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -211,9 +211,6 @@
     .btn-grey {
         @include addBtnColorProperties(#EEE, #555, #CCC, #333, #999);
     }
-    .btn-blue {
-        @include addBtnColorProperties(#1088bf, white, #d68807, white, #999);
-    }
     [disabled],
     .disabled {
         cursor: default !important;

--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -186,25 +186,33 @@
             }
         }
     }
-    .btn-grey:not(.link) {
-        background: #EEE;
-        color: #555;
+    @mixin addBtnColorProperties($bg, $color, $bg_hover, $color_hover, $bg_loading) {  
+        &:not(.link) {
+            background: $bg;
+            color: $color;
 
-        &:not([disabled]):hover,
-        &:not([disabled]):focus,
-        &:not(.disabled):hover,
-        &:not(.disabled):focus {
-            background: #CCC;
-            color: #333;
-        }
+            &:not([disabled]):hover,
+            &:not([disabled]):focus,
+            &:not(.disabled):hover,
+            &:not(.disabled):focus {
+            background: $bg_hover;
+            color: $color_hover;
+            }
 
-        &.disabled.submitted {
-            color: #555;
+            &.disabled.submitted {
+                color: $color;
 
-            .line-loading {
-                background: #999;
+                .line-loading {
+                    background: $bg_loading;
+                }
             }
         }
+    }
+    .btn-grey {
+        @include addBtnColorProperties(#EEE, #555, #CCC, #333, #999);
+    }
+    .btn-blue {
+        @include addBtnColorProperties(#1088bf, white, #d68807, white, #999);
     }
     [disabled],
     .disabled {

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -18,6 +18,11 @@
         border-bottom: 1px solid $color-secondary;
         margin: 1px 0 15px;
 
+        &.blue, 
+        &.blue a {
+            color:#1088bf !important;
+        }
+
         &.illu {
             padding-left: 60px;
 

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -82,6 +82,7 @@
             height: 32px;
             border-radius: 2px;
             vertical-align: middle;
+            padding:0 12px 0 8px;
 
             &::before {
                 content: '+ ';
@@ -89,6 +90,7 @@
                 vertical-align: middle;
                 padding-bottom: 3px; /* hack font vertical-align between + and ABC (letters) */
             }
+            margin-left:-18px;
         }
     }
 

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -18,11 +18,6 @@
         border-bottom: 1px solid $color-secondary;
         margin: 1px 0 15px;
 
-        &.blue, 
-        &.blue a {
-            color:#1088bf !important;
-        }
-
         &.illu {
             padding-left: 60px;
 
@@ -72,6 +67,10 @@
             line-height: 38px;
             height: 38px;
         }
+    }
+
+    .force-blue {
+        color:#1088bf !important;
     }
 
     li.simple-create-button {
@@ -153,6 +152,10 @@
 
     .new-btn-container {
         display: none;
+    }
+
+    .summary-part h4 > a.disabled {
+        background: none !important;
     }
 }
 

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -82,6 +82,14 @@
             line-height: 32px;
             height: 32px;
             border-radius: 2px;
+            vertical-align: middle;
+
+            &::before {
+                content: '+ ';
+                font-size: 28px;
+                vertical-align: middle;
+                padding-bottom: 3px; /* hack font vertical-align between + and ABC (letters) */
+            }
         }
     }
 

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -74,6 +74,17 @@
         }
     }
 
+    li.simple-create-button {
+        list-style-type: '';
+        .btn {
+            float:none;
+            display:inline-block;
+            line-height: 32px;
+            height: 32px;
+            border-radius: 2px;
+        }
+    }
+
     .license {
         float: right;
         margin: 0;

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -98,7 +98,7 @@
             {% endfor %}
             {% if can_add_something and child.can_add_extract %}
                 <li class="simple-create-button">
-                    <a class="btn btn-blue" href="{% url "content:create-extract" content.pk child.parent.slug child.slug %}">
+                    <a class="btn btn-grey" href="{% url "content:create-extract" content.pk child.parent.slug child.slug %}">
                         {% trans "Ajouter une section" %}
                     </a>
                 </li>
@@ -134,7 +134,7 @@
                         {% if can_add_something %}
                             <li class="simple-create-button">
                                 <h4>
-                                    <a class="btn btn-blue"
+                                    <a class="btn btn-grey"
                                         href="{% url "content:create-extract" content.pk child.parent.slug child.slug subchild.slug %}"
                                     >{% trans "Ajouter une section" %}</a>
                                 </h4>
@@ -179,7 +179,7 @@
         {% elif can_add_something and child.can_add_extract and child.is_chapter %}
             <ol>
                 <li class="simple-create-button">
-                    <a class="btn btn-blue" href="{% url "content:create-extract" content.pk content.slug child.parent.slug child.slug %}">
+                    <a class="btn btn-grey" href="{% url "content:create-extract" content.pk content.slug child.parent.slug child.slug %}">
                         {% trans "Ajouter une section" %}
                     </a>
                 </li>

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -20,63 +20,63 @@
     </a>
 </h2>
 
-{% if can_edit or is_staff %}
-    {%  if not version or version == content.sha_draft %}
-        <div class="actions-title">
-            <a href="{{ child.get_edit_url }}" class="ico-after edit btn btn-grey">
-                {% trans "Éditer" %}
-            </a>
-            <a href="#move-{{ child.slug }}" class="open-modal ico-after move btn btn-grey">{% trans "Déplacer" %}</a>
-                <form action="{% url "content:move-element" %}" method="post" class="modal modal-flex" id="move-{{ child.slug }}">
-                    <select name="moving_method">
-                        <option disabled="disabled">{% trans "Déplacer" %}</option>
-                        {% if child.position_in_parent > 1 %}
-                            <option value="up">{% trans "Monter" %}</option>
-                        {% endif %}
+{% if can_add_something %}
+    <div class="actions-title">
+        <a href="{{ child.get_edit_url }}" class="ico-after edit btn btn-grey">
+            {% trans "Éditer" %}
+        </a>
+        <a href="#move-{{ child.slug }}" class="open-modal ico-after move btn btn-grey">{% trans "Déplacer" %}</a>
+        <form action="{% url "content:move-element" %}" method="post" class="modal modal-flex" id="move-{{ child.slug }}">
+            <select name="moving_method">
+                <option disabled="disabled">{% trans "Déplacer" %}</option>
+                {% if child.position_in_parent > 1 %}
+                    <option value="up">{% trans "Monter" %}</option>
+                {% endif %}
 
-                        {% if child.position_in_parent < child.parent.children|length %}
-                            <option value="down">{% trans "Descendre" %}</option>
-                        {% endif %}
-                        <option disabled="disabled">&mdash; {% trans "Déplacer avant" %}</option>
-                        {% for element in child|target_tree %}
-                                <option value="before:{{element.0}}"
-                                {% if not element.3 %} disabled {% endif %}>
-                                     &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
-                                </option>
-                        {% endfor %}
-                        <option disabled="disabled">&mdash; {% trans "Déplacer après" %}</option>
-                        {% for element in child|target_tree %}
-                                <option value="after:{{element.0}}"
-                                {% if not element.3 %} disabled {% endif %}>
-                                     &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
-                                </option>
-                        {% endfor %}
-                    </select>
-                    <input type="hidden" name="child_slug" value="{{ child.slug }}">
-                    {% if child.text %}
-                        <input type="hidden" name="container_slug" value="{{ child.container.slug }}">
-                        <input type="hidden" name="first_level_slug" value="{{ child.get_first_level_slug }}">
-                    {%  else %}
-                        <input type="hidden" name="container_slug" value="{{ child.parent.slug }}">
-                    {% endif %}
+                {% if child.position_in_parent < child.parent.children|length %}
+                    <option value="down">{% trans "Descendre" %}</option>
+                {% endif %}
+                <option disabled="disabled">&mdash; {% trans "Déplacer avant" %}</option>
+                {% for element in child|target_tree %}
+                        <option value="before:{{element.0}}"
+                        {% if not element.3 %} disabled {% endif %}>
+                             &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
+                        </option>
+                {% endfor %}
+                <option disabled="disabled">&mdash; {% trans "Déplacer après" %}</option>
+                {% for element in child|target_tree %}
+                        <option value="after:{{element.0}}"
+                        {% if not element.3 %} disabled {% endif %}>
+                             &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
+                        </option>
+                {% endfor %}
+            </select>
+            <input type="hidden" name="child_slug" value="{{ child.slug }}">
+            {% if child.text %}
+                <input type="hidden" name="container_slug" value="{{ child.container.slug }}">
+                <input type="hidden" name="first_level_slug" value="{{ child.get_first_level_slug }}">
+            {%  else %}
+                <input type="hidden" name="container_slug" value="{{ child.parent.slug }}">
+            {% endif %}
 
-                    <input type="hidden" name="pk" value="{{ content.pk }}">
-                    {% csrf_token %}
-                    <button type="submit">
-                        {% trans "Déplacer" %}
-                    </button>
-                </form>
-            {% include "tutorialv2/includes/delete.part.html" with object=child additional_classes="ico-after cross btn btn-grey" %}
+            <input type="hidden" name="pk" value="{{ content.pk }}">
+            {% csrf_token %}
+            <button type="submit">
+                {% trans "Déplacer" %}
+            </button>
+        </form>
+        {% include "tutorialv2/includes/delete.part.html" with object=child additional_classes="ico-after cross btn btn-grey" %}
     </div>
-    {% endif %}
 {% endif %}
 
 {% if child.text %}
     {# child is an extract #}
     {% if child.get_text.strip|length == 0 %}
-        <p class="ico-after warning">
-            {% trans "Cette section est actuellement vide." %}
-        </p>
+        <div class="ico-after warning">
+            <p>
+                {% trans "Cette section est actuellement vide." %}
+            </p>
+        </div>
     {% else %}
         {{ child.get_text|emarkdown:is_js }}
     {% endif %}
@@ -96,6 +96,13 @@
                 >{{ extract.title }}</a>
             </li>
             {% endfor %}
+            {% if can_add_something and child.can_add_extract %}
+                <li style="list-style-type:'+'">
+                    <a href="{% url "content:create-extract" content.pk child.parent.slug child.slug %}">
+                        {% trans "Ajouter une nouvelle section" %}
+                    </a>
+                </li>
+            {% endif %}
         </ol>
     {%  elif child.has_sub_containers %}
         <ol class="summary-part">
@@ -124,13 +131,50 @@
                             </h4>
                         </li>
                     {% endfor %}
+                    {% if can_add_something %}
+                        <li>
+                            <h4>
+                                <a
+                                    {% if content.is_beta %}
+                                        href="{{ extract.get_absolute_url_beta }}"
+                                    {% else %}
+                                        href="{% url "content:create-extract" content.pk child.parent.slug child.slug subchild.slug %}"
+                                    {% endif %}
+                                >+ {% trans "Ajouter une section" %}</a>
+                            </h4>
+                        </li>
+                    {% endif %}
                 </ol>
             </li>
             {% endfor %}
         </ol>
     {% else %}
-        <p class="ico-after warning">
-          {{ "Ce"|feminize:child.get_level_as_string }} {{ child.get_level_as_string|lower }}  {% trans " est actuellement vide." %}
-        </p>
+        {% if not can_add_something or not child.is_chapter %}
+        <div class="ico-after warning">
+            <p>
+                {{ "Ce"|feminize:child.get_level_as_string }} {{ child.get_level_as_string|lower }} {% trans "est actuellement vide." %}
+            </p>
+            {% if can_add_something and not child.is_chapter %}
+                <ul>
+                    <li>
+                        <a href="{% url "content:create-container" content.pk content.slug child.slug %}">{% trans "Ajouter un chapitre" %}</a>
+                        {% trans " pour adopter le format bigtuto et ajouter des sections ;" %}
+                    </li>
+                    <li>
+                        <a href="{% url "content:create-extract" content.pk content.slug child.slug %}">{% trans "Ajouter une section" %}</a>
+                        {% trans " pour adopter le format normal composé uniquement de section." %}
+                    </li>
+                </ul>
+            {% endif %}
+        </div>
+        {% elif can_add_something and child.can_add_extract and child.is_chapter %}
+            <ol>
+                <li style="list-style-type:'+'">
+                    <a href="{% url "content:create-extract" content.pk content.slug child.parent.slug child.slug %}">
+                        {% trans "Ajouter une nouvelle section" %}
+                    </a>
+                </li>
+            </ol>
+        {% endif %}
     {% endif %}
 {% endif %}

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -97,8 +97,8 @@
             </li>
             {% endfor %}
             {% if can_add_something and child.can_add_extract %}
-                <li style="list-style-type:'+'">
-                    <a href="{% url "content:create-extract" content.pk child.parent.slug child.slug %}">
+                <li class="simple-create-button">
+                    <a class="btn btn-blue" href="{% url "content:create-extract" content.pk child.parent.slug child.slug %}">
                         {% trans "Ajouter une nouvelle section" %}
                     </a>
                 </li>
@@ -132,15 +132,15 @@
                         </li>
                     {% endfor %}
                     {% if can_add_something %}
-                        <li>
+                        <li class="simple-create-button">
                             <h4>
-                                <a
+                                <a class="btn btn-blue"
                                     {% if content.is_beta %}
                                         href="{{ extract.get_absolute_url_beta }}"
                                     {% else %}
                                         href="{% url "content:create-extract" content.pk child.parent.slug child.slug subchild.slug %}"
                                     {% endif %}
-                                >+ {% trans "Ajouter une section" %}</a>
+                                >{% trans "Ajouter une section" %}</a>
                             </h4>
                         </li>
                     {% endif %}
@@ -169,8 +169,8 @@
         </div>
         {% elif can_add_something and child.can_add_extract and child.is_chapter %}
             <ol>
-                <li style="list-style-type:'+'">
-                    <a href="{% url "content:create-extract" content.pk content.slug child.parent.slug child.slug %}">
+                <li class="simple-create-button">
+                    <a class="btn btn-blue" href="{% url "content:create-extract" content.pk content.slug child.parent.slug child.slug %}">
                         {% trans "Ajouter une nouvelle section" %}
                     </a>
                 </li>

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -99,7 +99,7 @@
             {% if can_add_something and child.can_add_extract %}
                 <li class="simple-create-button">
                     <a class="btn btn-blue" href="{% url "content:create-extract" content.pk child.parent.slug child.slug %}">
-                        {% trans "Ajouter une nouvelle section" %}
+                        {% trans "Ajouter une section" %}
                     </a>
                 </li>
             {% endif %}
@@ -180,7 +180,7 @@
             <ol>
                 <li class="simple-create-button">
                     <a class="btn btn-blue" href="{% url "content:create-extract" content.pk content.slug child.parent.slug child.slug %}">
-                        {% trans "Ajouter une nouvelle section" %}
+                        {% trans "Ajouter une section" %}
                     </a>
                 </li>
             </ol>

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -158,11 +158,11 @@
                 <ul>
                     <li>
                         <a href="{% url "content:create-container" content.pk content.slug child.slug %}">{% trans "Ajouter un chapitre" %}</a>
-                        {% trans " pour adopter le format bigtuto et ajouter des sections ;" %}
+                        {% trans " pour adopter le format big-tuto et ajouter des sections ;" %}
                     </li>
                     <li>
                         <a href="{% url "content:create-extract" content.pk content.slug child.slug %}">{% trans "Ajouter une section" %}</a>
-                        {% trans " pour adopter le format normal composé uniquement de section." %}
+                        {% trans " pour adopter le format moyen-tuto composé uniquement de section." %}
                     </li>
                 </ul>
             {% endif %}

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -104,49 +104,58 @@
                 </li>
             {% endif %}
         </ol>
-    {%  elif child.has_sub_containers %}
+    {% elif child.has_sub_containers %}
         <ol class="summary-part">
             {% for subchild in child.children %}
-            <li>
-                <h3>
-                    <a
-                    {% if content.is_beta %}
-                        href="{{ subchild.get_absolute_url_beta }}"
-                    {% else %}
-                        href="{{ subchild.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
-                    {% endif %}
-                    >{{ subchild.title }}</a>
-                </h3>
-                <ol class="summary-part">
-                    {% for extract in subchild.children %}
-                        <li>
-                            <h4>
-                                <a
-                                    {% if content.is_beta %}
-                                        href="{{ extract.get_absolute_url_beta }}"
-                                    {% else %}
-                                        href="{{ extract.container.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}#{{ extract.position_in_parent }}-{{ extract.slug }}"
-                                    {% endif %}
-                                >{{ extract.title }}</a>
-                            </h4>
-                        </li>
-                    {% endfor %}
-                    {% if can_add_something %}
-                        <li class="simple-create-button">
-                            <h4>
-                                <a class="btn btn-blue"
-                                    {% if content.is_beta %}
-                                        href="{{ extract.get_absolute_url_beta }}"
-                                    {% else %}
+                <li>
+                    <h3>
+                        <a
+                        {% if content.is_beta %}
+                            href="{{ subchild.get_absolute_url_beta }}"
+                        {% else %}
+                            href="{{ subchild.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
+                        {% endif %}
+                        >{{ subchild.title }}</a>
+                    </h3>
+                    <ol class="summary-part">
+                        {% for extract in subchild.children %}
+                            <li>
+                                <h4>
+                                    <a
+                                        {% if content.is_beta %}
+                                            href="{{ extract.get_absolute_url_beta }}"
+                                        {% else %}
+                                            href="{{ extract.container.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}#{{ extract.position_in_parent }}-{{ extract.slug }}"
+                                        {% endif %}
+                                    >{{ extract.title }}</a>
+                                </h4>
+                            </li>
+                        {% endfor %}
+                        {% if can_add_something %}
+                            <li class="simple-create-button">
+                                <h4>
+                                    <a class="btn btn-blue"
                                         href="{% url "content:create-extract" content.pk child.parent.slug child.slug subchild.slug %}"
-                                    {% endif %}
-                                >{% trans "Ajouter une section" %}</a>
-                            </h4>
-                        </li>
-                    {% endif %}
-                </ol>
-            </li>
+                                    >{% trans "Ajouter une section" %}</a>
+                                </h4>
+                            </li>
+                        {% endif %}
+                    </ol>
+                </li>
             {% endfor %}
+            {% if can_add_something and child.can_add_container %}
+                <li>
+                    <h3>
+                        <a class="force-blue"
+                            href="{% url "content:create-container" content.pk child.parent.slug child.slug %}"
+                        >{% trans "Ajouter un chapitre" %}</a>
+                    </h3>
+                    <ol class="summary-part">
+                        <li><h4><a class="disabled">{% trans "Section A" %}</a></h4></li>
+                        <li><h4><a class="disabled">{% trans "Section B" %}</a></h4></li>
+                    </ol>
+                </li>
+            {% endif %}
         </ol>
     {% else %}
         {% if not can_add_something or not child.is_chapter %}

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -133,7 +133,7 @@
                             {%  else %}
                                 {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
                             {%  endif %}">
-                        {% trans "Ajouter une nouvelle section" %}
+                        {% trans "Ajouter une section" %}
                     </a>
                 </li>
             {% endif %}
@@ -179,7 +179,7 @@
                         {%  else %}
                             {% url "content:create-container" content.pk content.slug container.parent.slug %}
                         {%  endif %}">
-                    {% trans "Ajouter un nouveau chapitre" %}
+                    {% trans "Ajouter un chapitre" %}
                 </a>
             </h2>
             <div class="actions-title">
@@ -202,7 +202,7 @@
                         {%  else %}
                             {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
                         {%  endif %}">
-                    {% trans "Ajouter une nouvelle section" %}
+                    {% trans "Ajouter une section" %}
                 </a>
             </h2>
             <div class="actions-title">

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -173,8 +173,8 @@
     {% endfor %}
     {% if can_add_something %}
         {% if container.can_add_container and not container.can_add_extract %}
-            <h2 class="blue">
-                <a href="{% if container.parent == content %}
+            <h2>
+                <a class="force-blue" href="{% if container.parent == content %}
                             {% url "content:create-container" content.pk content.slug container.slug %}
                         {%  else %}
                             {% url "content:create-container" content.pk content.slug container.parent.slug %}
@@ -196,7 +196,7 @@
             </div>
         {% endif %}
         {% if not container.can_add_container and container.can_add_extract %}
-            <h2 class="blue">
+            <h2 class="force-blue">
                 <a href="{% if container.parent == content %}
                             {% url "content:create-extract" content.pk content.slug container.slug %}
                         {%  else %}

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -128,7 +128,7 @@
             {% endfor %}
             {% if not container.can_add_container and container.can_add_extract and can_add_something %}
                 <li class="simple-create-button">
-                    <a class="btn btn-blue" href="{% if container.parent == content %}
+                    <a class="btn btn-grey" href="{% if container.parent == content %}
                                 {% url "content:create-extract" content.pk content.slug container.slug %}
                             {%  else %}
                                 {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -107,12 +107,17 @@
     {% if container.introduction and container.get_introduction %}
         {{ container.get_introduction|emarkdown:is_js }}
     {% elif not content.is_beta %}
-        <p class="ico-after warning">
-            {% trans "Il n’y a pas d’introduction." %}
-        </p>
+        <div class="ico-after warning">
+            <p>
+                {% trans "Il n’y a pas d’introduction." %}
+                {% if can_add_something %}
+                    {% trans "Vous pouvez " %}<a href="{{ container.get_edit_url }}">{% trans "en ajouter une" %}</a>.
+                {% endif %}
+            </p>
+        </div>
     {% endif %}
 
-     {% if container.has_extracts %}
+     {% if container.has_extracts or container.can_add_extract %}
         <ul>
             {% for extract in container.children %}
                 <li>
@@ -121,25 +126,64 @@
                     </a>
                 </li>
             {% endfor %}
+            {% if can_add_something and container.can_add_extract %}
+                <li style="list-style-type:'+'">
+                    <a href="{%  if container.parent == content %}
+                                {% url "content:create-extract" content.pk content.slug container.slug %}
+                            {%  else %}
+                                {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
+                            {%  endif %}">
+                        {% trans "Ajouter une nouvelle section" %}
+                    </a>
+                </li>
+            {% endif %}
         </ul>
     {% endif %}
 
     {% for child in container.children %}
         {%  include "tutorialv2/includes/child.part.html" with child=child %}
     {% empty %}
-        <p class="ico-after warning">
-            {{ "Ce"|feminize:container.get_level_as_string }} {{ container.get_level_as_string|lower }}  {% trans " est actuellement vide." %}
-        </p>
+        {% if not can_add_something or not container.can_add_extract %}
+            <div class="ico-after warning">
+                <p>
+                    {{ "Ce"|feminize:container.get_level_as_string }} {{ container.get_level_as_string|lower }}  {% trans " est actuellement vide." %}
+                </p>
+            </div>
+        {% endif %}
     {% endfor %}
+    {% if can_add_something and container.can_add_extract %}
+        <h2 class="blue">
+            <a href="{%  if container.parent == content %}
+                        {% url "content:create-extract" content.pk content.slug container.slug %}
+                    {%  else %}
+                        {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
+                    {%  endif %}">
+                {% trans "Ajouter une nouvelle section" %}
+            </a>
+        </h2>
+        <div class="actions-title">
+            <a href="{% url "content:create-extract" content.pk content.slug container.slug %}" class="ico-after more btn btn-grey">
+                {% trans "Ajouter" %}
+            </a>
+        </div>
+        <div class="ico-after information">
+            <p>{% trans "Cliquer sur ajouter pour rédiger une nouvelle section." %}</p>
+        </div>
+    {% endif %}
 
     <hr />
 
     {% if container.conclusion and container.get_conclusion %}
         {{ container.get_conclusion|emarkdown:is_js }}
     {% elif not content.is_beta %}
-        <p class="ico-after warning">
-            {% trans "Il n’y a pas de conclusion." %}
-        </p>
+        <div class="ico-after warning">
+            <p>
+                {% trans "Il n’y a pas de conclusion." %}
+                {% if can_add_something %}
+                    {% trans "Vous pouvez " %}<a href="{{ container.get_edit_url }}">{% trans "en ajouter une" %}</a>.
+                {% endif %}
+            </p>
+        </div>
     {% endif %}
 
     {% include "tutorialv2/includes/chapter_pager.part.html" with position="bottom" %}
@@ -152,108 +196,107 @@
 
 
 {% block sidebar_new %}
-    {% if can_edit or is_staff %}
-        {% if not version or version == content.sha_draf %}
-            <a href="{{ container.get_edit_url }}" class="ico-after edit blue new-btn">
-                {% trans "Éditer" %}
-            </a>
+    {% if can_add_something %}
+        <a href="{{ container.get_edit_url }}" class="ico-after edit blue new-btn">
+            {% trans "Éditer" %}
+        </a>
 
 
-            {%  if container.can_add_container %}
-                <a href="{% url "content:create-container" content.pk content.slug container.slug %}" class="ico-after more blue new-btn">
-                    {% trans "Ajouter " %} {{ "un"|feminize:container.get_next_level_as_string }} {{ container.get_next_level_as_string|lower }}
-                </a>
-            {% endif %}
-
-            {%  if container.can_add_extract %}
-                <a href="
-                    {%  if container.parent == content %}
-                        {% url "content:create-extract" content.pk content.slug container.slug %}
-                    {%  else %}
-                        {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
-                    {%  endif %}
-                 " class="ico-after more blue new-btn">
-                    {% trans "Ajouter une section" %}
-                </a>
-            {%  endif %}
-        {% else %}
-            <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
-                {% trans "Version brouillon" %}
+        {%  if container.can_add_container %}
+            <a href="{% url "content:create-container" content.pk content.slug container.slug %}" class="ico-after more blue new-btn">
+                {% trans "Ajouter " %} {{ "un"|feminize:container.get_next_level_as_string }} {{ container.get_next_level_as_string|lower }}
             </a>
         {% endif %}
+
+        {%  if container.can_add_extract %}
+            <a href="
+                {%  if container.parent == content %}
+                    {% url "content:create-extract" content.pk content.slug container.slug %}
+                {%  else %}
+                    {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
+                {%  endif %}
+             " class="ico-after more blue new-btn">
+                {% trans "Ajouter une section" %}
+            </a>
+        {%  endif %}
+    {% elif version or version != content.sha_draf %}
+        <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
+            {% trans "Version brouillon" %}
+        </a>
     {% endif %}
 {% endblock %}
 
 
 
 {% block sidebar_actions %}
-    {% if can_edit or is_staff %}
-        {% if not version or content.sha_draft == version %}
-            <li>
-                <a href="#move-chapter" class="open-modal ico-after move blue">
-                    {% blocktrans with prev="le"|feminize:container.get_level_as_string name=container.get_level_as_string|lower %}
-                        Déplacer <span class="wide">{{ prev }} {{ name }}</span>
-                    {% endblocktrans %}
-                </a>
-                <form action="{% url "content:move-element" %}" method="POST" class="modal modal-flex" id="move-chapter">
-                    <input type="hidden" name="pk" value="{{ content.pk }}"/>
+    {% if can_add_something %}
+        <li>
+            <a href="#move-chapter" class="open-modal ico-after move blue">
+                {% blocktrans with prev="le"|feminize:container.get_level_as_string name=container.get_level_as_string|lower %}
+                    Déplacer <span class="wide">{{ prev }} {{ name }}</span>
+                {% endblocktrans %}
+            </a>
+            <form action="{% url "content:move-element" %}" method="POST" class="modal modal-flex" id="move-chapter">
+                <input type="hidden" name="pk" value="{{ content.pk }}"/>
 
-                    <select name="moving_method" class="select-autosubmit">
+                <select name="moving_method" class="select-autosubmit">
 
-                        <option disabled="disabled">
-                            {% trans "Déplacer" %}
+                    <option disabled="disabled">
+                        {% trans "Déplacer" %}
+                    </option>
+
+                    {% if container.position_in_parent > 1 %}
+                        <option value="up">
+                            {% trans "Monter" %}
                         </option>
-
-                        {% if container.position_in_parent > 1 %}
-                            <option value="up">
-                                {% trans "Monter" %}
-                            </option>
-                        {% endif %}
-
-                        {% if container.position_in_parent < container.parent.children|length %}
-                            <option value="down">
-                                {% trans "Descendre" %}
-                            </option>
-                        {% endif %}
-                            <option disabled="disabled">&mdash; {% trans "Déplacer avant" %}</option>
-                            {% for element in containers_target %}
-                                    <option value="before:{{element.0}}"
-                                    {% if not element.3 %} disabled {% endif %}>
-                                         &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1 }}
-                                    </option>
-                            {% endfor %}
-                            <option disabled="disabled">&mdash; {% trans "Déplacer après" %}</option>
-                            {% for element in containers_target %}
-                                    <option value="after:{{element.0}}"
-                                    {% if not element.3 %} disabled {% endif %}>
-                                         &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1 }}
-                                    </option>
-                            {% endfor %}
-                    </select>
-                    {% if container.get_tree_depth > 2 %}
-                        <input type="hidden" name="first_level_slug" value="{{ parent.parent.slug }}">
-                    {% else %}
-                        <input type="hidden" name="first_level_slug" value="">
                     {% endif %}
-                    <input type="hidden" name="child_slug" value="{{ container.slug }}">
-                    <input type="hidden" name="container_slug" value="{{ container.parent.slug}}">
-                    {% csrf_token %}
 
-                    <button type="submit">{% trans "Déplacer" %}</button>
-                </form>
-            </li>
-        {% endif %}
-            <li>
-                <a data-url="{% url 'api:content:readiness' content.pk %}" class="readiness" data-is-ready="{{ container.ready_to_publish|yesno:"true,false" }}"
-                   data-container-slug="{{ container.slug }}"
-                    {% if container.parent.parent %}data-parent-container-slug="{{ container.parent.slug }}"{% endif %}
-                    data-is-ready-false="{% trans "Marquer comme prêt à valider." %}" data-is-ready-true="{% trans "Marquer comme à ne pas valider." %}">
-                    {% if container.ready_to_publish %}
-                        {% trans "Marquer comme à ne pas valider." %}
-                    {% else %}
-                        {% trans "Marquer comme prêt à valider." %}
+                    {% if container.position_in_parent < container.parent.children|length %}
+                        <option value="down">
+                            {% trans "Descendre" %}
+                        </option>
                     {% endif %}
-                </a></li>
+                        <option disabled="disabled">&mdash; {% trans "Déplacer avant" %}</option>
+                        {% for element in containers_target %}
+                                <option value="before:{{element.0}}"
+                                {% if not element.3 %} disabled {% endif %}>
+                                     &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1 }}
+                                </option>
+                        {% endfor %}
+                        <option disabled="disabled">&mdash; {% trans "Déplacer après" %}</option>
+                        {% for element in containers_target %}
+                                <option value="after:{{element.0}}"
+                                {% if not element.3 %} disabled {% endif %}>
+                                     &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1 }}
+                                </option>
+                        {% endfor %}
+                </select>
+                {% if container.get_tree_depth > 2 %}
+                    <input type="hidden" name="first_level_slug" value="{{ parent.parent.slug }}">
+                {% else %}
+                    <input type="hidden" name="first_level_slug" value="">
+                {% endif %}
+                <input type="hidden" name="child_slug" value="{{ container.slug }}">
+                <input type="hidden" name="container_slug" value="{{ container.parent.slug}}">
+                {% csrf_token %}
+
+                <button type="submit">{% trans "Déplacer" %}</button>
+            </form>
+        </li>
+    {% endif %}
+    {% if can_edit or is_staff %}
+        <li>
+            <a data-url="{% url 'api:content:readiness' content.pk %}" class="readiness" data-is-ready="{{ container.ready_to_publish|yesno:"true,false" }}"
+               data-container-slug="{{ container.slug }}"
+                {% if container.parent.parent %}data-parent-container-slug="{{ container.parent.slug }}"{% endif %}
+                data-is-ready-false="{% trans "Marquer comme prêt à valider." %}" data-is-ready-true="{% trans "Marquer comme à ne pas valider." %}">
+                {% if container.ready_to_publish %}
+                    {% trans "Marquer comme à ne pas valider." %}
+                {% else %}
+                    {% trans "Marquer comme prêt à valider." %}
+                {% endif %}
+            </a>
+        </li>
     {% endif %}
 {% endblock %}
 
@@ -262,16 +305,14 @@
 {% block sidebar_blocks %}
     {%   include "tutorialv2/includes/summary.part.html" with current_container=container %}
 
-    {% if can_edit or is_staff %}
-        {% if not version or content.sha_draft == version %}
-             <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Suppression">
-                <h3>{% trans "Suppression" %}</h3>
-                <ul>
-                    <li>
-                        {%  include "tutorialv2/includes/delete.part.html" with object=container additional_classes="ico-after cross red" %}
-                    </li>
-                </ul>
-            </div>
-        {% endif %}
+    {% if can_add_something %}
+         <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Suppression">
+            <h3>{% trans "Suppression" %}</h3>
+            <ul>
+                <li>
+                    {%  include "tutorialv2/includes/delete.part.html" with object=container additional_classes="ico-after cross red" %}
+                </li>
+            </ul>
+        </div>
     {% endif %}
 {% endblock %}

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -127,8 +127,8 @@
                 </li>
             {% endfor %}
             {% if not container.can_add_container and container.can_add_extract and can_add_something %}
-                <li style="list-style-type:'+'">
-                    <a href="{% if container.parent == content %}
+                <li class="simple-create-button">
+                    <a class="btn btn-blue" href="{% if container.parent == content %}
                                 {% url "content:create-extract" content.pk content.slug container.slug %}
                             {%  else %}
                                 {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -126,9 +126,9 @@
                     </a>
                 </li>
             {% endfor %}
-            {% if can_add_something and container.can_add_extract %}
+            {% if not container.can_add_container and container.can_add_extract and can_add_something %}
                 <li style="list-style-type:'+'">
-                    <a href="{%  if container.parent == content %}
+                    <a href="{% if container.parent == content %}
                                 {% url "content:create-extract" content.pk content.slug container.slug %}
                             {%  else %}
                                 {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
@@ -143,32 +143,81 @@
     {% for child in container.children %}
         {%  include "tutorialv2/includes/child.part.html" with child=child %}
     {% empty %}
-        {% if not can_add_something or not container.can_add_extract %}
+        {% if not can_add_something or not container.is_chapter %}
             <div class="ico-after warning">
                 <p>
                     {{ "Ce"|feminize:container.get_level_as_string }} {{ container.get_level_as_string|lower }}  {% trans " est actuellement vide." %}
                 </p>
+                {% if container.can_add_extract and container.can_add_container and can_add_something %}
+                    <ul>
+                        <li>
+                            <a href="{% if container.parent == content %}
+                                        {% url "content:create-container" content.pk content.slug container.slug %}
+                                    {%  else %}
+                                        {% url "content:create-container" content.pk content.slug container.parent.slug %}
+                                    {%  endif %}">{% trans "Ajouter un chapitre" %}</a>
+                            {% trans " pour adopter le format big-tuto et ajouter des sections ;" %}
+                        </li>
+                        <li>
+                            <a href="{% if container.parent == content %}
+                                        {% url "content:create-extract" content.pk content.slug container.slug %}
+                                    {%  else %}
+                                        {% url "content:create-extract" content.pk content.slug container.parent.slug %}
+                                    {%  endif %}">{% trans "Ajouter une section" %}</a>
+                            {% trans " pour adopter le format moyen-tuto composé uniquement de section." %}
+                        </li>
+                    </ul>
+                {% endif %}
             </div>
         {% endif %}
     {% endfor %}
-    {% if can_add_something and container.can_add_extract %}
-        <h2 class="blue">
-            <a href="{%  if container.parent == content %}
-                        {% url "content:create-extract" content.pk content.slug container.slug %}
-                    {%  else %}
-                        {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
-                    {%  endif %}">
-                {% trans "Ajouter une nouvelle section" %}
-            </a>
-        </h2>
-        <div class="actions-title">
-            <a href="{% url "content:create-extract" content.pk content.slug container.slug %}" class="ico-after more btn btn-grey">
-                {% trans "Ajouter" %}
-            </a>
-        </div>
-        <div class="ico-after information">
-            <p>{% trans "Cliquer sur ajouter pour rédiger une nouvelle section." %}</p>
-        </div>
+    {% if can_add_something %}
+        {% if container.can_add_container and not container.can_add_extract %}
+            <h2 class="blue">
+                <a href="{% if container.parent == content %}
+                            {% url "content:create-container" content.pk content.slug container.slug %}
+                        {%  else %}
+                            {% url "content:create-container" content.pk content.slug container.parent.slug %}
+                        {%  endif %}">
+                    {% trans "Ajouter un nouveau chapitre" %}
+                </a>
+            </h2>
+            <div class="actions-title">
+                <a href="{% if container.parent == content %}
+                            {% url "content:create-container" content.pk content.slug container.slug %}
+                        {%  else %}
+                            {% url "content:create-container" content.pk content.slug container.parent.slug %}
+                        {%  endif %}" class="ico-after more btn btn-grey">
+                    {% trans "Ajouter" %}
+                </a>
+            </div>
+            <div class="ico-after information">
+                <p>{% trans "Cliquer sur ajouter pour ajouter un nouveau chapitre." %}</p>
+            </div>
+        {% endif %}
+        {% if not container.can_add_container and container.can_add_extract %}
+            <h2 class="blue">
+                <a href="{% if container.parent == content %}
+                            {% url "content:create-extract" content.pk content.slug container.slug %}
+                        {%  else %}
+                            {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
+                        {%  endif %}">
+                    {% trans "Ajouter une nouvelle section" %}
+                </a>
+            </h2>
+            <div class="actions-title">
+                <a href="{% if container.parent == content %}
+                            {% url "content:create-extract" content.pk content.slug container.slug %}
+                        {%  else %}
+                            {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
+                        {%  endif %}" class="ico-after more btn btn-grey">
+                    {% trans "Ajouter" %}
+                </a>
+            </div>
+            <div class="ico-after information">
+                <p>{% trans "Cliquer sur ajouter pour rédiger une nouvelle section." %}</p>
+            </div>
+        {% endif %}
     {% endif %}
 
     <hr />

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -199,8 +199,8 @@
     {% endfor %}
     {% if can_add_something %}
         {% if content.can_add_container and not content.can_add_extract %}
-            <h2 class="blue">
-                <a href="{% url "content:create-container" content.pk content.slug %}">
+            <h2>
+                <a class="force-blue" href="{% url "content:create-container" content.pk content.slug %}">
                     {% trans "Ajouter une nouvelle partie" %}
                 </a>
             </h2>
@@ -210,12 +210,12 @@
                 </a>
             </div>
             <div class="ico-after information">
-                <p>{% trans "Cliquer sur ajouter pour créer une nouvelle partie." %}</p>
+                <p>{% trans "Cette partie n'est pas encore créée. Vous devez la créer avant de pouvoir y ajouter un élément." %}</p>
             </div>
         {% endif %}
         {% if not content.can_add_container and content.can_add_extract %}
-            <h2 class="blue">
-                <a href="{% url "content:create-extract" content.pk content.slug %}">
+            <h2>
+                <a class="force-blue" href="{% url "content:create-extract" content.pk content.slug %}">
                     {% trans "Ajouter une nouvelle section" %}
                 </a>
             </h2>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -161,8 +161,8 @@
                 </li>
             {% endfor %}
             {% if not content.can_add_container and content.can_add_extract and can_add_something %}
-                <li style="list-style-type:'+'">
-                    <a href="{% url "content:create-extract" content.pk content.slug %}">
+                <li class="simple-create-button">
+                    <a class="btn btn-blue" href="{% url "content:create-extract" content.pk content.slug %}">
                         {% trans "Ajouter une nouvelle section" %}
                     </a>
                 </li>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -138,12 +138,17 @@
 
 
 {% block content %}
-    {% if content.introduction and content.get_introduction != None %}
+    {% if content.introduction and content.get_introduction != "" %}
         {{ content.get_introduction|emarkdown:is_js }}
     {% elif not content.is_beta %}
-        <p class="ico-after warning">
-            {% trans "Il n’y a pas d’introduction." %}
-        </p>
+        <div class="ico-after warning">
+            <p>
+                {% trans "Il n’y a pas d’introduction." %}
+                {% if can_add_something %}
+                    {% trans "Vous pouvez " %}<a href="{% url "content:edit" content.pk content.slug %}">{% trans "en ajouter une" %}</a>.
+                {% endif %}
+            </p>
+        </div>
     {% endif %}
 
     {% if content.has_extracts %}
@@ -155,26 +160,91 @@
                     </a>
                 </li>
             {% endfor %}
+            {% if content.can_add_extract %}
+                <li style="list-style-type:'+'">
+                    <a href="{% url "content:create-extract" content.pk content.slug %}">
+                        {% trans "Ajouter une nouvelle section" %}
+                    </a>
+                </li>
+            {% endif %}
         </ul>
     {% endif %}
 
     {% for child in content.children %}
-        {%  include "tutorialv2/includes/child.part.html" with child=child %}
+        {% include "tutorialv2/includes/child.part.html" with child=child %}
     {% empty %}
-        <p class="ico-after warning">
-            {% trans "Ce contenu est actuellement vide." %}
-        </p>
+        {% if can_add_extract and content.can_add_container and can_add_something %}
+            <div class="ico-after warning">
+                <p>
+                    {% trans "Ce contenu est actuellement vide." %}{% trans "Vous pouvez :" %}
+                </p>
+                <ul>
+                    <li>
+                        <a href="{% url "content:create-container" content.pk content.slug %}">{% trans "Ajouter une partie" %}</a>
+                        {% trans " pour adopter le format big-tuto ou moyen-tuto. Vous pourrez y ajouter des chapitres ou directement des sections (-> moyen-tuto) ;" %} 
+                    </li>
+                    <li>
+                        <a href="{% url "content:create-extract" content.pk content.slug %}">{% trans "Ajouter une section" %}</a>
+                        {% trans " pour adopter le format mini-tuto composé uniquement de section." %}
+                    </li>
+                </ul>
+            </div>
+        {% elif not can_add_something or not content.can_add_extract and not content.can_add_container %}
+            <div class="ico-after warning">
+                <p>
+                    {% trans "Ce contenu est actuellement vide." %}
+                </p>
+            </div>
+        {% endif %}
     {% endfor %}
+    {% if can_add_something %}
+        {% if content.can_add_container and not content.can_add_extract %}
+            <h2 class="blue">
+                <a href="{% url "content:create-container" content.pk content.slug %}">
+                    {% trans "Ajouter une nouvelle partie" %}
+                </a>
+            </h2>
+            <div class="actions-title">
+                <a href="{% url "content:create-container" content.pk content.slug %}" class="ico-after more btn btn-grey">
+                    {% trans "Ajouter" %}
+                </a>
+            </div>
+            <div class="ico-after information">
+                <p>{% trans "Cliquer sur ajouter pour créer une nouvelle partie." %}</p>
+            </div>
+        {% endif %}
+        {% if not content.can_add_container and content.can_add_extract %}
+            <h2 class="blue">
+                <a href="{% url "content:create-extract" content.pk content.slug %}">
+                    {% trans "Ajouter une nouvelle section" %}
+                </a>
+            </h2>
+            <div class="actions-title">
+                <a href="{% url "content:create-extract" content.pk content.slug %}" class="ico-after more btn btn-grey">
+                    {% trans "Ajouter" %}
+                </a>
+            </div>
+            <div class="ico-after information">
+                <p>{% trans "Cliquer sur ajouter pour rédiger une nouvelle section." %}</p>
+            </div>
+        {% endif %}
+    {% endif %}
+
 
     <hr class="clearfix" />
     <hr />
 
-    {% if content.conclusion and content.get_conclusion != None %}
+    {% if content.conclusion and content.get_conclusion != "" %}
         {{ content.get_conclusion|emarkdown:is_js }}
     {% elif not content.is_beta %}
-        <p class="ico-after warning">
-            {% trans "Il n’y a pas de conclusion." %}
-        </p>
+        <div class="ico-after warning">
+            <p>
+                {% trans "Il n’y a pas de conclusion." %}
+                {% if can_add_something %}
+                    {% trans "Vous pouvez " %}<a href="{% url "content:edit" content.pk content.slug %}">{% trans "en ajouter une" %}</a>.
+                {% endif %}
+            </p>
+        </div>
     {% endif %}
 
     {% if content.is_beta %}
@@ -185,90 +255,86 @@
 
 
 {% block sidebar_new %}
-    {% if can_edit or is_staff %}
-        {% if not version or content.sha_draft == version %}
-            <a href="{% url "content:edit" content.pk content.slug %}" class="ico-after edit blue new-btn">
-                {% trans "Éditer" %}
-            </a>
+    {% if can_add_something %}
+        <a href="{% url "content:edit" content.pk content.slug %}" class="ico-after edit blue new-btn">
+            {% trans "Éditer" %}
+        </a>
 
-            {%  if content.can_add_container %}
-                <a href="{% url "content:create-container" content.pk content.slug %}" class="ico-after more blue new-btn">
-                    {% trans "Ajouter " %} {{ "un"|feminize:content.get_next_level_as_string }} {{ content.get_next_level_as_string|lower }}
-                </a>
-            {% endif %}
-
-            {%  if content.can_add_extract %}
-                <a href="{% url "content:create-extract" content.pk content.slug %}" class="ico-after more blue new-btn">
-                    {% trans "Ajouter une section" %}
-                </a>
-            {%  endif %}
-
-            <a href="{% url "content:import" content.pk content.slug %}" class="ico-after import blue new-btn">
-                {% trans "Importer une nouvelle version" %}
-            </a>
-
-        {% else %}
-            <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
-                {% trans "Version brouillon" %}
+        {%  if content.can_add_container %}
+            <a href="{% url "content:create-container" content.pk content.slug %}" class="ico-after more blue new-btn">
+                {% trans "Ajouter " %} {{ "un"|feminize:content.get_next_level_as_string }} {{ content.get_next_level_as_string|lower }}
             </a>
         {% endif %}
+
+        {%  if content.can_add_extract %}
+            <a href="{% url "content:create-extract" content.pk content.slug %}" class="ico-after more blue new-btn">
+                {% trans "Ajouter une section" %}
+            </a>
+        {%  endif %}
+
+        <a href="{% url "content:import" content.pk content.slug %}" class="ico-after import blue new-btn">
+            {% trans "Importer une nouvelle version" %}
+        </a>
+
+    {% else %}
+        <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
+            {% trans "Version brouillon" %}
+        </a>
     {% endif %}
 {% endblock %}
 
 
 
 {% block sidebar_actions %}
+    {# AUTHORS #}
+    {% if can_add_something %}
+        <li>
+            <a href="#add-author" class="open-modal ico-after more blue">
+                {% trans "Ajouter un auteur" %}
+            </a>
+            <form action="{% url "content:add-author" content.pk %}" method="post" class="modal modal-flex" id="add-author">
+                {% csrf_token %}
+                <input type="text" name="username" placeholder="Pseudo de l’utilisateur à ajouter" data-autocomplete="{ 'type': 'single' }">
+                <button type="submit" name="add_author">
+                    {% trans "Confirmer" %}
+                </button>
+            </form>
+        </li>
+        <li>
+            <a href="#manage-authors" class="open-modal ico-after gear blue">
+                {% trans "Gérer les auteurs" %}
+            </a>
+            <form action="{% url "content:remove-author" content.pk  %}" method="post" class="modal modal-flex" id="manage-authors" data-modal-close="Fermer">
+                <table class="fullwidth">
+                    <thead>
+                        <th>{% trans "Auteur" %}</th>
+                        <th width="100px">{% trans "Actions" %}</th>
+                    </thead>
+                    <tbody>
+                        {% for member in content.authors.all %}
+                            <tr>
+                                <td>{% include "misc/member_item.part.html" %}</td>
+                                <td>
+                                    {% if content.authors.count > 1 %}
+
+                                        <button type="submit" data-value="{{ member.username }}" name="username" value="{{ member.username }}" class="modal-inner">
+                                            {% trans "Supprimer" %}
+                                        </button>
+                                    {% else %}
+                                        {% trans "Vous êtes seul" %} !
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+
+                {% csrf_token %}
+            </form>
+        </li>
+    {% endif %}
+    {# END AUTHORS #}
     {% if can_edit or is_staff %}
-
-        {# AUTHORS #}
-        {% if not version or content.sha_draft == version %}
-            <li>
-                <a href="#add-author" class="open-modal ico-after more blue">
-                    {% trans "Ajouter un auteur" %}
-                </a>
-                <form action="{% url "content:add-author" content.pk %}" method="post" class="modal modal-flex" id="add-author">
-                    {% csrf_token %}
-                    <input type="text" name="username" placeholder="Pseudo de l’utilisateur à ajouter" data-autocomplete="{ 'type': 'single' }">
-                    <button type="submit" name="add_author">
-                        {% trans "Confirmer" %}
-                    </button>
-                </form>
-            </li>
-            <li>
-                <a href="#manage-authors" class="open-modal ico-after gear blue">
-                    {% trans "Gérer les auteurs" %}
-                </a>
-                <form action="{% url "content:remove-author" content.pk  %}" method="post" class="modal modal-flex" id="manage-authors" data-modal-close="Fermer">
-                    <table class="fullwidth">
-                        <thead>
-                            <th>{% trans "Auteur" %}</th>
-                            <th width="100px">{% trans "Actions" %}</th>
-                        </thead>
-                        <tbody>
-                            {% for member in content.authors.all %}
-                                <tr>
-                                    <td>{% include "misc/member_item.part.html" %}</td>
-                                    <td>
-                                        {% if content.authors.count > 1 %}
-
-                                            <button type="submit" data-value="{{ member.username }}" name="username" value="{{ member.username }}" class="modal-inner">
-                                                {% trans "Supprimer" %}
-                                            </button>
-                                        {% else %}
-                                            {% trans "Vous êtes seul" %} !
-                                        {% endif %}
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-
-                    {% csrf_token %}
-                </form>
-            </li>
-        {% endif %}
-        {# END AUTHORS #}
-
         {# BETA #}
         {% if content.can_be_in_beta %}
             {% if not content.in_beta %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -173,7 +173,7 @@
     {% for child in content.children %}
         {% include "tutorialv2/includes/child.part.html" with child=child %}
     {% empty %}
-        {% if can_add_extract and content.can_add_container and can_add_something %}
+        {% if content.can_add_extract and content.can_add_container and can_add_something %}
             <div class="ico-after warning">
                 <p>
                     {% trans "Ce contenu est actuellement vide." %}{% trans "Vous pouvez :" %}
@@ -181,7 +181,7 @@
                 <ul>
                     <li>
                         <a href="{% url "content:create-container" content.pk content.slug %}">{% trans "Ajouter une partie" %}</a>
-                        {% trans " pour adopter le format big-tuto ou moyen-tuto. Vous pourrez y ajouter des chapitres ou directement des sections (-> moyen-tuto) ;" %} 
+                        {% trans " pour adopter le format big-tuto ou moyen-tuto. Vous pourrez y ajouter des chapitres ou des sections ;" %} 
                     </li>
                     <li>
                         <a href="{% url "content:create-extract" content.pk content.slug %}">{% trans "Ajouter une section" %}</a>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -163,7 +163,7 @@
             {% if not content.can_add_container and content.can_add_extract and can_add_something %}
                 <li class="simple-create-button">
                     <a class="btn btn-blue" href="{% url "content:create-extract" content.pk content.slug %}">
-                        {% trans "Ajouter une nouvelle section" %}
+                        {% trans "Ajouter une section" %}
                     </a>
                 </li>
             {% endif %}
@@ -216,7 +216,7 @@
         {% if not content.can_add_container and content.can_add_extract %}
             <h2>
                 <a class="force-blue" href="{% url "content:create-extract" content.pk content.slug %}">
-                    {% trans "Ajouter une nouvelle section" %}
+                    {% trans "Ajouter une section" %}
                 </a>
             </h2>
             <div class="actions-title">

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -162,7 +162,7 @@
             {% endfor %}
             {% if not content.can_add_container and content.can_add_extract and can_add_something %}
                 <li class="simple-create-button">
-                    <a class="btn btn-blue" href="{% url "content:create-extract" content.pk content.slug %}">
+                    <a class="btn btn-grey" href="{% url "content:create-extract" content.pk content.slug %}">
                         {% trans "Ajouter une section" %}
                     </a>
                 </li>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -151,7 +151,7 @@
         </div>
     {% endif %}
 
-    {% if content.has_extracts %}
+    {% if content.has_extracts or content.can_add_extract %}
         <ul>
             {% for extract in content.children %}
                 <li>
@@ -160,7 +160,7 @@
                     </a>
                 </li>
             {% endfor %}
-            {% if content.can_add_extract %}
+            {% if not content.can_add_container and content.can_add_extract and can_add_something %}
                 <li style="list-style-type:'+'">
                     <a href="{% url "content:create-extract" content.pk content.slug %}">
                         {% trans "Ajouter une nouvelle section" %}

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -266,6 +266,8 @@ class SingleContentDetailViewMixin(SingleContentViewMixin, DetailView):
         if self.sha != self.object.sha_draft:
             context['version'] = self.sha
 
+        context['can_add_something'] = (self.is_author or self.is_staff) and (not self.sha or self.sha == self.object.sha_draft)
+
         if self.object.beta_topic:
             beta_topic = Topic.objects.get(pk=self.object.beta_topic.pk)
 

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -266,7 +266,9 @@ class SingleContentDetailViewMixin(SingleContentViewMixin, DetailView):
         if self.sha != self.object.sha_draft:
             context['version'] = self.sha
 
-        context['can_add_something'] = (self.is_author or self.is_staff) and (not self.sha or self.sha == self.object.sha_draft)
+        is_allowed = (self.is_author or self.is_staff)
+        is_same_version = (not self.sha or self.sha == self.object.sha_draft)
+        context['can_add_something'] = is_allowed and is_same_version
 
         if self.object.beta_topic:
             beta_topic = Topic.objects.get(pk=self.object.beta_topic.pk)

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -775,6 +775,27 @@ class Container:
         else:
             return _('Section')
 
+    def is_chapter(self):
+        """
+        Check if the container level is Chapter
+
+        :return: True if the container level is Chapter
+        :rtype: bool
+        """
+        if self.get_tree_depth() == 2:
+                return True
+        return False
+
+    def next_level_is_chapter(self):
+        """Same as ``self.is_chapter()`` but check the container's children
+
+        :return: True if the container next level is Chapter
+        :rtype: bool
+        """
+        if self.get_tree_depth() == 1 and self.can_add_container():
+                return True
+        return False
+
     def can_be_in_beta(self):
         """
         Check if content can be in beta.


### PR DESCRIPTION
Fonctionnalité, resolve : #5030

Q/A : 
 - Vérifier les liens de création/édition que ça redirige vers la bonne page ;
 - Vérifier la présence de "ajouter machin" dans les listes (le plus souvent il y a un "+" devant. -> Vérifier les liens aussi.
 - Lorsqu'on peut ajouter deux choses (partie ou chapitre). On a un message dans le warning : "le contenu est vide. vous pouvez : a ou b".
 - Vérifier aussi la validation et le contenu online.

J'ai ajouté : can_add_something, j'ai donc remplacé l'ancienne double condition : 
```
{% if can_edit or is_staff %}
   {%  if not version or version == content.sha_draft %}
```
Par : 
```
{% if can_add_something %}
```

Principe : 
  - Lorsque je propose d'ajouter quelques choses en cliquant sur le bouton, j'utilise le block info et non warning.
  - J'ai uniformisé le bloc warning avec le reste du site.
  - Il n'y a pas "Ce chapitre/partie est actuellement vide." si on peut ajouter un, j'ai préféré mettre le bouton d'ajout sans ce bloc warning pour alléger l'interface.


J'ai hésité : 

 - A modifier : `Cette section est actuellement vide. ` et ajouter : `, vous pouvez [écrire du texte](#).`