### PR TITLE
Fix problem with unordered data

### DIFF
--- a/zds/tutorialv2/views/published.py
+++ b/zds/tutorialv2/views/published.py
@@ -1169,6 +1169,7 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
                 stats[m] = []
                 for d in data:
                     stats[m].append({'date': d, m: data[d][m]})
+                stats[m] = sorted(stats[m], key=lambda k: k['date'])
             api_raw = [{'label': _('Global'),
                         'stats': stats}]
         else:
@@ -1196,6 +1197,7 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
                     stats[m] = []
                     for d in data[url.url]['stats']:
                         stats[m].append({'date': d, m: data[url.url]['stats'][d].get(m, 0)})
+                    stats[m] = sorted(stats[m], key=lambda k: k['date'])
                 element = {'label': url.name, 'stats': stats}
                 api_raw.append(element)
 


### PR DESCRIPTION
Règle le souci de données non ordonnée pour les stats. J'ignore toutefois pourquoi cela existe sur la [pré]-prod' et pas en local. Du coup je n'ai pas pu tester correctement localement... Si qqun a une idée je prends!

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné (optionnel) : #5152 

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

Idéalement il suffirait de vérifier que les données s'affichent correctement (i.e. dans l'ordre chronologique sur l'interface des stats. Cependant j'ai été incapable de reproduire en local...

<!-- Merci ! -->
