### PR TITLE
Support de la commande "--speed" pour watch

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -24,6 +24,7 @@ const postcssPlugins = [
 
 if (!fast) {
     postcssPlugins.push(cssnano());
+    console.log("The speed mode is not enabled.");
 } else {
     console.log("The speed mode is enabled.");
 }
@@ -154,6 +155,8 @@ gulp.task('watch-runner', () => {
 // https://github.com/gulpjs/gulp/issues/259#issuecomment-152177973
 gulp.task('watch', cb => {
     function spawnGulp(args) {
+        if (fast)
+            args.push("--speed");
         return require('child_process')
             .spawn(
                 'node_modules/.bin/gulp',


### PR DESCRIPTION
Fix : #5168

Si speed est défini je l'ajoute en argument comme l'[exemple de la doc de nodejs](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).