### PR TITLE
Ajout "voir les stats" sur la version en ligne

### DIFF
--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -257,6 +257,11 @@
                         {% trans "Version brouillon" %}
                     </a>
                 </li>
+                <li>
+                    <a href="{% url "content:stats-content" content.pk content.slug %}" class="ico-after stats blue">
+                        {% trans "Voir les statistiques" %}
+                    </a>
+                </li>
                 {% if is_staff %}
                     {% if content.requires_validation %}
                         <li>


### PR DESCRIPTION
Ajoute le bouton sur la version en ligne (en dessous de "Version brouillon")

Fix : #5159