### PR TITLE
Fix #5174: N'affiche pas revenir à la vue globale sur les articles/billets

### DIFF
--- a/templates/tutorialv2/stats/index.html
+++ b/templates/tutorialv2/stats/index.html
@@ -96,7 +96,9 @@
         {% endif %}
 
         {% if not display == 'global' %}
-            <a href="{% url "content:stats-content" content.pk content.slug %}" class="btn btn-submit">{% trans "Revenir à la vue globale" %}</a>
+            {%if container.is_chapter or container.is_part  %}
+                <a href="{% url "content:stats-content" content.pk content.slug %}" class="btn btn-submit">{% trans "Revenir à la vue globale" %}</a>
+            {% endif %}
         {% endif %}
         <hr class="clearfix">
         <div>


### PR DESCRIPTION
Fix #5174: 

Q/A : Je n'ai pas de big-tuto avec des stats pour vérifier que le bouton s'affiche correctement, mais en tout cas il est masqué correctement.