### PR TITLE
Ajout des epub dans robot.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -10,17 +10,23 @@ Sitemap: https://zestedesavoir.com/sitemap-topics.xml
 Sitemap: https://zestedesavoir.com/sitemap-tutos.xml
 
 User-agent: *
+Disallow: /articles/epub/
 Disallow: /articles/html/
 Disallow: /articles/md/
+Disallow: /articles/tex/
 Disallow: /articles/zip/
+Disallow: /billets/epub/
 Disallow: /billets/html/
 Disallow: /billets/md/
+Disallow: /billets/tex/
 Disallow: /billets/zip/
 Disallow: /contenus/
 Disallow: /mp/
 Disallow: /oldarticles/
 Disallow: /oldtutoriels/
 Disallow: /rechercher/
+Disallow: /tutoriels/epub/
 Disallow: /tutoriels/html/
 Disallow: /tutoriels/md/
+Disallow: /tutoriels/tex/
 Disallow: /tutoriels/zip/


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18501150/50271192-4f7e5280-0434-11e9-8447-937a77a47f9e.png)

Exclus les .epub à partir de l'url : https://zestedesavoir.com/tutoriels/epub/