### PR TITLE
Remet le bouton "télécharger l'archive" sur la version brouillon

### DIFF
--- a/templates/tutorialv2/base.html
+++ b/templates/tutorialv2/base.html
@@ -86,7 +86,7 @@
         {% if content %}
             {% if content.is_public or content.in_beta or can_edit or is_staff %}
                 <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Télécharger">
-                    {% if public_object.is_exported %}
+                    {% if not public_object or public_object.is_exported %}
                         {% include "tutorialv2/includes/list_of_exports.html" %}
                     {% endif %}
                 </div>


### PR DESCRIPTION
fix #5192 

# QA

- créer un contenu
- vérifiez que "télécharger l'archive apparaît dans la version brouillon"
- publiez-le
- vérifiez que "télécharger" apparait sur la version publique, et qu'on a toujours l'archive dans la version brouillon
- lancez `rm contents-public/<slug-du-contenu>/extra_contents/*.*` 
- vérifiez que le bouton "télécharger" n'apparaît **plus** sur la version publique mais que l'archive est toujours dans la version brouillon.

