### PR TITLE
Corrige la commande d'installation de zmarkdown dans la documentation

### DIFF
--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -132,7 +132,7 @@ Strictement équivalent à la commande suivantes:
 
 .. sourcecode:: bash
 
-    make install-zmd
+    make zmd-install
 
 Si vous ne souhaitez pas utiliser ce composant, il vous faut tout de même installer zmarkdown manuellement.
 Pour cela, rendez-vous sur `la documentation dédiée <extra-zmd.html>`_.


### PR DESCRIPTION
Une petite erreur repérée lors de l'installation d'une version locale de ZdS.

### Contrôle qualité

Simple relecture.