### PR TITLE
fix #5244

### DIFF
--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -28,7 +28,9 @@ function error {
 }
 
 # variables
-source define_variable.sh
+LOCAL_DIR="$(cd "$(dirname "$0")" && pwd)"
+source $LOCAL_DIR/define_variable.sh
+
 
 # os-specific package install
 if  ! $(_in "-packages" $@) && ( $(_in "+packages" $@) || $(_in "+base" $@) || $(_in "+full" $@) ); then


### PR DESCRIPTION
Cette PR corrige le problème que j'ai rencontré dans le ticket #5244 

Il permet de sourcer le fichier de variable quelque soit notre répertoire.

### Contrôle qualité


- Lancez `make install-linux-full`
- Vérifiez que vous n'avez plus d'erreur
