### PR TITLE
Améliore le responsive de l'header : Remet l'avatar

### DIFF
--- a/assets/js/mobile-menu.js
+++ b/assets/js/mobile-menu.js
@@ -67,13 +67,15 @@
                 });
 
 
-
                 /**
                  * Build sidebar menu from page
                  */
 
                 appendToSidebar($("#search"), true);
-                appendToSidebar($(".logbox .my-account"), true);
+
+                var $myaccount = appendToSidebar($("#my-account"), true);
+                $myaccount.addClass("mobile-menu-link mobile-menu-bloc");
+
                 appendToSidebar($(".header-menu"));
 
                 $(".page-container .mobile-menu-bloc .mobile-menu-bloc").each(function(){
@@ -162,14 +164,14 @@
 
 
 
-    function appendToSidebar($elem, force){
+    function appendToSidebar($elem, onlyCloneThisElement){
         if($elem.hasClass("mobile-menu-imported"))
-            return;
+            return false;
 
-        if(force){
+        if(onlyCloneThisElement){
             $elem.addClass("mobile-menu-imported");
-            $elem.clone().removeAttr("id").appendTo("#mobile-menu");
-            return;
+            $elem = $elem.clone().removeAttr("id").appendTo("#mobile-menu");
+            return $elem;
         }
 
         var $div = $("<div/>");
@@ -179,7 +181,12 @@
         if($elem.hasClass("mobile-show-ico"))
             $div.addClass("mobile-show-ico");
 
-        var $links = ($elem.hasClass("mobile-all-links")) ? $("a, button, span.disabled", $elem).not(".action-hover").addClass("mobile-menu-link") : $(".mobile-menu-link", $elem);
+        var addAllLinks = $elem.hasClass("mobile-all-links");
+
+        var $links = $elem.find((addAllLinks) ? "a, button, span.disabled" : ".mobile-menu-link");
+
+        if (addAllLinks)
+            $links = $links.not(".action-hover");
 
         $links.each(function(){
             if($(this).parents(".mobile-menu-imported, .modal").length === 0){
@@ -201,9 +208,14 @@
             }
         });
 
+        if (addAllLinks)
+            $div.find("a, button, span.disabled").addClass("mobile-menu-link");
+
         $elem.addClass("mobile-menu-imported");
 
         $div.appendTo($("#mobile-menu"));
+
+        return $div;
     }
 
 

--- a/assets/scss/components/_mobile-menu.scss
+++ b/assets/scss/components/_mobile-menu.scss
@@ -276,40 +276,5 @@
                 }
             }
         }
-
-
-        .logbox {
-            .notifs-links .ico-link,
-            .my-account {
-                position: absolute;
-                top: 0;
-                right: 0;
-                height: 50px;
-                width: 50px;
-
-                .avatar {
-                    height: 50px;
-                    width: 50px;
-                }
-            }
-            .notifs-links  {
-                :nth-child(1) .ico-link {
-                    right: 150px;
-                }
-                :nth-child(2) .ico-link {
-                    right: 100px;
-                }
-                :nth-child(3) .ico-link,
-                .ico-link:nth-child(3) {
-                    right: 50px;
-                }
-            }
-
-            &.unlogged {
-                position: absolute;
-                top: 0;
-                right: 0;
-            }
-        }
     }
 }

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -352,7 +352,7 @@ $logo-width: 240px;
         }
     }
 
-    .my-account {
+    #my-account {
         display: block;
         height: 60px;
         width: 60px;
@@ -411,6 +411,7 @@ $logo-width: 240px;
     .header-container {
         .header-logo {
             width: 40px;
+            min-width: 40px;
             height: 50px;
             margin-left: 50px;
         }
@@ -427,14 +428,19 @@ $logo-width: 240px;
         }
 
         .logbox {
+            display: flex;
+
             .notifs-links {
                 background: none;
                 width: 100%;
+            }
 
-                .ico-link {
-                    height: 50px;
-                    width: 50px;
-                }
+
+            .notifs-links .ico-link, 
+            #my-account, 
+            #my-account .avatar{
+                height: 50px;
+                width: 50px;
             }
 
             .dropdown {
@@ -463,6 +469,32 @@ $logo-width: 240px;
                 }
             }
         }
+    }
+}
+
+@media only screen and (max-width: 339px) {
+    .header-container {
+        .header-mobile-page-title {
+            margin:0;
+        }
+        .mobile-menu-btn,
+        .logbox .notifs-links .ico-link {
+            width:40px !important;
+        }
+        .mobile-menu-btn::after {
+            left:8px !important;
+        }
+    }
+}
+
+@media only screen and (max-width: 239px) {
+    .header-container .header-logo {
+        width: 20px;
+        min-width: 20px;
+        height: 20px;
+        position: absolute;
+        left: 10px;
+        top: 32px;
     }
 }
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -331,7 +331,7 @@
                 {% with profile=user.profile %}
                     <a href="{% url "member-detail" user.username %}"
                        id="my-account"
-                       class="my-account mobile-menu-link mobile-menu-bloc dont-click-if-sidebar"
+                       class="dont-click-if-sidebar"
                        title="{% trans 'Mon profil' %}"
                        data-title="{% trans 'Mon profil' %}"
 
@@ -344,7 +344,7 @@
                     </a>
                 {% endwith %}
 
-                <div class="dropdown my-account-dropdown mobile-menu-bloc mobile-all-links" data-title="{% trans 'Mon compte' %}">
+                <div class="dropdown my-account-dropdown mobile-all-links" data-title="{% trans 'Mon compte' %}">
                     <span class="dropdown-title">{{ user.username|truncatechars:25 }}</span>
 
                     <ul class="dropdown-list">

--- a/zds/tutorialv2/tests/__init__.py
+++ b/zds/tutorialv2/tests/__init__.py
@@ -65,7 +65,7 @@ class TutorialFrontMixin:
         # Wait until the user is logged in (this raises if the element
         # is not found).
 
-        find_element('.header-container .logbox .my-account .username')
+        find_element('.header-container .logbox #my-account .username')
 
     def login_author(self):
         self.login(self.user_author.profile)


### PR DESCRIPTION
Cette PR : 

 - améliore le responsive design ;
 - ~~Enlève demi-face ;~~ <-- annulé/revert
 - Remet l'avatar dans le header ;
 - Prépare "la place" pour le centre des flux. :)

~~Je pensais avoir fait une issue pour remettre la photo de profil, impossible de la retrouver.~~

Fix : #4615

Résultat attendu : 

![image](https://user-images.githubusercontent.com/18501150/52057808-55547100-2566-11e9-9cc6-ad8eabdb04af.png)

![image](https://user-images.githubusercontent.com/18501150/52057871-7b7a1100-2566-11e9-9156-1ded2430753b.png)

