### PR TITLE
Insère directement le format en 228px

### DIFF
--- a/zds/featured/tests.py
+++ b/zds/featured/tests.py
@@ -173,7 +173,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         self.assertEqual(initial_dict['authors'], '{}, {}'.format(author, author2))
         self.assertEqual(initial_dict['type'], _('Un tutoriel'))
         self.assertEqual(initial_dict['url'], 'http://testserver{}'.format(tutorial.get_absolute_url_online()))
-        self.assertEqual(initial_dict['image_url'], 'http://testserver{}'.format(image.physical.social_network.url))
+        self.assertEqual(initial_dict['image_url'], 'http://testserver{}'.format(image.physical['featured'].url))
 
     def test_success_initial_content_topic(self):
         author = ProfileFactory().user

--- a/zds/featured/tests.py
+++ b/zds/featured/tests.py
@@ -173,7 +173,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         self.assertEqual(initial_dict['authors'], '{}, {}'.format(author, author2))
         self.assertEqual(initial_dict['type'], _('Un tutoriel'))
         self.assertEqual(initial_dict['url'], 'http://testserver{}'.format(tutorial.get_absolute_url_online()))
-        self.assertEqual(initial_dict['image_url'], image.physical.url)
+        self.assertEqual(initial_dict['image_url'], 'http://testserver{}'.format(image.physical.social_network.url))
 
     def test_success_initial_content_topic(self):
         author = ProfileFactory().user

--- a/zds/featured/views.py
+++ b/zds/featured/views.py
@@ -72,7 +72,7 @@ class FeaturedResourceCreate(CreateView):
             return {}
         displayed_authors = ', '.join([str(x) for x in content.authors.all()])
         if content.content.image:
-            image_url = content.content.image.physical.url
+            image_url = content.content.image.physical['featured'].url
         else:
             image_url = None
         return {'title': content.title(),

--- a/zds/featured/views.py
+++ b/zds/featured/views.py
@@ -72,7 +72,7 @@ class FeaturedResourceCreate(CreateView):
             return {}
         displayed_authors = ', '.join([str(x) for x in content.authors.all()])
         if content.content.image:
-            image_url = content.content.image.physical['featured'].url
+            image_url = self.request.build_absolute_uri(content.content.image.physical['featured'].url)
         else:
             image_url = None
         return {'title': content.title(),


### PR DESCRIPTION
Corrige le 5ème point de : #5215 

Q/A : 

Cliquer sur le bouton "ajouter en Une" dans un tutoriel et constater que : 
   - l'image est en 228x228 ;
   - Le lien de l'image comporte l'*origin*.

![image](https://user-images.githubusercontent.com/18501150/52064903-cd766300-2575-11e9-9709-771f5112b8e6.png)
