### PR TITLE
Corrige le message pour installer `elasticsearch`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ zmd-stop: ## Stop the zmarkdown server
 ## ~ Elastic Search
 
 run-elasticsearch: ## Run the Elastic Search server
-	elasticsearch || echo 'No Elastic Search installed (you can add it locally with `./scripts/install_zds.sh +elasticsearch`)'
+	elasticsearch || echo 'No Elastic Search installed (you can add it locally with `./scripts/install_zds.sh +elastic-local`)'
 
 index-all: ## Index the database in a new Elastic Search index
 	python manage.py es_manager index_all


### PR DESCRIPTION
D'après : #5144 

# Q/A : 

Vérifier ici : https://github.com/zestedesavoir/zds-site/blob/dev/scripts/install_zds.sh#L112 ou en écrivant la commande ;)