### PR TITLE
Vérifie correctement si c'est un billet pour les tags des résultats de recherche

### DIFF
--- a/templates/searchv2/includes/publishedcontent.part.html
+++ b/templates/searchv2/includes/publishedcontent.part.html
@@ -53,7 +53,7 @@
     <ul class="content-tags" itemprop="keywords">
         {% for tag in search_result.tags|slice:":3" %}
             <li>
-                {% if search_result.is_opinion %}
+                {% if search_result.content_type == 'OPINION' %}
                     <a href="{% url 'opinion:list' %}?tag={{ tag|urlencode }}">{{ tag }}</a>
                 {% else %}
                     <a href="{% url 'publication:list' %}?tag={{ tag|urlencode }}">{{ tag }}</a>


### PR DESCRIPTION
Fix : #5196

# Q/A :
Faire une recherche d'un billet et constater d'être correctement rediriger vers la page des tags des billets.