### PR TITLE
Corrige l'envoi des notifications pour les pings

### DIFF
--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -70,6 +70,40 @@ class ForumNotification(TestCase):
         self.assertEqual(1, PingSubscription.objects.count(),
                          'As one user is pinged, only one subscription is created.')
 
+    def test_edit_with_more_than_max_ping(self):
+        overridden_zds_app['comment']['max_pings'] = 2
+        overridden_zds_app['comment']['enable_pings'] = True
+        pinged_users = [ProfileFactory(), ProfileFactory(), ProfileFactory(), ProfileFactory()]
+        self.assertTrue(self.client.login(username=self.user2.username, password='hostel77'))
+        self.client.post(
+            reverse('topic-new') + '?forum={0}'.format(self.forum11.pk),
+            {
+                'title': 'Super sujet',
+                'subtitle': 'Pour tester les notifs',
+                'text': '@{} @{} are pinged, not @{} @{}'.format(*[a.user.username for a in pinged_users]),
+                'tags': ''
+            },
+            follow=False)
+        topic = Topic.objects.last()
+        post = topic.last_message
+        self.assertEqual(2, PingSubscription.objects.count())
+        self.assertTrue(PingSubscription.objects.get_existing(pinged_users[0].user, post, True))
+        self.assertTrue(PingSubscription.objects.get_existing(pinged_users[1].user, post, True))
+        self.assertFalse(PingSubscription.objects.get_existing(pinged_users[2].user, post, True))
+        self.assertFalse(PingSubscription.objects.get_existing(pinged_users[3].user, post, True))
+        self.client.post(
+            reverse('topic-edit') + '?topic={}'.format(topic.pk),
+            {
+                'title': 'Super sujet',
+                'subtitle': 'Pour tester les notifs',
+                'text': '@{} @{} are pinged'.format(pinged_users[1].user.username, pinged_users[3].user.username),
+                'tags': ''
+            },
+            follow=False)
+        self.assertTrue(PingSubscription.objects.get_existing(pinged_users[3].user, post, True))
+        self.assertTrue(PingSubscription.objects.get_existing(pinged_users[1].user, post, True))
+        self.assertFalse(PingSubscription.objects.get_existing(pinged_users[0].user, post, True))
+
     def test_no_reping_on_edition(self):
         """
         to be more accurate : on edition, only ping **new** members


### PR DESCRIPTION
Corrige l'envoi des notifications pour les pings.

**QA :**

- éditer `zds/settings/abstract_base/zds.py` et remplacer `'max_pings': 15,` par `'max_pings': 2,` pour faciliter la QA ;
- lancer `make zmd-start` et `make run-back` ;
- créer un nouveau sujet avec user1 dont le contenu est `@user2 @user3 @user4 @user5` ;
- vérifier que user2 et user3 ont reçu une notification (sans cliquer dessus) mais que user4 et user5 n'ont rien reçu ;
  => la limitation du nombre de ping fonctionne correctement
- éditer le sujet de user1 et cliquer sur Valider sans rien changer au contenu ;
- vérifier que user2 et user3 ont reçu une notification (sans cliquer dessus) mais que user4 et user5 n'ont rien reçu ;
  => éditer un message contenant un nombre de pings au dessus de la limite sans modifier les pings n'envoie pas de nouvelles notifications
- éditer le sujet de user1 et remplacer le contenu par `@user2 @user4` ;
- vérifier que user2 et user4 ont reçu une notification (sans cliquer dessus) mais que user3 et user5 n'ont rien reçu ;
  => l'édition fonctionne correctement
- créer un nouveau sujet ou message avec user1 dont le contenu est `@user5 @user5` ;
- vérifier que user5 a reçu une seule notification ;
  => mentionner plusieurs fois = une seule notif
- créer un nouveau sujet ou message avec user1 dont le contenu est `@user1` ;
- vérifier que user1 n'a pas reçu de notification.
  => pas d'auto-ping
