### PR TITLE
Agrandit le lien pour s'inscrire

### DIFF
--- a/templates/email/member/confirm_registration.html
+++ b/templates/email/member/confirm_registration.html
@@ -13,7 +13,7 @@
     </p>
     <p>
         {% blocktrans %}
-            Il ne vous reste plus qu'à activer votre profil ! Pour ce faire, visitez <a href="{{ url }}">ce lien</a>.
+            Il ne vous reste plus qu'à activer votre profil ! <a href="{{ url }}">Valider votre compte et votre adresse e-mail</a>.
         {% endblocktrans %}
     </p>
     <p>


### PR DESCRIPTION
Quand on s'inscrit on doit cliquer sur "ce lien", ce qui est relativement petit, voici un correctif.

Ceci est aussi plus évident pour les personnes non-voyantes ou avec une synthèse vocale.