### PR TITLE
Ajoute un lien sur les catégories dans le menu principal (#5281)

### DIFF
--- a/assets/scss/components/_header-dropdown.scss
+++ b/assets/scss/components/_header-dropdown.scss
@@ -15,6 +15,21 @@
 
     .dropdown-title {
         color: #FFF;
+
+        a {
+            display: block;
+            width: 95%;
+            min-height: 25px;
+            line-height: 25px;
+            overflow: hidden;
+            transition: padding-left $transition-duration ease, background-color $transition-duration ease;
+
+            &:hover,
+            &:focus {
+                padding-left: 3%;
+                background-color: rgba(0, 0, 0, .3)
+            }
+        }
     }
 
     &.header-menu-dropdown .dropdown-list > li {
@@ -49,19 +64,21 @@
             li {
                 position: relative;
 
-                a {
-                    display: block;
-                    width: 95%;
-                    min-height: 25px;
-                    line-height: 25px;
-                    color: #95d7f5;
-                    overflow: hidden;
-                    transition: padding-left $transition-duration ease, background-color $transition-duration ease;
+                &.dropdown-list-element {
+                    a {
+                        color: #95d7f5;
+                        display: block;
+                        width: 95%;
+                        min-height: 25px;
+                        line-height: 25px;
+                        overflow: hidden;
+                        transition: padding-left $transition-duration ease, background-color $transition-duration ease;
 
-                    &:hover,
-                    &:focus {
-                        padding-left: 3%;
-                        background-color: rgba(0, 0, 0, .3)
+                        &:hover,
+                        &:focus {
+                            padding-left: 3%;
+                            background-color: rgba(0, 0, 0, .3)
+                        }
                     }
                 }
             }

--- a/templates/header.html
+++ b/templates/header.html
@@ -55,10 +55,12 @@
                                     <li>
                                         <ul>
                                             <li class="dropdown-title">
-                                                {{ title }}
+                                                <a href="{% url "publication:category" subcats.0.2 %}">
+                                                    {{ title }}
+                                                </a>
                                             </li>
                                             {% for subcat, slug, parent_slug in subcats %}
-                                                <li>
+                                                <li class="dropdown-list-element">
                                                     <a href="{% url 'publication:subcategory' slug_category=parent_slug slug=slug %}">
                                                         {{ subcat }}
                                                     </a>
@@ -113,7 +115,7 @@
                                                 {{ title }}
                                             </li>
                                             {% for subcat, slug, parent_slug in subcats %}
-                                                <li>
+                                                <li class="dropdown-list-element">
                                                     <a href="{% url "opinion:list" %}?category={{ slug }}">
                                                         {{ subcat }}
                                                     </a>
@@ -161,14 +163,18 @@
 
                         <ul class="dropdown-list">
                             {% with top=user|topbar_forum_categories %}
-                                {% for title, forums in top.categories %}
+                                {% for title, slug, forums in top.categories %}
                                     <li>
                                         <ul>
                                             <li class="dropdown-title">
-                                                {{ title }}
+                                                <a href="{% url "cat-forums-list" slug %}">
+                                                    {{ title }}
+                                                </a>
                                             </li>
                                             {% for forum in forums %}
-                                                <li {% if forum.has_group %}class="staff-only"{% endif %}><a href="{{ forum.get_absolute_url }}">{{ forum.title }}</a></li>
+                                                <li class="dropdown-list-element{% if forum.has_group %} staff-only{% endif %}">
+                                                    <a href="{{ forum.get_absolute_url }}">{{ forum.title }}</a>
+                                                </li>
                                             {% endfor %}
                                         </ul>
                                     </li>
@@ -189,7 +195,9 @@
                                             </li>
                                             {% for tag in top.tags %}
                                                 {% if tag.slug %}
-                                                    <li><a href="{{ tag.get_absolute_url }}">{{ tag.title }}</a></li>
+                                                    <li class="dropdown-list-element">
+                                                        <a href="{{ tag.get_absolute_url }}">{{ tag.title }}</a>
+                                                    </li>
                                                 {% endif %}
                                             {% endfor %}
                                         </ul>

--- a/zds/utils/templatetags/topbar.py
+++ b/zds/utils/templatetags/topbar.py
@@ -24,7 +24,7 @@ def topbar_forum_categories(user):
         cats[forum.category.position].append(forum)
 
     sorted_cats = sorted(cats)
-    topbar_cats = [(cats[cat][0].category.title, cats[cat]) for cat in sorted_cats]
+    topbar_cats = [(cats[cat][0].category.title, cats[cat][0].category.slug, cats[cat]) for cat in sorted_cats]
 
     excluded_tags = settings.ZDS_APP['forum']['top_tag_exclu']
     tags_by_popularity = (


### PR DESCRIPTION
Ajout de liens sur les catégories de premier niveau dans le menu. Exception faite des catégories de tribunes et de la catégorie _tag_ du menu _forum_, car il n'y a pas de page correspondante.

Numéro du ticket concerné : #5281



### Contrôle qualité

S'assurer que les liens des catégories fonctionnent correctement.
