### PR TITLE
Ajout d'un paramètre GET pour avoir une miniature Twitter large

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -67,7 +67,11 @@
 
     {# Twitter cards #}
     <meta property="twitter:domain" content="{{app.site.url}}/">
-    <meta property="twitter:card" content="summary">
+    {% if request.GET.twittercard == 'large' %}
+        <meta property="twitter:card" content="summary_large_image">
+    {% else %}
+        <meta property="twitter:card" content="summary">
+    {% endif %}
     <meta property="twitter:url" content="{{app.site.url}}{{ request.path }}">
     <meta property="twitter:title" content="{{ title|safe }}">
     <meta property="twitter:description" content="{{ description|safe }}">

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -47,7 +47,11 @@
 
 {% block meta_image %}{% spaceless %}
     {% if content.image %}
-        {{ content.image.physical|thumbnail_url:'social_network' }}
+        {% if request.GET.twittercard == "large"  %}
+            {{ content.image.physical|thumbnail_url:'social_network_large' }}
+        {% else %}}
+            {{ content.image.physical|thumbnail_url:'social_network' }}
+        {% endif %}
     {% else %}
         {% load static %}
         {% if content.type == 'TUTORIAL' %}

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -48,6 +48,7 @@ THUMBNAIL_ALIASES = {
         'social_network': {'size': (144, 144), 'crop': True},
         #                           ^^^  ^^^ -> minimum dimensions of 144x144
         # https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary
+        'social_network_large': {'size': (600, 314), 'crop': True}
     },
 }
 


### PR DESCRIPTION
Numéro du ticket concerné: #5291

En ajoutant `?twittercard=large` à la fin de l'URL d'un contenu, les balises meta `twitter:card` et `twitter:image` changent pour que Twitter affiche une large miniature lors du partage du lien vers un contenu.

J'ai également modifié l'URL dans les boutons de partage Twitter pour que l'URL partagée contienne automatiquement le paramètre GET supplémentaire (seulement s'il y a une image associée au contenu).


### Contrôle qualité

1. Aller sur un contenu qui contient une image
2. Le bouton de partage Twitter doit partager l'URL avec  `?twittercard=large` en plus

Note: c'est un peu compliqué à vérifier avec Twitter pour le moment, ce sera plus simple que ce sera dans la bêta.
