### PR TITLE
Affiche le diff des versions sur toute la largeur de l'écran (fix #5273)

### DIFF
--- a/templates/tutorialv2/view/diff.html
+++ b/templates/tutorialv2/view/diff.html
@@ -34,11 +34,7 @@
     </h1>
 
     {% include 'tutorialv2/includes/tags_authors.part.html' with online=False%}
-{% endblock %}
 
-
-
-{% block content_ext %}
     <a href="{{ content.get_absolute_url }}" class="btn btn-grey ico-after arrow-left">Retour</a>
 
     <ul>
@@ -57,7 +53,11 @@
             </a>)
         </li>
     </ul>
+{% endblock %}
 
+
+
+{% block content_ext %}
     <table>
         <tr>
             <th>{% trans "Légende" %}</th>

--- a/templates/tutorialv2/view/diff.html
+++ b/templates/tutorialv2/view/diff.html
@@ -39,6 +39,8 @@
 
 
 {% block content_ext %}
+    <a href="{{ content.get_absolute_url }}" class="btn btn-grey ico-after arrow-left">Retour</a>
+
     <ul>
         <li>
             <strong>Version 1 :</strong>

--- a/zds/utils/templatetags/htmldiff.py
+++ b/zds/utils/templatetags/htmldiff.py
@@ -22,10 +22,12 @@ def htmldiff(string1, string2):
     except AttributeError:
         txt2 = string2.splitlines()
 
-    diff = HtmlDiff(tabsize=4, wrapcolumn=80)
+    diff = HtmlDiff(tabsize=4)
     result = diff.make_table(txt1, txt2, context=True, numlines=2)
 
     if 'No Differences Found' in result:
         return format_html('<p>{}</p>', _('Pas de changements.'))
     else:
-        return format_html('<div class="diff_delta">{}</div>', mark_safe(result))
+        # the diff.make_table() replaces all spaces by non-breakable ones, which prevent line breaks:
+        r = mark_safe(result.replace('<td nowrap="nowrap">', '<td>').replace('&nbsp;', ' '))
+        return format_html('<div class="diff_delta">{}</div>', r)


### PR DESCRIPTION
Numéro du ticket concerné: fix #5273 

Le changement n'a même pas porté sur du CSS, mais seulement sur le module qui se charge de générer le diff: il limitait lui-même la longueur des lignes et ajouter de l'HTML spécifique pour ne pas aller à la ligne.