### PR TITLE
Ajout d'un bouton pour supprimer une image dans la page d'édition

### DIFF
--- a/templates/gallery/image/edit.html
+++ b/templates/gallery/image/edit.html
@@ -21,6 +21,12 @@
 
 {% block headline %}
     {% trans "Éditer une image" %}
+
+    {% if permissions.write %}
+        <a href="#form-delete-image" class="btn btn-cancel open-modal">
+            {% trans "Supprimer" %}
+        </a>
+    {% endif %}
 {% endblock %}
 
 
@@ -84,5 +90,15 @@
         </p>
 
         {% crispy as_avatar_form %}
+
+        {% if permissions.write %}
+            {# Confirmation modal for deleting image #}
+            <form id="form-delete-image" name="form" method="post" action="{% url "gallery-image-delete" gallery.pk %}" class="modal modal-flex">
+                {% csrf_token %}
+                <input type="hidden" name="image" value="{{ image.pk }}">
+                <p>{% trans "Attention, vous vous apprêtez à supprimer cette image." %}</p>
+                <button type="submit" name="delete" class="btn">{% trans "Confirmer" %}</button>
+            </form>
+        {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
Numéro du ticket concerné: #5289 

Voici le résultat:
![button-delete-image-gallery](https://user-images.githubusercontent.com/5911232/54480482-13873d80-4829-11e9-9001-7223202d0d54.png)
