### PR TITLE
(reprise #4999) Les parties à valider sont grisées

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -31,7 +31,7 @@ h2 {
     font-weight: 400;
 
     &.not-ready {
-        background: #DDD;
+        background: $color-not-ready-content;
     }
 }
 

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -29,6 +29,10 @@ h2 {
     border-top: 1px solid #e0e4e5;
     padding-left: 1%;
     font-weight: 400;
+
+    &.not-ready {
+        background: #DDD;
+    }
 }
 
 h3 {

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -31,7 +31,7 @@ h2 {
     font-weight: 400;
 
     &.not-ready {
-        background: $color-not-ready-content;
+        color: $color-not-ready-content;
     }
 }
 

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -30,7 +30,7 @@ h2 {
     padding-left: 1%;
     font-weight: 400;
 
-    &.not-ready {
+    &.not-ready a {
         color: $color-not-ready-content;
     }
 }
@@ -39,6 +39,9 @@ h3 {
     font-size: 20px;
     font-size: 2.0rem;
     margin-bottom: 14px;
+    &.not-ready a {
+        color: $color-not-ready-content;
+    }
 }
 
 h4 {

--- a/assets/scss/layout/_sidebar.scss
+++ b/assets/scss/layout/_sidebar.scss
@@ -39,10 +39,6 @@
         font-weight: normal;
         margin: 0;
         padding: 0;
-
-        &.not-ready {
-            background: $color-not-ready-content;
-        }
     }
     h3 {
         font-size: 18px;
@@ -345,6 +341,16 @@
                     margin-top: 5px;
                 }
             }
+            
+            &.not-ready {
+                background: $color-not-ready-content;
+            }
+        }
+        
+        li {
+            &.not-ready {
+                background: $color-not-ready-content;
+            }   
         }
 
         ol li.current {

--- a/assets/scss/layout/_sidebar.scss
+++ b/assets/scss/layout/_sidebar.scss
@@ -39,6 +39,10 @@
         font-weight: normal;
         margin: 0;
         padding: 0;
+
+        &.not-ready {
+            background: $color-not-ready-content;
+        }
     }
     h3 {
         font-size: 18px;

--- a/assets/scss/variables/_colors.scss
+++ b/assets/scss/variables/_colors.scss
@@ -20,3 +20,5 @@ $color-staff-hat: #2B5C73;
 
 $color-console-bg: #000;
 $color-console-text: #DDD;
+
+$color-not-ready-content: #D0D0D0;

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -5,7 +5,7 @@
 {% load feminize %}
 
 <h2 id="{{ child.position_in_parent }}-{{ child.slug }}"
-{% if not child.ready_to_publish %}
+{% if not child.ready_to_publish and not child.text %}
     class="not-ready"
 {% endif %}>
     <a

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -111,7 +111,7 @@
         <ol class="summary-part">
             {% for subchild in child.children %}
                 <li>
-                    <h3>
+                    <h3 class="{% if not subchild.ready_to_publish %}not-ready{% endif %}">
                         <a
                         {% if content.is_beta %}
                             href="{{ subchild.get_absolute_url_beta }}"

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -4,7 +4,10 @@
 {% load target_tree %}
 {% load feminize %}
 
-<h2 id="{{ child.position_in_parent }}-{{ child.slug }}">
+<h2 id="{{ child.position_in_parent }}-{{ child.slug }}"
+{% if not child.ready_to_publish %}
+    class="not-ready"
+{% endif %}>
     <a
     {% if content.is_beta %}
         href="{{ child.get_absolute_url_beta }}"

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -5,7 +5,7 @@
 {% load feminize %}
 
 <h2 id="{{ child.position_in_parent }}-{{ child.slug }}"
-{% if not child.ready_to_publish and not child.text %}
+{% if not child.is_validable %}
     class="not-ready"
 {% endif %}>
     <a

--- a/templates/tutorialv2/includes/summary.part.html
+++ b/templates/tutorialv2/includes/summary.part.html
@@ -67,7 +67,7 @@
                 <ol>
                     {% for subchild in child.children %}
                         <li class="{% if current_container.long_slug == subchild.long_slug %}current{% endif %}
-                            {% if not child.ready_to_publish and not child.text %} not-ready{% endif %}"
+                            {% if not subchild.ready_to_publish and not subchild.text %} not-ready{% endif %}"
                         >
                             <a data-num="{{ subchild.position_in_parent }}"
                                 {% if online %}

--- a/templates/tutorialv2/includes/summary.part.html
+++ b/templates/tutorialv2/includes/summary.part.html
@@ -30,7 +30,9 @@
         </ol>
     {% else %}
         {% for child in content.children %}
-             <h4 data-num="{{ child.position_in_parent|roman }}">
+             <h4 data-num="{{ child.position_in_parent|roman }}"
+                 {% if not child.ready_to_publish %} class="not-ready" {% endif %}
+             >
                 <a class="mobile-menu-link"
                     {% if online %}
                         href="{{ child.get_absolute_url_online }}"
@@ -64,7 +66,9 @@
             {% else %}
                 <ol>
                     {% for subchild in child.children %}
-                        <li {% if current_container.long_slug == subchild.long_slug %}class="current"{% endif %}>
+                        <li class="{% if current_container.long_slug == subchild.long_slug %}current{% endif %}
+                            {% if not child.ready_to_publish %} not-ready{% endif %}"
+                        >
                             <a data-num="{{ subchild.position_in_parent }}"
                                 {% if online %}
                                     href="{{ subchild.get_absolute_url_online }}"
@@ -85,7 +89,7 @@
                             {% if current_container.long_slug == subchild.long_slug %}
                                 <ol class="mobile-menu-bloc mobile-all-links" data-title="Sommaire du chapitre">
                                     {% for extract in subchild.children %}
-                                        <li>
+                                        <li {% if not child.ready_to_publish %} class="not-ready" {% endif %}>
                                             <a
                                                 {% if online %}
                                                     href="{{ extract.get_absolute_url_online }}"

--- a/templates/tutorialv2/includes/summary.part.html
+++ b/templates/tutorialv2/includes/summary.part.html
@@ -31,7 +31,7 @@
     {% else %}
         {% for child in content.children %}
              <h4 data-num="{{ child.position_in_parent|roman }}"
-                 {% if not child.ready_to_publish %} class="not-ready" {% endif %}
+                 {% if not child.ready_to_publish and not child.text %} class="not-ready" {% endif %}
              >
                 <a class="mobile-menu-link"
                     {% if online %}
@@ -67,7 +67,7 @@
                 <ol>
                     {% for subchild in child.children %}
                         <li class="{% if current_container.long_slug == subchild.long_slug %}current{% endif %}
-                            {% if not child.ready_to_publish %} not-ready{% endif %}"
+                            {% if not child.ready_to_publish and not child.text %} not-ready{% endif %}"
                         >
                             <a data-num="{{ subchild.position_in_parent }}"
                                 {% if online %}

--- a/templates/tutorialv2/includes/summary.part.html
+++ b/templates/tutorialv2/includes/summary.part.html
@@ -31,7 +31,7 @@
     {% else %}
         {% for child in content.children %}
              <h4 data-num="{{ child.position_in_parent|roman }}"
-                 {% if not child.ready_to_publish and not child.text %} class="not-ready" {% endif %}
+                 {% if not child.is_validable %} class="not-ready" {% endif %}
              >
                 <a class="mobile-menu-link"
                     {% if online %}
@@ -67,7 +67,7 @@
                 <ol>
                     {% for subchild in child.children %}
                         <li class="{% if current_container.long_slug == subchild.long_slug %}current{% endif %}
-                            {% if not subchild.ready_to_publish and not subchild.text %} not-ready{% endif %}"
+                            {% if not subchild.is_validable %} not-ready{% endif %}"
                         >
                             <a data-num="{{ subchild.position_in_parent }}"
                                 {% if online %}
@@ -89,7 +89,7 @@
                             {% if current_container.long_slug == subchild.long_slug %}
                                 <ol class="mobile-menu-bloc mobile-all-links" data-title="Sommaire du chapitre">
                                     {% for extract in subchild.children %}
-                                        <li {% if not child.ready_to_publish %} class="not-ready" {% endif %}>
+                                        <li {% if not extract.is_validable %} class="not-ready" {% endif %}>
                                             <a
                                                 {% if online %}
                                                     href="{{ extract.get_absolute_url_online }}"

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -879,6 +879,7 @@ class Container:
             return False
         return self.ready_to_publish
 
+
 class Extract:
     """
     A content extract from a Container.
@@ -1129,6 +1130,7 @@ class Extract:
 
     def is_validable(self):
         return self.container.is_validable()
+
 
 class VersionedContent(Container, TemplatableContentModelMixin):
     """

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -315,19 +315,21 @@ class Container:
             elif isinstance(child, Extract):
                 child.text = child.get_path(relative=True)
 
-    def get_path(self, relative=False):
+    def get_path(self, relative=False, os_sensitive=True):
         """Get the physical path to the draft version of the container.
         Note: this function rely on the fact that the top container is VersionedContainer.
 
         :param relative: if ``True``, the path will be relative, absolute otherwise.
         :type relative: bool
+        :param os_sensitive: if ```True`` will use os.path.join to ensure compatibility with all OS, otherwise \\
+        will build with ``/``, mainly for urls.
         :return: physical path
         :rtype: str
         """
         base = ''
         if self.parent:
             base = self.parent.get_path(relative=relative)
-        return os.path.join(base, self.slug)
+        return os.path.join(base, self.slug) if os_sensitive else '/'.join([base, self.slug]).strip('/')
 
     def get_prod_path(self, relative=False, file_ext='html'):
         """Get the physical path to the public version of the container. If the container have extracts, then it\
@@ -355,7 +357,7 @@ class Container:
         :return: url to access the container
         :rtype: str
         """
-        return self.top_container().get_absolute_url() + self.get_path(relative=True) + '/'
+        return self.top_container().get_absolute_url() + self.get_path(relative=True, os_sensitive=False) + '/'
 
     def get_absolute_url_online(self):
         """

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -869,7 +869,15 @@ class Container:
         # as introduction and conclusion are published in the full file, we remove reference to them
         self.introduction = None
         self.conclusion = None
-
+        
+    def is_validable(self):
+        """
+        Return ``true`` if the container can be validate ie. (would be in the public version if
+        the content is validate.
+        """
+        if self.parent is not None and not self.parent.is_validable():
+            return False
+        return self.ready_to_publish
 
 class Extract:
     """
@@ -1119,6 +1127,8 @@ class Extract:
             depth += 1
         return depth
 
+    def is_validable(self):
+        return self.container.is_validable()
 
 class VersionedContent(Container, TemplatableContentModelMixin):
     """

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -869,7 +869,7 @@ class Container:
         # as introduction and conclusion are published in the full file, we remove reference to them
         self.introduction = None
         self.conclusion = None
-        
+
     def is_validable(self):
         """
         Return ``true`` if the container can be validate ie. (would be in the public version if


### PR DESCRIPTION
reprise de #4999

Quand une partie ou un chapitre n'est pas à valider, il apparaît en plus sombre.

Ticket concerné : fix #4968 close #4999

### Contrôle qualité

- Reconstruire le front
- Créer un tutoriel.
- Créer une partie et la mettre en partie non prête à la validation, elle devrait apparaître en plus sombre
- Vérifier que c'est aussi le cas pour un chapitre non prêt à la validation. 
- Vérifier que les parties et les chapitres prêts à être validées ne sont pas affectés.

![screenshot_2018-08-05 s bibliotheque zeste de savoir](https://user-images.githubusercontent.com/12633306/43690948-53c72be6-98e1-11e8-87de-55cf30b567fe.png)

PS : les  extraits sont également affectés par cette modification.