### PR TITLE
[release_v28.1] Corrige l'affichage du dropdown pour les messages privés (fix #5317)

### DIFF
--- a/assets/scss/components/_header-dropdown.scss
+++ b/assets/scss/components/_header-dropdown.scss
@@ -15,20 +15,20 @@
 
     .dropdown-title {
         color: #FFF;
+    }
 
-        a {
-            display: block;
-            width: 95%;
-            min-height: 25px;
-            line-height: 25px;
-            overflow: hidden;
-            transition: padding-left $transition-duration ease, background-color $transition-duration ease;
+    .dropdown-list .dropdown-title a {
+        display: block;
+        width: 95%;
+        min-height: 25px;
+        line-height: 25px;
+        overflow: hidden;
+        transition: padding-left $transition-duration ease, background-color $transition-duration ease;
 
-            &:hover,
-            &:focus {
-                padding-left: 3%;
-                background-color: rgba(0, 0, 0, .3)
-            }
+        &:hover,
+        &:focus {
+            padding-left: 3%;
+            background-color: rgba(0, 0, 0, .3)
         }
     }
 


### PR DESCRIPTION
Corrige l'affichage du dropdown pour les messages privés

**QA :**
- `make build-front`
- Vérifier le bon affichage de *tous* les menus déroulants, en redimensionnant la fenêtre pour avoir le fonctionnement ordinateur, tablette ou smartphone.