### PR TITLE
Fix les redirections de tutoriel

### DIFF
--- a/doc/source/install/extra-install-es.rst
+++ b/doc/source/install/extra-install-es.rst
@@ -21,7 +21,7 @@ Installation
         -Xms512m
         -Xmx512m
 
-    Plus d'informations sont disponibles `dans la documentation <https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-system-settings.html#jvm-options>`_.
+    Plus d'informations sont disponibles `dans la documentation officielle <https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-system-settings.html#jvm-options>`_.
 
 Sous Linux
 ----------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,9 +6,9 @@ django-debug-toolbar==1.11
 flake8==3.5.0
 flake8_quotes==0.14.1
 autopep8==1.3.5
-sphinx==1.8.2
+sphinx==2.0.1
 selenium==3.14.1
-sphinx_rtd_theme==0.4.2
+sphinx_rtd_theme==0.4.3
 faker==0.8.12
 mock==2.0.0
 colorlog==3.1.2

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -312,8 +312,16 @@ class ContentTypeMixin(object):
 class MustRedirect(Exception):
     """Exception raised when this is not the last version of the content which is called"""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, url, *args, **kwargs):
+        """
+        initialize the exception
+
+        :param url: the targetted url
+        :param args: exception *args
+        :param kwargs: exception **kwargs
+        """
         super(MustRedirect, self).__init__(*args, **kwargs)
+        self.url = url
 
 
 class SingleOnlineContentViewMixin(ContentTypeMixin):
@@ -432,7 +440,7 @@ class SingleOnlineContentDetailViewMixin(SingleOnlineContentViewMixin, DetailVie
         try:
             self.public_content_object = self.get_public_object()
         except MustRedirect as redirection_url:
-            return HttpResponsePermanentRedirect(redirection_url)
+            return HttpResponsePermanentRedirect(redirection_url.url)
 
         self.object = self.get_object()
         self.versioned_object = self.get_versioned_object()

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -16,8 +16,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.template.loader import render_to_string
 
 from zds.tutorialv2.models.mixins import TemplatableContentModelMixin
-from zds.tutorialv2.utils import default_slug_pool, export_content, get_commit_author, InvalidOperationError,\
-    FailureDuringPublication
+from zds.tutorialv2.utils import default_slug_pool, export_content, get_commit_author, InvalidOperationError
 from zds.utils.misc import compute_hash
 from zds.tutorialv2.models import SINGLE_CONTAINER_CONTENT_TYPES, CONTENT_TYPES_BETA, CONTENT_TYPES_REQUIRING_VALIDATION
 from zds.tutorialv2.utils import get_blob, InvalidSlugError, check_slug
@@ -321,8 +320,8 @@ class Container:
 
         :param relative: if ``True``, the path will be relative, absolute otherwise.
         :type relative: bool
-        :param os_sensitive: if ```True`` will use os.path.join to ensure compatibility with all OS, otherwise \\
-        will build with ``/``, mainly for urls.
+        :param os_sensitive: if ``True`` will use os.path.join to ensure compatibility with all OS, otherwise \\
+                             will build with ``/``, mainly for urls.
         :return: physical path
         :rtype: str
         """
@@ -829,6 +828,7 @@ class Container:
             with file_path.open('w', encoding='utf-8') as f:
                 f.write(emarkdown(content, db_object.js_support))
         except (UnicodeError, UnicodeEncodeError):
+            from zds.tutorialv2.publication_utils import FailureDuringPublication
             raise FailureDuringPublication(
                 _("Une erreur est survenue durant la publication de l'introduction de « {} »,"
                   ' vérifiez le code markdown').format(self.title))

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -1448,7 +1448,11 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertIsNotNone(old_published)  # still exists
         self.assertTrue(old_published.must_redirect)  # do redirection if any
         self.assertIsNone(old_published.update_date)
-
+        result = self.client.get(old_published.get_absolute_url_online(), follow=False)
+        self.assertEqual(result.status_code, 301)
+        # extra contents are also redirected
+        result = self.client.get(old_published.get_absolute_url_md(), follow=False)
+        self.assertEqual(result.status_code, 301)
         new_published = PublishedContent.objects.filter(content__pk=self.tuto.pk).last()
         self.assertIsNotNone(new_published)  # new version exists
         self.assertNotEqual(old_published.pk, new_published.pk)  # not the old one

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -788,12 +788,4 @@ class BadArchiveError(Exception):
         self.message = reason
 
 
-class FailureDuringPublication(Exception):
-    """Exception raised if something goes wrong during the publication process
-    """
-
-    def __init__(self, *args, **kwargs):
-        super(FailureDuringPublication, self).__init__(*args, **kwargs)
-
-
 NamedUrl = namedtuple('NamedUrl', ['name', 'url', 'level'])

--- a/zds/tutorialv2/views/published.py
+++ b/zds/tutorialv2/views/published.py
@@ -211,7 +211,7 @@ class DownloadOnlineContent(SingleOnlineContentViewMixin, DownloadViewMixin):
         try:
             self.public_content_object = self.get_public_object()
         except MustRedirect as redirect_url:
-            return HttpResponsePermanentRedirect(redirect_url)
+            return HttpResponsePermanentRedirect(redirect_url.url)
 
         self.object = self.get_object()
         self.versioned_object = self.get_versioned_object()

--- a/zds/tutorialv2/views/validations.py
+++ b/zds/tutorialv2/views/validations.py
@@ -23,8 +23,8 @@ from zds.tutorialv2.forms import AskValidationForm, RejectValidationForm, Accept
 from zds.tutorialv2.mixins import SingleContentFormViewMixin, ModalFormView, \
     SingleOnlineContentFormViewMixin, RequiresValidationViewMixin, DoesNotRequireValidationFormViewMixin
 from zds.tutorialv2.models.database import Validation, PublishableContent, PickListOperation
-from zds.tutorialv2.publication_utils import publish_content, unpublish_content, notify_update
-from zds.tutorialv2.utils import clone_repo, FailureDuringPublication
+from zds.tutorialv2.publication_utils import publish_content, unpublish_content, notify_update, FailureDuringPublication
+from zds.tutorialv2.utils import clone_repo
 from zds.utils.forums import send_post, lock_topic
 from zds.utils.models import SubCategory, get_hat_from_settings
 from zds.utils.mps import send_mp


### PR DESCRIPTION
Un effet secondaire du passage à django 2.X est que la création des urls de redirection ne fait plus un `str(obj)` quand on ne passe pas un string; Nous passions une exception. Du coup la redirection n'était plus effective.

j'ai donc fait la modif et amélioré le test pour assurer qu'il n'y aurait plus de régression.

Lien sentry

https://sentry.sandhose.fr/zeste-de-savoir/zds-site/issues/1375/

# QA

- publiez un tuto, retenez l'url publique
- renommez le tuto
- republiez le tuto
- accéder au tuto via l'url publique
