### PR TITLE
Le texte ne persiste plus après la validation (fix #5324)

### DIFF
--- a/assets/js/editor-persistence.js
+++ b/assets/js/editor-persistence.js
@@ -4,7 +4,7 @@
 (function(document){
     "use strict";
 
-    var MAX_SAVED_ENTRIES = 32;
+    var MAX_SAVED_ENTRIES = 64;
 
     function getSavedEntries() {
         var source = localStorage.getItem("savedEditorText");
@@ -61,7 +61,13 @@
         editor.addEventListener("input", function() {
             // It’s not a big deal, but this event is not fired when
             // editor buttons are clicked.
-            save(uniqueId, editor.value); // TODO: Throttle?
+
+            // Do not save anything if the editor is empty
+            if(editor.value === "") {
+                remove(uniqueId);
+            } else {
+                save(uniqueId, editor.value); // TODO: Throttle?
+            }
         });
 
         form.addEventListener("submit", function (e) {

--- a/assets/js/editor-persistence.js
+++ b/assets/js/editor-persistence.js
@@ -47,23 +47,10 @@
         return Array.prototype.slice.call(arrayish);
     }
 
-    function getFormSubmit(element) {
-        if (!element) {
-            return null;
-        }
-
-        if (element.tagName === "FORM") {
-            return element.querySelector(
-                "button[type=submit], input[type=submit]"
-            );
-        }
-
-        return getFormSubmit(element.parentElement);
-    }
-
     function setupPersistenceOnEditor(editor) {
         var name = editor.getAttribute("name") || "";
         var uniqueId = window.location.pathname + "@" + name;
+        var form = editor.closest("form");
 
         var savedText = get(uniqueId);
         if (savedText && !editor.value) {
@@ -77,12 +64,9 @@
             save(uniqueId, editor.value); // TODO: Throttle?
         });
 
-        var submit = getFormSubmit(editor);
-        if (submit) {
-            submit.addEventListener("click", function () {
-                remove(uniqueId);
-            });
-        }
+        form.addEventListener("submit", function (e) {
+            remove(uniqueId);
+        });
     }
 
     toArray(document.querySelectorAll(".md-editor"))


### PR DESCRIPTION
Le texte ne persiste plus après la validation (fix #5324)

On prenait le premier `<button type="submit">` ou `<input type="submit">` trouvé juste après l'éditeur Markdown et on supprimait l'entrée lors du clic de celui-ci. Le problème est qu'on tombait très souvent sur le bouton d'Aperçu et pas sur celui d'envoi du formulaire. J'ai choisi comme solution d'ajouter un événement directement sur la balise du formulaire (on part de l'éditeur et on remonte vers le haut jusqu'au formulaire). À noter que j'utilise la fonction `closest()` qui n'est pas supportée par IE 11.