### PR TITLE
Ne lance pas les tests backend si seulement le frontend a été modifié

### DIFF
--- a/scripts/travis_header.sh
+++ b/scripts/travis_header.sh
@@ -110,6 +110,8 @@ if [[ "$ZDS_TEST_JOB" == *"zds.tutorialv2"* ]]; then
     zds_fold_end
 fi
 
-zds_fold_start "register_module" "* [packages] Register module for installation"
-    zds_register_module_for_installation
-zds_fold_end
+if [[ "$ZDS_TEST_JOB" != "none" ]]; then
+    zds_fold_start "register_module" "* [packages] Register module for installation"
+        zds_register_module_for_installation
+    zds_fold_end
+fi

--- a/scripts/travis_run.sh
+++ b/scripts/travis_run.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 
+if [[ "$ZDS_TEST_JOB" == "none" ]]; then
+    exit 0
+fi
+
+
 function print_info {
     echo -en "\033[0;36m"
     echo "$1"


### PR DESCRIPTION
Cela devrait corriger #5326 et permettre de débloquer plusieurs PRs, selon [cet article](https://reflectoring.io/skip-ci-build/#using-a-git-diff-in-the-ci-build).