### PR TITLE
bug messages tronqués

### DIFF
--- a/templates/forum/find/post.html
+++ b/templates/forum/find/post.html
@@ -43,7 +43,7 @@
     {% include "misc/paginator.html" with position="top" %}
 
     {% if posts %}
-        <div class="row">
+        <div class="table-wrapper">
             <table>
                 <thead>
                     <tr>


### PR DESCRIPTION
Ticket: #5304

### Contrôle qualité

**Nécessite d'avoir le serveur lancé mais pas en localhost**

* Aller sur un navigateur mobile sur https://zestedesavoir.com/forums/messages/273/
* Verifier que le tableau des messages n'est pas tronqué (c'est-à-dire que l'on puisse scroll)