### PR TITLE
montre bouton version brouillon juste aux auteurs

### DIFF
--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -266,11 +266,11 @@
              " class="ico-after more blue new-btn">
                 {% trans "Ajouter une section" %}
             </a>
+        {% elif not version or version != content.sha_draft %}
+            <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
+                {% trans "Version brouillon" %}
+            </a> -->
         {%  endif %}
-    {% elif version or version != content.sha_draf %}
-        <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
-            {% trans "Version brouillon" %}
-        </a>
     {% endif %}
 {% endblock %}
 

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -181,7 +181,7 @@
                 <ul>
                     <li>
                         <a href="{% url "content:create-container" content.pk content.slug %}">{% trans "Ajouter une partie" %}</a>
-                        {% trans " pour adopter le format big-tuto ou moyen-tuto. Vous pourrez y ajouter des chapitres ou des sections ;" %} 
+                        {% trans " pour adopter le format big-tuto ou moyen-tuto. Vous pourrez y ajouter des chapitres ou des sections ;" %}
                     </li>
                     <li>
                         <a href="{% url "content:create-extract" content.pk content.slug %}">{% trans "Ajouter une section" %}</a>
@@ -276,7 +276,6 @@
             {% trans "Importer une nouvelle version" %}
         </a>
 
-    {% else %}
         <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
             {% trans "Version brouillon" %}
         </a>


### PR DESCRIPTION
Dupliqué de https://github.com/zestedesavoir/zds-site/pull/5346

> Le lien vers la "Version Brouillon" est accessible uniquement pour ceux ayant les droits d'édition du contenu.
> 
> fixes #5340
> ### Contrôle qualité
> 
>     * Créer un contenu
> 
>     * Le mettre en bêta
> 
>     * Vérifier que vous ayez le lien "Version Brouillon" dans le menu à gauche depuis la bêta : il est censé être présent
> 
>     * Aller sur le lien de la bêta avec un autre compte non auteur du contenu
> 
>     * Rebelote : il n'est pas censé être présent
