### PR TITLE
Utiliser Mathjax que là où on en a besoin

### DIFF
--- a/templates/mathjax.html
+++ b/templates/mathjax.html
@@ -1,5 +1,5 @@
 <script type="text/javascript"
-        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?locale=fr&config=TeX-AMS_HTML"
         integrity="sha384-Ra6zh6uYMmH5ydwCqqMoykyf1T/+ZcnOQfFPhDrp2kI4OIxadnhsvvA2vv9A7xYv"
         crossorigin="anonymous"
         async>

--- a/templates/mathjax.html
+++ b/templates/mathjax.html
@@ -1,5 +1,5 @@
 <script type="text/javascript"
-        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?locale=fr&config=TeX-AMS_HTML"
+        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?locale=fr&config=TeX-AMS_HTML&delayStartupUntil=configured"
         integrity="sha384-Ra6zh6uYMmH5ydwCqqMoykyf1T/+ZcnOQfFPhDrp2kI4OIxadnhsvvA2vv9A7xYv"
         crossorigin="anonymous"
         async>

--- a/templates/mathjax_config.html
+++ b/templates/mathjax_config.html
@@ -1,11 +1,3 @@
-<script type="application/javascript">
-    $(".message-content span,.article-content span").each(function () {
-        var text = $(this).text();
-        if (text && text[0] == "$" && text[text.length - 1] == "$") {
-            $(this).addClass("mathjax-span");
-        }
-    });
-</script>
 <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
         tex2jax: {
@@ -17,5 +9,30 @@
         },
         TeX: { extensions: ["color.js", "cancel.js", "enclose.js", "bbox.js", "mathchoice.js", "newcommand.js", "verb.js", "unicode.js", "autobold.js", "mhchem.js"] },
         messageStyle: "none",
+    });
+</script>
+<script type="application/javascript">
+    // When the page has been loaded (which means the DOM and Mathjax has been loaded)
+    window.addEventListener("load", function() {
+
+        // We look for <span> inside contents
+        $(".message-content span, .article-content span").each(function () {
+            // We only want those with no CSS class
+            if($(this).attr("class") === undefined) {
+                var text = $(this).text();
+                // We check that they start with $ and end with $
+                if (text && text[0] == "$" && text[text.length - 1] == "$") {
+                    // We add a class to mark them
+                    $(this).addClass("mathjax-span");
+                }
+            }
+        });
+
+        // If there is content waiting for Mathjax
+        if($(".mathjax-span, .mathjax-wrapper").length) {
+            // We run Mathjax
+            MathJax.Hub.Configured();
+        }
+
     });
 </script>


### PR DESCRIPTION
**Résolution du problème (ticket #5341)**

Mathjax interprète le code MathML généré par KaTeX et présent dans le bloc `<span class="katex-mathml"><math>... code MathML ...</math></span>` de chaque formule de maths. Impossible dans la configuration de Mathjax de demander à MathML d'ignorer une balise ou une classe CSS donc j'ai décidé d'enlever le support de MathML. Actuellement on a la configuration Mathjax `TeX-AMS-MML_HTMLorMML` et on passe sur celle qui me parait la plus proche : `TeX-AMS_HTML`.

**QA :** C'est plus simple de tester directement en bêta sur :

- [un contenu pré-zmarkdown](https://beta.zestedesavoir.com/tutoriels/676/theoreme-et-histoire-de-pythagore/712_aspect-mathematique/3319_quelques-exercices-dapplication/) pour vérifier que les balises *inline* et *display* sont bien affichées ;
- [un contenu post-zmarkdown](https://beta.zestedesavoir.com/tutoriels/244/comment-rediger-des-maths-sur-zeste-de-savoir/) pour vérifier que le code MathML contenu dans `<span class="katex-mathml">` est bien intact.