### PR TITLE
retire les espaces en trop dans les titres

### DIFF
--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -30,7 +30,7 @@ si le contenu de ``var1`` est ``1`` et le contenu de ``var2`` est ``2``.
 Le module ``trail``
 ===================
 
-Ce module défini l'élément ``trail`` qui permet de retirer tous les sauts de ligne et les espaces dans le bloc de gabarit entre les balises HTML ainsi qu'à la fin et au début des lignes. Le code suivant :
+Ce module définit l'élément ``trail`` qui permet de retirer tous les sauts de ligne et les espaces dans le bloc de gabarit entre les balises HTML ainsi qu'à la fin et au début des lignes. Le code suivant :
 
 .. sourcecode:: html
 
@@ -51,7 +51,7 @@ Produira le code suivant :
 Le module ``captureas``
 =======================
 
-Ce module défini l'élément ``captureas``, qui permet de demander d'effectuer le rendu d'un bloc de gabarit et de stocker son contenu dans
+Ce module définit l'élément ``captureas``, qui permet de demander d'effectuer le rendu d'un bloc de gabarit et de stocker son contenu dans
 une variable. Ainsi le code suivant :
 
 .. sourcecode:: html
@@ -173,7 +173,7 @@ On conviendra du fait que c'est parfaitement illisible ;)
 Le module ``emarkdown``
 =======================
 
-Ce module défini des filtres utilisés dans la transformation du markdown en HTML ou le traitement du markdown.
+Ce module définit des filtres utilisés dans la transformation du markdown en HTML ou le traitement du markdown.
 
 Markdown vers HTML
 ------------------
@@ -406,7 +406,7 @@ Ce *templatetag* est employé pour l'affichage des badges. Vous trouverez plus d
 Le module ``roman``
 ===================
 
-Défini le filtre ``roman``, qui transforme un nombre entier en chiffre romain, utilisé pour l'affichage du sommaire des tutoriels. Par exemple, le code suivant :
+définit le filtre ``roman``, qui transforme un nombre entier en chiffre romain, utilisé pour l'affichage du sommaire des tutoriels. Par exemple, le code suivant :
 
 .. sourcecode:: html
 
@@ -418,7 +418,7 @@ affichera ``CDLIII``, qui est bien la façon d'écrire 453 en chiffres romain.
 Le module ``set``
 =================
 
-Ce module défini l'élément ``set``, permetant de définir de nouvelles variables, il est donc complémentaire au module ``captureas``.
+Ce module définit l'élément ``set``, permetant de définir de nouvelles variables, il est donc complémentaire au module ``captureas``.
 
 Le code suivant permet de définir la variable ``var`` comme valant ``True`` :
 
@@ -532,7 +532,7 @@ Exemple :
 Le module ``target_tree``
 =========================
 
-Ce module défini un *templatetag* utilisé dans le module de tutoriel (v2) dans le but de générer la hiérarchie des tutos et l'arbre
+Ce module définit un *templatetag* utilisé dans le module de tutoriel (v2) dans le but de générer la hiérarchie des tutos et l'arbre
 des déplacements possibles d'un élément. Il s'agit d'un wrapper autour de ``zds.tutorialv2.utils.get_target_tagged_tree``.
 
 Exemple :
@@ -550,7 +550,7 @@ Exemple :
 Le module ``url_category``
 ==========================
 
-Ce module défini un *templatetag* permetant d'accéder à l'url des listes de tutoriels et articles filtrés par tag. Il est employé pour l'affichage des *tags* des tutoriels et articles.
+Ce module définit un *templatetag* permetant d'accéder à l'url des listes de tutoriels et articles filtrés par tag. Il est employé pour l'affichage des *tags* des tutoriels et articles.
 
 Exemple :
 

--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -27,6 +27,27 @@ produira le code suivant :
 
 si le contenu de ``var1`` est ``1`` et le contenu de ``var2`` est ``2``.
 
+Le module ``trail``
+===================
+
+Ce module défini l'élément ``trail`` qui permet de retirer tous les sauts de ligne et les espaces dans le bloc de gabarit entre les balises HTML ainsi qu'à la fin et au début des lignes. Le code suivant :
+
+.. sourcecode:: html
+
+    {% load trail %}
+    {% trail %}
+    <h3>
+        Hello        world!
+        <a href="example.com">   Un exemple</a>
+    </h3>
+    {% endtrail %}
+
+Produira le code suivant :
+
+.. sourcecode:: html
+
+    <h3>Hello        world!<a href="example.com">   Un exemple</a></h3>
+
 Le module ``captureas``
 =======================
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,21 +12,23 @@
 <head>
     <meta charset="utf-8">
 
-    <title>
-        {% captureas title %}
-            {% captureas title_blocks %}
-                {% block title %}{% endblock %}
-                {% block title_base %}{% endblock %}
+    {% spaceless %}
+        <title>
+            {% captureas title %}
+                {% captureas title_blocks %}
+                    {% block title %}{% endblock %}
+                    {% block title_base %}{% endblock %}
+                {% endcaptureas %}
+                {% if title_blocks %}
+                    {{ title_blocks|safe }}
+                    &bull;
+                {% endif %}
+                {{app.site.literal_name}}
             {% endcaptureas %}
-            {% if title_blocks %}
-                {{ title_blocks|safe }}
-                &bull;
-            {% endif %}
-            {{app.site.literal_name}}
-        {% endcaptureas %}
-        {{ title|safe }}
-    </title>
-
+            {{ title|safe }}
+        </title>
+    {% endspaceless %}
+g
     <meta name="language" content="fr">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0">
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
 {% load thumbnail %}
 {% load interventions %}
 {% load messages %}
+{% load trail %}
 
 
 <!DOCTYPE html>
@@ -12,23 +13,26 @@
 <head>
     <meta charset="utf-8">
 
-    {% spaceless %}
-        <title>
-            {% captureas title %}
+
+    <title>
+        {% captureas title %}
+            {% trail %}
                 {% captureas title_blocks %}
-                    {% block title %}{% endblock %}
-                    {% block title_base %}{% endblock %}
+                    {% trail %}
+                        {% block title %}{% endblock %}
+                        {% block title_base %}{% endblock %}
+                    {% endtrail %}
                 {% endcaptureas %}
                 {% if title_blocks %}
                     {{ title_blocks|safe }}
                     &bull;
                 {% endif %}
                 {{app.site.literal_name}}
-            {% endcaptureas %}
-            {{ title|safe }}
-        </title>
-    {% endspaceless %}
-g
+            {% endtrail %}
+        {% endcaptureas %}
+        {{ title|safe }}
+    </title>
+
     <meta name="language" content="fr">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0">
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,23 +13,23 @@
 <head>
     <meta charset="utf-8">
 
+    {% captureas title %}
+        {% trail %}
+            {% captureas title_blocks %}
+                {% trail %}
+                    {% block title %}{% endblock %}
+                    {% block title_base %}{% endblock %}
+                {% endtrail %}
+            {% endcaptureas %}
+            {% if title_blocks %}
+                {{title_blocks|safe}} &bull; {{app.site.literal_name}}
+            {% else %}
+                {{app.site.literal_name}}
+            {% endif %}
+        {% endtrail %}
+    {% endcaptureas %}
 
     <title>
-        {% captureas title %}
-            {% trail %}
-                {% captureas title_blocks %}
-                    {% trail %}
-                        {% block title %}{% endblock %}
-                        {% block title_base %}{% endblock %}
-                    {% endtrail %}
-                {% endcaptureas %}
-                {% if title_blocks %}
-                    {{ title_blocks|safe }}
-                    &bull;
-                {% endif %}
-                {{app.site.literal_name}}
-            {% endtrail %}
-        {% endcaptureas %}
         {{ title|safe }}
     </title>
 

--- a/zds/utils/templatetags/trail.py
+++ b/zds/utils/templatetags/trail.py
@@ -1,0 +1,36 @@
+import re
+from django import template
+
+register = template.Library()
+
+"""
+Define a tag to remove trailing whitespaces
+"""
+
+@register.tag(name='trail')
+def do_trail(parser, token):
+    """
+    Define a tag to remove trailing whitespaces between tags and between tags and text
+
+    :param parser: The django template parser
+    :param token: tag token (tag_name + variable_name)
+    :return: Template node.
+    """
+
+    nodelist = parser.parse(('endtrail',))
+    parser.delete_first_token()
+    return TrailNode(nodelist)
+
+class TrailNode(template.Node):
+    """
+    Removes all spaces between tags, removes newlines and replaces large spaces and tabs by a single space or tab respectively
+    """
+    def __init__(self, nodelist):
+        self.nodelist = nodelist
+
+    def render(self, context):
+        str = re.sub(r'>\s+<', '><', self.nodelist.render(context))
+        str = re.sub(r'[\n\r\f\v]+', '', str)
+        str = re.sub(r' +', ' ', str)
+        str = re.sub(r'\t+', '\t', str)
+        return str

--- a/zds/utils/templatetags/trail.py
+++ b/zds/utils/templatetags/trail.py
@@ -3,6 +3,11 @@ from django import template
 
 register = template.Library()
 
+tag_regexp = re.compile(r'>\s+<')
+breaks_regexp = re.compile(r'[\n\r\f\v]+')
+spaces_line_begin_regexp = re.compile(r'^[ \t]+', flags=re.MULTILINE)
+spaces_line_end_regexp = re.compile(r'[ \t]+$', flags=re.MULTILINE)
+
 """
 Define a tag to remove trailing whitespaces
 """
@@ -29,8 +34,8 @@ class TrailNode(template.Node):
         self.nodelist = nodelist
 
     def render(self, context):
-        str = re.sub(r'>\s+<', '><', self.nodelist.render(context))
-        str = re.sub(r'[\n\r\f\v]+', '', str)
-        str = re.sub(r' +', ' ', str)
-        str = re.sub(r'\t+', '\t', str)
-        return str
+        new_text = tag_regexp.sub('><', self.nodelist.render(context))
+        new_text = spaces_line_begin_regexp.sub('', new_text)
+        new_text = spaces_line_end_regexp.sub('', new_text)
+        new_text = breaks_regexp.sub('', new_text)
+        return new_text

--- a/zds/utils/templatetags/trail.py
+++ b/zds/utils/templatetags/trail.py
@@ -12,6 +12,7 @@ spaces_line_end_regexp = re.compile(r'[ \t]+$', flags=re.MULTILINE)
 Define a tag to remove trailing whitespaces
 """
 
+
 @register.tag(name='trail')
 def do_trail(parser, token):
     """
@@ -26,9 +27,10 @@ def do_trail(parser, token):
     parser.delete_first_token()
     return TrailNode(nodelist)
 
+
 class TrailNode(template.Node):
     """
-    Removes all spaces between tags, removes newlines and replaces large spaces and tabs by a single space or tab respectively
+    Remove spaces between tags, before and after newlines and newlines
     """
     def __init__(self, nodelist):
         self.nodelist = nodelist


### PR DESCRIPTION
Ajout du template tag `spaceless` autour du titre du template de base aux autres pages du site

fixes #5283

### Contrôle qualité

* Poster un lien depuis Discord vers le site en beta avec ma PR dessus
* Vérifier qu'il n'y ait pas d'espaces dans la description que Discord réussit à obtenir
