### PR TITLE
Margin titres

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -10,7 +10,7 @@ h3 {
     &,
     a {
         color: darken($color-secondary, 11%);
-        margin-top: 40px;
+        // margin-top: 40px;
         text-decoration: none;
     }
 
@@ -249,7 +249,7 @@ h6 {
     background: #EEE;
 }
 
- 
+
 
 img {
     max-width: 100%;
@@ -431,7 +431,7 @@ td {
     margin: 0 auto;
     max-width: 560px;
     max-height: 315px;
-    
+
     // Needed in case .video-container is wrapped with <div class="align-center"> or with <figure>
     text-align: left;
 

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -10,7 +10,6 @@ h3 {
     &,
     a {
         color: darken($color-secondary, 11%);
-        margin-top: 40px;
         text-decoration: none;
     }
 

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -10,6 +10,7 @@ h3 {
     &,
     a {
         color: darken($color-secondary, 11%);
+        margin-top: 40px;
         text-decoration: none;
     }
 

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -10,7 +10,6 @@ h3 {
     &,
     a {
         color: darken($color-secondary, 11%);
-        // margin-top: 40px;
         text-decoration: none;
     }
 

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -14,6 +14,15 @@
     }
 
     .article-content {
+        .extract-wrapper {
+            h2 {
+                h3, h4, h5, h6 {
+                    &:first-child {
+                        margin-top: 14px;
+                    }
+                }
+            }
+        }
         p,
         > a,
         p a,
@@ -74,13 +83,18 @@
 
     .article-content,
     .message-content {
-        h3, h4, h5, h6 {
-            margin-top: 14px;
-        }
         margin-bottom: 20px;
         color: #424242;
 
         @import "base/content";
+    }
+
+    .message-content {
+        h3, h4, h5, h6 {
+            &:first-child {
+                margin-top: 14px;
+            }
+        }
     }
 
     .comments-title {

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -15,11 +15,9 @@
 
     .article-content {
         .extract-wrapper {
-            h2 {
-                h3, h4, h5, h6 {
-                    &:first-child {
-                        margin-top: 14px;
-                    }
+            h3, h4, h5, h6 {
+                &:first-child {
+                    margin-top: 14px;
                 }
             }
         }

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -74,8 +74,13 @@
 
     .article-content,
     .message-content {
-        margin-top: 20px;
-        margin-bottom: 20px;
+        .lev-1,
+        .lev-2
+        .lev-3
+        .lev-4 {
+            margin-top: 14px;
+            margin-bottom: 14px;
+        }
         color: #424242;
 
         @import "base/content";

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -75,9 +75,7 @@
     .article-content,
     .message-content {
         h3, h4, h5, h6 {
-            &:first-child {
-                margin-top: 14px;
-            }
+            margin-top: 14px;
         }
         margin-bottom: 20px;
         color: #424242;

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -74,13 +74,12 @@
 
     .article-content,
     .message-content {
-        .lev-1,
-        .lev-2
-        .lev-3
-        .lev-4 {
-            margin-top: 14px;
-            margin-bottom: 14px;
+        h3, h4, h5, h6 {
+            &:first-child {
+                margin-top: 14px;
+            }
         }
+        margin-bottom: 20px;
         color: #424242;
 
         @import "base/content";

--- a/templates/tutorialv2/export/chapter.html
+++ b/templates/tutorialv2/export/chapter.html
@@ -26,7 +26,9 @@
         </a>
     </h2>
     {% if extract.text %}
-        {{ extract.get_text|emarkdown:is_js }}
+        <div class="extract-wrapper">
+            {{ extract.get_text|emarkdown:is_js }}
+        </div>
     {% endif %}
 {% endfor %}
 

--- a/templates/tutorialv2/export/content.md
+++ b/templates/tutorialv2/export/content.md
@@ -12,21 +12,21 @@
 {% for child in content.children %}
 # {{ child.title|safe }}
 {% if content.has_extracts %} {#  minituto or article #}
-{% if child.text %}{{ child.get_text|safe|shift_heading_1 }}{% endif %}
+{% if child.text %}<div class="extract-wrapper">{{ child.get_text|safe|shift_heading_1 }}</div>{% endif %}
 {% elif child.ready_to_publish %}{# midsize or bigtuto #}
 {% if child.introduction %}{{ child.get_introduction|safe|shift_heading_1 }}{% endif %}
 {% for subchild in child.children %}
 ## {{ subchild.title|safe }}
 
 {% if child.has_extracts %} {# midsize tuto #}
-{% if subchild.text %}{{ subchild.get_text|safe|shift_heading_2 }}{% endif %}
+{% if subchild.text %}<div class="extract-wrapper">{{ subchild.get_text|safe|shift_heading_2 }}</div>{% endif %}
 {% elif subchild.ready_to_publish %}
 {% if subchild.introduction %}{{ subchild.get_introduction|safe|shift_heading_2 }}{% endif %}
 {% for extract in subchild.children %}
 
 ### {{ extract.title|safe }}
 
-{% if extract.text %}{{ extract.get_text|safe|shift_heading_3 }}{% endif %}{% endfor %}
+{% if extract.text %}<div class="extract-wrapper">{{ extract.get_text|safe|shift_heading_3 }}</div>{% endif %}{% endfor %}
 {% if subchild.conclusion %}
 {% captureas conclu %}{{ subchild.get_conclusion|safe|shift_heading_2 }}{% endcaptureas %}
 {% if conclu.strip != '' %}

--- a/templates/tutorialv2/export/content.md
+++ b/templates/tutorialv2/export/content.md
@@ -12,21 +12,21 @@
 {% for child in content.children %}
 # {{ child.title|safe }}
 {% if content.has_extracts %} {#  minituto or article #}
-{% if child.text %}<div class="extract-wrapper">{{ child.get_text|safe|shift_heading_1 }}</div>{% endif %}
+{% if child.text %}{{ child.get_text|safe|shift_heading_1 }}{% endif %}
 {% elif child.ready_to_publish %}{# midsize or bigtuto #}
 {% if child.introduction %}{{ child.get_introduction|safe|shift_heading_1 }}{% endif %}
 {% for subchild in child.children %}
 ## {{ subchild.title|safe }}
 
 {% if child.has_extracts %} {# midsize tuto #}
-{% if subchild.text %}<div class="extract-wrapper">{{ subchild.get_text|safe|shift_heading_2 }}</div>{% endif %}
+{% if subchild.text %}{{ subchild.get_text|safe|shift_heading_2 }}{% endif %}
 {% elif subchild.ready_to_publish %}
 {% if subchild.introduction %}{{ subchild.get_introduction|safe|shift_heading_2 }}{% endif %}
 {% for extract in subchild.children %}
 
 ### {{ extract.title|safe }}
 
-{% if extract.text %}<div class="extract-wrapper">{{ extract.get_text|safe|shift_heading_3 }}</div>{% endif %}{% endfor %}
+{% if extract.text %}{{ extract.get_text|safe|shift_heading_3 }}{% endif %}{% endfor %}
 {% if subchild.conclusion %}
 {% captureas conclu %}{{ subchild.get_conclusion|safe|shift_heading_2 }}{% endcaptureas %}
 {% if conclu.strip != '' %}

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -81,7 +81,9 @@
             </p>
         </div>
     {% else %}
-        {{ child.get_text|emarkdown:is_js }}
+        <div class="extract-wrapper">
+            {{ child.get_text|emarkdown:is_js }}
+        </div>
     {% endif %}
 {% else %}
     {# child is a container #}

--- a/templates/tutorialv2/includes/child_online.part.html
+++ b/templates/tutorialv2/includes/child_online.part.html
@@ -23,7 +23,9 @@
             {% trans "Cette section est actuellement vide." %}
         </p>
     {% else %}
-        {{ child.get_text|emarkdown:is_js }}
+        <div class="extract-wrapper">
+            {{ child.get_text|emarkdown:is_js }}
+        </div>
     {% endif %}
 {% else %}
     {# child is a container #}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -175,7 +175,6 @@
     {% if content.has_extracts %}
         {{ content.get_content_online|safe }}
     {% else %}
-
         {% if content.introduction %}
             {{ content.get_introduction_online|default:""|safe }}
         {% endif %}


### PR DESCRIPTION
Réduit le margin-top et margin-bottom des titres de zmd

fixes #5282

### Contrôle qualité

* Créer plusieurs commentaires avec un niveau de titre chacun
* Vérifier que les titres ont bien 14px de margin-top et margin-bottom dans le menu de dev (genre Firefox)

Remarque : l'écart entre la casquette et un titre est plus grand que sans la casquette : c'est dû au margin-bottom de la casquette elle-même.