### PR TITLE
Retire les abonnements aux sujets des forums privés quand on quitte un groupe

### DIFF
--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -39,8 +39,18 @@ def remove_group_subscription_on_quitting_groups(*, sender, instance, action, pk
         return
 
     for forum in Forum.objects.filter(groups__pk__in=list(pk_set)):
-        subscription = NewTopicSubscription.objects.get_existing(instance, forum, True)
-        if subscription:
+        subscriptions = []
+
+        forum_subscription = NewTopicSubscription.objects.get_existing(instance, forum, True)
+        if forum_subscription:
+            subscriptions.append(forum_subscription)
+
+        for topic in Topic.objects.filter(forum=forum):
+            topic_subscription = TopicAnswerSubscription.objects.get_existing(instance, topic, True)
+            if topic_subscription:
+                subscriptions.append(topic_subscription)
+
+        for subscription in subscriptions:
             subscription.is_active = False
             if subscription.last_notification:
                 subscription.last_notification.is_read = True


### PR DESCRIPTION
Corrige le ticket #5356 

**QA sur la bêta :**

- Quelqu'un m'enlève du groupe au groupe CA
- Quelqu'un écrit un message dans un sujet que je suivais
- On vérifie que je n'ai pas de notification persistante

**En production :** Il suffit de rajouter les ex-staffs au groupe Staff puis de les enlever à nouveau.