### PR TITLE
Améliore les descriptions des forums

### DIFF
--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -6,6 +6,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 {% load interventions %}
+{% load cache %}
 
 {% block title %}
     {% if topic.is_solved %}[{% trans "Résolu" %}]{% endif %} {{ topic.title }}
@@ -27,7 +28,11 @@
     </li>
 {% endblock %}
 
-
+{% block description %}
+    {% cache 180 "topic-description" topic.pk %}
+        {{ topic.meta_description }}
+    {% endcache %}
+{% endblock %}
 
 {% block schema %}
     itemscope itemtype="http://schema.org/Question"

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -224,7 +224,7 @@ class Topic(AbstractESDjangoIndexable):
     def meta_description(self):
         first_post = self.first_post()
         if len(first_post.text) < 120:
-            return first_post
+            return first_post.text
         return Topic.__remove_greetings(first_post)[:settings.ZDS_APP['forum']['description_size']]
 
     @staticmethod

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -234,7 +234,7 @@ class Topic(AbstractESDjangoIndexable):
         text = post.text
         for greeting in greetings:
             if text.strip().lower().startswith(greeting):
-                index_of_dot = max(text.index('\n') if '\n' in text else -1, 0)
+                index_of_dot = max(text.index('\n') if '\n' in text else -1, -1)
                 index_of_dot = min(index_of_dot, text.index('.') if '.' in text else max_size)
                 index_of_dot = min(index_of_dot, text.index('!') if '!' in text else max_size)
                 return text[index_of_dot + 1:].strip()

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -220,6 +220,25 @@ class Topic(AbstractESDjangoIndexable):
     def is_solved(self):
         return self.solved_by is not None
 
+    @property
+    def meta_description(self):
+        first_post = self.first_post()
+        if len(first_post.text) < 120:
+            return first_post
+        return Topic.__remove_greetings(first_post)[:120]
+
+    @staticmethod
+    def __remove_greetings(post):
+        greetings = settings.ZDS_APP['forum']['greetings']
+        text = post.text
+        for greeting in greetings:
+            if text.strip().lower().startswith(greeting):
+                index_of_dot = max(text.index('\n') if '\n' in text else -1, 0)
+                index_of_dot = min(index_of_dot, text.index('.') if '.' in text else 121)
+                index_of_dot = min(index_of_dot, text.index('!') if '!' in text else 121)
+                return text[index_of_dot + 1:].strip()
+        return text
+
     def get_absolute_url(self):
         return reverse('topic-posts-list', args=[self.pk, self.slug()])
 

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -225,17 +225,18 @@ class Topic(AbstractESDjangoIndexable):
         first_post = self.first_post()
         if len(first_post.text) < 120:
             return first_post
-        return Topic.__remove_greetings(first_post)[:120]
+        return Topic.__remove_greetings(first_post)[:settings.ZDS_APP['forum']['description_size']]
 
     @staticmethod
     def __remove_greetings(post):
         greetings = settings.ZDS_APP['forum']['greetings']
+        max_size = settings.ZDS_APP['forum']['description_size'] + 1
         text = post.text
         for greeting in greetings:
             if text.strip().lower().startswith(greeting):
                 index_of_dot = max(text.index('\n') if '\n' in text else -1, 0)
-                index_of_dot = min(index_of_dot, text.index('.') if '.' in text else 121)
-                index_of_dot = min(index_of_dot, text.index('!') if '!' in text else 121)
+                index_of_dot = min(index_of_dot, text.index('.') if '.' in text else max_size)
+                index_of_dot = min(index_of_dot, text.index('!') if '!' in text else max_size)
                 return text[index_of_dot + 1:].strip()
         return text
 

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -206,7 +206,8 @@ ZDS_APP = {
         # Exclude tags from top tags list. Tags listed here should not be relevant for most of users.
         # Be warned exclude too much tags can restrict performance
         'top_tag_exclu': ['bug', 'suggestion', 'tutoriel', 'beta', 'article'],
-        'greetings': ['salut', 'bonjour', 'yo ', 'hello', 'bon matin', 'tout le monde se secoue']
+        'greetings': ['salut', 'bonjour', 'yo ', 'hello', 'bon matin', 'tout le monde se secoue'],
+        'description_size': 120,
     },
     'topic': {
         'home_number': 5,

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -205,7 +205,8 @@ ZDS_APP = {
         'old_post_limit_days': 90,
         # Exclude tags from top tags list. Tags listed here should not be relevant for most of users.
         # Be warned exclude too much tags can restrict performance
-        'top_tag_exclu': ['bug', 'suggestion', 'tutoriel', 'beta', 'article']
+        'top_tag_exclu': ['bug', 'suggestion', 'tutoriel', 'beta', 'article'],
+        'greetings': ['salut', 'bonjour', 'yo ', 'hello', 'bon matin', 'tout le monde se secoue']
     },
     'topic': {
         'home_number': 5,

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -627,6 +627,7 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
 
     # sizes contain a python dict (as a string in database) with all information about file sizes
     sizes = models.CharField('Tailles des fichiers téléchargeables', max_length=512, default='{}')
+    _description = None
 
     @staticmethod
     def get_slug_from_file_path(file_path):
@@ -642,10 +643,14 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
             return self.load_public_version().title
 
     def description(self):
-        if self.versioned_model:
-            return self.versioned_model.description
-        else:
-            return self.load_public_version().description
+        if self._description:
+            return self._description
+        if not self.versioned_model:
+            self.load_public_version()
+        self._description = self.versioned_model.description or self.versioned_model.get_introduction()
+        if self._description:
+            self._description = self._description[:settings.ZDS_APP['forum']['description_size']]
+        return self._description
 
     def get_prod_path(self, relative=False):
         if not relative:


### PR DESCRIPTION
Fix #5274

# QA

regardez le résutlat dans votre inspecteur pour la balice `meta description` 

Premier message du topic | résultat
---|---
message court avec bonjour (<120 char) | description = message complet
message court sans bonjour (<120 char) | description = message complet
message long avec bonjour (>120 char) | description = le premier message sans la phrase de "bonjour", ensuite 120 caractères
message long sans bonjour (>120 char) | description = 120 premiers caractères

