### PR TITLE
Confirmer les actions par mot de passe

### DIFF
--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -95,6 +95,7 @@
         id="unregister"
         class="modal modal-flex"
     >
+        {{ form }}
         <p>
             {% trans "C’est votre dernière chance de rester parmi nous" %}...
         </p>

--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -1,5 +1,6 @@
 {% extends "member/settings/base.html" %}
 {% load i18n %}
+{% load crispy_forms_tags %}
 
 
 {% block breadcrumb %}
@@ -89,18 +90,6 @@
         <a href="#unregister" class="open-modal btn btn-cancel">{% trans "Me désinscrire" %}</a>
     </p>
 
-    <form
-        method="post"
-        action="{% url "member-unregister" %}"
-        id="unregister"
-        class="modal modal-flex"
-    >
-        {{ form }}
-        <p>
-            {% trans "C’est votre dernière chance de rester parmi nous" %}...
-        </p>
+    {% crispy unregister_form %}
 
-        {% csrf_token %}
-        <button type="submit">{% trans "Me désinscrire" %}</button>
-    </form>
 {% endblock %}

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -335,6 +335,43 @@ class GitHubTokenForm(forms.Form):
                 StrictButton(_('Enregistrer'), type='submit'),
             ))
 
+class UnregisterForm(forms.Form):
+    """
+    Unregister form
+    """
+    password = forms.CharField(
+        label=_('Mot de passe'),
+        widget=forms.PasswordInput,
+    )
+
+    def __init__(self, user, *args, **kwargs):
+        super(UnregisterForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_class = 'content-wrapper'
+        self.helper.form_method = 'post'
+
+        self.user = user
+
+        self.helper.layout = Layout(
+            Field('password'),
+        )
+
+    def clean(self):
+        cleaned_data = super(UnregisterForm, self).clean()
+
+        password = cleaned_data.get('password')
+
+        if password:
+            user_exist = authenticate(username=self.user.username, password=password)
+            # Check if the user exist.
+            if not user_exist and password != '':
+                self._errors['password'] = self.error_class([_('Mot de passe incorrect.')])
+                if 'password' in cleaned_data:
+                    del cleaned_data['password']
+        return cleaned_data
+
+
+
 
 class ChangeUserForm(forms.Form):
     """

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -335,6 +335,7 @@ class GitHubTokenForm(forms.Form):
                 StrictButton(_('Enregistrer'), type='submit'),
             ))
 
+
 class UnregisterForm(forms.Form):
     """
     Unregister form
@@ -371,8 +372,6 @@ class UnregisterForm(forms.Form):
         return cleaned_data
 
 
-
-
 class ChangeUserForm(forms.Form):
     """
     Update username and email
@@ -381,7 +380,6 @@ class ChangeUserForm(forms.Form):
         label=_('Mot de passe'),
         widget=forms.PasswordInput,
     )
-
 
     username = forms.CharField(
         label=_('Mon pseudo'),
@@ -453,7 +451,7 @@ class ChangeUserForm(forms.Form):
                 self._errors['password'] = self.error_class([_('Mot de passe incorrect.')])
                 if 'password' in cleaned_data:
                     del cleaned_data['password']
-            else: # the provided password is correct
+            else:  # the provided password is correct
                 if username != self.previous_username:
                     validate_not_empty(username)
                     validate_zds_username(username)

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -283,6 +283,7 @@ class ChangeUserFormTest(TestCase):
     def test_valid_change_username_user_form(self):
         data = {
             'username': 'MyNewPseudo',
+            'password': 'hostel77',
             'email': self.user1.user.email
         }
         form = ChangeUserForm(data=data, user=self.user1.user)
@@ -291,6 +292,7 @@ class ChangeUserFormTest(TestCase):
     def test_valid_change_email_user_form(self):
         data = {
             'username': self.user1.user.username,
+            'password': 'hostel77',
             'email': 'test@gmail.com'
         }
         form = ChangeUserForm(data=data, user=self.user1.user)
@@ -364,6 +366,7 @@ class ChangeUserFormTest(TestCase):
         ProfileFactory()
         data = {
             'username': '  ZeTester  ',
+            'password': 'hostel77',
             'email': self.user1.user.email,
         }
         form = ChangeUserForm(data=data, user=self.user1.user)
@@ -373,6 +376,7 @@ class ChangeUserFormTest(TestCase):
         ProfileFactory()
         data = {
             'username': 'Ze,Tester',
+            'password': 'hostel77',
             'email': self.user1.user.email,
         }
         form = ChangeUserForm(data=data, user=self.user1.user)
@@ -458,6 +462,7 @@ class UsernameAndEmailFormTest(TestCase):
     def test_valid_forgot_password_form(self):
         data = {
             'username': self.user1.user.username,
+            'password': 'hostel77',
             'email': ''
         }
         form = UsernameAndEmailForm(data=data)
@@ -466,6 +471,7 @@ class UsernameAndEmailFormTest(TestCase):
     def test_non_valid_non_ascii_forgot_password_form(self):
         data = {
             'username': self.userNonAscii.user.username,
+            'password': 'hostel77',
             'email': ''
         }
         form = UsernameAndEmailForm(data=data)
@@ -474,6 +480,7 @@ class UsernameAndEmailFormTest(TestCase):
     def test_non_valid_non_ascii_email_forgot_password_form(self):
         data = {
             'username': '',
+            'password': 'hostel77',
             'email': self.userNonAscii.user.email
         }
         form = UsernameAndEmailForm(data=data)

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -395,7 +395,7 @@ class ChangePasswordFormTest(TestCase):
 
     def test_valid_change_password_form(self):
         data = {
-            'password_old': self.old_password,
+            'password': self.old_password,
             'password_new': self.new_password,
             'password_confirm': self.new_password
         }
@@ -404,7 +404,7 @@ class ChangePasswordFormTest(TestCase):
 
     def test_old_wrong_change_password_form(self):
         data = {
-            'password_old': 'Wronnnng',
+            'password': 'Wronnnng',
             'password_new': self.new_password,
             'password_confirm': self.new_password
         }
@@ -413,7 +413,7 @@ class ChangePasswordFormTest(TestCase):
 
     def test_not_matching_change_password_form(self):
         data = {
-            'password_old': self.old_password,
+            'password': self.old_password,
             'password_new': self.new_password,
             'password_confirm': 'Wronnnng'
         }
@@ -423,7 +423,7 @@ class ChangePasswordFormTest(TestCase):
     def test_too_short_change_password_form(self):
         too_short = 'short'
         data = {
-            'password_old': self.old_password,
+            'password': self.old_password,
             'password_new': too_short,
             'password_confirm': too_short
         }
@@ -432,7 +432,7 @@ class ChangePasswordFormTest(TestCase):
 
     def test_too_long_change_password_form(self):
         data = {
-            'password_old': self.old_password,
+            'password': self.old_password,
             'password_new': stringof77chars,
             'password_confirm': stringof77chars
         }
@@ -442,7 +442,7 @@ class ChangePasswordFormTest(TestCase):
     def test_match_username_change_password_form(self):
         self.user1.user.username = 'LongName'
         data = {
-            'password_old': self.old_password,
+            'password': self.old_password,
             'password_new': self.user1.user.username,
             'password_confirm': self.user1.user.username
         }

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -436,6 +436,7 @@ class MemberTests(TutorialTestMixin, TestCase):
         self.client.logout()
         result = self.client.post(
             reverse('member-unregister'),
+            {'password': 'hostel77'},
             follow=False)
         self.assertEqual(result.status_code, 302)
 
@@ -447,7 +448,7 @@ class MemberTests(TutorialTestMixin, TestCase):
         self.assertEqual(login_check, True)
         result = self.client.post(
             reverse('member-unregister'),
-            { 'password': 'hostel77', },
+            {'password': 'hostel77'},
             follow=False)
         self.assertEqual(result.status_code, 302)
         self.assertEqual(User.objects.filter(username=user.user.username).count(), 0)

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -427,6 +427,28 @@ class MemberTests(TutorialTestMixin, TestCase):
         # check if the new user is active.
         self.assertTrue(User.objects.get(username='firm1').is_active)
 
+    def test_user_need_password_for_unregister(self):
+        self.client.logout()
+        # create user and login
+        user = ProfileFactory()
+        login_check = self.client.login(
+            username=user.user.username,
+            password='hostel77')
+        self.assertEqual(login_check, True)
+        # try to unregister user without password
+        result = self.client.post(
+            reverse('member-unregister'),
+            follow=False)
+        self.assertEqual(result.status_code, 200)
+
+        # it's possible to login again with user
+        self.client.logout()
+        login_check = self.client.login(
+            username=user.user.username,
+            password='hostel77')
+        self.assertEqual(login_check, True)
+
+
     def test_unregister(self):
         """
         To test that unregistering user is working.

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -447,6 +447,7 @@ class MemberTests(TutorialTestMixin, TestCase):
         self.assertEqual(login_check, True)
         result = self.client.post(
             reverse('member-unregister'),
+            { 'password': 'hostel77', },
             follow=False)
         self.assertEqual(result.status_code, 302)
         self.assertEqual(User.objects.filter(username=user.user.username).count(), 0)
@@ -549,6 +550,7 @@ class MemberTests(TutorialTestMixin, TestCase):
         self.assertEqual(login_check, True)
         result = self.client.post(
             reverse('member-unregister'),
+            {'password': 'hostel77'},
             follow=False)
         self.assertEqual(result.status_code, 302)
 
@@ -1146,6 +1148,7 @@ class MemberTests(TutorialTestMixin, TestCase):
         self.client.login(username=tester.user.username, password='hostel77')
         data = {
             'username': 'dummy',
+            'password': 'hostel77',
             'email': tester.user.email
         }
         result = self.client.post(reverse('update-username-email-member'), data, follow=False)
@@ -1261,6 +1264,7 @@ class MemberTests(TutorialTestMixin, TestCase):
         # Edit the email with an unknown provider
         self.client.post(reverse('update-username-email-member'), {
             'username': user.username,
+            'password': 'hostel77',
             'email': 'test@unknown-provider-edit.com'
         }, follow=False)
         # A new provider object should have been created

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -34,7 +34,7 @@ from zds.member.decorator import can_write_and_read_now, LoginRequiredMixin, Per
 from zds.member.forms import LoginForm, MiniProfileForm, ProfileForm, RegisterForm, \
     ChangePasswordForm, ChangeUserForm, NewPasswordForm, \
     PromoteMemberForm, KarmaForm, UsernameAndEmailForm, GitHubTokenForm, \
-    BannedEmailProviderForm, HatRequestForm
+    BannedEmailProviderForm, HatRequestForm, UnregisterForm
 from zds.member.models import Profile, TokenForgotPassword, TokenRegister, KarmaNote, Ban, \
     BannedEmailProvider, NewEmailProvider, set_old_smileys_cookie, remove_old_smileys_cookie
 from zds.mp.models import PrivatePost, PrivateTopic
@@ -438,7 +438,11 @@ def warning_unregister(request):
     Display a warning page showing what will happen when the user
     unregisters.
     """
-    return render(request, 'member/settings/unregister.html', {'user': request.user})
+
+    form = UnregisterForm(request.user)
+    return render(request, 'member/settings/unregister.html',
+            {'user': request.user, 'form': form})
+
 
 
 @login_required
@@ -446,81 +450,86 @@ def warning_unregister(request):
 @transaction.atomic
 def unregister(request):
     """Allow members to unregister."""
+    form = UnregisterForm(request.user, data=request.POST)
 
-    anonymous = get_object_or_404(User, username=settings.ZDS_APP['member']['anonymous_account'])
-    external = get_object_or_404(User, username=settings.ZDS_APP['member']['external_account'])
-    current = request.user
-    # Nota : as of v21 all about content paternity is held by a proper receiver in zds.tutorialv2.models.database
-    PickListOperation.objects.filter(staff_user=current).update(staff_user=anonymous)
-    PickListOperation.objects.filter(canceler_user=current).update(canceler_user=anonymous)
-    # Comments likes / dislikes
-    votes = CommentVote.objects.filter(user=current)
-    for vote in votes:
-        if vote.positive:
-            vote.comment.like -= 1
-        else:
-            vote.comment.dislike -= 1
-        vote.comment.save()
-    votes.delete()
-    # All contents anonymization
-    Comment.objects.filter(author=current).update(author=anonymous)
-    PrivatePost.objects.filter(author=current).update(author=anonymous)
-    CommentEdit.objects.filter(editor=current).update(editor=anonymous)
-    CommentEdit.objects.filter(deleted_by=current).update(deleted_by=anonymous)
-    # Karma notes, alerts and sanctions anonymization (to keep them)
-    KarmaNote.objects.filter(moderator=current).update(moderator=anonymous)
-    Ban.objects.filter(moderator=current).update(moderator=anonymous)
-    Alert.objects.filter(author=current).update(author=anonymous)
-    Alert.objects.filter(moderator=current).update(moderator=anonymous)
-    BannedEmailProvider.objects.filter(moderator=current).update(moderator=anonymous)
-    # Solved hat requests anonymization
-    HatRequest.objects.filter(moderator=current).update(moderator=anonymous)
-    # In case current user has been moderator in the past
-    Comment.objects.filter(editor=current).update(editor=anonymous)
-    for topic in PrivateTopic.objects.filter(author=current):
-        topic.participants.remove(current)
-        if topic.participants.count() > 0:
-            topic.author = topic.participants.first()
-            topic.participants.remove(topic.author)
+    if form.is_valid():
+        anonymous = get_object_or_404(User, username=settings.ZDS_APP['member']['anonymous_account'])
+        external = get_object_or_404(User, username=settings.ZDS_APP['member']['external_account'])
+        current = request.user
+        # Nota : as of v21 all about content paternity is held by a proper receiver in zds.tutorialv2.models.database
+        PickListOperation.objects.filter(staff_user=current).update(staff_user=anonymous)
+        PickListOperation.objects.filter(canceler_user=current).update(canceler_user=anonymous)
+        # Comments likes / dislikes
+        votes = CommentVote.objects.filter(user=current)
+        for vote in votes:
+            if vote.positive:
+                vote.comment.like -= 1
+            else:
+                vote.comment.dislike -= 1
+            vote.comment.save()
+        votes.delete()
+        # All contents anonymization
+        Comment.objects.filter(author=current).update(author=anonymous)
+        PrivatePost.objects.filter(author=current).update(author=anonymous)
+        CommentEdit.objects.filter(editor=current).update(editor=anonymous)
+        CommentEdit.objects.filter(deleted_by=current).update(deleted_by=anonymous)
+        # Karma notes, alerts and sanctions anonymization (to keep them)
+        KarmaNote.objects.filter(moderator=current).update(moderator=anonymous)
+        Ban.objects.filter(moderator=current).update(moderator=anonymous)
+        Alert.objects.filter(author=current).update(author=anonymous)
+        Alert.objects.filter(moderator=current).update(moderator=anonymous)
+        BannedEmailProvider.objects.filter(moderator=current).update(moderator=anonymous)
+        # Solved hat requests anonymization
+        HatRequest.objects.filter(moderator=current).update(moderator=anonymous)
+        # In case current user has been moderator in the past
+        Comment.objects.filter(editor=current).update(editor=anonymous)
+        for topic in PrivateTopic.objects.filter(author=current):
+            topic.participants.remove(current)
+            if topic.participants.count() > 0:
+                topic.author = topic.participants.first()
+                topic.participants.remove(topic.author)
+                topic.save()
+            else:
+                topic.delete()
+        for topic in PrivateTopic.objects.filter(participants__in=[current]):
+            topic.participants.remove(current)
             topic.save()
-        else:
-            topic.delete()
-    for topic in PrivateTopic.objects.filter(participants__in=[current]):
-        topic.participants.remove(current)
-        topic.save()
-    Topic.objects.filter(solved_by=current).update(solved_by=anonymous)
-    Topic.objects.filter(author=current).update(author=anonymous)
+        Topic.objects.filter(solved_by=current).update(solved_by=anonymous)
+        Topic.objects.filter(author=current).update(author=anonymous)
 
-    # Any content exclusively owned by the unregistering member will
-    # be deleted just before the User object (using a pre_delete
-    # receiver).
-    #
-    # Regarding galleries, there are two cases:
-    #
-    # - "personal galleries" with one owner (the unregistering
-    #   user). The user's ownership is removed and replaced by an
-    #   anonymous user in order not to lost the gallery.
-    #
-    # - "personal galleries" with many other owners. It is safe to
-    #   remove the user's ownership, the gallery won't be lost.
+        # Any content exclusively owned by the unregistering member will
+        # be deleted just before the User object (using a pre_delete
+        # receiver).
+        #
+        # Regarding galleries, there are two cases:
+        #
+        # - "personal galleries" with one owner (the unregistering
+        #   user). The user's ownership is removed and replaced by an
+        #   anonymous user in order not to lost the gallery.
+        #
+        # - "personal galleries" with many other owners. It is safe to
+        #   remove the user's ownership, the gallery won't be lost.
 
-    galleries = UserGallery.objects.filter(user=current)
-    for gallery in galleries:
-        if gallery.gallery.get_linked_users().count() == 1:
-            anonymous_gallery = UserGallery()
-            anonymous_gallery.user = external
-            anonymous_gallery.mode = 'w'
-            anonymous_gallery.gallery = gallery.gallery
-            anonymous_gallery.save()
-    galleries.delete()
+        galleries = UserGallery.objects.filter(user=current)
+        for gallery in galleries:
+            if gallery.gallery.get_linked_users().count() == 1:
+                anonymous_gallery = UserGallery()
+                anonymous_gallery.user = external
+                anonymous_gallery.mode = 'w'
+                anonymous_gallery.gallery = gallery.gallery
+                anonymous_gallery.save()
+        galleries.delete()
 
-    # Remove API access (tokens + applications)
-    for token in AccessToken.objects.filter(user=current):
-        token.revoke()
+        # Remove API access (tokens + applications)
+        for token in AccessToken.objects.filter(user=current):
+            token.revoke()
 
-    logout(request)
-    User.objects.filter(pk=current.pk).delete()
-    return redirect(reverse('homepage'))
+        logout(request)
+        User.objects.filter(pk=current.pk).delete()
+        return redirect(reverse('homepage'))
+    else:
+        return render(request, 'member/settings/unregister.html',
+                {'user': request.user, 'form': form})
 
 
 @require_POST

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -441,8 +441,7 @@ def warning_unregister(request):
 
     form = UnregisterForm(request.user)
     return render(request, 'member/settings/unregister.html',
-            {'user': request.user, 'form': form})
-
+                  {'user': request.user, 'form': form})
 
 
 @login_required
@@ -529,7 +528,7 @@ def unregister(request):
         return redirect(reverse('homepage'))
     else:
         return render(request, 'member/settings/unregister.html',
-                {'user': request.user, 'form': form})
+                      {'user': request.user, 'form': form})
 
 
 @require_POST

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -2,10 +2,12 @@ import logging
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.layout import Layout, ButtonHolder, Field, Div, HTML
-from django.utils.translation import ugettext_lazy as _
+from django.contrib.auth import authenticate
 from django.template import defaultfilters
-from zds.utils.models import Tag
+from django.utils.translation import ugettext_lazy as _
+
 from zds.utils.misc import contains_utf8mb4
+from zds.utils.models import Tag
 
 
 class CommonLayoutEditor(Layout):
@@ -159,3 +161,17 @@ class FieldValidatorMixin:
     def check_text_length_limit(self, text, max_length, message_format):
         if len(text) > max_length:
             self._errors['text'] = [message_format().format(max_length)]
+
+
+class FieldPasswordMixin:
+    def check_correct_password(self, cleaned_data):
+        password = cleaned_data.get('password')
+
+        if password and self.user:
+            user_exist = authenticate(username=self.user.username, password=password)
+            # Check if the user exist.
+            if not user_exist and password != '':
+                self._errors['password'] = self.error_class([_('Mot de passe incorrect.')])
+                if 'password' in cleaned_data:
+                    del cleaned_data['password']
+        return cleaned_data


### PR DESCRIPTION
Cette PR a pour but de rajouter des champs « Mot de passe » aux pages où c'est nécessaire.

La nécessité est lié à la sécurité. On doit pouvoir confirmé que c'est bien l'utilisateur qui souhaite se désinscrire.


Numéro du ticket concerné : #5372 

### Contrôle qualité

Le premier commit me semble OK.
Le deuxième est certainement perfectible !

Une aide serait apprécié pour la rédaction des tests. Je ne manipule pas souvent Django.

______________

Merci :)