### PR TITLE
Hard work on epub 

### DIFF
--- a/templates/tutorialv2/export/ebook/chapter.html
+++ b/templates/tutorialv2/export/ebook/chapter.html
@@ -7,25 +7,29 @@
         <link rel="stylesheet" href="{{ relative }}/styles/katex.min.css" media="all" type="text/css"/>
     </head>
     <body class="zmarkdown">
-        {% if container.introduction %}
-            {{ container.get_introduction|epub_markdown:image_directory }}
-        {% endif %}
+        <div class="content-wrapper">
+            <div class="article-content">
+                {% if container.introduction %}
+                    {{ container.get_introduction|epub_markdown:image_directory }}
+                {% endif %}
 
-        {% for extract in container.children %}
-            <h2 id="{{ extract.position_in_parent }}-{{ extract.slug }}">
-                <a href="#{{ extract.position_in_parent }}-{{ extract.slug }}">
-                    {{ extract.title }}
-                </a>
-            </h2>
-            {% if extract.text %}
-                {{ extract.get_text|epub_markdown:image_directory }}
-            {% endif %}
-        {% endfor %}
+                {% for extract in container.children %}
+                    <h2 id="{{ extract.position_in_parent }}-{{ extract.slug }}">
+                        <a href="#{{ extract.position_in_parent }}-{{ extract.slug }}">
+                            {{ extract.title }}
+                        </a>
+                    </h2>
+                    {% if extract.text %}
+                        {{ extract.get_text|epub_markdown:image_directory }}
+                    {% endif %}
+                {% endfor %}
 
-        <hr />
+                <hr />
 
-        {% if container.conclusion %}
-            {{ container.get_conclusion|epub_markdown:image_directory }}
-        {% endif %}
+                {% if container.conclusion %}
+                    {{ container.get_conclusion|epub_markdown:image_directory }}
+                {% endif %}
+            </div>
+        </div>
     </body>
 </html>

--- a/templates/tutorialv2/export/ebook/content.opf.xml
+++ b/templates/tutorialv2/export/ebook/content.opf.xml
@@ -48,9 +48,6 @@
     </manifest>
 
     <spine toc="ncx">
-        {% for image_path, guid in images %}
-            <itemref idref="{{ guid }}"/>
-        {% endfor %}
         {% for path, identifier, _ in chapters %}
             <itemref idref="{{ identifier }}"/>
         {% endfor %}

--- a/templates/tutorialv2/export/ebook/content.opf.xml
+++ b/templates/tutorialv2/export/ebook/content.opf.xml
@@ -25,9 +25,9 @@
         <meta name="cover" content="cover.png"/>
     </metadata>
     <manifest>
-        <item id="stylesheet-global" href="Text/styles/zmd.css" media-type="text/css"/>
-        <item id="stylesheet-nav" href="Text/styles/toc.css" media-type="text/css"/>
-        <item id="stylesheet-katex" href="Text/styles/katex.min.css" media-type="text/css"/>
+        <item id="stylesheet-global" href="styles/zmd.css" media-type="text/css"/>
+        <item id="stylesheet-nav" href="styles/toc.css" media-type="text/css"/>
+        <item id="stylesheet-katex" href="styles/katex.min.css" media-type="text/css"/>
         {% for path, identifier, _ in chapters %}
             <item id="{{ identifier }}"
                   href="Text/{{ path }}"

--- a/templates/tutorialv2/export/ebook/introduction.html
+++ b/templates/tutorialv2/export/ebook/introduction.html
@@ -1,0 +1,12 @@
+{% load emarkdown %}
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title></title>
+        <meta charset="UTF-8"/>
+        <link rel="stylesheet" href="{{ relative }}/styles/zmd.css" media="all" type="text/css"/>
+        <link rel="stylesheet" href="{{ relative }}/styles/katex.min.css" media="all" type="text/css"/>
+    </head>
+    <body class="zmarkdown">
+        {{ text|epub_markdown:image_directory }}
+    </body>
+</html>

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -427,7 +427,7 @@ class Container:
         """
         if self.introduction:
             return get_blob(self.top_container().repository.commit(self.top_container().current_version).tree,
-                            self.introduction)
+                            self.introduction.replace('\\', '/'))
 
     def get_conclusion(self):
         """
@@ -436,7 +436,7 @@ class Container:
         """
         if self.conclusion:
             return get_blob(self.top_container().repository.commit(self.top_container().current_version).tree,
-                            self.conclusion)
+                            self.conclusion.replace('\\', '/'))
 
     def get_introduction_online(self):
         """The introduction content for online version.
@@ -1006,9 +1006,11 @@ class Extract:
         :rtype: str
         """
         if self.text:
+            print(self.container.top_container().current_version, self.text.replace('\\', '/'))
             return get_blob(
                 self.container.top_container().repository.commit(self.container.top_container().current_version).tree,
-                self.text)
+                self.text.replace('\\', '/'))
+        return ''
 
     def compute_hash(self):
         """Compute an MD5 hash from the text, for comparison purpose

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -1006,7 +1006,6 @@ class Extract:
         :rtype: str
         """
         if self.text:
-            print(self.container.top_container().current_version, self.text.replace('\\', '/'))
             return get_blob(
                 self.container.top_container().repository.commit(self.container.top_container().current_version).tree,
                 self.text.replace('\\', '/'))

--- a/zds/tutorialv2/publish_container.py
+++ b/zds/tutorialv2/publish_container.py
@@ -49,8 +49,9 @@ def publish_container(db_object, base_dir, container, template='tutorialv2/expor
     img_relative_path = '..' if ctx['relative'] == '.' else '../' + ctx['relative']
     if container.has_extracts():  # the container can be rendered in one template
         wrapped_image_callback = image_callback(img_relative_path) if image_callback else image_callback
-        args = {'container': container, 'is_js': is_js, 'relative': ctx['relative']}
+        args = {'container': container, 'is_js': is_js}
         args.update(ctx)
+        args['relative'] = img_relative_path
         parsed = render_to_string(template, args)
         write_chapter_file(base_dir, container, Path(container.get_prod_path(True, file_ext)),
                            parsed, path_to_title_dict, wrapped_image_callback)

--- a/zds/tutorialv2/publish_container.py
+++ b/zds/tutorialv2/publish_container.py
@@ -46,10 +46,10 @@ def publish_container(db_object, base_dir, container, template='tutorialv2/expor
     if not path.isdir(current_dir):
         makedirs(current_dir)
 
+    img_relative_path = '..' if ctx['relative'] == '.' else '../' + ctx['relative']
     if container.has_extracts():  # the container can be rendered in one template
-        img_relative_path = '..' if ctx['relative'] == '.' else '../' + ctx['relative']
         wrapped_image_callback = image_callback(img_relative_path) if image_callback else image_callback
-        args = {'container': container, 'is_js': is_js, 'relative': img_relative_path}
+        args = {'container': container, 'is_js': is_js, 'relative': ctx['relative']}
         args.update(ctx)
         parsed = render_to_string(template, args)
         write_chapter_file(base_dir, container, Path(container.get_prod_path(True, file_ext)),
@@ -61,17 +61,23 @@ def publish_container(db_object, base_dir, container, template='tutorialv2/expor
         container.conclusion = None
 
     else:  # separate render of introduction and conclusion
-        wrapped_image_callback = image_callback(ctx['relative']) if image_callback else image_callback
+        wrapped_image_callback_intro_ccl = image_callback(img_relative_path) if image_callback else image_callback
         # create subdirectory
         if not path.isdir(current_dir):
             makedirs(current_dir)
-        ctx['relative'] = '../' + ctx['relative']
+        relative_ccl_path = '../' + ctx.get('relative', '.')
         if container.introduction and container.get_introduction():
             part_path = Path(container.get_prod_path(relative=True), 'introduction.' + file_ext)
-            parsed = emarkdown(container.get_introduction(), db_object.js_support)
+            args = {'text': container.get_introduction()}
+            args.update(ctx)
+            args['relative'] = relative_ccl_path
+            if ctx.get('intro_ccl_template', None):
+                parsed = render_to_string(ctx.get('intro_ccl_template'), args)
+            else:
+                parsed = emarkdown(container.get_introduction(), db_object.js_support)
             container.introduction = str(part_path)
             write_chapter_file(base_dir, container, part_path, parsed, path_to_title_dict,
-                               wrapped_image_callback)
+                               wrapped_image_callback_intro_ccl)
         children = copy.copy(container.children)
         container.children = []
         container.children_dict = {}
@@ -80,14 +86,22 @@ def publish_container(db_object, base_dir, container, template='tutorialv2/expor
             altered_version = copy.copy(child)
             container.children.append(altered_version)
             container.children_dict[altered_version.slug] = altered_version
+            if not child.has_extracts():
+                ctx['relative'] = '../' + ctx['relative']
             result = publish_container(db_object, base_dir, altered_version, file_ext=file_ext,
                                        image_callback=image_callback, template=template, **ctx)
             path_to_title_dict.update(result)
         if container.conclusion and container.get_conclusion():
             part_path = Path(container.get_prod_path(relative=True), 'conclusion.' + file_ext)
-            parsed = emarkdown(container.get_conclusion(), db_object.js_support)
+            args = {'text': container.get_conclusion()}
+            args.update(ctx)
+            args['relative'] = relative_ccl_path
+            if ctx.get('intro_ccl_template', None):
+                parsed = render_to_string(ctx.get('intro_ccl_template'), args)
+            else:
+                parsed = emarkdown(container.get_conclusion(), db_object.js_support)
             container.conclusion = str(part_path)
-            write_chapter_file(base_dir, container, part_path, parsed, path_to_title_dict, wrapped_image_callback)
+            write_chapter_file(base_dir, container, part_path, parsed, path_to_title_dict, wrapped_image_callback_intro_ccl)
 
     return path_to_title_dict
 
@@ -120,4 +134,8 @@ def write_chapter_file(base_dir, container, part_path, parsed, path_to_title_dic
             raise FailureDuringPublication(
                 _(u'Une erreur est survenue durant la publication de « {} », vérifiez le code markdown')
                 .format(container.title))
-    path_to_title_dict[str(part_path)] = container.title
+    # fix duplicate of introduction and conclusion in ebook ids
+    if part_path.name.startswith('conclusion.') or part_path.name.startswith('introduction.'):
+        path_to_title_dict[str(part_path)] = part_path.name.split('.')[0] + '_' + container.title
+    else:
+        path_to_title_dict[str(part_path)] = container.title

--- a/zds/tutorialv2/publish_container.py
+++ b/zds/tutorialv2/publish_container.py
@@ -101,7 +101,8 @@ def publish_container(db_object, base_dir, container, template='tutorialv2/expor
             else:
                 parsed = emarkdown(container.get_conclusion(), db_object.js_support)
             container.conclusion = str(part_path)
-            write_chapter_file(base_dir, container, part_path, parsed, path_to_title_dict, wrapped_image_callback_intro_ccl)
+            write_chapter_file(base_dir, container, part_path, parsed,
+                               path_to_title_dict, wrapped_image_callback_intro_ccl)
 
     return path_to_title_dict
 


### PR DESCRIPTION
Cette PR reprend le travail sur les epub là où il était laissé car on a un problème bloquant actuellement.

- fix #5377 
- réduit la taille des epubs en ne mettant pas les images qui ne sont pas prises
- fix les moments où le style n'est pas correctement ajouté, j'ai testé sur le reader de edge et sur le plugin epub reader de FF, sur tous les types de contenus
- fix le format des introduction, qui n'avaient pas de style intégré

# QA

créer un artile, un tuto avec seulement une partie et un tuto avec partie et chapitre, dans chacun d'entre eux, ajouter des éléments spécifiques à zds, du code, des images et des smiley.

Une fois cela fait démarrez le publication_watchdog

publiez ces éléments.

regardez les epubs, vérifiez qu'ils ont le style et les images qui apparaissent comme attendus. 

# todolist

- [x] pep8
