### PR TITLE
Supression du lien de partage d'un contenu via Google+

### DIFF
--- a/templates/misc/social_buttons.part.html
+++ b/templates/misc/social_buttons.part.html
@@ -20,14 +20,6 @@
             </a>
         </li>
         <li>
-            <a href="https://plus.google.com/share?url={{ app.site.url }}{{ link }}&amp;hl=fr"
-               class="ico-after google-plus blue"
-               rel="nofollow"
-            >
-                Google+
-            </a>
-        </li>
-        <li>
             <a href="http://sharetodiaspora.github.io/?url={{ app.site.url }}{{ link }}&amp;title={{ text }}"
                class="ico-after diaspora blue"
                rel="nofollow"


### PR DESCRIPTION
Suite à la fermeture de Google+, ce lien n'a plus raison d'être. (#5216)