### PR TITLE
Support pour Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "gulp": "node_modules/gulp/bin/gulp.js",
-    "build": "node_modules/gulp/bin/gulp.js build",
-    "watch": "node_modules/gulp/bin/gulp.js watch",
-    "lint": "node_modules/gulp/bin/gulp.js js:lint",
-    "clean": "node_modules/gulp/bin/gulp.js clean"
+    "gulp": "node ./node_modules/gulp/bin/gulp.js",
+    "build": "node ./node_modules/gulp/bin/gulp.js build",
+    "watch": "node ./node_modules/gulp/bin/gulp.js watch",
+    "lint": "node ./node_modules/gulp/bin/gulp.js js:lint",
+    "clean": "node ./node_modules/gulp/bin/gulp.js clean"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Windows ne supporte pas "node_modules" à la limite "./node_modules" puis il ne sait pas que gulp est un script nodejs donc il ne sait pas comment lancer la commande. On doit tout lui dire
notamment qu'on le lance avec node quand on souhaite lancer un script via powershell ou cmd, il faut ajouter '/' ou './', mettre le nom du dossier directement fait buguer.

QA : Regarder si travis passe (Travis test les commandes quand il installe le site)