### PR TITLE
Mise en avant des solutions pour accélérer l'espace de dev

### DIFF
--- a/doc/source/delay-issue.html
+++ b/doc/source/delay-issue.html
@@ -1,0 +1,24 @@
+=========================
+Problème de lenteur lors du dev ?
+=========================
+
+J'ai des lenteurs avec gulp (build|watch)
+---------------------
+
+Pour le développement et uniquement ce but, notre script `gulp` prend en entrée un paramètre "--speed" qui désactive les optimisations du code pour la prod. Ainsi `watch` à besoin de calculer moins de choses donc moins d'usage de CPU.
+
+Avec gulp il faudra faire :
+
+.. sourcecode:: bash
+    $ npm run watch -- --speed
+
+
+Le changement de page est très lent !
+---------------------
+
+Désactiver la barre de debug réduit la vitesse de chargement par 10. Si vous n'utilisez pas la DEBUG_TOOLBAR_CONFIG, vous pouvez la désactiver avec la commande ci-dessous au démarrage :
+
+Pour ce faire utilisez la configuration `dev_fast` qui désactive la Toolbar :
+
+.. sourcecode:: bash
+    python manage.py runserver --settings zds.settings.dev_fast

--- a/doc/source/install/extra-install-frontend.rst
+++ b/doc/source/install/extra-install-frontend.rst
@@ -131,7 +131,10 @@ Coder plus simplement avec ``watch``
 
 Si votre ordinateur n'est pas très puissant ou la commande ``watch`` est lente. Vous aurez besoin de l'option ``--speed``. Cette option permet de désactiver les fonctions de parsing pour la prod. Ainsi ``watch`` a besoin de moins de CPU.
 
-``npm run gulp -- --speed``
+.. sourcecode:: bash
+
+    $ npm run watch -- --speed
+
 
 -----
 

--- a/zds/settings/dev_fast.py
+++ b/zds/settings/dev_fast.py
@@ -1,0 +1,5 @@
+from .dev import *
+
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': lambda r: False,
+}


### PR DESCRIPTION
Fix: #5287

L'un des principales défauts quand on développe sur zds-site c'est la lenteur qui n'est pas forcement justifié (ce n'est pas du tout accueillant !).

Souvent lorsqu'un nouveau contributeur arrive, c'est pour modifier le front donc il n'a pas besoin de la toolbar, cette PR à pour but de mettre en avant les corrections possibles contre cette lenteur assez frustrante. 