### PR TITLE
Clarifie le nom du Job 2 et Job 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ jobs:
   include:
     - name: "Job 1 : tuto (zds.tutorialv2)"
       env: ZDS_TEST_JOB="zds.tutorialv2"
-    - name: "Job 2 : test1 (zds.member zds.utils zds.forum)"
+    - name: "Job 2 : back test (zds.member zds.utils zds.forum)"
       env: ZDS_TEST_JOB="zds.member zds.utils zds.forum"
-    - name: "Job 3 : front & test2 (zds.mp zds.gallery zds.pages zds.featured zds.notification zds.searchv2)"
+    - name: "Job 3 : front test (zds.mp zds.gallery zds.pages zds.featured zds.notification zds.searchv2)"
       env: ZDS_TEST_JOB="front zds.mp zds.gallery zds.pages zds.featured zds.notification zds.searchv2"
     - name: "Job 4 : selenium"
       env: ZDS_TEST_JOB="selenium"


### PR DESCRIPTION
Le nom du Job 2 n'était pas assez précis.

# Q/A : 

Vérifier le nom du Job 2 et 3 : 

> "Job 2 : back test (zds.member zds.utils zds.forum)"
> "Job 3 : front test (zds.mp zds.gallery zds.pages zds.featured zds.notification zds.searchv2)"