### PR TITLE
Ajoute une commande pour publier un contenu

### DIFF
--- a/zds/tutorialv2/management/commands/validate_content.py
+++ b/zds/tutorialv2/management/commands/validate_content.py
@@ -1,0 +1,48 @@
+import logging
+
+from django.core.management import BaseCommand
+from django.utils.translation import gettext as _
+
+from zds.tutorialv2.models.database import PublishableContent, Validation
+from zds.tutorialv2.publication_utils import publish_content, FailureDuringPublication, notify_update, \
+    save_validation_state
+
+
+class Command(BaseCommand):
+    help = 'Publish one content by its id. This require the content to be in validation and reserved by someone'
+
+    def add_arguments(self, parser):
+        parser.add_argument('content', type=Command.id_validator)
+        parser.add_argument('--major', dest='is_major', action='store_true')
+        parser.add_argument('--source', dest='source', type=str, default='')
+
+    @staticmethod
+    def id_validator(content_pk):
+        try:
+            content_pk = int(content_pk)
+        except ValueError:
+            raise ValueError('Identifier should be integer')
+        content = PublishableContent.objects.filter(pk=content_pk).first()
+        if not content:
+            raise ValueError('Content does not exist')
+
+        if not Validation.objects.filter(content=content, status='PENDING_V').first():
+            raise ValueError('Content is not being validated')
+
+        return content
+
+    def handle(self, *args, content: PublishableContent, is_major=False, **options):
+        content.current_validation =  Validation.objects.filter(content=content, status='PENDING_V').first()
+        versioned = content.load_version(sha=content.current_validation.version)
+        is_update = content.sha_public
+        try:
+            published = publish_content(content, versioned, is_major_update=is_major)
+        except FailureDuringPublication as e:
+            self.stdout.write('Publication failed')
+            logging.getLogger(__name__).exception('Failure during publication', exc_info=e)
+        else:
+            save_validation_state(content, is_update, published, content.current_validaton, versioned,
+                                  options.get('source', ''), is_major, user=content.current_validation.validator,
+                                  comment=_("Géré depuis la commande d'administration"))
+            notify_update(content, is_update, is_major)
+            self.stdout.write(_('La contenu a été validé'))

--- a/zds/tutorialv2/management/commands/validate_content.py
+++ b/zds/tutorialv2/management/commands/validate_content.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
             self.stdout.write('Publication failed')
             logging.getLogger(__name__).exception('Failure during publication', exc_info=e)
         else:
-            save_validation_state(content, is_update, published, content.current_validaton, versioned,
+            save_validation_state(content, is_update, published, content.current_validation, versioned,
                                   options.get('source', ''), is_major, user=content.current_validation.validator,
                                   comment=_("Géré depuis la commande d'administration"))
             notify_update(content, is_update, is_major)

--- a/zds/tutorialv2/management/commands/validate_content.py
+++ b/zds/tutorialv2/management/commands/validate_content.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         return content
 
     def handle(self, *args, content: PublishableContent, is_major=False, **options):
-        content.current_validation =  Validation.objects.filter(content=content, status='PENDING_V').first()
+        content.current_validation = Validation.objects.filter(content=content, status='PENDING_V').first()
         versioned = content.load_version(sha=content.current_validation.version)
         is_update = content.sha_public
         try:

--- a/zds/tutorialv2/views/validations.py
+++ b/zds/tutorialv2/views/validations.py
@@ -23,9 +23,9 @@ from zds.tutorialv2.forms import AskValidationForm, RejectValidationForm, Accept
 from zds.tutorialv2.mixins import SingleContentFormViewMixin, ModalFormView, \
     SingleOnlineContentFormViewMixin, RequiresValidationViewMixin, DoesNotRequireValidationFormViewMixin
 from zds.tutorialv2.models.database import Validation, PublishableContent, PickListOperation
-from zds.tutorialv2.publication_utils import publish_content, unpublish_content, notify_update, FailureDuringPublication
+from zds.tutorialv2.publication_utils import publish_content, unpublish_content, notify_update, \
+    FailureDuringPublication, save_validation_state
 from zds.tutorialv2.utils import clone_repo
-from zds.utils.forums import send_post, lock_topic
 from zds.utils.models import SubCategory, get_hat_from_settings
 from zds.utils.mps import send_mp
 
@@ -450,40 +450,15 @@ class AcceptValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
         except FailureDuringPublication as e:
             messages.error(self.request, e.message)
         else:
-            self.save_validation_state(db_object, form, is_update, published, validation, versioned)
+            save_validation_state(db_object, is_update, published, validation, versioned,
+                                  source=form.cleaned_data['source'], is_major=form.cleaned_data['is_major'],
+                                  user=self.request.user, request=self.request, comment=form.cleaned_data['text'])
             notify_update(db_object, is_update, form.cleaned_data['is_major'])
 
             messages.success(self.request, _('Le contenu a bien été validé.'))
             self.success_url = published.get_absolute_url_online()
 
         return super(AcceptValidation, self).form_valid(form)
-
-    def save_validation_state(self, db_object, form, is_update, published, validation, versioned):
-        # save in database
-        db_object.sha_public = validation.version
-        db_object.source = form.cleaned_data['source']
-        db_object.sha_validation = None
-        db_object.public_version = published
-        if form.cleaned_data['is_major'] or not is_update or db_object.pubdate is None:
-            db_object.pubdate = datetime.now()
-            db_object.is_obsolete = False
-
-        # close beta if is an article
-        if db_object.type == 'ARTICLE':
-            db_object.sha_beta = None
-            topic = db_object.beta_topic
-            if topic is not None and not topic.is_locked:
-                msg_post = render_to_string(
-                    'tutorialv2/messages/beta_desactivate.md', {'content': versioned}
-                )
-                send_post(self.request, topic, self.request.user, msg_post)
-                lock_topic(topic)
-        db_object.save()
-        # save validation object
-        validation.comment_validator = form.cleaned_data['text']
-        validation.status = 'ACCEPT'
-        validation.date_validation = datetime.now()
-        validation.save()
 
 
 class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnlineContentFormViewMixin):

--- a/zds/utils/forums.py
+++ b/zds/utils/forums.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime
 
 from django.contrib import messages
@@ -105,15 +106,18 @@ def send_post(request, topic, author, text,):
         post.position = topic.last_message.position + 1
     else:
         post.position = 1
-
-    post.update_content(
-        text,
-        on_error=lambda m: messages.error(
-            request,
-            _('Erreur du serveur Markdown:\n{}').format('\n- '.join(m))))
-
-    post.ip_address = get_client_ip(request)
-    post.hat = get_hat_from_request(request)
+    if request:
+        post.update_content(
+            text,
+            on_error=lambda m: messages.error(
+                request,
+                _('Erreur du serveur Markdown:\n{}').format('\n- '.join(m))))
+        post.ip_address = get_client_ip(request)
+        post.hat = get_hat_from_request(request)
+    else:
+        post.update_content(
+            text,
+            on_error=lambda m: logging.getLogger(__name__).error('--'.join(m)))
     post.save()
 
     topic.last_message = post


### PR DESCRIPTION
cette commande est nécessaire pour publier les
tutoriels qui sont trop longs à publier par rapport
au timeout de gunicorn.

# QA

- créer un tuto
- mettez-le en réservation
- lancez `python manage.py publish_content {id_de_votre_contenu}`
- observez que le contenu est publié
- lancez `python manage.py publication_watchdog`
- observé que les exports sont générés (ne vérifier que leur présence)