### PR TITLE
Met à jour la version du JDK

### DIFF
--- a/scripts/define_variable.sh
+++ b/scripts/define_variable.sh
@@ -20,9 +20,9 @@ if [[ $ZDS_LATEX_REPO == "" ]]; then
     ZDS_LATEX_REPO="https://github.com/zestedesavoir/latex-template.git"
 fi
 
-if [[ $ZDS_JDK_HASH == "" ]]; then
-    ZDS_JDK_HASH="f51449fcd52f4d52b93a989c5c56ed3c"
+if [[ $ZDS_JDK_VERSION == "" ]]; then
+    ZDS_JDK_VERSION="11.0.4"
     # shellcheck disable=SC2034
-    ZDS_JDK_VERSION="11.0.2"
-    ZDS_JDK_REV="+9"
+    ZDS_JDK_REV="11"
 fi
+

--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -272,15 +272,15 @@ if  ! $(_in "-jdk-local" $@) && ( $(_in "+jdk-local" $@) || $(_in "+full" $@) );
         rm -rf jdk
     fi
 
-    baseURL="https://download.oracle.com/otn-pub/java/jdk/"
-    foldername="jdk-${ZDS_JDK_VERSION}"
-    folderPATH="${ZDS_JDK_VERSION}${ZDS_JDK_REV}/${ZDS_JDK_HASH}/${foldername}_linux-x64_bin.tar.gz"
+    baseURL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/"
+    foldername="jdk-${ZDS_JDK_VERSION}+${ZDS_JDK_REV}"
+    folderPATH="${foldername}/OpenJDK11U-jdk_x64_linux_hotspot_${ZDS_JDK_VERSION}_${ZDS_JDK_REV}.tar.gz"
 
     echo "GET ${baseURL}${folderPATH}"
-    wget_nv -O ${foldername}.tar.gz --header "Cookie: oraclelicense=accept-securebackup-cookie" ${baseURL}${folderPATH}
+    wget_nv -O ${foldername}.tar.gz ${baseURL}${folderPATH}
+    tar xf ${foldername}.tar.gz
 
     if [[ $? == 0 ]]; then
-        tar xf ${foldername}.tar.gz
         rm ${foldername}.tar.gz
         mv ${foldername} jdk
 
@@ -290,7 +290,7 @@ if  ! $(_in "-jdk-local" $@) && ( $(_in "+jdk-local" $@) || $(_in "+full" $@) );
         export JAVA_HOME="$(pwd)/jdk"
         export ES_JAVA_OPTS="-Xms512m -Xmx512m"
     else
-        print_error "!! Cannot get jdk ${JDK_VERSION}"
+        print_error "!! Cannot get or extract jdk ${ZDS_JDK_VERSION}"
         exit 1
     fi
     cd $ZDSSITE_DIR


### PR DESCRIPTION
Met à jour la version du JDK car l'ancienne n'est apparemment plus disponible au téléchargement (erreur 404)

Fixes #5413 