### PR TITLE
Fix #5418 : script d'installation automatique compatible Debian 10

### DIFF
--- a/scripts/dependencies/debian.txt
+++ b/scripts/dependencies/debian.txt
@@ -1,11 +1,11 @@
 #title=Debian
-#desc=Utilisation de apt-get / Testé sur : Debian Jessie (8), Debian Stretch (9.8).
+#desc=Utilisation de apt-get / Testé sur : Debian Jessie (8), Debian Stretch (9) et Debian Buster (10).
 #installcmd=apt-get -y install
 git
 wget
 curl
 unzip
-realpath
+coreutils
 python3-dev
 python3-pip
 python3-venv


### PR DESCRIPTION
Numéro du ticket concerné : #5418

### Contrôle qualité

  - Sur Debian 10, lancer le script d'installation avec `make install-linux`
  - Constatez que le script ne plante plus sur l'installation de realpath qui est contenu dans le paquet coreutils.

Net install : https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.0.0-amd64-netinst.iso
