### PR TITLE
[v28.2]Fait en sorte que le bouton d'export réagisse

### DIFF
--- a/assets/js/content-export.js
+++ b/assets/js/content-export.js
@@ -1,16 +1,27 @@
 (function ($) {
     $("[data-export-button]").click(function (e) {
         e.preventDefault();
-        var $button = $(e.target);
-        var url = $button.data("export-button");
-        var csrf = $("input[name=csrfmiddlewaretoken]").val();
+        const $button = $(e.target);
+        const url = $button.data("export-button");
+        const csrf = $("input[name=csrfmiddlewaretoken]").val();
         $button.prop("disabled", true);
+        $button.prop("aria-busy", true);
         $.ajax(url, {
             method: "POST",
             headers: {
                "X-CSRFToken": csrf,
             },
             data: {},
+        }).done(() => {
+            $button.prop("disabled", false);
+            $button.text($button.attr("data-success-text"));
+            $button.prop("aria-busy", false);
+            setTimeout(() => $button.text($button.attr("data-base-text")), 5000);
+        }).fail(() => {
+            $button.prop("disabled", false);
+            $button.text($button.attr("data-error-text"));
+            $button.prop("aria-busy", false);
+            setTimeout(() => $button.text($button.attr("data-base-text")), 5000);
         });
     });
 })(jQuery);

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -289,7 +289,10 @@
                     </a>
                 </li>
                 <li>
-                    <button data-export-button="{% url "api:content:generate_export" content.pk %}" class="ico-after gear blue">
+                    <button data-export-button="{% url "api:content:generate_export" content.pk %}" class="ico-after gear blue"
+                    data-success-text="{% trans "Export en cours, veuillez attendre quelques minutes" %}"
+                    data-error-text="{% trans "La demande d'export a échoué" %}"
+                    data-base-text="{% trans "Exporter le contenu (epub, pdf, latex...)" %}">
                         {% trans "Exporter le contenu (epub, pdf, latex...)" %}
                     </button>
                 </li>


### PR DESCRIPTION
# QA
- publiez un tuto
- appuyez sur le bouton "Exporter le contenu"
- Assurez vous que le message "Export en cours" s'affiche à la place de exporter puis qu'il redevient "exporter".

