### PR TITLE
[28.2] Remplace "tutoriaux" par "tutoriels" (fix #5423)

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -337,7 +337,7 @@
                                                     {% blocktrans count public_tutos_count=public_tutos_count %}
                                                         {{ public_tutos_count }} tutoriel publié
                                                     {% plural %}
-                                                        {{ public_tutos_count }} tutoriaux publiés
+                                                        {{ public_tutos_count }} tutoriels publiés
                                                     {% endblocktrans %}
                                                 </p>
                                             </a>
@@ -388,7 +388,7 @@
                                                             {% blocktrans count beta_tutos_count=beta_tutos_count %}
                                                                 {{ beta_tutos_count }} tutoriel en bêta
                                                             {% plural %}
-                                                                {{ beta_tutos_count }} tutoriaux en bêta
+                                                                {{ beta_tutos_count }} tutoriels en bêta
                                                             {% endblocktrans %}
                                                         </p>
                                                     </a>


### PR DESCRIPTION
Remplace "tutoriaux" par "tutoriels" (corrige #5423)