### PR TITLE
[28.2] N'affiche pas d'erreur dans la console en dehors de la page de profil

### DIFF
--- a/assets/js/userprofile-bio.js
+++ b/assets/js/userprofile-bio.js
@@ -9,7 +9,7 @@
     "use strict";
 
     var $bioContainer = $("body.userprofilepage .user-bio-and-activity .bio-container");
-    if (!$bioContainer) return; // We are not on a profile page
+    if (!$bioContainer[0]) return; // We are not on a profile page
 
     var $bioTextContainer = $bioContainer.find(".message-content");
     var $bioOverflowToggleHandle = $bioContainer.find(".biography-overflow");


### PR DESCRIPTION
N'affiche pas d'erreur dans la console en dehors de la page de profil (corrige #5425 )

**QA :**

- Lancer le serveur
- Sur la page d'accueil, vérifier qu'il n'y a pas de message d'erreur dans la console Javascript
- Sur la page de profil, vérifier que la biographie est affichée correctement