### PR TITLE
Enlève l'avertissement pour le KarmaForm

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -14,7 +14,6 @@ from crispy_forms.layout import HTML, Layout, \
 from zds.member.models import Profile, KarmaNote, BannedEmailProvider
 from zds.member.validators import validate_not_empty, validate_zds_email, validate_zds_username, validate_passwords, \
     validate_zds_password
-from zds.utils.forms import CommonLayoutModalText
 from zds.utils.misc import contains_utf8mb4
 from zds.utils.models import Licence, HatRequest, Hat
 from zds.utils import get_current_user
@@ -618,10 +617,8 @@ class KarmaForm(forms.Form):
         self.helper.form_class = 'modal modal-flex'
         self.helper.form_id = 'karmatiser-modal'
         self.helper.form_method = 'post'
-        # TODO : see how to fix the "commonlayoutmodaltext" issue that generates some
-        # useless exceptions. (field 'text' does not exists the choices are 'note' and 'karma')
+
         self.helper.layout = Layout(
-            CommonLayoutModalText(),
             Field('note'),
             Field('karma'),
             Hidden('profile_pk', '{{ profile.pk }}'),


### PR DESCRIPTION
Enlève l'avertissement qui s'affiche dans la console quand on affiche la page de profil d'un membre : 

```
WARNING:root:Could not resolve form field 'text'.
Traceback (most recent call last):
  File "/home/situphen/Code/zds-site/zdsenv/lib/python3.6/site-packages/django/forms/forms.py", line 163, in __getitem__
    field = self.fields[name]
KeyError: 'text'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/situphen/Code/zds-site/zdsenv/lib/python3.6/site-packages/crispy_forms/utils.py", line 81, in render_field
    bound_field = form[field]
  File "/home/situphen/Code/zds-site/zdsenv/lib/python3.6/site-packages/django/forms/forms.py", line 169, in __getitem__
    ', '.join(sorted(f for f in self.fields)),
KeyError: "Key 'text' not found in 'KarmaForm'. Choices are: karma, note."
```

**QA :**

- Lancer le serveur
- Se connecter avec admin
- Aller sur une page de profil
- Vérifier que le message ne s'affiche plus dans la console
- Vérifier que l'on peut toujours changer le karma d'un utilisateur