### PR TITLE
[28.2] Remet en état de fonctionnement la documentation de l'API

### DIFF
--- a/templates/rest_framework_swagger/index.html
+++ b/templates/rest_framework_swagger/index.html
@@ -19,43 +19,24 @@
 
 
 {% block doc_api %}
-    <div class="swagger-section">
-        <div id="message-bar" class="swagger-ui-wrap" data-sw-translate> </div>
-        <div id="swagger-ui-container" class="swagger-ui-wrap"></div>
-    </div>
+    <div id="rest-swagger-ui"></div>
+    {% csrf_token %}
 {% endblock %}
 
 
 
 {% block extra_css %}
-    <link href='{% static "rest_framework_swagger/css/screen.css" %}' media='screen' rel='stylesheet' type='text/css'/>
-    <link href='{% static "rest_framework_swagger/css/print.css" %}' media='print' rel='stylesheet' type='text/css'/>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
+    <link href="{% static 'rest_framework_swagger/bundles/vendors.bundle.css' %}" rel="stylesheet" type="text/css">
+    <link href="{% static 'rest_framework_swagger/bundles/app.bundle.css' %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 
 {% block extra_js %}
-    <script src='{% static "rest_framework_swagger/lib/object-assign-pollyfill.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/jquery-1.8.0.min.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/jquery.slideto.min.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/jquery.wiggle.min.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/jquery.ba-bbq.min.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/handlebars-2.0.0.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/js-yaml.min.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/lodash.min.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/backbone-min.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/swagger-ui.min.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/highlight.9.1.0.pack.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/highlight.9.1.0.pack_extended.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/jsoneditor.min.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/marked.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lib/swagger-oauth.js" %}' type='text/javascript'></script>
-
-    <script src='{% static "rest_framework_swagger/lang/translator.js" %}' type='text/javascript'></script>
-    <script src='{% static "rest_framework_swagger/lang/fr.js" %}' type='text/javascript'></script>
-
-    <script id="drs-settings" type="application/json">
-        {{ drs_settings | safe }}
+    <script>
+        window.drsSettings = {{ drs_settings|safe }};
+        window.drsSpec = {{ spec|safe }};
     </script>
-
-    <script src='{% static "rest_framework_swagger/init.js" %}' type='text/javascript'></script>
+    <script src="{% static 'rest_framework_swagger/bundles/vendors.bundle.js' %}"></script>
+    <script src="{% static 'rest_framework_swagger/bundles/app.bundle.js' %}"></script>
 {% endblock %}

--- a/zds/member/api/permissions.py
+++ b/zds/member/api/permissions.py
@@ -36,7 +36,8 @@ class IsOwner(permissions.BasePermission):
             owners = [obj.author.pk]
         elif hasattr(obj, 'authors'):
             owners = list(obj.authors.values_list('pk', flat=True))
-
+        else:
+            owners = []
         return request.user.pk in owners
 
 

--- a/zds/tutorialv2/api/views.py
+++ b/zds/tutorialv2/api/views.py
@@ -68,6 +68,7 @@ class ContainerPublicationReadinessView(UpdateAPIView):
 
 class ExportView(CreateAPIView):
     permission_classes = (IsAuthorOrStaff,)
+    serializer_class = Serializer
 
     def ensure_directories(self, content: PublishableContent):
         final_directory = Path(content.public_version.get_extra_contents_directory())

--- a/zds/tutorialv2/api/views.py
+++ b/zds/tutorialv2/api/views.py
@@ -6,7 +6,7 @@ from django.utils import translation
 from django.utils.translation import gettext as _
 from rest_framework import status
 from rest_framework.fields import empty
-from rest_framework.generics import UpdateAPIView, CreateAPIView, get_object_or_404
+from rest_framework.generics import UpdateAPIView, ListCreateAPIView, get_object_or_404
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer, CharField, BooleanField
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
@@ -15,7 +15,7 @@ from zds.member.api.permissions import CanReadAndWriteNowOrReadOnly, IsNotOwnerO
 from zds.tutorialv2.publication_utils import PublicatorRegistry
 from zds.tutorialv2.utils import search_container_or_404
 from zds.utils.api.views import KarmaView
-from zds.tutorialv2.models.database import ContentReaction, PublishableContent
+from zds.tutorialv2.models.database import ContentReaction, PublishableContent, PublicationEvent
 
 
 class ContainerReadinessSerializer(Serializer):
@@ -66,9 +66,12 @@ class ContainerPublicationReadinessView(UpdateAPIView):
         return content
 
 
-class ExportView(CreateAPIView):
+class ExportView(ListCreateAPIView):
     permission_classes = (IsAuthorOrStaff,)
     serializer_class = Serializer
+
+    def get_queryset(self):
+        return PublicationEvent.objects.filter(published_object__content__pk=self.kwargs.get('pk', 0))
 
     def ensure_directories(self, content: PublishableContent):
         final_directory = Path(content.public_version.get_extra_contents_directory())


### PR DESCRIPTION
Remet en état de fonctionnement la documentation de l'API

- Corrige un oubli dans `ExportView` qui cause une erreur 500
- Met à jour l'HTML et le CSS de Django Rest Swagger pour la documentation

**QA :**

- Lancer le serveur
- Vérifier que la documentation est bien affichée sur http://localhost:8000/api/
- Vérifier que le bouton "Exporter le contenu" fonctionne encore