### PR TITLE
[hotfix] L'absence de sous-titre n'est plus remplacée par None

### DIFF
--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -25,9 +25,9 @@
     {% endfor %}
     <meta name="DC.type" content="text" />
     <meta name="DC.title" content="{{ content.title }}" />
-    <meta name="DC.abstract" content="{{ content.title }}{% if content.description %} – {{ content.description }}{% endif %}" />
+    <meta name="DC.abstract" content="{{ content.title }}{% if content.meta_description %} – {{ content.meta_description }}{% endif %}" />
     <meta name="DC.subject" lang="fr" content="{% joinby content.subcategory.all %}{% if content.tags.all %} – {% joinby content.tags.all separator=' ; ' final_separator=' ; ' %}{% endif %}" />
-    {% if content.description %}<meta name="DC.description" lang="fr" content="{{ content.description }}" />{% endif %}
+    {% if content.meta_description %}<meta name="DC.description" lang="fr" content="{{ content.meta_description }}" />{% endif %}
     <meta name="DC.date" content="{% if content.pubdate %}{{ content.pubdate|date:'Y/m/d' }}{% else %}{{ content.update_date|date:'Y/m/d' }}{% endif %}" />
     <meta name="DC.format" content="text/html" />
     {% if content.source %}<meta name="DC.source" content="{{ content.source }}" />{% endif %}
@@ -36,8 +36,8 @@
 {% endblock %}
 
 {% block description %}
-    {% if content.description %}
-        {{ content.description }}
+    {% if content.meta_description %}
+        {{ content.meta_description }}
     {% else %}
         Site et association de partage de connaissances animé par sa communauté. Vous y trouverez des tutoriels et des articles de tous niveaux et des forums.
     {% endif %}

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -647,7 +647,7 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
             return self._description
         if not self.versioned_model:
             self.load_public_version()
-        self._description = self.versioned_model.description or self.versioned_model.get_introduction()
+        self._description = self.versioned_model.description or self.versioned_model.get_introduction() or ''
         if self._description:
             self._description = self._description[:settings.ZDS_APP['forum']['description_size']]
         return self._description

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -627,7 +627,7 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
 
     # sizes contain a python dict (as a string in database) with all information about file sizes
     sizes = models.CharField('Tailles des fichiers téléchargeables', max_length=512, default='{}')
-    _description = None
+    _meta_description = None
 
     @staticmethod
     def get_slug_from_file_path(file_path):
@@ -643,14 +643,21 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
             return self.load_public_version().title
 
     def description(self):
-        if self._description:
-            return self._description
+        if self.versioned_model:
+            return self.versioned_model.description
+        else:
+            return self.load_public_version().description
+
+    def meta_description(self):
+        """Generate a description for the HTML tag <meta name='description'>"""
+        if self._meta_description:
+            return self._meta_description
         if not self.versioned_model:
             self.load_public_version()
-        self._description = self.versioned_model.description or self.versioned_model.get_introduction() or ''
-        if self._description:
-            self._description = self._description[:settings.ZDS_APP['forum']['description_size']]
-        return self._description
+        self._meta_description = self.versioned_model.description or self.versioned_model.get_introduction() or ''
+        if self._meta_description:
+            self._meta_description = self._meta_description[:settings.ZDS_APP['forum']['description_size']]
+        return self._meta_description
 
     def get_prod_path(self, relative=False):
         if not relative:


### PR DESCRIPTION
L'absence de sous-titre n'est plus remplacée par None (#5445)

**QA :**

- Lancer le serveur
- Vérifier que les contenus sans sous-titre s'affichent correctement