### PR TITLE
Supprime CommonLayoutModalText

### DIFF
--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1084,7 +1084,6 @@ class PublicationForm(forms.Form):
         self.helper.form_id = 'valid-publication'
 
         self.helper.layout = Layout(
-            CommonLayoutModalText(),
             Field('source'),
             HTML("<p>Ce billet sera publié directement et n'engage que vous.</p>"),
             StrictButton(_('Publier'), type='submit')
@@ -1148,7 +1147,6 @@ class PickOpinionForm(forms.Form):
         self.helper.layout = Layout(
             HTML('<p>Êtes-vous certain(e) de vouloir valider ce billet ? '
                  'Il pourra maintenant être présent sur la page d’accueil.</p>'),
-            CommonLayoutModalText(),
             Field('version'),
             StrictButton(
                 _('Valider'),
@@ -1174,7 +1172,6 @@ class DoNotPickOpinionForm(forms.Form):
 
         self.helper.layout = Layout(
             HTML(_("<p>Ce billet n'apparaîtra plus dans la liste des billets à choisir.</p>")),
-            CommonLayoutModalText(),
             Field('operation'),
             StrictButton(
                 _('Valider'),
@@ -1250,7 +1247,6 @@ class PromoteOpinionToArticleForm(forms.Form):
 
         self.helper.layout = Layout(
             HTML('<p>Êtes-vous certain(e) de vouloir promouvoir ce billet en article ?</p>'),
-            CommonLayoutModalText(),
             Field('version'),
             StrictButton(
                 _('Valider'),

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -7,7 +7,7 @@ from crispy_forms.layout import HTML, Layout, Submit, Field, ButtonHolder, Hidde
 from django.urls import reverse
 from django.core.validators import MinLengthValidator
 
-from zds.utils.forms import CommonLayoutModalText, CommonLayoutEditor, CommonLayoutVersionEditor
+from zds.utils.forms import CommonLayoutEditor, CommonLayoutVersionEditor
 from zds.utils.models import SubCategory, Licence
 from zds.tutorialv2.models import TYPE_CHOICES
 from zds.utils.models import HelpWriting
@@ -625,7 +625,7 @@ class AskValidationForm(forms.Form):
         self.helper.form_id = 'ask-validation'
 
         self.helper.layout = Layout(
-            CommonLayoutModalText(),
+            Field('text'),
             Field('source'),
             Field('version'),
             StrictButton(
@@ -721,7 +721,7 @@ class AcceptValidationForm(forms.Form):
         self.helper.form_id = 'valid-publish'
 
         self.helper.layout = Layout(
-            CommonLayoutModalText(),
+            Field('text'),
             Field('source'),
             Field('is_major'),
             StrictButton(_('Publier'), type='submit')
@@ -760,7 +760,7 @@ class CancelValidationForm(forms.Form):
 
         self.helper.layout = Layout(
             HTML('<p>Êtes-vous certain de vouloir annuler la validation de ce contenu ?</p>'),
-            CommonLayoutModalText(),
+            Field('text'),
             ButtonHolder(
                 StrictButton(
                     _('Confirmer'),
@@ -826,7 +826,7 @@ class RejectValidationForm(forms.Form):
         self.helper.form_id = 'reject'
 
         self.helper.layout = Layout(
-            CommonLayoutModalText(),
+            Field('text'),
             ButtonHolder(
                 StrictButton(
                     _('Rejeter'),
@@ -881,7 +881,7 @@ class RevokeValidationForm(forms.Form):
         self.helper.form_id = 'unpublish'
 
         self.helper.layout = Layout(
-            CommonLayoutModalText(),
+            Field('text'),
             Field('version'),
             StrictButton(
                 _('Dépublier'),
@@ -1120,7 +1120,7 @@ class UnpublicationForm(forms.Form):
         self.helper.form_id = 'unpublish'
 
         self.helper.layout = Layout(
-            CommonLayoutModalText(),
+            Field('text'),
             Field('version'),
             StrictButton(
                 _('Dépublier'),

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -54,15 +54,6 @@ class CommonLayoutVersionEditor(Layout):
         )
 
 
-class CommonLayoutModalText(Layout):
-
-    def __init__(self, *args, **kwargs):
-        super(CommonLayoutModalText, self).__init__(
-            Field('text'),
-            *args, **kwargs
-        )
-
-
 class TagValidator(object):
     """
     validate tags


### PR DESCRIPTION
Je suis encore tombé sur un avertissement à cause de la présence de `CommonLayoutModalText` dans un formulaire qui n'en a pas besoin. J'ai fait une petite recherche puis j'ai trouvé d'autres endroits où il n'y en a pas besoin. Puis en fait je me suis rendu compte que `CommonLayoutModalText` n'est rien de mieux qu'un pauvre `Field('text')` donc j'ai fait le remplacement car KISS.

```
WARNING:root:Could not resolve form field 'text'.
Traceback (most recent call last):
  File "/home/situphen/Code/zds-site/zdsenv/lib/python3.6/site-packages/django/forms/forms.py", line 163, in __getitem__
    field = self.fields[name]
KeyError: 'text'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/situphen/Code/zds-site/zdsenv/lib/python3.6/site-packages/crispy_forms/utils.py", line 81, in render_field
    bound_field = form[field]
  File "/home/situphen/Code/zds-site/zdsenv/lib/python3.6/site-packages/django/forms/forms.py", line 169, in __getitem__
    ', '.join(sorted(f for f in self.fields)),
KeyError: "Key 'text' not found in 'PromoteOpinionToArticleForm'. Choices are: version."
```

**QA :**

- Lancer le serveur
- Vérifier que chacun des formulaires modifiés fonctionnent