### PR TITLE
Amélioration de la liste déroulante "Déplacer"

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -90,6 +90,8 @@ function js() {
         require.resolve('moment/moment.js'),
         require.resolve('moment/locale/fr.js'),
         require.resolve('chart.js/dist/Chart.js'),
+        require.resolve('sortablejs'),
+        require.resolve('jquery-sortablejs'),
         // Used by other scripts, must be first
         'assets/js/modal.js',
         'assets/js/tooltips.js',

--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -1,0 +1,181 @@
+/*
+ * Allow the user to compare two commits
+ */
+(function(document, $, undefined){
+  "use strict";
+
+  function hideMoveButton() {
+    /* TODO : REMOVE this and update the selectlist with js */
+    /* because the list is not updated */
+    $(".simple-move-button").hide();
+  }
+
+  function sendMoveAction(evt) {
+    hideMoveButton();
+
+    // sending
+    const $item = $(evt.item);
+    const $from = $(evt.from);
+    const movingMethod = (($prev) => {
+      const path = ((tree) => {
+        $item.parents("[data-children-type]:not([data-pk])").each((n, parent) => {
+          tree.push($(parent).attr("data-slug"));
+        });
+        tree = tree.reverse();
+        if (tree.length > 0) {
+          tree.push("");
+        }
+        return tree.join("/");
+      })([]);
+
+      if ($prev[0]) {
+        return "after:" + path + $prev.attr("data-slug");
+      } else {
+        return "before:" + path + $item.next().attr("data-slug");
+        // TODO : [BACK] Add support of beginning
+        // return "beginning:" + path;
+      }
+    })($item.prev());
+
+    const isExtract = ($from.attr("data-children-type") === "extract");
+
+    const pk = $item.parents("[data-pk]").attr("data-pk");
+    const slug = $item.attr("data-slug");
+
+    const form = {
+      // new 
+      "moving_method": movingMethod,
+      // old
+      "container_slug": $from.attr("data-slug"),
+      "first_level_slug": (isExtract) ? $from.parents("[data-children-type]").attr("data-slug") : undefined,
+      // current
+      "child_slug": slug,
+      "pk": pk,
+      // csrf
+      "csrfmiddlewaretoken": $("input[name=csrfmiddlewaretoken]").val()
+    };
+
+    $.post("/contenus/deplacer/", form);
+
+    // modifie les URLs
+    const path = ((tree) => {
+      $item.parents("[data-children-type]").each((n, parent) => {
+        tree.push($(parent).attr("data-slug"));
+      });
+      tree = tree.reverse();
+      tree.push(slug);
+      return tree.join("/");
+    })([]);
+
+    $item.find("> .actions-title a.edit").attr("href", `/contenus/editer-conteneur/${pk}/${path}/`);
+    $("form#delete-" + slug).attr("action", `/contenus/supprimer/${pk}/${path}/`);
+    $item.find("[data-children-type] > [data-slug] a").each(function () {
+      const $parent = $(this).parents("[data-slug]").eq(0);
+      const mySlug = $parent.attr("data-slug");
+      if (slug !== $(this).attr("data-slug")) {
+        $(this).attr("href", `/contenus/${pk}/${path}/#${$parent.index()+1}-${mySlug}`);
+      } else {
+        $(this).attr("href", `/contenus/${pk}/${path}/`);
+      }
+    });
+    $item.find(".simple-create-button")
+      .attr("href", `/contenus/nouvelle-section/${pk}/${path}/`);
+  }
+
+  function canDrop($item, $to, $from) {
+    // TODO : [BACK] Change slug if we have the same.
+    const filter = "[data-slug=" + $item.attr("data-slug") + "]";
+    if ($to.children(filter).length >= (1 + $to.is($from))) {
+      return false;
+    }
+
+    // TODO : [BACK] Add "beginning" moving_method
+    if (!$to.children(":not(.simple-create-button):not(.simple-create-part)")[0]) {
+      return false;
+    }
+
+    return true;
+  }
+
+  $(document).ready(function() {
+    $("ol[data-children-type=extract]").sortable({
+      group: "extract",
+      handle: "a",
+      filter: function (pointer, dragged) {
+        return $(dragged).is(".simple-create-button");
+      },
+      onMove: (evt) => {
+        const $item = $(evt.dragged);
+        const $to = $(evt.related).parent();
+        const $from = $(evt.dragged).parent();
+
+        if (!canDrop($item, $to, $from)) {
+          return false;
+        }
+
+        if (!$to.is($from)) {
+          // Element is dragged into the list from another list
+          if ($from.parent().is(".article-containers > .article-part")) { // is: chapter > extract
+            $item.find("> h4 > a").unwrap().wrap("<h3></h3>");
+          } else { // is: part > chapter > extract 
+            $item.find("> h3 > a").unwrap().wrap("<h4></h4>");
+          }
+        }
+
+        if ($(evt.related).is(".simple-create-button")) {
+          return -1;
+        }
+      },
+      onEnd: sendMoveAction
+    });
+
+    $("*[data-children-type=container]").sortable({
+      group: "container",
+      handle: ["h2", "h3 a"],
+      filter: function (pointer, dragged) {
+        return $(dragged).is(".simple-create-part");
+      },
+      onMove: (evt) => {
+        const $item = $(evt.dragged);
+        const $to = $(evt.related).parent();
+        const $from = $(evt.dragged).parent();
+
+        if (!canDrop($item, $to, $from)) {
+          return false;
+        }
+
+        if (!$to.is($from)) {
+          // Element is dragged into the list from another list
+          if ($to.is("section")) { // is: chapter > extract
+            $item.find("> h3 > a").unwrap().wrap("<h2></h2>");
+            $item.find("ol h4 > a").unwrap().wrap("<h3></h3>");
+
+            if ($item.find(".simple-create-part")[0]) {
+              $item.children(".article-containers").show();
+              $item.children("ol.summary-part").hide();
+            }
+          } else { // is: part > chapter > extract 
+            $item.find("> h2 > a").unwrap().wrap("<h3></h3>");
+            $item.find("ol h3 > a").unwrap().wrap("<h4></h4>");
+
+            if ($item.find(".simple-create-part")[0]) {
+              $item.children(".article-containers").hide();
+              $item.append(
+                `<ol class="summary-part" data-children-type="extract">
+                  <li class="simple-create-button">
+                    <a class="btn btn-grey">Ajouter une section</a>
+                  </li>
+                </ol>`
+              );
+            }
+          }
+        }
+
+        if ($(evt.related).is(".simple-create-part")) {
+          return -1;
+        }
+      },
+      onEnd: sendMoveAction
+    });
+  });
+})(document, jQuery);

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -62,28 +62,6 @@ h6 {
     margin-bottom: 10px;
 }
 
-.actions-title {
-    float: right;
-    margin: -60px 10px 0 0;
-
-    .btn {
-        height: 30px;
-        line-height: 30px;
-        margin-left: 3px;
-        opacity: .7;
-        z-index: 1;
-
-        &.ico-after:after {
-            margin-top: 7px;
-        }
-
-        &:hover,
-        &:focus {
-            opacity: 1;
-        }
-    }
-}
-
 
 
 .custom-block {

--- a/assets/scss/base/_typography.scss
+++ b/assets/scss/base/_typography.scss
@@ -17,6 +17,10 @@ hr {
     padding: 0;
 }
 
+.hr-btop {
+    border-top: 1px solid #ccc;
+}
+
 a,
 .link {
     color: lighten($color-primary, 20%);

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -86,6 +86,10 @@
         textarea {
             margin: 0 0 15px;
         }
+
+        & > select {
+            width:100%;
+        }
     }
 
     .modal-footer {

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -24,7 +24,7 @@
         p,
         > a,
         p a,
-        ul:not(.pagination),
+        ul:not(.pagination):not(.actions-title),
         ol:not(.summary-part) {
             font-family: $font-serif;
         }
@@ -43,45 +43,191 @@
         }
     }
 
-    .article-content .summary-part {
-        font-size: 20px;
-        color: darken($color-secondary, 11%);
+    .article-containers {
+        display: flex;
+        flex-wrap: wrap;
+    }
 
-        h3,
-        h4 {
-            font-weight: normal;
-            width: 90%;
+    .article-containers > .article-part {
+        flex: 0 50%;
+        width: 100%;
+        box-sizing: border-box;
+        padding-left: 1em;
+
+        &.simple-create-part {
+            flex: 0 100%;
+        }
+    }
+
+
+    .article-content.parts {
+        /* >> The drag'n'drop will be not capricious if we replace margin by padding */
+        /* .. 1 .. */
+        /* Convert h2 margin-bottom to padding-top */
+        .article-part h2 {
+            margin-bottom: 0px;
+        }
+
+        /* Canceled by [.. 3 ..]
+        .article-containers {
+            padding-top: 20px;
+        } */
+
+        /* .. 2 .. */
+        /* Convert h2 margin-top to padding-bottom */
+        .article-part h2 {
+            margin-top: 0px;
+        }
+
+
+        .article-containers,
+        & > .article-part > ol {
+            padding-bottom: 20px;
+        }
+
+        margin-top: 20px;
+
+        /* .. 3 .. */
+        /* Stay in when we are on h2 */
+        .article-part h2 {
+            margin-bottom: -52px;
+        }
+
+        .article-part.simple-create-part h2 {
+            margin-bottom: 0;
+        }
+
+        & > .article-part > ol,
+        & > .article-part > .article-containers {
+            /* [.. 3 ..] + [.. 1 ..] = 52 + 20 = 72 */
+            padding-top: 72px;
+        }
+
+        & > .article-part > .extract-wrapper {
+            padding-top: 52px;
+        }
+
+        /* .. 4 .. */
+        padding: 20px 0;
+        /* << */
+    }
+
+    .article-content .article-part {
+        overflow: hidden;
+        position: relative;
+
+        /* full width draggable area */
+        h2 {
+            padding-left:0;
 
             a {
-                text-decoration: none;
-
-                &:hover,
-                &:focus {
-                    text-decoration: underline;
-                }
+                margin: 0;
+                display: inline-block;
+                width: 100%;
+                padding-left: 1%;
             }
         }
 
-        h3 {
-            font-size: 20px;
-            margin: 0 0 5px;
+        &:not(.is-chapter) {
+            h3, h4 {
+                font-weight: normal;
+                margin: 0 0 5px;
+                a {
+                    text-decoration: none;
+                    &:hover,
+                    &:focus {
+                        text-decoration: underline;
+                    }
+                }
+            }
+
+            li h3 a,
+            li h4 a {
+                color: lighten($color-primary, 20%);
+                transition: color $transition-duration ease, text-decoration $transition-duration ease;
+
+                &:hover {
+                    color: darken($color-secondary, 15%);
+                }
+            }
+
+            h3, h4 {
+                font-size: 16px;
+            }
         }
 
-        .summary-part {
-            list-style: none;
-            padding-left: 0;
-            margin-bottom: 15px;
+        & > .article-containers .actions-title {
+            display: none;
+        }
 
-            h4 {
-                font-size: 14px;
-                margin: 2px 0;
+        & > .article-part h3 {
+            font-size: 20px;
+            padding-left: 15px;
+        }
+
+        & > .article-part ol {}
+
+        h4 > a.disabled {
+            background: none !important;
+        }
+    }
+
+    .article-content li.simple-create-button {
+        list-style-type: '';
+        .btn {
+            float:none;
+            font-size: 14px;
+            display:inline-block;
+            line-height: 32px;
+            height: 32px;
+            border-radius: 2px;
+            vertical-align: bottom;
+            padding:0 12px 0 8px;
+            white-space: nowrap;
+
+            &::before {
+                content: '+ ';
+                font-size: 28px;
+                vertical-align: bottom;
+                padding-bottom: 3px; /* hack font vertical-align between + and ABC (letters) */
+            }
+            margin-left:-18px;
+        }
+    }
+
+    .article-content .article-part .actions-title {
+        position: absolute;
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        top: 11px;
+        right: 10px;
+
+        li {
+            display: inline-block;
+        }
+
+        li .btn {
+            float: none !important;
+            height: 30px;
+            line-height: 30px;
+            margin-left: 3px;
+            opacity: .7;
+            z-index: 1;
+
+            &.ico-after:after {
+                margin-top: 7px;
+            }
+
+            &:hover,
+            &:focus {
+                opacity: 1;
             }
         }
     }
 
     .article-content,
     .message-content {
-        margin-bottom: 20px;
         color: #424242;
 
         @import "base/content";

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -76,27 +76,6 @@
         color:#1088bf !important;
     }
 
-    li.simple-create-button {
-        list-style-type: '';
-        .btn {
-            float:none;
-            display:inline-block;
-            line-height: 32px;
-            height: 32px;
-            border-radius: 2px;
-            vertical-align: middle;
-            padding:0 12px 0 8px;
-
-            &::before {
-                content: '+ ';
-                font-size: 28px;
-                vertical-align: middle;
-                padding-bottom: 3px; /* hack font vertical-align between + and ABC (letters) */
-            }
-            margin-left:-18px;
-        }
-    }
-
     .license {
         float: right;
         margin: 0;
@@ -157,10 +136,6 @@
 
     .new-btn-container {
         display: none;
-    }
-
-    .summary-part h4 > a.disabled {
-        background: none !important;
     }
 }
 
@@ -257,15 +232,6 @@
 
                 &:first-child {
                     margin: 0;
-                }
-            }
-
-            .article-content > .summary-part > li {
-                float: left;
-                width: 50%;
-
-                &:nth-child(2n+1) {
-                    clear: both;
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
     "gulp.spritesmith": "6.10.1",
     "highlight.js": "^9.15.9",
     "jquery": "3.4.1",
+    "jquery-sortablejs": "1.0.1",
     "katex": "0.10.1",
     "moment": "^2.20.1",
-    "normalize.css": "8.0.1"
+    "normalize.css": "8.0.1",
+    "sortablejs": "1.10.0"
   },
   "devDependencies": {
     "gulp-jshint": "2.1.0",

--- a/templates/tutorialv2/base_content.html
+++ b/templates/tutorialv2/base_content.html
@@ -1,0 +1,14 @@
+{% extends "tutorialv2/base.html" %}
+
+
+{% block content_page %}
+    <section class="article-content">
+        {% block content_intro %}{% endblock %}
+    </section>
+    <section class="article-content parts" data-children-type="container" data-slug="{% block dnd_child_slug %}{{ content.slug }}{% endblock %}" data-pk="{{ content.pk }}">
+        {% block content_parts %}{% endblock %}
+    </section>
+    <section class="article-content hr-btop clearfix">
+        {% block content_conclu %}{% endblock %}
+    </section>
+{% endblock %}

--- a/templates/tutorialv2/includes/actions_title_buttons.part.html
+++ b/templates/tutorialv2/includes/actions_title_buttons.part.html
@@ -1,0 +1,56 @@
+{% load i18n %}
+{% load target_tree %}
+{% load times %}
+
+<ul class="actions-title summary-part">
+    <li>
+        {% include "tutorialv2/includes/delete.part.html" with object=child additional_classes="ico-after cross btn btn-grey" %}
+    </li>
+    <li>
+        <a href="#move-{{ child.slug }}" class="open-modal ico-after move btn btn-grey simple-move-button">{% trans "Déplacer" %}</a>
+        <form action="{% url "content:move-element" %}" method="post" class="modal modal-flex" id="move-{{ child.slug }}">
+            <select name="moving_method">
+                <option disabled="disabled">{% trans "Déplacer" %}</option>
+                {% if child.position_in_parent > 1 %}
+                    <option value="up">{% trans "Monter" %}</option>
+                {% endif %}
+
+                {% if child.position_in_parent < child.parent.children|length %}
+                    <option value="down">{% trans "Descendre" %}</option>
+                {% endif %}
+                <option disabled="disabled">&mdash; {% trans "Déplacer avant" %}</option>
+                {% for element in child|target_tree %}
+                        <option value="before:{{element.0}}"
+                        {% if not element.3 %} disabled {% endif %}>
+                             &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
+                        </option>
+                {% endfor %}
+                <option disabled="disabled">&mdash; {% trans "Déplacer après" %}</option>
+                {% for element in child|target_tree %}
+                        <option value="after:{{element.0}}"
+                        {% if not element.3 %} disabled {% endif %}>
+                             &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
+                        </option>
+                {% endfor %}
+            </select>
+            <input type="hidden" name="child_slug" value="{{ child.slug }}">
+            {% if child.text %}
+                <input type="hidden" name="container_slug" value="{{ child.container.slug }}">
+                <input type="hidden" name="first_level_slug" value="{{ child.get_first_level_slug }}">
+            {%  else %}
+                <input type="hidden" name="container_slug" value="{{ child.parent.slug }}">
+            {% endif %}
+
+            <input type="hidden" name="pk" value="{{ content.pk }}">
+            {% csrf_token %}
+            <button type="submit">
+                {% trans "Déplacer" %}
+            </button>
+        </form>
+    </li>
+    <li>
+        <a href="{{ child.get_edit_url }}" class="ico-after edit btn btn-grey">
+            {% trans "Éditer" %}
+        </a>
+    </li>
+</ul>

--- a/templates/tutorialv2/includes/actions_title_buttons.part.html
+++ b/templates/tutorialv2/includes/actions_title_buttons.part.html
@@ -9,8 +9,9 @@
     <li>
         <a href="#move-{{ child.slug }}" class="open-modal ico-after move btn btn-grey simple-move-button">{% trans "Déplacer" %}</a>
         <form action="{% url "content:move-element" %}" method="post" class="modal modal-flex" id="move-{{ child.slug }}">
+            <label>{% blocktrans with title=child.title %}Déplacer {{ title }} :{% endblocktrans %}</label>
+
             <select name="moving_method">
-                <option disabled="disabled">{% trans "Déplacer" %}</option>
                 {% if child.position_in_parent > 1 %}
                     <option value="up">{% trans "Monter" %}</option>
                 {% endif %}
@@ -18,20 +19,24 @@
                 {% if child.position_in_parent < child.parent.children|length %}
                     <option value="down">{% trans "Descendre" %}</option>
                 {% endif %}
-                <option disabled="disabled">&mdash; {% trans "Déplacer avant" %}</option>
-                {% for element in child|target_tree %}
-                        <option value="before:{{element.0}}"
-                        {% if not element.3 %} disabled {% endif %}>
-                             &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
-                        </option>
-                {% endfor %}
-                <option disabled="disabled">&mdash; {% trans "Déplacer après" %}</option>
-                {% for element in child|target_tree %}
+
+                <optgroup label="{% trans "Déplacer après" %}">
+                    {% for element in child|target_tree %}
+
+                        {% if not prevElement.3 and element.3  %}
+                            <option value="before:{{element.0}}">
+                                 {% for _ in element.2|times %}&mdash;{% endfor %}Intro {{ prevElement.1|truncatechars:50 }}
+                            </option>
+                        {% endif %}
+
                         <option value="after:{{element.0}}"
                         {% if not element.3 %} disabled {% endif %}>
-                             &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
+                             {% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
                         </option>
-                {% endfor %}
+
+                        {% set element as prevElement %}
+                    {% endfor %}
+                </optgroup>
             </select>
             <input type="hidden" name="child_slug" value="{{ child.slug }}">
             {% if child.text %}

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -3,6 +3,7 @@
 {% load times %}
 {% load target_tree %}
 {% load feminize %}
+{% load set %}
 
 <div class="article-part {% if child.text %}is-chapter{% endif %}" data-slug="{{ child.slug }}">
     <h2 id="{{ child.position_in_parent }}-{{ child.slug }}"

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -4,191 +4,156 @@
 {% load target_tree %}
 {% load feminize %}
 
-<h2 id="{{ child.position_in_parent }}-{{ child.slug }}"
-{% if not child.is_validable %}
-    class="not-ready"
-{% endif %}>
-    <a
-    {% if content.is_beta %}
-        href="{{ child.get_absolute_url_beta }}"
-    {% else %}
-        {%  if child.text %}
-            href="{{ child.container.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}#{{ child.position_in_parent }}-{{ child.slug }}"
+<div class="article-part {% if child.text %}is-chapter{% endif %}" data-slug="{{ child.slug }}">
+    <h2 id="{{ child.position_in_parent }}-{{ child.slug }}"
+    {% if not child.is_validable %}
+        class="not-ready"
+    {% endif %}>
+        <a
+        {% if content.is_beta %}
+            href="{{ child.get_absolute_url_beta }}"
         {% else %}
-            href="{{ child.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
-        {% endif %}
-    {% endif %}
-    >
-        {{ child.title }}
-    </a>
-</h2>
-
-{% if can_add_something %}
-    <div class="actions-title">
-        <a href="{{ child.get_edit_url }}" class="ico-after edit btn btn-grey">
-            {% trans "Éditer" %}
-        </a>
-        <a href="#move-{{ child.slug }}" class="open-modal ico-after move btn btn-grey">{% trans "Déplacer" %}</a>
-        <form action="{% url "content:move-element" %}" method="post" class="modal modal-flex" id="move-{{ child.slug }}">
-            <select name="moving_method">
-                <option disabled="disabled">{% trans "Déplacer" %}</option>
-                {% if child.position_in_parent > 1 %}
-                    <option value="up">{% trans "Monter" %}</option>
-                {% endif %}
-
-                {% if child.position_in_parent < child.parent.children|length %}
-                    <option value="down">{% trans "Descendre" %}</option>
-                {% endif %}
-                <option disabled="disabled">&mdash; {% trans "Déplacer avant" %}</option>
-                {% for element in child|target_tree %}
-                        <option value="before:{{element.0}}"
-                        {% if not element.3 %} disabled {% endif %}>
-                             &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
-                        </option>
-                {% endfor %}
-                <option disabled="disabled">&mdash; {% trans "Déplacer après" %}</option>
-                {% for element in child|target_tree %}
-                        <option value="after:{{element.0}}"
-                        {% if not element.3 %} disabled {% endif %}>
-                             &mdash;&mdash;{% for _ in element.2|times %}&mdash;{% endfor %}{{ element.1|truncatechars:50 }}
-                        </option>
-                {% endfor %}
-            </select>
-            <input type="hidden" name="child_slug" value="{{ child.slug }}">
-            {% if child.text %}
-                <input type="hidden" name="container_slug" value="{{ child.container.slug }}">
-                <input type="hidden" name="first_level_slug" value="{{ child.get_first_level_slug }}">
-            {%  else %}
-                <input type="hidden" name="container_slug" value="{{ child.parent.slug }}">
+            {%  if child.text %}
+                href="{{ child.container.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}#{{ child.position_in_parent }}-{{ child.slug }}"
+            {% else %}
+                href="{{ child.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
             {% endif %}
+        {% endif %}
+        >
+            {{ child.title }}
+        </a>
+    </h2>
 
-            <input type="hidden" name="pk" value="{{ content.pk }}">
-            {% csrf_token %}
-            <button type="submit">
-                {% trans "Déplacer" %}
-            </button>
-        </form>
-        {% include "tutorialv2/includes/delete.part.html" with object=child additional_classes="ico-after cross btn btn-grey" %}
-    </div>
-{% endif %}
+    {% if can_add_something %}
+        {% include "tutorialv2/includes/actions_title_buttons.part.html" %}
+    {% endif %}
 
-{% if child.text %}
-    {# child is an extract #}
-    {% if child.get_text.strip|length == 0 %}
-        <div class="ico-after warning">
-            <p>
-                {% trans "Cette section est actuellement vide." %}
-            </p>
+    {% if child.text %}
+        {# child is an extract #}
+
+        <div class="extract-wrapper">
+            {% if child.get_text.strip|length == 0 %}
+                <div class="ico-after warning">
+                    <p>
+                        {% trans "Cette section est actuellement vide." %}
+                    </p>
+                </div>
+            {% else %}
+                {{ child.get_text|emarkdown:is_js }}
+            {% endif %}
         </div>
     {% else %}
-        <div class="extract-wrapper">
-            {{ child.get_text|emarkdown:is_js }}
-        </div>
-    {% endif %}
-{% else %}
-    {# child is a container #}
+        {# child is a container #}
 
-    {% if child.has_extracts %}
-        <ol>
-            {% for extract in child.children %}
-            <li>
-                <a
-                    {% if content.is_beta %}
-                        href="{{ extract.get_absolute_url_beta }}"
-                    {% else %}
-                        href="{{ extract.container.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}#{{ extract.position_in_parent }}-{{ extract.slug }}"
-                    {% endif %}
-                >{{ extract.title }}</a>
-            </li>
-            {% endfor %}
-            {% if can_add_something and child.can_add_extract %}
-                <li class="simple-create-button">
-                    <a class="btn btn-grey" href="{% url "content:create-extract" content.pk child.parent.slug child.slug %}">
-                        {% trans "Ajouter une section" %}
-                    </a>
-                </li>
-            {% endif %}
-        </ol>
-    {% elif child.has_sub_containers %}
-        <ol class="summary-part">
-            {% for subchild in child.children %}
-                <li>
-                    <h3 class="{% if not subchild.ready_to_publish %}not-ready{% endif %}">
+        {% if child.has_extracts %}
+            <ol class="summary-part" data-children-type="extract" data-slug="{{ child.slug }}">
+                {% for extract in child.children %}
+                <li data-slug="{{ extract.slug }}">
+                    <h3>
                         <a
-                        {% if content.is_beta %}
-                            href="{{ subchild.get_absolute_url_beta }}"
-                        {% else %}
-                            href="{{ subchild.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
-                        {% endif %}
-                        >{{ subchild.title }}</a>
+                            {% if content.is_beta %}
+                                href="{{ extract.get_absolute_url_beta }}"
+                            {% else %}
+                                href="{{ extract.container.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}#{{ extract.position_in_parent }}-{{ extract.slug }}"
+                            {% endif %}
+                        >{{ extract.title }}</a>
                     </h3>
-                    <ol class="summary-part">
-                        {% for extract in subchild.children %}
-                            <li>
-                                <h4>
-                                    <a
-                                        {% if content.is_beta %}
-                                            href="{{ extract.get_absolute_url_beta }}"
-                                        {% else %}
-                                            href="{{ extract.container.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}#{{ extract.position_in_parent }}-{{ extract.slug }}"
-                                        {% endif %}
-                                    >{{ extract.title }}</a>
-                                </h4>
-                            </li>
-                        {% endfor %}
+                </li>
+                {% endfor %}
+                {% if can_add_something and child.can_add_extract %}
+                    <li class="simple-create-button">
+                        <a class="btn btn-grey" href="{% url "content:create-extract" content.pk child.parent.slug child.slug %}">
+                            {% trans "Ajouter une section" %}
+                        </a>
+                    </li>
+                {% endif %}
+            </ol>
+        {% elif child.has_sub_containers %}
+            <div class="article-containers" data-children-type="container" data-slug="{{ child.slug }}">
+                {% for subchild in child.children %}
+                    <div class="article-part" data-slug="{{ subchild.slug }}">
+                        <h3 class="{% if not subchild.ready_to_publish %}not-ready{% endif %}">
+                            <a
+                            {% if content.is_beta %}
+                                href="{{ subchild.get_absolute_url_beta }}"
+                            {% else %}
+                                href="{{ subchild.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}"
+                            {% endif %}
+                            >{{ subchild.title }}</a>
+                        </h3>
                         {% if can_add_something %}
-                            <li class="simple-create-button">
-                                <h4>
+                            {% include "tutorialv2/includes/actions_title_buttons.part.html" with child=subchild %}
+                        {% endif %}
+                        <ol class="summary-part" data-children-type="extract" data-slug="{{ subchild.slug }}">
+                            {% for extract in subchild.children %}
+                                <li data-slug="{{ extract.slug }}">
+                                    <h4>
+                                        <a
+                                            {% if content.is_beta %}
+                                                href="{{ extract.get_absolute_url_beta }}"
+                                            {% else %}
+                                                href="{{ extract.container.get_absolute_url }}{% if version %}?version={{ version }}{% endif %}#{{ extract.position_in_parent }}-{{ extract.slug }}"
+                                            {% endif %}
+                                        >{{ extract.title }}</a>
+                                    </h4>
+                                </li>
+                            {% endfor %}
+                            {% if can_add_something %}
+                                <li class="simple-create-button">
                                     <a class="btn btn-grey"
                                         href="{% url "content:create-extract" content.pk child.parent.slug child.slug subchild.slug %}"
                                     >{% trans "Ajouter une section" %}</a>
-                                </h4>
-                            </li>
-                        {% endif %}
-                    </ol>
-                </li>
-            {% endfor %}
-            {% if can_add_something and child.can_add_container %}
-                <li>
-                    <h3>
-                        <a class="force-blue"
-                            href="{% url "content:create-container" content.pk child.parent.slug child.slug %}"
-                        >{% trans "Ajouter un chapitre" %}</a>
-                    </h3>
-                    <ol class="summary-part">
-                        <li><h4><a class="disabled">{% trans "Section A" %}</a></h4></li>
-                        <li><h4><a class="disabled">{% trans "Section B" %}</a></h4></li>
-                    </ol>
-                </li>
-            {% endif %}
-        </ol>
-    {% else %}
-        {% if not can_add_something or not child.is_chapter %}
-        <div class="ico-after warning">
-            <p>
-                {{ "Ce"|feminize:child.get_level_as_string }} {{ child.get_level_as_string|lower }} {% trans "est actuellement vide." %}
-            </p>
-            {% if can_add_something and not child.is_chapter %}
-                <ul>
-                    <li>
-                        <a href="{% url "content:create-container" content.pk content.slug child.slug %}">{% trans "Ajouter un chapitre" %}</a>
-                        {% trans " pour adopter le format big-tuto et ajouter des sections ;" %}
+                                </li>
+                            {% endif %}
+                        </ol>
+                    </div>
+                {% endfor %}
+                {% if can_add_something and child.can_add_container %}
+                    <div class="article-part simple-create-part">
+                        <h3>
+                            <a class="force-blue"
+                                href="{% url "content:create-container" content.pk child.parent.slug child.slug %}"
+                            >{% trans "Ajouter un chapitre" %}</a>
+                        </h3>
+                        <ol class="summary-part">
+                            <li><h4><a class="disabled">{% trans "Section A" %}</a></h4></li>
+                            <li><h4><a class="disabled">{% trans "Section B" %}</a></h4></li>
+                        </ol>
+                    </div>
+                {% endif %}
+            </div>
+        {% else %}
+            {% if not can_add_something or not child.is_chapter %}
+                <div class="article-containers" data-children-type="container" data-slug="{{ child.slug }}">
+                    <div class="article-part simple-create-part">
+                        <div class="ico-after warning">
+                            <p>
+                                {{ "Ce"|feminize:child.get_level_as_string }} {{ child.get_level_as_string|lower }} {% trans "est actuellement vide." %}
+                            </p>
+                            {% if can_add_something and not child.is_chapter %}
+                                <ul>
+                                    <li>
+                                        <a href="{% url "content:create-container" content.pk content.slug child.slug %}">{% trans "Ajouter un chapitre" %}</a>
+                                        {% trans " pour adopter le format big-tuto et ajouter des sections ;" %}
+                                    </li>
+                                    <li>
+                                        <a href="{% url "content:create-extract" content.pk content.slug child.slug %}">{% trans "Ajouter une section" %}</a>
+                                        {% trans " pour adopter le format mini-tuto, composé uniquement de sections." %}
+                                    </li>
+                                </ul>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            {% elif can_add_something and child.can_add_extract and child.is_chapter %}
+                <ol>
+                    <li class="simple-create-button">
+                        <a class="btn btn-grey" href="{% url "content:create-extract" content.pk content.slug child.parent.slug child.slug %}">
+                            {% trans "Ajouter une section" %}
+                        </a>
                     </li>
-                    <li>
-                        <a href="{% url "content:create-extract" content.pk content.slug child.slug %}">{% trans "Ajouter une section" %}</a>
-                        {% trans " pour adopter le format mini-tuto, composé uniquement de sections." %}
-                    </li>
-                </ul>
+                </ol>
             {% endif %}
-        </div>
-        {% elif can_add_something and child.can_add_extract and child.is_chapter %}
-            <ol>
-                <li class="simple-create-button">
-                    <a class="btn btn-grey" href="{% url "content:create-extract" content.pk content.slug child.parent.slug child.slug %}">
-                        {% trans "Ajouter une section" %}
-                    </a>
-                </li>
-            </ol>
         {% endif %}
     {% endif %}
-{% endif %}
+</div>

--- a/templates/tutorialv2/includes/child_online.part.html
+++ b/templates/tutorialv2/includes/child_online.part.html
@@ -30,37 +30,41 @@
 {% else %}
     {# child is a container #}
 
-    {% if child.has_extracts %}
-        <ol>
-            {% for extract in child.children %}
-                <li>
-                    <a href="{{ extract.container.get_absolute_url_online }}#{{ extract.position_in_parent }}-{{ extract.slug }}">{{ extract.title }}</a>
-                </li>
-            {% endfor %}
-        </ol>
-    {%  elif child.has_sub_containers %}
-        <ol class="summary-part">
-            {% for subchild in child.children %}
-            <li>
-                <h3>
-                    <a
-                        href="{{ subchild.get_absolute_url_online }}"
+    <div class="article-part">
+        {% if child.has_extracts %}
+            <ol class="summary-part">
+                {% for extract in child.children %}
+                    <li>
+                        <h3>
+                            <a href="{{ extract.container.get_absolute_url_online }}#{{ extract.position_in_parent }}-{{ extract.slug }}">{{ extract.title }}</a>
+                        </h3>
+                    </li>
+                {% endfor %}
+            </ol>
+        {%  elif child.has_sub_containers %}
+            <div class="article-containers">
+                {% for subchild in child.children %}
+                <div class="article-part">
+                    <h3>
+                        <a
+                            href="{{ subchild.get_absolute_url_online }}"
 
-                    >{{ subchild.title }}</a>
-                </h3>
-                <ol class="summary-part">
-                    {% for extract in subchild.children %}
-                        <li>
-                            <h4>
-                                <a href="{{ extract.container.get_absolute_url_online }}#{{ extract.position_in_parent }}-{{ extract.slug }}">{{ extract.title }}</a>
-                            </h4>
-                        </li>
-                    {% endfor %}
-                </ol>
-            </li>
-            {% endfor %}
-        </ol>
-    {% endif %}
+                        >{{ subchild.title }}</a>
+                    </h3>
+                    <ol class="summary-part">
+                        {% for extract in subchild.children %}
+                            <li>
+                                <h4>
+                                    <a href="{{ extract.container.get_absolute_url_online }}#{{ extract.position_in_parent }}-{{ extract.slug }}">{{ extract.title }}</a>
+                                </h4>
+                            </li>
+                        {% endfor %}
+                    </ol>
+                </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    </div>
 {% endif %}
 
 

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -1,4 +1,4 @@
-{% extends "tutorialv2/base.html" %}
+{% extends "tutorialv2/base_content.html" %}
 {% load set %}
 {% load thumbnail %}
 {%  load emarkdown %}
@@ -96,7 +96,7 @@
 
 
 
-{% block content %}
+{% block content_intro %}
     {% if not container.ready_to_publish %}
         <div class="alert-box ico-alerts">
             {% trans "Cette partie n'est pas prête à la publication. En cas de validation, elle ne sera pas publiée." %}
@@ -116,8 +116,7 @@
             </p>
         </div>
     {% endif %}
-
-     {% if container.has_extracts or container.can_add_extract %}
+    {% if container.has_extracts or container.can_add_extract %}
         <ul>
             {% for extract in container.children %}
                 <li>
@@ -139,88 +138,100 @@
             {% endif %}
         </ul>
     {% endif %}
+{% endblock %}
 
+{% block dnd_child_slug %}{{ container.slug }}{% endblock %}
+
+{% block content_parts %}
     {% for child in container.children %}
         {%  include "tutorialv2/includes/child.part.html" with child=child %}
     {% empty %}
-        {% if not can_add_something or not container.is_chapter %}
-            <div class="ico-after warning">
-                <p>
-                    {{ "Ce"|feminize:container.get_level_as_string }} {{ container.get_level_as_string|lower }}  {% trans " est actuellement vide." %}
-                </p>
-                {% if container.can_add_extract and container.can_add_container and can_add_something %}
-                    <ul>
-                        <li>
-                            <a href="{% if container.parent == content %}
-                                        {% url "content:create-container" content.pk content.slug container.slug %}
-                                    {%  else %}
-                                        {% url "content:create-container" content.pk content.slug container.parent.slug %}
-                                    {%  endif %}">{% trans "Ajouter un chapitre" %}</a>
-                            {% trans " pour adopter le format big-tuto et ajouter des sections ;" %}
-                        </li>
-                        <li>
-                            <a href="{% if container.parent == content %}
-                                        {% url "content:create-extract" content.pk content.slug container.slug %}
-                                    {%  else %}
-                                        {% url "content:create-extract" content.pk content.slug container.parent.slug %}
-                                    {%  endif %}">{% trans "Ajouter une section" %}</a>
-                        </li>
-                    </ul>
-                {% endif %}
-            </div>
-        {% endif %}
+        <div class="article-part simple-create-part">
+            {% if not can_add_something or not container.is_chapter %}
+                <div class="ico-after warning">
+                    <p>
+                        {{ "Ce"|feminize:container.get_level_as_string }} {{ container.get_level_as_string|lower }}  {% trans " est actuellement vide." %}
+                    </p>
+                    {% if container.can_add_extract and container.can_add_container and can_add_something %}
+                        <ul>
+                            <li>
+                                <a href="{% if container.parent == content %}
+                                            {% url "content:create-container" content.pk content.slug container.slug %}
+                                        {%  else %}
+                                            {% url "content:create-container" content.pk content.slug container.parent.slug %}
+                                        {%  endif %}">{% trans "Ajouter un chapitre" %}</a>
+                                {% trans " pour adopter le format big-tuto et ajouter des sections ;" %}
+                            </li>
+                            <li>
+                                <a href="{% if container.parent == content %}
+                                            {% url "content:create-extract" content.pk content.slug container.slug %}
+                                        {%  else %}
+                                            {% url "content:create-extract" content.pk content.slug container.parent.slug %}
+                                        {%  endif %}">{% trans "Ajouter une section" %}</a>
+                            </li>
+                        </ul>
+                    {% endif %}
+                </div>
+            {% endif %}
+        </div>
     {% endfor %}
     {% if can_add_something %}
-        {% if container.can_add_container and not container.can_add_extract %}
-            <h2>
-                <a class="force-blue" href="{% if container.parent == content %}
-                            {% url "content:create-container" content.pk content.slug container.slug %}
-                        {%  else %}
-                            {% url "content:create-container" content.pk content.slug container.parent.slug %}
-                        {%  endif %}">
-                    {% trans "Ajouter un chapitre" %}
-                </a>
-            </h2>
-            <div class="actions-title">
-                <a href="{% if container.parent == content %}
-                            {% url "content:create-container" content.pk content.slug container.slug %}
-                        {%  else %}
-                            {% url "content:create-container" content.pk content.slug container.parent.slug %}
-                        {%  endif %}" class="ico-after more btn btn-grey">
-                    {% trans "Ajouter" %}
-                </a>
-            </div>
-            <div class="ico-after information">
-                <p>{% trans "Cliquer sur ajouter pour ajouter un nouveau chapitre." %}</p>
-            </div>
-        {% endif %}
-        {% if not container.can_add_container and container.can_add_extract %}
-            <h2 class="force-blue">
-                <a href="{% if container.parent == content %}
-                            {% url "content:create-extract" content.pk content.slug container.slug %}
-                        {%  else %}
-                            {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
-                        {%  endif %}">
-                    {% trans "Ajouter une section" %}
-                </a>
-            </h2>
-            <div class="actions-title">
-                <a href="{% if container.parent == content %}
-                            {% url "content:create-extract" content.pk content.slug container.slug %}
-                        {%  else %}
-                            {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
-                        {%  endif %}" class="ico-after more btn btn-grey">
-                    {% trans "Ajouter" %}
-                </a>
-            </div>
-            <div class="ico-after information">
-                <p>{% trans "Cliquer sur ajouter pour rédiger une nouvelle section." %}</p>
-            </div>
-        {% endif %}
+        <div class="article-part simple-create-part">
+            {% if container.can_add_container and not container.can_add_extract %}
+                <h2>
+                    <a class="force-blue" href="{% if container.parent == content %}
+                                {% url "content:create-container" content.pk content.slug container.slug %}
+                            {%  else %}
+                                {% url "content:create-container" content.pk content.slug container.parent.slug %}
+                            {%  endif %}">
+                        {% trans "Ajouter un chapitre" %}
+                    </a>
+                </h2>
+                <ul class="actions-title">
+                    <li>
+                        <a href="{% if container.parent == content %}
+                                    {% url "content:create-container" content.pk content.slug container.slug %}
+                                {%  else %}
+                                    {% url "content:create-container" content.pk content.slug container.parent.slug %}
+                                {%  endif %}" class="ico-after more btn btn-grey">
+                            {% trans "Ajouter" %}
+                        </a>
+                    </li>
+                </ul>
+                <div class="ico-after information">
+                    <p>{% trans "Cliquer sur ajouter pour ajouter un nouveau chapitre." %}</p>
+                </div>
+            {% endif %}
+            {% if not container.can_add_container and container.can_add_extract %}
+                <h2 class="force-blue">
+                    <a href="{% if container.parent == content %}
+                                {% url "content:create-extract" content.pk content.slug container.slug %}
+                            {%  else %}
+                                {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
+                            {%  endif %}">
+                        {% trans "Ajouter une section" %}
+                    </a>
+                </h2>
+                <ul class="actions-title">
+                    <li>
+                        <a href="{% if container.parent == content %}
+                                    {% url "content:create-extract" content.pk content.slug container.slug %}
+                                {%  else %}
+                                    {% url "content:create-extract" content.pk content.slug container.parent.slug container.slug %}
+                                {%  endif %}" class="ico-after more btn btn-grey">
+                            {% trans "Ajouter" %}
+                        </a>
+                    </li>
+                </ul>
+                <div class="ico-after information">
+                    <p>{% trans "Cliquer sur ajouter pour rédiger une nouvelle section." %}</p>
+                </div>
+            {% endif %}
+        </div>
     {% endif %}
+{% endblock %}
 
-    <hr />
-
+{% block content_conclu %}
     {% if container.conclusion and container.get_conclusion %}
         {{ container.get_conclusion|emarkdown:is_js }}
     {% elif not content.is_beta %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -1,4 +1,4 @@
-{% extends "tutorialv2/base.html" %}
+{% extends "tutorialv2/base_content.html" %}
 {% load emarkdown %}
 {% load crispy_forms_tags %}
 {% load thumbnail %}
@@ -137,7 +137,7 @@
 {% endblock %}
 
 
-{% block content %}
+{% block content_intro %}
     {% if content.introduction and content.get_introduction != "" %}
         {{ content.get_introduction|emarkdown:is_js }}
     {% elif not content.is_beta %}
@@ -150,7 +150,6 @@
             </p>
         </div>
     {% endif %}
-
     {% if content.has_extracts or content.can_add_extract %}
         <ul>
             {% for extract in content.children %}
@@ -169,71 +168,83 @@
             {% endif %}
         </ul>
     {% endif %}
+{% endblock %}
 
+{% block content_parts %}
     {% for child in content.children %}
         {% include "tutorialv2/includes/child.part.html" with child=child %}
     {% empty %}
         {% if content.can_add_extract and content.can_add_container and can_add_something %}
-            <div class="ico-after warning">
-                <p>
-                    {% trans "Ce contenu est actuellement vide." %}{% trans "Vous pouvez :" %}
-                </p>
-                <ul>
-                    <li>
-                        <a href="{% url "content:create-container" content.pk content.slug %}">{% trans "Ajouter une partie" %}</a>
-                        {% trans " pour adopter le format big-tuto ou moyen-tuto. Vous pourrez y ajouter des chapitres ou des sections ;" %}
-                    </li>
-                    <li>
-                        <a href="{% url "content:create-extract" content.pk content.slug %}">{% trans "Ajouter une section" %}</a>
-                        {% trans " pour adopter le format mini-tuto composé uniquement de section." %}
-                    </li>
-                </ul>
+            <div class="article-part simple-create-part">
+                <div class="ico-after warning">
+                    <p>
+                        {% trans "Ce contenu est actuellement vide." %}{% trans "Vous pouvez :" %}
+                    </p>
+                    <ul>
+                        <li>
+                            <a href="{% url "content:create-container" content.pk content.slug %}">{% trans "Ajouter une partie" %}</a>
+                            {% trans " pour adopter le format big-tuto ou moyen-tuto. Vous pourrez y ajouter des chapitres ou des sections ;" %}
+                        </li>
+                        <li>
+                            <a href="{% url "content:create-extract" content.pk content.slug %}">{% trans "Ajouter une section" %}</a>
+                            {% trans " pour adopter le format mini-tuto composé uniquement de section." %}
+                        </li>
+                    </ul>
+                </div>
             </div>
         {% elif not can_add_something or not content.can_add_extract and not content.can_add_container %}
-            <div class="ico-after warning">
-                <p>
-                    {% trans "Ce contenu est actuellement vide." %}
-                </p>
+            <div class="extract-wrapper">
+                <div class="ico-after warning">
+                    <p>
+                        {% trans "Ce contenu est actuellement vide." %}
+                    </p>
+                </div>
             </div>
         {% endif %}
     {% endfor %}
     {% if can_add_something %}
         {% if content.can_add_container and not content.can_add_extract %}
-            <h2>
-                <a class="force-blue" href="{% url "content:create-container" content.pk content.slug %}">
-                    {% trans "Ajouter une nouvelle partie" %}
-                </a>
-            </h2>
-            <div class="actions-title">
-                <a href="{% url "content:create-container" content.pk content.slug %}" class="ico-after more btn btn-grey">
-                    {% trans "Ajouter" %}
-                </a>
-            </div>
-            <div class="ico-after information">
-                <p>{% trans "Cette partie n'est pas encore créée. Vous devez la créer avant de pouvoir y ajouter un élément." %}</p>
+            <div class="article-part simple-create-part">
+                <h2>
+                    <a class="force-blue" href="{% url "content:create-container" content.pk content.slug %}">
+                        {% trans "Ajouter une nouvelle partie" %}
+                    </a>
+                </h2>
+                <ul class="actions-title">
+                    <li>
+                        <a href="{% url "content:create-container" content.pk content.slug %}" class="ico-after more btn btn-grey">
+                            {% trans "Ajouter" %}
+                        </a>
+                    </li>
+                </ul>
+                <div class="ico-after information">
+                    <p>{% trans "Cette partie n'est pas encore créée. Vous devez la créer avant de pouvoir y ajouter un élément." %}</p>
+                </div>
             </div>
         {% endif %}
         {% if not content.can_add_container and content.can_add_extract %}
-            <h2>
-                <a class="force-blue" href="{% url "content:create-extract" content.pk content.slug %}">
-                    {% trans "Ajouter une section" %}
-                </a>
-            </h2>
-            <div class="actions-title">
-                <a href="{% url "content:create-extract" content.pk content.slug %}" class="ico-after more btn btn-grey">
-                    {% trans "Ajouter" %}
-                </a>
-            </div>
-            <div class="ico-after information">
-                <p>{% trans "Cliquer sur ajouter pour rédiger une nouvelle section." %}</p>
+            <div class="article-part simple-create-part">
+                <h2>
+                    <a class="force-blue" href="{% url "content:create-extract" content.pk content.slug %}">
+                        {% trans "Ajouter une section" %}
+                    </a>
+                </h2>
+                <ul class="actions-title">
+                    <li>
+                        <a href="{% url "content:create-extract" content.pk content.slug %}" class="ico-after more btn btn-grey">
+                            {% trans "Ajouter" %}
+                        </a>
+                    </li>
+                </ul>
+                <div class="ico-after information">
+                    <p>{% trans "Cliquer sur ajouter pour rédiger une nouvelle section." %}</p>
+                </div>
             </div>
         {% endif %}
     {% endif %}
+{% endblock %}
 
-
-    <hr class="clearfix" />
-    <hr />
-
+{% block content_conclu %}
     {% if content.conclusion and content.get_conclusion != "" %}
         {{ content.get_conclusion|emarkdown:is_js }}
     {% elif not content.is_beta %}
@@ -250,6 +261,7 @@
     {% if content.is_beta %}
         {% include "tutorialv2/includes/warn_typo.part.html" with content=content %}
     {% endif %}
+</section>
 {% endblock %}
 
 


### PR DESCRIPTION
J'ai besoin d'aide pour la suite de la PR, je n'ai pas compris le principe de `target_tree`.

Cette PR à juste pour but d'améliorer la liste déroulante, le d'n'd sera dans une autre PR.

RENDU : 

![image](https://user-images.githubusercontent.com/18501150/65893327-12be8f00-e3a8-11e9-8fba-00a4c2842c42.png)

J'ai ajouté "Intro xxxxx" pour pouvoir déplacer au début car si on déplacer Après un élément, on ne pourra jamais déplacer avant le première élément (car aucun élément à sélectionner avant).

On a pas le comportement voulu si on déplace une partie ou un chapitre : 
![image](https://user-images.githubusercontent.com/18501150/65893595-7c3e9d80-e3a8-11e9-89d4-ab20490f6801.png)

