### PR TITLE
Enlève des caractères en trop dans le front (fix #5459)

### DIFF
--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -269,7 +269,7 @@
         {% elif not version or version != content.sha_draft %}
             <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
                 {% trans "Version brouillon" %}
-            </a> -->
+            </a>
         {%  endif %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Tout est dit dans le titre.

Par contre, je n'ai pas réussi à reproduire le bug !
