### PR TITLE
Precise un loader pour la fonction yaml.load

### DIFF
--- a/zds/utils/management/commands/load_factory_data.py
+++ b/zds/utils/management/commands/load_factory_data.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
 
         for filename in glob.glob(files):
             stream = open(filename, 'r')
-            fixture_list = yaml.load(stream)
+            fixture_list = yaml.load(stream, Loader=yaml.FullLoader)
             for fixture in fixture_list:
                 splitted = str(fixture['factory']).split('.')
                 module_part = '.'.join(splitted[:-1])


### PR DESCRIPTION
Lorsque je lançais `make generate-fixtures`, j'avais le message suivant:
> [chemin]/zds-site/zds/utils/management/commands/load_factory_data.py:29: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  fixture_list = yaml.load(stream)

En effet, le lien donné explique qu'utiliser `yaml.load()` sans préciser le loader est déprécié, à cause d'une faille de sécurité. J'ai donc précisé le loader à utiliser (j'ai choisi `FullLoader`; il est sécurisé et a le même comportement que si le loader n'est pas précisé).