### PR TITLE
fix #5216 : ajout de mastodon dans les liens de partage de contenus

### DIFF
--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -1,0 +1,24 @@
+
+(function($, undefined) {
+    "use strict";
+    var shareModal = $("#share-to-mastodon");
+    var shareButton = shareModal.find("button");
+
+    shareModal.find("input[name='instance']").on("change paste keyup", function(e) {
+        // start by 6 chars (https://)
+        if(this.value.startsWith("https://")) {
+            shareButton.attr("disabled", false);
+        } else {
+            shareButton.attr("disabled", true);
+        }
+    });
+
+    shareButton.on("click", function(e) {
+
+        var instance = shareModal.find("input[name='instance']").val();
+        var text = shareModal.find("input[name='text']").val();
+        var mastodon_url = instance + "/share?text=" + encodeURIComponent(text);
+
+        window.open(mastodon_url);
+    });
+})(jQuery);

--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -2,6 +2,7 @@
 (function($, undefined) {
     "use strict";
     let shareModal = $("#share-to-mastodon");
+    let shareButton = shareModal.find("button");
 
     shareModal.find("input[name='instance']").on("change paste keyup", function() {
         // start by chars (https://)
@@ -12,7 +13,7 @@
         }
     });
 
-    $form.on("submit", function() {
-        $form.attr("action", shareModal.find("input[name='instance']").val() + "/share");
+    shareModal.on("submit", function() {
+        shareModal.attr("action", shareModal.find("input[name='instance']").val() + "/share");
     });
 })(jQuery);

--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -2,7 +2,6 @@
 (function($, undefined) {
     "use strict";
     let shareModal = $("#share-to-mastodon");
-    let shareButton = shareModal.find("button");
 
     shareModal.find("input[name='instance']").on("change paste keyup", function() {
         // start by chars (https://)
@@ -13,10 +12,7 @@
         }
     });
 
-    shareButton.on("click", function() {
-        let instance = shareModal.find("input[name='instance']").val();
-        let text = shareModal.find("input[name='text']").val();
-        let mastodonUrl = instance + "/share?text=" + encodeURIComponent(text);
-        window.open(mastodonUrl);
+    $form.on("submit", function() {
+        $form.attr("action", shareModal.find("input[name='instance']").val() + "/share");
     });
 })(jQuery);

--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -4,8 +4,8 @@
     var shareModal = $("#share-to-mastodon");
     var shareButton = shareModal.find("button");
 
-    shareModal.find("input[name='instance']").on("change paste keyup", function(e) {
-        // start by 6 chars (https://)
+    shareModal.find("input[name='instance']").on("change paste keyup", function() {
+        // start by chars (https://)
         if(this.value.startsWith("https://")) {
             shareButton.attr("disabled", false);
         } else {
@@ -13,12 +13,12 @@
         }
     });
 
-    shareButton.on("click", function(e) {
+    shareButton.on("click", function() {
 
         var instance = shareModal.find("input[name='instance']").val();
         var text = shareModal.find("input[name='text']").val();
-        var mastodon_url = instance + "/share?text=" + encodeURIComponent(text);
+        var mastodonUrl = instance + "/share?text=" + encodeURIComponent(text);
 
-        window.open(mastodon_url);
+        window.open(mastodonUrl);
     });
 })(jQuery);

--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -1,24 +1,22 @@
 
 (function($, undefined) {
     "use strict";
-    var shareModal = $("#share-to-mastodon");
-    var shareButton = shareModal.find("button");
+    let shareModal = $("#share-to-mastodon");
+    let shareButton = shareModal.find("button");
 
     shareModal.find("input[name='instance']").on("change paste keyup", function() {
         // start by chars (https://)
         if(this.value.startsWith("https://")) {
-            shareButton.attr("disabled", false);
+            shareButton.prop("disabled", false);
         } else {
-            shareButton.attr("disabled", true);
+            shareButton.prop("disabled", true);
         }
     });
 
     shareButton.on("click", function() {
-
-        var instance = shareModal.find("input[name='instance']").val();
-        var text = shareModal.find("input[name='text']").val();
-        var mastodonUrl = instance + "/share?text=" + encodeURIComponent(text);
-
+        let instance = shareModal.find("input[name='instance']").val();
+        let text = shareModal.find("input[name='text']").val();
+        let mastodonUrl = instance + "/share?text=" + encodeURIComponent(text);
         window.open(mastodonUrl);
     });
 })(jQuery);

--- a/templates/misc/social_buttons.part.html
+++ b/templates/misc/social_buttons.part.html
@@ -26,15 +26,15 @@
             >
                 Mastodon
             </a>
-            <div id="share-to-mastodon" class="modal modal-flex">
+            <form id="share-to-mastodon" class="modal modal-flex" target="_blank" method="GET">
                 <p>
-                    {% trans "Entrez l'adresse de votre instance Mastodon (ex: https://framapiaf.org)" %}.
+                    {% trans "Entrez l'adresse de votre instance Mastodon (ex: https://mamot.fr)" %}.
                 </p>
                 <input type="text" class="input" name="instance" placeholder="https://" required>
-                <input type="hidden" class="input" name="text" value="{{ app.site.url }}{{ link }}&amp;t={{ text }}">
+                <input type="hidden" class="input" name="text" value="{{ text }} {{ app.site.url }}{{ link }}">
 
                 <button type="submit" disabled>{% trans "Partager" %}</button>
-            </div>
+            </form>
         </li>
         <li>
             <a href="http://sharetodiaspora.github.io/?url={{ app.site.url }}{{ link }}&amp;title={{ text }}"

--- a/templates/misc/social_buttons.part.html
+++ b/templates/misc/social_buttons.part.html
@@ -20,6 +20,23 @@
             </a>
         </li>
         <li>
+            <a href="#share-to-mastodon"
+               class="open-modal ico-after mastodon blue"
+               rel="nofollow"
+            >
+                Mastodon
+            </a>
+            <div id="share-to-mastodon" class="modal modal-flex">
+                <p>
+                    {% trans "Entrez l'adresse de votre instance Mastodon (ex: https://framapiaf.org)" %}.
+                </p>
+                <input type="text" class="input" name="instance" placeholder="https://" required>
+                <input type="hidden" class="input" name="text" value="{{ app.site.url }}{{ link }}&amp;t={{ text }}">
+
+                <button type="submit" disabled>{% trans "Partager" %}</button>
+            </div>
+        </li>
+        <li>
             <a href="http://sharetodiaspora.github.io/?url={{ app.site.url }}{{ link }}&amp;title={{ text }}"
                class="ico-after diaspora blue"
                rel="nofollow"


### PR DESCRIPTION
fix #5216  qui ajoute mastodon dans la liste des réseaux vers lesquels partager.

Cf. capture:

![Capture d’écran de 2019-10-17 01-22-23](https://user-images.githubusercontent.com/6066015/66966172-98b32900-f07c-11e9-806a-7c6737c90445.png)

Le choix a été fait de manière a ce que lors du clic sur le partage on demande a l'utilisateur son instance, via une modale.

![Capture d’écran de 2019-10-17 01-23-13](https://user-images.githubusercontent.com/6066015/66966206-b8e2e800-f07c-11e9-885e-344ece9e22a8.png)

En renseignant son instance, l'utilisateur est redirigé sur Mastodon avec le lien de son contenu.

### Contrôle qualité

- builder le front
- lancer le serveur
- Allez sur n'importe quel type de contenu (tutoriel, billet, article) et vérifiez que vous avez bien le lien de partage vers Mastodon
- Cliquez sur le lien et entrez votre instance, vérifiez que vous êtes bien redirigé vers votre instance.

Merci.