### PR TITLE
Affiche l'éditeur dès que le DOM est chargé

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -670,7 +670,7 @@
         }
     };
 
-    zForm.addEvent(window, "load", (function(_this) {
+    zForm.addEvent(document, "DOMContentLoaded", (function(_this) {
         return function() {
             _this.init();
         };


### PR DESCRIPTION
Sur le forum, [des membres se sont plaint de la lenteur de l'affichage de l'éditeur](https://zestedesavoir.com/forums/sujet/13132/les-boutons-de-mise-en-forme-mettent-du-temps-a-apparaitre/). J'ai donc investigué et je me suis rendu compte qu'on charge l'éditeur avec l'événement `window.onload`, c'est-à-dire après que toutes les ressources de la page (dont les images) soient chargés. Je propose de passer par l'événement `document.onDOMContentLoaded` pour charger l'éditeur dès que le DOM est prêt. Ainsi, si une ressource met du temps à charger, cela ne bloque pas l'affichage de la page.

**QA :**

- Se mettre sur `upstream/dev`
- Lancer le serveur
- Publier un message avec `![Image inaccessible](http://10.255.255.1/test.png)`
- Vérifier que la page est en attente d'une requête et l'éditeur ne s'affiche pas
- Basculer sur ma branche
- Générer le front avec `make build-front`
- Recharger la page
- Vérifier que la page est en attente d'un requête mais l'éditeur s'affiche correctement