### PR TITLE
Attend que ZMD soit lancé pour continuer l'installation

### DIFF
--- a/scripts/define_variable.sh
+++ b/scripts/define_variable.sh
@@ -26,3 +26,7 @@ if [[ $ZDS_JDK_VERSION == "" ]]; then
     ZDS_JDK_REV="11"
 fi
 
+if [[ $ZMD_URL == "" ]]; then
+    ZMD_URL="http://localhost:27272"
+fi
+

--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -508,6 +508,21 @@ if  ! $(_in "-data" $@) && ( $(_in "+data" $@) || $(_in "+base" $@) || $(_in "+f
         exit 1
     fi
 
+    # We check if ZMD is really up:
+    nb_zmd_try=0
+
+    while ! curl -s $ZMD_URL > /dev/null && [ $nb_zmd_try -lt 40 ]
+    do
+        sleep 0.2
+        nb_zmd_try=$(($nb_zmd_try+1))
+    done
+
+    if [ $nb_zmd_try -eq 40 ]
+    then
+        print_error "!! Cannot connect to zmd to generate-fixtures (use \`-data\` to skip)"
+        exit 1
+    fi
+
     python manage.py loaddata fixtures/*.yaml; exVal=$?
 
     python manage.py load_factory_data fixtures/advanced/aide_tuto_media.yaml; exVal=($exVal + $?)


### PR DESCRIPTION
Numéro du ticket concerné: #5480 



### Contrôle qualité

Pour chaque test, lancer 
```bash
./scripts/install_zds.sh -packages -virtualenv -node -back -front -zmd +data
```

Trois cas sont à tester:
1. cas *normal*: lancer la commande d'installation: tout devrait fonctionner, éventuellement le premier ping échoue
2. ZMD ne démarre *pas du tout*: commenter les lignes 504 à 509 du fichier `install_zds.sh`, celles qui lancent ZMD. Le script d'installation devrait finir par quitter, avant de charger les fixtures.
3. ZMD *est lent à démarrer*: tout en gardant les lignes de lancement de ZMD commentées, lancer le script d'installation, attendre que le premier ping échoue, puis dans une autre console, lancer `make zmd-start`. Les fixtures devraient se charger.