### PR TITLE
Met à jour Pillow pour corriger la faille CVE-2019-16865

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ python-memcached==1.59
 lxml==4.3.3
 factory-boy==2.8.1
 pygeoip==0.3.2
-pillow==5.0.0
+pillow==6.2.1
 gitpython==2.1.9
 easy-thumbnails==2.6.0
 beautifulsoup4==4.7.1


### PR DESCRIPTION
D'après l'alerte Github : 

> An issue was discovered in Pillow before 6.2.0. When reading specially crafted invalid image files, the library can either allocate very large amounts of memory or take an extremely long period of time to process the image.