### PR TITLE
Corrige la vue ExportView de l'API

### DIFF
--- a/zds/tutorialv2/api/urls.py
+++ b/zds/tutorialv2/api/urls.py
@@ -7,5 +7,5 @@ urlpatterns = [
             ContentReactionKarmaView.as_view(), name='reaction-karma'),
     re_path(r'^publication/preparation/(?P<pk>[0-9]+)/',
             ContainerPublicationReadinessView.as_view(), name='readiness'),
-    re_path('export/(?P<pk>[0-9]+)/', ExportView.as_view(), name='generate_export')
+    re_path(r'^export/(?P<pk>[0-9]+)/', ExportView.as_view(), name='generate_export')
 ]


### PR DESCRIPTION
Corrige la vue ExportView de l'API

Merci @philippemilink pour m'avoir permis de reproduire le bug en local !

**QA :**

- Lancer le serveur
- Vérifier que la documentation de l'API est bien accessible en étant déconnecté ou connecté avec un simple utilisateur
- Vérifier que le bouton "Exporter le contenu" fonctionne correctement