### PR TITLE
fix #5045 : correction du style des checkbox

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -479,3 +479,24 @@ div.align-left, figure pre code.hljs {
     padding: .5em;
 
 }
+
+// checkbox menu
+
+ul li p {
+    margin: 0;
+}
+
+li.task-list-item {
+    list-style-type: none;
+    position: relative;
+
+    p {
+
+    }
+
+    input[type=checkbox] {
+        top: 4px;
+        position: absolute;
+        left: -20px;
+    }
+}

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -490,10 +490,6 @@ li.task-list-item {
     list-style-type: none;
     position: relative;
 
-    p {
-
-    }
-
     input[type=checkbox] {
         top: 4px;
         position: absolute;


### PR DESCRIPTION
Cette PR corrige le ticket #5045.

Il était impossible a faire en css vu le dom que l'on a sous la main, d'ou le choix de le faire en JS.


### Contrôle qualité

- Builder le front
- Tester l'ajout d'un markdown contenant des checkbox dedans.

Pour info 

### Avant

![](https://user-images.githubusercontent.com/2022803/44955033-e7b7f200-aeac-11e8-9e84-cbaa71ebc783.png)

### Après

![Capture d’écran de 2019-10-30 23-33-05](https://user-images.githubusercontent.com/6066015/67904177-e85e1e00-fb6d-11e9-9f7e-42c9d49381fa.png)
