### PR TITLE
Fix #5209 : url de la CC-0 dans les pdf

### DIFF
--- a/fixtures/licences.yaml
+++ b/fixtures/licences.yaml
@@ -16,3 +16,9 @@
         code : Tous droits réservés
         title : Tous droits réservés
         description :  Droit d'auteur pur et dur.
+-   model: utils.Licence
+    pk: 42
+    fields:
+        code: CC 0
+        title: Licence CC 0
+        description: Domaine public - Licence CC 0

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -373,6 +373,9 @@ class ZMarkdownRebberLatexPublicator(Publicator):
         licence_logo = licences.get(licence_short, False)
         if licence_logo:
             licence_url = 'https://creativecommons.org/licenses/{}/4.0/legalcode'.format(licence_short)
+            # we need a specific case for CC-0 as it is "public-domain"
+            if licence_logo == licences['0']:
+                licence_url = 'https://creativecommons.org/publicdomain/zero/1.0/legalcode.fr'
         else:
             licence = str(_('Tous droits réservés'))
             licence_logo = licences['copyright']


### PR DESCRIPTION
Cette PR corrige l'url de la license CC-0 dans les PDF

# pour la QA

- assurez-vous que la license CC-0 existe sur votre instance
- lancez le publication_watchdog
- publiez un tuto, un billet ou un article avec CC-0 activé
- si vous avez latex d'installé, téléchargez le PDF et vérifier que l'icône de la licence renvoie vers le lien `https://creativecommons.org/publicdomain/zero/1.0/legalcode.fr`
- si vous n'avez pas latex d'installez, regardez le fichier latex créé dans le dossier `{slug_du_contenu}__building/extra_contents/{slug_du_contenu}.tex` et regardez que cette url y figure.