### PR TITLE
Améliore (très légérement) la doc

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -241,7 +241,7 @@ Dans l'interface d'administration de Django, se rendre dans la section "OAuth2_p
 
 .. note::
 
-    Si vous `chargez les fixtures <./utils/fixture_loaders.html>`_, un tel client est déjà créé, avec les identifiants suivants:
+    Si vous `chargez les fixtures <./utils/fixture_loaders.html>`_, un tel client, lié à l'utilisateur ``admin``, est déjà créé, avec les identifiants suivants:
 
     - ``client_id``: ``w14aIFqE7z90ti1rXE8hCRMRUOPBP4rXpfLZIKmT`` ;
     - ``client_secret``: ``0q4ee800NWs8cSHa0FIbkTLwEncMqYHOCAxNkt9zRmd10bRk1J18TkbviO5QHy2b66ggzyLADm79tJw5BQf2XfApPnk0nogcFaYhtNO33uNlzzT8sXfxu3zzBFu5Wejv``.

--- a/doc/source/delay-issue.rst
+++ b/doc/source/delay-issue.rst
@@ -1,24 +1,24 @@
-=========================
+=================================
 Problème de lenteur lors du dev ?
-=========================
+=================================
 
 J'ai des lenteurs avec gulp (build|watch)
----------------------
+-----------------------------------------
 
-Pour le développement et uniquement ce but, notre script `gulp` prend en entrée un paramètre "--speed" qui désactive les optimisations du code pour la prod. Ainsi `watch` à besoin de calculer moins de choses donc moins d'usage de CPU.
+Pour le développement et uniquement ce but, notre script `gulp` prend en entrée un paramètre ``--speed`` qui désactive les optimisations du code pour la prod. Ainsi ``watch`` a besoin de calculer moins de choses donc utilise moins de CPU.
 
 Avec gulp il faudra faire :
 
 .. sourcecode:: bash
+
     $ npm run watch -- --speed
 
 
 Le changement de page est très lent !
----------------------
+--------------------------------------
 
-Désactiver la barre de debug réduit la vitesse de chargement par 10. Si vous n'utilisez pas la DEBUG_TOOLBAR_CONFIG, vous pouvez la désactiver avec la commande ci-dessous au démarrage :
-
-Pour ce faire utilisez la configuration `dev_fast` qui désactive la Toolbar :
+Désactiver la barre de debug réduit la vitesse de chargement par 10. Si vous n'utilisez pas la ``DEBUG_TOOLBAR_CONFIG``, vous pouvez la désactiver avec la configuration ``dev_fast``:
 
 .. sourcecode:: bash
+
     python manage.py runserver --settings zds.settings.dev_fast


### PR DESCRIPTION
Cette PR contient deux choses dans la doc:
- sur la page *Problèmes de lenteur*, les codes bash n'apparaissaient pas. J'ai également amélioré certains éléments de mise en forme. Il y avaient également des erreurs dans la génération de la doc à cause de séparateurs de titres trop courts.
- sur la page *API*: je précise que c'est l'utilisateur `admin` qui possède le client de l'API installé par les fixtures (j'ai du aller voir dans l'administration Django pour le trouver !)

**QA:**
1. se placer dans le dossier `doc/`
2. `make html`: il ne doit pas y avoir d'erreur rouge (juste un petit warning d'une dépréciation)
3. s'assurer que la doc contient bien ce que je décris :wink: 
