### PR TITLE
Centre et élargit la doc de l'API

### DIFF
--- a/templates/rest_framework_swagger/index.html
+++ b/templates/rest_framework_swagger/index.html
@@ -19,7 +19,9 @@
 
 
 {% block doc_api %}
-    <div id="rest-swagger-ui"></div>
+    <div class="wrapper">
+        <div id="rest-swagger-ui"></div>
+    </div>
     {% csrf_token %}
 {% endblock %}
 


### PR DESCRIPTION
Avant:
![api-non-centree-1](https://user-images.githubusercontent.com/5911232/68045238-4f4c1600-fcd9-11e9-98e5-f466b8b951f5.png)
![api-non-centree-2](https://user-images.githubusercontent.com/5911232/68045240-5115d980-fcd9-11e9-8c04-cc02a6b8865e.png)

Après:
![api-centree-1](https://user-images.githubusercontent.com/5911232/68045258-583ce780-fcd9-11e9-9c58-7d3d0780afee.png)
![api-centree-2](https://user-images.githubusercontent.com/5911232/68045266-5d019b80-fcd9-11e9-826d-fc7f821ff70e.png)

**QA:**
Se rendre sur la page `/api/` et constater les changements.
