### PR TITLE
fix #5462 : n'affiche la version brouillon qu'en cas de besoin

### DIFF
--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -275,7 +275,7 @@
         <a href="{% url "content:import" content.pk content.slug %}" class="ico-after import blue new-btn">
             {% trans "Importer une nouvelle version" %}
         </a>
-
+    {% elif not version or version != content.sha_draft %}
         <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
             {% trans "Version brouillon" %}
         </a>


### PR DESCRIPTION
Cette PR corrige #5462 . Lorsqu'on est sur la version brouillon d'un contenu, le lien vers la version brouillon ne devrait pas être affiché car on n'en a pas besoin.

### Contrôle qualité

- Lancer le site avec les fixtures de base
- Connectez vous avec `user`/`user`
- Allez dans ses billets et consulter la version brouillon dudit billet, vous ne devriez pas voir apparaitre le bouton "Version" brouillon dans la sidebar.
- Allez sur la version publiée, et vérifiez que vous voyez un bouton pour revenir à la version de validation.
