### PR TITLE
Profil: enlève le gras de la barre de recherche (fix #5509)

### DIFF
--- a/assets/scss/pages/_flexpage.scss
+++ b/assets/scss/pages/_flexpage.scss
@@ -311,6 +311,7 @@ $content-width: 1145px;
                     flex: 1 1 auto;
                     width: initial !important;
                     min-width: 0;
+                    font-weight: 100;
                 }
 
                 button {


### PR DESCRIPTION
Fix #5509 

### QA
- Recompiler le front: `make build-front`
- Visiter une page de profil: le texte de la barre de recherche n'apparaît plus en gras
- S'assurer que les autres barres de recherche du site (accueil, page de recherche) n'ont pas de modification dans leur apparence.