### PR TITLE
Affiche les nombres en gras sur la page de profil (fix #5507)

### DIFF
--- a/assets/scss/base/_typography.scss
+++ b/assets/scss/base/_typography.scss
@@ -38,3 +38,7 @@ button.link {
     border: none;
     text-decoration: underline;
 }
+
+.bold {
+    font-weight: bold;
+}

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -99,9 +99,9 @@
                                 <div class="line-item">
                                     {% spaceless %}
                                         <span class="has-separator">
-                                            {% for link, text in summary %}
+                                            {% for link, count, text in summary %}
                                                 {% captureas summary_link_html %}
-                                                {% if link %}<a href="{{ link }}">{% endif %}
+                                                {% if link %}<a href="{{ link }}"><span class="bold">{{ count }}</span> {% endif %}
                                                 {{ text }}{% if link %}</a>{% endif %}{% endcaptureas %}
 
                                                 {% if forloop.last %}
@@ -140,9 +140,9 @@
                             {% trans "Aucun abonné" %}
                         {% else %}
                             {% blocktrans count subscriber_count=subscriber_count %}
-                                {{ subscriber_count }} abonné
+                                <span class="bold">{{ subscriber_count }}</span> abonné
                             {% plural %}
-                                {{ subscriber_count }} abonnés
+                                <span class="bold">{{ subscriber_count }}</span> abonnés
                             {% endblocktrans %}
                         {% endif %}
                     {% endcaptureas %}
@@ -335,9 +335,9 @@
                                             <a href="{% url "tutorial:find-tutorial" usr.username %}?filter=public" class="tail">
                                                 <p>
                                                     {% blocktrans count public_tutos_count=public_tutos_count %}
-                                                        {{ public_tutos_count }} tutoriel publié
+                                                        <span class="bold">{{ public_tutos_count }}</span> tutoriel publié
                                                     {% plural %}
-                                                        {{ public_tutos_count }} tutoriels publiés
+                                                        <span class="bold">{{ public_tutos_count }}</span> tutoriels publiés
                                                     {% endblocktrans %}
                                                 </p>
                                             </a>
@@ -347,9 +347,9 @@
                                             <a href="{% url "article:find-article" usr.username %}?filter=public" class="tail">
                                                 <p>
                                                     {% blocktrans count articles_public_count=articles_public_count %}
-                                                        {{ articles_public_count }} article publié
+                                                        <span class="bold">{{ articles_public_count }}</span> article publié
                                                     {% plural %}
-                                                        {{ articles_public_count }} articles publiés
+                                                        <span class="bold">{{ articles_public_count }}</span> articles publiés
                                                     {% endblocktrans %}
                                                 </p>
                                             </a>
@@ -359,9 +359,9 @@
                                             <a href="{% url "opinion:find-opinion" usr.username %}?filter=public" class="tail">
                                                 <p>
                                                     {% blocktrans count opinions_public_count=opinions_public_count %}
-                                                        {{ opinions_public_count }} billet publié
+                                                        <span class="bold">{{ opinions_public_count }}</span> billet publié
                                                     {% plural %}
-                                                        {{ opinions_public_count }} billets publiés
+                                                        <span class="bold">{{ opinions_public_count }}</span> billets publiés
                                                     {% endblocktrans %}
                                                 </p>
                                             </a>
@@ -386,9 +386,9 @@
                                                 <a href="{% url "tutorial:find-tutorial" usr.username %}?filter=beta" class="tail">
                                                         <p>
                                                             {% blocktrans count beta_tutos_count=beta_tutos_count %}
-                                                                {{ beta_tutos_count }} tutoriel en bêta
+                                                                <span class="bold">{{ beta_tutos_count }}</span> tutoriel en bêta
                                                             {% plural %}
-                                                                {{ beta_tutos_count }} tutoriels en bêta
+                                                                <span class="bold">{{ beta_tutos_count }}</span> tutoriels en bêta
                                                             {% endblocktrans %}
                                                         </p>
                                                     </a>
@@ -398,9 +398,9 @@
                                                 <a href="{% url "article:find-article" usr.username %}?filter=beta" class="tail">
                                                     <p>
                                                         {% blocktrans count beta_articles_count=beta_articles_count %}
-                                                            {{ beta_articles_count }} article en bêta
+                                                            <span class="bold">{{ beta_articles_count }}</span> article en bêta
                                                         {% plural %}
-                                                            {{ beta_articles_count }} articles en bêta
+                                                            <span class="bold">{{ beta_articles_count }}</span> articles en bêta
                                                         {% endblocktrans %}
                                                     </p>
                                                 </a>
@@ -419,9 +419,9 @@
                                             <a href="{% url 'topic-find' usr.pk %}" class="tail">
                                                 <p>
                                                     {% blocktrans count topics_count=topics_count %}
-                                                        {{ topics_count }} sujet créé
+                                                        <span class="bold">{{ topics_count }}</span> sujet créé
                                                     {% plural %}
-                                                        {{ topics_count }} sujets créés
+                                                        <span class="bold">{{ topics_count }}</span> sujets créés
                                                     {% endblocktrans %}
                                                 </p>
                                             </a>
@@ -431,9 +431,9 @@
                                             <a href="{% url 'post-find' usr.pk %}" class="tail">
                                                 <p>
                                                     {% blocktrans count messages_count=messages_count %}
-                                                        {{ messages_count }} message posté
+                                                        <span class="bold">{{ messages_count }}</span> message posté
                                                     {% plural %}
-                                                        {{ messages_count }} messages postés
+                                                        <span class="bold">{{ messages_count }}</span> messages postés
                                                     {% endblocktrans %}
                                                 </p>
                                             </a>

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -80,7 +80,7 @@ class MemberDetail(DetailView):
         Returns a summary of this profile's activity, as a list of list of tuples.
         Each first-level list item is an activity category (e.g. contents, forums, etc.)
         Each second-level list item is a stat in this activity category.
-        Each tuple is (link url, displayed text), where the link url can be None if it's not a link.
+        Each tuple is (link url, count, displayed name of the item), where the link url can be None if it's not a link.
 
         :param profile: The profile.
         :return: The summary data.
@@ -99,27 +99,30 @@ class MemberDetail(DetailView):
 
         summary = []
         if count_tutorials + count_articles + count_opinions == 0:
-            summary.append((None, __('Aucun contenu publié')))
+            summary.append((None, 0, __('Aucun contenu publié')))
 
         if count_tutorials > 0:
             summary.append(
                 (
                     reverse_lazy('tutorial:find-tutorial', args=(profile.user.username,)),
-                    __('{} tutoriel{}').format(count_tutorials, pluralize_fr(count_tutorials))
+                    count_tutorials,
+                    __('tutoriel{}').format(pluralize_fr(count_tutorials))
                 )
             )
         if count_articles > 0:
             summary.append(
                 (
                     reverse_lazy('article:find-article', args=(profile.user.username,)),
-                    __('{} article{}').format(count_articles, pluralize_fr(count_articles))
+                    count_articles,
+                    __('article{}').format(pluralize_fr(count_articles))
                 )
             )
         if count_opinions > 0:
             summary.append(
                 (
                     reverse_lazy('opinion:find-opinion', args=(profile.user.username,)),
-                    __('{} billet{}').format(count_opinions, pluralize_fr(count_opinions))
+                    count_opinions,
+                    __('billet{}').format(pluralize_fr(count_opinions))
                 )
             )
         summaries.append(summary)
@@ -129,16 +132,18 @@ class MemberDetail(DetailView):
             summary.append(
                 (
                     reverse_lazy('post-find', args=(profile.user.pk,)),
-                    __('{} message{}').format(count_post, pluralize_fr(count_post))
+                    count_post,
+                    __('message{}').format(pluralize_fr(count_post))
                 )
             )
         else:
-            summary.append((None, __('Aucun message')))
+            summary.append((None, 0, __('Aucun message')))
         if count_topic > 0:
             summary.append(
                 (
                     reverse_lazy('topic-find', args=(profile.user.pk,)),
-                    __('{} sujet{}').format(count_topic, pluralize_fr(count_topic))
+                    count_topic,
+                    __('sujet{}').format(pluralize_fr(count_topic))
                 )
             )
 


### PR DESCRIPTION
Fix #5507 

Affiche tous les nombres présents sur la page de profil en gras.

### Code

- j'ai scindé le texte affiché en *nombre* et *texte* dans `get_summaries` pour ne pas coder en dur dans le back des éléments de template
- j'ai ajouté une classe CSS pour afficher un élément en gras, je n'en ai pas trouvé qui ne faisait que ça !
- pour reprendre le débat de l'issue (`<b>` vs `<strong>` vs `<span class="">`), je vous renvoie vers https://developer.mozilla.org/fr/docs/Web/HTML/Element/b: *Cet élément ne doit pas être utilisé pour mettre en forme des éléments, c'est la propriété CSS font-weight qu'il faut utiliser.*


### Contrôle qualité

1. Compiler le front: `make build-front`
2. Vérifier sur les pages de profil des membres que tout s'affiche correctement.