### PR TITLE
Changement de titre dans la documentation de l'API

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -309,8 +309,8 @@ Si le token n'est plus valide ou que vous avez perdu l'``access_token`` de l'uti
 
 A la suite de cela, de nouveaux tokens seront renvoyés et devront être sauvegardés pour une prochaine utilisation si nécessaire.
 
-Django REST Swagger
-===================
+Documentation (utilisation)
+============================
 
 Django REST Swagger est une bibliothèque qui génère automatiquement la documentation d'une API Django basée sur la bibliothèque Django REST framework.
 


### PR DESCRIPTION
Changement du titre : "Django REST Swagger" par "Documentation (utilisation)" pour rendre plus clair le menu de gauche et savoir immédiatement de quoi il s'agit.

Dans la mesure où c'est la dernière partie de la page, que ça peut être l'élément recherché par le lecteur de la documentation. S'il ne connait pas ou oublie ce qu'est Swagger, cela peut lui faire gagner du temps.