### PR TITLE
Corrige l'erreur 404 sur l'ajout d'une section

### DIFF
--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -103,8 +103,12 @@
             {% endfor %}
             {% if can_add_something and child.can_add_extract %}
                 <li class="simple-create-button">
-                    <a class="btn btn-grey" href="{% url "content:create-extract" content.pk child.parent.slug child.slug %}">
-                        {% trans "Ajouter une section" %}
+                    <a class="btn btn-grey" href="{% if child.parent == content %}
+                                {% url "content:create-extract" content.pk content.slug child.slug %}
+                            {%  else %}
+                                {% url "content:create-extract" content.pk content.slug child.parent.slug child.slug %}
+                            {%  endif %}">
+                        {% trans "Ajouter une section a" %}
                     </a>
                 </li>
             {% endif %}


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #5455 

### Contrôle qualité

- Lancez le site et créez ou importez un big tutoriel avec 1 partie, 1 chapitre et 1 section.
- Rendez-vous sur la page de la partie et cliquez dans le sommaire sur "Ajouter une section"
- Constatez que vous n'avez pas de 404, mais plutot une page qui vous permet de rajouter une section.

Merci.