### PR TITLE
Corrige les twitter cards sur les conteneurs

### DIFF
--- a/templates/tutorialv2/includes/image_illu.part.html
+++ b/templates/tutorialv2/includes/image_illu.part.html
@@ -1,0 +1,18 @@
+{% load thumbnail %}{% spaceless %}
+    {% if content.image %}
+        {% if request.GET.twittercard == "large"  %}
+            {{ content.image.physical|thumbnail_url:'social_network_large' }}
+        {% else %}
+            {{ content.image.physical|thumbnail_url:'social_network' }}
+        {% endif %}
+    {% else %}
+        {% load static %}
+        {% if content.type == 'TUTORIAL' %}
+            {% static "images/tutorial-illu.png" %}
+        {% elif content.type == 'ARTICLE' %}
+            {% static "images/article-illu.png" %}
+        {% elif content.type == 'OPINION' %}
+            {% static "images/opinion-illu.png" %}
+        {% endif %}
+    {% endif %}
+{% endspaceless %}

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -11,7 +11,13 @@
     {{ container.title }} - {{ content.title }}
 {% endblock %}
 
-
+{% block description %}
+    {% if content.description %}
+        {{ content.description }}
+    {% else %}
+        Site et association de partage de connaissances animé par sa communauté. Vous y trouverez des tutoriels et des articles de tous niveaux et des forums.
+    {% endif %}
+{% endblock %}
 
 {% block opengraph %}
     {% include "tutorialv2/includes/opengraph.part.html" %}

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -17,7 +17,9 @@
     {% include "tutorialv2/includes/opengraph.part.html" %}
 {% endblock %}
 
-
+{% block meta_image %}{% spaceless %}
+    {% include "tutorialv2/includes/image_illu.part.html" with content=content %}
+{% endspaceless %}{% endblock %}
 
 {% block breadcrumb %}
     {%  if container.parent.parent %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -36,8 +36,8 @@
 {% endblock %}
 
 {% block description %}
-    {% if content.meta_description %}
-        {{ content.meta_description }}
+    {% if content.description %}
+        {{ content.description }}
     {% else %}
         Site et association de partage de connaissances animé par sa communauté. Vous y trouverez des tutoriels et des articles de tous niveaux et des forums.
     {% endif %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -46,22 +46,7 @@
 
 
 {% block meta_image %}{% spaceless %}
-    {% if content.image %}
-        {% if request.GET.twittercard == "large"  %}
-            {{ content.image.physical|thumbnail_url:'social_network_large' }}
-        {% else %}
-            {{ content.image.physical|thumbnail_url:'social_network' }}
-        {% endif %}
-    {% else %}
-        {% load static %}
-        {% if content.type == 'TUTORIAL' %}
-            {% static "images/tutorial-illu.png" %}
-        {% elif content.type == 'ARTICLE' %}
-            {% static "images/article-illu.png" %}
-        {% elif content.type == 'OPINION' %}
-            {% static "images/opinion-illu.png" %}
-        {% endif %}
-    {% endif %}
+    {% include "tutorialv2/includes/image_illu.part.html" with content=content %}
 {% endspaceless %}{% endblock %}
 
 

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -2238,20 +2238,21 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
         self.assertEqual(tutorial.public_version.authors.count(), 1)
 
-
     def check_images_socials(self, result, pattern_link_image, title, description):
-        for meta in ["twitter:image", "og:image:url"]:
-            self.assertRegex(result.content.decode("utf-8"),
-                             r"<meta(\s+)(\S+)" + meta +"(\S+)(\s+)content=\"http://(\S+)/" + pattern_link_image + "(\S+)\"")
-        for meta in ["og:image:secure_url"]:
-            self.assertRegex(result.content.decode("utf-8"),
-                             r"<meta(\s+)(\S+)" + meta +"(\S+)(\s+)content=\"https://(\S+)/" + pattern_link_image + "(\S+)\"")
-        for meta in ["twitter:description"]:
-            self.assertRegex(result.content.decode("utf-8"),
-                             r"<meta(\s+)(\S+)"+meta+"(\S+)(\s+)content=\""+description)
-        for meta in ["twitter:title", "og:title"]:
-            self.assertRegex(result.content.decode("utf-8"),
-                             r"<meta(\s+)(\S+)"+meta+"(\S+)(\s+)content=\""+title)
+        start_reg = r'<meta(\s+)(\S+)'
+
+        for meta in ['twitter:image', 'og:image:url']:
+            self.assertRegex(result.content.decode('utf-8'),
+                             start_reg + meta + '(\S+)(\s+)content=\"http://(\S+)/' + pattern_link_image + '(\S+)\"')
+        for meta in ['og:image:secure_url']:
+            self.assertRegex(result.content.decode('utf-8'),
+                             start_reg + meta + '(\S+)(\s+)content=\"https://(\S+)/' + pattern_link_image + '(\S+)\"')
+        for meta in ['twitter:description']:
+            self.assertRegex(result.content.decode('utf-8'),
+                             start_reg + meta + '(\S+)(\s+)content=\"' + description)
+        for meta in ['twitter:title', 'og:title']:
+            self.assertRegex(result.content.decode('utf-8'),
+                             start_reg + meta + '(\S+)(\s+)content=\"' + title)
 
     def test_social_cards_without_image(self):
         """
@@ -2264,19 +2265,24 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.get(reverse('tutorial:view', kwargs={'pk': self.tuto.pk, 'slug': self.tuto.slug}))
         self.assertEqual(result.status_code, 200)
 
-        self.check_images_socials(result, "static/images/tutorial-illu", self.tuto.title, self.tuto.description)
+        self.check_images_socials(result, 'static/images/tutorial-illu', self.tuto.title, self.tuto.description)
 
         # check part cards
-        result = self.client.get(reverse('tutorial:view-container', kwargs={'pk': self.tuto.pk, 'slug': self.tuto.slug, 'container_slug': self.part1.slug}))
+        result = self.client.get(reverse('tutorial:view-container', kwargs={'pk': self.tuto.pk,
+                                                                            'slug': self.tuto.slug,
+                                                                            'container_slug': self.part1.slug}))
         self.assertEqual(result.status_code, 200)
 
-        self.check_images_socials(result, "static/images/tutorial-illu", self.part1.title, self.tuto.description)
+        self.check_images_socials(result, 'static/images/tutorial-illu', self.part1.title, self.tuto.description)
 
         # check chapter cards
-        result = self.client.get(reverse('tutorial:view-container', kwargs={'pk': self.tuto.pk, 'slug': self.tuto.slug, 'parent_container_slug': self.part1.slug, 'container_slug': self.chapter1.slug}))
+        result = self.client.get(reverse('tutorial:view-container', kwargs={'pk': self.tuto.pk,
+                                                                            'slug': self.tuto.slug,
+                                                                            'parent_container_slug': self.part1.slug,
+                                                                            'container_slug': self.chapter1.slug}))
         self.assertEqual(result.status_code, 200)
 
-        self.check_images_socials(result, "static/images/tutorial-illu", self.chapter1.title, self.tuto.description)
+        self.check_images_socials(result, 'static/images/tutorial-illu', self.chapter1.title, self.tuto.description)
 
     def test_social_cards_with_image(self):
         """
@@ -2294,8 +2300,8 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             {
                 'title': self.tuto.title,
                 'description': self.tuto.description,
-                'introduction': "",
-                'conclusion': "",
+                'introduction': '',
+                'conclusion': '',
                 'type': 'TUTORIAL',
                 'licence': self.tuto.licence.pk,
                 'subcategory': self.subcategory.pk,
@@ -2308,18 +2314,24 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.logout()
 
         # check tutorial cards
-        result = self.client.get(reverse('tutorial:view', kwargs={'pk': self.tuto.pk, 'slug': self.tuto.slug}))
+        result = self.client.get(reverse('tutorial:view', kwargs={'pk': self.tuto.pk,
+                                                                  'slug': self.tuto.slug}))
         self.assertEqual(result.status_code, 200)
 
-        self.check_images_socials(result, "media/galleries/", self.tuto.title, self.tuto.description)
+        self.check_images_socials(result, 'media/galleries/', self.tuto.title, self.tuto.description)
         # check part cards
-        result = self.client.get(reverse('tutorial:view-container', kwargs={'pk': self.tuto.pk, 'slug': self.tuto.slug, 'container_slug': self.part1.slug}))
+        result = self.client.get(reverse('tutorial:view-container', kwargs={'pk': self.tuto.pk,
+                                                                            'slug': self.tuto.slug,
+                                                                            'container_slug': self.part1.slug}))
         self.assertEqual(result.status_code, 200)
 
-        self.check_images_socials(result, "media/galleries/", self.part1.title, self.tuto.description)
+        self.check_images_socials(result, 'media/galleries/', self.part1.title, self.tuto.description)
 
         # check chapter cards
-        result = self.client.get(reverse('tutorial:view-container', kwargs={'pk': self.tuto.pk, 'slug': self.tuto.slug, 'parent_container_slug': self.part1.slug, 'container_slug': self.chapter1.slug}))
+        result = self.client.get(reverse('tutorial:view-container', kwargs={'pk': self.tuto.pk,
+                                                                            'slug': self.tuto.slug,
+                                                                            'parent_container_slug': self.part1.slug,
+                                                                            'container_slug': self.chapter1.slug}))
         self.assertEqual(result.status_code, 200)
 
-        self.check_images_socials(result, "media/galleries/", self.chapter1.title, self.tuto.description)
+        self.check_images_socials(result, 'media/galleries/', self.chapter1.title, self.tuto.description)


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #5447 

Les tests ont été rajouté comme demandé dans le ticket.

### Contrôle qualité

- Lancez le site
- Allez sur un contenu publié et vérifié que vous voyez bien dans les meta du html la propriété `twitter:image` pour un contenu
- Allez sur un conteneur (chapitre, partie) publié et vérifiez que vous voyez bien dans les meta du html la propriété `twitter:image` correspondante à l'image du tutoriel et non à l'icone de zds.
- Allez sur un conteneur (chapitre, partie) publié mais sans image et vérifiez que vous obtenez bien l'url de l'image du site.
