### PR TITLE
Précise le paramètre dns pour la configuration de développement

### DIFF
--- a/zds/settings/dev.py
+++ b/zds/settings/dev.py
@@ -76,3 +76,4 @@ LOGGING = {
 }
 
 ZDS_APP['site']['url'] = 'http://127.0.0.1:8000'
+ZDS_APP['site']['dns'] = '127.0.0.1:8000'


### PR DESCRIPTION
Cette PR corrige un bug que j'ai remarqué en faisant une review (https://github.com/zestedesavoir/zds-site/pull/5521#issuecomment-554663350).

Certaines images avaient comme URL https://zestedesavoir.com/chemin/vers/une/image.jpg quand on fonctionnait avec une configuration de développement. @A-312 a identifié le problème, je propose donc une correction.

## QA
 
1. Lancer le site avec une configuration de développement (`make run-back`)
2. Regarder le code source de la page d'accueil, par exemple la ligne 41:
  - **avant**: le chemin de la valeur de cette meta pointe vers zestedesavoir.com: 
    ```
    <meta property="og:image:url" content="http://zestedesavoir.com/static/images/favicons/512.png">
    ```
  - **après**: le chemin de la valeur de cette meta pointe vers le serveur local: 
    ```
    <meta property="og:image:url" content="http://http://127.0.0.1:8000/static/images/favicons/512.png">
    ```