### PR TITLE
fix #5489 : rend utilisable l'ajout d'un auteur sur la page beta

### DIFF
--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -59,9 +59,16 @@
 
         {% if add_author == True %}
             <li>
-                <a href="#add-author" class="open-modal ico-after more blue">
+                <a href="#add-author-content" class="open-modal ico-after more blue">
                     {% trans "Ajouter un auteur" %}
                 </a>
+                <form action="{% url "content:add-author" content.pk %}" method="post" class="modal modal-flex" id="add-author-content">
+                    {% csrf_token %}
+                    <input type="text" name="username" placeholder="Pseudo de l’utilisateur à ajouter" data-autocomplete="{ 'type': 'single' }">
+                    <button type="submit" name="add_author">
+                        {% trans "Confirmer" %}
+                    </button>
+                </form>
             </li>
         {% endif %}
     </ul>


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #5489 

Cette PR rend le bouton "ajouter une auteur" à coté de la liste des auteurs lorsqu'on est sur un contenu en beta (avec l'url `/beta` donc) utilisable.

Avant, cliquez dessus ne faisait rien, maintenant, une modale est ouverte et on peut chercher un membre à ajouter.

### Contrôle qualité

- Lancez le site  `make run-back`
- Rendez-vous sur un contenu, mettez le en beta
- Alez sur l'url du contenu en beta et cliquez sur "Ajouter un auteur"
- Saisissez le nom du membre et voyez qu'il a bien été ajouté en tant qu'auteur.
