### PR TITLE
Déplacer une partie avec des chapitres dans une autre ce n'est plus possible

### DIFF
--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -94,6 +94,14 @@
       return false;
     }
 
+    const $itemContainer = $item.children("[data-children-type=container]");
+    const haveChildChapter = (!!$itemContainer.children("div.article-part[data-slug]")[0]);
+
+    // move part in part is forbidden
+    if (haveChildChapter && $to.parents("[data-children-type=container]")[0]) {
+      return false;
+    }
+
     return true;
   }
 


### PR DESCRIPTION
Fix: #5533 

# Q/A : 

Créer une partie, mettre un chapitre à l'intérieur, essayer de déplacer cette partie dans une partie voisine, vous ne devriez pas pouvoir le faire.

Par contre vous devriez pouvoir déplacer une partie vide ou un chapitre (vide ou plein) à l'intérieur de cette partie.