### PR TITLE
Impossible de déplacer un élément en dessous de "Ajouter un chapitre"

### DIFF
--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -123,7 +123,7 @@
         }
 
         if ($(evt.related).is(".simple-create-button")) {
-          return -1;
+          return false;
         }
       },
       onEnd: sendMoveAction
@@ -172,7 +172,7 @@
         }
 
         if ($(evt.related).is(".simple-create-part")) {
-          return -1;
+          return false;
         }
       },
       onEnd: sendMoveAction


### PR DESCRIPTION
Fix: #5532 


# Q/A 

Essayer de déplacer un chapitre. Vous ne devriez pas pouvoir déplacer un chapitre en dessous de : 

![](https://user-images.githubusercontent.com/18501150/69499378-dd3ea980-0ef1-11ea-931e-25a53ad4bec4.png)

Mais seulement au dessus