### PR TITLE
légère épuration de la création d'un contenu

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -204,3 +204,8 @@
         text-align: center;
     }
 }
+
+#twolevelselect {
+    height: 300px;
+    width: 100%;
+}

--- a/templates/crispy/twolevelselectmultiple.html
+++ b/templates/crispy/twolevelselectmultiple.html
@@ -1,0 +1,58 @@
+{# This tempate is used by Django Crispy Form #}
+{# We only add a templatetag (order_categories line 24) to sort categories in the "new content" page #}
+
+{% load crispy_forms_filters %}
+{% load form_categories %}
+{% load l10n %}
+
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    <{% if tag %}{{ tag }}{% else %}div{% endif %}
+        id="div_{{ field.auto_id }}"
+        class="control-group
+               {% if wrapper_class %}
+                   {{ wrapper_class }}
+               {% endif %}
+
+               {% if form_show_errors and field.errors%}
+                   error
+               {% endif %}
+
+               {% if field.css_classes %}
+                   {{ field.css_classes }}
+               {% endif %}">
+
+        {% if field.label and not field|is_checkbox and form_show_labels %}
+            <label for="{{ field.id_for_label }}"
+                   class="control-label {% if field.field.required %}requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
+
+        <div class="controls"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+            {% include 'bootstrap/layout/field_errors_block.html' %}
+
+            {% regroup field.field.choices|order_categories|dictsort:"order" by parent as categories_list %}
+
+            <select id="twolevelselect" multiple>
+                {% for category in categories_list %}
+                <optgroup label="{{ category.grouper }}">
+                {% for option in category.list %}
+                    <option
+                        id="id_{{ field.html_name }}_{{ option.choice.0|unlocalize }}"
+                        name="{{ field.html_name }}"
+                        {% if option.choice.0 in field.value or option.choice.0|stringformat:"s" in field.value or option.choice.0|stringformat:"s" == field.value|stringformat:"s" %} Selected {% endif %}
+                        value="{{ option.choice.0|unlocalize }}"
+                        {{ field.field.widget.attrs|flatatt }}>{{ option.choice.1|unlocalize }}</option>
+                {% endfor %}
+                </optgroup>
+                {% endfor %}
+            </select>
+
+            {% include 'bootstrap/layout/help_text.html' %}
+        </div>
+    </{% if tag %}{{ tag }}{% else %}div{% endif %}>
+{% endif %}

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -333,7 +333,7 @@ class ContentForm(ContainerForm):
             with text=form.conclusion.value %}{% endif %}'),
             Field('last_hash'),
             Field('licence'),
-            Field('subcategory', template='crispy/checkboxselectmultiple.html'),
+            Field('subcategory', template='crispy/twolevelselectmultiple.html'),
         )
 
         if not hide_help:


### PR DESCRIPTION
Cette PR permet de réduire la longueur de la zone dédiée à la sélection d'une catégorie. Actuellement en production, on a quelque chose de vraiment pas ergonomique, on est obligé de scroller jusqu'au bout pour trouver le bouton de création du contenu.

Cette PR ne prétend pas faire des miracle, mais en attendant de lancer le chantier de l'interface de création d'un tutoriel, je me dis que c'est toujours ça de pris.

## Avant

![Capture d’écran de 2019-11-24 21-34-57](https://user-images.githubusercontent.com/6066015/69501143-5e9e3800-0f02-11ea-9697-ee33851f73a2.png)

## Après

![Capture d’écran de 2019-11-24 21-33-55](https://user-images.githubusercontent.com/6066015/69501144-62ca5580-0f02-11ea-8ce0-70498af6cf84.png)

Numéro du ticket concerné (optionnel) : Aucun

### Contrôle qualité

- Builder le front `make build-front`
- Créez un tutoriel et sélectionnez une catégorie et constatez que vous avez bien créez le contenu dans la bonne catégorie.
- Editer le tutoriel et vérifiez que la catégorie est bien sélectionnée.