### PR TITLE
Enlève le surlignage sur les "Section A/B" de "Ajouter un chapitre"

### DIFF
--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -148,7 +148,7 @@
           // Element is dragged into the list from another list
           if ($to.is("section")) { // is: chapter > extract
             $item.find("> h3 > a").unwrap().wrap("<h2></h2>");
-            $item.find("ol h4 > a").unwrap().wrap("<h3></h3>");
+            $item.find("> ol h4 > a").unwrap().wrap("<h3></h3>");
 
             if ($item.find(".simple-create-part")[0]) {
               $item.children(".article-containers").show();
@@ -156,7 +156,7 @@
             }
           } else { // is: part > chapter > extract 
             $item.find("> h2 > a").unwrap().wrap("<h3></h3>");
-            $item.find("ol h3 > a").unwrap().wrap("<h4></h4>");
+            $item.find("> ol h3 > a").unwrap().wrap("<h4></h4>");
 
             if ($item.find(".simple-create-part")[0]) {
               $item.children(".article-containers").hide();


### PR DESCRIPTION
Mon sélecteur était trop permissif, il transformait les h4 en h3, ce qui empêchait cette règle de fonctionner : https://github.com/zestedesavoir/zds-site/blob/9d5e1f4b202fdce9fa0ed9e4e2a95b348fe8c84e/assets/scss/layout/_content.scss#L170-L172

Fix: #5531

# Q/A : 

Créer un big-tuto avec : 
 - partie 1
 - partie 2
     - chapitre A

Déplacer la partie 2 au dessus de la partie 1 constater ne pas avoir de background gris sur section A & B, vous devriez avoir : 

![](https://user-images.githubusercontent.com/18501150/69498692-04de4380-0eeb-11ea-94ca-04d606c1953a.png)