### PR TITLE
Revert "Impossible de déplacer un élément en dessous de "Ajouter un c…

### DIFF
--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -131,7 +131,7 @@
         }
 
         if ($(evt.related).is(".simple-create-button")) {
-          return false;
+          return -1;
         }
       },
       onEnd: sendMoveAction
@@ -180,7 +180,7 @@
         }
 
         if ($(evt.related).is(".simple-create-part")) {
-          return false;
+          return -1;
         }
       },
       onEnd: sendMoveAction


### PR DESCRIPTION
Il faut undo ce commit car il crée des dégâts collatéraux (difficulté à déplacer un chapitre dans une partie, si la partie n'a qu'un chapitre par exemple).