### PR TITLE
improve install script for fish shell user

### DIFF
--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -262,6 +262,18 @@ if  ! $(_in "-node" $@) && ( $(_in "+node" $@) || $(_in "+base" $@) || $(_in "+f
             echo $ACTIVATE_NVM >> $ZDS_ENV/bin/activate
             echo $ACTIVATE_NVM >> $ZDS_ENV/bin/activate.csh
             echo $ACTIVATE_NVM >> $ZDS_ENV/bin/activate.fish
+
+            # bash compatibility for nvm with fish
+            # see https://eshlox.net/2019/01/27/how-to-use-nvm-with-fish-shell
+            if [[ $SHELL =~ "fish" ]]; then
+                curl https://git.io/fisher --create-dirs -sLo ~/.config/fish/functions/fisher.fish
+                fish -c "fisher add edc/bass"
+                cat <<EOF > ~/.config/fish/functions/nvm.fish
+function nvm
+    bass source ~/.nvm/nvm.sh --no-use ';' nvm $argv
+end
+EOF
+            fi
         fi
     else
         print_error "!! Cannot obtain nvm v${ZDS_NVM_VERSION}"
@@ -559,7 +571,13 @@ if  ! $(_in "-data" $@) && ( $(_in "+data" $@) || $(_in "+base" $@) || $(_in "+f
 fi
 
 if  ! $(_in "--force-skip-activating" $@); then
-    print_info "Done. You can now run instance with \`source $ZDS_VENV/bin/activate\`, and then, \`make zmd-start && make run-back\`"
+    if [[ $SHELL =~ "csh" ]]; then
+        print_info "Done. You can now run instance with \`source $ZDS_VENV/bin/activate.csh\`, and then, \`make zmd-start && make run-back\`"
+    elif [[ $SHELL =~ "fish" ]]; then
+        print_info "Done. You can now run instance with \`source $ZDS_VENV/bin/activate.fish\`, and then, \`make zmd-start && make run-back\`"
+    else
+        print_info "Done. You can now run instance with \`source $ZDS_VENV/bin/activate\`, and then, \`make zmd-start && make run-back\`"
+    fi
 else
     print_info "Done. You can now run instance with \`make zmd-start && make run-back\`"
 fi


### PR DESCRIPTION
Installation d'une solution de compatibilité pour Fish ([Fisher ](https://github.com/jorgebucaran/fisher)  et bass) pour faire fonctionner `nvm`.

Voir [https://eshlox.net/2019/01/27/how-to-use-nvm-with-fish-shell](https://eshlox.net/2019/01/27/how-to-use-nvm-with-fish-shell) pour plus de détail.

Et affichage du bon fichier d'activation pour virtualenv en fonction du shell utilisé pour l'utilisateur courant.

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné : #5522 

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

Pour les utilisateurs du shell Fish, cela installe Fisher (`completions/fisher.fish`, `functions/fisher.fish`) et le plugin `bass` (`functions/bass.fish`, `functions/__bass.py`) et le fichier `functions/nvm.fish` dans le dossier de config de fish (`~/.config/fish`).
Condition : Ne pas avoir la ligne `nvm use > /dev/null # activate nvm (from install_zds.sh)` dans le fichier `zdsenv/bin/activate`

Et affiche le bon fichier d'activation pour les shells `csh` (`tcsh` inclus) et `fish`.
Par exemple avec le shell Fish, cela doit afficher : 
```
Done. You can now run instance with `source zdsenv/bin/activate.fish`, and then, `make zmd-start && make run-back`
```

<!-- Merci ! -->
