### PR TITLE
Met à jour les dépendances Python

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
 -r requirements.txt
 
-coverage==4.5.3
-PyYAML==5.1
-django-debug-toolbar==1.11
-flake8==3.7.7
-flake8_quotes==2.0.1
+coverage==4.5.4
+PyYAML==5.2
+django-debug-toolbar==2.1
+flake8==3.7.9
+flake8-quotes==2.1.1
 autopep8==1.4.4
-sphinx==2.0.1
-selenium==3.14.1
+Sphinx==2.3.1
+selenium==3.141.0
 sphinx_rtd_theme==0.4.3
-faker==0.8.12
+Faker==3.0.0
 mock==3.0.5
-colorlog==3.1.2
-django-extensions==2.1.6
+colorlog==4.0.2
+django-extensions==2.2.5

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-gunicorn==19.9.0
-mysqlclient==1.3.11
+gunicorn==20.0.4
+mysqlclient==1.4.6
 raven==6.10.0
 ujson==1.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,35 +1,35 @@
 # Implicit dependencies (optional dependencies of dependencies)
 social-auth-app-django==3.1.0
-elasticsearch==5.5.2
+elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
 sqlparse==0.3.0
 
 # Explicit dependencies (references in code)
 Django==2.1.15
-django-crispy-forms==1.7.2
-django-model-utils==3.1.2
+django-crispy-forms==1.8.1
+django-model-utils==4.0.0
 django-munin==0.2.1
 python-memcached==1.59
-lxml==4.3.3
+lxml==4.4.2
 factory-boy==2.8.1
 pygeoip==0.3.2
-pillow==6.2.1
-gitpython==2.1.9
-easy-thumbnails==2.6.0
-beautifulsoup4==4.7.1
-django-recaptcha==1.3.1
-google-api-python-client==1.7.8
+Pillow==6.2.1
+GitPython==3.0.5
+easy-thumbnails==2.7
+beautifulsoup4==4.8.2
+django-recaptcha==2.0.5
+google-api-python-client==1.7.11
 toml==0.10.0
-requests==2.21.0
+requests==2.22.0
 
 # Api dependencies
-djangorestframework==3.9.4
+djangorestframework==3.11.0
 djangorestframework-xml==1.4.0
-django-filter==2.0.0
-django-oauth-toolkit==1.0.0
-drf-extensions==0.4.0
+django-filter==2.2.0
+django-oauth-toolkit==1.2.0
+drf-extensions==0.5.0
 django-rest-swagger==2.2.0
-django-cors-middleware==1.3.1
+django-cors-middleware==1.5.0
 dry-rest-permissions==0.1.10
 oauth2client==4.1.3
 

--- a/zds/mp/api/serializers.py
+++ b/zds/mp/api/serializers.py
@@ -56,7 +56,7 @@ class PrivateTopicCreateSerializer(serializers.ModelSerializer, TitleValidator, 
 
     def create(self, validated_data):
         # This hack is necessary because `text` isn't a field of PrivateTopic.
-        self._fields.pop('text')
+        self.fields.pop('text')
         return send_mp(self.context.get('request').user,
                        validated_data.get('participants'),
                        validated_data.get('title'),

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -189,6 +189,7 @@ SITE_ID = 1
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'zds.api.pagination.DefaultPagination',
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     # Active OAuth2 authentication.
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'oauth2_provider.contrib.rest_framework.OAuth2Authentication',


### PR DESCRIPTION
Met à jour les dépendances Python, sauf : 

- `factory-boy` qui demande beaucoup de changements donc ce sera dans une autre PR
- `django` qui reste en 2.1.x le temps que les serveurs passent sur Debian 10
- `coverage` qui reste en 4.x car `coveralls` ne supporte pas encore 5.x

**QA :**

- `make install-back`
- `make run-back`
- Vérifier que tout fonctionne correctement