### PR TITLE
Utilise ManifestStaticfilesStorage au lieu de CachedStaticfilesStorage

### DIFF
--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -64,7 +64,7 @@ SESSION_COOKIE_AGE = 60 * 60 * 24 * 7 * 4
 MEDIA_ROOT = '/opt/zds/data/media'
 
 STATIC_ROOT = '/opt/zds/data/static'
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 
 django_template_engine['APP_DIRS'] = False
 django_template_engine['OPTIONS']['loaders'] = [


### PR DESCRIPTION
Utilise ManifestStaticfilesStorage au lieu de CachedStaticfilesStorage car c'est la méthode recommandée actuellement par Django et que CachedStaticfilesStorage va probablement être déprécié en 3.0.