### PR TITLE
Mise à jour vers Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
-dist: trusty
+dist: bionic
 language: python
 sudo: required
 
 
 python:
-  - 3.5
+  - 3.7
 
 
 addons:
   firefox: "latest"
   apt:
     packages:
-      - mysql-server-5.6
-      - mysql-client-core-5.6
-      - mysql-client-5.6
+      - mysql-server-5.7
+      - mysql-client-core-5.7
+      - mysql-client-5.7
       - libmysqlclient-dev
       - language-pack-fr
 
@@ -67,7 +67,7 @@ cache:
     - $HOME/.local/share/fonts
     - $HOME/.texlive
     - $HOME/.cache/pip
-    - $HOME/virtualenv/python3.5.6/bin
+    - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/bin
     - $HOME/build/zestedesavoir/zds-site/zdsenv
     - $HOME/.nvm
     - $HOME/node_modules

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # [Zeste de Savoir](https://zestedesavoir.com)
 
-Site internet communautaire propulsé par le framework [Django](https://www.djangoproject.com/) 2.1 et [Python](https://www.python.org/) 3.
+Site internet communautaire propulsé par le framework [Django](https://www.djangoproject.com/) 2.2 et [Python](https://www.python.org/) 3.
 Zeste de Savoir est basé sur un fork de [Progdupeupl](https://pdp.microjoe.org) ([voir le dépôt Git](https://github.com/progdupeupl/pdp_website)).
 
 Jetez donc un coup d’œil à notre [feuille de route](https://github.com/zestedesavoir/zds-site/wiki/Feuille-de-route).

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,9 @@
 social-auth-app-django==3.1.0
 elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
-sqlparse==0.3.0
 
 # Explicit dependencies (references in code)
-Django==2.1.15
+Django==2.2.9
 django-crispy-forms==1.8.1
 django-model-utils==4.0.0
 django-munin==0.2.1

--- a/scripts/ci_mysql_setup.sh
+++ b/scripts/ci_mysql_setup.sh
@@ -2,10 +2,9 @@
 
 set -ex
 
-sudo sed -i'' 's/\[client\]/\[client\]\ndefault-character-set=utf8mb4/' /etc/mysql/my.cnf
-sudo sed -i'' 's/\[mysql\]/\[mysql\]\ndefault-character-set=utf8mb4/' /etc/mysql/my.cnf
-sudo sed -i'' 's/\[mysqld\]/\[mysqld\]\ninnodb_file_per_table=on\ninnodb_file_format=barracuda\ninnodb_large_prefix=on\ncharacter-set-client-handshake=false\ncharacter-set-server=utf8mb4\ncollation-server=utf8mb4_unicode_ci/' /etc/mysql/my.cnf
-sudo /etc/init.d/mysql restart
+sudo sed -i'' 's/\[mysqld\]/\[mysqld\]\ninnodb_file_per_table=on\ninnodb_file_format=barracuda\ninnodb_large_prefix=on\ncharacter-set-client-handshake=false\ncharacter-set-server=utf8mb4\ncollation-server=utf8mb4_unicode_ci/' /etc/mysql/mysql.conf.d/mysqld.cnf
+sudo systemctl restart mysql
+
 # Travis should fail as soon as possible
 mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';"
 # Avoid "mysql has gone away" errors

--- a/scripts/travis_run.sh
+++ b/scripts/travis_run.sh
@@ -39,7 +39,7 @@ activate_env "./$ZDS_VENV"
         export PATH="$PATH:/home/travis/build/zestedesavoir/zds-site/geckodriver"
         export DISPLAY=":99.0"
 	# Use hack for virtualenv (fix some task with "command not found")
-	export PATH="$PATH:/home/travis/virtualenv/python3.5.6/bin"
+	export PATH="$PATH:/home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin"
 
 	run_script "start_elasticsearch"
 

--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -65,19 +65,19 @@
 
             <h4>{% trans "Site" %}</h4>
             <ul>
-                <li><a href="http://www.python.org/">Python 3</a></li>
-                <li><a href="https://www.djangoproject.com/">Django 2.1</a></li>
+                <li><a href="https://www.python.org/">Python 3</a></li>
+                <li><a href="https://www.djangoproject.com/">Django 2.2</a></li>
             </ul>
 
             <h4>HTTP(S) + WSGI</h4>
             <ul>
-                <li><a href="http://nginx.org/">NGinx</a></li>
-                <li><a href="http://gunicorn.org/">Gunicorn</a></li>
+                <li><a href="https://nginx.org/en/">NGinx</a></li>
+                <li><a href="https://gunicorn.org/">Gunicorn</a></li>
             </ul>
 
             <h4>{% trans "Base de données" %}</h4>
             <ul>
-                <li><a href="http://www.mysql.com/">MySQL</a></li>
+                <li><a href="https://mariadb.org/">MariaDB</a></li>
             </ul>
 
             <h4>{% trans "Géolocalisation des adresses IP" %}</h4>
@@ -85,7 +85,7 @@
                 {% trans "Données GeoLite créées par MaxMind, disponibles sous licence CC-BY-SA 3.0 unported." %}
             </p>
             <ul>
-                <li><a href="http://www.maxmind.com">http://www.maxmind.com</a></li>
+                <li><a href="https://www.maxmind.com/">http://www.maxmind.com</a></li>
             </ul>
         </div>
 
@@ -97,13 +97,13 @@
 
             <h4>{% trans "Feuilles de style" %}</h4>
             <ul>
-                <li><a href="http://necolas.github.io/normalize.css/">Normalize.css</a></li>
-                <li><a href="http://sass-lang.com/">SCSS</a></li>
+                <li><a href="https://necolas.github.io/normalize.css/">Normalize.css</a></li>
+                <li><a href="https://sass-lang.com/">SCSS</a></li>
             </ul>
 
             <h4>Javascript</h4>
             <ul>
-                <li><a href="http://jquery.com/">jQuery 2.x</a></li>
+                <li><a href="https://jquery.com/">jQuery 2.x</a></li>
             </ul>
         </div>
     </div>

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -5794,7 +5794,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
                 'licence': self.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': content_draft.compute_hash(),
-                'image': content_draft.image
+                'image': content_draft.image or 'None'
             },
             follow=False)
         self.assertEqual(result.status_code, 302)

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -1724,7 +1724,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
                 'licence': self.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': content_draft.compute_hash(),
-                'image': content_draft.image
+                'image': content_draft.image or 'None'
             },
             follow=False)
         self.assertEqual(result.status_code, 302)


### PR DESCRIPTION
Mise à jour vers Django 2.2

- Bascule Travis CI sur Ubuntu 18.04 avec Python 3.7 et MySQL 5.7

**QA**

- `make install-back`
- `make run-back`
- Vérifier que le site fonctionne bien