### PR TITLE
Améliore les timeouts pour la génération des pdfs

### DIFF
--- a/zds/tutorialv2/management/commands/publication_watchdog.py
+++ b/zds/tutorialv2/management/commands/publication_watchdog.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
     help = 'Launch a watchdog that generate all exported formats (epub, pdf...) files without blocking request handling'
 
     def handle(self, *args, **options):
-        with ThreadPoolExecutor(5) as executor:
+        with ThreadPoolExecutor(1) as executor:
             try:
                 while True:
                     Command.launch_publicators(executor)

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -447,7 +447,8 @@ class ZMarkdownRebberLatexPublicator(Publicator):
         command_process = subprocess.Popen(command,
                                            shell=True, cwd=path.dirname(texfile),
                                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        command_process.communicate(timeout=120)
+        # let's put 10 min of timeout because we do not generate latex everyday
+        command_process.communicate(timeout=600)
 
         with contextlib.suppress(ImportError):
             from raven import breadcrumbs

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -45,7 +45,8 @@ def _render_markdown_once(md_input, *, output_format='html', **kwargs):
     try:
         timeout = 10
         if output_format.startswith('tex'):
-            timeout = 30
+            # latex may be really long to generate but it is also restrained by server configuration
+            timeout = 120
         response = post('{}{}'.format(settings.ZDS_APP['zmd']['server'], endpoint), json={
             'opts': kwargs,
             'md': str(md_input),


### PR DESCRIPTION
# QA (on beta, c'est mieux)
Publier un gros tutoriel

lancer le watchdog

assurez-vous que ça passe

@sandhose il faudra aussi changer la configuration de zmd pour que le wait ne soit pas de 30 secondes (ou 60 je sais plus) sinon ça ne suffira pas.