### PR TITLE
Ajoute une dépendance implicite et obligatoire de social-auth-app-django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Implicit dependencies (optional dependencies of dependencies)
 social-auth-app-django==3.1.0
+python-social-auth==0.3.6
 elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
 


### PR DESCRIPTION
Ajoute une dépendance implicite et obligatoire de social-auth-app-django

Corrige le ticket #5560 