### PR TITLE
Corrige l'interdiction des pseudo avec un espace en début ou à la fin lors de l'inscription

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -13,7 +13,7 @@ from crispy_forms.layout import HTML, Layout, \
 
 from zds.member.models import Profile, KarmaNote, BannedEmailProvider
 from zds.member.validators import validate_not_empty, validate_zds_email, validate_zds_username, validate_passwords, \
-    validate_zds_password
+    validate_zds_password, validate_raw_zds_username
 from zds.utils.misc import contains_utf8mb4
 from zds.utils.models import Licence, HatRequest, Hat
 from zds.utils import get_current_user
@@ -136,6 +136,7 @@ class RegisterForm(forms.Form):
         self.helper.layout = layout
 
     def clean(self):
+        validate_raw_zds_username(self.data)
         cleaned_data = super(RegisterForm, self).clean()
         return validate_passwords(cleaned_data)
 

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -395,6 +395,7 @@ class ChangeUserForm(forms.Form):
         )
 
     def clean(self):
+        validate_raw_zds_username(self.data)
         cleaned_data = super(ChangeUserForm, self).clean()
         cleaned_data['previous_username'] = self.previous_username
         cleaned_data['previous_email'] = self.previous_email

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -186,7 +186,6 @@ class RegisterFormTest(TestCase):
         self.assertFalse(form.is_valid())
 
     def test_username_spaces_register_form(self):
-        # since Django 1.9, models.CharField is striped by default
         ProfileFactory()
         data = {
             'email': 'test@gmail.com',
@@ -195,7 +194,7 @@ class RegisterFormTest(TestCase):
             'password_confirm': 'ZePassword'
         }
         form = RegisterForm(data=data)
-        self.assertTrue(form.is_valid())
+        self.assertFalse(form.is_valid())
 
     def test_username_coma_register_form(self):
         ProfileFactory()
@@ -400,14 +399,13 @@ class ChangeUserFormTest(TestCase):
         self.assertFalse(form.is_valid())
 
     def test_username_spaces_register_form(self):
-        # since Django 1.9, models.CharField is striped by default
         ProfileFactory()
         data = {
             'username': '  ZeTester  ',
             'email': self.user1.user.email,
         }
         form = ChangeUserForm(data=data, user=self.user1.user)
-        self.assertTrue(form.is_valid())
+        self.assertFalse(form.is_valid())
 
     def test_username_coma_register_form(self):
         ProfileFactory()

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -394,6 +394,50 @@ class MemberTests(TutorialTestMixin, TestCase):
                             '?next=' + reverse('gallery-list'),
                             count=1)
 
+    def test_register_with_not_allowed_chars(self):
+        """
+        Test register account with not allowed chars
+        :return:
+        """
+        users = [
+            # empty username
+            {
+                'username': '',
+                'password': 'flavour',
+                'password_confirm': 'flavour',
+                'email': 'firm1@zestedesavoir.com'
+            },
+            # space after username
+            {
+                'username': 'firm1 ',
+                'password': 'flavour',
+                'password_confirm': 'flavour',
+                'email': 'firm1@zestedesavoir.com'
+            },
+            # space before username
+            {
+                'username': ' firm1',
+                'password': 'flavour',
+                'password_confirm': 'flavour',
+                'email': 'firm1@zestedesavoir.com'
+            },
+            # username with utf8mb4 chars
+            {
+                'username': ' firm1',
+                'password': 'flavour',
+                'password_confirm': 'flavour',
+                'email': 'firm1@zestedesavoir.com'
+            }
+        ]
+
+        for user in users:
+            result = self.client.post(reverse('register-member'), user, follow=False)
+            self.assertEqual(result.status_code, 200)
+            # check any email has been sent.
+            self.assertEqual(len(mail.outbox), 0)
+            # user doesn't exist
+            self.assertEqual(User.objects.filter(username=user['username']).count(), 0)
+
     def test_register(self):
         """
         To test user registration.
@@ -672,7 +716,8 @@ class MemberTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # check email has been sent
-        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(len(mail.outbox), 1, msg="{} mail send for username {}".format(str(len(mail.outbox)),
+                                                                                        self.mas.user.username))
 
         # clic on the link which has been sent in mail
         user = User.objects.get(username=self.mas.user.username)

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -716,8 +716,7 @@ class MemberTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # check email has been sent
-        self.assertEqual(len(mail.outbox), 1, msg="{} mail send for username {}".format(str(len(mail.outbox)),
-                                                                                        self.mas.user.username))
+        self.assertEqual(len(mail.outbox), 1)
 
         # clic on the link which has been sent in mail
         user = User.objects.get(username=self.mas.user.username)

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -95,7 +95,7 @@ def validate_raw_zds_username(data):
     Check if raw username hasn't space on left or right
     """
     msg = None
-    username = data.get("username", None)
+    username = data.get('username', None)
     if username is None:
         msg = _('Le nom d\'utilisateur n\'est pas fourni')
     elif username != username.strip():

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -80,14 +80,27 @@ def validate_zds_username(value, check_username_available=True):
     user_count = User.objects.filter(username=value).count()
     if ',' in value:
         msg = _('Le nom d\'utilisateur ne peut contenir de virgules')
-    elif value != value.strip():
-        msg = _('Le nom d\'utilisateur ne peut commencer ou finir par des espaces')
     elif contains_utf8mb4(value):
         msg = _('Le nom d\'utilisateur ne peut pas contenir des caractères utf8mb4')
     elif check_username_available and user_count > 0:
         msg = _('Ce nom d\'utilisateur est déjà utilisé')
     elif not check_username_available and user_count == 0:
         msg = _('Ce nom d\'utilisateur n\'existe pas')
+    if msg is not None:
+        raise ValidationError(msg)
+
+
+def validate_raw_zds_username(data):
+    """
+    Check if raw username hasn't space on left or right
+    """
+    msg = None
+    username = data.get("username", None)
+    if username is None:
+        msg = _('Le nom d\'utilisateur n\'est pas fourni')
+    elif username != username.strip():
+        msg = _('Le nom d\'utilisateur ne peut commencer ou finir par des espaces')
+
     if msg is not None:
         raise ValidationError(msg)
 


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #5563

Cette PR permet de vérifier que le pseudo envoyé à l'inscription ne comporte pas d'espace. Le problème était du au fait qu'avant on utilisais un simple validators sur le champ. Sauf que ce validator ne s'applique que sur des données "cleanés".
Et puisque django, par défaut nettoie (et donc enlève les espaces) d'une chaine avant de l'envoyer au validateur, on ne voyais jamais le cas présenté. De plus django va nettoyer "toto  " en "toto" pour l'envoyer au validateur, mais pour crée la donne en base, il va garder "toto  ".

J'ai donc du créer une fonction qui valide les données avant clean et remonte une erreur en cas de problème.

J'ai rajouté les tests de non régressions qui vont bien pour s'assurer que ces cas ne se reproduisent plus.

### Contrôle qualité

- Démarrez le site
- Essayez de vous inscrire avec un pseudo avec espace à la fin ou au début
- Constatez que vous obtenez un message d'erreur.
