### PR TITLE
improvement/avoid-multipost-when-updating-a-tutorial: Éviter de créer des messages automatiques en doublon avec un message manuel lors de la mise à jour d'une bêta de tutoriel, en appliquant correctement la limite de 15 minutes entre deux messages

### DIFF
--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -798,7 +798,10 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto = PublishableContent.objects.get(pk=tuto.pk)
         self.assertEqual(tuto.sha_beta, current_sha_beta)
 
-        self.assertEqual(Post.objects.filter(topic=beta_topic).count(), 2)  # a new message was added !
+        # No new message added since the last time, because the last message
+        # was posted since less than 15 minutes ago.
+
+        self.assertEqual(Post.objects.filter(topic=beta_topic).count(), 1)
 
         # test if third author follow the topic
         self.assertIsNotNone(TopicAnswerSubscription.objects.get_existing(third_author, beta_topic, is_active=True))
@@ -838,7 +841,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             follow=False)
         self.assertEqual(result.status_code, 302)
 
-        self.assertEqual(Post.objects.filter(topic=beta_topic).count(), 3)  # a new message was added !
+        self.assertEqual(Post.objects.filter(topic=beta_topic).count(), 2)  # a new message was added !
         self.assertTrue(Topic.objects.get(pk=beta_topic.pk).is_locked)  # beta was inactived, so topic is locked !
 
         # then test for guest
@@ -873,7 +876,10 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto = PublishableContent.objects.get(pk=tuto.pk)
         self.assertEqual(tuto.sha_beta, old_sha_beta)
 
-        self.assertEqual(Post.objects.filter(topic=beta_topic).count(), 4)  # a new message was added !
+        # No new message added since the last time, because the last message
+        # was posted since less than 15 minutes ago.
+
+        self.assertEqual(Post.objects.filter(topic=beta_topic).count(), 3)  # a new message was added !
         self.assertFalse(Topic.objects.get(pk=beta_topic.pk).is_locked)  # not locked anymore
 
         # then test for guest


### PR DESCRIPTION
Bonjour,

Lorsque la bêta de tutoriel est mise à jour, un message automatique est posté sur le sujet.

Ce message n'est pas supprimable. Il contourne également la limite de 15 minutes entre deux messages.

* Si l'auteur choisit de mettre à jour la bêta, puis de poster un message pour expliquer ses changements, il va naturellement avoir la possibilité de modifier le message automatique pour le faire (étant donné la limite de 15 minutes qui l'y contraint).

* Si cependant il choisit de poster un message pour expliquer ses changements, puis de mettre à jour la bêta (il a le droit aussi), alors il va se retrouver avec deux messages, dont un automatique,  sur son sujet, sans que ce ne soit particulièrement utile à lui ou au lecteur. En effet, actuellement, la [limite](https://github.com/zestedesavoir/zds-site/blob/76ef17d/zds/forum/models.py#L386) de 15 minutes entre deux réponses à un même sujet ne s'applique pas correctement.

Cette pull request se contente de modifier ce dernier point sur ce dernier cas : la limite sera appliquée correctement lors de la création d'un nouveau message de réponse automatique.

## Contrôle qualité

Les étapes suivantes peuvent être effectuées pour vérifier le bon fonctionnement de cette pull request :

* Créer un tutoriel.
* Mettre le tutoriel en bêta.
* Répondre au sujet concerné avec le même compte.
* Moins de 15 minutes après, mettre à jour la bêta du tutoriel.

Cordialement,