### PR TITLE
fix  : correction du bouton liste des taches lorsque la zone de texte est vide

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -125,14 +125,16 @@
         } else {
             // find checklist
             var isCheckList = true;
-            for (i = posStart.line; i <= posEnd.line; i++) {
-                if((! cm.getLine(i).match(/^- \[(.{1})\](\s*)/)) && (cm.getLine(i) !== "")) {
-                    isCheckList = false;
-                    break;
+            if (!(posStart.line == posEnd.line && posStart.ch == posEnd.ch)) {
+                for (i = posStart.line; i <= posEnd.line; i++) {
+                    if((! cm.getLine(i).match(/^- \[(.{1})\](\s*)/)) && (cm.getLine(i) !== "")) {
+                        isCheckList = false;
+                        break;
+                    }
                 }
-            }
-            if(isCheckList) {
-                ret.checklist = true;
+                if(isCheckList) {
+                    ret.checklist = true;
+                }
             }
         }
         return ret;


### PR DESCRIPTION
Numéro du ticket concerné : #5565

Cette PR corrige le ticket ci-dessus, à savoir le cas du clic sur le bouton de liste des taches quand il n y a rien dans la zone de texte.

### Contrôle qualité

- Builder le front `make build-front`
- Allez dans une zone de texte et sans rien saisir à l'intérieur, cliquez sur le bouton "liste de tache" et constatez qu'une nouvelle ligne est crée.
