### PR TITLE
Adaptation de la taille de la zone de texte en fonction du lieu

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -337,6 +337,10 @@
 
     $(".md-editor").each(function(){
         var formEditor = $(this).closest("form");
+        let minHeight = "500px";
+        if ($(this).hasClass("mini-editor")) {
+            minHeight = "200px";
+        }
 
         var customMarkdownParser = function(plainText) {
             var result;
@@ -365,7 +369,7 @@
                     delay: 1000,
                 },
                 indentWithTabs: false,
-                minHeight: "500px",
+                minHeight: minHeight,
                 placeholder: "Votre message au format Markdown",
                 promptURLs: true,
                 promptTexts: {

--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -54,7 +54,7 @@
                     <textarea
                         name="text"
                         id="text"
-                        class="md-editor"
+                        class="md-editor mini-editor"
                         {% if topic.is_locked or topic.antispam or topic.alone %}disabled{% endif %}
                         placeholder="Votre message au format Markdown"
                     >{{ text }}</textarea>

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -666,7 +666,7 @@ class HatRequestForm(forms.ModelForm):
             }),
             'reason': forms.Textarea(attrs={
                 'placeholder': _('Expliquez pourquoi vous devriez porter cette casquette (3000 caractères maximum).'),
-                'class': 'md-editor preview-source'
+                'class': 'md-editor mini-editor preview-source'
             }),
         }
 

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -12,7 +12,7 @@ class CommonLayoutEditor(Layout):
 
     def __init__(self, *args, **kwargs):
         super(CommonLayoutEditor, self).__init__(
-            Field('text', css_class='md-editor'),
+            Field('text', css_class='md-editor mini-editor'),
             HTML("<div class='message-bottom'>"),
             HTML("<div class='message-submit'>"),
             StrictButton(


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : demande de @artragis 

Cette PR adapte la taille de la zone de saisie markdown, en fonction de la ou on se trouve (rédaction de contenu ou forum/message/mp).

### Contrôle qualité

- Builder le front `make build-front` et lancez le site
- Essayer de créer un tutoriel, et constatez que la zone de texte et assez grande pour l'introduction, conclusion, extrait, etc;
- Essayez de répondre a un message du forum ou mp et constatez que la zone est plus courte.



