### PR TITLE
Change le style des signatures pour ne plus décaler les boutons

### DIFF
--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -257,8 +257,7 @@
                 border-top: 1px solid #D2D5D6;
                 padding: 3px 0 3px 10px;
                 margin: 0 10px 0 0;
-                font-size: 12px;
-                font-size: 1.2rem;
+                font-size: 1.15rem;
                 color: #999;
                 flex: 1;
                 overflow: hidden;
@@ -266,6 +265,9 @@
                 p {
                     margin: 0;
                     padding: 0;
+                    img.smiley {
+                        max-height: 1.6rem;
+                    }
                 }
 
                 a {
@@ -630,8 +632,10 @@ form.topic-message {
                     white-space: nowrap;
                     overflow: hidden;
                     text-overflow: ellipsis;
+                    img.smiley {
+                        max-height: 1.6rem;
+                    }
                 }
-
                 &.full p {
                     white-space: normal;
                 }

--- a/assets/scss/components/_user-profile.scss
+++ b/assets/scss/components/_user-profile.scss
@@ -205,15 +205,17 @@ body.userprofilepage {
                         padding: 3px 0 3px 10px;
                         margin: 0 10px 0 0;
                         font-size: 12px;
-                        font-size: 1.2rem;
+                        font-size: 1.15rem;
                         color: #999;
 
                         // FIXME duplicated from _topic_message.scss
                         p {
                             margin: 0;
                             padding: 0;
+                            img.smiley {
+                                max-height: 1.6rem;
+                            }
                         }
-
                         a {
                             color: #999;
                             transition: color $transition-duration ease, text-decoration $transition-duration ease;


### PR DESCRIPTION
fix #5198 
# QA

- sur user A mettre une signature qui vaut `:) oO :(`
- avec user A répondre à un message sur le forum
- avec user B qui est staff, visiter le message
- observez que les smiley ne sont pas excessivement grand (du moins plus petit qu'avant) et que lorsque vous passez sur "cette réponse m'a aidé", il n'y a plus d'espace blanc entre la ligne verte et la bordure de la réponse

