### PR TITLE
Corrige le titre des Unes

### DIFF
--- a/assets/scss/components/_featured-item.scss
+++ b/assets/scss/components/_featured-item.scss
@@ -51,6 +51,8 @@
              vertical-align: middle;
              height: 0;
              transition: height $transition-duration ease;
+             color: #fff;
+             border: none;
          }
 
          p {


### PR DESCRIPTION
Corrige le titre des Unes dont l'apparence a été modifié lors du passage de `h3` vers `h2` avec #5539 

**QA :**

- `make build-front`
- Vérifier que les titres des Unes s'affichent correctement par rapport à ce qu'il y a en prod actuellement