### PR TITLE
Corrige l'affichage des erreurs syntaxes lancées par gulp

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -98,6 +98,11 @@ function js() {
         'assets/js/*.js',
     ], { base: '.', sourcemaps: true })
         .pipe(gulpif(!fast, terser())) // Minifies the JS
+        .on('error', function (error) {
+          if (error.plugin.startsWith('gulp-terser')) {
+            this.emit('end')
+          }
+        })
         .pipe(concat('script.js', { newline: ';\r\n' })) // One JS file to rule them all
         .pipe(gulp.dest('dist/js/', { sourcemaps: '.' }));
 }

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -66,6 +66,8 @@ function customSassError(error) {
         })
         console.log('Original message:', error.messageFormatted)
         this.emit('end')
+    } else {
+        console.log(error.message)
     }
     // TODO: https://github.com/A-312/gulp-terser-js#can-i-use-terser-to-format-error-of-an-other-gulp-module-
 }
@@ -120,7 +122,9 @@ function js() {
         .pipe(gulpif(!fast, terser())) // Minifies the JS
         .on('error', function (error) {
           if (error.plugin.startsWith('gulp-terser')) {
-            this.emit('end')
+              this.emit('end')
+          } else {
+              console.log(error.message)
           }
         })
         .pipe(concat('script.js', { newline: ';\r\n' })) // One JS file to rule them all


### PR DESCRIPTION
@Situphen corrigé!

## Q/A : 

 - Ajouter une erreur de syntaxe dans : 
      - Un fichier js => observer que le contenu du fichier n'est plus affiché en entier ;
      - Un fichier css (sass) => observer l'aperçu des lignes de code qui s'affiche.