### PR TITLE
Utilise rel="nofollow" sur les signatures

### DIFF
--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -178,7 +178,7 @@ def emarkdown_inline(text):
     :rtype: str
     """
     rendered = emarkdown(text, inline=True)
-    return rendered
+    return mark_safe(rendered.replace('<a href=', '<a rel="nofollow" href='))
 
 
 def sub_hd(match, count):

--- a/zds/utils/tests/tests_emarkdown.py
+++ b/zds/utils/tests/tests_emarkdown.py
@@ -40,7 +40,13 @@ class EMarkdownTest(TestCase):
 
         self.assertEqual(tr, expected)
 
-        # Todo: Find a way to force parsing crash or simulate it.
+    def test_emarkdown_inline_with_link(self):
+        # The goal is not to test zmarkdown but test that template tag correctly call it
+        self.context['content'] = '[zds](zestedesavoir.com)'
+        tr = Template('{% load emarkdown %}{{ content | emarkdown_inline}}').render(self.context)
+
+        expected = '<p><a rel="nofollow" href="zestedesavoir.com">zds</a></p>'
+        self.assertEqual(tr, expected)
 
     def test_shift_heading(self):
         tr = Template('{% load emarkdown %}{{ content | shift_heading_1}}').render(self.context)


### PR DESCRIPTION
fix #5276 

# QA 

- ajouter une signature qui a un lien
- poster un message sur le forum
- avec votre inspecteur vérifiez qu'elle a un rel="nofollow" sur le lien