### PR TITLE
(EasyMDE) Corrige l'envoi des formulaires avec l'attribut "required"

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -648,5 +648,7 @@
         easyMDE.codemirror.addKeyMap({
             "Cmd-Enter": submit
         })
+
+        this.removeAttribute("required");
     });
 })(jQuery);


### PR DESCRIPTION
Corrige l'envoi des formulaires avec l'attribut "required" #5594 

On enlève l'attribut `required` du `textarea`

**QA :**

- `make run`
- Vérifier qu'on peut créer un nouveau sujet
- Vérifier qu'on peut envoyer un nouveau message