### PR TITLE
(EasyMDE) Correction temporaire de la sauvegarde automatique

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -379,7 +379,7 @@
                 autosave: {
                     enabled: true,
                     uniqueId: window.location.pathname + "@" + this.getAttribute("name"),
-                    delay: 1000,
+                    delay: 5000, // FIXME: Temporary fix #5589
                 },
                 indentWithTabs: false,
                 minHeight: minHeight,


### PR DESCRIPTION
Correction temporaire de la sauvegarde automatique en attendant la correction chez EasyMDE car ce bug est très énervant. On sauvegarde toutes les 5s au lieu de 1s, ça ne me parait pas trop risqué. #5589

**QA :**

- `make run`
- Envoyer un message
- Vérifier que le message ne réapparait pas dans l'éditeur au rechargement de la page