### PR TITLE
Retire les balises HTML visibles sur la page de profil lorsqu'un membre a des abonnés

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -140,9 +140,9 @@
                             {% trans "Aucun abonné" %}
                         {% else %}
                             {% blocktrans count subscriber_count=subscriber_count %}
-                                <span class="bold">{{ subscriber_count }}</span> abonné
+                                {{ subscriber_count }} abonné
                             {% plural %}
-                                <span class="bold">{{ subscriber_count }}</span> abonnés
+                                {{ subscriber_count }} abonnés
                             {% endblocktrans %}
                         {% endif %}
                     {% endcaptureas %}


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #5605 

Le problème venait de la présence de balises pour mettre le nombre d'abonné⋅e⋅s en gras dans le texte « 12 abonnés » à droite de l'en-tête d'une page de profil. Ce texte complet n'est visible que si on est déconnecté⋅e, ou si on regarde son propre profil (sinon, seul le nombre seul est visible à côté du bouton « s'abonner »).

Le même texte (avec les balises) était utilisé pour ces deux cas où le texte complet est visible, ainsi que dans tous les cas pour l'attribut `aria-label` sur le nombre seul, afin que les lecteurs d'écrans comprennent ce qu'il veut dire (sinon, ce serait un nombre sans contexte).

Il y avait deux façons de corriger ça : retirer complètement le gras, ou le retirer juste pour `aria-label`. J'ai fait le choix de le retirer complètement, car je trouve personnellement que ça permet une meilleure cohérence graphique sur cette partie de la page de profil, nulle part graissée.

### Contrôle qualité

- `make run-back`
- Se connecter avec `admin`.
- Aller sur la page de profil de `user` et le suivre.
    - Actualiser la page, et vérifier que l'affichage est toujours correct (pas de balises HTML).
- Aller sur la page de `user1` (ou de n'importe quel autre membre) et le suivre.
- Se déconnecter puis se connecter avec `user`.
- Aller sur sa propre page de profil (de `user`, donc). Vérifier que l'affichage est correct. Il ne devrait pas y avoir de gras sur le compteur d'abonnés.
- Aller sur la page de profil de `user1` (ou quelque soit l'autre membre utilisé). Vérifier que l'affichage est correct. S'abonner. Vérifier que l'affichage est toujours correct après un rafraîchissement de la page.

_Closes #5605_