### PR TITLE
Ensure that a serif font is used on all kinds of tables generated by users through the Markdown parser

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -24,6 +24,8 @@
         p,
         > a,
         p a,
+        th,
+        td,
         ul:not(.pagination),
         ol:not(.summary-part) {
             font-family: $font-serif;


### PR DESCRIPTION
Bonjour,

Actuellement, il existe plusieurs types de tableaux Markdown générés par le [parser Markdown de ZdS](https://github.com/zestedesavoir/zmarkdown). Le soucis est que certains mettent des balises `<p>` à l'intérieur des balises `<td>` et `<th>`, et d'autres non, ce qui fait qu'ils ont un aspect différent : cela parce que la classe CSS qui applique une police « sans-serif » sur le contenu écrit par les rédacteurs n'est appliquée que sur les `<p>`.

Illustration : si j'essaie de poster ce contenu :

```markdown


| Parfum  | Teinte |
|---------|--------|
| Vanille | Blanc  |
| Citron  | Soleil |
| Fraise  | Rose   |


+---------+--------+
| Parfum  | Teinte |
+=========+========+
| Vanille | Blanc  |
+---------+--------+
| Citron  | Soleil |
+---------+--------+
| Fraise  | Rose   |
+---------+--------+


```

Cela donne :

![image](https://user-images.githubusercontent.com/25437947/72829711-98c85380-3c7f-11ea-964c-95bbc7dfca24.png)


Les proportions des fontes utilisées sont notamment différentes.

Cette pull request vise à corriger ce soucis.


### Contrôle qualité

Le payload ci-dessus permet de vérifier les changements.

Cordialement,