### PR TITLE
Accessibilité et performance: follow up des conseils dareboost

### DIFF
--- a/assets/js/userprofile-bio.js
+++ b/assets/js/userprofile-bio.js
@@ -8,7 +8,7 @@
 (function($, undefined) {
     "use strict";
 
-    var $bioContainer = $("body.userprofilepage .user-bio-and-activity .bio-container");
+    var $bioContainer = $("body.userprofilepage .bio-container");
     if (!$bioContainer[0]) return; // We are not on a profile page
 
     var $bioTextContainer = $bioContainer.find(".message-content");

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -6,7 +6,9 @@
 
 .main .content-container {
     padding-top: 30px;
-
+    button.ico-search {
+        font-size: 0px;
+    }
     h1,
     h2 {
         font-size: 22px;

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -124,7 +124,7 @@
                                 <label for="id_q" class="control-label">{% trans 'Recherche' %}</label>
                                 <input id="id_q" maxlength="150" name="q" required="required" type="search" placeholder="dans l'activité du membre (prochainement)" readonly>
                                 <input type="hidden" name="models" value="content">
-                                <button class="btn ico-after ico-search" type="submit" title="{% trans 'Rechercher' %}"></button>
+                                <button class="btn ico-after ico-search" type="submit" title="{% trans 'Rechercher' %}"><span>{% trans 'Rechercher' %}</span></button>
                             </form>
 
                             <aside class="under-search">

--- a/templates/searchv2/includes/publishedcontent.part.html
+++ b/templates/searchv2/includes/publishedcontent.part.html
@@ -16,7 +16,7 @@
         </h3>
     </a>
 
-    <p class="content-description">
+    <p class="content-description" {% if not search_result.text and not search_result.description %}aria-hidden="true"{% endif %}>
         {% if search_result.text %}
             {% highlight search_result "text" %}
         {% else %}

--- a/templates/tutorialv2/includes/content_item.part.html
+++ b/templates/tutorialv2/includes/content_item.part.html
@@ -77,7 +77,7 @@
                 {{ content_title }}
             </h3>
 
-            <p class="content-description">
+            <p class="content-description" {% if not show_description or not content_subtile %}aria-hidden="true"{% endif %}>
                 {% if content_subtitle and show_description %}
                     {{ content_subtitle }}
                 {% endif %}

--- a/templates/tutorialv2/includes/content_item.part.html
+++ b/templates/tutorialv2/includes/content_item.part.html
@@ -77,7 +77,7 @@
                 {{ content_title }}
             </h3>
 
-            <p class="content-description" {% if not show_description or not content_subtile %}aria-hidden="true"{% endif %}>
+            <p class="content-description" {% if not show_description or not content_subtitle %}aria-hidden="true"{% endif %}>
                 {% if content_subtitle and show_description %}
                     {{ content_subtitle }}
                 {% endif %}

--- a/templates/tutorialv2/view/base_categories.html
+++ b/templates/tutorialv2/view/base_categories.html
@@ -126,7 +126,7 @@
                                         <input type="hidden" name="subcategory" value="{{ subcategory.slug }}">
                                     {% endif %}
                                 {% endif %}
-                                <button class="btn ico-after ico-search" type="submit" title="Rechercher"></button>
+                                <button class="btn ico-after ico-search" type="submit" title="Rechercher"><span>{% trans 'Rechercher' %}</span></button>
                             </form>
                         </div>
                     {% endif %}

--- a/zds/searchv2/forms.py
+++ b/zds/searchv2/forms.py
@@ -65,7 +65,7 @@ class SearchForm(forms.Form):
 
         self.helper.layout = Layout(
             Field('q'),
-            StrictButton('', type='submit', css_class='ico-after ico-search', title=_('Rechercher')),
+            StrictButton(_('Rechercher'), type='submit', css_class='ico-after ico-search', title=_('Rechercher')),
             Field('category'),
             Field('subcategory'),
             Field('from_library')


### PR DESCRIPTION
J'ai lancé une analyse sur le site dareboost.com

Globalement nos résultats sont bons, mais on a quelques points d'amélioration:

- interdit de mettre des `<button>` et `<p>` vide car ça gène les lecteurs d'écran
- un sélecteur JS qui est pas assez performant
- quelques autres (que je ne gère pas ici)

# QA

- Publier un tuto sans lui donner de description
- Sur la page d'accueil regarder le cartouche du tuto, ouvrez l'inspecteur
- le `<p class="content-description">` aun aria-hidden
- ajouter une description et publier
- Sur la page d'accueil regarder le cartouche du tuto, ouvrez l'inspecteur
- le `<p class="content-description">` n'a PAS de aria-hidden