### PR TITLE
Corrige la mauvaise description (inversion mini et moyen-tuto)

### DIFF
--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -180,7 +180,7 @@
                     </li>
                     <li>
                         <a href="{% url "content:create-extract" content.pk content.slug child.slug %}">{% trans "Ajouter une section" %}</a>
-                        {% trans " pour adopter le format mini-tuto, composé uniquement de sections." %}
+                        {% trans " pour adopter le format moyen-tuto, composé uniquement de sections." %}
                     </li>
                 </ul>
             {% endif %}

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -164,6 +164,7 @@
                                     {%  else %}
                                         {% url "content:create-extract" content.pk content.slug container.parent.slug %}
                                     {%  endif %}">{% trans "Ajouter une section" %}</a>
+                            {% trans " pour adopter le format moyen-tuto, composé uniquement de sections." %}
                         </li>
                     </ul>
                 {% endif %}


### PR DESCRIPTION
Un moyen tuto c'est : chapitre + section, je me suis trompé dans la description des boutons, et il manquait une description pour un bouton.

Pour Q/A : 
 - Être sur la racine du tuto: /contenus/31/big-tuto/
 - Être sur l'url d'un chapitre (container) vide: /big-tuto/partie-vide/