### PR TITLE
Corrige la formulation d'une phrase

### DIFF
--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -76,7 +76,7 @@
         {% if count_contributions > 0 %}
         <br/>
         <span class="authors-label">
-            {% trans "La publication de ce contenu a necessité l'intervention de" %} <a href="#view-contributions" class="open-modal">{{ count_contributions }} {% trans "contributeur" %}{{ count_contributions|pluralize }}</a>
+            {% trans "Ce contenu a bénéficié des apports de" %} <a href="#view-contributions" class="open-modal">{{ count_contributions }} {% trans "contributeur" %}{{ count_contributions|pluralize }}</a>
         </span>
         <div class="modal modal-flex" id="view-contributions">
             <table>


### PR DESCRIPTION
Corrige la formulation d'une phrase, suite à [une suggestion sur le forum](https://zestedesavoir.com/billets/3417/chronique-zest-of-dev-16/#p214621) :

> L’ajout des contributeurs est une super fonctionnalité, mais je trouve la formulation "La publication de ce contenu a nécessité l’intervention de 2 contributeurs" un peu maladroite. Elle donne l’impression qu’ils ont débloqué un truc majeur à l’étape de publication, et que sans leur aide la publication n’aurait pas été possible.
> 
> Proposition alternative: "Ce contenu a bénéficié des apports de 2 contributeurs", plus neutre.
