### PR TITLE
(EasyMDE) Mise à jour des icônes vers Font Awesome 5

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -119,6 +119,8 @@ function js() {
     require.resolve('moment/locale/fr.js'),
     require.resolve('chart.js/dist/Chart.js'),
     require.resolve('easymde/dist/easymde.min.js'),
+    require.resolve('@fortawesome/fontawesome-free/js/all.js'),
+    require.resolve('@fortawesome/fontawesome-free/js/v4-shims.js'),
     // Used by other scripts, must be first
     'assets/js/modal.js',
     'assets/js/tooltips.js',

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -365,6 +365,7 @@
     /* global EasyMDE */
     var easyMDE = new EasyMDE({
       element: this,
+      autoDownloadFontAwesome: false,
       autosave: {
         enabled: true,
         uniqueId: window.location.pathname + '@' + this.getAttribute('name'),

--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -121,7 +121,7 @@
         }
     }
     [type=submit],
-    button:not(.link),
+    :not(.editor-toolbar) > button:not(.link),
     .btn {
         position: relative;
         height: 40px;

--- a/assets/scss/components/_editor.scss
+++ b/assets/scss/components/_editor.scss
@@ -1,24 +1,16 @@
-.content-container {
-    form {
-        .editor-toolbar {
-            border: 0;
+.editor-toolbar {
+    border: 0;
 
-            button:not(.link) {
-                height: auto;
-                line-height: 0px;
-                color: #000;
-                padding: 0;
-                display: inline;
-                float: unset;
-            }
-        }
-
-        .CodeMirror {
-            width: 100%;
-        }
-
-        .editor-preview {
-            background-color: #FDFDFD;
-        }
+    button {
+        display: inline;
+        font-size: 16px;
     }
+}
+
+.CodeMirror {
+    width: 100%;
+}
+
+.editor-preview {
+    background-color: #FDFDFD;
 }

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
   },
   "homepage": "https://github.com/zestedesavoir/zds-site",
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.12.0",
     "autoprefixer": "^9.7.2",
     "chart.js": "^2.9.3",
     "cookies-eu-banner": "^2.0.1",
     "cssnano": "4.1.10",
     "del": "5.1.0",
+    "easymde": "^2.9.0",
     "gulp": "^4.0.2",
     "gulp-concat": "2.6.1",
     "gulp-if": "^3.0.0",
@@ -43,8 +45,7 @@
     "jquery": "3.4.1",
     "katex": "0.10.1",
     "moment": "^2.24.0",
-    "normalize.css": "8.0.1",
-    "easymde": "^2.9.0"
+    "normalize.css": "8.0.1"
   },
   "devDependencies": {
     "eslint-config-standard": "~14.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@fortawesome/fontawesome-free@^5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.0.tgz#8ceb9f09edfb85ea18a6c7bf098f6f5dd5ffd62b"
+  integrity sha512-vKDJUuE2GAdBERaQWmmtsciAMzjwNrROXA5KTGSZvayAsmuTGjam5z6QNqNPCwDfVljLWuov1nEC3mEQf/n6fQ==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"


### PR DESCRIPTION
- Mise à jour des icônes vers Font Awesome 5 (avec la compatibilité Font Awesome 4 pour les classes CSS)
- Amélioration du codeCSS
  - Icônes plus grandes (16 px) car sinon le rendu n'est pas beau (c'est déjà le cas actuellement avec Font Awesome 4)
  - Bouton avec bordure au survol (style par défaut de EasyMDE)

![Aperçu de l'éditeur](https://user-images.githubusercontent.com/6664636/73223616-06382080-4167-11ea-9988-f0ee9d24a4d2.png)

**QA** :

- `source zdsenv/bin/activate` puis `make install-front` puis `make build-front` puis `make run-back`
- Vérifier l'affichage des icônes de l'éditeur sur ordinateur et sur mobile