### PR TITLE
passe le nombre de sujets sur la page profile à 6

### DIFF
--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -199,7 +199,7 @@ ZDS_APP = {
         'beta_forum_id': zds_config.get('publications_being_written_forum_id', 1),
         'max_post_length': 1000000,
         'top_tag_max': 5,
-        'home_number': 5,
+        'home_number': 6,
         'old_post_limit_days': 90,
         # Exclude tags from top tags list. Tags listed here should not be relevant for most of users.
         # Be warned exclude too much tags can restrict performance


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #5614

### Contrôle qualité

- Demarrez le site
- Connectez vous avec user
- Créez plus de 6 sujets et vérifiez que sur sa page de profile, il y a bien 6 sujets maxium qui sont affichés.
