### PR TITLE
Corrige le message du bandeau des cookies

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -172,7 +172,7 @@
 
         <div id="cookies-eu-banner">
             <p>
-                {% trans "Nous souhaitons déposer des cookies à des fins de mesure d'audience avec Google Analytics. Vous êtes libre d'accepter ou de refuser. En poursuivant votre navigation sur ce site sans exprimer votre choix, vous autorisez la mesure d'audience." %}
+                {% trans "Nous souhaitons déposer des cookies à des fins de mesure d'audience avec Google Analytics. Vous êtes libre d'accepter ou de refuser." %}
             </p>
             <a href="/pages/cookies" id="cookies-eu-more">{% trans "En savoir plus" %}</a>
             <button id="cookies-eu-accept">{% trans "Accepter" %}</button>


### PR DESCRIPTION
Suite à #5476, on attend explicitement que l'utilisateur accepte ou rejette les cookies. La phrase "En poursuivant votre navigation sur ce site sans exprimer votre choix, vous autorisez la mesure d'audience." ne sert donc à rien.