### PR TITLE
Amélioration de la gestion des sanctions

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -685,7 +685,7 @@
                                     </button>
                                 </form>
                                 <a href="#ls-{{ profile.pk }}" class="open-modal tail">
-                                    <p>{% trans "Lecture seule" %}</p>
+                                    <p>{% trans "Lecture seule définitive" %}</p>
                                 </a>
                                 <form action="{% url "member-modify-profile" profile.user.pk %}"
                                       method="post"
@@ -706,7 +706,16 @@
                                 </form>
                             {% else %}
                                 <a href="#ls-temp-{{ profile.pk }}" class="open-modal tail">
-                                    <p>{% trans "Ôter la lecture seule" %}</p>
+                                    <p>
+                                        {% trans "Ôter la lecture seule" %}<br/>
+                                        {% if profile.end_ban_write %}
+                                            {% blocktrans with time_until_end_ban_write=profile.end_ban_write|timeuntil %}
+                                                (il reste {{ time_until_end_ban_write }})
+                                            {% endblocktrans %}
+                                        {% else %}
+                                            {% trans "(illimitée)" %}
+                                        {% endif %}
+                                    </p>
                                 </a>
                                 <form action="{% url "member-modify-profile" profile.user.pk %}"
                                       method="post"
@@ -779,7 +788,16 @@
                                 </form>
                             {% else %}
                             <a href="#unban-{{ profile.pk }}" class="open-modal tail">
-                                <p>{% trans "Ôter le bannissement" %}</p>
+                                <p>
+                                    {% trans "Ôter le bannissement" %}<br/>
+                                    {% if profile.end_ban_read %}
+                                        {% blocktrans with time_until_end_ban_read=profile.end_ban_read|timeuntil %}
+                                             (il reste {{ time_until_end_ban_read }})
+                                        {% endblocktrans %}
+                                    {% else %}
+                                        {% trans "(illimité)" %}
+                                    {% endif %}
+                                </p>
                             </a>
                             <form action="{% url "member-modify-profile" profile.user.pk %}"
                                   method="post"

--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -171,10 +171,9 @@ class MemberSanctionState(object):
         """
         return _('Bonjour **{0}**,\n\n'
                  '**Bonne nouvelle**, la sanction qui '
-                 'pesait sur vous a été levée par **{1}**.\n\n'
-                 'Ce qui signifie que {3}\n\n'
-                 'Le motif est :\n\n'
+                 'pesait sur vous a été levée par **{1}** pour la raison suivante :\n\n'
                  '> {4}\n\n'
+                 'Cela signifie que {3}\n\n'
                  'Cordialement, \n\n L\'équipe {5}.')
 
     def get_message_sanction(self):
@@ -185,10 +184,9 @@ class MemberSanctionState(object):
         :rtype: ugettext_lazy
         """
         return _('Bonjour **{0}**,\n\n'
-                 'Vous avez été santionné par **{1}**.\n\n'
-                 'La sanction est de type *{2}*, ce qui signifie que {3}\n\n'
-                 'Le motif de votre sanction est :\n\n'
+                 'Vous avez été sanctionné par **{1}** pour la raison suivante :\n\n'
                  '> {4}\n\n'
+                 'La sanction est de type *{2}*, ce qui signifie que {3}\n\n'
                  'Cordialement, \n\nL\'équipe {5}.')
 
     def notify_member(self, ban, msg):
@@ -221,14 +219,14 @@ class ReadingOnlySanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _('Lecture Seule')
+        return _('Lecture seule illimitée')
 
     def get_text(self):
         return self.array_infos.get('ls-text', '')
 
     def get_detail(self):
         return (_('vous ne pouvez plus poster dans les forums, ni dans les '
-                  'commentaires d\'articles et de tutoriels.'))
+                  'commentaires d\'articles et de tutoriels jusqu\'à nouvel ordre.'))
 
     def apply_sanction(self, profile, ban):
         profile.end_ban_write = None
@@ -243,7 +241,8 @@ class TemporaryReadingOnlySanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _('Lecture Seule Temporaire')
+        jrs = int(self.array_infos.get('ls-jrs'))
+        return _('Lecture seule temporaire ({0} jour{1})').format(jrs, pluralize(jrs))
 
     def get_text(self):
         return self.array_infos.get('ls-text', '')
@@ -251,7 +250,7 @@ class TemporaryReadingOnlySanction(MemberSanctionState):
     def get_detail(self):
         jrs = int(self.array_infos.get('ls-jrs'))
         return (_('vous ne pouvez plus poster dans les forums, ni dans les '
-                  'commentaires d\'articles et de tutoriels pendant {0} jour{1}.')
+                  'commentaires d\'articles et de tutoriels pendant {0} jour{1}.')
                 .format(jrs, pluralize(jrs)))
 
     def apply_sanction(self, profile, ban):
@@ -268,7 +267,7 @@ class DeleteReadingOnlySanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _("Autorisation d'écrire")
+        return _("Levée de la lecture seule")
 
     def get_text(self):
         return self.array_infos.get('unls-text', '')
@@ -290,13 +289,13 @@ class BanSanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _('Ban définitif')
+        return _('Bannissement illimité')
 
     def get_text(self):
         return self.array_infos.get('ban-text', '')
 
     def get_detail(self):
-        return _('vous ne pouvez plus vous connecter sur {0}.') \
+        return _('vous ne pouvez plus vous connecter sur {0} jusqu\'à nouvel ordre.')\
             .format(settings.ZDS_APP['site']['literal_name'])
 
     def apply_sanction(self, profile, ban):
@@ -312,14 +311,15 @@ class TemporaryBanSanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _('Ban Temporaire')
+        jrs = int(self.array_infos.get('ban-jrs'))
+        return _('Bannissement temporaire ({0} jour{1})').format(jrs, pluralize(jrs))
 
     def get_text(self):
         return self.array_infos.get('ban-text', '')
 
     def get_detail(self):
         jrs = int(self.array_infos.get('ban-jrs'))
-        return (_('vous ne pouvez plus vous connecter sur {0} pendant {1} jour{2}.')
+        return (_('vous ne pouvez plus vous connecter sur {0} pendant {1} jour{2}.')
                 .format(settings.ZDS_APP['site']['literal_name'],
                         jrs,
                         pluralize(jrs)))
@@ -338,7 +338,7 @@ class DeleteBanSanction(MemberSanctionState):
     """
 
     def get_type(self):
-        return _('Autorisation de se connecter')
+        return _('Levée du bannissement')
 
     def get_text(self):
         return self.array_infos.get('unban-text', '')

--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -207,8 +207,8 @@ class MemberSanctionState(object):
             ban.type,
             '',
             msg,
-            True,
-            direct=True,
+            send_by_mail=True,
+            direct=False,
             hat=get_hat_from_settings('moderation'),
         )
 


### PR DESCRIPTION
Changements :

* ajoute la durée restante des sanctions (lecture seule, ban) sur le profil d'un sanctionné dans l'encart de modération ;
* améliore l'historique de modération et les MP de notification (affichage de la durée de la sanction, reformulations) ;
* corrige l'absence de notifications pour les MP de sanction (l'hypothèse que le membre n'en a pas besoin est fausse, puisqu'il peut être amené à revenir, même s'il est banni pour une durée indéterminée).

Fix #5598 

### Contrôle qualité
Pour l'affichage de la durée restante :

* En tant que staff, infliger une lecture seule temporaire et constater que la durée de sanction restante s'affiche en dessous de "Ôter la lecture seule".
* En tant que staff, infliger une lecture seule définitive et constater que "illimitée" s'affiche en dessous de "Ôter la lecture seule".
* En tant que staff, infliger un bannissement temporaire et constater que la durée de sanction restante s'affiche en desous de "Ôter le bannissement".
* En tant que staff, mettre quelqu'un en lecture seule et constater que "illimité" s'affiche en dessous de "Ôter le bannissement".

Pour l'historique de modération :

* En tant que staff, infliger une lecture seule temporaire, puis constater que l'historique de modération fait figurer la durée totale de la sanction dans sa description.
* En tant que staff, infliger un bannissement temporaire, puis constater que l'historique de modération fait figurer la durée totale de la sanction dans sa description.

Pour l'amélioration des MP :

* En tant que membre sanctionné, après avoir subit une lecture seule temporaire, vérifier que :
    * un MP non lu est bien notifié dans le header,
    * le MP de notification comporte la durée de sanction temporaire dans le titre,
    * que son contenu est correct.
* En tant que membre sanctionné, après avoir subit un bannissement temporaire (et avoir été débanni évidemment), vérifier que :
    * un MP non lu est bien notifié dans le header,
    * le MP de notification comporte la durée de sanction temporaire dans le titre,
    * que son contenu est correct.

Les MP de notification sont *a priori* accompagnés d'emails, mais je ne sais pas les tester.