### PR TITLE
Évite d'ajouter un auteur en double au MP de validation quand il est aussi validateur

### DIFF
--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -1900,7 +1900,8 @@ class AddAuthorToContent(LoggedWithReadWriteHability, SingleContentFormViewMixin
         for user in form.cleaned_data['users']:
             if user.pk not in all_authors_pk and user != self.request.user:
                 self.object.authors.add(user)
-                if self.object.validation_private_message:
+                if self.object.validation_private_message\
+                   and not self.object.validation_private_message.is_participant(user):
                     self.object.validation_private_message.participants.add(user)
                 all_authors_pk.append(user.pk)
                 url_index = reverse(self.object.type.lower() + ':find-' + self.object.type.lower(), args=[user.pk])


### PR DESCRIPTION
Fix #5602.

Cette PR règle le bug, mais pas la cause racine (voir #5654).

### Contrôle qualité

* En tant que staff, réserver un contenu pour créer le MP de validation.
* En tant qu'auteur du contenu, ajouter staff en tant qu'auteur.
* Aller dans le MP de validation et constater que staff n'est listé qu'une fois.