### PR TITLE
Correction : retire un morceau de template inutile pour les MP (fix #5133)

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -173,11 +173,12 @@
                     {% trans "Reprise du dernier message de la page précédente" %}
                 </p>
             {% endif %}
-            <p class="message-helpful tick ico-after green {% if not message.is_useful or not message.is_visible %}hidden{% endif %}"
-               data-ajax-output="mark-message-as-useful">
-                {% trans "Cette réponse a aidé l’auteur du sujet" %}
-            </p>
-
+            {% if not is_mp %}
+                <p class="message-helpful tick ico-after green {% if not message.is_useful or not message.is_visible %}hidden{% endif %}"
+                   data-ajax-output="mark-message-as-useful">
+                    {% trans "Cette réponse a aidé l’auteur du sujet" %}
+                </p>
+            {% endif %}
             {% if message.is_visible != False %}
                 <div itemprop="text">
                     {{ message.text_html|safe }}


### PR DESCRIPTION
Fix #5133.

### Contrôle qualité

Se connecter avec n'importe quel compte et regarder que le HTML ne contient plus la partie "Cette réponse m'a aidé".