### PR TITLE
Marquer un MP non lu (fix #5212)

### DIFF
--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -63,9 +63,9 @@
                     </p>
                 {% endwith %}
                 <p class="topic-last-answer">
-                    {% with answer=topic.get_last_answer %}
+                    {% with answer=topic.get_last_answer last_read_url=topic.resolve_last_read_post_absolute_url %}
                         {% if answer %}
-                            <a href="{{ answer.get_absolute_url }}">
+                            <a href="{{ last_read_url }}">
                                 <span class="topic-last-answer-long-date">
                                     {% trans "Dernière réponse" %}
                                     <br>

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -66,13 +66,19 @@
                 {% url "private-posts-new" topic.pk topic.slug %}?cite={{ message.pk }}
             {% endcaptureas %}
 
+            {% if forloop.first and page_obj.number > 1 %}
+                {% set True as is_repeated_message %}
+            {% else %}
+                {% set False as is_repeated_message %}
+            {% endif %}
+
             {% if topic.last_message.pk == message.pk %}
                 {% set True as can_edit %}
             {% else %}
                 {% set False as can_edit %}
             {% endif %}
 
-            {% include "misc/message.part.html" with can_hide=False is_mp=True %}
+            {% include "misc/message.part.html" with can_hide=False is_mp=True can_unread=True %}
         {% endfor %}
     </div>
 

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -66,6 +66,10 @@
                 {% url "private-posts-new" topic.pk topic.slug %}?cite={{ message.pk }}
             {% endcaptureas %}
 
+            {% captureas unread_link %}
+                {% url "private-post-unread" %}?message={{ message.pk }}
+            {% endcaptureas %}
+
             {% if forloop.first and page_obj.number > 1 %}
                 {% set True as is_repeated_message %}
             {% else %}

--- a/zds/mp/commons.py
+++ b/zds/mp/commons.py
@@ -1,6 +1,12 @@
 from datetime import datetime
 
+from django.views.generic.detail import SingleObjectMixin
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+
+from zds.mp.models import PrivateTopicRead, PrivatePost
 from zds.utils.templatetags.emarkdown import emarkdown
+from zds.notification import signals
 
 
 class LeavePrivateTopic(object):
@@ -36,3 +42,41 @@ class UpdatePrivatePost(object):
         instance.update = datetime.now()
         instance.save()
         return instance
+
+    @staticmethod
+    def perform_unread_private_post(post, user):
+        """
+        Mark the private post as unread. If it is in first position, the whole topic is marked as unread.
+        """
+        # mark the previous post as read
+        try:
+            previous_post = PrivatePost.objects.get(privatetopic=post.privatetopic,
+                                                    position_in_topic=post.position_in_topic - 1)
+            # update the record, if it exists
+            try:
+                topic = PrivateTopicRead.objects.get(privatetopic=post.privatetopic, user=user)
+                topic.privatepost = previous_post
+            # no existing record to update, create a new record
+            except PrivateTopicRead.DoesNotExist:
+                topic = PrivateTopicRead(privatepost=previous_post, privatetopic=post.privatetopic, user=user)
+            topic.save()
+        # no previous post to mark as read, remove the topic from read list instead
+        except PrivatePost.DoesNotExist:
+            try:
+                topic = PrivateTopicRead.objects.get(privatetopic=post.privatetopic, user=user)
+                topic.delete()
+            except PrivateTopicRead.DoesNotExist:  # record already removed, nothing to do
+                pass
+
+        signals.answer_unread.send(sender=post.privatetopic.__class__, instance=post, user=user)
+
+
+class SinglePrivatePostObjectMixin(SingleObjectMixin):
+    object = None
+
+    def get_object(self, queryset=None):
+        try:
+            post_pk = int(self.request.GET.get('message'))
+        except (KeyError, ValueError, TypeError):
+            raise Http404
+        return get_object_or_404(PrivatePost, pk=post_pk)

--- a/zds/mp/urls.py
+++ b/zds/mp/urls.py
@@ -2,7 +2,7 @@ from django.urls import re_path
 
 from zds.mp.views import PrivateTopicList, PrivatePostList, PrivateTopicNew, PrivateTopicAddParticipant, \
     PrivateTopicLeaveDetail, PrivateTopicLeaveList, \
-    PrivatePostAnswer, PrivatePostEdit, PrivateTopicEdit
+    PrivatePostAnswer, PrivatePostEdit, PrivatePostUnread, PrivateTopicEdit
 
 
 urlpatterns = [
@@ -26,4 +26,5 @@ urlpatterns = [
             PrivatePostAnswer.as_view(), name='private-posts-new'),
     re_path(r'^(?P<topic_pk>\d+)/(?P<topic_slug>.+)/messages/(?P<pk>\d+)/editer/$',
             PrivatePostEdit.as_view(), name='private-posts-edit'),
+    re_path(r'^message/nonlu/$', PrivatePostUnread.as_view(), name='private-post-unread'),
 ]

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -168,6 +168,22 @@ def mark_pm_reactions_read(sender, *, user, instance, **__):
         subscription.mark_notification_read()
 
 
+@receiver(answer_unread, sender=PrivateTopic)
+def unread_private_topic_event(sender, *, user, instance, **__):
+    """
+    Send a notification to the user, without sending an email, when a private post is marked as unread.
+
+    :param instance: the private post being marked as unread
+    :param user: the user marking the answer as unread
+
+    """
+    private_post = instance
+
+    subscription = PrivateTopicAnswerSubscription.objects.get_existing(user, private_post.privatetopic, is_active=True)
+    if subscription:
+        subscription.send_notification(content=private_post, sender=private_post.author, send_email=False)
+
+
 @receiver(content_read, sender=ContentReaction)
 @receiver(content_read, sender=Post)
 def mark_comment_read(sender, *, instance, user, **__):


### PR DESCRIPTION
Changements :

* ajoute la possibilité de marquer des MP comme non lus ;
* correction: affiche le MP repris de la page précédente avec le bon style.

Fix #5212

### Contrôle qualité

Pour tester le marquage des MP comme non lus, en tant qu'utilisateur connecté ayant des MP :

* lire un MP non lu, retourner sur la liste des MP et constater qu'il est lu ;
* aller dans un MP lu, cliquer sur "non lu" sur un des messages (pas le premier) :
     * constater qu'on est renvoyé vers la liste des MP,
     * constater que le message est en gras (non lu donc),
     * constater que le lien indiquant le dernier message pointe vers le dernier MP non lu (celui précédent le message cliqué comme "non lu")
* faire pareil avec le message en première position et constater la même chose ;
* tester que la pagination est aussi bien gérée sur les longs MP.

Pour la correction du style du message repris de la page précédente :
* faire un long MP (> 21 message chez moi) pour avoir de la pagination ;
* constater que la deuxième page qui apparaît a bien son premier message avec le style gris et le message "Reprise [...]".