### PR TITLE
Enlève la ligne de debug de firm1

### DIFF
--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -108,7 +108,7 @@
                             {%  else %}
                                 {% url "content:create-extract" content.pk content.slug child.parent.slug child.slug %}
                             {%  endif %}">
-                        {% trans "Ajouter une section a" %}
+                        {% trans "Ajouter une section" %}
                     </a>
                 </li>
             {% endif %}


### PR DESCRIPTION
Remarquer l'absence de "Ajouter une section a"

![image](https://user-images.githubusercontent.com/18501150/76346876-013dc380-6306-11ea-817b-359fcfa8e6b3.png)

*Pour l'histoire : Au début je m'étais accusé pour cette erreur (mais il me semblait avoir déjà corrigé une erreur similaire), puis je suis allé voir pour me dégrever de cette erreur. Au final, ce n'était effectivement pas moi ! 😝 Le nom de la PR n'a aucune animosité, il s'agit juste d'un amusement/blague.*