### PR TITLE
Met à jour GitPython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ lxml==4.4.2
 factory-boy==2.8.1
 pygeoip==0.3.2
 Pillow==7.0.0
-GitPython==3.0.5
+GitPython==3.1.0
 easy-thumbnails==2.7
 beautifulsoup4==4.8.2
 django-recaptcha==2.0.5
@@ -22,9 +22,6 @@ google-api-python-client==1.7.11
 toml==0.10.0
 requests==2.22.0
 homoglyphs==1.3.5
-
-# Unknown but missing during installation
-gitdb==0.6.4
 
 # Api dependencies
 djangorestframework==3.11.0


### PR DESCRIPTION
Il y a eu des soucis entre `GitPython` et sa dépendance `gitdb` qui existe aussi sous le nom `gitdb2`, ce qui a causé pour nous l'erreur `ModuleNotFoundError: No module named 'gitdb.exc'` décrite dans #5667 (soucis identique au ticket https://github.com/gitpython-developers/GitPython/issues/983). C'est normalement résolu avec les versions récentes. Les changements sont vraiment mineurs (voir [la liste des changements](https://github.com/gitpython-developers/GitPython/blob/master/doc/source/changes.rst)), on ne devrait pas avoir de soucis.

Closes #5667

**QA :**

- `source zdsenv/bin/activate` puis `make install-back` puis `make run-back`
- Vérifier que le site web se lance et que l'édition d'un contenu fonctionne correctement
- Il faut une vérification sur **Windows** et une autre sur **Linux**