### PR TITLE
Ajout d'une ligne de debug pour l'installation sous Windows

### DIFF
--- a/scripts/win/install_zds.ps1
+++ b/scripts/win/install_zds.ps1
@@ -90,6 +90,8 @@ if (-not (Test-Path "$ZDS_SITE\zdsenv")) {
 . "$ZDS_SITE\zdsenv\Scripts\activate.ps1"
 if ($env:virtual_env -ne "$ZDS_SITE\zdsenv") {
   Error "Error: Cannot load virtualenv."
+} else {
+  PrintInfo " | -> Virtualenv loaded: $VIRTUAL_ENV"
 }
 
 


### PR DESCRIPTION
cette ligne permet de s'assurer que le virtualenv est le bon

Q/A:

Vérifier sa présence en faisant : `powershell scripts/win/install_zds.ps1`. On devrait avoir: `  | -> Virtualenv loaded: <path>/zdsenv/`