### PR TITLE
Met à jour les dépendances Python

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
 -r requirements.txt
 
-coverage==4.5.4
-PyYAML==5.2
-django-debug-toolbar==2.1
+coverage==5.0.4
+PyYAML==5.3.1
+django-debug-toolbar==2.2
 flake8==3.7.9
 flake8-quotes==2.1.1
-autopep8==1.4.4
-Sphinx==2.3.1
+autopep8==1.5
+Sphinx==2.4.4
 selenium==3.141.0
 sphinx_rtd_theme==0.4.3
 Faker==3.0.0
 mock==3.0.5
-colorlog==4.0.2
-django-extensions==2.2.5
+colorlog==4.1.0
+django-extensions==2.2.8

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -3,4 +3,4 @@
 gunicorn==20.0.4
 mysqlclient==1.4.6
 raven==6.10.0
-ujson==1.35
+ujson==2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,30 +5,30 @@ elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
 
 # Explicit dependencies (references in code)
-Django==2.2.9
-django-crispy-forms==1.8.1
+Django==2.2.11
+django-crispy-forms==1.9.0
 django-model-utils==4.0.0
 django-munin==0.2.1
 python-memcached==1.59
-lxml==4.4.2
+lxml==4.5.0
 factory-boy==2.8.1
 pygeoip==0.3.2
 Pillow==7.0.0
 GitPython==3.1.0
 easy-thumbnails==2.7
 beautifulsoup4==4.8.2
-django-recaptcha==2.0.5
-google-api-python-client==1.7.11
+django-recaptcha==2.0.6
+google-api-python-client==1.8.0
 toml==0.10.0
-requests==2.22.0
+requests==2.23.0
 homoglyphs==1.3.5
 
 # Api dependencies
 djangorestframework==3.11.0
 djangorestframework-xml==1.4.0
 django-filter==2.2.0
-django-oauth-toolkit==1.2.0
-drf-extensions==0.5.0
+django-oauth-toolkit==1.3.0
+drf-extensions==0.6.0
 django-rest-swagger==2.2.0
 django-cors-middleware==1.5.0
 dry-rest-permissions==0.1.10


### PR DESCRIPTION
Met à jour les dépendances Python

- Dernières mises à jour de sécurité de Django, mais qui d'après ce que j'ai lu ne nous concernent pas
- Mise à jour de Sphinx, la documentation est générée mais j'ai l'impression que de nouveaux avertissements sont apparus
- À part ça, les mises à jour sont surtout des corrections de bugs, des suppressions de supports (Py 3.4 et Django 2.0/2.1 notamment) et l'ajout de support (Py 3.8 et +)

**QA :**

- `source zdsenv/bin/activate` puis `make install-back` puis `make migrate-db` puis `make run`
- Vérifier que le site web fonctionne correctement