### PR TITLE
Corrections autour du message de signalement de faute

### DIFF
--- a/templates/tutorialv2/messages/warn_typo.md
+++ b/templates/tutorialv2/messages/warn_typo.md
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load captureas %}
 {% load feminize %}
+{% captureas level %}{{ target.get_level_as_string|lower }}{% endcaptureas %}
+{% captureas feminized %}{{"le"|feminize:level}}{% endcaptureas %}
 {% if public %}
     {% captureas content_url %} {{ content.get_absolute_url_online }} {% endcaptureas %}
     {% captureas target_url %} {{ target.get_absolute_url_online }} {% endcaptureas %}
@@ -19,7 +21,7 @@ Salut !
 
 Il me semble avoir déniché une erreur dans {{ type }} « [{{ title }}]({{ content_url }}) ».{% endblocktrans %}
 {% if target != content %}
-{% blocktrans with title=target.title|safe %}Fourbe, elle se situe sournoisement dans {{ "le"|feminize:target.get_level_as_string }} {{ target.get_level_as_string }} « [{{ title }}]({{ target_url }}) ».{% endblocktrans %}
+{% blocktrans with title=target.title|safe %}Fourbe, elle se situe sournoisement dans {{ feminized }} {{ level }} « [{{ title }}]({{ target_url }}) ».{% endblocktrans %}
 {% endif %}
 {{ text|safe }}
 {% endspaceless %}

--- a/templates/tutorialv2/messages/warn_typo.md
+++ b/templates/tutorialv2/messages/warn_typo.md
@@ -1,3 +1,4 @@
+{% spaceless %}
 {% load i18n %}
 {% load captureas %}
 {% load feminize %}
@@ -16,16 +17,9 @@
 {% blocktrans with username=user.username|safe title=content.title|safe type=type|safe %}
 Salut !
 
-Il me semble avoir déniché une erreur dans {{ type }}
-« [{{ title }}]({{ content_url }}) ».
-{% endblocktrans %}
-
+Il me semble avoir déniché une erreur dans {{ type }} « [{{ title }}]({{ content_url }}) ».{% endblocktrans %}
 {% if target != content %}
-{% blocktrans with title=target.title|safe %}
-Fourbe, elle se situe sournoisement dans 
-{{ "le"|feminize:target.get_level_as_string }} {{ target.get_level_as_string }} 
-« [{{ title }}]({{ target_url }}) ».
-{% endblocktrans %}
+{% blocktrans with title=target.title|safe %}Fourbe, elle se situe sournoisement dans {{ "le"|feminize:target.get_level_as_string }} {{ target.get_level_as_string }} « [{{ title }}]({{ target_url }}) ».{% endblocktrans %}
 {% endif %}
-
 {{ text|safe }}
+{% endspaceless %}

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -1574,10 +1574,7 @@ class WarnTypo(SingleContentFormViewMixin):
             if form.content.is_opinion:
                 _type = _('le billet')
 
-            if form.content.get_tree_depth() == 0:
-                pm_title = _('J\'ai trouvé une faute dans {} « {} ».').format(_type, form.content.title)
-            else:
-                pm_title = _('J\'ai trouvé une faute dans le chapitre « {} ».').format(form.content.title)
+            pm_title = _('J\'ai trouvé une faute dans {} « {} ».').format(_type, form.content.title)
 
             msg = render_to_string(
                 'tutorialv2/messages/warn_typo.md',


### PR DESCRIPTION
Différentes corrections autour du message de signalement de faute :

* nettoie le markdown (fix #3026),
* retire du code essentiellement inutile,
* corrige le template du message pour afficher correctement le niveau hiérarchique.

### Contrôle qualité

Pour le nettoyage du markdown, en tant qu'utilisateur connecté :
* faire une remarque sur un article,
* aller voir le MP envoyé à l'auteur,
* cliquer sur « éditer » et constater que le markdown est propre.

Pour le nettoyage du markdown et la correction du template, toujours avec le même utilisateur
* se rendre sur un big tuto dans un niveau hiérarchique bas (un chapitre typiquement),
* faire une remarque,
* aller voir le MP envoyé à l'auteur et son markdown,
* constater qu'on voit écrit "une erreur ... dans le chapitre ..." et que le markdown est propre.

On peut faire des tests similaires avec des billets aussi pour s'assurer des non-régressions. 