### PR TITLE
Refactorisation du code des MP

### DIFF
--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -27,7 +27,7 @@
     <div class="alert-box ico-after ico-alert light">
         {% trans "Vous venez de poster. Merci de patienter au moins 15 minutes entre deux messages consécutifs afin de limiter le flood." %}
     </div>
-{% elif topic.alone %}
+{% elif topic.one_participant_remaining %}
     <div class="alert-box info cross light">
         {% trans "Vous êtes seul dans cette conversation." %}
     </div>
@@ -59,7 +59,7 @@
                         name="text"
                         id="text"
                         class="md-editor mini-editor"
-                        {% if topic.is_locked or topic.antispam or topic.alone %}disabled{% endif %}
+                        {% if topic.is_locked or topic.antispam or topic.one_participant_remaining %}disabled{% endif %}
                         placeholder="Votre message au format Markdown"
                     >{{ text }}</textarea>
                     {% include 'misc/hat_choice.html' %}
@@ -72,7 +72,7 @@
                             name="preview"
                             class="btn-grey"
                             data-ajax-input="preview-message"
-                            {% if topic.is_locked or topic.antispam or topic.alone %}disabled{% endif %}
+                            {% if topic.is_locked or topic.antispam or topic.one_participant_remaining %}disabled{% endif %}
                         >
                             {% trans "Aperçu" %}
                         </button>
@@ -80,7 +80,7 @@
                         <button
                             type="submit"
                             name="answer"
-                            {% if topic.is_locked or topic.antispam or topic.alone %}disabled{% endif %}
+                            {% if topic.is_locked or topic.antispam or topic.one_participant_remaining %}disabled{% endif %}
                         >
                             {% trans "Envoyer" %}
                         </button>

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -586,17 +586,12 @@ def unregister(request):
     HatRequest.objects.filter(moderator=current).update(moderator=anonymous)
     # In case current user has been moderator in the past
     Comment.objects.filter(editor=current).update(editor=anonymous)
-    for topic in PrivateTopic.objects.filter(author=current):
-        topic.participants.remove(current)
-        if topic.participants.count() > 0:
-            topic.author = topic.participants.first()
-            topic.participants.remove(topic.author)
-            topic.save()
-        else:
+    for topic in PrivateTopic.objects.filter(Q(author=current) | Q(participants__in=[current])):
+        if topic.one_participant_remaining():
             topic.delete()
-    for topic in PrivateTopic.objects.filter(participants__in=[current]):
-        topic.participants.remove(current)
-        topic.save()
+        else:
+            topic.remove_participant(current)
+            topic.save()
     Topic.objects.filter(solved_by=current).update(solved_by=anonymous)
     Topic.objects.filter(author=current).update(author=anonymous)
 
@@ -1240,9 +1235,9 @@ def activate_account(request):
             _('Bienvenue sur {}').format(settings.ZDS_APP['site']['literal_name']),
             _('Le manuel du nouveau membre'),
             msg,
-            False,
-            True,
-            False,
+            send_by_mail=False,
+            leave=True,
+            direct=False,
             hat=get_hat_from_settings('moderation'))
     token.delete()
 
@@ -1383,8 +1378,8 @@ def settings_promote(request, user_pk):
             _('Modification des groupes'),
             '',
             msg,
-            True,
-            True,
+            send_by_mail=True,
+            leave=True,
             hat=get_hat_from_settings('moderation'),
         )
 

--- a/zds/mp/api/permissions.py
+++ b/zds/mp/api/permissions.py
@@ -29,7 +29,7 @@ class IsNotAloneInPrivatePost(permissions.BasePermission):
 
     def has_permission(self, request, view):
         private_topic = get_object_or_404(PrivateTopic, pk=view.kwargs.get('pk_ptopic'))
-        return not private_topic.alone()
+        return not private_topic.one_participant_remaining()
 
 
 class IsLastPrivatePostOfCurrentUser(permissions.BasePermission):

--- a/zds/mp/api/serializers.py
+++ b/zds/mp/api/serializers.py
@@ -62,8 +62,8 @@ class PrivateTopicCreateSerializer(serializers.ModelSerializer, TitleValidator, 
                        validated_data.get('title'),
                        validated_data.get('subtitle') or '',
                        validated_data.get('text'),
-                       True,
-                       False)
+                       send_by_mail=True,
+                       leave=False)
 
     def get_current_user(self):
         return self.context.get('request').user
@@ -126,7 +126,8 @@ class PrivatePostActionSerializer(serializers.ModelSerializer, TextValidator, Up
         author = self.context.get('view').request.user
 
         # Send post in mp
-        send_message_mp(author, topic, self.validated_data.get('text'), True, False)
+        send_message_mp(author, topic, self.validated_data.get('text'),
+                        send_by_mail=True, direct=False)
         return topic.last_message
 
     def update(self, instance, validated_data):

--- a/zds/mp/commons.py
+++ b/zds/mp/commons.py
@@ -14,17 +14,12 @@ class LeavePrivateTopic(object):
     Leave a private topic.
     """
 
-    def perform_destroy(self, instance):
-        if instance.participants.count() == 0:
-            instance.delete()
-        elif self.get_current_user().pk == instance.author.pk:
-            move = instance.participants.first()
-            instance.author = move
-            instance.participants.remove(move)
-            instance.save()
+    def perform_destroy(self, topic):
+        if topic.one_participant_remaining():
+            topic.delete()
         else:
-            instance.participants.remove(self.get_current_user())
-            instance.save()
+            topic.remove_participant(self.get_current_user())
+            topic.save()
 
     def get_current_user(self):
         raise NotImplementedError('`get_current_user()` must be implemented.')

--- a/zds/mp/decorator.py
+++ b/zds/mp/decorator.py
@@ -13,7 +13,7 @@ def is_participant(func):
     """
     def _is_participant(request, *args, **kwargs):
         private_topic = get_object_or_404(PrivateTopic, pk=kwargs.get('pk'))
-        if not request.user == private_topic.author and request.user not in list(private_topic.participants.all()):
+        if not private_topic.is_participant(request.user):
             raise PermissionDenied
         if 'cite' in request.GET:
             try:

--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -127,7 +127,7 @@ class PrivatePostForm(forms.Form):
             Hidden('last_post', '{{ last_post_pk }}'),
         )
 
-        if topic.alone():
+        if topic.one_participant_remaining():
             self.helper['text'].wrap(
                 Field,
                 placeholder=_('Vous êtes seul dans cette conversation, '

--- a/zds/mp/tests/tests_models.py
+++ b/zds/mp/tests/tests_models.py
@@ -1,11 +1,14 @@
+from math import ceil
+
 from django.test import TestCase
 from django.urls import reverse
-from math import ceil
+from django.contrib.auth.models import Group
+from django.conf import settings
 
 from zds.member.factories import ProfileFactory
 from zds.mp.factories import PrivateTopicFactory, PrivatePostFactory
-from zds.mp.models import mark_read, is_privatetopic_unread
-from django.conf import settings
+from zds.mp.models import mark_read, is_privatetopic_unread, \
+    is_reachable, NotParticipatingError, NotReachableError
 
 # by moment, i wrote the scenario to be simpler
 
@@ -16,34 +19,41 @@ class PrivateTopicTest(TestCase):
         # scenario - topic1 :
         # post1 - user1 - unread
         # post2 - user2 - unread
+        self.user1 = ProfileFactory().user
+        self.user2 = ProfileFactory().user
+        self.outsider = ProfileFactory().user
 
-        self.profile1 = ProfileFactory()
-        self.profile2 = ProfileFactory()
-        self.topic1 = PrivateTopicFactory(author=self.profile1.user)
-        self.topic1.participants.add(self.profile2.user)
+        # Create the bot accound and add it to the bot group
+        self.bot = ProfileFactory().user
+        bot_group = Group(name=settings.ZDS_APP['member']['bot_group'])
+        bot_group.save()
+        self.bot.groups.add(bot_group)
+
+        self.topic1 = PrivateTopicFactory(author=self.user1)
+        self.topic1.participants.add(self.user2)
         self.post1 = PrivatePostFactory(
             privatetopic=self.topic1,
-            author=self.profile1.user,
+            author=self.user1,
             position_in_topic=1)
 
         self.post2 = PrivatePostFactory(
             privatetopic=self.topic1,
-            author=self.profile2.user,
+            author=self.user2,
             position_in_topic=2)
 
-    def test_absolute_url(self):
+    def test_get_absolute_url(self):
         url = reverse('private-posts-list', args=[self.topic1.pk, self.topic1.slug()])
 
         self.assertEqual(self.topic1.get_absolute_url(), url)
 
-    def test_post_count(self):
+    def test_get_post_count(self):
         self.assertEqual(2, self.topic1.get_post_count())
 
     def test_get_last_answer(self):
-        topic = PrivateTopicFactory(author=self.profile2.user)
+        topic = PrivateTopicFactory(author=self.user2)
         PrivatePostFactory(
             privatetopic=topic,
-            author=self.profile2.user,
+            author=self.user2,
             position_in_topic=1)
 
         self.assertEqual(self.post2, self.topic1.get_last_answer())
@@ -52,7 +62,7 @@ class PrivateTopicTest(TestCase):
         self.assertIsNone(topic.get_last_answer())
 
     def test_first_post(self):
-        topic = PrivateTopicFactory(author=self.profile2.user)
+        topic = PrivateTopicFactory(author=self.user2)
         self.assertEqual(self.post1, self.topic1.first_post())
         self.assertIsNone(topic.first_post())
 
@@ -62,15 +72,15 @@ class PrivateTopicTest(TestCase):
         # post2 - user2 - unread
         self.assertEqual(
             self.post1,
-            self.topic1.last_read_post(self.profile1.user))
+            self.topic1.last_read_post(self.user1))
 
         # scenario - topic1 :
         # post1 - user1 - read
         # post2 - user2 - read
-        mark_read(self.topic1, user=self.profile1.user)
+        mark_read(self.topic1, user=self.user1)
         self.assertEqual(
             self.post2,
-            self.topic1.last_read_post(self.profile1.user))
+            self.topic1.last_read_post(self.user1))
 
         # scenario - topic1 :
         # post1 - user1 - read
@@ -78,11 +88,11 @@ class PrivateTopicTest(TestCase):
         # post3 - user2 - unread
         PrivatePostFactory(
             privatetopic=self.topic1,
-            author=self.profile2.user,
+            author=self.user2,
             position_in_topic=3)
         self.assertEqual(
             self.post2,
-            self.topic1.last_read_post(self.profile1.user))
+            self.topic1.last_read_post(self.user1))
 
     def test_first_unread_post(self):
         # scenario - topic1 :
@@ -90,38 +100,38 @@ class PrivateTopicTest(TestCase):
         # post2 - user2 - unread
         self.assertEqual(
             self.post1,
-            self.topic1.first_unread_post(self.profile1.user))
+            self.topic1.first_unread_post(self.user1))
 
         # scenario - topic1 :
         # post1 - user1 - read
         # post2 - user2 - read
         # post3 - user2 - unread
-        mark_read(self.topic1, self.profile1.user)
+        mark_read(self.topic1, self.user1)
         post3 = PrivatePostFactory(
             privatetopic=self.topic1,
-            author=self.profile2.user,
+            author=self.user2,
             position_in_topic=3)
 
         self.assertEqual(
             post3,
-            self.topic1.first_unread_post(self.profile1.user))
+            self.topic1.first_unread_post(self.user1))
 
-    def test_alone(self):
-        topic2 = PrivateTopicFactory(author=self.profile1.user)
-        self.assertFalse(self.topic1.alone())
-        self.assertTrue(topic2.alone())
+    def test_one_participant_remaining(self):
+        topic2 = PrivateTopicFactory(author=self.user1)
+        self.assertFalse(self.topic1.one_participant_remaining())
+        self.assertTrue(topic2.one_participant_remaining())
 
-    def test_never_read(self):
+    def test_is_unread(self):
         # scenario - topic1 :
         # post1 - user1 - unread
         # post2 - user2 - unread
-        self.assertTrue(self.topic1.is_unread(self.profile1.user))
+        self.assertTrue(self.topic1.is_unread(self.user1))
 
         # scenario - topic1 :
         # post1 - user1 - read
         # post2 - user2 - read
-        mark_read(self.topic1, self.profile1.user)
-        self.assertFalse(self.topic1.is_unread(self.profile1.user))
+        mark_read(self.topic1, self.user1)
+        self.assertFalse(self.topic1.is_unread(self.user1))
 
         # scenario - topic1 :
         # post1 - user1 - read
@@ -129,10 +139,10 @@ class PrivateTopicTest(TestCase):
         # post3 - user2 - unread
         PrivatePostFactory(
             privatetopic=self.topic1,
-            author=self.profile2.user,
+            author=self.user2,
             position_in_topic=3)
 
-        self.assertTrue(self.topic1.is_unread(self.profile1.user))
+        self.assertTrue(self.topic1.is_unread(self.user1))
 
     def test_topic_never_read_get_last_read(self):
         """ Trying to read last message of a never read Private Topic
@@ -141,6 +151,76 @@ class PrivateTopicTest(TestCase):
         tester = ProfileFactory()
         self.topic1.participants.add(tester.user)
         self.assertEqual(self.topic1.last_read_post(user=tester.user), self.post1)
+
+    def test_is_author(self):
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertTrue(self.topic1.is_author(self.user1))
+        self.assertFalse(self.topic1.is_author(self.user2))
+
+    def test_set_as_author_same_author(self):
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+        self.topic1.set_as_author(self.user1)
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+
+    def test_set_as_author_new_author(self):
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+        self.topic1.set_as_author(self.user2)
+        self.assertEqual(self.topic1.author, self.user2)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user1])
+
+    def test_set_as_author_outsider(self):
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+        with self.assertRaises(NotParticipatingError):
+            self.topic1.set_as_author(self.outsider)
+
+    def test_is_participant(self):
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+        self.assertTrue(self.topic1.is_participant(self.user1))
+        self.assertTrue(self.topic1.is_participant(self.user2))
+        self.assertFalse(self.topic1.is_participant(self.outsider))
+
+    def test_add_participant_unreachable_user(self):
+        self.assertFalse(is_reachable(self.bot))
+        with self.assertRaises(NotReachableError):
+            self.topic1.add_participant(self.bot)
+
+    def test_add_participant_already_participating(self):
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+        self.topic1.add_participant(self.user2)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+
+    def test_add_participant_normal(self):
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+        self.topic1.add_participant(self.outsider)
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2, self.outsider])
+
+    def test_remove_participant_not_participating(self):
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+        self.topic1.remove_participant(self.outsider)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+
+    def test_remove_participant_author(self):
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+        self.topic1.remove_participant(self.user1)
+        self.assertEqual(self.topic1.author, self.user2)
+        self.assertEqual(list(self.topic1.participants.all()), [])
+
+    def test_remove_participant_normal(self):
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [self.user2])
+        self.topic1.remove_participant(self.user2)
+        self.assertEqual(self.topic1.author, self.user1)
+        self.assertEqual(list(self.topic1.participants.all()), [])
 
 
 class PrivatePostTest(TestCase):

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -147,6 +147,7 @@ class TopicViewTest(TestCase):
     def setUp(self):
         self.profile1 = ProfileFactory()
         self.profile2 = ProfileFactory()
+        self.profile3 = ProfileFactory()
         self.topic1 = PrivateTopicFactory(author=self.profile1.user)
         self.topic1.participants.add(self.profile2.user)
         self.post1 = PrivatePostFactory(
@@ -171,15 +172,15 @@ class TopicViewTest(TestCase):
         self.assertEqual(404, response.status_code)
 
     def test_fail_topic_no_permission(self):
-        topic = PrivateTopicFactory(author=self.profile1.user)
+        """Check that a member not participating in a private topic is forbidden to view it."""
 
         login_check = self.client.login(
-            username=self.profile2.user.username,
+            username=self.profile3.user.username,
             password='hostel77'
         )
         self.assertTrue(login_check)
 
-        response = self.client.get(reverse('private-posts-list', args=[topic.pk, topic.slug]), follow=True)
+        response = self.client.get(reverse('private-posts-list', args=[self.topic1.pk, self.topic1.slug]), follow=True)
 
         self.assertEqual(403, response.status_code)
 
@@ -946,6 +947,9 @@ class AddParticipantViewTest(TestCase):
                 'username': self.anonymous_account.username
             }
         )
+
+        # TODO (Arnaud-D): this test actually succeeds because of a Http404.
+        #  NotReachableError is not raised.
         self.assertFalse(self.anonymous_account in self.topic1.participants.all())
 
     def test_fail_add_participant_who_no_exist(self):

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -22,7 +22,7 @@ from zds.gallery.models import Image
 from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.mp.models import PrivateTopic, is_privatetopic_unread, PrivatePost
 from zds.notification.models import TopicAnswerSubscription, ContentReactionAnswerSubscription, \
-    NewPublicationSubscription, Notification, Subscription
+    NewPublicationSubscription, Notification
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory, \
     SubCategoryFactory, PublishedContentFactory, tricky_text_content, BetaContentFactory
 from zds.tutorialv2.models.database import PublishableContent, Validation, PublishedContent, ContentReaction, \
@@ -5641,7 +5641,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=False)
         self.assertEqual(302, result.status_code)
         self.assertEqual(public_count - 1, PublishedContent.objects.count())
-        self.assertEqual(Subscription.objects.filter(is_active=False).count(), 2)  # author + subscriber
+        self.assertEqual(ContentReactionAnswerSubscription.objects.filter(is_active=False).count(), 1)
 
     def test_validation_history(self):
         published = PublishedContentFactory(author_list=[self.user_author])

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -12,7 +12,7 @@ from zds.forum.factories import ForumFactory, ForumCategoryFactory
 from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.mp.models import PrivateTopic, is_privatetopic_unread
-from zds.notification.models import ContentReactionAnswerSubscription, Notification, Subscription
+from zds.notification.models import ContentReactionAnswerSubscription, Notification
 from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory, \
     SubCategoryFactory, PublishedContentFactory
 from zds.tutorialv2.models.database import PublishableContent, Validation, PublishedContent, ContentReaction, \
@@ -1608,7 +1608,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=False)
         self.assertEqual(302, result.status_code)
         self.assertEqual(public_count - 1, PublishedContent.objects.count())
-        self.assertEqual(Subscription.objects.filter(is_active=False).count(), 2)  # author + subscriber
+        self.assertEqual(ContentReactionAnswerSubscription.objects.filter(is_active=False).count(), 1)
 
     def test_validation_history(self):
         published = PublishedContentFactory(author_list=[self.user_author])

--- a/zds/tutorialv2/views/validations.py
+++ b/zds/tutorialv2/views/validations.py
@@ -181,7 +181,7 @@ class AskValidationForContent(LoggedWithReadWriteHability, SingleContentFormView
                     self.object.validation_message_title,
                     self.versioned_object.title,
                     msg,
-                    False,
+                    send_by_mail=False,
                     hat=get_hat_from_settings('validation')
                 )
             else:
@@ -266,7 +266,7 @@ class CancelValidation(LoginRequiredMixin, ModalFormView):
                     _('Demande de validation annulée').format(),
                     versioned.title,
                     msg,
-                    False,
+                    send_by_mail=False,
                     hat=get_hat_from_settings('validation'),
                 )
                 validation.content.save(force_slug_update=False)
@@ -322,7 +322,7 @@ class ReserveValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
                         _('Contenu réservé - {0}').format(validation.content.title),
                         validation.content.title,
                         msg,
-                        True,
+                        send_by_mail=True,
                         leave=False,
                         direct=False,
                         mark_as_read=True,
@@ -417,7 +417,7 @@ class RejectValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
                 _('Rejet de la demande de publication').format(),
                 validation.content.title,
                 msg,
-                True,
+                send_by_mail=True,
                 direct=False,
                 hat=get_hat_from_settings('validation'),
             )
@@ -426,7 +426,7 @@ class RejectValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
             send_message_mp(bot,
                             validation.content.validation_private_message,
                             msg,
-                            no_notification_for=self.request.user)
+                            no_notification_for=[self.request.user])
 
         messages.info(self.request, _('Le contenu a bien été refusé.'))
         self.success_url = reverse('validation:list')
@@ -543,7 +543,7 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
                 self.object.validation_message_title,
                 validation.content.title,
                 msg,
-                True,
+                send_by_mail=True,
                 direct=False,
                 hat=get_hat_from_settings('validation'),
             )
@@ -553,7 +553,7 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
                 bot,
                 validation.content.validation_private_message,
                 msg,
-                no_notification_for=self.request.user
+                no_notification_for=[self.request.user]
             )
 
         messages.success(self.request, _('Le contenu a bien été dépublié.'))
@@ -656,7 +656,7 @@ class UnpublishOpinion(LoginRequiredMixin, SingleOnlineContentFormViewMixin, Doe
                     self.object.validation_message_title,
                     versioned.title,
                     msg,
-                    True,
+                    send_by_mail=True,
                     direct=False,
                     hat=get_hat_from_settings('moderation'),
                 )
@@ -666,7 +666,7 @@ class UnpublishOpinion(LoginRequiredMixin, SingleOnlineContentFormViewMixin, Doe
                                 self.object.validation_private_message,
                                 msg,
                                 hat=get_hat_from_settings('moderation'),
-                                no_notification_for=self.request.user
+                                no_notification_for=[self.request.user]
                                 )
 
         messages.success(self.request, _('Le contenu a bien été dépublié.'))
@@ -736,7 +736,7 @@ class DoNotPickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormView
                         self.object.validation_message_title,
                         versioned.title,
                         msg,
-                        True,
+                        send_by_mail=True,
                         direct=False,
                         hat=get_hat_from_settings('moderation'),
                     )
@@ -746,7 +746,7 @@ class DoNotPickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormView
                                     self.object.validation_private_message,
                                     msg,
                                     hat=get_hat_from_settings('moderation'),
-                                    no_notification_for=self.request.user)
+                                    no_notification_for=[self.request.user])
         except ValueError:
             logger.exception('Could not %s the opinion %s', form.cleaned_data['operation'], str(self.object))
             return HttpResponse(json.dumps({'result': 'FAIL', 'reason': str(_('Mauvaise opération'))}), status=400)
@@ -833,7 +833,7 @@ class PickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMixin
                 self.object.validation_message_title,
                 versioned.title,
                 msg,
-                True,
+                send_by_mail=True,
                 direct=False,
                 hat=get_hat_from_settings('moderation'),
             )
@@ -843,7 +843,7 @@ class PickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMixin
                             self.object.validation_private_message,
                             msg,
                             hat=get_hat_from_settings('moderation'),
-                            no_notification_for=self.request.user)
+                            no_notification_for=[self.request.user])
 
         messages.success(self.request, _('Le billet a bien été choisi.'))
 
@@ -904,7 +904,7 @@ class UnpickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMix
                 self.object.validation_message_title,
                 versioned.title,
                 msg,
-                True,
+                send_by_mail=True,
                 direct=False,
                 hat=get_hat_from_settings('moderation'),
             )
@@ -1047,7 +1047,7 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
             _('Billet proposé comme article'),
             versionned_article.title,
             msg,
-            True,
+            send_by_mail=True,
             direct=False,
             hat=get_hat_from_settings('validation'),
         )

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -581,7 +581,7 @@ class Alert(models.Model):
                 msg_title,
                 '',
                 msg_content,
-                True,
+                send_by_mail=True,
                 hat=get_hat_from_settings('moderation'),
             )
             self.privatetopic = privatetopic

--- a/zds/utils/mps.py
+++ b/zds/utils/mps.py
@@ -23,15 +23,22 @@ def send_mp(
         direct=False,
         mark_as_read=False,
         hat=None,
-        automaticaly_read=None):
+        automatically_read=None):
     """
-    Send MP at members.
-    Most of the param are obvious, excepted :
+    Send a private message in a new private topic.
 
+    :param author: sender of the message and author of the private topic
+    :param users: list of users receiving the message (participants of the private topic)
+    :param title: title of the private topic
+    :param subtitle: subtitle of the private topic
+    :param text: content of the private message
+    :param send_by_mail:
     :param direct: send a mail directly without mp (ex : ban members who wont connect again)
-    :param leave: the author leave the conversation (usefull for the bot : it wont read the response a member could
-    send)
-    :param automaticaly_read: a user or a list of users that will automatically be marked as reader of the mp
+    :param leave: if True, do not add the sender to the topic
+    :param mark_as_read:
+    :param hat: hat with which to send the private message
+    :param automatically_read: a user or a list of users that will automatically be marked as having read of the mp
+    :raise UnreachableUserError:
     """
 
     # Creating the thread
@@ -50,15 +57,13 @@ def send_mp(
     topic = send_message_mp(author, n_topic, text, send_by_mail, direct, hat)
     if mark_as_read:
         mark_read(topic, author)
-    if automaticaly_read:
-        if not isinstance(automaticaly_read, list):
-            automaticaly_read = [automaticaly_read]
-        for not_notified_user in automaticaly_read:
+    if automatically_read:
+        if not isinstance(automatically_read, list):
+            automatically_read = [automatically_read]
+        for not_notified_user in automatically_read:
             mark_read(n_topic, not_notified_user)
     if leave:
-        move = topic.participants.first()
-        topic.author = move
-        topic.participants.remove(move)
+        topic.remove_participant(topic.author)
         topic.save()
 
     return topic
@@ -74,9 +79,14 @@ def send_message_mp(
         no_notification_for=None):
     """
     Send a post in an MP.
-    Most of the param are obvious, excepted :
-    * direct : send a mail directly without mp (ex : ban members who wont connect again)
-    * leave : the author leave the conversation (usefull for the bot : it wont read the response a member could send)
+
+    :param author: sender of the private message
+    :param n_topic: topic in which it will be sent
+    :param text: content of the message
+    :param send_by_mail: if True, also notify by email
+    :param direct: send a mail directly without private message (ex : banned members who won't connect again)
+    :param hat: hat attached to the message
+    :param no_notification_for: list of participants who won't be notified of the message
     """
 
     # Getting the position of the post


### PR DESCRIPTION
J'essaie de refactoriser le code des MP pour harmoniser certains comportements et éviter certains bugs.

Fix #5654.

Au menu :

- ajout et retrait de participants robustes ;
- clarification de l'usage des fonctions send_mp et send_message_mp (mais pas de leur fonctionnement interne) ;
- quelques renommages pour plus de clarté.

# QA

Il faut essayer de jouer un peu avec l'ajout/suppression de participants : 

- créer des MP ;
- ajouter des participants à des MP existants ;
- quitter de MP en n'étant pas le dernier ;
- quitter des MP en étant le dernier dedans ;
- faire envoyer/recevoir des MP automatiques et voir que tout est bon ici aussi.