### PR TITLE
On ne lance pas coveralls quand le mode ci_turbo est activé

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ after_success:
 
   - |
     # upload coverage
-    if [[ "$ZDS_TEST_JOB" != "none" ]]; then
+    if [[ "$ZDS_TEST_JOB" != "none" && "$ZDS_TEST_JOB" != *"ci_turbo"* ]]; then
       coveralls
     fi
 

--- a/scripts/ci_turbo.sh
+++ b/scripts/ci_turbo.sh
@@ -22,7 +22,7 @@ then
     # Don't test the backend if only the `/assets/` directory changed
     if [[ "$ZDS_TEST_JOB" == *"front"* ]]
     then
-        export ZDS_TEST_JOB="front"
+        export ZDS_TEST_JOB="front ci_turbo"
     else
         export ZDS_TEST_JOB="none"
     fi


### PR DESCRIPTION
(Actuellement on envoyait le rapport coveralls pour le job front...)

<!-- Veuillez décrire vos changements à l’emplacement de ce commentaire (inutile dans le cas de tout petits changements). -->

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné (optionnel) : #5701 

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

Regardez si travis se port bien.

<!-- Écrivez éventuellement ici quelques instructions pour nous aider à vérifier vos changement.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

<!-- Merci ! -->
