### PR TITLE
Retire la taille maximale d'un password

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -18,9 +18,7 @@ from zds.utils.misc import contains_utf8mb4
 from zds.utils.models import Licence, HatRequest, Hat
 from zds.utils import get_current_user
 
-# Max password length for the user.
-# Unlike other fields, this is not the length of DB field
-MAX_PASSWORD_LENGTH = 76
+
 # Min password length for the user.
 MIN_PASSWORD_LENGTH = 6
 
@@ -42,7 +40,6 @@ class LoginForm(forms.Form):
 
     password = forms.CharField(
         label=_('Mot de passe'),
-        max_length=MAX_PASSWORD_LENGTH,
         required=True,
         widget=forms.PasswordInput,
     )
@@ -90,7 +87,6 @@ class RegisterForm(forms.Form):
 
     password = forms.CharField(
         label=_('Mot de passe'),
-        max_length=MAX_PASSWORD_LENGTH,
         min_length=MIN_PASSWORD_LENGTH,
         required=True,
         widget=forms.PasswordInput,
@@ -99,7 +95,6 @@ class RegisterForm(forms.Form):
 
     password_confirm = forms.CharField(
         label=_('Confirmation du mot de passe'),
-        max_length=MAX_PASSWORD_LENGTH,
         min_length=MIN_PASSWORD_LENGTH,
         required=True,
         widget=forms.PasswordInput,
@@ -420,7 +415,6 @@ class ChangePasswordForm(forms.Form):
 
     password_new = forms.CharField(
         label=_('Nouveau mot de passe'),
-        max_length=MAX_PASSWORD_LENGTH,
         min_length=MIN_PASSWORD_LENGTH,
         widget=forms.PasswordInput,
         validators=[validate_zds_password],
@@ -428,7 +422,6 @@ class ChangePasswordForm(forms.Form):
 
     password_confirm = forms.CharField(
         label=_('Confirmer le nouveau mot de passe'),
-        max_length=MAX_PASSWORD_LENGTH,
         min_length=MIN_PASSWORD_LENGTH,
         widget=forms.PasswordInput,
         validators=[validate_zds_password],
@@ -532,14 +525,12 @@ class NewPasswordForm(forms.Form):
     """
     password = forms.CharField(
         label=_('Mot de passe'),
-        max_length=MAX_PASSWORD_LENGTH,
         min_length=MIN_PASSWORD_LENGTH,
         widget=forms.PasswordInput,
         validators=[validate_zds_password],
     )
     password_confirm = forms.CharField(
         label=_('Confirmation'),
-        max_length=MAX_PASSWORD_LENGTH,
         min_length=MIN_PASSWORD_LENGTH,
         widget=forms.PasswordInput,
         validators=[validate_zds_password],

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -143,16 +143,6 @@ class RegisterFormTest(TestCase):
         form = RegisterForm(data=data)
         self.assertFalse(form.is_valid())
 
-    def test_too_long_password_register_form(self):
-        data = {
-            'email': 'test@gmail.com',
-            'username': 'ZeTester',
-            'password': stringof77chars,
-            'password_confirm': stringof77chars
-        }
-        form = RegisterForm(data=data)
-        self.assertFalse(form.is_valid())
-
     def test_password_match_username_password_register_form(self):
         data = {
             'email': 'test@gmail.com',
@@ -464,15 +454,6 @@ class ChangePasswordFormTest(TestCase):
         form = ChangePasswordForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
-    def test_too_long_change_password_form(self):
-        data = {
-            'password_old': self.old_password,
-            'password_new': stringof77chars,
-            'password_confirm': stringof77chars
-        }
-        form = ChangePasswordForm(data=data, user=self.user1.user)
-        self.assertFalse(form.is_valid())
-
     def test_match_username_change_password_form(self):
         self.user1.user.username = 'LongName'
         data = {
@@ -596,15 +577,6 @@ class NewPasswordFormTest(TestCase):
         data = {
             'password': too_short,
             'password_confirm': too_short
-        }
-        form = NewPasswordForm(data=data, identifier=self.user1.user.username)
-        self.assertFalse(form.is_valid())
-
-    def test_password_too_long_new_password_form(self):
-        toolong = 'abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789-----'
-        data = {
-            'password': toolong,
-            'password_confirm': toolong
         }
         form = NewPasswordForm(data=data, identifier=self.user1.user.username)
         self.assertFalse(form.is_valid())


### PR DESCRIPTION
Fix #5676

# QA

- Se connecter avec un utilisateur
- générer un mot de passe de 128 caractères
- dans le profile utilisateur, changer le mot de passe pour le nouveau
- vous reconnecter avec le nouveau mot de passe

Ca ne sert à rien de mettre un maximum de taille pour le mot de passe