### PR TITLE
Ajoute des guides pas-à-pas à la documentation

### DIFF
--- a/doc/source/guides.rst
+++ b/doc/source/guides.rst
@@ -1,0 +1,13 @@
+================
+Guides pas-à-pas
+================
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   guides/install-linux.rst
+   guides/update-env.rst
+   guides/run-linux.rst
+
+.. include:: /includes/contact-us.rst

--- a/doc/source/guides/install-linux.rst
+++ b/doc/source/guides/install-linux.rst
@@ -10,13 +10,13 @@ Préparation
 Préparation pour contribuer au projet
 -------------------------------------
 
-Toutes les contributions au projet prennent place sur le site web Github, un espace de travail très connu des projets *open-source*. Un `compte Github <https://github.com/join>`_ est donc nécessaire pour contribuer au projet !
+Toutes les contributions au projet prennent place sur le site web Github, un espace de travail très connu des projets *open-source*. La première étape est donc de `se créer un compte Github <https://github.com/join>`_ pour contribuer au projet !
 
-La première étape est de créer `un fork <https://help.github.com/en/github/getting-started-with-github/fork-a-repo>`_, votre copie personnelle du projet. Pour se faire, une fois connecté à votre compte Github, rendez vous sur `la page du dépôt zds-site <https://github.com/zestedesavoir/zds-site>`_ et cliquez sur le bouton *Fork* en haut à droite. Cette opération peut prendre quelques minutes, c'est tout à fait normal.
+La deuxième étape est de créer `un fork <https://help.github.com/en/github/getting-started-with-github/fork-a-repo>`_, votre copie personnelle du projet. Pour ce faire, une fois connecté à votre compte Github, rendez-vous sur `la page du dépôt zds-site <https://github.com/zestedesavoir/zds-site>`_ et cliquez sur le bouton *Fork* en haut à droite. Cette opération peut prendre quelques minutes, c'est tout à fait normal.
 
-La deuxième étape va être d'installer le gestionnaire de version Git, un outil qui nous permet de travailler à plusieurs sur le projet sans se marcher dessus ! Ce logiciel est très probablement disponible dans le gestionnaire de paquet de votre distribution. Si ce n'est pas le cas, je vous invite à lire `la page d'installation de Git <https://git-scm.com/downloads>`_.
+La troisème étape consiste à installer le gestionnaire de version Git, un outil qui nous permet de travailler à plusieurs sur le projet sans se marcher dessus ! Ce logiciel est très probablement disponible dans le gestionnaire de paquet de votre distribution. Si ce n'est pas le cas, je vous invite à lire `la page d'installation de Git <https://git-scm.com/downloads>`_.
 
-La troisième étape est la création d'une copie locale du projet, sur votre ordinateur, en utilisant l'outil Git fraîchement installé :
+Enfin, la quatrième étape est la création d'une copie locale du projet, sur votre ordinateur, en utilisant l'outil Git fraîchement installé :
 
 .. sourcecode:: bash
 
@@ -39,7 +39,18 @@ Si vous ne souhaitez pas contribuer au projet mais simplement le tester, vous n'
    wget https://github.com/zestedesavoir/zds-site/archive/dev.zip
    unzip dev.zip
    cd dev
- 
+
+Installation de l'utilitaire Make
+---------------------------------
+
+Nous utilisons l'utilitaire Make pour avoir des commandes simples à retenir. Celui-ci est très probablement déjà installé sur votre distribution, ce que vous pouvez vérifier tout simplement avec :
+
+.. sourcecode:: bash
+
+   make
+
+S'il est installé, cela vous affichera la liste des commandes de notre projet. Sinon, il vous faudra l'installer avec ``sudo apt install build-essential`` sur Ubuntu et ses dérivés ou `le télécharger sur cette page <https://www.gnu.org/software/make/#download>`_.
+
 Installation
 ============
 
@@ -52,7 +63,7 @@ Si notre projet est assez complexe et a besoin de beaucoup d'outils différents 
 
    make install-linux
 
-Et oui, c'est tout ! Si l'utilitaire Make n'est pas installé sur votre ordinateur et que vous ne souhaitez pas l'installer, vous pouvez lancer directement la commande ``./scripts/install_zds.sh +base`` si celle-ci n'a pas changé.
+Et oui, c'est tout !
 
 Dès le lancement, cette commande vous demandera quelle est votre distribution Linux pour savoir quel gestionnaire de paquet utiliser et quels paquets installer. Votre mot de passe d'administrateur vous sera demandé pour pouvoir installer ces paquets.
 
@@ -74,12 +85,10 @@ Là encore, une seule commande suffit :
 
    make install-linux-full
 
-Si l'utilitaire Make n'est pas installé sur votre ordinateur et que vous ne souhaitez pas l'installer, vous pouvez lancer directement la commande ``./scripts/install_zds.sh +full`` si celle-ci n'a pas changé.
-
 En savoir plus sur l'installation
 ---------------------------------
 
-Si vous êtes curieux.se sur le fonctionnement du script d'installation, je vous invite à lire `cette page détaillée <../install/install-linux.html>`_.
+Si le fonctionnement du script d'installation vous intéresse, je vous invite à lire `cette page détaillée <../install/install-linux.html>`_.
 
 Aller plus loin
 ===============

--- a/doc/source/guides/install-linux.rst
+++ b/doc/source/guides/install-linux.rst
@@ -1,0 +1,89 @@
+===================================
+Installer Zeste de Savoir sur Linux
+===================================
+
+Vous voulez installer Zeste de Savoir sur votre distribution GNU/Linux ? Vous êtes au bon endroit !
+
+Préparation
+===========
+
+Préparation pour contribuer au projet
+-------------------------------------
+
+Toutes les contributions au projet prennent place sur le site web Github, un espace de travail très connu des projets *open-source*. Un `compte Github <https://github.com/join>`_ est donc nécessaire pour contribuer au projet !
+
+La première étape est de créer `un fork <https://help.github.com/en/github/getting-started-with-github/fork-a-repo>`_, votre copie personnelle du projet. Pour se faire, une fois connecté à votre compte Github, rendez vous sur `la page du dépôt zds-site <https://github.com/zestedesavoir/zds-site>`_ et cliquez sur le bouton *Fork* en haut à droite. Cette opération peut prendre quelques minutes, c'est tout à fait normal.
+
+La deuxième étape va être d'installer le gestionnaire de version Git, un outil qui nous permet de travailler à plusieurs sur le projet sans se marcher dessus ! Ce logiciel est très probablement disponible dans le gestionnaire de paquet de votre distribution. Si ce n'est pas le cas, je vous invite à lire `la page d'installation de Git <https://git-scm.com/downloads>`_.
+
+La troisième étape est la création d'une copie locale du projet, sur votre ordinateur, en utilisant l'outil Git fraîchement installé :
+
+.. sourcecode:: bash
+
+   git clone https://github.com/<VOTRE_PSEUDO_GITHUB>/zds-site.git
+   cd zds-site
+   git remote add upstream https://github.com/zestedesavoir/zds-site.git
+   git fetch upstream
+
+Bien entendu, ``<VOTRE_PSEUDO_GITHUB>`` doit être remplacé par votre pseudo sur Github.
+
+Voilà, vous avez maintenant une copie locale du projet, liée à votre copie personnelle (*origin*) et la copie officielle (*upstream*) sur Github !
+
+Préparation pour simplement tester le projet
+--------------------------------------------
+
+Si vous ne souhaitez pas contribuer au projet mais simplement le tester, vous n'avez pas besoin de Git ! Il vous suffit de télécharger l'archive contenant le code source et extraire les fichiers :
+
+.. sourcecode:: bash
+
+   wget https://github.com/zestedesavoir/zds-site/archive/dev.zip
+   unzip dev.zip
+   cd dev
+ 
+Installation
+============
+
+Installation de base
+--------------------
+
+Si notre projet est assez complexe et a besoin de beaucoup d'outils différents pour fonctionner, ce n'est pas pour autant qu'il est difficile de l'installer ! Une seule commande suffit :
+
+.. sourcecode:: bash
+
+   make install-linux
+
+Et oui, c'est tout ! Si l'utilitaire Make n'est pas installé sur votre ordinateur et que vous ne souhaitez pas l'installer, vous pouvez lancer directement la commande ``./scripts/install_zds.sh +base`` si celle-ci n'a pas changé.
+
+Dès le lancement, cette commande vous demandera quelle est votre distribution Linux pour savoir quel gestionnaire de paquet utiliser et quels paquets installer. Votre mot de passe d'administrateur vous sera demandé pour pouvoir installer ces paquets.
+
+Ensuite, le reste de l'installation se fait tout seul sans rien vous demander ! En fonction de votre connexion Internet et de la puissance de votre ordinateur cela peut prendre du temps, soyez patient !
+
+**Si vous rencontrez un soucis, n'hésitez pas à nous contacter !**
+
+Installation complète
+---------------------
+
+L'installation de base suffit grandement pour lancer le site web et découvrir le projet, mais elle est incomplète. Deux outils manquent à l'appel :
+
+- LaTeX, nécessaire pour la génération des PDFs des contenus ;
+- ElasticSearch, nécessaire pour la page de recherche.
+
+Là encore, une seule commande suffit :
+
+.. sourcecode:: bash
+
+   make install-linux-full
+
+Si l'utilitaire Make n'est pas installé sur votre ordinateur et que vous ne souhaitez pas l'installer, vous pouvez lancer directement la commande ``./scripts/install_zds.sh +full`` si celle-ci n'a pas changé.
+
+En savoir plus sur l'installation
+---------------------------------
+
+Si vous êtes curieux.se sur le fonctionnement du script d'installation, je vous invite à lire `cette page détaillée <../install/install-linux.html>`_.
+
+Aller plus loin
+===============
+
+Vous avez réussi à installer Zeste de Savoir ? Il est maintenant temps de `le lancer <run-linux.html>`_ !
+
+.. include:: /includes/contact-us.rst

--- a/doc/source/guides/run-linux.rst
+++ b/doc/source/guides/run-linux.rst
@@ -1,0 +1,53 @@
+================================
+Lancer Zeste de Savoir sur Linux
+================================
+
+Vous avez réussi à `installer Zeste de Savoir sur votre distribution GNU/Linux <install-linux.html>`_ ? Il est maintenant temps de le lancer !
+
+Si cela fait déjà un moment, n'hésitez pas à `mettre à jour votre environnement de développement <../guides.html>`_ avant de suivre ce guide.
+
+Activer l'environnement
+=======================
+
+La première chose à faire avant de pouvoir travailler sur le projet est de se déplacer dans le dossier du projet et d'activer l'environnement :
+
+.. sourcecode:: bash
+
+   source zdsenv/bin/activate
+
+Cet environnement permet de ne pas polluer votre distribution avec les logiciels installés spécifiquement pour Zeste de Savoir et de ne pas interférer avec vos autres projets de développement.
+
+Lancer zmarkdown
+================
+
+Si vous souhaitez écrire des messages sur le forum, des commentaires, des messages privés ou rédiger des contenus, il est nécessaire de lancer le serveur zmarkdown :
+
+.. sourcecode:: bash
+
+   make zmd-start
+
+Lorsque vous aurez fini, vous pourrez l'arrêter avec :
+
+.. sourcecode:: bash
+
+   make zmd-stop
+
+Lancer le serveur
+=================
+
+Il suffit tout simplement d'écrire :
+
+.. sourcecode:: bash
+
+   make run-back
+
+Ensuite, ouvrez votre navigateur et aller au choix sur http://localhost:8000 ou http://127.0.0.1:8000.
+
+Vous pouvez vous connecter avec le membre ``user``, le membre ``staff`` ou n'importe quel autre membre présent sur http://localhost:8000/membres/, le mot de passe est identique au pseudo.
+
+S'amuser
+========
+
+Votre instance locale de Zeste de Savoir vous appartient, vous êtes libre d'y faire tout ce que vous souhaitez ! N'hésitez pas à explorer les fonctionnalités que vous connaissez moins : la validation des contenus, la modération des messages et des membres, etc. Ainsi, vous aurez un aperçu global des fonctionnalités !
+
+.. include:: ../includes/contact-us.rst

--- a/doc/source/guides/update-env.rst
+++ b/doc/source/guides/update-env.rst
@@ -1,0 +1,71 @@
+================================================
+Mettre à jour son environnement de développement
+================================================
+
+Vous n'avez pas participé au projet depuis quelque temps ? Suivez ce guide pour mettre à jour votre environnement de développement !
+
+Récupérer les dernières modifications
+=====================================
+
+Il va falloir utiliser l'utilitaire Git pour :
+
+1. mettre à jour la copie locale du dépôt officiel (nommée ``upstream``) ;
+2. se positionner sur la branche ``dev`` de cette copie.
+
+.. sourcecode:: bash
+   :linenos:
+
+   git fetch upstream
+   git checkout upstream/dev
+
+Activer l'environnement
+=======================
+
+La première chose à faire avant de pouvoir travailler sur le projet est de se déplacer dans le dossier du projet et d’activer l’environnement :
+
+.. sourcecode:: bash
+
+   source zdsenv/bin/activate
+
+Cet environnement permet de ne pas polluer votre distribution avec les logiciels installés spécifiquement pour Zeste de Savoir et de ne pas interférer avec vos autres projets de développement.
+
+Mettre à jour les dépendances
+=============================
+
+Ces trois commandes permettent de mettre à jour :
+
+1. les paquets Python nécessaires pour le serveur (*backend*) ;
+2. les paquets Node.JS nécessaires pour les éléments graphiques (*frontend*) ;
+3. zmarkdown, notre moteur Markdown personnalisé.
+
+.. sourcecode:: bash
+   :linenos:
+
+   make install-back
+   make install-front
+   make zmd-install
+
+Générer les éléments graphiques
+===============================
+
+Les éléments graphiques ont probablement été modifiés, il va falloir les générer à nouveau :
+
+.. sourcecode:: bash
+
+   make build-front
+
+Appliquer les migrations sur la base de données
+===============================================
+
+Il est possible que la structure de la base de données ait été légèrement modifiée, il nous faut donc appliquer ces changements :
+
+.. sourcecode:: bash
+
+   make migrate-db
+
+Aller plus loin
+===============
+
+Votre environnement de développement est maintenant à jour, vous pouvez donc `lancer Zeste de Savoir <run-linux.html>`_ !
+
+.. include:: /includes/contact-us.rst

--- a/doc/source/includes/contact-us.rst
+++ b/doc/source/includes/contact-us.rst
@@ -1,0 +1,4 @@
+.. note::
+
+   **N'hésitez pas à nous contacter !** Si vous avez besoin d'aide ou si vous souhaitez simplement discuter du projet, contactez-nous sur le canal ``#dev-de-zds`` de `notre serveur Discord <https://discord.gg/ue5MTKq>`_ ou `le forum Dev Zone <https://zestedesavoir.com/forums/communaute/dev-zone/>`_.
+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,6 +10,7 @@ Sommaire
 .. toctree::
    :maxdepth: 2
 
+   guides
    install
    contributing
    workflow


### PR DESCRIPTION
Un des soucis avec notre documentation actuelle c'est qu'elle a deux objectifs : 

- permettre aux nouveaux contributeurs de découvrir le projet
- documenter le projet en détails

Ces deux objectifs sont à mon avis contradictoire, donner tous les détails ne permet pas aux nouveaux contributeurs de découvrir le projet en douceur. C'est pourquoi je propose la création de guides pas-à-pas pour les nouveaux contributeurs, tout en gardant les autres pages de la documentation pour l'explication en détails.

-------------

Je propose trois premiers guides : 

- Installer le projet sur Linux
- Mettre à jour son environnement de développement
- Lancer Zeste de Savoir sur Linux

D'autres guides viendront le jour, mais je préfère plusieurs petites PR qu'une seule énorme PR.

**QA :**

- Relecture sur le fond et la forme
- Travis