### PR TITLE
Affiche la bonne date de dernière modification

### DIFF
--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -23,7 +23,7 @@
 {% endif %}
 
 {% if online %}
-    {% set public_object.get_last_action_date as update_date %}
+    {% set public_object.last_publication_date as update_date %}
 {% else %}
     {% set  content.update_date as update_date %}
 {% endif %}

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -904,9 +904,6 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
 
         return self.get_absolute_url_to_extra_content('zip')
 
-    def get_last_action_date(self):
-        return self.update_date or self.publication_date
-
     def get_char_count(self, md_file_path=None):
         """ Compute the number of letters for a given content
 


### PR DESCRIPTION
Fix #3832 

# QA

- Publier un tuto
- faire quelques modifications
- Republier le tuto, en le marquant comme mise à jour majeure
- la date de mise à jour qui est affichée sur la version publiée est la bonne

Refaire la manipulation en ne cochant pas la maj majeure, et observez le même résultat.