### PR TITLE
Problème lors de l'installation de Windows si on n'a pas node d'installé

### DIFF
--- a/scripts/win/install_zds.ps1
+++ b/scripts/win/install_zds.ps1
@@ -124,6 +124,8 @@ if (-not (_in "-node") -and ((_in "+node") -or (_in "+base") -or (_in "+full")))
     Error "Error: Cannot install nodejs." 11
   }
 
+  $env:PATH = "$env:VIRTUAL_ENV\App\node;" + $env:PATH
+
   if (!((Get-Content zdsenv\Scripts\activate.ps1) -match "node")) {
     PrintInfo " | -> Add node in %PATH% of virtualenv."
     $text = "set `"PATH=%VIRTUAL_ENV%\App\node;%PATH%`""


### PR DESCRIPTION
Ajoute node à la variable d'environnement pendant l'installation, je ne sais pas si c'est efficace.


Q/A:
 1. Désinstaller ou désactiver node via nvm
 2. Essayer `node` -> command not found
 3. Tester l'installation (notamment `+node` et `+front`)