### PR TITLE
Ajoute un bandeau pour distinguer les versions locale, bêta et prod

### DIFF
--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -56,7 +56,7 @@ body {
 }
 
 .page-container {
-    height: 100%;
+    min-height: 100%;
 
     display: flex;
     flex-direction: column;

--- a/assets/scss/components/_very-top-banner.scss
+++ b/assets/scss/components/_very-top-banner.scss
@@ -1,0 +1,19 @@
+#very-top-banner {
+    position: sticky;
+    z-index: 2;
+    top: 0;
+
+    box-sizing: border-box;
+    height: 25px;
+    width: 100%;
+
+    border-bottom: 2px solid black;
+    text-align: center;
+    font-weight: bold;
+
+    a {
+        color: white;
+        float: right;
+        margin: 0 5px;
+    }
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -77,6 +77,7 @@
 @import "components/topic-message";
 @import "components/topic-new";
 @import "components/user-profile";
+@import "components/very-top-banner";
 @import "components/linkbox";
 @import "components/more-link";
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -162,6 +162,17 @@
 
 
     <div class="page-container">
+        {% with banner=app.very_top_banner %}
+            {% if banner %}
+                <div id="very-top-banner"
+                     style="background-color: {{ banner.background_color }}; color: {{ banner.color }}; border-color: {{ banner.border_color }};"
+                >
+                    <span>{{ banner.message }}</span>
+                    <a aria-hidden="true" href="javascript:document.querySelector('#very-top-banner').remove()">Masquer</a>
+                </div>
+            {% endif %}
+        {% endwith %}
+
         <ul id="accessibility">
             <li>
                 <a href="#menu">{% trans "Aller au menu" %}</a>

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -274,5 +274,6 @@ ZDS_APP = {
         'server': 'http://127.0.0.1:27272',
         'disable_pings': False
     },
-    'stats_ga_viewid': 'ga:86962671'
+    'stats_ga_viewid': 'ga:86962671',
+    'very_top_banner': {}
 }

--- a/zds/settings/beta.py
+++ b/zds/settings/beta.py
@@ -2,5 +2,3 @@ from .prod import *
 
 ZDS_APP['site']['dns'] = 'beta.zestedesavoir.com'
 ZDS_APP['site']['url'] = 'https://beta.zestedesavoir.com'
-
-# TODO

--- a/zds/settings/dev.py
+++ b/zds/settings/dev.py
@@ -77,3 +77,10 @@ LOGGING = {
 
 ZDS_APP['site']['url'] = 'http://127.0.0.1:8000'
 ZDS_APP['site']['dns'] = '127.0.0.1:8000'
+
+ZDS_APP['very_top_banner'] = {
+    'background_color': '#666',
+    'border_color': '#353535',
+    'color': 'white',
+    'message': 'Version locale'
+}

--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -213,3 +213,5 @@ ZDS_APP['content']['extra_content_generation_policy'] = 'WATCHDOG'
 ZDS_APP['comment']['enable_pings'] = False
 
 ZDS_APP['visual_changes'] = zds_config.get('visual_changes', [])
+
+ZDS_APP['very_top_banner'] = config.get('very_top_banner', False)


### PR DESCRIPTION
Ajoute un bandeau pour distinguer les versions locale, bêta et prod dont le message ainsi que les couleurs de texte et de fond sont à définir dans les paramètres. Ce bandeau reste en haut de la page même quand on défile la page.

Ce bandeau pourra aussi servir de message d'information avant les longues maintenances de plus d'une demie-heure.

Fix #5712 

**Aperçu du rendu**

![Aperçu en local](https://user-images.githubusercontent.com/6664636/79267389-60f53480-7e99-11ea-9050-3739f93cb9f9.png)

![Aperçu en bêta](https://user-images.githubusercontent.com/6664636/79267401-63f02500-7e99-11ea-95ed-eee0627bf48c.png)

Depuis, j'ai ajouté une petite bordure noire de 2px en bas du bandeau.

**Pour tester les couleurs de bêta :**

```py
ZDS_APP['very_top_banner'] = {
    'display': True,
    'background_color': '#800',
    'color': 'white',
    'message': 'Version bêta'
}
```

**QA**

- `source zdsenv/bin/activate** puis `make run`
- Vérifier que l'affichage du bandeau fonctionne...
  - sur différents navigateurs
  - sur ordinateur et mobile
  - avec ou sans le bandeau des cookies

Est-ce nécessaire d'ajouter une croix pour fermer le bandeau ?