### PR TITLE
Corrige l'affichage de la neige avec le bandeau des cookies

### DIFF
--- a/assets/js/snow.js
+++ b/assets/js/snow.js
@@ -9,10 +9,7 @@
 
     canvas.style.zIndex = -1
     canvas.style.position = 'absolute'
-    canvas.style.top =
-            canvas.style.left =
-            canvas.style.right =
-            canvas.style.bottom = 0
+    canvas.style.left = 0
 
     canvas.style.background = window
       .getComputedStyle(this._parent)


### PR DESCRIPTION
Lorsqu'on est sur tablette, l'affichage de la neige avec le bandeau des cookies ne fonctionne pas correctement. Ce n'est pas super pour nos visiteurs durant la période de Noël !

**Soucis**

![Aperçu du soucis](https://user-images.githubusercontent.com/6664636/79271527-3e1a4e80-7ea0-11ea-880c-dc0853c756cc.png)

**Correction du soucis**

![Résolution du soucis](https://user-images.githubusercontent.com/6664636/79271558-4d010100-7ea0-11ea-93f4-058afe0f1161.png)

**QA**

- Lancer `source zdsenv/bin/activate` puis `make run`
- Ajouter `ZDS_APP['visual_changes'] = ['snow']` au fichier `zds/settings/dev.py`
- Vérifier que la neige s'affiche correctement lorsqu'il y a le bandeau des cookies
  - sur ordinateur et mobile
  - sur différents navigateurs