### PR TITLE
Corrige l'affichage des publications des membres.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,10 +3699,10 @@ just-debounce@^1.0.0:
   resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.0.0.tgz#87fccfaeffc0b68cd19d55f6722943f929ea35ea"
   integrity sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=
 
-katex@0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.10.1.tgz#5bb0b72bf19cecfc1fa217a9261760e5d301efff"
-  integrity sha512-iZXZ2L8pEP7HXBLAaeWkdLxnoRQ8Fdks8IuIVt01tYb+D8e0em5JYgfe6J48wXsuEr512IRCN5Kvwb9FjZH6kg==
+katex@0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.11.1.tgz#df30ca40c565c9df01a466a00d53e079e84ffaa2"
+  integrity sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==
   dependencies:
     commander "^2.19.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,10 +3699,10 @@ just-debounce@^1.0.0:
   resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.0.0.tgz#87fccfaeffc0b68cd19d55f6722943f929ea35ea"
   integrity sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=
 
-katex@0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.11.1.tgz#df30ca40c565c9df01a466a00d53e079e84ffaa2"
-  integrity sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==
+katex@0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.10.1.tgz#5bb0b72bf19cecfc1fa217a9261760e5d301efff"
+  integrity sha512-iZXZ2L8pEP7HXBLAaeWkdLxnoRQ8Fdks8IuIVt01tYb+D8e0em5JYgfe6J48wXsuEr512IRCN5Kvwb9FjZH6kg==
   dependencies:
     commander "^2.19.0"
 

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -162,14 +162,41 @@ class Profile(models.Model):
     def get_user_public_contents_queryset(self, _type=None):
         """
         :param _type: if provided, request a specific type of content
-        :return: Queryset of contents with this user as author.
+        :return: Queryset of public contents with this user as author.
         """
-        queryset = PublishedContent.objects.filter(authors__in=[self.user])
+        queryset = PublishableContent.objects.filter(public_version__authors__in=[self.user])
 
         if _type:
-            queryset = queryset.filter(content_type=_type)
+            queryset = queryset.filter(type=_type)
 
         return queryset
+
+    def get_user_draft_contents_queryset(self, _type=None):
+        """
+        :param _type: if provided, request a specific type of content
+        :return: Queryset of draft contents with this user as author.
+        """
+        return self.get_user_contents_queryset(_type).filter(
+            sha_draft__isnull=False,
+            sha_beta__isnull=True,
+            sha_validation__isnull=True,
+            sha_public__isnull=True
+        )
+
+    def get_user_validate_contents_queryset(self, _type=None):
+        """
+        :param _type: if provided, request a specific type of content
+        :return: Queryset of contents in validation with this user as author.
+        """
+        print("\n\n\n\n\nEn validation\n\n\n\n\n\n\n")
+        return self.get_user_contents_queryset(_type).filter(sha_validation__isnull=False)
+
+    def get_user_beta_contents_queryset(self, _type=None):
+        """
+        :param _type: if provided, request a specific type of content
+        :return: Queryset of contents in beta with this user as author.
+        """
+        return self.get_user_contents_queryset(_type).filter(sha_beta__isnull=False)
 
     def get_content_count(self, _type=None):
         """
@@ -194,33 +221,28 @@ class Profile(models.Model):
         :param _type: if provided, request a specific type of content
         :return: All draft tutorials with this user as author.
         """
-        return self.get_user_contents_queryset(_type).filter(
-            sha_draft__isnull=False,
-            sha_beta__isnull=True,
-            sha_validation__isnull=True,
-            sha_public__isnull=True
-        ).all()
+        return self.get_user_draft_contents_queryset(_type).all()
 
     def get_public_contents(self, _type=None):
         """
         :param _type: if provided, request a specific type of content
         :return: All published contents with this user as author.
         """
-        return self.get_user_public_contents_queryset(_type).filter(must_redirect=False).all()
+        return self.get_user_public_contents_queryset(_type).all()
 
     def get_validate_contents(self, _type=None):
         """
         :param _type: if provided, request a specific type of content
         :return: All contents in validation with this user as author.
         """
-        return self.get_user_contents_queryset(_type).filter(sha_validation__isnull=False).all()
+        return self.get_user_validate_contents_queryset(_type).all()
 
     def get_beta_contents(self, _type=None):
         """
         :param _type: if provided, request a specific type of content
         :return: All tutorials in beta with this user as author.
         """
-        return self.get_user_contents_queryset(_type).filter(sha_beta__isnull=False).all()
+        return self.get_user_beta_contents_queryset(_type).all()
 
     def get_tuto_count(self):
         """

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 from zds.forum.models import Post, Topic
 from zds.member import NEW_PROVIDER_USES
 from zds.member.managers import ProfileManager
-from zds.tutorialv2.models.database import PublishableContent, PublishedContent
+from zds.tutorialv2.models.database import PublishableContent
 from zds.utils.models import Alert, Licence, Hat
 
 from zds.forum.models import Forum
@@ -188,7 +188,6 @@ class Profile(models.Model):
         :param _type: if provided, request a specific type of content
         :return: Queryset of contents in validation with this user as author.
         """
-        print("\n\n\n\n\nEn validation\n\n\n\n\n\n\n")
         return self.get_user_contents_queryset(_type).filter(sha_validation__isnull=False)
 
     def get_user_beta_contents_queryset(self, _type=None):

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -2132,7 +2132,6 @@ class ContentOfAuthor(ZdSPagingListView):
             .select_related('licence')\
             .select_related('image')
 
-
         # Sort.
         if 'sort' in self.request.GET and self.request.GET['sort'].lower() in self.sorts:
             self.sort = self.request.GET['sort']

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -2080,12 +2080,10 @@ class ContentOfAuthor(ZdSPagingListView):
     model = PublishableContent
 
     authorized_filters = OrderedDict([
-        ('public', [lambda q: q.filter(sha_public__isnull=False), _('Publiés'), True, 'tick green']),
-        ('validation', [lambda q: q.filter(sha_validation__isnull=False), _('En validation'), False, 'tick']),
-        ('beta', [lambda q: q.filter(sha_beta__isnull=False), _('En bêta'), True, 'beta']),
-        ('redaction', [
-            lambda q: q.filter(sha_validation__isnull=True, sha_public__isnull=True, sha_beta__isnull=True),
-            _('Brouillons'), False, 'edit']),
+        ('public', [lambda p, t: p.get_user_public_contents_queryset(t), _('Publiés'), True, 'tick green']),
+        ('validation', [lambda p, t: p.get_user_validate_contents_queryset(t), _('En validation'), False, 'tick']),
+        ('beta', [lambda p, t: p.get_user_beta_contents_queryset(t), _('En bêta'), True, 'beta']),
+        ('redaction', [lambda p, t: p.get_user_draft_contents_queryset(t), _('Brouillons'), False, 'edit']),
     ])
     sorts = OrderedDict([
         ('creation', [lambda q: q.order_by('creation_date'), _('Par date de création')]),
@@ -2108,19 +2106,12 @@ class ContentOfAuthor(ZdSPagingListView):
         return super(ContentOfAuthor, self).dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
-        if self.type == 'ALL':
-            queryset = PublishableContent.objects.filter(authors__pk__in=[self.user.pk])
-        elif self.type in list(TYPE_CHOICES_DICT.keys()):
-            queryset = PublishableContent.objects.filter(authors__pk__in=[self.user.pk], type=self.type)
-        else:
+        profile = self.user.profile
+        if self.type not in list(TYPE_CHOICES_DICT.keys()):
             raise Http404('Ce type de contenu est inconnu dans le système.')
-
-        # prefetch:
-        queryset = queryset\
-            .prefetch_related('authors')\
-            .prefetch_related('subcategory')\
-            .select_related('licence')\
-            .select_related('image')
+        _type = self.type
+        if self.type == 'ALL':
+            _type = None
 
         # Filter.
         if 'filter' in self.request.GET:
@@ -2129,8 +2120,18 @@ class ContentOfAuthor(ZdSPagingListView):
                 raise Http404("Le filtre n'est pas autorisé.")
         elif self.user != self.request.user:
             self.filter = 'public'
-        if self.filter != '':
-            queryset = self.authorized_filters[self.filter][0](queryset)
+
+        if self.filter == '':
+            queryset = profile.get_user_contents_queryset(_type=_type)
+        else:
+            queryset = self.authorized_filters[self.filter][0](profile, _type)
+        # prefetch:
+        queryset = queryset\
+            .prefetch_related('authors')\
+            .prefetch_related('subcategory')\
+            .select_related('licence')\
+            .select_related('image')
+
 
         # Sort.
         if 'sort' in self.request.GET and self.request.GET['sort'].lower() in self.sorts:


### PR DESCRIPTION
Corrige l'affichage de toutes les publications des membres. Le nombre de publications est correct et les tutoriels affichés sont les bons (avant, quand un auteur était retiré d'un tutoriel qui avait déjà été publié, le tutoriel n'apparaissait plus dans la liste des contenus publiés par l'auteur, mais il apparaissait dans la liste des contenus publiés par un auteur si cet auteur avait été ajouté après la publication).

Numéro du ticket concerné : #5422 

### Contrôle qualité

- Créer un tutoriel avec un auteur `A`.
- Le publier.
- Lui rajouter un auteur `B` et le mettre en bêta. 
- Vérifier que le tutoriel n'apparaît pas dans la liste des tutoriels publiés par `B`, mais apparaît dans la liste de ses tutoriels en bêta. Vérifier que le nombre de tutoriels publiés par `B` et son nombre de tutoriels en bêta est correct.
- Modifier le tutoriel et le republier.
- Retirer `B` des auteurs du tutoriel.
- Vérifier que le tutoriel apparaît dans la liste des tutoriels publiés par `B` et que le nombre de tutoriels publiés par `B` est correct. 