### PR TITLE
fix #5093 : calcul du nombre de caractère réel d'un contenu

### DIFF
--- a/doc/source/utils/adjust_char_count.rst
+++ b/doc/source/utils/adjust_char_count.rst
@@ -1,0 +1,26 @@
+===============================================
+Raffraichir le nombre de caractère d'un contenu
+===============================================
+
+Pour estimer le temps de lecture d'un contenu, nous utilisons le nombre de caractère de celui-ci (sans les fiotures du markdown).
+
+Pour des raisons de performance ce nombre de caractère est calculé au moment de la publication d'un contenu et stocké dans une table.
+
+Pour différente raison (changement de la formule de calcul, recalcul d'un ancien contenu, etc.) on peut avoir envie
+de recalculer le nombre de caractères d'un contenu. Cette commande sert exactement à répondre à ce besoin.
+
+.. sourcecode:: bash
+
+    python manage.py adjust_char_count
+
+Le nombre de caractère de tous les contenus publiés sera alors recalculé.
+
+Vous pouvez préciser une liste de contenus, pour celà l'argument ``--id`` existe:
+
+.. sourcecode:: bash
+
+    python manage.py adjust_char_count --id=125,142,56
+
+.. attention::
+
+    Les ``id`` qui ne seraient pas valides sont automatiquement éliminés. Si aucun n'est valide, la commande ne fait rien.

--- a/zds/tutorialv2/management/commands/adjust_char_count.py
+++ b/zds/tutorialv2/management/commands/adjust_char_count.py
@@ -1,15 +1,31 @@
 import logging
+
 from django.core.management.base import BaseCommand
+
 from zds.tutorialv2.models.database import PublishedContent
 
 
 class Command(BaseCommand):
     """
     `python manage.py adjust_char_count`; set the number of characters for every published content.
+
     """
 
+    help = 'Set the number of characters for every published content'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--id', dest='id', type=str)
+
     def handle(self, *args, **options):
-        for content in PublishedContent.objects.filter(char_count=None, must_redirect=False):
+        opt = options.get('id')
+        if opt:
+            ids = list(set(opt.split(',')))
+            query = PublishedContent.objects.filter(content_pk__in=ids, must_redirect=False)
+        else:
+            query = PublishedContent.objects.filter(must_redirect=False)
+
+        for content in query:
+            logging.error('ids = ' + str(content))
             content.char_count = content.get_char_count()
             content.save()
             logging.info('content %s got %d letters', content.title(), content.char_count)

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -1,47 +1,42 @@
-from pathlib import Path
-
-from django.db.models import CASCADE
-from datetime import datetime
 import contextlib
-
-from zds.mp.models import PrivateTopic
-from zds.tutorialv2.models.mixins import TemplatableContentModelMixin, OnlineLinkableContentMixin
-from zds import json_handler
-
-from math import ceil
+import logging
+import os
 import shutil
+from datetime import datetime
+from math import ceil
+from pathlib import Path
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.urls import reverse
 from django.db import models
-from django.http import Http404
-from django.utils.http import urlencode
-from django.utils.translation import ugettext_lazy as _
+from django.db.models import CASCADE
 from django.db.models.signals import pre_delete, post_delete, pre_save
 from django.dispatch import receiver
-
-from git import Repo, BadObject
-from gitdb.exc import BadName
-import os
-from uuslug import uuslug
-
+from django.http import Http404
+from django.urls import reverse
+from django.utils.http import urlencode
+from django.utils.translation import ugettext_lazy as _
 from elasticsearch_dsl import Mapping, Q as ES_Q
 from elasticsearch_dsl.field import Text, Keyword, Date, Boolean
+from git import Repo, BadObject
+from gitdb.exc import BadName
+from uuslug import uuslug
 
+from zds import json_handler
 from zds.forum.models import Topic
 from zds.gallery.models import Image, Gallery, UserGallery, GALLERY_WRITE
+from zds.mp.models import PrivateTopic
+from zds.searchv2.models import AbstractESDjangoIndexable, AbstractESIndexable, delete_document_in_elasticsearch, \
+    ESIndexManager
 from zds.tutorialv2.managers import PublishedContentManager, PublishableContentManager
-from zds.tutorialv2.models.versioned import NotAPublicVersion
 from zds.tutorialv2.models import TYPE_CHOICES, STATUS_CHOICES, CONTENT_TYPES_REQUIRING_VALIDATION, PICK_OPERATIONS
+from zds.tutorialv2.models.mixins import TemplatableContentModelMixin, OnlineLinkableContentMixin
+from zds.tutorialv2.models.versioned import NotAPublicVersion
 from zds.tutorialv2.utils import get_content_from_json, BadManifestError
 from zds.utils import get_current_user
 from zds.utils.models import SubCategory, Licence, HelpWriting, Comment, Tag
-from zds.searchv2.models import AbstractESDjangoIndexable, AbstractESIndexable, delete_document_in_elasticsearch, \
-    ESIndexManager
+from zds.utils.templatetags.emarkdown import render_markdown_stats
 from zds.utils.tutorials import get_blob
-import logging
-
 
 ALLOWED_TYPES = ['pdf', 'md', 'html', 'epub', 'zip', 'tex']
 logger = logging.getLogger(__name__)
@@ -915,16 +910,15 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
         :return: Number of letters in the md file
         :rtype: int
         """
-
         if not md_file_path:
             md_file_path = os.path.join(self.get_extra_contents_directory(), self.content_public_slug + '.md')
 
         try:
-            with open(md_file_path, 'rb') as md_file:
-                content = md_file.read().decode('utf-8')
+            with open(md_file_path, encoding='utf-8') as md_file_handler:
+                content = md_file_handler.read()
             current_content = PublishedContent.objects.filter(content_pk=self.content_pk, must_redirect=False).first()
             if current_content:
-                return len(content)
+                return render_markdown_stats(content)
         except OSError as e:
             logger.warning('could not get file %s to compute nb letters (error=%s)', md_file_path, e)
 

--- a/zds/tutorialv2/views/published.py
+++ b/zds/tutorialv2/views/published.py
@@ -161,10 +161,12 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
         context['subscriber_count'] = ContentReactionAnswerSubscription.objects.get_subscriptions(self.object).count()
         # We need reading time expressed in minutes
         try:
-            context['reading_time'] = int(
-                self.versioned_object.get_tree_level() * self.object.public_version.char_count /
-                settings.ZDS_APP['content']['characters_per_minute']
-            )
+            char_count = self.object.public_version.char_count
+            if char_count:
+                context['reading_time'] = int(
+                    self.versioned_object.get_tree_level() * char_count /
+                    settings.ZDS_APP['content']['characters_per_minute']
+                )
         except ZeroDivisionError as e:
             logger.warning('could not compute reading time: setting characters_per_minute is set to zero (error=%s)', e)
 

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -118,6 +118,17 @@ def render_markdown(md_input, *, on_error=None, **kwargs):
         return mark_safe('<div class="error ico-after"><p>{}</p></div>'.format(json.dumps(messages))), metadata, []
 
 
+def render_markdown_stats(md_input, **kwargs):
+    """
+    Returns contents statistics (words and chars)
+    """
+    kwargs['stats'] = True
+    content, metadata, messages = _render_markdown_once(md_input, **kwargs)
+    if metadata:
+        return metadata.get('stats', {}).get('signs', {})
+    return None
+
+
 @register.filter(name='epub_markdown', needs_autoescape=False)
 def epub_markdown(md_input, image_directory):
     return emarkdown(md_input, output_format='epub', images_download_dir=image_directory.absolute,


### PR DESCRIPTION
Cette PR permet d'utiliser une formule de calcul plus juste (sans les fioritures markdown) pour calculer le nombre de caractère d'u contenu.

Numéro du ticket concerné : #5093


### Contrôle qualité

- Lancer le site avec idéalement quelques _fixtures_ (quelques contenus avec du contenu pour estimer) générée avant le passage sur ma PR.
- Constatez la durée de lecture estimée du contenu (qui devraient être sur estimée)
- Lancer la commande suivante : `python manage.py adjust_char_count`
- Constatez en retournant sur le site que l'estimation du temps de lecture s'est grandement amélioré car c'est zmd qui fait le calcul du nombre de caractère.
- Tester aussi le cas ou vous publié un nouveau contenu, et constatez qu'une valeur est présente dans l'estimation du temps de lecture.

