### PR TITLE
Correction du problème de plein écran sur le nouvel éditeur

### DIFF
--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -642,18 +642,18 @@
         {
           name: 'switch-contentAreaStyle',
           action: (evt) => {
-            if(easyMDE.isFullscreenActive()) {
-                easyMDE.toggleFullScreen()
+            if (easyMDE.isFullscreenActive()) {
+              easyMDE.toggleFullScreen()
             }
             const wrapper = easyMDE.codemirror.getWrapperElement()
             $(wrapper.parentElement).children('.textarea-multivers').toggle()
             $(wrapper).toggle()
             // deactivating buttons incompatible with the textarea mode
             var $toolbar = $(easyMDE.element.parentElement).children('.editor-toolbar')
-            if($toolbar.hasClass('disabled-for-textarea-mode')) {
-                $toolbar.removeClass("disabled-for-textarea-mode")
+            if ($toolbar.hasClass('disabled-for-textarea-mode')) {
+              $toolbar.removeClass('disabled-for-textarea-mode')
             } else {
-                $toolbar.addClass("disabled-for-textarea-mode")
+              $toolbar.addClass('disabled-for-textarea-mode')
             }
             easyMDE.codemirror.refresh()
           },

--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -642,9 +642,19 @@
         {
           name: 'switch-contentAreaStyle',
           action: (evt) => {
+            if(easyMDE.isFullscreenActive()) {
+                easyMDE.toggleFullScreen()
+            }
             const wrapper = easyMDE.codemirror.getWrapperElement()
             $(wrapper.parentElement).children('.textarea-multivers').toggle()
             $(wrapper).toggle()
+            // deactivating buttons incompatible with the textarea mode
+            var $toolbar = $(easyMDE.element.parentElement).children('.editor-toolbar')
+            if($toolbar.hasClass('disabled-for-textarea-mode')) {
+                $toolbar.removeClass("disabled-for-textarea-mode")
+            } else {
+                $toolbar.addClass("disabled-for-textarea-mode")
+            }
             easyMDE.codemirror.refresh()
           },
           className: 'fas fa-broom',
@@ -654,19 +664,19 @@
         {
           name: 'preview',
           action: EasyMDE.togglePreview,
-          className: 'fa fa-eye no-disable',
+          className: 'fa fa-eye no-disable disable-for-textarea-mode',
           title: 'Aperçu'
         },
         {
           name: 'side-by-side',
           action: EasyMDE.toggleSideBySide,
-          className: 'fa fa-columns no-disable no-mobile',
+          className: 'fa fa-columns no-disable no-mobile disable-for-textarea-mode',
           title: 'Aperçu sur le coté'
         },
         {
           name: 'fullscreen',
           action: EasyMDE.toggleFullScreen,
-          className: 'fa fa-arrows-alt no-disable no-mobile',
+          className: 'fa fa-arrows-alt no-disable no-mobile disable-for-textarea-mode',
           title: 'Plein écran'
         }
       ]
@@ -774,7 +784,7 @@ function mirroringEasyMDE(easyMDE, textarea) {
     }, 12) // <-- after default trigger (I mean after browser trigger)
   })
 
-  $(easyMDE.element.parentElement).children('.editor-toolbar').before($twin)
+  $(easyMDE.element.parentElement).children('.editor-statusbar').before($twin)
 
   return $twin
 }

--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -718,7 +718,7 @@
         .appendTo($alertbox)
         .after($hide)
 
-      $alertbox.insertAfter($(this).parent().children('.editor-toolbar'))
+      $(easyMDE.element.parentElement).children('.editor-toolbar').before($alertbox)
     }
 
     window.editors[this.id] = easyMDE
@@ -774,7 +774,7 @@ function mirroringEasyMDE(easyMDE, textarea) {
     }, 12) // <-- after default trigger (I mean after browser trigger)
   })
 
-  $(easyMDE.element.parentElement).children('.CodeMirror').before($twin)
+  $(easyMDE.element.parentElement).children('.editor-toolbar').before($twin)
 
   return $twin
 }

--- a/assets/scss/components/_editor-new.scss
+++ b/assets/scss/components/_editor-new.scss
@@ -8,6 +8,15 @@
         .editor-toolbar {
             border: 0;
 
+            &.disabled-for-textarea-mode {
+                button {
+                    &.disable-for-textarea-mode {
+                        opacity: .6;
+                        pointer-events: none;
+                    }
+                }
+            }
+
             button:not(.link) {
                 height: auto;
                 line-height: 0px;


### PR DESCRIPTION
Cette PR permet de corriger le passage en plein écran sur le nouvel éditeur tel que pointé par le ticket #5692 .

Puisque ce bug est bloquant pour la 29.1, je préfère la solution qui consiste a corriger rapidement chez nous et le correctif un peu plus propre arrivera avec la prochaine version de easymde (du coup pas besoin de leur mettre la pression pour rien).

Numéro du ticket concerné : #5692

### Contrôle qualité

- Démarrer le site
- Pensez à builder le front (sur linux `make build-front`)
- Allez sur une zone de texte (sur un sujet de forum par exemple) cliquez sur le bouton de passage en plein écran
- Vérifiez que la barre d'outil est passée aussi en plein écran que l'on a plus le bug tel qu'on le voit en beta en ce moment (cf. capture ci-dessous)

![](https://user-images.githubusercontent.com/6664636/79016020-4572ec80-7b6e-11ea-8971-ea180bcf9783.png)