### PR TITLE
Ajoute bouton pour annuler les filtres.

### DIFF
--- a/templates/tutorialv2/index.html
+++ b/templates/tutorialv2/index.html
@@ -200,7 +200,7 @@
                         {% endif %}
                     {% endfor %}
                     {% if user == usr %}
-                        <li><a href="{% url namespace|add:':find-'|add:type usr.username %}" class="ico-after cross {% if filter == '' %}selected{% endif %}">Aucun filtre</a></li>
+                        <li><a href="{% url namespace|add:':find-'|add:type usr.username %}" class="ico-after cross red {% if filter == '' %}selected{% endif %}">Aucun filtre</a></li>
                     {% endif %}
                 </ul>
             </div>

--- a/templates/tutorialv2/index.html
+++ b/templates/tutorialv2/index.html
@@ -193,16 +193,15 @@
             <div class="mobile-menu-bloc mobile-all-links" data-title="Filtrer">
                 <h3>{% trans "Filtrer" %}</h3>
                 <ul>
+                    {% captureas namespace %}{% if type == 'all' %}content{% else %}{{ type }}{% endif %}{% endcaptureas %}
                     {% for current_filter in filters %}
-                        {% if contents != None or tutorials != None or opinions != None or articles != None %}
-                            {% captureas namespace %}{% if type == 'all' %}content{% else %}{{ type }}{% endif %}{% endcaptureas %}
+                        {% if opinions == None or current_filter.key != 'validation' and current_filter.key != 'beta' %}
                             <li><a href="{% url namespace|add:':find-'|add:type usr.username %}?filter={{ current_filter.key }}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
-                        {% elif opinions != None %}
-                            {% if current_filter.key != 'validation' and current_filter.key != 'beta' %}
-                                <li><a href="{% url 'opinion:find-opinion' usr.username %}?filter={{ current_filter.key }}" class="ico-after {{ current_filter.icon }} {% if filter == current_filter.key %}selected{% endif %}">{{ current_filter.text }}</a> </li>
-                            {% endif %}
                         {% endif %}
                     {% endfor %}
+                    {% if user == usr %}
+                        <li><a href="{% url namespace|add:':find-'|add:type usr.username %}" class="ico-after cross {% if filter == '' %}selected{% endif %}">Aucun filtre</a></li>
+                    {% endif %}
                 </ul>
             </div>
         {% endif %}


### PR DESCRIPTION
Ajoute un bouton pour supprimer le filtre dans l'affichage de ses tutoriels. Corrige l'affichage des filtres pour les billets (supprime les filtres pour la bêta et la validation).

Numéro du ticket concerné : #5285 

### Contrôle qualité

- Créer des tutoriels et vérifier que le bouton « Aucun filtre » apparaît bien et renvoie bien vers une page où tous les tutoriels de l'utilisateur apparaissent. 
- Vérifier également le comportement sur la page des articles et celles des contenus. 
- Vérifier que le bouton n'apparaît pas sur les pages de contenus d'autres membres, mais seulement sur sa page de tutoriels.