### PR TITLE
correction du problème de migrations

### DIFF
--- a/zds/forum/migrations/0018_auto_20200315_1749.py
+++ b/zds/forum/migrations/0018_auto_20200315_1749.py
@@ -4,6 +4,7 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
+    atomic = False
 
     dependencies = [
         ('forum', '0017_auto_20190114_1301'),


### PR DESCRIPTION
Cette PR corrige un  problème de migrations qui n'est pas supportée par certaines version de Sqlite (et donc ne touche que les dev).

Lorsque l'on effectuait une migration des forums, on pouvait se retrouver avec un problème de base de donnée sur SQLITE.

### Contrôle qualité

- Installer zds
- Lancer les migrations (sous linux `make migrate-db`)
- Vérifiez en allant sur le site que la page d'accueil ne renvoit pas d'erreur.
