### PR TITLE
Corrige bouton aucun filtre.

### DIFF
--- a/templates/tutorialv2/index.html
+++ b/templates/tutorialv2/index.html
@@ -200,7 +200,7 @@
                         {% endif %}
                     {% endfor %}
                     {% if user == usr %}
-                        <li><a href="{% url namespace|add:':find-'|add:type usr.username %}" class="ico-after cross red {% if filter == '' %}selected{% endif %}">Aucun filtre</a></li>
+                        <li><a href="{% url namespace|add:':find-'|add:type usr.username %}" class="ico-after cross red {% if filter == '' %}selected{% endif %}">{% trans 'Aucun filtre' %}</a></li>
                     {% endif %}
                 </ul>
             </div>


### PR DESCRIPTION
Rajoute la balise `trans` pour le texte du bouton. Pour la QA, aller dans ses tutoriels et vérifier que le bouton « Aucun filtre » est bien présent.