### PR TITLE
Avoir seulement des champs optionnels dans le formulaire de création de contenu

### DIFF
--- a/zds/tutorialv2/factories.py
+++ b/zds/tutorialv2/factories.py
@@ -44,7 +44,7 @@ class PublishableContentFactory(factory.DjangoModelFactory):
     pubdate = datetime.now()
 
     @classmethod
-    def _prepare(cls, create, *, light=True, author_list=None, licence: Licence = None, **kwargs):
+    def _prepare(cls, create, *, light=True, author_list=None, licence: Licence = None, add_category=True, **kwargs):
         auths = author_list or []
         given_licence = licence or Licence.objects.first()
         if isinstance(given_licence, str) and given_licence:
@@ -60,6 +60,9 @@ class PublishableContentFactory(factory.DjangoModelFactory):
         publishable_content.licence = licence
         for auth in auths:
             publishable_content.authors.add(auth)
+
+        if add_category:
+            publishable_content.subcategory.add(SubCategoryFactory())
 
         publishable_content.save()
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -22,11 +22,7 @@ class FormWithTitle(forms.Form):
     title = forms.CharField(
         label=_('Titre'),
         max_length=PublishableContent._meta.get_field('title').max_length,
-        widget=forms.TextInput(
-            attrs={
-                'required': 'required',
-            }
-        )
+        required=False
     )
 
     def clean(self):
@@ -34,11 +30,9 @@ class FormWithTitle(forms.Form):
 
         title = cleaned_data.get('title')
 
-        if title is not None and not title.strip():
-            self._errors['title'] = self.error_class(
-                [_('Le champ du titre ne peut être vide.')])
-            if 'title' in cleaned_data:
-                del cleaned_data['title']
+        if title is None or not title.strip():
+            title = 'Titre par défaut'
+            cleaned_data['title'] = title
 
         try:
             slugify_raise_on_invalid(title)

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -282,7 +282,7 @@ class ContentForm(ContainerForm):
     subcategory = forms.ModelMultipleChoiceField(
         label=_('Sélectionnez les catégories qui correspondent à votre contenu.'),
         queryset=SubCategory.objects.order_by('title').all(),
-        required=True,
+        required=False,
         widget=forms.CheckboxSelectMultiple()
     )
 
@@ -296,7 +296,7 @@ class ContentForm(ContainerForm):
             )
         ),
         queryset=Licence.objects.order_by('title').all(),
-        required=True,
+        required=False,
         empty_label=_('Choisir une licence')
     )
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -695,7 +695,13 @@ class AskValidationForm(forms.Form):
         self.helper.form_class = 'modal modal-flex'
         self.helper.form_id = 'ask-validation'
 
+        self.no_subcategories = content.subcategory.count() == 0
+        no_category_msg = HTML(_("""<p><strong>Votre contenu n'est dans aucune catégorie.
+                                    Vous devez choisir une catégorie avant de demander la validation !</strong></p>
+                                 """))
         self.helper.layout = Layout(
+            no_category_msg if self.no_subcategories else None,
+            HTML(_('<p>Pensez à vérifier la licence de votre contenu avant de demander la validation.</p>')),
             Field('text'),
             Field('source'),
             Field('version'),
@@ -720,6 +726,10 @@ class AskValidationForm(forms.Form):
                 [_('Votre commentaire doit faire au moins 3 caractères.')])
             if 'text' in cleaned_data:
                 del cleaned_data['text']
+
+        if self.no_subcategories:
+            self._errors['no_subcategories'] = self.error_class(
+                [_('Vous devez spécifier une catégorie pour votre publication.')])
 
         return cleaned_data
 

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -4096,7 +4096,8 @@ class ContentTests(TutorialTestMixin, TestCase):
             'subcategory': self.subcategory.pk,
         }
 
-        disallowed_titles = ['-', '_', '__', '-_-', '$', '@', '&', '{}', '    ', '...']
+        # empty title not disallowed because it is converted to the default title
+        disallowed_titles = ['-', '_', '__', '-_-', '$', '@', '&', '{}', '...']
 
         for title in disallowed_titles:
             dic['title'] = title

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -310,6 +310,12 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
             messages.error(self.request, _('Une nouvelle version a été postée avant que vous ne validiez.'))
             return self.form_invalid(form)
 
+        # Forbid removing all categories of a validated content
+        if publishable.in_public() and not form.cleaned_data['subcategory']:
+            messages.error(self.request,
+                           _('Vous devez choisir au moins une catégorie, car ce contenu est déjà publié.'))
+            return self.form_invalid(form)
+
         # first, update DB (in order to get a new slug if needed)
         title_is_changed = publishable.title != form.cleaned_data['title']
         publishable.title = form.cleaned_data['title']


### PR DESCRIPTION
J'essaie de faire des petits pas pour l'évolution des outils pour les auteurs, avec l'idée que des petits pas sont plus faciles à faire et à valider, et donc permettront d'avancer sans se retrouver face à un mur infranchissable.

Cette PR permet la création de contenus en un seul clic : tous les champs sont optionnels. En contrepartie, à la demande de validation :

* on vérifie qu'une catégorie a été donnée,
* on suggère à l'auteur de vérifier la licence.

Le fait que le titre lui-même soit optionnel conduit à ajouter un mécanisme de titre par défaut. Un effet de bord (agréable pour moi) de ce changement est de pouvoir créer des parties/chapitre/sections sans se soucier de leur titre, puisqu'elles aussi vont avoir un titre par défaut.

~~**Note.** Cette PR introduit un drôle de comportement : quand on enlève toutes les catégories d'un contenu publié (parce qu'il n'y aucune validation de ça), il se retrouve affiché dans aucune catégorie (normal). On ne peut les voir que sur les listes de tous les tutos, tous les articles ou tous les billets. Je pense qu'on devrait faire un genre de *fallback* du type : si aucune catégorie présente alors on affiche dans "autre/autre". Selon moi, ça devrait faire l'objet d'une autre PR.~~

### Contrôle qualité

En tant que membre connecté,

* créer un contenu (article, tuto, ou billet),
* ne rien remplir,
* cliquer sur valider,
* constater qu'un titre par défaut est mis,
* constater qu'aucune catégorie n'est mise,
* constater que la licence est celle paramétrée dans le profil ou "Tout droits réservés".

Faire la même chose mais dans le menu d'édition du tutoriel. Vérifier notamment que vider un titre existant provoque aussi un titre par défaut.

Ensuite, demander une validation :

* constater un message d'avertissement sur l'absence de catégorie,
* valider avec un message de validation,
* constater un message d'erreur,
* ajouter une catégorie,
* constater la disparition du message d'avertissement,
* valider avec un message de validation,
* constater que la demande est faite.

Faire la même chose pour les billets, sauf qu'il s'agit d'une publication et non d'une demande de validation.

Sur un contenu publié :
* éditer le contenu,
* enlever toutes les catégories,
* constater une erreur à la validation du formulaire.