### PR TITLE
Déplace le champ du lien canonique dans le formulaire des contenus

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -96,9 +96,8 @@
     <link rel="stylesheet" href="{% static "css/idea.css" %}">
     <link rel="stylesheet" href="{% static "css/katex.min.css" %}">
     <link rel="stylesheet" href="{% static "css/main.css" %}">
-    {% if not debug %}
-        {% block canonical %}{% endblock %}
-    {% endif %}
+
+    {% block canonical %}{% endblock %}
 
     {# Webfont async loading #}
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700|Source+Code+Pro:400,700|Merriweather:400,700' rel='stylesheet' type='text/css'>

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -288,6 +288,18 @@ class ContentForm(ContainerForm):
         widget=forms.CheckboxSelectMultiple()
     )
 
+    source = forms.CharField(
+        label=_("""Si votre contenu est publié en dehors de Zeste de Savoir (blog, site personnel, etc.),
+                   indiquez le lien de la publication originale : """),
+        max_length=PublishableContent._meta.get_field('source').max_length,
+        required=False,
+        widget=forms.TextInput(
+            attrs={
+                'placeholder': _('https://...')
+            }
+        )
+    )
+
     def _create_layout(self, hide_help):
         html_part = HTML(_("<p>Demander de l'aide à la communauté !<br>"
                            "Si vous avez besoin d'un coup de main, "
@@ -314,7 +326,8 @@ class ContentForm(ContainerForm):
             HTML('{% if form.conclusion.value %}{% include "misc/preview.part.html" \
             with text=form.conclusion.value %}{% endif %}'),
             Field('last_hash'),
-            Field('subcategory', template='crispy/checkboxselectmultiple.html'),
+            Field('source'),
+            Field('subcategory', template='crispy/checkboxselectmultiple.html')
         )
 
         if not hide_help:
@@ -697,15 +710,6 @@ class AskValidationForm(forms.Form):
             }
         )
     )
-    source = forms.CharField(
-        label='',
-        required=False,
-        widget=forms.TextInput(
-            attrs={
-                'placeholder': _("Pour un contenu importé d'un autre site, adresse de la source.")
-            }
-        )
-    )
 
     version = forms.CharField(widget=forms.HiddenInput(), required=True)
 
@@ -747,7 +751,6 @@ class AskValidationForm(forms.Form):
             no_category_msg if self.no_subcategories else None,
             no_license_msg if self.no_license else None,
             Field('text'),
-            Field('source'),
             Field('version'),
             StrictButton(
                 _('Confirmer'),
@@ -808,16 +811,6 @@ class AcceptValidationForm(forms.Form):
         initial=True
     )
 
-    source = forms.CharField(
-        label='',
-        required=False,
-        widget=forms.TextInput(
-            attrs={
-                'placeholder': _("Pour un contenu importé d'un autre site, adresse de la source.")
-            }
-        )
-    )
-
     def __init__(self, validation, *args, **kwargs):
         """
 
@@ -849,7 +842,6 @@ class AcceptValidationForm(forms.Form):
 
         self.helper.layout = Layout(
             Field('text'),
-            Field('source'),
             Field('is_major'),
             StrictButton(_('Publier'), type='submit')
         )
@@ -1191,16 +1183,6 @@ class PublicationForm(forms.Form):
     The publication form (used only for content without preliminary validation).
     """
 
-    source = forms.CharField(
-        label='',
-        required=False,
-        widget=forms.TextInput(
-            attrs={
-                'placeholder': _('Pour un contenu importé d\'un autre site, adresse de la source.')
-            }
-        )
-    )
-
     def __init__(self, content, *args, **kwargs):
         super(PublicationForm, self).__init__(*args, **kwargs)
 
@@ -1228,7 +1210,6 @@ class PublicationForm(forms.Form):
         self.helper.layout = Layout(
             no_category_msg if self.no_subcategories else None,
             no_license_msg if self.no_license else None,
-            Field('source'),
             HTML(_("<p>Ce billet sera publié directement et n'engage que vous.</p>")),
             StrictButton(_('Publier'), type='submit')
         )

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -1990,8 +1990,6 @@ class ContentTests(TutorialTestMixin, TestCase):
         """test if the author suscribes to their own content"""
 
         text_validation = "Valide moi ce truc, s'il te plait"
-        source = 'http://example.com'  # thanks the IANA for that one ;-)
-        different_source = 'http://example.org'
         text_accept = "C'est cool, merci !"
 
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
@@ -2010,14 +2008,11 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': text_validation,
-                'source': source,
                 'version': self.tuto_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Validation.objects.count(), 1)
-
-        self.assertEqual(PublishableContent.objects.get(pk=tuto.pk).source, source)  # source is set
 
         validation = Validation.objects.filter(content=tuto).last()
         self.assertIsNotNone(validation)
@@ -2057,8 +2052,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_accept,
-                'is_major': True,
-                'source': different_source  # because ;)
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -2100,14 +2094,11 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': text_validation,
-                'source': source,
                 'version': versioned.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Validation.objects.count(), 2)
-
-        self.assertEqual(PublishableContent.objects.get(pk=tuto.pk).source, source)  # source is set
 
         validation = Validation.objects.filter(content=tuto).last()
         self.assertIsNotNone(validation)
@@ -2147,8 +2138,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_accept,
-                'is_major': True,
-                'source': different_source  # because ;)
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -2168,8 +2158,6 @@ class ContentTests(TutorialTestMixin, TestCase):
         """test the different case of validation"""
 
         text_validation = "Valide moi ce truc, s'il te plait"
-        source = 'http://example.com'  # thanks the IANA for that one ;-)
-        different_source = 'http://example.org'
         text_accept = "C'est cool, merci !"
         text_reject = 'Je refuse ce contenu.'
 
@@ -2189,7 +2177,6 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': '',
-                'source': source,
                 'version': self.tuto_draft.current_version
             },
             follow=False)
@@ -2200,14 +2187,11 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': text_validation,
-                'source': source,
                 'version': self.tuto_draft.current_version
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Validation.objects.count(), 1)
-
-        self.assertEqual(PublishableContent.objects.get(pk=tuto.pk).source, source)  # source is set
 
         validation = Validation.objects.filter(content=tuto).last()
         self.assertIsNotNone(validation)
@@ -2229,8 +2213,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_accept,
-                'is_major': True,
-                'source': ''
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 403)
@@ -2320,7 +2303,6 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': text_validation,
-                'source': source,
                 'version': self.tuto_draft.current_version
             },
             follow=False)
@@ -2351,8 +2333,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_accept,
-                'is_major': True,
-                'source': ''
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 403)
@@ -2400,7 +2381,6 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': text_validation,
-                'source': source,
                 'version': self.tuto_draft.current_version
             },
             follow=False)
@@ -2431,8 +2411,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': '',
-                'is_major': True,
-                'source': ''
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -2444,8 +2423,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_accept,
-                'is_major': True,
-                'source': different_source  # because ;)
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -2470,7 +2448,6 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertTrue(ContentReactionAnswerSubscription.objects
                         .get_existing(user=self.user_author, content_object=tuto).is_active)
 
-        self.assertEqual(published.content.source, different_source)
         self.assertEqual(published.content_public_slug, self.tuto_draft.slug)
         self.assertTrue(os.path.exists(published.get_prod_path()))
         # ... another test cover the file creation and so all, lets skip this part
@@ -2612,7 +2589,6 @@ class ContentTests(TutorialTestMixin, TestCase):
         """this test ensure that the validator is warned if the content he is validing is removed"""
 
         text_validation = "Valide moi ce truc, s'il te plait"
-        source = 'http://example.com'
         text_cancel = 'Veux pas !'
 
         # let's create a medium-size tutorial
@@ -2632,7 +2608,6 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': text_validation,
-                'source': source,
                 'version': self.tuto_draft.current_version
             },
             follow=False)
@@ -2748,7 +2723,6 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': self.tuto.pk, 'slug': self.tuto.slug}),
             {
                 'text': 'blaaaaa',
-                'source': '',
                 'version': 'unexistingversion'
             },
             follow=False)
@@ -3185,7 +3159,6 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': 'valide moi ça, please',
-                'source': '',
                 'version': versioned.current_version
             },
             follow=False)
@@ -3213,8 +3186,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': "ça m'a l'air intéressant, je valide",
-                'is_major': True,
-                'source': ''
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -3676,7 +3648,6 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': 'Valide ?',
-                'source': '',
                 'version': versioned.current_version
             },
             follow=False)
@@ -3704,8 +3675,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': 'Je valide !',
-                'is_major': True,
-                'source': ''
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -3799,7 +3769,6 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': 'Valide ?',
-                'source': '',
                 'version': tuto.sha_draft
             },
             follow=False)
@@ -3827,8 +3796,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': 'Je valide !',
-                'is_major': False,  # !
-                'source': ''
+                'is_major': False  # !
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -3856,7 +3824,6 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': 'Valide ?',
-                'source': '',
                 'version': tuto.sha_draft
             },
             follow=False)
@@ -3884,8 +3851,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': 'Je valide !',
-                'is_major': False,
-                'source': ''
+                'is_major': False
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -4222,7 +4188,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': article.pk, 'slug': article.slug}),
             {
                 'text': text_validation,
-                'source': '',
                 'version': article_draft.current_version
             },
             follow=False)
@@ -4250,8 +4215,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_publication,
-                'is_major': True,
-                'source': ''
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -4302,7 +4266,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': midsize_tuto.pk, 'slug': midsize_tuto.slug}),
             {
                 'text': text_validation,
-                'source': '',
                 'version': midsize_tuto_draft.current_version
             },
             follow=False)
@@ -4330,8 +4293,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_publication,
-                'is_major': True,
-                'source': ''
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -4413,7 +4375,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': bigtuto.pk, 'slug': bigtuto.slug}),
             {
                 'text': text_validation,
-                'source': '',
                 'version': bigtuto_draft.current_version
             },
             follow=False)
@@ -4441,8 +4402,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_publication,
-                'is_major': True,
-                'source': ''
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -5484,7 +5443,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tuto.pk, 'slug': tuto.slug}),
             {
                 'text': text_validation,
-                'source': '',
                 'version': tuto.sha_draft
             },
             follow=False)
@@ -5512,8 +5470,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_publication,
-                'is_major': False,  # minor modification (just the title)
-                'source': ''
+                'is_major': False  # minor modification (just the title)
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -5572,7 +5529,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', args=[tuto.pk, tuto.slug]),
             {
                 'text': 'something good',
-                'source': '',
                 'version': tuto.sha_draft
             },
             follow=False)
@@ -5712,7 +5668,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': published.pk, 'slug': published.slug}),
             {
                 'text': 'abcdefg',
-                'source': '',
                 'version': published.load_version().current_version
             },
             follow=False)
@@ -5739,7 +5694,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': publishable.pk, 'slug': publishable.slug}),
             {
                 'text': 'abcdefg',
-                'source': '',
                 'version': publishable.load_version().current_version
             },
             follow=False)
@@ -5769,7 +5723,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(self.client.login(username=self.user_author.username, password='hostel77'), True)
         result = self.client.post(
             reverse('validation:ask', kwargs={'pk': content_draft.pk, 'slug': content_draft.slug}),
-            {'text': text_validation, 'source': '', 'version': content_draft.current_version},
+            {'text': text_validation, 'version': content_draft.current_version},
             follow=False)
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Validation.objects.count(), 1)
@@ -5802,7 +5756,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
         result = self.client.post(
             reverse('validation:ask', kwargs={'pk': content_draft.pk, 'slug': content_draft.slug}),
-            {'text': text_validation, 'source': '', 'version': content_draft.current_version},
+            {'text': text_validation, 'version': content_draft.current_version},
             follow=False)
         self.assertEqual(result.status_code, 302)
 
@@ -5843,7 +5797,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': article.pk, 'slug': article.slug}),
             {
                 'text': text_validation,
-                'source': '',
                 'version': article_draft.current_version
             },
             follow=False)
@@ -5877,8 +5830,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_publication,
-                'is_major': True,
-                'source': ''
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -5900,7 +5852,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': article.pk, 'slug': article.slug}),
             {
                 'text': text_validation,
-                'source': '',
                 'version': article_draft.current_version
             },
             follow=False)
@@ -5928,8 +5879,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_publication,
-                'is_major': True,
-                'source': ''
+                'is_major': True
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -6253,7 +6203,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tutorial.pk, 'slug': tutorial.slug}),
             {
                 'text': text_validation,
-                'source': '',
                 'version': tutorial_draft.current_version
             },
             follow=False)
@@ -6270,8 +6219,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_publication,
-                'is_major': True,
-                'source': ''
+                'is_major': True
             },
             follow=False)
         self.assertEqual(tutorial.public_version.authors.count(), 2)
@@ -6287,7 +6235,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:ask', kwargs={'pk': tutorial.pk, 'slug': tutorial.slug}),
             {
                 'text': text_validation,
-                'source': '',
                 'version': tutorial_draft.current_version
             },
             follow=False)
@@ -6304,8 +6251,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             reverse('validation:accept', kwargs={'pk': validation.pk}),
             {
                 'text': text_publication,
-                'is_major': False,
-                'source': ''
+                'is_major': False
             },
             follow=False)
 

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -103,6 +103,7 @@ class CreateContent(LoggedWithReadWriteHability, FormWithPreview):
         self.content.description = form.cleaned_data['description']
         self.content.type = form.cleaned_data['type']
         self.content.licence = self.request.user.profile.licence  # Use the preferred license of the user if it exists
+        self.content.source = form.cleaned_data['source']
         self.content.creation_date = datetime.now()
 
         # Creating the gallery
@@ -280,6 +281,7 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         initial['type'] = versioned.type
         initial['introduction'] = versioned.get_introduction()
         initial['conclusion'] = versioned.get_conclusion()
+        initial['source'] = versioned.source
         initial['subcategory'] = self.object.subcategory.all()
         initial['tags'] = ', '.join([tag['title'] for tag in self.object.tags.values('title')]) or ''
         initial['helps'] = self.object.helps.all()
@@ -319,6 +321,7 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         title_is_changed = publishable.title != form.cleaned_data['title']
         publishable.title = form.cleaned_data['title']
         publishable.description = form.cleaned_data['description']
+        publishable.source = form.cleaned_data['source']
 
         publishable.update_date = datetime.now()
 

--- a/zds/tutorialv2/views/validations.py
+++ b/zds/tutorialv2/views/validations.py
@@ -190,7 +190,7 @@ class AskValidationForContent(LoggedWithReadWriteHability, SingleContentFormView
                                 msg)
 
         # update the content with the source and the version of the validation
-        self.object.source = form.cleaned_data['source']
+        self.object.source = self.versioned_object.source
         self.object.sha_validation = validation.version
         self.object.save()
 
@@ -474,7 +474,7 @@ class AcceptValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
             messages.error(self.request, e.message)
         else:
             save_validation_state(db_object, is_update, published, validation, versioned,
-                                  source=form.cleaned_data['source'], is_major=form.cleaned_data['is_major'],
+                                  source=db_object.source, is_major=form.cleaned_data['is_major'],
                                   user=self.request.user, request=self.request, comment=form.cleaned_data['text'])
             notify_update(db_object, is_update, form.cleaned_data['is_major'])
 
@@ -594,12 +594,11 @@ class PublishOpinion(LoggedWithReadWriteHability, DoesNotRequireValidationFormVi
             messages.error(self.request, e.message)
         else:
             # save in database
-
-            db_object.source = form.cleaned_data['source']
+            db_object.source = db_object.source
             db_object.sha_validation = None
-
             db_object.public_version = published
             db_object.save()
+
             # if only ignore, we remove it from history
             PickListOperation.objects.filter(content=db_object,
                                              operation__in=['NO_PICK', 'PICK']).update(is_effective=False)


### PR DESCRIPTION
Actuellement, le champ pour mettre une URL canonique est dans le formulaire de demande de validation, ainsi que dans celui de validation, ce qui est pour le moins curieux.

Cette PR vise à le transférer dans le formulaire de création ou édition de contenu.

### Contrôle qualité

#### Création/édition du champ

En tant que membre connecté :

* créer un tutoriel, 
* constater la présence du champ "lien canonique",
* valider avec juste les champs obligatoires et constater que ce champ ne l'est pas.
* recommencer la même chose en remplissant le champ et constater qu'il est bien enregistré en allant dans le formulaire "Éditer".

Depuis le formulaire "éditer :

* mettre à jour le champ lien canonique,
* constater qu'il est bien mis à jour.

#### Validation/Publication

En tant que membre connecté,

* demander la validation,
* constater que le champ lien canonique n'est pas dans le formulaire,
* valider le formulaire en mettant un commentaire.

Ensuite, en tant que staff,

* réserver le tuto,
*  valider et publier,
* constater qu'il n'y a pas de champ lien canonique dans le formulaire,
* constater que le tuto publié a bien dans son code source le lien canonique.

En tant que membre connecté avec un tuto en validation,

* mettre à jour la version en validation,
* constater que le champ n'a pas de lien canonique.

#### Indépendance brouillon/publication

Ma PR permet de modifier les liens canoniques sans passer par la validation ou publication (pour les billets). C'est déjà le cas dans la version actuelle, il suffit de faire une demande de validation pour y arriver ! Je ne vais donc pas corriger ça avec cette PR. C'est un bug similaire à  #754.

Recommencer la même procédure de test pour les articles et les billets (la validation étant remplacée par la publication).