### PR TITLE
Évite de suroptimiser les SVG avec Gulp

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -142,8 +142,19 @@ function js() {
 
 // Optimizes the images
 function images() {
+  var plugins = [
+    imagemin.gifsicle(),
+    imagemin.mozjpeg(),
+    imagemin.optipng(),
+    // Avoid over-optimizing svg animations
+    imagemin.svgo({
+      plugins: [
+        { removeHiddenElems: false }
+      ]
+    })
+  ]
   return gulp.src(['assets/{images,smileys,licenses}/**/*', '!assets/images/sprite/*.png'])
-    .pipe(gulpif(!fast, imagemin())) // Minify the images
+    .pipe(gulpif(!fast, imagemin(plugins))) // Minify the images
     .pipe(gulp.dest('dist/'))
 }
 


### PR DESCRIPTION
Change une option dans le gulp file pour éviter de suroptimiser les SVG des nouveaux emojis.

* Sans le changement : saved 313 kB - 54%
* Avec le changement : saved 289 kB - 49.8%

Ça correspond essentiellement aux non-optimisations des SVG animés, donc c'est ce qui est attendu.

Fix #5718.

### Contrôle qualité

* Faire `make build-front`.
* Faire un message ou aperçu de message avec des emoji animés, par exemple : ` :)  :D  ;)  :p  :lol:  :euh:  :(  :o  :B  :colere2:  o_O  ^^  :-°  :ange:  :colere:  :diable:  :magicien:  :ninja:  X/  :pirate:  :'(  :honte:  :soleil:  :waw:  :zorro: `
* Constater que "ninja" et les autres sont animés avec fluidité.