### PR TITLE
Retire les aides du formulaire de création/édition de contenu

### DIFF
--- a/assets/js/content-helps.js
+++ b/assets/js/content-helps.js
@@ -18,6 +18,7 @@
 
     const $current = $(e.target)
     const $form = $current.parent()
+    const data = $form.serialize()
     const newActivation = $current.attr('data-activated') !== 'true'
 
     // Change status before request for instant feeling.
@@ -27,20 +28,10 @@
 
     $.ajax($form.attr('action'), {
       method: 'POST',
-      data: {
-        activated: newActivation ? 'true' : 'false',
-        help_wanted: $current.text()
-      },
-      success: () => {
-        const currentHelpClasses = $current[0].classList
-
-        currentHelpClasses.toggle('selected', newActivation)
-        currentHelpClasses.toggle('ico-after', newActivation)
-        currentHelpClasses.toggle('tick', newActivation)
-        currentHelpClasses.toggle('green', newActivation)
-
-        $current.attr('data-activated', newActivation.toString())
-      }
+      data,
+      success: resultData => changeHelpButtonState($current,
+        resultData.help_wanted),
+      error: () => changeHelpButtonState($current, !newActivation),
     })
   })
 })(jQuery)

--- a/assets/js/content-helps.js
+++ b/assets/js/content-helps.js
@@ -1,5 +1,5 @@
 (function($) {
-  $('.help-toogle').click((e) => {
+  $('.help-toggle').click((e) => {
     const $current = $(e.target)
     e.preventDefault()
     const newActivation = $current.attr('data-activated') !== 'true'
@@ -13,13 +13,14 @@
         help_wanted: $current.text()
       },
       success: () => {
-        if (newActivation) {
-          $current.addClass('help-activated')
-          $current.attr('data-activated', 'true')
-        } else {
-          $current.removeClass('help-activated')
-          $current.attr('data-activated', 'false')
-        }
+        let current_el_classes = $current[0].classList
+
+        current_el_classes.toggle('selected', newActivation)
+        current_el_classes.toggle('ico-after', newActivation)
+        current_el_classes.toggle('tick', newActivation)
+        current_el_classes.toggle('green', newActivation)
+
+        $current.attr('data-activated', newActivation.toString())
       }
     })
   })

--- a/assets/js/content-helps.js
+++ b/assets/js/content-helps.js
@@ -1,0 +1,26 @@
+(function($) {
+  $('.help-toogle').click((e) => {
+    const $current = $(e.target)
+    e.preventDefault()
+    const newActivation = $current.attr('data-activated') !== 'true'
+    $.ajax($current.attr('href'), {
+      headers: {
+        'X-CSRFToken': $('input[name=csrfmiddlewaretoken]').val()
+      },
+      method: 'POST',
+      data: {
+        activated: newActivation ? 'true' : 'false',
+        help_wanted: $current.text()
+      },
+      success: () => {
+        if (newActivation) {
+          $current.addClass('help-activated')
+          $current.attr('data-activated', 'true')
+        } else {
+          $current.removeClass('help-activated')
+          $current.attr('data-activated', 'false')
+        }
+      }
+    })
+  })
+})(jQuery)

--- a/assets/js/content-helps.js
+++ b/assets/js/content-helps.js
@@ -1,16 +1,16 @@
 (function($) {
-  function changeHelpButtonState($help_button, state) {
-    const helpButtonClasses = $help_button[0].classList
+  function changeHelpButtonState($helpButton, state) {
+    const helpButtonClasses = $helpButton[0].classList
 
     helpButtonClasses.toggle('selected', state)
     helpButtonClasses.toggle('ico-after', state)
     helpButtonClasses.toggle('tick', state)
     helpButtonClasses.toggle('green', state)
 
-    $help_button.attr('data-activated', state.toString())
-    $help_button.blur()
+    $helpButton.attr('data-activated', state.toString())
+    $helpButton.blur()
 
-    $help_button.parent().find('input[name="activated"]').val((!state).toString())
+    $helpButton.parent().find('input[name="activated"]').val((!state).toString())
   }
 
   $('.help-toggle').click((e) => {
@@ -18,8 +18,6 @@
 
     const $current = $(e.target)
     const $form = $current.parent()
-    const data = $form.serialize()
-
     const newActivation = $current.attr('data-activated') !== 'true'
 
     // Change status before request for instant feeling.

--- a/assets/js/content-helps.js
+++ b/assets/js/content-helps.js
@@ -1,12 +1,33 @@
 (function($) {
+  function changeHelpButtonState($help_button, state) {
+    const helpButtonClasses = $help_button[0].classList
+
+    helpButtonClasses.toggle('selected', state)
+    helpButtonClasses.toggle('ico-after', state)
+    helpButtonClasses.toggle('tick', state)
+    helpButtonClasses.toggle('green', state)
+
+    $help_button.attr('data-activated', state.toString())
+    $help_button.blur()
+
+    $help_button.parent().find('input[name="activated"]').val((!state).toString())
+  }
+
   $('.help-toggle').click((e) => {
-    const $current = $(e.target)
     e.preventDefault()
+
+    const $current = $(e.target)
+    const $form = $current.parent()
+    const data = $form.serialize()
+
     const newActivation = $current.attr('data-activated') !== 'true'
-    $.ajax($current.attr('href'), {
-      headers: {
-        'X-CSRFToken': $('input[name=csrfmiddlewaretoken]').val()
-      },
+
+    // Change status before request for instant feeling.
+    // Will be changed back on error.
+    // This update the form so serialize must be called before/
+    changeHelpButtonState($current, newActivation)
+
+    $.ajax($form.attr('action'), {
       method: 'POST',
       data: {
         activated: newActivation ? 'true' : 'false',

--- a/assets/js/content-helps.js
+++ b/assets/js/content-helps.js
@@ -31,7 +31,7 @@
       data,
       success: resultData => changeHelpButtonState($current,
         resultData.help_wanted),
-      error: () => changeHelpButtonState($current, !newActivation),
+      error: () => changeHelpButtonState($current, !newActivation)
     })
   })
 })(jQuery)

--- a/assets/js/content-helps.js
+++ b/assets/js/content-helps.js
@@ -13,12 +13,12 @@
         help_wanted: $current.text()
       },
       success: () => {
-        let current_el_classes = $current[0].classList
+        const currentHelpClasses = $current[0].classList
 
-        current_el_classes.toggle('selected', newActivation)
-        current_el_classes.toggle('ico-after', newActivation)
-        current_el_classes.toggle('tick', newActivation)
-        current_el_classes.toggle('green', newActivation)
+        currentHelpClasses.toggle('selected', newActivation)
+        currentHelpClasses.toggle('ico-after', newActivation)
+        currentHelpClasses.toggle('tick', newActivation)
+        currentHelpClasses.toggle('green', newActivation)
 
         $current.attr('data-activated', newActivation.toString())
       }

--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -332,9 +332,6 @@
     .checkbox-new-content {
         padding: 0;
     }
-    #div_id_helps .checkbox {
-      padding: 0;
-    }
 }
 
 @media only screen and #{$media-wide} {

--- a/assets/scss/layout/_sidebar.scss
+++ b/assets/scss/layout/_sidebar.scss
@@ -342,16 +342,16 @@
                     margin-top: 5px;
                 }
             }
-            
+
             &.not-ready {
                 background: $color-not-ready-content;
             }
         }
-        
+
         li {
             &.not-ready {
                 background: $color-not-ready-content;
-            }   
+            }
         }
 
         ol li.current {
@@ -377,30 +377,5 @@
                 }
             }
         }
-    }
-}
-
-.sidebar ul li a.help-toogle {
-    &:after {
-        position: absolute;
-        display: block;
-        left: 20px;
-        margin-left: 30px;
-        margin-right: 5px;
-        content: " ";
-    }
-
-    &.help-activated:after{
-        color: $color-success;
-        content: " ";
-        @include sprite();
-        @include sprite-position($tick-green);
-        width: 16px;
-        height: 16px;
-        top: 7px;
-        padding-left: 0;
-    }
-    &.help-activated {
-        font-weight: bolder;
     }
 }

--- a/assets/scss/layout/_sidebar.scss
+++ b/assets/scss/layout/_sidebar.scss
@@ -379,3 +379,13 @@
         }
     }
 }
+.help-activated:after{
+  position: absolute;
+  display: block;
+  content: "✓";
+  border-left: 2px solid green;
+  top: 0px;
+}
+.help-wanted img{
+    max-width: 100%;
+}

--- a/assets/scss/layout/_sidebar.scss
+++ b/assets/scss/layout/_sidebar.scss
@@ -384,34 +384,23 @@
     &:after {
         position: absolute;
         display: block;
-        top: -10px;
-        left: -5px;
+        left: 20px;
         margin-left: 30px;
         margin-right: 5px;
-        height: 50px;
-        padding: 2px;
-        border-left: 4px solid rgba(0,0,0,0);
+        content: " ";
     }
-    /**
-    In there names are in french because rules were created for zds-only use
-     */
-    &.help-redacteur:after {
-        transform: scale(0.6,0.6);
-        content: url('/media/aide_redacteur.png.48x48_q95_crop.png');
-    }
-    &.help-repreneur:after {
-        transform: scale(0.6,0.6);
-        content: url('/media/aide_repreneur.png.48x48_q95_crop.png');
-    }
-    &.help-illustrateur:after {
-        transform: scale(0.6,0.6);
-        content: url('/media/aide_illustrateur.png.48x48_q95_crop.png');
-    }
-    &.help-correcteur:after {
-        transform: scale(0.6,0.6);
-        content: url('/media/aide_correcteur.png.48x48_q95_crop.png');
-    }
+
     &.help-activated:after{
-        border-left: 4px solid $color-success;
+        color: $color-success;
+        content: " ";
+        @include sprite();
+        @include sprite-position($tick-green);
+        width: 16px;
+        height: 16px;
+        top: 7px;
+        padding-left: 0;
+    }
+    &.help-activated {
+        font-weight: bolder;
     }
 }

--- a/assets/scss/layout/_sidebar.scss
+++ b/assets/scss/layout/_sidebar.scss
@@ -379,13 +379,39 @@
         }
     }
 }
-.help-activated:after{
-  position: absolute;
-  display: block;
-  content: "✓";
-  border-left: 2px solid green;
-  top: 0px;
-}
-.help-wanted img{
-    max-width: 100%;
+
+.sidebar ul li a.help-toogle {
+    &:after {
+        position: absolute;
+        display: block;
+        top: -10px;
+        left: -5px;
+        margin-left: 30px;
+        margin-right: 5px;
+        height: 50px;
+        padding: 2px;
+        border-left: 4px solid rgba(0,0,0,0);
+    }
+    /**
+    In there names are in french because rules were created for zds-only use
+     */
+    &.help-redacteur:after {
+        transform: scale(0.6,0.6);
+        content: url('/media/aide_redacteur.png.48x48_q95_crop.png');
+    }
+    &.help-repreneur:after {
+        transform: scale(0.6,0.6);
+        content: url('/media/aide_repreneur.png.48x48_q95_crop.png');
+    }
+    &.help-illustrateur:after {
+        transform: scale(0.6,0.6);
+        content: url('/media/aide_illustrateur.png.48x48_q95_crop.png');
+    }
+    &.help-correcteur:after {
+        transform: scale(0.6,0.6);
+        content: url('/media/aide_correcteur.png.48x48_q95_crop.png');
+    }
+    &.help-activated:after{
+        border-left: 4px solid $color-success;
+    }
 }

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -73,7 +73,7 @@
         </div>
     {% endif %}
 
-    {% if helps.count %}
+    {% if helps %}
         <div class="content-wrapper">
             <div class="alert-box info">
                 {% if content.authors.count > 1 %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -714,9 +714,9 @@
             {% for help in helps %}
                 <li>
                     <a href="{% url 'content:helps-change' content.pk %}"
-                       class="help-toogle {% if help.pk in content_helps %}help-activated{% endif %}"
+                       class="help-toogle {% if help.pk in content_helps %}help-activated{% endif %} help-{{ help.slug }}"
                        data-activated="{% if help.pk in content_helps %}true{% else %}false{% endif %}">
-                        <img src="{{ help.image.help_illu.url }}" alt="{{ help.title }}"> {{ help.title }}
+                        {{ help.title }}
                     </a>
                 </li>
             {% endfor %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -115,7 +115,7 @@
             </div>
         </div>
 
-        {% if helps.count %}
+        {% if helps %}
             <div class="content-wrapper">
                 <div class="alert-box info">
                     {% if content.authors.count > 1 %}
@@ -124,7 +124,7 @@
                         {% trans "L’auteur de ce contenu recherche" %}
                     {% endif %}
 
-                    {% for help in helps.all %}{% if not forloop.first %}{% if forloop.last %}{% trans ' et ' %}{% else %}{% trans ', ' %}{% endif %}{% endif %}un {{ help.title|lower }}{% if forloop.last %}{% trans '.' %}{% endif %}{% endfor %}
+                    {% for help in content.helps.all %}{% if not forloop.first %}{% if forloop.last %}{% trans ' et ' %}{% else %}{% trans ', ' %}{% endif %}{% endif %}un {{ help.title|lower }}{% if forloop.last %}{% trans '.' %}{% endif %}{% endfor %}
 
                     {% if not can_edit %}
                         {% blocktrans with plural=content.authors.count|pluralize_fr %}
@@ -473,7 +473,6 @@
             {% endif %}
         {% endif %}
         {# END BETA #}
-
         {# ONLINE VERSION #}
         {% if public_content_object %}
             <li>
@@ -708,6 +707,22 @@
         {%  include "tutorialv2/includes/editorialization.part.html"  %}
     </div>
 
+    {% if can_edit and not content.is_opinion %}
+        <h3>{% trans "Demander de l'aide à la communauté" %}</h3>
+        <ul>
+            {# HELPS #}
+            {% for help in helps %}
+                <li>
+                    <a href="{% url 'content:helps-change' content.pk %}"
+                       class="help-toogle {% if help.pk in content_helps %}help-activated{% endif %}"
+                       data-activated="{% if help.pk in content_helps %}true{% else %}false{% endif %}">
+                        <img src="{{ help.image.help_illu.url }}" alt="{{ help.title }}"> {{ help.title }}
+                    </a>
+                </li>
+            {% endfor %}
+            {# END HELPS #}
+        </ul>
+    {% endif %}
     {%  include "tutorialv2/includes/summary.part.html"  %}
 
     {% if can_edit %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -708,7 +708,23 @@
     </div>
 
     {% if can_edit and not content.is_opinion %}
-        <h3>{% trans "Demander de l'aide à la communauté" %}</h3>
+        <h3 id="title-help">
+            {% trans "Demander de l'aide" %}
+            <a href="#what-is-a-help" class="help-question-mark open-modal"
+               title="{% trans "Qu'est-ce qu'une aide à la rédaction ?" %}" aria-haspopup="dialog">?</a>
+        </h3>
+        <div id="what-is-a-help" class="modal modal-flex" data-modal-title="{% trans "Qu'est-ce qu'une aide à la rédaction ?" %}"
+             data-modal-close="{% trans "Fermer" %}">
+            {% url 'content:helps' as help_url %}
+            {% blocktrans%}
+                <p>
+                    Lorsque vous rédigez un tutoriel ou un article, il se peut que vous ayiez
+                    besoin d'aide. La communauté est là pour vous ! En sélectionnant un des éléments
+                    ci-dessous, votre contenu sera répertorié dans la page <a href="{{ help_url }}">des aides</a>
+                    et la communauté pourra vous contacter.
+                </p>
+            {% endblocktrans %}
+        </div>
         <ul>
             {# HELPS #}
             {% for help in helps %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -721,7 +721,7 @@
                     <p>
                         Lorsque vous rédigez un tutoriel ou un article, il se peut que vous ayiez
                         besoin d'aide. La communauté est là pour vous ! En sélectionnant un des éléments
-                        ci-dessous, votre contenu sera répertorié dans la page <a href="{{ help_url }}">des aides</a>
+                        ci-dessous, votre contenu sera répertorié dans <a href="{{ help_url }}">la page des aides</a>
                         et la communauté pourra vous contacter.
                     </p>
                 {% endblocktrans %}
@@ -731,9 +731,10 @@
                 {% for help in helps %}
                     <li>
                         <form action="{% url 'content:helps-change' content.pk %}" method="POST">
-                            <input type="hidden" name="activated" value="{% if help.pk in content_helps %}true{% else %}false{% endif %}">
+                            {% csrf_token %}
+                            <input type="hidden" name="activated" value="{% if help.pk in content_helps %}false{% else %}true{% endif %}">
                             <input type="hidden" name="help_wanted" value="{{ help.title }}">
-                            <button href="{% url 'content:helps-change' content.pk %}" type="submit"
+                            <button type="submit"
                                class="help-toggle {% if help.pk in content_helps %}selected ico-after tick green{% endif %} help-{{ help.slug }}"
                                data-activated="{% if help.pk in content_helps %}true{% else %}false{% endif %}">
                                 {{ help.title }}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -708,36 +708,42 @@
     </div>
 
     {% if can_edit and not content.is_opinion %}
-        <h3 id="title-help">
-            {% trans "Demander de l'aide" %}
-            <a href="#what-is-a-help" class="help-question-mark open-modal"
-               title="{% trans "Qu'est-ce qu'une aide à la rédaction ?" %}" aria-haspopup="dialog">?</a>
-        </h3>
-        <div id="what-is-a-help" class="modal modal-flex" data-modal-title="{% trans "Qu'est-ce qu'une aide à la rédaction ?" %}"
-             data-modal-close="{% trans "Fermer" %}">
-            {% url 'content:helps' as help_url %}
-            {% blocktrans%}
-                <p>
-                    Lorsque vous rédigez un tutoriel ou un article, il se peut que vous ayiez
-                    besoin d'aide. La communauté est là pour vous ! En sélectionnant un des éléments
-                    ci-dessous, votre contenu sera répertorié dans la page <a href="{{ help_url }}">des aides</a>
-                    et la communauté pourra vous contacter.
-                </p>
-            {% endblocktrans %}
+        <div class="actions">
+            <h3 id="title-help">
+                {% trans "Demander de l'aide" %}
+                <a href="#what-is-a-help" class="help-question-mark open-modal"
+                   title="{% trans "Qu'est-ce qu'une aide à la rédaction ?" %}" aria-haspopup="dialog">?</a>
+            </h3>
+            <div id="what-is-a-help" class="modal modal-flex" data-modal-title="{% trans "Qu'est-ce qu'une aide à la rédaction ?" %}"
+                 data-modal-close="{% trans "Fermer" %}">
+                {% url 'content:helps' as help_url %}
+                {% blocktrans%}
+                    <p>
+                        Lorsque vous rédigez un tutoriel ou un article, il se peut que vous ayiez
+                        besoin d'aide. La communauté est là pour vous ! En sélectionnant un des éléments
+                        ci-dessous, votre contenu sera répertorié dans la page <a href="{{ help_url }}">des aides</a>
+                        et la communauté pourra vous contacter.
+                    </p>
+                {% endblocktrans %}
+            </div>
+            <ul>
+                {# HELPS #}
+                {% for help in helps %}
+                    <li>
+                        <form action="{% url 'content:helps-change' content.pk %}" method="POST">
+                            <input type="hidden" name="activated" value="{% if help.pk in content_helps %}true{% else %}false{% endif %}">
+                            <input type="hidden" name="help_wanted" value="{{ help.title }}">
+                            <button href="{% url 'content:helps-change' content.pk %}" type="submit"
+                               class="help-toggle {% if help.pk in content_helps %}selected ico-after tick green{% endif %} help-{{ help.slug }}"
+                               data-activated="{% if help.pk in content_helps %}true{% else %}false{% endif %}">
+                                {{ help.title }}
+                            </button>
+                        </form>
+                    </li>
+                {% endfor %}
+                {# END HELPS #}
+            </ul>
         </div>
-        <ul>
-            {# HELPS #}
-            {% for help in helps %}
-                <li>
-                    <a href="{% url 'content:helps-change' content.pk %}"
-                       class="help-toogle {% if help.pk in content_helps %}help-activated{% endif %} help-{{ help.slug }}"
-                       data-activated="{% if help.pk in content_helps %}true{% else %}false{% endif %}">
-                        {{ help.title }}
-                    </a>
-                </li>
-            {% endfor %}
-            {# END HELPS #}
-        </ul>
     {% endif %}
     {%  include "tutorialv2/includes/summary.part.html"  %}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1646,10 +1646,10 @@ each-props@^1.3.0:
     is-plain-object "^2.0.1"
     object.defaults "^1.1.0"
 
-easymde@2.10.2-360.0:
-  version "2.10.2-360.0"
-  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.10.2-360.0.tgz#da4e22df3aa1916ae547d84467260fa5d28d1afb"
-  integrity sha512-Mbh9iYATsDHNBmVZviwmIGjJncF+wc1CPQyaovzXNWRUX/K4ToJV9a3hBZmcKeQVYRWPVp6J3cMhuEDWMyZPeg==
+easymde@2.9.1-299.0:
+  version "2.9.1-299.0"
+  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.9.1-299.0.tgz#0b039343294908021ca88059940aab51ea09adb9"
+  integrity sha512-pV0gfX1iWFvfxP35iYXJfb0iKgS45XT+l7fvJ9jq06rIhJDx/DlSp6GJy9P8fdY8ouHAiUZyvALIfn/kuCy6uQ==
   dependencies:
     codemirror "^5.53.2"
     codemirror-spell-checker "1.1.2"

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1450,7 +1450,7 @@ class RemoveSuggestionForm(forms.Form):
     )
 
 
-class ToogleHelpForm(forms.Form):
+class ToggleHelpForm(forms.Form):
     help_wanted = forms.CharField()
     activated = forms.BooleanField(required=False)
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -270,16 +270,9 @@ class ContentForm(ContainerForm):
         widget=forms.CheckboxSelectMultiple()
     )
 
-    helps = forms.ModelMultipleChoiceField(
-        label=_("Pour m'aider, je cherche un..."),
-        queryset=HelpWriting.objects.all(),
-        required=False,
-        widget=forms.CheckboxSelectMultiple()
-    )
-
     source = forms.CharField(
         label=_("""Si votre contenu est publié en dehors de Zeste de Savoir (blog, site personnel, etc.),
-                   indiquez le lien de la publication originale : """),
+                       indiquez le lien de la publication originale : """),
         max_length=PublishableContent._meta.get_field('source').max_length,
         required=False,
         widget=forms.TextInput(
@@ -289,14 +282,7 @@ class ContentForm(ContainerForm):
         )
     )
 
-    def _create_layout(self, hide_help):
-        html_part = HTML(_("<p>Demander de l'aide à la communauté !<br>"
-                           "Si vous avez besoin d'un coup de main, "
-                           "sélectionnez une ou plusieurs catégories d'aide ci-dessous "
-                           'et votre contenu apparaîtra alors sur <a href='
-                           '\"{% url \"content:helps\" %}\" '
-                           "alt=\"aider les auteurs\">la page d'aide</a>.</p>"))
-
+    def _create_layout(self):
         self.helper.layout = Layout(
             IncludeEasyMDE(),
             Field('title'),
@@ -318,21 +304,16 @@ class ContentForm(ContainerForm):
             Field('subcategory', template='crispy/checkboxselectmultiple.html')
         )
 
-        if not hide_help:
-            self.helper.layout.append(html_part)
-            self.helper.layout.append(Field('helps'))
-
         self.helper.layout.append(Field('msg_commit'))
         self.helper.layout.append(ButtonHolder(StrictButton('Valider', type='submit')))
 
     def __init__(self, *args, **kwargs):
-        for_tribune = kwargs.pop('for_tribune', False)
         super(ContentForm, self).__init__(*args, **kwargs)
 
         self.helper = FormHelper()
         self.helper.form_class = 'content-wrapper'
         self.helper.form_method = 'post'
-        self._create_layout(for_tribune)
+        self._create_layout()
 
         if 'type' in self.initial:
             self.helper['type'].wrap(
@@ -1467,3 +1448,15 @@ class RemoveSuggestionForm(forms.Form):
         label=_('Suggestion'),
         required=True,
     )
+
+
+class ToogleHelpForm(forms.Form):
+    help_wanted = forms.CharField()
+    activated = forms.BooleanField(required=False)
+
+    def clean(self):
+        clean_data = super().clean()
+        clean_data['help_wanted'] = HelpWriting.objects.filter(title=(self.data['help_wanted'] or '').strip()).first()
+        if not clean_data['help_wanted']:
+            self.add_error('help_wanted', _('Inconnu'))
+        return clean_data

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -11,6 +11,7 @@ from django.views.generic import View
 from zds.forum.models import Topic
 from zds.tutorialv2.models.database import PublishableContent, PublishedContent, ContentRead
 from zds.tutorialv2.utils import mark_read
+from zds.utils.models import HelpWriting
 
 
 class SingleContentViewMixin(object):
@@ -259,7 +260,8 @@ class SingleContentDetailViewMixin(SingleContentViewMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(SingleContentDetailViewMixin, self).get_context_data(**kwargs)
-
+        context['helps'] = list(HelpWriting.objects.all())
+        context['content_helps'] = self.object.helps.values_list('pk', flat=True)
         context['content'] = self.versioned_object
         context['can_edit'] = self.is_author
         context['is_staff'] = self.is_staff

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -82,8 +82,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
                 username=self.user_author.username,
                 password='hostel77'),
             True)
-        resp = self.client.get(reverse('content:create-opinion'))
-        self.assertNotContains(resp, 'id="div_id_helps"', msg_prefix='help field must not be displayed')
 
     def test_help_for_article(self):
         self.assertEqual(
@@ -93,7 +91,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             True)
         resp = self.client.get(reverse('content:create-article'))
         self.assertEqual(200, resp.status_code)
-        self.assertContains(resp, 'id="div_id_helps"', msg_prefix='help field must be displayed')
 
     def test_opinion_publication_staff(self):
         """

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -6256,3 +6256,25 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=False)
 
         self.assertEqual(tutorial.public_version.authors.count(), 1)
+
+    def test_add_help_tuto(self):
+        self.client.login(username=self.user_author.username, password='hostel77')
+        tutorial = PublishableContentFactory(author_list=[self.user_author])
+        help_wanted = HelpWritingFactory()
+        resp = self.client.post(reverse('content:helps-change', args=[tutorial.pk]),
+                                {
+                                    'activated': True,
+                                    'help_wanted': help_wanted.title})
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(1, PublishableContent.objects.filter(pk=tutorial.pk).first().helps.count())
+
+    def test_add_help_opinion(self):
+        self.client.login(username=self.user_author.username, password='hostel77')
+        tutorial = PublishableContentFactory(author_list=[self.user_author], type='OPINION')
+        help_wanted = HelpWritingFactory()
+        resp = self.client.post(reverse('content:helps-change', args=[tutorial.pk]),
+                                {
+                                    'activated': True,
+                                    'help_wanted': help_wanted.title})
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(0, PublishableContent.objects.filter(pk=tutorial.pk).first().helps.count())

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -6265,7 +6265,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
                                 {
                                     'activated': True,
                                     'help_wanted': help_wanted.title})
-        self.assertEqual(200, resp.status_code)
+        self.assertEqual(302, resp.status_code)
         self.assertEqual(1, PublishableContent.objects.filter(pk=tutorial.pk).first().helps.count())
 
     def test_add_help_opinion(self):

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -11,7 +11,7 @@ from zds.tutorialv2.views.contents import (DisplayContent, CreateContent, EditCo
                                            RemoveAuthorFromContent, WarnTypo, DisplayBetaContent, DisplayBetaContainer,
                                            ContentOfAuthor, RedirectOldContentOfAuthor, AddContributorToContent,
                                            RemoveContributorFromContent, ContentOfContributors,
-                                           AddSuggestion, RemoveSuggestion, EditContentTags)
+                                           AddSuggestion, RemoveSuggestion, ChangeHelp, EditContentTags)
 
 from zds.tutorialv2.views.published import (SendNoteFormView, UpdateNoteView,
                                             HideReaction, ShowReaction, SendNoteAlert, SolveNoteAlert, TagsListView,
@@ -40,6 +40,7 @@ urlpatterns = [
     path('tribunes/<int:pk>/', RedirectOldContentOfAuthor.as_view(type='OPINION')),
 
     re_path(r'^aides/$', ContentsWithHelps.as_view(), name='helps'),
+    re_path(r'^aides/(?P<pk>\d+)/change$', ChangeHelp.as_view(), name='helps-change'),
     re_path(r'^(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/(?P<container_slug>.+)/$',
             DisplayContainer.as_view(public_is_prioritary=False),
             name='view-container'),

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -15,7 +16,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Count, Q
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.shortcuts import redirect, get_object_or_404
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -37,7 +38,7 @@ from zds.tutorialv2.forms import ContentForm, JsFiddleActivationForm, AskValidat
     RejectValidationForm, RevokeValidationForm, WarnTypoForm, ImportContentForm, ImportNewContentForm, ContainerForm, \
     ExtractForm, BetaForm, MoveElementForm, AuthorForm, RemoveAuthorForm, CancelValidationForm, PublicationForm, \
     UnpublicationForm, ContributionForm, RemoveContributionForm, SearchSuggestionForm, RemoveSuggestionForm, \
-    EditContentLicenseForm, EditContentTagsForm
+    EditContentLicenseForm, EditContentTagsForm, ToogleHelpForm
 from zds.tutorialv2.mixins import SingleContentDetailViewMixin, SingleContentFormViewMixin, SingleContentViewMixin, \
     SingleContentDownloadViewMixin, SingleContentPostMixin, FormWithPreview
 from zds.tutorialv2.models import TYPE_CHOICES_DICT
@@ -78,11 +79,6 @@ class CreateContent(LoggedWithReadWriteHability, FormWithPreview):
     form_class = ContentForm
     content = None
     created_content_type = 'TUTORIAL'
-
-    def get_form_kwargs(self):
-        kwargs = super(CreateContent, self).get_form_kwargs()
-        kwargs['for_tribune'] = self.created_content_type == 'OPINION'
-        return kwargs
 
     def get_form(self, form_class=ContentForm):
         form = super(CreateContent, self).get_form(form_class)
@@ -136,10 +132,6 @@ class CreateContent(LoggedWithReadWriteHability, FormWithPreview):
         # Add subcategories on tutorial
         for subcat in form.cleaned_data['subcategory']:
             self.content.subcategory.add(subcat)
-
-        # Add helps if needed
-        for helpwriting in form.cleaned_data['helps']:
-            self.content.helps.add(helpwriting)
 
         self.content.save(force_slug_update=False)
 
@@ -257,7 +249,7 @@ class DisplayBetaContent(DisplayContent):
 
     def get_context_data(self, **kwargs):
         context = super(DisplayBetaContent, self).get_context_data(**kwargs)
-        context['helps'] = self.object.helps
+        context['helps'] = list(self.object.helps.all())
         context['pm_link'] = self.object.get_absolute_contact_url()
         return context
 
@@ -266,11 +258,6 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
     template_name = 'tutorialv2/edit/content.html'
     model = PublishableContent
     form_class = ContentForm
-
-    def get_form_kwargs(self):
-        kwargs = super(EditContent, self).get_form_kwargs()
-        kwargs['for_tribune'] = self.object.type == 'OPINION'
-        return kwargs
 
     def get_initial(self):
         """rewrite function to pre-populate form"""
@@ -284,7 +271,6 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         initial['conclusion'] = versioned.get_conclusion()
         initial['source'] = versioned.source
         initial['subcategory'] = self.object.subcategory.all()
-        initial['helps'] = self.object.helps.all()
         initial['last_hash'] = versioned.compute_hash()
 
         return initial
@@ -358,12 +344,6 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         publishable.subcategory.clear()
         for subcat in form.cleaned_data['subcategory']:
             publishable.subcategory.add(subcat)
-
-        # help can only be obtained on contents requiring validation before publication
-        if versioned.requires_validation():
-            publishable.helps.clear()
-            for help_ in form.cleaned_data['helps']:
-                publishable.helps.add(help_)
 
         publishable.save(force_slug_update=False)
 
@@ -1155,7 +1135,7 @@ class DisplayBetaContainer(DisplayContainer):
 
     def get_context_data(self, **kwargs):
         context = super(DisplayBetaContainer, self).get_context_data(**kwargs)
-        context['helps'] = self.object.helps
+        context['helps'] = list(self.object.helps.all())
         context['pm_link'] = self.object.get_absolute_contact_url()
         return context
 
@@ -1713,7 +1693,7 @@ class ContentsWithHelps(ZdSPagingListView):
         if self.specific_need:
             context['specific_need'] = helps.filter(slug=self.specific_need).first()
 
-        context['helps'] = helps.all()
+        context['helps'] = list(helps.all())
         context['total_contents_number'] = queryset.count()
         return context
 
@@ -2087,6 +2067,30 @@ class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormView
         return super(RemoveAuthorFromContent, self).form_valid(form)
 
 
+class ChangeHelp(LoggedWithReadWriteHability, SingleContentFormViewMixin):
+    form_class = ToogleHelpForm
+
+    def form_valid(self, form):
+        """
+        change help needing state, assume this is ajax request
+        :param form: the data
+        :return: json answer
+        """
+        if self.object.is_opinion:
+            return HttpResponse(json.dumps({'errors': str(_("Impossible de demander de l'aide pour un billet"))}),
+                                status=400, content_type='application/json')
+        data = form.cleaned_data
+        if data['activated']:
+            self.object.helps.add(data['help_wanted'])
+        else:
+            self.object.helps.remove(data['help_wanted'])
+        self.object.save(force_slug_update=False)
+        return HttpResponse(json.dumps({'result': 'ok'}), content_type='application/json')
+
+    def form_invalid(self, form):
+        return HttpResponse(json.dumps({'errors': form.errors}), status=400, content_type='application/json')
+
+
 class ContentOfContributors(ZdSPagingListView):
     type = 'ALL'
     context_object_name = 'contribution_contents'
@@ -2340,7 +2344,7 @@ class RemoveSuggestion(LoggedWithReadWriteHability, SingleContentFormViewMixin):
         return super(RemoveSuggestion, self).form_valid(form)
 
     def form_invalid(self, form):
-        messages.error(self.request, _("Les suggestions sélectionnées n'existent pas."))
+        messages.error(self.request, str(_("Les suggestions sélectionnées n'existent pas.")))
         if self.object.public_version:
             self.success_url = self.object.get_absolute_url_online()
         else:

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -38,7 +38,7 @@ from zds.tutorialv2.forms import ContentForm, JsFiddleActivationForm, AskValidat
     RejectValidationForm, RevokeValidationForm, WarnTypoForm, ImportContentForm, ImportNewContentForm, ContainerForm, \
     ExtractForm, BetaForm, MoveElementForm, AuthorForm, RemoveAuthorForm, CancelValidationForm, PublicationForm, \
     UnpublicationForm, ContributionForm, RemoveContributionForm, SearchSuggestionForm, RemoveSuggestionForm, \
-    EditContentLicenseForm, EditContentTagsForm, ToogleHelpForm
+    EditContentLicenseForm, EditContentTagsForm, ToggleHelpForm
 from zds.tutorialv2.mixins import SingleContentDetailViewMixin, SingleContentFormViewMixin, SingleContentViewMixin, \
     SingleContentDownloadViewMixin, SingleContentPostMixin, FormWithPreview
 from zds.tutorialv2.models import TYPE_CHOICES_DICT
@@ -2068,7 +2068,7 @@ class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormView
 
 
 class ChangeHelp(LoggedWithReadWriteHability, SingleContentFormViewMixin):
-    form_class = ToogleHelpForm
+    form_class = ToggleHelpForm
 
     def form_valid(self, form):
         """
@@ -2085,7 +2085,11 @@ class ChangeHelp(LoggedWithReadWriteHability, SingleContentFormViewMixin):
         else:
             self.object.helps.remove(data['help_wanted'])
         self.object.save(force_slug_update=False)
-        return HttpResponse(json.dumps({'result': 'ok'}), content_type='application/json')
+        if self.request.is_ajax():
+            return HttpResponse(json.dumps({'result': 'ok', 'help_wanted': data['activated']}),
+                                content_type='application/json')
+        self.success_url = self.object.get_absolute_url()
+        return super().form_valid(form)
 
     def form_invalid(self, form):
         if self.request.is_ajax():

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -2088,7 +2088,9 @@ class ChangeHelp(LoggedWithReadWriteHability, SingleContentFormViewMixin):
         return HttpResponse(json.dumps({'result': 'ok'}), content_type='application/json')
 
     def form_invalid(self, form):
-        return HttpResponse(json.dumps({'errors': form.errors}), status=400, content_type='application/json')
+        if self.request.is_ajax():
+            return HttpResponse(json.dumps({'errors': form.errors}), status=400, content_type='application/json')
+        return super().form_invalid(form)
 
 
 class ContentOfContributors(ZdSPagingListView):


### PR DESCRIPTION
On les place désormais dans la sidebar, avec une ajaxification
Le but est d'avoir des boutons simples à utiliser pour demander de l'aide.

# QA 

- Créer un tuto
- Observez que le formulaire de demander d'aide n'existe plus
- Éditer le tuto
- Observez que le formulaire de demande d'aide n'existe plus
- dans la page d'accueil du tuto, dans la sidebar, une partie "Demander de l'aide à la communauté apparaît.
- Lorsqu'on clique sur un des boutons, il change de statu (désactivé => activé, activé => désactivé ) et lorsqu'on recharge la page c'est le bon statu qui apparâit
- Regarder que cette section n'apparaît pas pour les billets