### PR TITLE
Des templates github pour les tickets

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,11 +9,11 @@ assignees: ''
 
 **Description du bug**
 
-Une description claire et concise ce ce qu'est le bug.
+Une description claire et concise du bug.
 
 **Comment reproduire ?**
 
-La liste des étapes qui permet de reproduire le bug:
+La liste des étapes qui permet de reproduire le bug :
 
 1. Allez sur le site '...'
 2. Connectez vous avec le compte '....'
@@ -22,13 +22,13 @@ La liste des étapes qui permet de reproduire le bug:
 
 **Comportement attendu**
 
-Un description claire et concise du comportement qui est attendu.
+Une description claire et concise du comportement attendu.
 
 **Capture d'écran**
 
-Si possible, une capture d'écran qui explique du problème.
+Si possible, une capture d'écran qui explique le problème.
 
-**Information de la version**
+**Informations techniques**
 
 - OS: [ex: Windows, MacOS]
 - Navigateur: [ex: Chrome 72]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Un bug
+about: Faire un rapport de bug sur un comportement anormal du site.
+title: ''
+labels: S-BUG
+assignees: ''
+
+---
+
+**Description du bug**
+
+Une description claire et concise ce ce qu'est le bug.
+
+**Comment reproduire ?**
+
+La liste des étapes qui permet de reproduire le bug:
+
+1. Allez sur le site '...'
+2. Connectez vous avec le compte '....'
+3. Cliquez sur le lien suivant '....'
+4. Constatez l'erreur qui est '...'
+
+**Comportement attendu**
+
+Un description claire et concise du comportement qui est attendu.
+
+**Capture d'écran**
+
+Si possible, une capture d'écran qui explique du problème.
+
+**Information de la version**
+
+- OS: [ex: Windows, MacOS]
+- Navigateur: [ex: Chrome 72]
+- Version/environnement de zds: [ex: production, beta, branche XXX]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Demande de fonctionnalité
+about: Proposer une idée de fonctionnalité pour le site
+title: ''
+labels: S-Évolution
+assignees: ''
+
+---
+
+**Description du besoin**
+
+Une description claire et concise du besoin que l'on veut résoudre avec cette fonctionnalité.
+
+Exemple: Je suis toujours frustré quand [...]
+
+**Description de la solution**
+
+Une description claire et concise de comment tu vois la solution qui répondrait à ce besoin.
+
+**Description des alternatives**
+
+Une description claire et concise des solution alternative qui aurait pu aussi permettre de répondre au besoin et pourquoi elles ont été écartées.
+
+**Contexte additionnel**
+
+Ajoute n'importe quel autre contexte qui peut aider à mieux comprendre l'idée (capture d'écran, mock-ups, etc.)
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Demande de fonctionnalité
-about: Proposer une idée de fonctionnalité pour le site
+about: Proposer une idée de fonctionnalité pour le site.
 title: ''
 labels: S-Évolution
 assignees: ''
@@ -15,13 +15,13 @@ Exemple: Je suis toujours frustré quand [...]
 
 **Description de la solution**
 
-Une description claire et concise de comment tu vois la solution qui répondrait à ce besoin.
+Une description claire et concise de comment vous voyez la solution qui répondrait à ce besoin.
 
 **Description des alternatives**
 
-Une description claire et concise des solution alternative qui aurait pu aussi permettre de répondre au besoin et pourquoi elles ont été écartées.
+Une description claire et concise des solutions alternatives qui auraient pu aussi permettre de répondre au besoin et pourquoi elles ont été écartées.
 
 **Contexte additionnel**
 
-Ajoute n'importe quel autre contexte qui peut aider à mieux comprendre l'idée (capture d'écran, mock-ups, etc.)
+Ajoute n'importe quel autre élément de contexte qui peut aider à mieux comprendre l'idée (capture d'écran, mock-ups, etc).
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,7 @@
 ---
 name: Question
-about: Poser une question sur quelque chose qui n'est pas claire sur le site
+about: Poser une question sur quelque chose qui n'est pas clair sur le site ou dans le code.
 title: ''
-labels: C-Docs
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,13 @@
+---
+name: Question
+about: Poser une question sur quelque chose qui n'est pas claire sur le site
+title: ''
+labels: C-Docs
+assignees: ''
+
+---
+
+**La question**
+
+Posez votre question en donnant le plus de détails possible pour être certain d'avoir une réponse.
+


### PR DESCRIPTION
Ajoute des templates github pour permettre de mieux décrire les tickets.

On rajoute ici 3 types de tickets :

- Les rapport de bug
- Les demandes de fonctionnalités
- Les question

L'idée du template c'est qu'il ne soit pas hyper long et au moins qu'on ait l'essentiel des informations utiles pour attaquer l'issue directement.

Pour la QA, je pense qu'il faut juste repasser sur l'orthographe.