### PR TITLE
Ajoute un attribut alt aux images de unes et cartouches de contenu de la page d'accueil

### DIFF
--- a/templates/featured/includes/featured_resource_item.part.html
+++ b/templates/featured/includes/featured_resource_item.part.html
@@ -3,7 +3,7 @@
 
 <article class="featured-resource-item">
     <a href="{{ featured_resource.url }}">
-        <img src="{{ featured_resource.image_url|remove_url_scheme }}" alt="illustration {{featured.title}}" class="featured-resource-illu">
+        <img src="{{ featured_resource.image_url|remove_url_scheme }}" alt="Illustration {{ featured.title }}" class="featured-resource-illu">
         <div class="featured-resource-meta">
             <h2>{{ featured_resource.title }}</h2>
             <p class="featured-resource-description">{{ featured_resource.type }} {% if featured_resource.authors %} {% trans "par" %} <i>{{ featured_resource.authors }}</i>{% endif %}</p>

--- a/templates/featured/includes/featured_resource_item.part.html
+++ b/templates/featured/includes/featured_resource_item.part.html
@@ -3,7 +3,7 @@
 
 <article class="featured-resource-item">
     <a href="{{ featured_resource.url }}">
-        <img src="{{ featured_resource.image_url|remove_url_scheme }}" alt="" class="featured-resource-illu">
+        <img src="{{ featured_resource.image_url|remove_url_scheme }}" alt="illustration {{featured.title}}" class="featured-resource-illu">
         <div class="featured-resource-meta">
             <h2>{{ featured_resource.title }}</h2>
             <p class="featured-resource-description">{{ featured_resource.type }} {% if featured_resource.authors %} {% trans "par" %} <i>{{ featured_resource.authors }}</i>{% endif %}</p>

--- a/templates/featured/includes/featured_resource_item.part.html
+++ b/templates/featured/includes/featured_resource_item.part.html
@@ -3,7 +3,7 @@
 
 <article class="featured-resource-item">
     <a href="{{ featured_resource.url }}">
-        <img src="{{ featured_resource.image_url|remove_url_scheme }}" alt="Illustration {{ featured.title }}" class="featured-resource-illu">
+        <img src="{{ featured_resource.image_url|remove_url_scheme }}" alt="Illustration {{ featured_resource.title }}" class="featured-resource-illu">
         <div class="featured-resource-meta">
             <h2>{{ featured_resource.title }}</h2>
             <p class="featured-resource-description">{{ featured_resource.type }} {% if featured_resource.authors %} {% trans "par" %} <i>{{ featured_resource.authors }}</i>{% endif %}</p>

--- a/templates/tutorialv2/includes/content_item.part.html
+++ b/templates/tutorialv2/includes/content_item.part.html
@@ -67,7 +67,7 @@
 
     <a href="{{ link }}" tabindex="-1" class="content-illu {{ content.type|lower }}-illu">
         {% if content.image %}
-            <img src="{{ content.image.physical.content_thumb.url }}" alt="logo de {{content.public_title}}">
+            <img src="{{ content.image.physical.content_thumb.url }}" alt="Logo de {{ content.public_title }}">
         {% endif %}
     </a>
 

--- a/templates/tutorialv2/includes/content_item.part.html
+++ b/templates/tutorialv2/includes/content_item.part.html
@@ -67,7 +67,7 @@
 
     <a href="{{ link }}" tabindex="-1" class="content-illu {{ content.type|lower }}-illu">
         {% if content.image %}
-            <img src="{{ content.image.physical.content_thumb.url }}" alt="">
+            <img src="{{ content.image.physical.content_thumb.url }}" alt="logo de {{content.public_title}}">
         {% endif %}
     </a>
 

--- a/templates/tutorialv2/includes/content_item.part.html
+++ b/templates/tutorialv2/includes/content_item.part.html
@@ -67,7 +67,7 @@
 
     <a href="{{ link }}" tabindex="-1" class="content-illu {{ content.type|lower }}-illu">
         {% if content.image %}
-            <img src="{{ content.image.physical.content_thumb.url }}" alt="Logo de {{ content.public_title }}">
+            <img src="{{ content.image.physical.content_thumb.url }}" alt="Logo de {{ content_title }}">
         {% endif %}
     </a>
 


### PR DESCRIPTION
J'ai ajouté un attribut `alt` aux images de unes (`illustration {{featured.title}}`) et aux cartouches de contenu sur la page d'accueil (`logo de {{content.public_title}}`)

Numéro du ticket concerné : #5674 

Merci !
