### PR TITLE
Utilise des pathlib.Path pour BASE_DIR et MEDIA_ROOT

### DIFF
--- a/zds/gallery/api/tests.py
+++ b/zds/gallery/api/tests.py
@@ -290,7 +290,7 @@ class ImageListAPITest(APITestCase):
             {
                 'title': title,
                 'legend': legend,
-                'physical': open('{}/fixtures/noir_black.png'.format(settings.BASE_DIR), 'rb')
+                'physical': (settings.BASE_DIR / 'fixtures' / 'noir_black.png').open('rb')
             },
             format='multipart'
         )
@@ -311,7 +311,7 @@ class ImageListAPITest(APITestCase):
             {
                 'title': title,
                 'legend': legend,
-                'physical': open('{}/assets/licenses/0.svg'.format(settings.BASE_DIR), 'rb')
+                'physical': (settings.BASE_DIR / 'assets' / 'licenses' / '0.svg').open('rb')
             },
             format='multipart'
         )
@@ -328,7 +328,7 @@ class ImageListAPITest(APITestCase):
             {
                 'title': title,
                 'legend': legend,
-                'physical': open('{}/fixtures/noir_black.png'.format(settings.BASE_DIR), 'rb')
+                'physical': (settings.BASE_DIR / 'fixtures' / 'noir_black.png').open('rb')
             },
             format='multipart'
         )
@@ -345,7 +345,7 @@ class ImageListAPITest(APITestCase):
             {
                 'title': title,
                 'legend': legend,
-                'physical': open('{}/fixtures/noir_black.png'.format(settings.BASE_DIR), 'rb')
+                'physical': (settings.BASE_DIR / 'fixtures' / 'noir_black.png').open('rb')
             },
             format='multipart'
         )
@@ -415,7 +415,7 @@ class ImageDetailAPITest(APITestCase):
             {
                 'title': title,
                 'legend': legend,
-                'physical': open('{}/fixtures/noir_black.png'.format(settings.BASE_DIR), 'rb')
+                'physical': (settings.BASE_DIR / 'fixtures' / 'noir_black.png').open('rb')
             },
             format='multipart'
         )
@@ -436,7 +436,7 @@ class ImageDetailAPITest(APITestCase):
             {
                 'title': title,
                 'legend': legend,
-                'physical': open('{}/assets/licenses/0.svg'.format(settings.BASE_DIR), 'rb')
+                'physical': (settings.BASE_DIR / 'assets' / 'licenses' / '0.svg').open('rb')
             }
         )
 

--- a/zds/gallery/factories.py
+++ b/zds/gallery/factories.py
@@ -1,5 +1,4 @@
 import contextlib
-from pathlib import Path
 
 import factory
 
@@ -40,7 +39,7 @@ class GalleryFactory(factory.DjangoModelFactory):
     def _prepare(cls, create, **kwargs):
         gal = super(GalleryFactory, cls)._prepare(create, **kwargs)
         with contextlib.suppress(OSError):
-            Path(gal.get_gallery_path()).mkdir(parents=True)
+            gal.get_gallery_path().mkdir(parents=True)
         return gal
 
 

--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -222,7 +222,7 @@ class Gallery(models.Model):
         :return: filesystem path to this gallery root
         :rtype: unicode
         """
-        return os.path.join(settings.MEDIA_ROOT, 'galleries', str(self.pk))
+        return settings.MEDIA_ROOT / 'galleries' / str(self.pk)
 
     def get_linked_users(self):
         """Get all the linked users for this gallery whatever their rights

--- a/zds/gallery/tests/tests_forms.py
+++ b/zds/gallery/tests/tests_forms.py
@@ -1,5 +1,3 @@
-import os
-
 from django.test import TestCase
 from django.core.files.uploadedfile import SimpleUploadedFile
 
@@ -70,7 +68,7 @@ class UserGalleryFormTest(TestCase):
 class ImageFormTest(TestCase):
 
     def test_valid_image_form(self):
-        upload_file = open(os.path.join(settings.BASE_DIR, 'fixtures', 'logo.png'), 'rb')
+        upload_file = (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
 
         data = {
             'title': 'Test Image',
@@ -86,7 +84,7 @@ class ImageFormTest(TestCase):
         upload_file.close()
 
     def test_valid_archive_image_form(self):
-        upload_file = open(os.path.join(settings.BASE_DIR, 'fixtures', 'archive-gallery.zip'), 'rb')
+        upload_file = (settings.BASE_DIR / 'fixtures' / 'archive-gallery.zip').open('rb')
 
         data = {}
         files = {
@@ -98,7 +96,7 @@ class ImageFormTest(TestCase):
         upload_file.close()
 
     def test_empty_title_image_form(self):
-        upload_file = open(os.path.join(settings.BASE_DIR, 'fixtures', 'logo.png'), 'rb')
+        upload_file = (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
 
         data = {
             'title': '',
@@ -128,7 +126,7 @@ class ImageFormTest(TestCase):
         self.assertFalse(form.is_valid())
 
     def test_too_big_pic_image_form(self):
-        upload_file = open(os.path.join(settings.BASE_DIR, 'fixtures', 'image_test.jpg'), 'rb')
+        upload_file = (settings.BASE_DIR / 'fixtures' / 'image_test.jpg').open('rb')
 
         data = {
             'title': 'Test Title',
@@ -144,7 +142,7 @@ class ImageFormTest(TestCase):
         upload_file.close()
 
     def test_bot_a_pic_image_form(self):
-        upload_file = open(os.path.join(settings.BASE_DIR, 'fixtures', 'forums.yaml'), 'rb')
+        upload_file = (settings.BASE_DIR / 'fixtures' / 'forums.yaml').open('rb')
 
         data = {
             'title': 'Test Title',
@@ -160,7 +158,7 @@ class ImageFormTest(TestCase):
         upload_file.close()
 
     def test_too_long_title_image_form(self):
-        upload_file = open(os.path.join(settings.BASE_DIR, 'fixtures', 'logo.png'), 'rb')
+        upload_file = (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
 
         data = {
             'title': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam condimentum enim amet.',
@@ -174,7 +172,7 @@ class ImageFormTest(TestCase):
         upload_file.close()
 
     def test_too_long_legend_image_form(self):
-        upload_file = open(os.path.join(settings.BASE_DIR, 'fixtures', 'logo.png'), 'rb')
+        upload_file = (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
 
         data = {
             'title': 'Test Title',

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -598,7 +598,7 @@ class EditImageViewTest(TestCase):
         login_check = self.client.login(username=self.profile3.user.username, password='hostel77')
         self.assertTrue(login_check)
 
-        with open(os.path.join(settings.BASE_DIR, 'fixtures', 'logo.png'), 'rb') as fp:
+        with (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb') as fp:
 
             self.client.post(
                 reverse(
@@ -624,7 +624,7 @@ class EditImageViewTest(TestCase):
 
         nb_files = len(os.listdir(self.gallery.get_gallery_path()))
 
-        with open(os.path.join(settings.BASE_DIR, 'fixtures', 'logo.png'), 'rb') as fp:
+        with (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb') as fp:
 
             response = self.client.post(
                 reverse(
@@ -785,7 +785,7 @@ class NewImageViewTest(TestCase):
         self.assertTrue(login_check)
         self.assertEqual(0, len(self.gallery.get_images()))
 
-        with open(os.path.join(settings.BASE_DIR, 'fixtures', 'logo.png'), 'rb') as fp:
+        with (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb') as fp:
             response = self.client.post(
                 reverse(
                     'gallery-image-new',
@@ -810,7 +810,7 @@ class NewImageViewTest(TestCase):
         self.assertTrue(login_check)
         self.assertEqual(0, len(self.gallery.get_images()))
 
-        with open(os.path.join(settings.BASE_DIR, 'fixtures', 'logo.png'), 'rb') as fp:
+        with (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb') as fp:
             response = self.client.post(
                 reverse(
                     'gallery-image-new',
@@ -833,7 +833,7 @@ class NewImageViewTest(TestCase):
         self.assertTrue(login_check)
         self.assertEqual(0, len(self.gallery.get_images()))
 
-        with open(os.path.join(settings.BASE_DIR, 'fixtures', 'logo.png'), 'rb') as fp:
+        with (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb') as fp:
             response = self.client.post(
                 reverse(
                     'gallery-image-new',
@@ -855,7 +855,7 @@ class NewImageViewTest(TestCase):
         login_check = self.client.login(username=self.profile1.user.username, password='hostel77')
         self.assertTrue(login_check)
 
-        with open(os.path.join(settings.BASE_DIR, 'fixtures', 'logo.png'), 'rb') as fp:
+        with (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb') as fp:
             response = self.client.post(
                 reverse(
                     'gallery-image-new',
@@ -876,7 +876,7 @@ class NewImageViewTest(TestCase):
         login_check = self.client.login(username=self.profile1.user.username, password='hostel77')
         self.assertTrue(login_check)
 
-        with open(os.path.join(settings.BASE_DIR, 'fixtures', 'archive-gallery.zip'), 'rb') as fp:
+        with (settings.BASE_DIR / 'fixtures' / 'archive-gallery.zip').open('rb') as fp:
             response = self.client.post(
                 reverse(
                     'gallery-image-import',
@@ -905,7 +905,7 @@ class NewImageViewTest(TestCase):
         login_check = self.client.login(username=self.profile1.user.username, password='hostel77')
         self.assertTrue(login_check)
 
-        with open(os.path.join(settings.BASE_DIR, 'fixtures', 'archive-gallery.zip'), 'rb'):
+        with (settings.BASE_DIR / 'fixtures' / 'archive-gallery.zip').open('rb'):
             response = self.client.post(
                 reverse(
                     'gallery-image-import',
@@ -925,7 +925,7 @@ class NewImageViewTest(TestCase):
         login_check = self.client.login(username=self.profile2.user.username, password='hostel77')
         self.assertTrue(login_check)
 
-        with open(os.path.join(settings.BASE_DIR, 'fixtures', 'archive-gallery.zip'), 'rb') as fp:
+        with (settings.BASE_DIR / 'fixtures' / 'archive-gallery.zip').open('rb') as fp:
             response = self.client.post(
                 reverse(
                     'gallery-image-import',

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -1,4 +1,3 @@
-import os.path
 import random
 from datetime import datetime
 
@@ -22,7 +21,7 @@ from zds.utils.models import Alert, CommentEdit, Comment
 
 
 try:
-    with open(os.path.join(settings.BASE_DIR, 'quotes.txt'), 'r', encoding='utf-8') as quotes_file:
+    with (settings.BASE_DIR / 'quotes.txt').open('r', encoding='utf-8') as quotes_file:
         QUOTES = quotes_file.readlines()
 except OSError:
     QUOTES = [settings.ZDS_APP['site']['slogan']]

--- a/zds/searchv2/forms.py
+++ b/zds/searchv2/forms.py
@@ -1,4 +1,3 @@
-import os
 import random
 
 from django import forms
@@ -56,7 +55,7 @@ class SearchForm(forms.Form):
         self.helper.form_action = reverse('search:query')
 
         try:
-            with open(os.path.join(settings.BASE_DIR, 'suggestions.txt'), 'r') as suggestions_file:
+            with (settings.BASE_DIR / 'suggestions.txt').open('r') as suggestions_file:
                 suggestions = ', '.join(random.sample(suggestions_file.readlines(), 5)) + '…'
         except OSError:
             suggestions = _('Mathématiques, Droit, UDK, Langues, Python…')

--- a/zds/settings/abstract_base/base_dir.py
+++ b/zds/settings/abstract_base/base_dir.py
@@ -2,4 +2,4 @@ from pathlib import Path
 
 PROJECT_PACKAGE_DIR = Path(__file__).resolve().parent.parent.parent
 
-BASE_DIR = str(PROJECT_PACKAGE_DIR.parent)
+BASE_DIR = PROJECT_PACKAGE_DIR.parent

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -13,7 +13,7 @@ INTERNAL_IPS = ('127.0.0.1',)  # debug toolbar
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': join(BASE_DIR, 'base.db'),
+        'NAME': str(BASE_DIR / 'base.db'),
         'USER': '',
         'PASSWORD': '',
         'HOST': '',
@@ -36,7 +36,7 @@ LANGUAGE_CODE = 'fr-fr'
 USE_I18N = True
 
 LOCALE_PATHS = (
-    join(BASE_DIR, 'conf/locale/'),
+    str(BASE_DIR / 'conf' / 'locale'),
 )
 
 # If you set this to False, Django will not format dates, numbers and
@@ -53,7 +53,7 @@ LANGUAGES = (
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: '/home/media/media.lawrence.com/media/'
-MEDIA_ROOT = join(BASE_DIR, 'media')
+MEDIA_ROOT = BASE_DIR / 'media'
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
@@ -64,7 +64,7 @@ MEDIA_URL = '/media/'
 # Don't put anything in this directory yourself; store your static files
 # in apps' 'static/' subdirectories and in STATICFILES_DIRS.
 # Example: '/home/media/media.lawrence.com/static/'
-STATIC_ROOT = join(BASE_DIR, 'static')
+STATIC_ROOT = str(BASE_DIR / 'static')
 
 # URL prefix for static files.
 # Example: 'http://media.lawrence.com/static/'
@@ -75,7 +75,7 @@ STATICFILES_DIRS = (
     # Put strings here, like '/home/html/static' or 'C:/www/django/static'.
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
-    join(BASE_DIR, 'dist'),
+    str(BASE_DIR / 'dist'),
 )
 
 # List of finder classes that know how to find static files in
@@ -118,7 +118,7 @@ django_template_engine = {
     'BACKEND': 'django.template.backends.django.DjangoTemplates',
     'APP_DIRS': True,
     'DIRS': [
-        join(BASE_DIR, 'templates'),
+        str(BASE_DIR / 'templates'),
     ],
     'OPTIONS': {
         'context_processors': [

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -64,7 +64,7 @@ MEDIA_URL = '/media/'
 # Don't put anything in this directory yourself; store your static files
 # in apps' 'static/' subdirectories and in STATICFILES_DIRS.
 # Example: '/home/media/media.lawrence.com/static/'
-STATIC_ROOT = str(BASE_DIR / 'static')
+STATIC_ROOT = BASE_DIR / 'static'
 
 # URL prefix for static files.
 # Example: 'http://media.lawrence.com/static/'

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -1,4 +1,3 @@
-from os.path import join
 from pathlib import Path
 
 from django.utils.translation import gettext_lazy as _
@@ -8,7 +7,7 @@ from .base_dir import BASE_DIR
 
 zds_config = config.get('zds', {})
 
-GEOIP_PATH = join(BASE_DIR, 'geodata')
+GEOIP_PATH = str(BASE_DIR / 'geodata')
 GEOIP_CITY = 'GeoLite2-City.mmdb'
 
 ES_ENABLED = True
@@ -159,13 +158,13 @@ ZDS_APP = {
         'home_number': 5
     },
     'content': {
-        'repo_private_path': join(BASE_DIR, 'contents-private'),
-        'repo_public_path': join(BASE_DIR, 'contents-public'),
+        'repo_private_path': BASE_DIR / 'contents-private',
+        'repo_public_path': BASE_DIR / 'contents-public',
         'extra_contents_dirname': 'extra_contents',
         # can also be 'extra_content_generation_policy': 'SYNC'
         # or 'extra_content_generation_policy': 'NOTHING'
         'extra_content_generation_policy': 'WATCHDOG',
-        'extra_content_watchdog_dir': join(BASE_DIR, 'watchdog-build'),
+        'extra_content_watchdog_dir': BASE_DIR / 'watchdog-build',
         'max_tree_depth': 3,
         'default_licence_pk': 7,
         'content_per_page': 42,
@@ -178,7 +177,7 @@ ZDS_APP = {
         'suggestions_per_page': 2,
         'feed_length': 5,
         'user_page_number': 5,
-        'default_image': join(BASE_DIR, 'fixtures', 'noir_black.png'),
+        'default_image': BASE_DIR / 'fixtures' / 'noir_black.png',
         'import_image_prefix': 'archive',
         'build_pdf_when_published': True,
         'maximum_slug_size': 150,
@@ -187,8 +186,8 @@ ZDS_APP = {
             'https://zestedesavoir.com/articles/222/la-ligne-editoriale-officielle-de-zeste-de-savoir/',
         'epub_stylesheets': {
             'toc': Path('toc.css'),
-            'full': Path(BASE_DIR) / 'dist' / 'css' / 'zmd.css',
-            'katex': Path(BASE_DIR) / 'dist' / 'css' / 'katex.min.css'
+            'full': BASE_DIR / 'dist' / 'css' / 'zmd.css',
+            'katex': BASE_DIR / 'dist' / 'css' / 'katex.min.css'
         },
         'latex_template_repo': 'NOT_EXISTING_DIR'
     },

--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -63,7 +63,7 @@ SESSION_COOKIE_AGE = 60 * 60 * 24 * 7 * 4
 
 MEDIA_ROOT = Path('/opt/zds/data/media')
 
-STATIC_ROOT = '/opt/zds/data/static'
+STATIC_ROOT = Path('/opt/zds/data/static')
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 
 django_template_engine['APP_DIRS'] = False

--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -61,7 +61,7 @@ CACHES = {
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 SESSION_COOKIE_AGE = 60 * 60 * 24 * 7 * 4
 
-MEDIA_ROOT = '/opt/zds/data/media'
+MEDIA_ROOT = Path('/opt/zds/data/media')
 
 STATIC_ROOT = '/opt/zds/data/static'
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'

--- a/zds/tutorialv2/epub_utils.py
+++ b/zds/tutorialv2/epub_utils.py
@@ -133,7 +133,7 @@ def build_ebook(published_content_entity, working_dir, final_file_path):
     mimetype_conf = __build_mime_type_conf()
     mime_path = Path(working_dir, 'ebook', mimetype_conf['filename'])
     with contextlib.suppress(FileExistsError, FileNotFoundError):
-        for img in Path(published_content_entity.content.gallery.get_gallery_path()).iterdir():
+        for img in published_content_entity.content.gallery.get_gallery_path().iterdir():
             shutil.copy(str(img), str(target_image_dir))
 
     with mime_path.open(mode='w', encoding='utf-8') as mimefile:
@@ -148,8 +148,8 @@ def build_ebook(published_content_entity, working_dir, final_file_path):
     copy_or_create_empty(settings.ZDS_APP['content']['epub_stylesheets']['toc'], style_dir_path, 'toc.css')
     copy_or_create_empty(settings.ZDS_APP['content']['epub_stylesheets']['full'], style_dir_path, 'zmd.css')
     copy_or_create_empty(settings.ZDS_APP['content']['epub_stylesheets']['katex'], style_dir_path, 'katex.css')
-    style_images_path = Path(settings.BASE_DIR, 'dist', 'images')
-    smiley_images_path = Path(settings.BASE_DIR, 'dist', 'smileys', 'svg')
+    style_images_path = settings.BASE_DIR / 'dist' / 'images'
+    smiley_images_path = settings.BASE_DIR / 'dist' / 'smileys' / 'svg'
     if style_images_path.exists():
         import_asset(style_images_path, target_image_dir)
     if smiley_images_path.exists():

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -357,8 +357,8 @@ class ZMarkdownRebberLatexPublicator(Publicator):
         image_dir = base_directory / 'images'
         with contextlib.suppress(FileExistsError):
             image_dir.mkdir(parents=True)
-        if Path(settings.MEDIA_ROOT, 'galleries', str(gallery_pk)).exists():
-            for image in Path(settings.MEDIA_ROOT, 'galleries', str(gallery_pk)).iterdir():
+        if (settings.MEDIA_ROOT / 'galleries' / str(gallery_pk)).exists():
+            for image in (settings.MEDIA_ROOT / 'galleries' / str(gallery_pk)).iterdir():
                 with contextlib.suppress(OSError):
                     shutil.copy2(str(image.absolute()), str(image_dir))
         content_type = depth_to_size_map[public_versionned_source.get_tree_level()]
@@ -366,7 +366,6 @@ class ZMarkdownRebberLatexPublicator(Publicator):
             content_type += ', ' + self.latex_classes
         title = published_content_entity.title()
         authors = [a.username for a in published_content_entity.authors.all()]
-        smileys_directory = SMILEYS_BASE_PATH + '/svg'
 
         licence = published_content_entity.content.licence.code
         licence_short = licence.replace('CC', '').strip().lower()
@@ -381,7 +380,7 @@ class ZMarkdownRebberLatexPublicator(Publicator):
             licence_logo = licences['copyright']
             licence_url = ''
 
-        replacement_image_url = settings.MEDIA_ROOT
+        replacement_image_url = str(settings.MEDIA_ROOT)
         if not replacement_image_url.endswith('/') and settings.MEDIA_URL.endswith('/'):
             replacement_image_url += '/'
         elif replacement_image_url.endswith('/') and not settings.MEDIA_URL.endswith('/'):
@@ -394,10 +393,10 @@ class ZMarkdownRebberLatexPublicator(Publicator):
             title=title,
             authors=authors,
             license=licence,
-            license_directory=LICENSES_BASE_PATH,
+            license_directory=str(LICENSES_BASE_PATH),
             license_logo=licence_logo,
             license_url=licence_url,
-            smileys_directory=smileys_directory,
+            smileys_directory=str(SMILEYS_BASE_PATH / 'svg'),
             images_download_dir=str(base_directory / 'images'),
             local_url_to_local_path=[settings.MEDIA_URL, replacement_image_url]
         )

--- a/zds/tutorialv2/tests/__init__.py
+++ b/zds/tutorialv2/tests/__init__.py
@@ -1,5 +1,4 @@
 import copy
-import os
 
 from django.conf import settings
 import shutil
@@ -10,18 +9,16 @@ from selenium.webdriver.support.wait import WebDriverWait
 
 from zds.tutorialv2.models.database import Validation
 
-BASE_DIR = settings.BASE_DIR
-
 overridden_zds_app = copy.deepcopy(settings.ZDS_APP)
-overridden_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overridden_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overridden_zds_app['content']['repo_private_path'] = settings.BASE_DIR / 'contents-private-test'
+overridden_zds_app['content']['repo_public_path'] = settings.BASE_DIR / 'contents-public-test'
 overridden_zds_app['content']['extra_content_generation_policy'] = 'SYNC'
 overridden_zds_app['content']['build_pdf_when_published'] = False
 
 
 class override_for_contents(override_settings):
     def __init__(self, **kwargs):
-        kwargs.update(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'), ZDS_APP=overridden_zds_app)
+        kwargs.update(MEDIA_ROOT=settings.BASE_DIR / 'media-test', ZDS_APP=overridden_zds_app)
 
         if 'ES_ENABLED' not in kwargs:
             kwargs.update(ES_ENABLED=False)

--- a/zds/tutorialv2/tests/tests_feeds.py
+++ b/zds/tutorialv2/tests/tests_feeds.py
@@ -1,5 +1,3 @@
-import os
-
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -17,11 +15,11 @@ from zds.tutorialv2.tests import TutorialTestMixin
 from copy import deepcopy
 
 overridden_zds_app = deepcopy(settings.ZDS_APP)
-overridden_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
-overridden_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
+overridden_zds_app['content']['repo_private_path'] = settings.BASE_DIR / 'contents-private-test'
+overridden_zds_app['content']['repo_public_path'] = settings.BASE_DIR / 'contents-public-test'
 
 
-@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=settings.BASE_DIR / 'media-test')
 @override_settings(ZDS_APP=overridden_zds_app)
 class LastTutorialsFeedRSSTest(TutorialTestMixin, TestCase):
 

--- a/zds/tutorialv2/tests/tests_front.py
+++ b/zds/tutorialv2/tests/tests_front.py
@@ -22,16 +22,15 @@ from zds.tutorialv2.models.database import PublishedContent, PublishableContent
 from zds.tutorialv2.tests import TutorialTestMixin, TutorialFrontMixin
 from copy import deepcopy
 from django.conf import settings
-import os
 
 from zds.utils.factories import CategoryFactory
 
 overridden_zds_app = deepcopy(settings.ZDS_APP)
-overridden_zds_app['content']['repo_private_path'] = os.path.join(settings.BASE_DIR, 'contents-private-test')
-overridden_zds_app['content']['repo_public_path'] = os.path.join(settings.BASE_DIR, 'contents-public-test')
+overridden_zds_app['content']['repo_private_path'] = settings.BASE_DIR / 'contents-private-test'
+overridden_zds_app['content']['repo_public_path'] = settings.BASE_DIR / 'contents-public-test'
 
 
-@override_settings(MEDIA_ROOT=os.path.join(settings.BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=settings.BASE_DIR / 'media-test')
 @override_settings(ZDS_APP=overridden_zds_app)
 @override_settings(ES_ENABLED=False)
 @tag('front')

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -261,14 +261,13 @@ class UtilsTests(TutorialTestMixin, TestCase):
 
     def test_update_manifest(self):
         opts = {}
-        shutil.copy(
-            os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'balise_audio', 'manifest.json'),
-            os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'balise_audio', 'manifest2.json')
-        )
+        path_manifest1 = settings.BASE_DIR / 'fixtures' / 'tuto' / 'balise_audio' / 'manifest.json'
+        path_manifest2 = settings.BASE_DIR / 'fixtures' / 'tuto' / 'balise_audio' / 'manifest2.json'
+        args = [str(path_manifest2)]
+        shutil.copy(path_manifest1, path_manifest2)
         LicenceFactory(code='CC BY')
-        args = [os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'balise_audio', 'manifest2.json')]
         call_command('upgrade_manifest_to_v2', *args, **opts)
-        manifest = open(os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'balise_audio', 'manifest2.json'), 'r')
+        manifest = path_manifest2.open('r')
         json = json_handler.loads(manifest.read())
 
         self.assertTrue('version' in json)
@@ -277,13 +276,12 @@ class UtilsTests(TutorialTestMixin, TestCase):
         self.assertEqual(len(json['children']), 3)
         self.assertEqual(json['children'][0]['object'], 'extract')
         os.unlink(args[0])
-        args = [os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'big_tuto_v1', 'manifest2.json')]
-        shutil.copy(
-            os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'big_tuto_v1', 'manifest.json'),
-            os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'big_tuto_v1', 'manifest2.json')
-        )
+        path_manifest1 = settings.BASE_DIR / 'fixtures' / 'tuto' / 'big_tuto_v1' / 'manifest.json'
+        path_manifest2 = settings.BASE_DIR / 'fixtures' / 'tuto' / 'big_tuto_v1' / 'manifest2.json'
+        args = [str(path_manifest2)]
+        shutil.copy(path_manifest1, path_manifest2)
         call_command('upgrade_manifest_to_v2', *args, **opts)
-        manifest = open(os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'big_tuto_v1', 'manifest2.json'), 'r')
+        manifest = path_manifest2.open('r')
         json = json_handler.loads(manifest.read())
         os.unlink(args[0])
         self.assertTrue('version' in json)
@@ -293,13 +291,12 @@ class UtilsTests(TutorialTestMixin, TestCase):
         self.assertEqual(json['children'][0]['object'], 'container')
         self.assertEqual(len(json['children'][0]['children']), 3)
         self.assertEqual(len(json['children'][0]['children'][0]['children']), 3)
-        args = [os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'article_v1', 'manifest2.json')]
-        shutil.copy(
-            os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'article_v1', 'manifest.json'),
-            os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'article_v1', 'manifest2.json')
-        )
+        path_manifest1 = settings.BASE_DIR / 'fixtures' / 'tuto' / 'article_v1' / 'manifest.json'
+        path_manifest2 = settings.BASE_DIR / 'fixtures' / 'tuto' / 'article_v1' / 'manifest2.json'
+        args = [path_manifest2]
+        shutil.copy(path_manifest1, path_manifest2)
         call_command('upgrade_manifest_to_v2', *args, **opts)
-        manifest = open(os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'article_v1', 'manifest2.json'), 'r')
+        manifest = path_manifest2.open('r')
         json = json_handler.loads(manifest.read())
 
         self.assertTrue('version' in json)

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -271,7 +271,7 @@ class ContentTests(TutorialTestMixin, TestCase):
                 'type': 'TUTORIAL',
                 'licence': self.licence.pk,
                 'subcategory': self.subcategory.pk,
-                'image': open('{}/fixtures/noir_black.png'.format(settings.BASE_DIR), 'rb')
+                'image': (settings.BASE_DIR / 'fixtures' / 'noir_black.png').open('rb')
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -320,7 +320,7 @@ class ContentTests(TutorialTestMixin, TestCase):
                 'licence': new_licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': versioned.compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR), 'rb')
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -1761,10 +1761,10 @@ class ContentTests(TutorialTestMixin, TestCase):
                 username=self.user_author.username,
                 password='hostel77'),
             True)
-        archive_path = os.path.join(settings.BASE_DIR, 'fixtures', 'tuto', 'BadArchive.zip')
+        archive_path = settings.BASE_DIR / 'fixtures' / 'tuto' / 'BadArchive.zip'
         answer = self.client.post(reverse('content:import',
                                           args=[new_article.pk, new_article.slug]),
-                                  {'archive': open(archive_path, 'rb'),
+                                  {'archive': archive_path.open('rb'),
                                    'image_archive': None,
                                    'msg_commit': "let it go, let it goooooooo ! can't hold it back anymoooooore!"})
         self.assertEqual(200, answer.status_code)
@@ -2097,7 +2097,7 @@ class ContentTests(TutorialTestMixin, TestCase):
                 'licence': tuto.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': tuto.load_version(tuto.sha_draft).compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR), 'rb')
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False)
 
@@ -3572,25 +3572,25 @@ class ContentTests(TutorialTestMixin, TestCase):
                 username=self.user_author.username,
                 password='hostel77'),
             True)
-        base = os.path.join(settings.BASE_DIR, 'fixtures', 'tuto')
+        base = settings.BASE_DIR / 'fixtures' / 'tuto'
         old_contents = [
-            os.path.join(base, 'article_v1'),
-            os.path.join(base, 'balise_audio'),
-            os.path.join(base, 'big_tuto_v1'),
+            base / 'article_v1',
+            base / 'balise_audio',
+            base / 'big_tuto_v1',
         ]
         for old_path in old_contents:
-            draft_zip_path = old_path + '.zip'
+            draft_zip_path = old_path.with_suffix('.zip')
             shutil.make_archive(old_path, 'zip', old_path)
 
             result = self.client.post(
                 reverse('content:import-new'),
                 {
-                    'archive': open(draft_zip_path, 'rb'),
+                    'archive': draft_zip_path.open('rb'),
                     'subcategory': self.subcategory.pk
                 },
                 follow=False
             )
-            manifest = open(os.path.join(old_path, 'manifest.json'), 'rb')
+            manifest = (old_path / 'manifest.json').open('rb')
             json = json_handler.loads(manifest.read())
             manifest.close()
             self.assertEqual(result.status_code, 302)
@@ -3602,16 +3602,16 @@ class ContentTests(TutorialTestMixin, TestCase):
                 username=self.user_author.username,
                 password='hostel77'),
             True)
-        base = os.path.join(settings.BASE_DIR, 'fixtures', 'tuto')
-        old_path = os.path.join(base, 'article_v1')
+        base = settings.BASE_DIR / 'fixtures' / 'tuto'
+        old_path = base / 'article_v1'
 
-        shutil.move(os.path.join(old_path, 'text.md'), os.path.join(old_path, 'text2.md'))
+        shutil.move(old_path / 'text.md', old_path / 'text2.md')
         shutil.make_archive(old_path, 'zip', old_path)
-        shutil.move(os.path.join(old_path, 'text2.md'), os.path.join(old_path, 'text.md'))
+        shutil.move(old_path / 'text2.md', old_path / 'text.md')
         result = self.client.post(
             reverse('content:import-new'),
             {
-                'archive': open(old_path + '.zip', 'rb'),
+                'archive': old_path.with_suffix('.zip').open('rb'),
                 'subcategory': self.subcategory.pk
             },
             follow=False
@@ -3621,15 +3621,15 @@ class ContentTests(TutorialTestMixin, TestCase):
         levels = [msg.level for msg in msgs]
         self.assertIn(messages.ERROR, levels)
 
-        shutil.copyfile(os.path.join(old_path, 'manifest.json'), os.path.join(old_path, 'manifest2.json'))
-        with open(os.path.join(old_path, 'manifest.json'), 'w') as man_file:
+        shutil.copyfile(old_path / 'manifest.json', old_path / 'manifest2.json')
+        with (old_path / 'manifest.json').open('w') as man_file:
             man_file.write('{"version":2, "type":"Kitty Cat"}')
         shutil.make_archive(old_path, 'zip', old_path)
-        shutil.copyfile(os.path.join(old_path, 'manifest2.json'), os.path.join(old_path, 'manifest.json'))
+        shutil.copyfile(old_path / 'manifest2.json', old_path / 'manifest.json')
         result = self.client.post(
             reverse('content:import-new'),
             {
-                'archive': open(old_path + '.zip', 'rb'),
+                'archive': old_path.with_suffix('.zip').open('rb'),
                 'subcategory': self.subcategory.pk
             },
             follow=False
@@ -5472,7 +5472,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
                 'licence': self.tuto.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': tuto.load_version().compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR), 'rb')
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -5646,7 +5646,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
                 'licence': article.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': article.load_version(article.sha_draft).compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR), 'rb')
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False)
         public_count = PublishedContent.objects.count()

--- a/zds/tutorialv2/tests/tests_views/tests_edgecases.py
+++ b/zds/tutorialv2/tests/tests_views/tests_edgecases.py
@@ -47,7 +47,7 @@ class ContentTests(TutorialTestMixin, TestCase):
                 'licence': self.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': opinion.load_version().compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR), 'rb')
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -66,7 +66,7 @@ class ContentTests(TutorialTestMixin, TestCase):
                 'licence': self.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': article.load_version().compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(settings.BASE_DIR), 'rb')
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=True)
         self.assertEqual(200, result.status_code)

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -1,7 +1,5 @@
 import datetime
 
-import os
-
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core import mail
@@ -28,16 +26,13 @@ from copy import deepcopy
 from zds import json_handler
 
 
-BASE_DIR = settings.BASE_DIR
-
-
 overridden_zds_app = deepcopy(settings.ZDS_APP)
-overridden_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overridden_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overridden_zds_app['content']['repo_private_path'] = settings.BASE_DIR / 'contents-private-test'
+overridden_zds_app['content']['repo_public_path'] = settings.BASE_DIR / 'contents-public-test'
 overridden_zds_app['content']['extra_content_generation_policy'] = 'SYNC'
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=settings.BASE_DIR / 'media-test')
 @override_settings(ZDS_APP=overridden_zds_app)
 @override_settings(ES_ENABLED=False)
 class PublishedContentTests(TutorialTestMixin, TestCase):
@@ -1391,7 +1386,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
                 'licence': self.tuto.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': tuto.load_version().compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(BASE_DIR), 'rb')
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False)
         self.assertEqual(result.status_code, 302)
@@ -1569,7 +1564,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
                 'licence': article.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': article.load_version(article.sha_draft).compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(BASE_DIR), 'rb')
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False)
         public_count = PublishedContent.objects.count()
@@ -2306,7 +2301,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
                 'licence': self.tuto.licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': self.tuto.load_version().compute_hash(),
-                'image': open('{}/fixtures/logo.png'.format(BASE_DIR), 'rb')
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=True)
 

--- a/zds/tutorialv2/tests/tests_views/tests_stats.py
+++ b/zds/tutorialv2/tests/tests_views/tests_stats.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 from copy import deepcopy
 from random import randint, uniform, shuffle
 
@@ -15,11 +14,9 @@ from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory
 from zds.tutorialv2.models.database import Validation, PublishedContent
 from zds.tutorialv2.tests import TutorialTestMixin
 
-BASE_DIR = settings.BASE_DIR
-
 overridden_zds_app = deepcopy(settings.ZDS_APP)
-overridden_zds_app['content']['repo_private_path'] = os.path.join(BASE_DIR, 'contents-private-test')
-overridden_zds_app['content']['repo_public_path'] = os.path.join(BASE_DIR, 'contents-public-test')
+overridden_zds_app['content']['repo_private_path'] = settings.BASE_DIR / 'contents-private-test'
+overridden_zds_app['content']['repo_public_path'] = settings.BASE_DIR / 'contents-public-test'
 overridden_zds_app['content']['extra_content_generation_policy'] = 'SYNC'
 
 
@@ -191,7 +188,7 @@ def fake_config_ga_credentials(view):
     return MockGAService()
 
 
-@override_settings(MEDIA_ROOT=os.path.join(BASE_DIR, 'media-test'))
+@override_settings(MEDIA_ROOT=settings.BASE_DIR / 'media-test')
 @override_settings(ZDS_APP=overridden_zds_app)
 @override_settings(ES_ENABLED=False)
 class StatTests(TestCase, TutorialTestMixin):

--- a/zds/tutorialv2/views/published.py
+++ b/zds/tutorialv2/views/published.py
@@ -1092,10 +1092,10 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
     template_name = 'tutorialv2/stats/index.html'
     form_class = ContentCompareStatsURLForm
     urls = []
-    CACHE_PATH = os.path.join(settings.BASE_DIR, '.ga-api-cache')
+    CACHE_PATH = str(settings.BASE_DIR / '.ga-api-cache')
     SCOPES = ['https://www.googleapis.com/auth/analytics.readonly']
     DISCOVERY_URI = 'https://analyticsreporting.googleapis.com/$discovery/rest'
-    CLIENT_SECRETS_PATH = os.path.join(settings.BASE_DIR, 'api_analytics_secrets.json')
+    CLIENT_SECRETS_PATH = str(settings.BASE_DIR / 'api_analytics_secrets.json')
     VIEW_ID = settings.ZDS_APP['stats_ga_viewid']
 
     def post(self, request, *args, **kwargs):

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -124,7 +124,7 @@ if settings.SERVE:
     from django.views.static import serve
     urlpatterns += [
         re_path(r'^static/(?P<path>.*)$', serve,
-                {'document_root': settings.STATIC_ROOT}),
+                {'document_root': str(settings.STATIC_ROOT)}),
         re_path(r'^media/(?P<path>.*)$', serve,
                 {'document_root': str(settings.MEDIA_ROOT)}),
     ]

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -126,7 +126,7 @@ if settings.SERVE:
         re_path(r'^static/(?P<path>.*)$', serve,
                 {'document_root': settings.STATIC_ROOT}),
         re_path(r'^media/(?P<path>.*)$', serve,
-                {'document_root': settings.MEDIA_ROOT}),
+                {'document_root': str(settings.MEDIA_ROOT)}),
     ]
 
 if settings.DEBUG:

--- a/zds/utils/factories.py
+++ b/zds/utils/factories.py
@@ -26,7 +26,7 @@ class HelpWritingFactory(factory.DjangoModelFactory):
             image_path = join(settings.BASE_DIR, 'fixtures', fixture_image_path)
 
         if image_path is not None:
-            copyfile(image_path, join(settings.MEDIA_ROOT, basename(image_path)))
+            copyfile(image_path, settings.MEDIA_ROOT / basename(image_path))
             help_writing.image = basename(image_path)
             help_writing.save()
 

--- a/zds/utils/templatetags/smileys_def.py
+++ b/zds/utils/templatetags/smileys_def.py
@@ -1,8 +1,8 @@
 import os
 from django.conf import settings
 
-SMILEYS_BASE_PATH = os.path.join(settings.BASE_DIR, 'dist/smileys')
-LICENSES_BASE_PATH = os.path.join(settings.BASE_DIR, 'dist/licenses')
+SMILEYS_BASE_PATH = settings.BASE_DIR / 'dist' / 'smileys'
+LICENSES_BASE_PATH = settings.BASE_DIR / 'dist' / 'licenses'
 SMILEYS_BASE_URL = os.path.join(settings.STATIC_URL, 'smileys')
 
 SMILEYS_BASE = {


### PR DESCRIPTION
Reprise de #4875

Fix  #4744.

### Contrôle qualité

La suite de test devrait suffire. Faire quelques opérations utilisant les fichiers en plus (utilisation du module de tuto, upload d'images, etc).
