### PR TITLE
Garantit le fonctionnement des raccourcis claviers sur toutes les modales

### DIFF
--- a/assets/js/autocompletion.js
+++ b/assets/js/autocompletion.js
@@ -67,10 +67,11 @@
           }
           break
         case 13: // Enter
-          e.preventDefault()
-          e.stopPropagation()
-
-          this.enter()
+          if (!e.ctrlKey) { // Do not capture Ctrl + Enter, as it is used to validate modals
+            e.preventDefault()
+            e.stopPropagation()
+            this.enter()
+          }
           break
       }
     },

--- a/doc/source/front-end/elements-specifiques-au-site.rst
+++ b/doc/source/front-end/elements-specifiques-au-site.rst
@@ -61,7 +61,7 @@ de l'attribut (ici ``Fermez-moi !``) deviendra le texte du bouton.
    </div>
 
 Si on désire un second bouton pointant vers un lien arbitraire, il suffit d'ajouter à la fin de l'élément
-contenant la boîte un lien avec les classes ``btn`` et ``btn-success`` ; il sera automatiquement ajouté
+contenant la boîte un lien avec les classes ``btn`` et ``btn-submit`` ; il sera automatiquement ajouté
 à côté du bouton de fermeture de la modale.
 
 .. sourcecode:: html

--- a/templates/featured/index.html
+++ b/templates/featured/index.html
@@ -68,7 +68,7 @@
         <form id="form-delete-featured" name="form" method="post" action="{% url "featured-resource-list-delete" %}" class="modal modal-flex">
             {% csrf_token %}
             <p>{% trans "Attention, vous vous apprêtez à supprimer toutes les unes sélectionnées." %}</p>
-            <button type="submit" name="delete_multi" class="btn">{% trans "Confirmer" %}</button>
+            <button type="submit" name="delete_multi" class="btn btn-submit">{% trans "Confirmer" %}</button>
         </form>
     {% else %}
         <p>

--- a/templates/featured/resource/update.html
+++ b/templates/featured/resource/update.html
@@ -44,7 +44,7 @@
                     </p>
 
                     {% csrf_token %}
-                    <button type="submit" name="delete">{% trans "Confirmer" %}</button>
+                    <button type="submit" name="delete" class="btn btn-submit">{% trans "Confirmer" %}</button>
                 </form>
             </li>
         </ul>

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -260,7 +260,7 @@
                             <p>
                                 {% trans 'Voulez-vous vraiment dissocier ce sujet de son ticket GitHub ?' %}
                             </p>
-                            <button type="submit" name="unlink">{% trans 'Confirmer' %}</button>
+                            <button type="submit" name="unlink" class="btn btn-submit">{% trans 'Confirmer' %}</button>
                         </form>
                     {% endif %}
                 {% else %}
@@ -280,7 +280,7 @@
                                         <input type="checkbox" name="tag-{{ tag }}" value="{{ tag }}" id="tag-{{ tag }}">
                                     </label>
                                 {% endfor %}
-                                <button type="submit" name="create">{% trans 'Envoyer' %}</button>
+                                <button type="submit" name="create" class="btn btn-submit">{% trans 'Envoyer' %}</button>
                             {% else %}
                                 <p>{% trans "Il semblerait que vous n’ayez pas spécifié de token d’identification GitHub, vous ne pouvez donc pas créer de ticket pour ce sujet." %}</p>
                                 {% url 'update-github' as update_github %}
@@ -303,7 +303,7 @@
                                 {% trans "Quel est le numéro du ticket GitHub que vous souhaitez associer ?" %}
                             </p>
                             <input type="number" name="issue" min="1" placeholder="{% trans "Numéro du ticket (sans #)" %}" required>
-                            <button type="submit" name="link">{% trans 'Associer' %}</button>
+                            <button type="submit" name="link" class="btn btn-submit">{% trans 'Associer' %}</button>
                         </form>
                     </li>
                 {% endif %}
@@ -347,7 +347,7 @@
                             {% trans "du sujet ?" %}
                         </p>
 
-                        <button type="submit" name="lock-open-topic-{{ topic.pk }}">
+                        <button type="submit" name="lock-open-topic-{{ topic.pk }}" class="btn btn-submit">
                             {% trans "Confirmer" %}
                         </button>
                     </form>

--- a/templates/gallery/base.html
+++ b/templates/gallery/base.html
@@ -56,7 +56,7 @@
                                         <input name="g_items" type="hidden" value="{{ gallery.pk }}" form="delete-galleries" />
                                         <p>{% trans "Êtes-vous certain de vouloir supprimer cette galerie ?" %}</p>
                                         {% csrf_token %}
-                                        <button type="submit" name="delete_multi" class="btn">{% trans "Supprimer" %}</button>
+                                        <button type="submit" name="delete_multi" class="btn btn-submit">{% trans "Supprimer" %}</button>
                                     </form>
                                 </li>
                             {% endif %}

--- a/templates/gallery/gallery/details.html
+++ b/templates/gallery/gallery/details.html
@@ -126,7 +126,7 @@
                 <input type="hidden" name="gallery" value="{{ gallery.pk }}">
                 {% csrf_token %}
                 <p>{% trans "Attention, vous vous appretez à supprimer toutes les images sélectionnées." %}</p>
-                <button type="submit" name="delete_multi" class="btn">{% trans "Confirmer" %}</button>
+                <button type="submit" name="delete_multi" class="btn btn-submit">{% trans "Confirmer" %}</button>
             </form>
         {% endif %}
 

--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -105,7 +105,7 @@
                         </p>
 
                         {% csrf_token %}
-                        <button type="submit" name="delete_multi" class="btn">{% trans "Confirmer" %}</button>
+                        <button type="submit" name="delete_multi" class="btn btn-submit">{% trans "Confirmer" %}</button>
                     </form>
                 </li>
             </ul>

--- a/templates/gallery/image/edit.html
+++ b/templates/gallery/image/edit.html
@@ -97,7 +97,7 @@
                 {% csrf_token %}
                 <input type="hidden" name="image" value="{{ image.pk }}">
                 <p>{% trans "Attention, vous vous apprêtez à supprimer cette image." %}</p>
-                <button type="submit" name="delete" class="btn">{% trans "Confirmer" %}</button>
+                <button type="submit" name="delete" class="btn btn-submit">{% trans "Confirmer" %}</button>
             </form>
         {% endif %}
     </div>

--- a/templates/member/hat.html
+++ b/templates/member/hat.html
@@ -90,7 +90,7 @@
                                         {% endblocktrans %}
                                     </p>
                                     <p>{% trans "Vous ne pourrez plus poster avec cette casquette et elle n'apparaîtra plus sur votre profil. Les messages ayant été postés avec le resteront. Notez toutefois que vous ne pourrez pas conserver la casquette si vous les éditez." %}</p>
-                                    <button type="submit">{% trans 'Confirmer' %}</button>
+                                    <button type="submit" class="btn btn-submit">{% trans 'Confirmer' %}</button>
                                 </form>
                             </li>
                         {% endif %}

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -241,7 +241,7 @@
                                                         Voulez-vous vraiment retirer la casquette « {{ hat }} » à {{ username }} ?
                                                     {% endblocktrans %}
                                                 </p>
-                                                <button type="submit">{% trans 'Confirmer' %}</button>
+                                                <button type="submit" class="btn btn-submit">{% trans 'Confirmer' %}</button>
                                             </form>
                                         {% endif %}
                                     </li>
@@ -560,7 +560,7 @@
                                         </ul>
                                         <p>{% trans "La casquette sera créée si elle n’existe pas." %}</p>
                                         <input type="text" name="hat" maxlength="40" placeholder="{% trans 'Casquette à attribuer.' %}" required />
-                                        <button type="submit">{% trans 'Valider' %}</button>
+                                        <button type="submit" class="btn btn-submit">{% trans 'Valider' %}</button>
                                     </form>
                                 {% endif %}
 
@@ -680,7 +680,8 @@
                                            min="1">
                                     {% csrf_token %}
                                     <button type="submit"
-                                            name="ls-temp">
+                                            name="ls-temp"
+                                            class="btn btn-submit">
                                         {% trans "Confirmer" %}
                                     </button>
                                 </form>
@@ -700,7 +701,8 @@
                                            placeholder="{% trans 'Spam, Troll, etc.' %}">
                                     {% csrf_token %}
                                     <button type="submit"
-                                            name="ls">
+                                            name="ls"
+                                            class="btn btn-submit">
                                         {% trans "Confirmer" %}
                                     </button>
                                 </form>
@@ -732,7 +734,8 @@
                                            placeholder="{% trans 'Bonne action ?' %}">
                                     {% csrf_token %}
                                     <button type="submit"
-                                            name="un-ls">
+                                            name="un-ls"
+                                            class="btn btn-submit">
                                         {% trans "Confirmer" %}
                                     </button>
                                 </form>
@@ -762,7 +765,8 @@
                                            min="1">
                                     {% csrf_token %}
                                     <button type="submit"
-                                            name="ban-temp">
+                                            name="ban-temp"
+                                            class="btn  btn-submit">
                                         {% trans "Confirmer" %}
                                     </button>
                                 </form>
@@ -782,7 +786,8 @@
                                            placeholder="{% trans 'Spam, Troll, etc.' %}">
                                     {% csrf_token %}
                                     <button type="submit"
-                                            name="ban">
+                                            name="ban"
+                                            class="btn btn-submit">
                                         {% trans "Confirmer" %}
                                     </button>
                                 </form>
@@ -812,7 +817,8 @@
                                        placeholder="{% trans 'Bonne action ?' %}">
                                 {% csrf_token %}
                                 <button type="submit"
-                                        name="un-ban">
+                                        name="un-ban"
+                                        class="btn btn-submit">
                                     {% trans "Confirmer" %}
                                 </button>
                             </form>
@@ -881,7 +887,7 @@
                                 <form id="solve-alert-{{ alert.pk }}" method="post" action="{% url 'solve-profile-alert' alert.pk %}" class="modal modal-flex">
                                     <textarea name="text" class="input" placeholder="{% trans 'Message à envoyer au membre ayant lancé l’alerte' %}"></textarea>
                                     {% csrf_token %}
-                                    <button type="submit" class="button expand alert tiny">{% trans "Résoudre l’alerte" %}</button>
+                                    <button type="submit" class="btn btn-submit button expand alert tiny">{% trans "Résoudre l’alerte" %}</button>
                                 </form>
                             {% endif %}
                         </div>
@@ -900,7 +906,7 @@
                     </label>
                     <textarea type="text" name="reason" id="report-reason" placeholder='{% trans "Spam, Contenu illégal, …" %}' pattern=".{3,}" required title='{% trans "Minimum 3 caractères pour signaler" %}' rows="4"></textarea>
 
-                    <button type="submit">
+                    <button type="submit" class="btn btn-submit">
                         {% trans "Signaler" %}
                     </button>
                 </form>

--- a/templates/member/settings/github.html
+++ b/templates/member/settings/github.html
@@ -41,7 +41,7 @@
                 {% trans "Voulez-vous vraiment supprimer votre token GitHub ?" %}
             </p>
 
-            <button type="submit">{% trans "Confirmer" %}</button>
+            <button type="submit" class="btn btn-submit">{% trans "Confirmer" %}</button>
         </form>
     {% endif %}
 

--- a/templates/member/settings/hat_request.html
+++ b/templates/member/settings/hat_request.html
@@ -90,7 +90,7 @@
                     {% endif %}
                     <textarea name="comment" placeholder="{% trans "Commentaire (facultatif)." %}" maxlength="1000"></textarea>
                     {% csrf_token %}
-                    <button type="submit" name="grant">{% trans "Accorder" %}</button>
+                    <button type="submit" name="grant" class="btn btn-submit">{% trans "Accorder" %}</button>
                 </form>
 
                 <a href="#deny-hat" class="new-btn ico-after red cross open-modal">
@@ -100,7 +100,7 @@
                 <form id="deny-hat" class="modal modal-flex" method="post" action="{% url 'solve-hat-request' hat_request.pk %}">
                     <textarea name="comment" placeholder="{% trans "Commentaire de refus (facultatif)." %}" maxlength="1000"></textarea>
                     {% csrf_token %}
-                    <button type="submit">{% trans "Refuser" %}</button>
+                    <button type="submit" class="btn btn-submit">{% trans "Refuser" %}</button>
                 </form>
             {% else %}
                 <a href="{% url "solved-hat-requests" %}" class="new-btn ico-after arrow-left blue">

--- a/templates/member/settings/hats.html
+++ b/templates/member/settings/hats.html
@@ -58,7 +58,7 @@
                             {% endblocktrans %}
                         </p>
                         <p>{% trans "Vous ne pourrez plus poster avec cette casquette et elle n’apparaîtra plus sur votre profil. Les messages ayant été postés avec le resteront. Notez toutefois que vous ne pourrez pas conserver la casquette si vous les éditez." %}</p>
-                        <button type="submit">{% trans 'Confirmer' %}</button>
+                        <button type="submit" class="btn btn-submit">{% trans 'Confirmer' %}</button>
                     </form>
                 {% endif %}
             {% endfor %}

--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -100,6 +100,6 @@
         </p>
 
         {% csrf_token %}
-        <button type="submit">{% trans "Me désinscrire" %}</button>
+        <button type="submit" class="btn btn-submit">{% trans "Me désinscrire" %}</button>
     </form>
 {% endblock %}

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -85,7 +85,7 @@
                                             </p>
                                         {% endif %}
 
-                                        <button type="submit" name="delete_message">
+                                        <button type="submit" name="delete_message" class="btn btn-submit">
                                             {% trans "Confirmer" %}
                                         </button>
                                     </form>
@@ -126,7 +126,7 @@
                                     {% endblocktrans %}
                                 </p>
 
-                                <button type="submit" name="show_message">
+                                <button type="submit" name="show_message" class="btn btn-submit">
                                     {% trans "Confirmer" %}
                                 </button>
                             </form>
@@ -144,7 +144,7 @@
                                 {% trans "Pour quelle raison signalez-vous ce message ?" %}
                             </label>
                             <textarea type="text" name="signal_text" id="signal-message-{{ message.id }}-field" placeholder="Flood, Troll, Hors sujet, …" pattern=".{3,}" required title='{% trans "Minimum 3 caractères pour signaler" %}' rows="4"></textarea>
-                            <button type="submit" name="signal_message">
+                            <button type="submit" name="signal_message" class="btn btn-submit">
                                 {% trans "Signaler" %}
                             </button>
                         </form>
@@ -238,7 +238,7 @@
                             <input type="hidden" name="alert_pk" value="{{ alert.pk }}">
 
                             {% csrf_token %}
-                            <button type="submit" name="delete-post" class="button expand alert tiny">{% trans "Résoudre l’alerte" %}</button>
+                            <button type="submit" name="delete-post" class="btn btn-submit button expand alert tiny">{% trans "Résoudre l’alerte" %}</button>
                         </form>
                     {% endif %}
                 </div>

--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -61,7 +61,7 @@
                             {% trans "Indiquez la page à laquelle vous souhaitez vous rendre." %}
                         </p>
                         <input type="number" name="page" min="1" max="{{ pages|last }}">
-                        <button type="submit">
+                        <button type="submit" class="btn btn-submit">
                             {% trans "Aller à la page" %}
                         </button>
                     </form>

--- a/templates/misc/paginator.html
+++ b/templates/misc/paginator.html
@@ -55,7 +55,7 @@
                             {% trans "Indiquez la page à laquelle vous souhaitez vous rendre." %}
                         </p>
                         <input type="number" name="page" min="1" max="{{ pages|last }}">
-                        <button type="submit">
+                        <button type="submit" class="btn btn-submit">
                             {% trans "Aller à la page" %}
                         </button>
                     </form>

--- a/templates/misc/social_buttons.part.html
+++ b/templates/misc/social_buttons.part.html
@@ -33,7 +33,7 @@
                 <input type="text" class="input" name="instance" placeholder="https://" required>
                 <input type="hidden" class="input" name="text" value="{{ text }} {{ app.site.url }}{{ link }}">
 
-                <button type="submit" disabled>{% trans "Partager" %}</button>
+                <button type="submit"  class="btn btn-submit" disabled>{% trans "Partager" %}</button>
             </form>
         </li>
         <li>

--- a/templates/misc/validation.part.html
+++ b/templates/misc/validation.part.html
@@ -38,7 +38,7 @@
                     Êtes-vous certains de vouloir <strong>annuler la réservation</strong> ?
                 {% endblocktrans %}
             </p>
-            <button type="submit">
+            <button type="submit" class="btn btn-submit">
                 {% trans "Confirmer" %}
             </button>
         </form>

--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -109,7 +109,7 @@
                     </p>
 
                     {% csrf_token %}
-                    <button type="submit" name="delete" class="btn">{% trans "Confirmer" %}</button>
+                    <button type="submit" name="delete" class="btn btn-submit">{% trans "Confirmer" %}</button>
                 </form>
             </li>
         </ul>

--- a/templates/mp/post/edit.html
+++ b/templates/mp/post/edit.html
@@ -53,7 +53,7 @@
                         <input type="text" class="input" name="username" placeholder="Pseudo du membre">
 
                         {% csrf_token %}
-                        <button type="submit">{% trans "Ajouter" %}</button>
+                        <button type="submit" class="btn btn-submit">{% trans "Ajouter" %}</button>
                     </form>
                 </li>
             </ul>

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -121,7 +121,7 @@
                                data-autocomplete="{'type':'single'}">
 
                         {% csrf_token %}
-                        <button type="submit">{% trans "Ajouter" %}</button>
+                        <button type="submit" class="btn btn-submit">{% trans "Ajouter" %}</button>
                     </form>
                 </li>
 
@@ -142,7 +142,7 @@
                     </p>
 
                     {% csrf_token %}
-                    <button type="submit" name="leave">{% trans "Confirmer" %}</button>
+                    <button type="submit" name="leave" class="btn btn-submit">{% trans "Confirmer" %}</button>
                 </form>
             </li>
         </ul>

--- a/templates/notification/followed.html
+++ b/templates/notification/followed.html
@@ -69,7 +69,7 @@
                         <p>
                             {% trans 'Voulez-vous vraiment marquer toutes vos notifications comme lues ?' %}
                         </p>
-                        <button type="submit">{% trans 'Confirmer' %}</button>
+                        <button type="submit" class="btn btn-submit">{% trans 'Confirmer' %}</button>
                     </form>
                 </li>
             </ul>

--- a/templates/tutorialv2/includes/alert.html
+++ b/templates/tutorialv2/includes/alert.html
@@ -13,7 +13,7 @@
             </label>
             <textarea type="text" name="signal_text" id="signal-content-{{ content.pk }}-field" placeholder="Illégal, dangereux, injurieux, …" pattern=".{3,}" required title='{% trans "Minimum 3 caractères pour signaler" %}' rows="4"></textarea>
 
-            <button type="submit" name="signal_content">
+            <button type="submit" name="signal_content" class="btn btn-submit">
                 {% trans "Signaler" %}
             </button>
         </form>

--- a/templates/tutorialv2/includes/child.part.html
+++ b/templates/tutorialv2/includes/child.part.html
@@ -64,7 +64,7 @@
 
             <input type="hidden" name="pk" value="{{ content.pk }}">
             {% csrf_token %}
-            <button type="submit">
+            <button type="submit" class="btn btn-submit">
                 {% trans "Déplacer" %}
             </button>
         </form>

--- a/templates/tutorialv2/includes/delete.part.html
+++ b/templates/tutorialv2/includes/delete.part.html
@@ -8,7 +8,7 @@
         {% endblocktrans %}
     </p>
     {% csrf_token %}
-    <button type="submit" name="delete">
+    <button type="submit" name="delete" class="btn btn-submit">
         {% trans "Confirmer" %}
     </button>
 </form>

--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -65,7 +65,7 @@
                 <form action="{% url "content:add-author" content.pk %}" method="post" class="modal modal-flex" id="add-author-content">
                     {% csrf_token %}
                     <input type="text" name="username" placeholder="Pseudo de l’utilisateur à ajouter" data-autocomplete="{ 'type': 'single' }">
-                    <button type="submit" name="add_author">
+                    <button type="submit" name="add_author" class="btn btn-submit">
                         {% trans "Confirmer" %}
                     </button>
                 </form>

--- a/templates/tutorialv2/stats/index.html
+++ b/templates/tutorialv2/stats/index.html
@@ -222,7 +222,7 @@
                             <label for="end_date">{% trans "au" %}</label>
                             <input type="date" value="{% now 'Y-m-d' %}" name="end_date" id="end_date" max="{% now 'Y-m-d' %}">
                         {% endif %}
-                        <button type="submit">
+                        <button type="submit" class="btn btn-submit">
                             {% trans "Actualiser" %}
                         </button>
                     </form>

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -329,7 +329,7 @@
                 <input type="hidden" name="container_slug" value="{{ container.parent.slug}}">
                 {% csrf_token %}
 
-                <button type="submit">{% trans "Déplacer" %}</button>
+                <button type="submit" class="btn btn-submit">{% trans "Déplacer" %}</button>
             </form>
         </li>
     {% endif %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -300,7 +300,7 @@
             <form action="{% url "content:add-author" content.pk %}" method="post" class="modal modal-flex" id="add-author">
                 {% csrf_token %}
                 <input type="text" name="username" placeholder="Pseudo de l’utilisateur à ajouter" data-autocomplete="{ 'type': 'single' }">
-                <button type="submit" name="add_author">
+                <button type="submit" name="add_author" class="btn btn-submit">
                     {% trans "Confirmer" %}
                 </button>
             </form>
@@ -399,7 +399,7 @@
                             "<em>{{ content_title }}</em>" dans la version que vous voyez actuellement ?
                             {% endblocktrans %}
                         </p>
-                        <button type="submit">
+                        <button type="submit" class="btn btn-submit">
                             {% trans "Confirmer" %}
                         </button>
                     </form>
@@ -431,7 +431,7 @@
                                 Si cette mise à jour fait suite à des commentaires obtenus lors de la bêta, pensez à en remercier leurs auteurs dans votre conclusion.
                                 {% endblocktrans %}
                             </p>
-                            <button type="submit">
+                            <button type="submit" class="btn btn-submit">
                                 {% trans "Confirmer" %}
                             </button>
                         </form>
@@ -455,7 +455,7 @@
                             Êtes-vous certain de vouloir <strong>désactiver</strong> la bêta de ce contenu "<em>{{ content_title }}</em>" ?
                             {% endblocktrans %}
                         </p>
-                        <button type="submit">
+                        <button type="submit" class="btn btn-submit">
                             {% trans "Confirmer" %}
                         </button>
                     </form>
@@ -689,7 +689,7 @@
                                         {% include "misc/member_item.part.html" with member=validation.validator %}.
                                         {% trans "Êtes-vous certain de vouloir le retirer" %} ?
                                     </p>
-                                    <button type="submit">
+                                    <button type="submit" class="btn btn-submit">
                                         {% trans "Confirmer" %}
                                     </button>
                                 </form>
@@ -734,7 +734,7 @@
                                     <p><textarea name="text" class="textarea" placeholder="Raison de la suppression" cols="40"></textarea></p>
                                 {%  endif %}
 
-                                <button type="submit">
+                                <button type="submit" class="btn btn-submit">
                                     {% trans "Confirmer" %}
                                 </button>
                             </form>

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -125,7 +125,7 @@
                             <input type="hidden" name="alert_pk" value="{{ alert.pk }}">
 
                             {% csrf_token %}
-                            <button type="submit" name="delete-post" class="button expand alert tiny">{% trans "Résoudre l’alerte" %}</button>
+                            <button type="submit" name="delete-post" class="btn btn-submit button expand alert tiny">{% trans "Résoudre l’alerte" %}</button>
                         </form>
                     {% endif %}
                 </div>
@@ -338,7 +338,7 @@
                                         Il sera dépublié et ne pourra pas être republié.
                                     {% endblocktrans %}
                                 </p>
-                                <button type="submit">
+                                <button type="submit" class="btn btn-submit">
                                     {% trans "Confirmer" %}
                                 </button>
                             </form>

--- a/templates/tutorialv2/view/history.html
+++ b/templates/tutorialv2/view/history.html
@@ -166,7 +166,7 @@
                                             "<em>{{ content_title }}</em>" dans sa version de {{ date_version }} ?
                                         {% endblocktrans %}
                                     </p>
-                                    <button type="submit">
+                                    <button type="submit" class="btn btn-submit">
                                         {% trans "Confirmer" %}
                                     </button>
                                 </form>

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -169,5 +169,5 @@ class MoveTopicForm(forms.Form):
             Field('forum'),
             Hidden('move', ''),
             Hidden('topic', topic.pk),
-            StrictButton(_('Valider'), type='submit'),
+            StrictButton(_('Valider'), type='submit', css_class='btn-submit'),
         )

--- a/zds/gallery/forms.py
+++ b/zds/gallery/forms.py
@@ -103,7 +103,7 @@ class UserGalleryForm(forms.Form):
             Field('user', autocomplete='off'),
             Field('mode'),
             Field('action', value='add'),
-            StrictButton(_('Ajouter'), type='submit'),
+            StrictButton(_('Ajouter'), type='submit', css_class='btn-submit'),
         )
 
     def clean(self):

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -618,7 +618,7 @@ class KarmaForm(forms.Form):
             Field('karma'),
             Hidden('profile_pk', '{{ profile.pk }}'),
             ButtonHolder(
-                StrictButton('Valider', type='submit'),
+                StrictButton('Valider', type='submit', css_class='btn-submit'),
             ),
         )
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -90,7 +90,7 @@ class ContributionForm(forms.Form):
             Field('contribution_role'),
             Field('comment'),
             ButtonHolder(
-                StrictButton(_('Ajouter'), type='submit'),
+                StrictButton(_('Ajouter'), type='submit', css_class='btn-submit'),
             )
         )
         super(ContributionForm, self).__init__(*args, **kwargs)
@@ -752,9 +752,7 @@ class AskValidationForm(forms.Form):
             no_license_msg if self.no_license else None,
             Field('text'),
             Field('version'),
-            StrictButton(
-                _('Confirmer'),
-                type='submit')
+            StrictButton(_('Confirmer'), type='submit', css_class='btn-submit')
         )
 
     def clean(self):
@@ -843,7 +841,7 @@ class AcceptValidationForm(forms.Form):
         self.helper.layout = Layout(
             Field('text'),
             Field('is_major'),
-            StrictButton(_('Publier'), type='submit')
+            StrictButton(_('Publier'), type='submit', css_class='btn-submit')
         )
 
 
@@ -881,9 +879,8 @@ class CancelValidationForm(forms.Form):
             HTML('<p>Êtes-vous certain de vouloir annuler la validation de ce contenu ?</p>'),
             Field('text'),
             ButtonHolder(
-                StrictButton(
-                    _('Confirmer'),
-                    type='submit'))
+                StrictButton(_('Confirmer'), type='submit', css_class='btn-submit')
+            )
         )
 
     def clean(self):
@@ -947,9 +944,8 @@ class RejectValidationForm(forms.Form):
         self.helper.layout = Layout(
             Field('text'),
             ButtonHolder(
-                StrictButton(
-                    _('Rejeter'),
-                    type='submit'))
+                StrictButton(_('Rejeter'), type='submit', css_class='btn-submit')
+            )
         )
 
     def clean(self):
@@ -1002,9 +998,7 @@ class RevokeValidationForm(forms.Form):
         self.helper.layout = Layout(
             Field('text'),
             Field('version'),
-            StrictButton(
-                _('Dépublier'),
-                type='submit')
+            StrictButton(_('Dépublier'), type='submit', css_class='btn-submit')
         )
 
     def clean(self):
@@ -1046,9 +1040,8 @@ class JsFiddleActivationForm(forms.Form):
         self.helper.layout = Layout(
             Field('js_support'),
             ButtonHolder(
-                StrictButton(
-                    _('Valider'),
-                    type='submit'),),
+                StrictButton(_('Valider'), type='submit', css_class='btn-submit'),
+            ),
             Hidden('pk', '{{ content.pk }}'), )
 
     def clean(self):
@@ -1155,7 +1148,9 @@ class WarnTypoForm(forms.Form):
             HTML(msg),
             Hidden('pk', '{{ content.pk }}'),
             Hidden('version', version),
-            ButtonHolder(StrictButton(_('Envoyer'), type='submit'))
+            ButtonHolder(
+                StrictButton(_('Envoyer'), type='submit', css_class='btn-submit')
+            )
         )
 
     def clean(self):
@@ -1210,7 +1205,7 @@ class PublicationForm(forms.Form):
             no_category_msg if self.no_subcategories else None,
             no_license_msg if self.no_license else None,
             HTML(_("<p>Ce billet sera publié directement et n'engage que vous.</p>")),
-            StrictButton(_('Publier'), type='submit')
+            StrictButton(_('Publier'), type='submit', css_class='btn-submit')
         )
 
     def clean(self):
@@ -1261,9 +1256,7 @@ class UnpublicationForm(forms.Form):
         self.helper.layout = Layout(
             Field('text'),
             Field('version'),
-            StrictButton(
-                _('Dépublier'),
-                type='submit')
+            StrictButton(_('Dépublier'), type='submit', css_class='btn-submit')
         )
 
 
@@ -1287,9 +1280,7 @@ class PickOpinionForm(forms.Form):
             HTML('<p>Êtes-vous certain(e) de vouloir valider ce billet ? '
                  'Il pourra maintenant être présent sur la page d’accueil.</p>'),
             Field('version'),
-            StrictButton(
-                _('Valider'),
-                type='submit')
+            StrictButton(_('Valider'), type='submit', css_class='btn-submit')
         )
 
 
@@ -1312,9 +1303,7 @@ class DoNotPickOpinionForm(forms.Form):
         self.helper.layout = Layout(
             HTML(_("<p>Ce billet n'apparaîtra plus dans la liste des billets à choisir.</p>")),
             Field('operation'),
-            StrictButton(
-                _('Valider'),
-                type='submit')
+            StrictButton(_('Valider'), type='submit', css_class='btn-submit')
         )
 
     def clean(self):
@@ -1362,9 +1351,7 @@ class UnpickOpinionForm(forms.Form):
         self.helper.layout = Layout(
             Field('version'),
             Field('text'),
-            StrictButton(
-                _('Enlever'),
-                type='submit')
+            StrictButton(_('Enlever'), type='submit', css_class='btn-submit')
         )
 
 
@@ -1389,9 +1376,7 @@ class PromoteOpinionToArticleForm(forms.Form):
                     Cela copiera le billet pour en faire un article,
                     puis créera une demande de validation pour ce dernier.</p>"""),
             Field('version'),
-            StrictButton(
-                _('Valider'),
-                type='submit')
+            StrictButton(_('Valider'), type='submit', css_class='btn-submit')
         )
 
 


### PR DESCRIPTION
J'ai fait la correction non-subtile du bug des raccourcis clavier sur les modales.

Je suis repassé sur toutes les modales pour garantir la présence de ``class="btn btn-submit"`` : 

* celles générées par crispy (17 modales) ;
* celles dans les templates (une soixantaine je crois).

C'est nécessaire d'avoir cette classe, notamment pour les formulaires avec textarea, parce que le JavaScript cherche la classe ``btn-submit`` pour gérer ça. 

Il y aurait peut-être une option en corrigeant le script, mais j'ai suivi la doc des modales qui dit qu'il faut utiliser les bonnes classes pour rajouter un bouton.

J'espère ne pas en avoir oublié.

Fix #3201.

## Contrôle qualité

Pour faire court :
- connectez-vous avec différents utilisateurs pour avoir le plus de droits possibles ;
- actualiser le cache (``Ctrl + F5``), sinon ça peut être surprenant ;
- tester toutes les modales que vous pouvez trouver.

Les modales pour les tickets GitHub ne concernent que les dev si j'ai bien compris. Il faut tester avec un utilisateur qui a les bons droits.

Normalement, toutes les modales fonctionnent sur le même modèle. Je ne demande pas de *tout* tester, c'est trop long. Moi-même, je ne l'ai pas fait...

### Pour faire (très) long

Un petit aperçu de toutes les modales du site. Non exhaustif.

#### Contenus validés et opinions

Gestion de auteurs et contributeurs :

- Ajouter une contribution
- Voir les contributions
- Ajouter un auteur
- Voir les auteurs

Gestion de la validation et options des contenus validés :

- Demander la validation
- Annuler la validation
- Accepter et publier
- Rejeter la demande de validation
- Dévalider un contenu validé
- Activer JSFiddle

Gestion des opinions

- Publier
- Choisir
- Ne pas choisir
- déchoisir
- Promouvoir en article

Autre :
- Signaler une faute
- Déplacer des parties

#### Galeries

- supprimer une/des galeries
- supprimer une/des images


#### Forums

- déplacer des sujets
- ouvrir ou ferme des sujets
- associer et dissocier des tickets GitHub
- créer des tickets GitHub
- alertes et résolution d'alerte
- masquer/démasquer des messages

#### Divers

- changement de page
- partages sociaux


#### Unes

- supprimer des unes
-

#### Membres

- ajouter du karma
- LS permanent
- LS temporaire, 
- ban permanent
- ban temporaire
- ôter la LS
- ôter le ban
- casquettes

#### MP

- plein de choses aussi