### PR TITLE
Permet aux membres en lecture seule de télécharger l'archive d'un contenu

### DIFF
--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -458,7 +458,7 @@ class DeleteContent(LoggedWithReadWriteHability, SingleContentViewMixin, DeleteV
         return redirect(reverse(object_type + ':find-' + object_type, args=[request.user.username]))
 
 
-class DownloadContent(LoggedWithReadWriteHability, SingleContentDownloadViewMixin):
+class DownloadContent(LoginRequiredMixin, SingleContentDownloadViewMixin):
     """
     Download a zip archive with all the content of the repository directory
     """


### PR DESCRIPTION
Cette PR permet aux membres en lecture seule de télécharger l'archive d'un contenu. Voir issue #5731  .

### Contrôle qualité
  - Lancer le serveur de test ;
  - Faire passer un membre en lecture seule;
  - Accéder à un contenu;
- Vérifier s'il est possible de le télécharger.

Merci !
