### PR TITLE
Permet aux membres en lecture seule de supprimer leurs contenus en bêta

### DIFF
--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -374,7 +374,7 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         return super().form_valid(form)
 
 
-class DeleteContent(LoggedWithReadWriteHability, SingleContentViewMixin, DeleteView):
+class DeleteContent(LoginRequiredMixin, SingleContentViewMixin, DeleteView):
     model = PublishableContent
     template_name = None
     http_method_names = ['delete', 'post']


### PR DESCRIPTION
Cette PR permet aux membres en lecture seule de supprimer leurs contenus en bêta (mais pas ceux déjà publiés). Voir Issue #5732 

### Contrôle qualité

  - Lancer le serveur de test ;
  - Créer un contenu en bêta avec un compte de membre lambda ;
  - Faire passer ce membre en lecture seule avec le compte `staff`;
  - Vérifier s'il peut encore supprimer son contenu.

Merci !
