### PR TITLE
[v29.1] Corrige le calcul du temps de lecture pour les gros contenus

### DIFF
--- a/zds/tutorialv2/management/commands/adjust_char_count.py
+++ b/zds/tutorialv2/management/commands/adjust_char_count.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.core.management.base import BaseCommand
 
 from zds.tutorialv2.models.database import PublishedContent
@@ -25,7 +23,7 @@ class Command(BaseCommand):
             query = PublishedContent.objects.filter(must_redirect=False)
 
         for content in query:
-            logging.error('ids = ' + str(content))
+            self.stdout.write('Processing « {} »...'.format(content.title()))
             content.char_count = content.get_char_count()
             content.save()
-            logging.info('content %s got %d letters', content.title(), content.char_count)
+            self.stdout.write('  It got {} letters.'.format(content.char_count))

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -123,7 +123,9 @@ def render_markdown_stats(md_input, **kwargs):
     Returns contents statistics (words and chars)
     """
     kwargs['stats'] = True
-    content, metadata, messages = _render_markdown_once(md_input, **kwargs)
+    kwargs['disable_images_download'] = True
+    logger.setLevel(logging.INFO)
+    content, metadata, messages = _render_markdown_once(md_input, output_format='tex', **kwargs)
     if metadata:
         return metadata.get('stats', {}).get('signs', {})
     return None


### PR DESCRIPTION
Corrige le calcul du temps de lecture pour les gros contenus en récupérant les statistiques de zmarkdown sur `/latex` et non pas `/html`.

Closes #5762

**QA :**

- Lancer `source zdsenv/bin/activate` puis `make zmd-start` puis `make run-back`
- Télécharger [l'archive du tutoriel Arduino](https://beta.zestedesavoir.com/tutoriels/zip/686/arduino-premiers-pas-en-informatique-embarquee.zip)
- Se connecter avec un compte Staff
- Aller dans "Mes tutoriels" puis "Importer un nouveau contenu" et importer l'archive du tutoriel Arduino
- L'envoyer en validation, le réserver et le publier
- Dans la barre d'adresse du tutoriel, repérer son identifiant
- Dans un nouveau terminal, lancer `source zdsenv/bin/activate` puis `python manage.py --id ID_DU_TUTO`
- Vérifier que la commande fonctionne sans erreur et que le temps de lecture estimé est correct