### PR TITLE
Permet d'obtenir les membres joignables si le groupe bot n'existe pas.

### DIFF
--- a/zds/member/managers.py
+++ b/zds/member/managers.py
@@ -14,7 +14,7 @@ class ProfileManager(models.Manager):
         :rtype: QuerySet
         """
         now = datetime.now()
-        excluded_groups = [Group.objects.get(name=settings.ZDS_APP['member']['bot_group'])]
+        excluded_groups = [Group.objects.filter(name=settings.ZDS_APP['member']['bot_group']).first()]
         qs = self.get_queryset() \
             .exclude(user__is_active=False) \
             .exclude(user__groups__in=excluded_groups) \


### PR DESCRIPTION
Si le groupe bot n'existe pas (par exemple dans les tests où on ne veut pas forcément créer le groupe), le `get` va lancer une exception. En le remplaçant par un `first` après un `filter`, on obtient `None` et il n'y a pas de groupes exlu.

### Contrôle qualité

Vérifier qu'on ne peut pas contacter les bots, que le bouton d'envoi de message n'apparaît pas sur la page de profil des bots.