### PR TITLE
[v29.1] Met à jour Jquery pour des raisons de sécurité

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gulp-terser-js": "5.1.2",
     "gulp.spritesmith": "6.11.0",
     "highlight.js": "9.18.1",
-    "jquery": "3.4.1",
+    "jquery": "3.5.0",
     "katex": "0.11.1",
     "moment": "2.24.0",
     "normalize.css": "8.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3597,10 +3597,10 @@ jpeg-js@^0.3.2:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.7.tgz#471a89d06011640592d314158608690172b1028d"
   integrity sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==
 
-jquery@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+jquery@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
+  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
 
 js-base64@^2.1.8:
   version "2.5.2"


### PR DESCRIPTION
Met à jour Jquery en 3.5.0 pour des raisons de sécurité. En théorie cela ne nous impacte pas car nous sommes protégés des failles XSS côté serveur mais bon on n'est jamais à l'abri.

[Voir l'explication sur leur blog](https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/)

**QA :**

- Lancer `source zdsenv/bin/activate && make install-front && make build-front && make zmd-start && make run-back`
- Vérifier que le site fonctionne correctement, notamment ce qui touche au JS