### PR TITLE
Déplace le choix de la licence d'une publication dans un formulaire séparé

### DIFF
--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -318,6 +318,7 @@
     .checkbox,
     .radio {
         padding: 10px 0;
+        height: 100%;
 
         input {
             margin-top: 8px;

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -24,8 +24,14 @@
     {% if content.licence %}
         <p class="license">
             {{ content.licence }}
+            <a href="#edit-license" class="open-modal">{% trans "Modifier la licence" %}</a>
+        </p>
+    {% else %}
+        <p class="license">
+            <a href="#edit-license" class="open-modal">Choisissez la licence de votre publication !</a>
         </p>
     {% endif %}
+    {% crispy form_edit_license %}
 
     <h1 {% if content.image %}class="illu"{% endif %}>
         {% if content.image %}

--- a/zds/tutorialv2/factories.py
+++ b/zds/tutorialv2/factories.py
@@ -44,12 +44,14 @@ class PublishableContentFactory(factory.DjangoModelFactory):
     pubdate = datetime.now()
 
     @classmethod
-    def _prepare(cls, create, *, light=True, author_list=None, licence: Licence = None, add_category=True, **kwargs):
+    def _prepare(cls, create, *, light=True, author_list=None, licence: Licence = None,
+                 add_license=True, add_category=True, **kwargs):
         auths = author_list or []
-        given_licence = licence or Licence.objects.first()
-        if isinstance(given_licence, str) and given_licence:
-            given_licence = Licence.objects.filter(title=given_licence).first() or Licence.objects.first()
-        licence = given_licence or LicenceFactory()
+        if add_license:
+            given_licence = licence or Licence.objects.first()
+            if isinstance(given_licence, str) and given_licence:
+                given_licence = Licence.objects.filter(title=given_licence).first() or Licence.objects.first()
+            licence = given_licence or LicenceFactory()
 
         text = text_content
         if not light:

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -174,7 +174,9 @@ class ModalFormView(FormView):
         else:
             errors = form.errors.as_data()
             if len(errors) > 0:
-                messages.error(self.request, list(errors.values())[0][0])  # only the first error is provided
+                # only the first error is provided
+                error_message = list(errors.values())[0][0].messages[0]
+                messages.error(self.request, error_message)
             else:
                 messages.error(
                     self.request, _('Une erreur inconnue est survenue durant le traitement des données.'))

--- a/zds/tutorialv2/tests/tests_front.py
+++ b/zds/tutorialv2/tests/tests_front.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.webdriver import WebDriver
 from django.test import tag
 from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.support.ui import Select, WebDriverWait
+from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.common.action_chains import ActionChains
 
@@ -159,8 +159,6 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
         WebDriverWait(self.selenium, 10).until(ec.element_to_be_clickable(
             (By.CSS_SELECTOR, 'input[type=checkbox][name=subcategory]')
         )).click()
-        license_select = Select(find_element('#id_licence'))
-        license_select.select_by_index(len(license_select.options) - 1)
 
         find_element('#id_title').send_keys('Oulipo')
 

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -306,9 +306,6 @@ class ContentTests(TutorialTestMixin, TestCase):
         result_string = ''.join(a.decode() for a in result.streaming_content)
         self.assertIn('<strong>markdown</strong>', result_string, 'We need the text to be properly formatted')
 
-        # edit tutorial:
-        new_licence = LicenceFactory()
-
         result = self.client.post(
             reverse('content:edit', args=[pk, slug]),
             {
@@ -317,7 +314,6 @@ class ContentTests(TutorialTestMixin, TestCase):
                 'introduction': random,
                 'conclusion': random,
                 'type': 'TUTORIAL',
-                'licence': new_licence.pk,
                 'subcategory': self.subcategory.pk,
                 'last_hash': versioned.compute_hash(),
                 'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
@@ -330,12 +326,12 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto = PublishableContent.objects.get(pk=pk)
         self.assertEqual(tuto.title, random)
         self.assertEqual(tuto.description, random)
-        self.assertEqual(tuto.licence.pk, new_licence.pk)
+        self.assertEqual(tuto.licence, None)
         versioned = tuto.load_version()
         self.assertEqual(versioned.get_introduction(), random)
         self.assertEqual(versioned.get_conclusion(), random)
         self.assertEqual(versioned.description, random)
-        self.assertEqual(versioned.licence.pk, new_licence.pk)
+        self.assertEqual(versioned.licence, None)
         self.assertNotEqual(versioned.slug, slug)
 
         slug = tuto.slug  # make the title change also change the slug !!
@@ -1517,7 +1513,6 @@ class ContentTests(TutorialTestMixin, TestCase):
                 'introduction': some_text,
                 'conclusion': some_text,
                 'type': 'TUTORIAL',
-                'licence': self.licence.pk,
                 'subcategory': self.subcategory.pk,
             },
             follow=False)

--- a/zds/tutorialv2/tests/tests_views/tests_editcontentlicense.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontentlicense.py
@@ -1,0 +1,235 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from zds.tutorialv2.models.database import PublishableContent
+from zds.member.models import Profile
+from zds.tutorialv2.views.contents import EditContentLicense
+from zds.tutorialv2.forms import EditContentLicenseForm
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory
+
+
+@override_for_contents()
+class EditContentLicensePermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+
+        # Create a license
+        self.licence = LicenceFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author])
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-license', kwargs={'pk': self.content.pk})
+        self.form_data = {'license': self.licence.pk, 'update_preferred_license': False}
+        self.content_data = {'pk': self.content.pk, 'slug': self.content.slug}
+        self.content_url = reverse('content:view', kwargs=self.content_data)
+        self.login_url = reverse('member-login') + '?next=' + self.form_url
+
+    def test_not_authenticated(self):
+        """Test that on form submission, unauthenticated users are redirected to the login page."""
+        self.client.logout()  # ensure no user is authenticated
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_author(self):
+        """Test that on form submission, authors are redirected to the content page."""
+        login_success = self.client.login(username=self.author.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff(self):
+        """Test that on form submission, staffs are redirected to the content page."""
+        login_success = self.client.login(username=self.staff.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_outsider(self):
+        """Test that on form submission, unauthorized users get a 403."""
+        login_success = self.client.login(username=self.outsider.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEquals(response.status_code, 403)
+
+
+@override_for_contents()
+class EditContentLicenseWorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create a license
+        self.license = LicenceFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author.user], add_license=False)
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-license', kwargs={'pk': self.content.pk})
+        self.error_messages = EditContentLicenseForm.declared_fields['license'].error_messages
+        self.success_message_license = EditContentLicense.success_message_license
+        self.success_message_profile_update = EditContentLicense.success_message_profile_update
+
+        # Log in with an authorized user (e.g the author of the content) to perform the tests
+        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        self.assertTrue(login_success)
+
+    def get_test_cases(self):
+        return {
+            'empty_form': {
+                'inputs': {},
+                'expected_outputs': [self.error_messages['required']]
+            },
+            'empty_fields': {
+                'inputs': {'license': '', 'update_preferred_license': ''},
+                'expected_outputs': [self.error_messages['required']]
+            },
+            'invalid_license': {
+                'inputs': {'license': 'valeur_bidonnée', 'update_preferred_license': ''},
+                'expected_outputs': [self.error_messages['invalid_choice']]
+            },
+            'success_license': {
+                'inputs': {'license': self.license.pk, 'update_preferred_license': False},
+                'expected_outputs': [self.success_message_license]
+            },
+            'success_license_profile': {
+                'inputs': {'license': self.license.pk, 'update_preferred_license': True},
+                'expected_outputs': [self.success_message_license, self.success_message_profile_update]
+            }
+        }
+
+    def test_form_workflow(self):
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                response = self.client.post(self.form_url, case['inputs'], follow=True)
+                for msg in case['expected_outputs']:
+                    self.assertContains(response, msg)
+
+
+@override_for_contents()
+class EditContentLicenseFunctionalTests(TutorialTestMixin, TestCase):
+    """Test the detailed behavior of the feature, such as updates of the database or repositories."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create licenses
+        self.license_1 = LicenceFactory()
+        self.license_2 = LicenceFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author.user], add_license=False)
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-license', kwargs={'pk': self.content.pk})
+
+        # Log in with an authorized user (e.g the author of the content) to perform the tests
+        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        self.assertTrue(login_success)
+
+    def test_form_function(self):
+        """Test many use cases for the form."""
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                self.enforce_preconditions(case['preconditions'])
+                self.post_form(case['inputs'])
+                self.check_effects(case['expected_outputs'])
+
+    def get_test_cases(self):
+        """List test cases for the license editing form."""
+        return {
+            'from blank to license 1, no preference, no udpate of preferences': {
+                'preconditions': {'content_license': None, 'preferred_license': None},
+                'inputs': {'license': self.license_1, 'update_preferred_license': False},
+                'expected_outputs': {'content_license': self.license_1, 'preferred_license': None}
+            },
+            'from blank to license 1, no preference, udpate of preferences': {
+                'preconditions': {'content_license': None, 'preferred_license': None},
+                'inputs': {'license': self.license_1, 'update_preferred_license': True},
+                'expected_outputs': {'content_license': self.license_1, 'preferred_license': self.license_1}
+            },
+            'from blank to license 2, no preference, no udpate of preferences': {
+                'preconditions': {'content_license': None, 'preferred_license': None},
+                'inputs': {'license': self.license_2, 'update_preferred_license': False},
+                'expected_outputs': {'content_license': self.license_2, 'preferred_license': None}
+            },
+            'from blank to license 2, no preference, udpate of preferences': {
+                'preconditions': {'content_license': None, 'preferred_license': None},
+                'inputs': {'license': self.license_2, 'update_preferred_license': True},
+                'expected_outputs': {'content_license': self.license_2, 'preferred_license': self.license_2}
+            },
+            'from blank to license 1, preference, no udpate of preferences': {
+                'preconditions': {'content_license': None, 'preferred_license': self.license_2},
+                'inputs': {'license': self.license_1, 'update_preferred_license': False},
+                'expected_outputs': {'content_license': self.license_1, 'preferred_license': self.license_2}
+            },
+            'from blank to license 1, preference, udpate of preferences': {
+                'preconditions': {'content_license': None, 'preferred_license': self.license_2},
+                'inputs': {'license': self.license_1, 'update_preferred_license': True},
+                'expected_outputs': {'content_license': self.license_1, 'preferred_license': self.license_1}
+            },
+            'from license 1 to license 2, no preference, no udpate of preferences': {
+                'preconditions': {'content_license': self.license_1, 'preferred_license': None},
+                'inputs': {'license': self.license_2, 'update_preferred_license': False},
+                'expected_outputs': {'content_license': self.license_2, 'preferred_license': None}
+            },
+            'from license 1 to license 2, no preference, udpate of preferences': {
+                'preconditions': {'content_license': self.license_1, 'preferred_license': None},
+                'inputs': {'license': self.license_2, 'update_preferred_license': True},
+                'expected_outputs': {'content_license': self.license_2, 'preferred_license': self.license_2}
+            },
+        }
+
+    def enforce_preconditions(self, preconditions):
+        """Prepare the test environment to match given preconditions"""
+
+        # Enforce preconditions for license in database
+        self.content.licence = preconditions['content_license']
+        self.content.save()
+        self.assertEqual(self.content.licence, preconditions['content_license'])
+
+        # Enforce preconditions for license in repository
+        versioned = self.content.load_version()
+        versioned.licence = preconditions['content_license']
+        sha = versioned.repo_update_top_container('Title', self.content.slug, 'introduction', 'conclusion')
+        updated_versioned = self.content.load_version(sha)
+        self.assertEqual(updated_versioned.licence, preconditions['content_license'])
+
+        # Enforce preconditions for preferred license
+        self.author.licence = preconditions['preferred_license']
+        self.author.save()
+        updated_profile = Profile.objects.get(pk=self.author.pk)
+        self.assertEqual(updated_profile.licence, preconditions['preferred_license'])
+
+    def post_form(self, inputs):
+        """Post the form with given inputs."""
+        form_data = {'license': inputs['license'].pk,
+                     'update_preferred_license': inputs['update_preferred_license']}
+        self.client.post(self.form_url, form_data)
+
+    def check_effects(self, expected_outputs):
+        """Check the effects of having sent the form."""
+
+        # Check updating of the database
+        updated_content = PublishableContent.objects.get(pk=self.content.pk)
+        updated_profile = Profile.objects.get(pk=self.author.pk)
+        self.assertEqual(updated_content.licence, expected_outputs['content_license'])
+        self.assertEqual(updated_profile.licence, expected_outputs['preferred_license'])
+
+        # Check updating of the repository
+        versioned = updated_content.load_version()
+        self.assertEqual(versioned.licence, expected_outputs['content_license'])

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -1,7 +1,7 @@
 from django.urls import path, re_path
 from django.views.generic.base import RedirectView
 
-from zds.tutorialv2.views.contents import (DisplayContent, CreateContent, EditContent,
+from zds.tutorialv2.views.contents import (DisplayContent, CreateContent, EditContent, EditContentLicense,
                                            DeleteContent, CreateContainer, DisplayContainer, EditContainer,
                                            CreateExtract, EditExtract,
                                            DeleteContainerOrExtract, ManageBetaContent, DisplayHistory, DisplayDiff,
@@ -156,6 +156,10 @@ urlpatterns = [
             AddAuthorToContent.as_view(), name='add-author'),
     re_path(r'^enlever-auteur/(?P<pk>\d+)/$',
             RemoveAuthorFromContent.as_view(), name='remove-author'),
+
+    # Modify the license
+    re_path(r'^modifier-licence/(?P<pk>\d+)/$', EditContentLicense.as_view(), name='edit-license'),
+
     # beta:
     re_path(r'^activer-beta/(?P<pk>\d+)/(?P<slug>.+)/$', ManageBetaContent.as_view(action='set'),
             name='set-beta'),

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -355,9 +355,8 @@ def get_content_from_json(json, sha, slug_last_draft, public=False, max_title_le
                 versioned.licence = hint_licence
             else:
                 versioned.licence = Licence.objects.filter(code=json['licence']).first()
-
-        if 'licence' not in json or not versioned.licence:
-            versioned.licence = Licence.objects.filter(pk=settings.ZDS_APP['content']['default_licence_pk']).first()
+        # Note: There is no fallback to a default license in case of problems.
+        # The author will have to set it himself prior to publication.
 
         if 'introduction' in json:
             versioned.introduction = json['introduction']
@@ -391,9 +390,9 @@ def get_content_from_json(json, sha, slug_last_draft, public=False, max_title_le
             versioned.conclusion = json['conclusion']
         if 'licence' in json:
             versioned.licence = Licence.objects.filter(code=json['licence']).first()
+        # Note: There is no fallback to a default license in case of problems.
+        # The author will have to set it himself prior to publication.
 
-        if 'licence' not in json or not versioned.licence:
-            versioned.licence = Licence.objects.filter(pk=settings.ZDS_APP['content']['default_licence_pk']).first()
         versioned.ready_to_publish = True  # the parent is always ready to publish
         if _type == 'ARTICLE':
             extract = Extract('text', '')

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -36,7 +36,8 @@ from zds.notification.models import TopicAnswerSubscription, NewPublicationSubsc
 from zds.tutorialv2.forms import ContentForm, JsFiddleActivationForm, AskValidationForm, AcceptValidationForm, \
     RejectValidationForm, RevokeValidationForm, WarnTypoForm, ImportContentForm, ImportNewContentForm, ContainerForm, \
     ExtractForm, BetaForm, MoveElementForm, AuthorForm, RemoveAuthorForm, CancelValidationForm, PublicationForm, \
-    UnpublicationForm, ContributionForm, RemoveContributionForm, SearchSuggestionForm, RemoveSuggestionForm
+    UnpublicationForm, ContributionForm, RemoveContributionForm, SearchSuggestionForm, RemoveSuggestionForm, \
+    EditContentLicenseForm
 from zds.tutorialv2.mixins import SingleContentDetailViewMixin, SingleContentFormViewMixin, SingleContentViewMixin, \
     SingleContentDownloadViewMixin, SingleContentPostMixin, FormWithPreview
 from zds.tutorialv2.models import TYPE_CHOICES_DICT
@@ -86,9 +87,6 @@ class CreateContent(LoggedWithReadWriteHability, FormWithPreview):
     def get_form(self, form_class=ContentForm):
         form = super(CreateContent, self).get_form(form_class)
         form.initial['type'] = self.created_content_type
-        # Check for default licence in the profile
-        profile = self.request.user.profile
-        form.initial['licence'] = profile.licence
         return form
 
     def get_context_data(self, **kwargs):
@@ -104,7 +102,7 @@ class CreateContent(LoggedWithReadWriteHability, FormWithPreview):
         self.content.title = form.cleaned_data['title']
         self.content.description = form.cleaned_data['description']
         self.content.type = form.cleaned_data['type']
-        self.content.licence = form.cleaned_data['licence']
+        self.content.licence = self.request.user.profile.licence  # Use the preferred license of the user if it exists
         self.content.creation_date = datetime.now()
 
         # Creating the gallery
@@ -195,6 +193,9 @@ class DisplayContent(LoginRequiredMixin, SingleContentDetailViewMixin):
 
         context['validation'] = validation
         context['formJs'] = form_js
+        context['form_edit_license'] = EditContentLicenseForm(
+            self.versioned_object,
+            initial={'license': self.versioned_object.licence})
 
         if self.versioned_object.requires_validation:
             context['formPublication'] = PublicationForm(self.versioned_object, initial={'source': self.object.source})
@@ -279,11 +280,9 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         initial['type'] = versioned.type
         initial['introduction'] = versioned.get_introduction()
         initial['conclusion'] = versioned.get_conclusion()
-        initial['licence'] = versioned.licence
         initial['subcategory'] = self.object.subcategory.all()
         initial['tags'] = ', '.join([tag['title'] for tag in self.object.tags.values('title')]) or ''
         initial['helps'] = self.object.helps.all()
-
         initial['last_hash'] = versioned.compute_hash()
 
         return initial
@@ -320,7 +319,6 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         title_is_changed = publishable.title != form.cleaned_data['title']
         publishable.title = form.cleaned_data['title']
         publishable.description = form.cleaned_data['description']
-        publishable.licence = form.cleaned_data['licence']
 
         publishable.update_date = datetime.now()
 
@@ -344,7 +342,6 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         logger.debug('content %s updated, slug is %s', publishable.pk, publishable.slug)
         # now, update the versioned information
         versioned.description = form.cleaned_data['description']
-        versioned.licence = form.cleaned_data['licence']
 
         sha = versioned.repo_update_top_container(form.cleaned_data['title'],
                                                   publishable.slug,
@@ -372,6 +369,52 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
 
         self.success_url = reverse('content:view', args=[publishable.pk, publishable.slug])
         return super().form_valid(form)
+
+
+class EditContentLicense(LoginRequiredMixin, SingleContentFormViewMixin):
+    modal_form = True
+    model = PublishableContent
+    form_class = EditContentLicenseForm
+    success_message_license = _('La licence de la publication a bien été changée.')
+    success_message_profile_update = _('Votre licence préférée a bien été mise à jour.')
+
+    def get_form_kwargs(self):
+        kwargs = super(EditContentLicense, self).get_form_kwargs()
+        kwargs['content'] = self.versioned_object
+        return kwargs
+
+    def form_valid(self, form):
+        publishable = self.object
+
+        # Update license in database
+        publishable.licence = form.cleaned_data['license']
+        publishable.update_date = datetime.now()
+        publishable.save(force_slug_update=False)
+
+        # Update license in repository
+        self.versioned_object.licence = form.cleaned_data['license']
+        sha = self.versioned_object.repo_update_top_container(
+            publishable.title,
+            publishable.slug,
+            self.versioned_object.get_introduction(),
+            self.versioned_object.get_conclusion(),
+            'Nouvelle licence ({})'.format(form.cleaned_data['license'])
+        )
+
+        # Update relationships in database
+        publishable.sha_draft = sha
+        publishable.save(force_slug_update=False)
+
+        messages.success(self.request, EditContentLicense.success_message_license)
+
+        # Update the preferred license of the user
+        if form.cleaned_data['update_preferred_license']:
+            profile = get_object_or_404(Profile, user=self.request.user)
+            profile.licence = form.cleaned_data['license']
+            profile.save()
+            messages.success(self.request, EditContentLicense.success_message_profile_update)
+
+        return redirect(form.previous_page_url)
 
 
 class DeleteContent(LoginRequiredMixin, SingleContentViewMixin, DeleteView):
@@ -758,9 +801,11 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
                 return super(UpdateContentWithArchive, self).form_invalid(form)
             else:
 
-                # warn user if licence have changed:
+                # Warn the user if the license has been changed
                 manifest = json_handler.loads(str(zfile.read('manifest.json'), 'utf-8'))
-                if 'licence' not in manifest or manifest['licence'] != new_version.licence.code:
+                if new_version.licence \
+                   and 'licence' in manifest \
+                   and manifest['licence'] != new_version.licence.code:
                     messages.info(
                         self.request, _('la licence « {} » a été appliquée.').format(new_version.licence.code))
 
@@ -869,11 +914,13 @@ class CreateContentFromArchive(LoggedWithReadWriteHability, FormView):
                 return super(CreateContentFromArchive, self).form_invalid(form)
             else:
 
-                # warn user if licence have changed:
+                # Warn the user if the license has been changed
                 manifest = json_handler.loads(str(zfile.read('manifest.json'), 'utf-8'))
-                if 'licence' not in manifest or manifest['licence'] != new_content.licence.code:
-                    messages.info(
-                        self.request, _('la licence « {} » a été appliquée.'.format(new_content.licence.code)))
+                if new_content.licence \
+                   and 'licence' in manifest \
+                   and manifest['licence'] != new_content.licence.code:
+                    messages.info(self.request,
+                                  _('la licence « {} » a été appliquée.'.format(new_content.licence.code)))
 
                 # first, create DB object (in order to get a slug)
                 self.object = PublishableContent()


### PR DESCRIPTION
Actuellement, le choix de la licence d'une publication se fait dans le formulaire "éditer" qui est un fourre-tout. Cette PR déplace ce choix dans un formulaire séparé, sous forme de modale, avec possibilité de mettre à jour sa licence préférée au passage.

L'objectif est de :
* diminuer la friction à la création de contenu en allégeant le formulaire initial ;
* faciliter l'accès à la licence par défaut (et donc les créations ultérieures de contenu) ;
* encourager le choix d'une licence permettant le partage (plutôt que aller par défaut sur « Tous droits réservés »).

Le rendu est le suivant :

![image](https://user-images.githubusercontent.com/35631001/81235020-4aef1580-8ffa-11ea-8114-d48e1d0f0cd4.png)

J'aurai peut être besoin de retours sur l'aspect _front_. J'ai fait ce que j'ai pu, mais c'est pas très peaufiné.

### Contrôle qualité

#### Test 1 : Création de contenu sans licence préférée

En tant qu'utilisateur connecté sans licence préférée indiquée dans le profil :

* créer une publication (tuto, article et billet) ;
* constater qu'il n'y a pas de licence affichée ;
* constater la présence d'un lien à la place pour choisir la licence.

#### Test 2 : Ajout d'une licence au contenu

En tant qu'auteur d'un contenu (tuto, article, billet) sans licence choisie :

* aller sur la page du contenu en question ;
* cliquer sur le lien "choisir une licence" ;
* constater que les liens des explications marchent ;
* constater qu'on ne peut pas valider sans faire de choix ;
* constater qu'après annulation, la licence n'est pas modifiée ;
* constater qu'après validation, la licence est bien mise à jour.

#### Test 3 : Création de contenu avec une licence préférée

En tant qu'utilisateur connecté avec une licence préférée indiquée dans le profil :

* créer une publication (tuto, article et billet) ;
* constater que la licence préférée a été mise et est affichée en haut à gauche ;
* constater la présence du lien pour modifier la licence.

#### Test 4 : Modification de la licence

En tant qu'auteur d'un contenu (tuto, article, billet) avec une licence définie :

* aller sur la page du contenu en question ;
* cliquer sur le lien "choisir une licence" ;
* constater que la licence actuelle est présélectionnée ;
* constater qu'après annulation, la licence n'est pas modifiée ;
* constater qu'après validation, la licence est bien mise à jour.

#### Test 5 : Mise à jour de la licence par défaut

En tant qu'auteur d'un contenu (tuto, article, billet) :

* aller sur la page du contenu en question ;
* cliquer sur le lien "modifier la licence" ;
* choisir une licence (différente de celle par défaut si l'utilisateur l'a définie)  ;
* cocher la case "je souhaite utiliser ..." ;
* valider
* constater que la licence préférée est mise à jour (voir dans le profil).

#### Test 6 : Non-mise à jour de la licence par défaut

En tant qu'auteur d'un contenu (tuto, article, billet) :

* aller sur la page du contenu en question ;
* cliquer sur le lien "modifier la licence" ;
* choisir une licence (différente de celle par défaut si l'utilisateur l'a définie)  ;
* ne **pas** cocher la case "je souhaite utiliser ..." ;
* valider
* constater que la licence préférée n'est pas mise à jour (voir dans le profil).