### PR TITLE
Sépare le code JS externe de notre code JS

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -110,15 +110,22 @@ function jsLint() {
     .pipe(eslint.failAfterError())
 }
 
+// Get JS minified files from packages
+function jsPackages() {
+  return gulp.src([
+    require.resolve('jquery/dist/jquery.min.js'),
+    require.resolve('cookies-eu-banner/dist/cookies-eu-banner.min.js'),
+    require.resolve('moment/min/moment.min.js'),
+    require.resolve('moment/locale/fr.js'),
+    require.resolve('chart.js/dist/Chart.min.js'),
+    require.resolve('easymde/dist/easymde.min.js')
+  ])
+    .pipe(gulp.dest('dist/js/'))
+}
+
 // Generates JS for the website
 function js() {
   return gulp.src([
-    require.resolve('jquery'),
-    require.resolve('cookies-eu-banner'),
-    require.resolve('moment/moment.js'),
-    require.resolve('moment/locale/fr.js'),
-    require.resolve('chart.js/dist/Chart.js'),
-    require.resolve('easymde/dist/easymde.min.js'),
     // Used by other scripts, must be first
     'assets/js/modal.js',
     'assets/js/tooltips.js',
@@ -196,7 +203,7 @@ function watch() {
 }
 
 // Build the front
-var build = gulp.parallel(prepareZmd, prepareEasyMde, js, images, gulp.series(spriteCss, gulp.parallel(css, spriteImages)))
+var build = gulp.parallel(prepareZmd, prepareEasyMde, jsPackages, js, images, gulp.series(spriteCss, gulp.parallel(css, spriteImages)))
 
 exports.build = build
 exports.watch = gulp.series(build, watch)

--- a/templates/base.html
+++ b/templates/base.html
@@ -268,7 +268,6 @@
 
     {# Javascript stuff start #}
     <script src="{% static "js/jquery.min.js" %}"></script>
-    <script src="{% static "js/easymde.min.js" %}"></script>
     <script src="{% static "js/script.js" %}"></script>
     {% block extra_js %}
     {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -267,8 +267,9 @@
 
 
     {# Javascript stuff start #}
+    <script src="{% static "js/jquery.min.js" %}"></script>
+    <script src="{% static "js/easymde.min.js" %}"></script>
     <script src="{% static "js/script.js" %}"></script>
-
     {% block extra_js %}
     {% endblock %}
 
@@ -276,6 +277,7 @@
 
     {# Google Analytics #}
     {% if debug or app.google_analytics_enabled %}
+    <script src="{% static "js/cookies-eu-banner.min.js" %}"></script>
     <script>
         new CookiesEuBanner(function(){
             {% if app.google_analytics_enabled %}

--- a/templates/easymde.html
+++ b/templates/easymde.html
@@ -1,0 +1,5 @@
+{% load static %}
+
+{% block extra_js %}
+    <script src="{% static 'js/easymde.min.js' %}"></script>
+{% endblock %}

--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -1,6 +1,10 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
+
+{% include "easymde.html" %}
+
+
 {% if topic.is_locked %}
     <div class="alert-box ico-after lock light">
         {% trans "Ce sujet est verrouillé." %}

--- a/templates/tutorialv2/stats/index.html
+++ b/templates/tutorialv2/stats/index.html
@@ -4,6 +4,7 @@
 {% load append_query_params %}
 {% load datedelta_from_day %}
 {% load seconds_to_duration %}
+{% load static %}
 
 {% block title %}
     {% trans "Statistiques du contenu" %}
@@ -12,6 +13,13 @@
 {% block breadcrumb %}
     <li><a href="{% url "content:stats-content" content.pk content.slug %}">{% trans "Statistiques" %}</a></li>
     <li>{{ content.title }}</li>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    <script src="{% static 'js/moment.min.js' %}"></script>
+    <script src="{% static 'js/fr.js' %}"></script>
+    <script src="{% static 'js/Chart.min.js' %}"></script>
 {% endblock %}
 
 {% block content_out %}

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -14,6 +14,7 @@ from crispy_forms.layout import HTML, Layout, \
 from zds.member.models import Profile, KarmaNote, BannedEmailProvider
 from zds.member.validators import validate_not_empty, validate_zds_email, validate_zds_username, validate_passwords, \
     validate_zds_password, validate_raw_zds_username
+from zds.utils.forms import IncludeEasyMDE
 from zds.utils.misc import contains_utf8mb4
 from zds.utils.models import Licence, HatRequest, Hat
 from zds.utils import get_current_user
@@ -195,6 +196,7 @@ class MiniProfileForm(forms.Form):
         self.helper.form_method = 'post'
 
         self.helper.layout = Layout(
+            IncludeEasyMDE(),
             Field('biography'),
             Field('site'),
             Field('avatar_url'),
@@ -671,6 +673,7 @@ class HatRequestForm(forms.ModelForm):
         self.helper.form_action = '{}#send-request'.format(reverse('hats-settings'))
 
         self.helper.layout = Layout(
+            IncludeEasyMDE(),
             Field('hat'),
             Field('reason'),
             ButtonHolder(

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -15,7 +15,7 @@ from zds.tutorialv2.models.database import PublishableContent, ContentContributi
 from django.utils.translation import ugettext_lazy as _
 from zds.member.models import Profile
 from zds.tutorialv2.utils import slugify_raise_on_invalid, InvalidSlugError
-from zds.utils.forms import TagValidator
+from zds.utils.forms import TagValidator, IncludeEasyMDE
 
 
 class FormWithTitle(forms.Form):
@@ -222,6 +222,7 @@ class ContainerForm(FormWithTitle):
         self.helper.form_method = 'post'
 
         self.helper.layout = Layout(
+            IncludeEasyMDE(),
             Field('title'),
             Field('introduction', css_class='md-editor preview-source'),
             ButtonHolder(StrictButton(_('Aperçu'), type='preview', name='preview',
@@ -310,6 +311,7 @@ class ContentForm(ContainerForm):
                            "alt=\"aider les auteurs\">la page d'aide</a>.</p>"))
 
         self.helper.layout = Layout(
+            IncludeEasyMDE(),
             Field('title'),
             Field('description'),
             Field('tags'),

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -8,10 +8,21 @@ from zds.utils.models import Tag
 from zds.utils.misc import contains_utf8mb4
 
 
+class IncludeEasyMDE(Layout):
+    """Include EasyMDE JS File for this form"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            HTML('{% include "easymde.html" %}'),
+            *args, **kwargs
+        )
+
+
 class CommonLayoutEditor(Layout):
 
     def __init__(self, *args, **kwargs):
         super(CommonLayoutEditor, self).__init__(
+            IncludeEasyMDE(),
             Field('text', css_class='md-editor mini-editor'),
             HTML("<div class='message-bottom'>"),
             HTML("<div class='message-submit'>"),
@@ -36,6 +47,7 @@ class CommonLayoutVersionEditor(Layout):
     def __init__(self, *args, **kwargs):
         super(CommonLayoutVersionEditor, self).__init__(
             Div(
+                IncludeEasyMDE(),
                 Field('text', css_class='md-editor'),
                 Field('msg_commit'),
                 ButtonHolder(


### PR DESCRIPTION
Cette modification séparer le code JS externe de notre code JS, ce qui permet : 

- de ne pas recharger les fichiers JS externe s'ils n'ont pas changé ;
- de ne charger Moment.js et Chart.js que sur la page des statistiques ;
- de ne charger EasyMDE que sur les pages avec l'éditeur.

**QA :**

- `source zdsenv/bin/activate && make build-front && make run-back`
- Vérifier que Moment.js et Chart.js ne sont chargés que sur la page des statistiques et que celle-ci fonctionne correctement
- Vérifier que EasyMDE n'est chargé que sur les pages où il y a l'éditeur et que celles-ci fonctionnent correctement