### PR TITLE
Déplace la modification des tags dans un formulaire séparé

### DIFF
--- a/templates/tutorialv2/includes/editorialization.part.html
+++ b/templates/tutorialv2/includes/editorialization.part.html
@@ -2,42 +2,51 @@
 {% load crispy_forms_tags %}
 
 {% if not content.is_opinion %}
-    <h3>Editorialisation</h3>
+    <h3>Éditorialisation</h3>
     <ul>
         <li>
-            <a href="#add-suggestion" class="open-modal ico-after more blue">
-                {% trans "Ajouter une suggestion" %}
+            <a href="#edit-tags" class="open-modal ico-after gear blue">
+                Modifier les tags
             </a>
-            {% crispy formAddSuggestion %}
+            {% crispy form_edit_tags %}
         </li>
-        <li>
-            <a href="#manage-suggestion" class="open-modal ico-after gear blue">
-                {% trans "Gérer les suggestions" %}
-            </a>
-            <form action="{% url "content:remove-suggestion" content.pk  %}" method="post" class="modal modal-large" id="manage-suggestion" data-modal-close="Fermer">
-                <table class="fullwidth">
-                    <thead>
-                        <th>{% trans "Contenus suggérés" %}</th>
-                        <th width="15%">{% trans "Actions" %}</th>
-                    </thead>
-                    <tbody>
-                        {% for content_suggestion in content_suggestions %}
-                            <tr>
-                                <td>{{content_suggestion.suggestion.title}}</td>
-                                <td>
-                                    <button type="submit" data-value="{{ content_suggestion.pk }}" name="pk_suggestion" value="{{ content_suggestion.pk }}" class="modal-inner">
-                                        {% trans "Supprimer" %}
-                                    </button>
-                                </td>
-                            </tr>
-                        {% empty %}
-                            <tr><td colspan="2">Aucune suggestion de contenu.</td></tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
 
-                {% csrf_token %}
-            </form>
-        </li>
+        {% if is_staff %}
+            <li>
+                <a href="#add-suggestion" class="open-modal ico-after more blue">
+                    {% trans "Ajouter une suggestion" %}
+                </a>
+                {% crispy formAddSuggestion %}
+            </li>
+            <li>
+                <a href="#manage-suggestion" class="open-modal ico-after gear blue">
+                    {% trans "Gérer les suggestions" %}
+                </a>
+                <form action="{% url "content:remove-suggestion" content.pk  %}" method="post" class="modal modal-large" id="manage-suggestion" data-modal-close="Fermer">
+                    <table class="fullwidth">
+                        <thead>
+                            <th>{% trans "Contenus suggérés" %}</th>
+                            <th width="15%">{% trans "Actions" %}</th>
+                        </thead>
+                        <tbody>
+                            {% for content_suggestion in content_suggestions %}
+                                <tr>
+                                    <td>{{content_suggestion.suggestion.title}}</td>
+                                    <td>
+                                        <button type="submit" data-value="{{ content_suggestion.pk }}" name="pk_suggestion" value="{{ content_suggestion.pk }}" class="modal-inner">
+                                            {% trans "Supprimer" %}
+                                        </button>
+                                    </td>
+                                </tr>
+                            {% empty %}
+                                <tr><td colspan="2">Aucune suggestion de contenu.</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+
+                    {% csrf_token %}
+                </form>
+            </li>
+        {% endif %}
     </ul>
 {% endif %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -699,10 +699,11 @@
                 {% endif %}
             </ul>
         </div>
-        <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Editorialisation">
-        {%  include "tutorialv2/includes/editorialization.part.html"  %}
-        </div>
     {% endif %}
+
+    <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Éditorialisation">
+        {%  include "tutorialv2/includes/editorialization.part.html"  %}
+    </div>
 
     {%  include "tutorialv2/includes/summary.part.html"  %}
 

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -373,9 +373,9 @@
             </ul>
         </div>
     {% endif %}
-    {% if is_staff %}
-        <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Editorialisation">
-        {%  include "tutorialv2/includes/editorialization.part.html"  %}
+    {% if is_staff or is_author %}
+        <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Éditorialisation">
+            {%  include "tutorialv2/includes/editorialization.part.html"  %}
         </div>
     {% endif %}
     {% include "misc/social_buttons.part.html" with link=content.get_absolute_url_online text=content.title %}

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -314,7 +314,7 @@ class TopicEdit(UpdateView, SingleObjectMixin, TopicEditMixin, FeatureableMixin)
             'title': self.object.title,
             'subtitle': self.object.subtitle,
             'text': self.object.first_post().text,
-            'tags': ', '.join([tag['title'] for tag in self.object.tags.values('title')]) or ''
+            'tags': ', '.join(self.object.tags.values_list('title', flat=True))
         })
         return render(request, self.template_name, {'topic': self.object, 'form': form, 'is_staff': is_staff})
 

--- a/zds/tutorialv2/tests/tests_views/tests_editcontenttags.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontenttags.py
@@ -1,0 +1,218 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.html import escape
+
+from zds.tutorialv2.models.database import PublishableContent
+from zds.tutorialv2.views.contents import EditContentTags
+from zds.tutorialv2.forms import EditContentTagsForm
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.tutorialv2.factories import PublishableContentFactory
+from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.forum.factories import TagFactory
+from zds.utils.forms import TagValidator
+from zds.utils.models import Tag
+
+
+@override_for_contents()
+class EditContentTagsPermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author])
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-tags', kwargs={'pk': self.content.pk})
+        self.form_data = {'tags': 'test2, test2'}
+        self.content_data = {'pk': self.content.pk, 'slug': self.content.slug}
+        self.content_url = reverse('content:view', kwargs=self.content_data)
+        self.login_url = reverse('member-login') + '?next=' + self.form_url
+
+    def test_not_authenticated(self):
+        """Test that on form submission, unauthenticated users are redirected to the login page."""
+        self.client.logout()  # ensure no user is authenticated
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_author(self):
+        """Test that on form submission, authors are redirected to the content page."""
+        login_success = self.client.login(username=self.author.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff(self):
+        """Test that on form submission, staffs are redirected to the content page."""
+        login_success = self.client.login(username=self.staff.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_outsider(self):
+        """Test that on form submission, unauthorized users get a 403."""
+        login_success = self.client.login(username=self.outsider.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEquals(response.status_code, 403)
+
+
+@override_for_contents()
+class EditContentTagsWorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author.user])
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-tags', kwargs={'pk': self.content.pk})
+        self.error_messages = EditContentTagsForm.declared_fields['tags'].error_messages
+        self.success_message = EditContentTags.success_message
+
+        # Log in with an authorized user (e.g the author of the content) to perform the tests
+        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        self.assertTrue(login_success)
+
+    def get_test_cases(self):
+        special_char_for_slug = '?'
+        tag_length_max = Tag._meta.get_field('title').max_length
+        tag_too_long = 'a' * (tag_length_max + 1)
+        tag_utf8mb4 = '😁'
+        return {
+            'empty_form': {
+                'inputs': {},
+                'expected_outputs': [self.success_message]
+            },
+            'empty_fields': {
+                'inputs': {'tags': ''},
+                'expected_outputs': [self.success_message]
+            },
+            'success_tags': {
+                'inputs': {'tags': 'test, test1'},
+                'expected_outputs': [self.success_message]
+            },
+            'stripped_to_empty': {
+                'inputs': {'tags': ' '},
+                'expected_outputs': [self.success_message]
+            },
+            'tags_string_too_long': {
+                'inputs': {'tags': 'a' * (EditContentTagsForm.declared_fields['tags'].max_length + 1)},
+                'expected_outputs': [self.error_messages['max_length']]
+            },
+            'invalid_slug_tag': {
+                'inputs': {'tags': special_char_for_slug},
+                'expected_outputs': [TagValidator.error_empty_slug.format(special_char_for_slug)]
+            },
+            'tag_too_long': {
+                'inputs': {'tags': tag_too_long},
+                'expected_outputs': [TagValidator.error_tag_too_long.format(tag_too_long, tag_length_max)]
+            },
+            'tag_utf8mb4': {
+                'inputs': {'tags': tag_utf8mb4},
+                'expected_outputs': [TagValidator.error_utf8mb4.format(tag_utf8mb4)]
+            }
+        }
+
+    def test_form_workflow(self):
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                response = self.client.post(self.form_url, case['inputs'], follow=True)
+                for msg in case['expected_outputs']:
+                    self.assertContains(response, escape(msg))
+                    print(response)
+
+
+@override_for_contents()
+class EditContentTagsFunctionalTests(TutorialTestMixin, TestCase):
+    # TODO
+    """Test the detailed behavior of the feature, such as updates of the database or repositories."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create tags
+        self.tag_0 = TagFactory()
+        self.tag_1 = TagFactory()
+        self.tag_from_other_content = TagFactory()
+        self.tags_name = [self.tag_0.title, self.tag_1.title, self.tag_from_other_content.title]
+
+        # Create contents
+        self.content = PublishableContentFactory(author_list=[self.author.user])
+        self.other_content = PublishableContentFactory(author_list=[self.author.user])
+        self.other_content.tags.add(self.tag_from_other_content)
+        self.other_content.save()
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-tags', kwargs={'pk': self.content.pk})
+
+        # Log in with an authorized user (e.g the author of the content) to perform the tests
+        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        self.assertTrue(login_success)
+
+    def test_form_function(self):
+        """Test many use cases for the form."""
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                self.enforce_preconditions(case['preconditions'])
+                self.post_form(case['inputs'])
+                self.check_effects(case['expected_outputs'])
+
+    def get_test_cases(self):
+        """List test cases for the license editing form."""
+        new_tag_name = 'new_tag_for_sure'
+        return {
+            'nothing': {
+                'preconditions': {'all_tags': self.tags_name, 'content_tags': []},
+                'inputs': {'tags': ''},
+                'expected_outputs': {'all_tags': self.tags_name,
+                                     'content_tags': []}
+            },
+            'existing_tag': {
+                'preconditions': {'all_tags': self.tags_name, 'content_tags': []},
+                'inputs': {'tags': self.tag_1.title},
+                'expected_outputs': {'all_tags': self.tags_name,
+                                     'content_tags': [self.tag_1.title]}
+            },
+            'new_tag': {
+                'preconditions': {'all_tags': self.tags_name, 'content_tags': []},
+                'inputs': {'tags': new_tag_name},
+                'expected_outputs': {'all_tags': self.tags_name + [new_tag_name],
+                                     'content_tags': [new_tag_name]}
+            },
+        }
+
+    def enforce_preconditions(self, preconditions):
+        """Prepare the test environment to match given preconditions"""
+        tags = []
+        for t in preconditions['content_tags']:
+            tags.append(Tag.objects.get(title=t))
+        self.content.tags.clear()
+        for t in tags:
+            self.content.tags.add(t)
+        self.content.save()
+        tags_as_string = [tag.title for tag in self.content.tags.all()]
+        self.assertEqual(tags_as_string, preconditions['content_tags'])
+
+    def post_form(self, inputs):
+        """Post the form with given inputs."""
+        form_data = {'tags': inputs['tags']}
+        self.client.post(self.form_url, form_data)
+
+    def check_effects(self, expected_outputs):
+        """Check the effects of having sent the form."""
+        updated_content = PublishableContent.objects.get(pk=self.content.pk)
+        content_tags_as_string = [tag.title for tag in updated_content.tags.all()]
+        all_tags_as_string = [tag.title for tag in Tag.objects.all()]
+        self.assertEqual(content_tags_as_string, expected_outputs['content_tags'])
+        self.assertEqual(all_tags_as_string, expected_outputs['all_tags'])

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -11,7 +11,7 @@ from zds.tutorialv2.views.contents import (DisplayContent, CreateContent, EditCo
                                            RemoveAuthorFromContent, WarnTypo, DisplayBetaContent, DisplayBetaContainer,
                                            ContentOfAuthor, RedirectOldContentOfAuthor, AddContributorToContent,
                                            RemoveContributorFromContent, ContentOfContributors,
-                                           AddSuggestion, RemoveSuggestion)
+                                           AddSuggestion, RemoveSuggestion, EditContentTags)
 
 from zds.tutorialv2.views.published import (SendNoteFormView, UpdateNoteView,
                                             HideReaction, ShowReaction, SendNoteAlert, SolveNoteAlert, TagsListView,
@@ -159,6 +159,9 @@ urlpatterns = [
 
     # Modify the license
     re_path(r'^modifier-licence/(?P<pk>\d+)/$', EditContentLicense.as_view(), name='edit-license'),
+
+    # Modify the tags
+    re_path(r'^modifier-tags/(?P<pk>\d+)/$', EditContentTags.as_view(), name='edit-tags'),
 
     # beta:
     re_path(r'^activer-beta/(?P<pk>\d+)/(?P<slug>.+)/$', ManageBetaContent.as_view(action='set'),

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -196,7 +196,7 @@ class DisplayContent(LoginRequiredMixin, SingleContentDetailViewMixin):
             self.versioned_object,
             initial={'license': self.versioned_object.licence})
 
-        initial_tags_field = ', '.join([tag['title'] for tag in self.object.tags.values('title')]) or ''
+        initial_tags_field = ', '.join(self.object.tags.values_list('title', flat=True))
         context['form_edit_tags'] = EditContentTagsForm(self.versioned_object, initial={'tags': initial_tags_field})
 
         if self.versioned_object.requires_validation:
@@ -430,7 +430,7 @@ class EditContentTags(LoggedWithReadWriteHability, SingleContentFormViewMixin):
 
     def get_initial(self):
         initial = super(EditContentTags, self).get_initial()
-        initial['tags'] = ', '.join([tag['title'] for tag in self.object.tags.values('title')]) or ''
+        initial['tags'] = ', '.join(self.object.tags.values_list('title', flat=True))
         return initial
 
     def form_valid(self, form):

--- a/zds/tutorialv2/views/published.py
+++ b/zds/tutorialv2/views/published.py
@@ -32,7 +32,8 @@ from zds.member.views import get_client_ip
 from zds.notification import signals
 from zds.notification.models import ContentReactionAnswerSubscription, NewPublicationSubscription
 from zds.tutorialv2.forms import RevokeValidationForm, WarnTypoForm, NoteForm, NoteEditForm, UnpublicationForm, \
-    PickOpinionForm, PromoteOpinionToArticleForm, UnpickOpinionForm, ContentCompareStatsURLForm, SearchSuggestionForm
+    PickOpinionForm, PromoteOpinionToArticleForm, UnpickOpinionForm, ContentCompareStatsURLForm, SearchSuggestionForm, \
+    EditContentTagsForm
 from zds.tutorialv2.mixins import SingleOnlineContentDetailViewMixin, SingleOnlineContentViewMixin, DownloadViewMixin, \
     ContentTypeMixin, SingleOnlineContentFormViewMixin, MustRedirect
 from zds.tutorialv2.models import TYPE_CHOICES_DICT, CONTENT_TYPE_LIST
@@ -131,6 +132,9 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
             excluded_for_search.append(str(self.object.pk))
             context['formAddSuggestion'] = SearchSuggestionForm(content=self.object,
                                                                 initial={'excluded_pk': ','.join(excluded_for_search)})
+
+        initial_tags_field = ', '.join([tag['title'] for tag in self.object.tags.values('title')]) or ''
+        context['form_edit_tags'] = EditContentTagsForm(self.versioned_object, initial={'tags': initial_tags_field})
 
         # pagination of comments
         make_pagination(context,

--- a/zds/tutorialv2/views/published.py
+++ b/zds/tutorialv2/views/published.py
@@ -133,7 +133,7 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
             context['formAddSuggestion'] = SearchSuggestionForm(content=self.object,
                                                                 initial={'excluded_pk': ','.join(excluded_for_search)})
 
-        initial_tags_field = ', '.join([tag['title'] for tag in self.object.tags.values('title')]) or ''
+        initial_tags_field = ', '.join(self.object.tags.values_list('title', flat=True))
         context['form_edit_tags'] = EditContentTagsForm(self.versioned_object, initial={'tags': initial_tags_field})
 
         # pagination of comments

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -141,9 +141,8 @@ class TagValidator(object):
         :return: ``True`` if the tag slug is good
         """
         if not defaultfilters.slugify(tag):
-            error = TagValidator.error_empty_slug.format(tag)
-            self.errors.append(error)
-            self.logger.warning('%s bad slug', tag)
+            self.errors.append(TagValidator.error_empty_slug.format(tag))
+            self.logger.warning('"%s" bad slug', tag)
             return False
         return True
 

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -70,6 +70,10 @@ class TagValidator(object):
     """
     validate tags
     """
+    error_empty_slug = _("Le tag « {} » n'est constitué que de caractères spéciaux et est donc incorrect.")
+    error_tag_too_long = _('Le tag « {} » est trop long (maximum {} caractères).')
+    error_utf8mb4 = _('Le tag « {} » contient des caractères utf8mb4.')
+
     def __init__(self):
         self.__errors = []
         self.logger = logging.getLogger(__name__)
@@ -96,8 +100,7 @@ class TagValidator(object):
         :return: ``True`` if length is valid
         """
         if len(tag) > Tag._meta.get_field('title').max_length:
-            self.errors.append(_('Le tag {} est trop long (maximum {} caractères)'.format(
-                tag, Tag._meta.get_field('title').max_length)))
+            self.errors.append(TagValidator.error_tag_too_long.format(tag, Tag._meta.get_field('title').max_length))
             self.logger.debug('%s est trop long expected=%d got=%d', tag,
                               Tag._meta.get_field('title').max_length, len(tag))
             return False
@@ -125,8 +128,8 @@ class TagValidator(object):
         :return: ``True`` if no utf8mb4 string is found
         """
         if contains_utf8mb4(tag):
-            self.errors.append(_('Le tag {} contient des caractères utf8mb4').format(tag))
-            self.logger.warn('%s contains utf8mb4 char', tag)
+            self.errors.append(TagValidator.error_utf8mb4.format(tag))
+            self.logger.warning('%s contains utf8mb4 char', tag)
             return False
         return True
 
@@ -138,8 +141,9 @@ class TagValidator(object):
         :return: ``True`` if the tag slug is good
         """
         if not defaultfilters.slugify(tag):
-            self.errors.append(_("Le tag {} n'est constitué que de caractères spéciaux et est donc incorrect"))
-            self.logger.warn('%s bad slug', tag)
+            error = TagValidator.error_empty_slug.format(tag)
+            self.errors.append(error)
+            self.logger.warning('%s bad slug', tag)
             return False
         return True
 


### PR DESCRIPTION
Je continue le mouvement de simplification de la création de contenu en déplaçant le choix des tags dans un formulaire séparé sous forme de modale.

Je ne suis pas très subtil sur le design, ça ressemble à ça pour l'instant :

![image](https://user-images.githubusercontent.com/35631001/81979672-a722ec80-962d-11ea-9c60-2748ada562b8.png)


Il me reste du travail :

- [x] améliorer la modales pour rajouter une phrase ou deux d'explication sur ce que sont les tags
- [x] tests unitaires pour la nouvelle vue
- [x] quelques lignes de codes qui me paraissent maladroites et que je veux regarder de plus près
- [x] gérer l'affichage du bouton sur la version en ligne, puisque ce n'est pas une info versionnée, mais éditoriale
- [X] écrire quelques lignes d'instructions pour la QA.


### Contrôle qualité

En tant qu'auteur puis staff :
* accéder à la page d'un contenu ;
* constater la présence du lien "modifier le tags" ;
* cliquer dessus pour afficher la modale ;
* mettre des tags et vérifier que le formulaire est validé sans problème d'accès.

En tant qu'auteur ou staff :
* mettre à jour les tags et constater qu'ils sont correctement mis à jour ;
* constater que c'est aussi le cas sur la version en ligne ;
* constater la présence du message de succès quand tout s'est bien passé ;
* constater la présence du message d'erreur en cas de problème.

En tant que visiteur puis simple membre :
* constater que le bouton modifier les tags n'apparaît pas.