### PR TITLE
Fixe la version de zmarkdown pour pouvoir utiliser ce fichier en production

### DIFF
--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "^8.2.0",
+    "zmarkdown": "8.3.0",
     "pm2": "^4.2.3"
   },
   "engines": {


### PR DESCRIPTION
Je souhaite que l'on fixe la version de zmarkdown car ça me permettra d'utiliser directement ce fichier en production au lieu d'utiliser une copie.

Lié au ticket https://github.com/zestedesavoir/ansible-zestedesavoir/issues/21