### PR TITLE
Fusion des liens vers les contenus en validation

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -6,6 +6,7 @@
 {% load remove_url_scheme %}
 {% load set %}
 {% load topbar %}
+{% load captureas %}
 
 <header>
     <div class="mobile-menu-btn ico-after"></div>
@@ -370,18 +371,22 @@
                         {% if perms.tutorialv2.change_validation %}
                             {% with waiting_tutorials_count="TUTORIAL"|waiting_count waiting_articles_count="ARTICLE"|waiting_count waiting_opinions_count="OPINION"|waiting_count %}
                                 <li class="staff-only">
-                                    <a href="{% url "validation:list" %}?type=tuto">
-                                        {% trans "Validation des tutoriels" %}
-                                        {% if waiting_tutorials_count > 0 %}
-                                            ({{ waiting_tutorials_count }})
-                                        {% endif %}
-                                    </a>
-                                </li>
-                                <li class="staff-only">
-                                    <a href="{% url "validation:list" %}?type=article">
-                                        {% trans "Validation des articles" %}
-                                        {% if waiting_articles_count > 0 %}
-                                            ({{ waiting_articles_count }})
+                                    <a href="{% url "validation:list" %}">
+                                        {% trans "Validation" %}
+
+                                        {% captureas tutorials_chunk %}
+                                            {{ waiting_tutorials_count }} tutoriel{{ waiting_tutorials_count|pluralize:"s" }}
+                                        {% endcaptureas %}
+                                        {% captureas articles_chunk %}
+                                            {{ waiting_articles_count }} article{{ waiting_articles_count|pluralize:"s" }}
+                                        {% endcaptureas %}
+
+                                        {% if waiting_tutorials_count > 0 and waiting_articles_count > 0 %}
+                                            ({{ tutorials_chunk }} et {{ articles_chunk }})
+                                        {% elif waiting_tutorials_count > 0 and not waiting_articles_count > 0 %}
+                                            ({{ tutorials_chunk }})
+                                        {% elif not waiting_tutorials_count > 0 and waiting_articles_count > 0 %}
+                                            ({{ articles_chunk }})
                                         {% endif %}
                                     </a>
                                 </li>

--- a/zds/utils/tests/tests_interventions.py
+++ b/zds/utils/tests/tests_interventions.py
@@ -110,7 +110,7 @@ class InterventionsTest(TestCase):
         # check that the number of waiting tutorials is correct
         response = self.client.post(reverse('homepage'))
         self.assertEqual(200, response.status_code)
-        self.assertContains(response, '(1)')
+        self.assertContains(response, '(1 tutoriel)')
 
         # Mark the content as reserved
         self.validation.status = 'PENDING_V'
@@ -119,7 +119,7 @@ class InterventionsTest(TestCase):
         # and check that the count was removed
         response = self.client.post(reverse('homepage'))
         self.assertEqual(200, response.status_code)
-        self.assertNotContains(response, '(1)')
+        self.assertNotContains(response, '(1 tutoriel)')
 
     def test_interventions_humane_delta(self):
         tr = Template('{% load interventions %}'


### PR DESCRIPTION
Fix #5802.

![image](https://user-images.githubusercontent.com/35631001/82592498-4ea99d00-9ba1-11ea-81a2-f4b490e094cf.png)

### Contrôle qualité

En tant que staff, jouer avec les réservations de tuto et articles et constater qu'on a les bons singuliers/pluriels, et les bons arrangements "X tutoriels/ X articles / X tutoriels et Y articles"

Vérifier qu'on est amené vers la page des validations sans filtre actif par défaut.