### PR TITLE
Modification des titres et sous-titres de contenu "in place"

### DIFF
--- a/assets/js/inplace-fields.js
+++ b/assets/js/inplace-fields.js
@@ -1,0 +1,27 @@
+/* ===== Zeste de Savoir ==================================================== */
+/*  Show and hide in-place forms                                              */
+/* ========================================================================== */
+
+(function($) {
+  'use strict'
+
+  /* Edit title */
+  function toggleDisplayTitle(e) {
+    $('#title-show').toggleClass('hidden')
+    $('#title-edit').toggleClass('hidden')
+    e.preventDefault()
+  }
+
+  $('#show-title-edit').on('click', toggleDisplayTitle)
+  $('#hide-title-edit').on('click', toggleDisplayTitle)
+
+  /* Edit subtitle */
+  function toggleDisplaySubtitle(e) {
+    $('#subtitle-show').toggleClass('hidden')
+    $('#subtitle-edit').toggleClass('hidden')
+    e.preventDefault()
+  }
+
+  $('#show-subtitle-edit').on('click', toggleDisplaySubtitle)
+  $('#hide-subtitle-edit').on('click', toggleDisplaySubtitle)
+})(jQuery)

--- a/assets/js/mobile-menu.js
+++ b/assets/js/mobile-menu.js
@@ -297,13 +297,9 @@
       var $newBtns = $('.sidebar .new-btn:not(.mobile-btn-imported)')
       if ($newBtns.length > 0) {
         var $prevElem = $('#content')
-          .find('> .content-wrapper, > .full-content-wrapper, > .content-col-2')
-          .first()
-          .find('h1, h2')
-          .first()
-        if ($prevElem.next('.license').length > 0) { $prevElem = $prevElem.next('.license') }
-        if ($prevElem.next('.subtitle').length > 0) { $prevElem = $prevElem.next('.subtitle') }
-        if ($prevElem.next('.taglist').length > 0) { $prevElem = $prevElem.next('.taglist') }
+          .find('> .content-wrapper, > .full-content-wrapper, > .content-col-2').first()
+          .find('header').first()
+          .find('.title').first()
 
         var $newBtnContainer = $('<div/>', {
           class: 'new-btn-container'

--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -241,7 +241,6 @@
 
     .btn-inline {
         display: inline-block;
-        cursor: pointer;
     }
     .btn-no-float {
         float: none !important;
@@ -254,6 +253,17 @@
 
         &:not(.submitted){
             color: $grey-300 !important;
+        }
+    }
+
+    button.link {
+        color: $color-link;
+        text-decoration: underline;
+
+
+        &:hover {
+            color: $color-link-hover;
+            text-decoration: none;
         }
     }
 

--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -241,6 +241,7 @@
 
     .btn-inline {
         display: inline-block;
+        cursor: pointer;
     }
     .btn-no-float {
         float: none !important;

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -102,6 +102,7 @@
 @import "pages/tutorial-history";
 @import "pages/content-editor";
 @import "pages/content-exports";
+@import "pages/content-header";
 
 /*-------------------------
 11. High pixel ratio (retina)

--- a/assets/scss/pages/_content-editor.scss
+++ b/assets/scss/pages/_content-editor.scss
@@ -9,7 +9,6 @@
 }
 
 .edit-button {
-  cursor: pointer;
   position: relative;
 
   margin: 0 $length-4;

--- a/assets/scss/pages/_content-editor.scss
+++ b/assets/scss/pages/_content-editor.scss
@@ -9,6 +9,7 @@
 }
 
 .edit-button {
+  cursor: pointer;
   position: relative;
 
   margin: 0 $length-4;

--- a/assets/scss/pages/_content-header.scss
+++ b/assets/scss/pages/_content-header.scss
@@ -89,28 +89,6 @@
             margin: 0;
             padding: 0;
             font-weight: normal;
-            //font-size: 2.2rem;
-        }
-
-        button.btn, button.btn-submit, button.link, button {
-            flex-grow: 0;
-            vertical-align: middle;
-            cursor: pointer;
-            line-height: 32px;
-            height: 32px;
-        }
-
-        button.link {
-            flex-grow: 0;
-            box-sizing: border-box;
-            color: lighten($color-primary, 20%);
-            transition: color $transition-duration ease, text-decoration $transition-duration ease;
-            text-decoration: underline;
-
-            &:hover {
-                color: darken($color-secondary, 15%);
-                text-decoration: none;
-            }
         }
     }
 }

--- a/assets/scss/pages/_content-header.scss
+++ b/assets/scss/pages/_content-header.scss
@@ -1,0 +1,116 @@
+.title {
+    margin-bottom: 15px;
+
+    .icon img {
+        display: block;
+        float: left;
+        width: 50px;
+        height: 50px;
+    }
+
+    .is-title {
+        display: flex;
+
+        padding: 0;
+        border-bottom: 1px solid $color-secondary;
+
+        >div {
+            flex-grow: 1;
+            display: flex;
+
+            h1 {
+                border: 0px;
+                margin-bottom: 0px;
+            }
+
+            .illu {
+                padding-left: 8px;
+            }
+        }
+
+        aside {
+            flex-grow: 0;
+            justify-content: flex-end;
+            display: flex;
+
+            .license {
+                justify-content: flex-end;
+                margin: 0;
+                margin-top: 10px;
+            }
+        }
+    }
+
+    .is-subtitle {
+        clear: both;
+        display: flex;
+
+        margin: 0;
+        margin-bottom:15px;
+        border-bottom: 1px solid #eee;
+
+        >div{
+            flex-grow: 1;
+            display: flex;
+            padding: 5px 0px;
+
+            h2 {
+                border: 0px;
+                margin-bottom: 0;
+                font-size: 18px;
+                font-size: 1.8rem;
+                line-height: 23px;
+                color: #999;
+                font-weight: normal;
+            }
+        }
+    }
+}
+
+.title-edit, .subtitle-edit {
+    flex-grow: 10;
+    display: flex;
+
+    form {
+        display: flex;
+
+        .control-group, .controls {
+            display: flex;
+            flex-grow: 1;
+        }
+
+        .control-label {
+            display: none;
+        }
+
+        input {
+            flex-grow: 1;
+            vertical-align: middle;
+            margin: 0;
+            padding: 0;
+            font-weight: normal;
+            //font-size: 2.2rem;
+        }
+
+        button.btn, button.btn-submit, button.link, button {
+            flex-grow: 0;
+            vertical-align: middle;
+            cursor: pointer;
+            line-height: 32px;
+            height: 32px;
+        }
+
+        button.link {
+            flex-grow: 0;
+            box-sizing: border-box;
+            color: lighten($color-primary, 20%);
+            transition: color $transition-duration ease, text-decoration $transition-duration ease;
+            text-decoration: underline;
+
+            &:hover {
+                color: darken($color-secondary, 15%);
+                text-decoration: none;
+            }
+        }
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -217,18 +217,29 @@
                                 {% block schema %}{% endblock %}
                             {% endcaptureas %}
                             <section class="content-wrapper" {{ schema|safe }}>
-                                <h1 {% if schema %}itemprop="name"{% endif %}>
-                                    {% block headline %}{% endblock %}
-                                </h1>
-
-                                {% captureas headlinesub %}
-                                    {% block headline_sub %}{% endblock %}
-                                {% endcaptureas %}
-
-                                {% if headlinesub %}
-                                    <h2 class="subtitle" {% if schema %}itemprop="description"{% endif %}>{{ headlinesub|safe }}</h2>
-                                {% endif %}
-
+                                <div class="title">
+                                    <div class="is-title">
+                                        <div>
+                                            <div class="editable-element" id="title-show">
+                                                <h1 {% if schema %}itemprop="name"{% endif %}>
+                                                    {% block headline %}{% endblock %}
+                                                </h1>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    {% captureas headlinesub %}
+                                        {% block headline_sub %}{% endblock %}
+                                    {% endcaptureas %}
+                                    {% if headlinesub %}
+                                        <div class="is-subtitle">
+                                            <div>
+                                                <div class="editable-element" id="subtitle-show">
+                                                    <h2 class="subtitle" {% if schema %}itemprop="description"{% endif %}>{{ headlinesub|safe }}</h2>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                </div>
                                 {% block content %}{% endblock %}
                             </section>
                         {% endblock %}

--- a/templates/tutorialv2/includes/content_title.part.html
+++ b/templates/tutorialv2/includes/content_title.part.html
@@ -1,0 +1,74 @@
+{% load i18n %}
+{% load crispy_forms_tags %}
+
+<div class="title">
+    {% if content.image %}
+        <div class="icon">
+            <img src="{{ content.image.physical.tutorial_illu.url }}" alt="">
+        </div>
+    {% endif %}
+    <div class="is-title">
+        <div>
+            <div class="editable-element" id="title-show">
+                <h1 {% if content.image %}class="illu"{% endif %}>{{ content.title }}</h1>
+                {% if editable %}
+                    <a href="" class="edit-button" id="show-title-edit">
+                        <span class="visuallyhidden">{% trans "Modifier le titre" %}</span>
+                    </a>
+                {% endif %}
+            </div>
+            {% if editable %}
+                <div class="title-edit hidden {% if content.image %}illu{% endif %}" id="title-edit">
+                    {% spaceless %}{% crispy form_edit_title %}{% endspaceless %}
+                </div>
+            {% endif %}
+        </div>
+
+        <aside>
+            {% if content.licence %}
+                <div class="editable-element license">
+                    <p>{{ content.licence }}</p>
+                    {% if editable %}
+                        <a href="#edit-license" class="open-modal edit-button" title="{% trans "Modifier la licence" %}">
+                            <span class="visuallyhidden">{% trans "Modifier la licence" %}</span>
+                        </a>
+                    {% endif %}
+                </div>
+            {% else %}
+                <p class="license">
+                    <a href="#edit-license" class="open-modal">{% trans "Choisissez la licence de votre publication !" %}</a>
+                </p>
+            {% endif %}
+            {% if editable %}
+                {% crispy form_edit_license %}
+            {% endif %}
+        </aside>
+    </div>
+
+    {% if content.description or editable %}
+        <div class="is-subtitle">
+            <div>
+                <div class="editable-element" id="subtitle-show">
+                    {% if content.description %}
+                        <h2 class="subtitle">{{ content.description }}</h2>
+                    {% endif %}
+                    {% if editable %}
+                        {% if content.description %}
+                            <a href="" id="show-subtitle-edit" class="edit-button">
+                                <span class="visuallyhidden">{% trans "Modifier le sous-titre" %}</span>
+                            </a>
+                        {% else %}
+                            <a href="" id="show-subtitle-edit" class="link">{% trans "Ajouter un sous-titre" %}</a>
+                        {% endif %}
+                    {% endif %}
+                </div>
+
+                {% if editable %}
+                    <div class="subtitle-edit hidden" id="subtitle-edit">
+                        {% spaceless %}{% crispy form_edit_subtitle %}{% endspaceless %}
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    {% endif %}
+</div>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -19,38 +19,11 @@
 {% endblock %}
 
 
-
 {% block headline %}
-    {% if is_staff or can_edit %}
-        {% if content.licence %}
-          <div class="editable-element license">
-            <p>{{ content.licence }}</p>
-            <a href="#edit-license" class="open-modal edit-button" title="{% trans "Modifier la licence" %}">
-              <span class="visuallyhidden">{% trans "Modifier la licence" %}</span>
-            </a>
-          </div>
-        {% else %}
-            <p class="license">
-                <a href="#edit-license" class="open-modal">Choisissez la licence de votre publication !</a>
-            </p>
-        {% endif %}
-
-        {% crispy form_edit_license %}
-    {% elif content.licence %}
-        <span class="license">{{ content.licence }}</span>
-    {% endif %}
-
-    <h1 {% if content.image %}class="illu"{% endif %}>
-        {% if content.image %}
-            <img src="{{ content.image.physical.tutorial_illu.url }}" alt="">
-        {% endif %}
-        {{ content.title }}
-    </h1>
-
-    {% if content.description %}
-        <h2 class="subtitle">
-            {{ content.description }}
-        </h2>
+    {% if can_edit or is_staff %}
+        {% include "tutorialv2/includes/content_title.part.html" with content=content editable=True %}
+    {% else %}
+        {% include "tutorialv2/includes/content_title.part.html" with content=content editable=False %}
     {% endif %}
 
     {% if can_edit %}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -71,24 +71,7 @@
 
 
 {% block headline %}
-    {% if content.licence %}
-        <span class="license" itemprop="license">
-            {{ content.licence }}
-        </span>
-    {% endif %}
-
-    <h1 {% if content.image %}class="illu"{% endif %} itemprop="name">
-        {% if content.image %}
-            <img src="{{ content.image.physical.tutorial_illu.url }}" alt="" itemprop="thumbnailUrl">
-        {% endif %}
-        {{ content.title }}
-    </h1>
-
-    {% if content.description %}
-        <h2 class="subtitle" itemprop="description">
-            {{ content.description }}
-        </h2>
-    {% endif %}
+    {% include "tutorialv2/includes/content_title.part.html" with editable=False %}
 
     {% include 'tutorialv2/includes/tags_authors.part.html' with content=content online=True %}
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -261,22 +261,28 @@ class ContentForm(ContainerForm):
     def _create_layout(self):
         self.helper.layout = Layout(
             IncludeEasyMDE(),
-            Field('title'),
-            Field('type'),
-            Field('image'),
-            Field('introduction', css_class='md-editor preview-source'),
-            ButtonHolder(StrictButton(_('Aperçu'), type='preview', name='preview',
-                                      css_class='btn btn-grey preview-btn'),),
-            HTML('{% if form.introduction.value %}{% include "misc/preview.part.html" \
-            with text=form.introduction.value %}{% endif %}'),
-            Field('conclusion', css_class='md-editor preview-source'),
-            ButtonHolder(StrictButton(_('Aperçu'), type='preview', name='preview',
-                                      css_class='btn btn-grey preview-btn'),),
-            HTML('{% if form.conclusion.value %}{% include "misc/preview.part.html" \
-            with text=form.conclusion.value %}{% endif %}'),
-            Field('last_hash'),
-            Field('source'),
-            Field('subcategory', template='crispy/checkboxselectmultiple.html')
+            Field("title"),
+            Field("type"),
+            Field("image"),
+            Field("introduction", css_class="md-editor preview-source"),
+            ButtonHolder(
+                StrictButton(_("Aperçu"), type="preview", name="preview", css_class="btn btn-grey preview-btn"),
+            ),
+            HTML(
+                '{% if form.introduction.value %}{% include "misc/preview.part.html" \
+            with text=form.introduction.value %}{% endif %}'
+            ),
+            Field("conclusion", css_class="md-editor preview-source"),
+            ButtonHolder(
+                StrictButton(_("Aperçu"), type="preview", name="preview", css_class="btn btn-grey preview-btn"),
+            ),
+            HTML(
+                '{% if form.conclusion.value %}{% include "misc/preview.part.html" \
+            with text=form.conclusion.value %}{% endif %}'
+            ),
+            Field("last_hash"),
+            Field("source"),
+            Field("subcategory", template="crispy/checkboxselectmultiple.html"),
         )
 
         self.helper.layout.append(Field("msg_commit"))
@@ -404,69 +410,73 @@ class EditContentLicenseForm(forms.Form):
 
 class EditContentTitleForm(forms.Form):
     title = forms.CharField(
-        label=_('Titre'),
-        max_length=PublishableContent._meta.get_field('title').max_length,
+        label=_("Titre"),
+        max_length=PublishableContent._meta.get_field("title").max_length,
         required=True,
-        error_messages={'required': _('Le titre ne peut pas être vide.'),
-                        'invalid_slug': _("Ce titre n'est pas autorisé, son slug est invalide !"),
-                        'max_length': _('Ce titre est trop long.')}
+        error_messages={
+            "required": _("Le titre ne peut pas être vide."),
+            "invalid_slug": _("Ce titre n'est pas autorisé, son slug est invalide !"),
+            "max_length": _("Ce titre est trop long."),
+        },
     )
 
     def __init__(self, versioned_content, *args, **kwargs):
-        kwargs['initial'] = {'title': versioned_content.title}
+        kwargs["initial"] = {"title": versioned_content.title}
         super(forms.Form, self).__init__(*args, **kwargs)
 
         self.helper = FormHelper()
-        self.helper.form_class = 'content-wrapper'
-        self.helper.form_method = 'post'
-        self.helper.form_id = 'title-edit-form'
-        self.helper.form_action = reverse('content:edit-title', kwargs={'pk': versioned_content.pk})
-        self.previous_page_url = reverse('content:view',
-                                         kwargs={'pk': versioned_content.pk, 'slug': versioned_content.slug})
+        self.helper.form_class = "content-wrapper"
+        self.helper.form_method = "post"
+        self.helper.form_id = "title-edit-form"
+        self.helper.form_action = reverse("content:edit-title", kwargs={"pk": versioned_content.pk})
+        self.previous_page_url = reverse(
+            "content:view", kwargs={"pk": versioned_content.pk, "slug": versioned_content.slug}
+        )
         self._create_layout()
 
     def _create_layout(self):
         self.helper.layout = Layout(
-            Field('title'),
-            StrictButton(_('Enregistrer'), type='submit', css_class='btn-submit'),
-            StrictButton(_('Annuler'), css_class='link', id='hide-title-edit')
+            Field("title"),
+            StrictButton(_("Enregistrer"), type="submit", css_class="btn-submit"),
+            StrictButton(_("Annuler"), css_class="link", id="hide-title-edit"),
         )
 
     def clean(self):
         cleaned_data = super(EditContentTitleForm, self).clean()
         try:
-            slugify_raise_on_invalid(cleaned_data.get('title'))
+            slugify_raise_on_invalid(cleaned_data.get("title"))
         except InvalidSlugError:
-            self.add_error('title', self.declared_fields['title'].error_messages['invalid_slug'])
+            self.add_error("title", self.declared_fields["title"].error_messages["invalid_slug"])
         return cleaned_data
 
 
 class EditContentSubtitleForm(forms.Form):
     subtitle = forms.CharField(
-        label=_('Sous-titre'),
-        max_length=PublishableContent._meta.get_field('description').max_length,
+        label=_("Sous-titre"),
+        max_length=PublishableContent._meta.get_field("description").max_length,
         required=False,
-        error_messages={'max_length': _('Le sous-titre est trop long.')}
+        error_messages={"max_length": _("Le sous-titre est trop long.")},
     )
 
     def __init__(self, versioned_content, *args, **kwargs):
-        kwargs['initial'] = {'subtitle': versioned_content.description}
+        kwargs["initial"] = {"subtitle": versioned_content.description}
         super(forms.Form, self).__init__(*args, **kwargs)
 
         self.helper = FormHelper()
-        self.helper.form_class = 'content-wrapper'
-        self.helper.form_method = 'post'
-        self.helper.form_id = 'subtitle-edit-form'
-        self.helper.form_action = reverse('content:edit-subtitle', kwargs={'pk': versioned_content.pk})
-        self.previous_page_url = reverse('content:view',
-                                         kwargs={'pk': versioned_content.pk, 'slug': versioned_content.slug})
+        self.helper.form_class = "content-wrapper"
+        self.helper.form_method = "post"
+        self.helper.form_id = "subtitle-edit-form"
+        self.helper.form_action = reverse("content:edit-subtitle", kwargs={"pk": versioned_content.pk})
+        self.previous_page_url = reverse(
+            "content:view", kwargs={"pk": versioned_content.pk, "slug": versioned_content.slug}
+        )
         self._create_layout()
 
     def _create_layout(self):
         self.helper.layout = Layout(
-            Field('subtitle'),
-            StrictButton(_('Enregistrer'), type='submit', css_class='btn-submit'),
-            StrictButton(_('Annuler'), css_class='link', id='hide-subtitle-edit')
+            Field("subtitle"),
+            StrictButton(_("Enregistrer"), type="submit", css_class="btn-submit"),
+            StrictButton(_("Annuler"), css_class="link", id="hide-subtitle-edit"),
         )
 
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -231,13 +231,6 @@ class ContainerForm(FormWithTitle):
 
 
 class ContentForm(ContainerForm):
-
-    description = forms.CharField(
-        label=_("Description"),
-        max_length=PublishableContent._meta.get_field("description").max_length,
-        required=False,
-    )
-
     image = forms.FileField(
         label=_("Sélectionnez le logo du contenu (max. {} Ko).").format(
             str(settings.ZDS_APP["gallery"]["image_max_size"] / 1024)
@@ -268,29 +261,22 @@ class ContentForm(ContainerForm):
     def _create_layout(self):
         self.helper.layout = Layout(
             IncludeEasyMDE(),
-            Field("title"),
-            Field("description"),
-            Field("type"),
-            Field("image"),
-            Field("introduction", css_class="md-editor preview-source"),
-            ButtonHolder(
-                StrictButton(_("Aperçu"), type="preview", name="preview", css_class="btn btn-grey preview-btn"),
-            ),
-            HTML(
-                '{% if form.introduction.value %}{% include "misc/preview.part.html" \
-            with text=form.introduction.value %}{% endif %}'
-            ),
-            Field("conclusion", css_class="md-editor preview-source"),
-            ButtonHolder(
-                StrictButton(_("Aperçu"), type="preview", name="preview", css_class="btn btn-grey preview-btn"),
-            ),
-            HTML(
-                '{% if form.conclusion.value %}{% include "misc/preview.part.html" \
-            with text=form.conclusion.value %}{% endif %}'
-            ),
-            Field("last_hash"),
-            Field("source"),
-            Field("subcategory", template="crispy/checkboxselectmultiple.html"),
+            Field('title'),
+            Field('type'),
+            Field('image'),
+            Field('introduction', css_class='md-editor preview-source'),
+            ButtonHolder(StrictButton(_('Aperçu'), type='preview', name='preview',
+                                      css_class='btn btn-grey preview-btn'),),
+            HTML('{% if form.introduction.value %}{% include "misc/preview.part.html" \
+            with text=form.introduction.value %}{% endif %}'),
+            Field('conclusion', css_class='md-editor preview-source'),
+            ButtonHolder(StrictButton(_('Aperçu'), type='preview', name='preview',
+                                      css_class='btn btn-grey preview-btn'),),
+            HTML('{% if form.conclusion.value %}{% include "misc/preview.part.html" \
+            with text=form.conclusion.value %}{% endif %}'),
+            Field('last_hash'),
+            Field('source'),
+            Field('subcategory', template='crispy/checkboxselectmultiple.html')
         )
 
         self.helper.layout.append(Field("msg_commit"))
@@ -413,6 +399,74 @@ class EditContentLicenseForm(forms.Form):
             Field("license"),
             Field("update_preferred_license"),
             ButtonHolder(StrictButton("Valider", type="submit")),
+        )
+
+
+class EditContentTitleForm(forms.Form):
+    title = forms.CharField(
+        label=_('Titre'),
+        max_length=PublishableContent._meta.get_field('title').max_length,
+        required=True,
+        error_messages={'required': _('Le titre ne peut pas être vide.'),
+                        'invalid_slug': _("Ce titre n'est pas autorisé, son slug est invalide !"),
+                        'max_length': _('Ce titre est trop long.')}
+    )
+
+    def __init__(self, versioned_content, *args, **kwargs):
+        kwargs['initial'] = {'title': versioned_content.title}
+        super(forms.Form, self).__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+        self.helper.form_class = 'content-wrapper'
+        self.helper.form_method = 'post'
+        self.helper.form_id = 'title-edit-form'
+        self.helper.form_action = reverse('content:edit-title', kwargs={'pk': versioned_content.pk})
+        self.previous_page_url = reverse('content:view',
+                                         kwargs={'pk': versioned_content.pk, 'slug': versioned_content.slug})
+        self._create_layout()
+
+    def _create_layout(self):
+        self.helper.layout = Layout(
+            Field('title'),
+            StrictButton(_('Enregistrer'), type='submit', css_class='btn-submit'),
+            StrictButton(_('Annuler'), css_class='link', id='hide-title-edit')
+        )
+
+    def clean(self):
+        cleaned_data = super(EditContentTitleForm, self).clean()
+        try:
+            slugify_raise_on_invalid(cleaned_data.get('title'))
+        except InvalidSlugError:
+            self.add_error('title', self.declared_fields['title'].error_messages['invalid_slug'])
+        return cleaned_data
+
+
+class EditContentSubtitleForm(forms.Form):
+    subtitle = forms.CharField(
+        label=_('Sous-titre'),
+        max_length=PublishableContent._meta.get_field('description').max_length,
+        required=False,
+        error_messages={'max_length': _('Le sous-titre est trop long.')}
+    )
+
+    def __init__(self, versioned_content, *args, **kwargs):
+        kwargs['initial'] = {'subtitle': versioned_content.description}
+        super(forms.Form, self).__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+        self.helper.form_class = 'content-wrapper'
+        self.helper.form_method = 'post'
+        self.helper.form_id = 'subtitle-edit-form'
+        self.helper.form_action = reverse('content:edit-subtitle', kwargs={'pk': versioned_content.pk})
+        self.previous_page_url = reverse('content:view',
+                                         kwargs={'pk': versioned_content.pk, 'slug': versioned_content.slug})
+        self._create_layout()
+
+    def _create_layout(self):
+        self.helper.layout = Layout(
+            Field('subtitle'),
+            StrictButton(_('Enregistrer'), type='submit', css_class='btn-submit'),
+            StrictButton(_('Annuler'), css_class='link', id='hide-subtitle-edit')
         )
 
 

--- a/zds/tutorialv2/tests/tests_models.py
+++ b/zds/tutorialv2/tests/tests_models.py
@@ -454,7 +454,6 @@ class ContentTests(TutorialTestMixin, TestCase):
             reverse("content:edit", args=[article.pk, article.slug]),
             {
                 "title": old_title + "bla",
-                "description": old_description + "bla",
                 "type": "ARTICLE",
                 "licence": article.licence.pk,
                 "subcategory": SubCategoryFactory().pk,

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -267,14 +267,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:create-tutorial"),
             {
-                "title": title,
-                "description": description,
-                "introduction": intro,
-                "conclusion": conclusion,
-                "type": "TUTORIAL",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "image": (settings.BASE_DIR / "fixtures" / "noir_black.png").open("rb"),
+                'title': title,
+                'introduction': intro,
+                'conclusion': conclusion,
+                'type': 'TUTORIAL',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'image': (settings.BASE_DIR / 'fixtures' / 'noir_black.png').open('rb')
             },
             follow=False,
         )
@@ -309,14 +308,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[pk, slug]),
             {
-                "title": random,
-                "description": random,
-                "introduction": random,
-                "conclusion": random,
-                "type": "TUTORIAL",
-                "subcategory": self.subcategory.pk,
-                "last_hash": versioned.compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
+                'title': random,
+                'introduction': random,
+                'conclusion': random,
+                'type': 'TUTORIAL',
+                'subcategory': self.subcategory.pk,
+                'last_hash': versioned.compute_hash(),
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False,
         )
@@ -326,12 +324,12 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         tuto = PublishableContent.objects.get(pk=pk)
         self.assertEqual(tuto.title, random)
-        self.assertEqual(tuto.description, random)
+        self.assertEqual(tuto.description, '')
         self.assertEqual(tuto.licence, None)
         versioned = tuto.load_version()
         self.assertEqual(versioned.get_introduction(), random)
         self.assertEqual(versioned.get_conclusion(), random)
-        self.assertEqual(versioned.description, random)
+        self.assertEqual(versioned.description, '')
         self.assertEqual(versioned.licence, None)
         self.assertNotEqual(versioned.slug, slug)
 
@@ -922,14 +920,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                "title": random,
-                "description": random,
-                "introduction": random,
-                "conclusion": random,
-                "type": "TUTORIAL",
-                "licence": new_licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": versioned.compute_hash(),
+                'title': random,
+                'introduction': random,
+                'conclusion': random,
+                'type': 'TUTORIAL',
+                'licence': new_licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': versioned.compute_hash()
             },
             follow=False,
         )
@@ -1280,13 +1277,12 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:create-tutorial"),
             {
-                "title": given_title,
-                "description": some_text,
-                "introduction": some_text,
-                "conclusion": some_text,
-                "type": "TUTORIAL",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
+                'title': given_title,
+                'introduction': some_text,
+                'conclusion': some_text,
+                'type': 'TUTORIAL',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
             },
             follow=False,
         )
@@ -1440,12 +1436,11 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:create-tutorial"),
             {
-                "title": given_title,
-                "description": some_text,
-                "introduction": some_text,
-                "conclusion": some_text,
-                "type": "TUTORIAL",
-                "subcategory": self.subcategory.pk,
+                'title': given_title,
+                'introduction': some_text,
+                'conclusion': some_text,
+                'type': 'TUTORIAL',
+                'subcategory': self.subcategory.pk,
             },
             follow=False,
         )
@@ -1556,13 +1551,12 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:create-tutorial"),
             {
-                "title": given_title,
-                "description": some_text,
-                "introduction": some_text,
-                "conclusion": some_text,
-                "type": "TUTORIAL",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
+                'title': given_title,
+                'introduction': some_text,
+                'conclusion': some_text,
+                'type': 'TUTORIAL',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
             },
             follow=False,
         )
@@ -1945,15 +1939,14 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                "title": "new title so that everything explode",
-                "description": tuto.description,
-                "introduction": tuto.load_version().get_introduction(),
-                "conclusion": tuto.load_version().get_conclusion(),
-                "type": "ARTICLE",
-                "licence": tuto.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": tuto.load_version(tuto.sha_draft).compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
+                'title': 'new title so that everything explode',
+                'introduction': tuto.load_version().get_introduction(),
+                'conclusion': tuto.load_version().get_conclusion(),
+                'type': 'ARTICLE',
+                'licence': tuto.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': tuto.load_version(tuto.sha_draft).compute_hash(),
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False,
         )
@@ -2868,14 +2861,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                "title": tuto.title,
-                "description": tuto.description,
-                "introduction": random,
-                "conclusion": random,
-                "type": "TUTORIAL",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": "",
+                'title': tuto.title,
+                'introduction': random,
+                'conclusion': random,
+                'type': 'TUTORIAL',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': ''
             },
             follow=True,
         )
@@ -2895,14 +2887,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                "title": tuto.title,
-                "description": tuto.description,
-                "introduction": random,
-                "conclusion": random,
-                "type": "TUTORIAL",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": versioned.compute_hash(),  # good hash
+                'title': tuto.title,
+                'introduction': random,
+                'conclusion': random,
+                'type': 'TUTORIAL',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': versioned.compute_hash()  # good hash
             },
             follow=True,
         )
@@ -3497,13 +3488,12 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.client.force_login(self.user_author)
 
         dic = {
-            "title": "",
-            "description": "une description",
-            "introduction": "une intro",
-            "conclusion": "une conclusion",
-            "type": "TUTORIAL",
-            "licence": self.licence.pk,
-            "subcategory": self.subcategory.pk,
+            'title': '',
+            'introduction': 'une intro',
+            'conclusion': 'une conclusion',
+            'type': 'TUTORIAL',
+            'licence': self.licence.pk,
+            'subcategory': self.subcategory.pk,
         }
 
         # empty title not disallowed because it is converted to the default title
@@ -4679,15 +4669,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                "title": "{} ({})".format(self.tuto.title, "modified"),  # will change slug
-                "description": random,
-                "introduction": random,
-                "conclusion": random,
-                "type": "TUTORIAL",
-                "licence": self.tuto.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": tuto.load_version().compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
+                'title': '{} ({})'.format(self.tuto.title, 'modified'),  # will change slug
+                'introduction': random,
+                'conclusion': random,
+                'type': 'TUTORIAL',
+                'licence': self.tuto.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': tuto.load_version().compute_hash(),
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False,
         )
@@ -4782,14 +4771,13 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                "title": new_title,
-                "description": tuto.description,
-                "introduction": "a",
-                "conclusion": "b",
-                "type": "TUTORIAL",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": tuto.sha_draft,
+                'title': new_title,
+                'introduction': 'a',
+                'conclusion': 'b',
+                'type': 'TUTORIAL',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': tuto.sha_draft,
             },
             follow=False,
         )
@@ -4827,15 +4815,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[article.pk, article.slug]),
             {
-                "title": "new title so that everything explode",
-                "description": article.description,
-                "introduction": article.load_version().get_introduction(),
-                "conclusion": article.load_version().get_conclusion(),
-                "type": "ARTICLE",
-                "licence": article.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": article.load_version(article.sha_draft).compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
+                'title': 'new title so that everything explode',
+                'introduction': article.load_version().get_introduction(),
+                'conclusion': article.load_version().get_conclusion(),
+                'type': 'ARTICLE',
+                'licence': article.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': article.load_version(article.sha_draft).compute_hash(),
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False,
         )
@@ -4884,14 +4871,13 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[published.pk, published.slug]),
             {
-                "title": published.title,
-                "description": published.description,
-                "introduction": "crappy crap",
-                "conclusion": "crappy crap",
-                "type": "TUTORIAL",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": published.load_version().compute_hash(),  # good hash
+                'title': published.title,
+                'introduction': 'crappy crap',
+                'conclusion': 'crappy crap',
+                'type': 'TUTORIAL',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': published.load_version().compute_hash()  # good hash
             },
             follow=True,
         )
@@ -4958,15 +4944,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[content_draft.pk, content_draft.slug]),
             {
-                "title": content_draft.title + "2",
-                "description": content_draft.description,
-                "introduction": content_draft.introduction,
-                "conclusion": content_draft.conclusion,
-                "type": content_draft.type,
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": content_draft.compute_hash(),
-                "image": content_draft.image or "None",
+                'title': content_draft.title + '2',
+                'introduction': content_draft.introduction,
+                'conclusion': content_draft.conclusion,
+                'type': content_draft.type,
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': content_draft.compute_hash(),
+                'image': content_draft.image or 'None'
             },
             follow=False,
         )

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -267,13 +267,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:create-tutorial"),
             {
-                'title': title,
-                'introduction': intro,
-                'conclusion': conclusion,
-                'type': 'TUTORIAL',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'image': (settings.BASE_DIR / 'fixtures' / 'noir_black.png').open('rb')
+                "title": title,
+                "introduction": intro,
+                "conclusion": conclusion,
+                "type": "TUTORIAL",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "image": (settings.BASE_DIR / "fixtures" / "noir_black.png").open("rb"),
             },
             follow=False,
         )
@@ -308,13 +308,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[pk, slug]),
             {
-                'title': random,
-                'introduction': random,
-                'conclusion': random,
-                'type': 'TUTORIAL',
-                'subcategory': self.subcategory.pk,
-                'last_hash': versioned.compute_hash(),
-                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
+                "title": random,
+                "introduction": random,
+                "conclusion": random,
+                "type": "TUTORIAL",
+                "subcategory": self.subcategory.pk,
+                "last_hash": versioned.compute_hash(),
+                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
             },
             follow=False,
         )
@@ -324,12 +324,12 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         tuto = PublishableContent.objects.get(pk=pk)
         self.assertEqual(tuto.title, random)
-        self.assertEqual(tuto.description, '')
+        self.assertEqual(tuto.description, "")
         self.assertEqual(tuto.licence, None)
         versioned = tuto.load_version()
         self.assertEqual(versioned.get_introduction(), random)
         self.assertEqual(versioned.get_conclusion(), random)
-        self.assertEqual(versioned.description, '')
+        self.assertEqual(versioned.description, "")
         self.assertEqual(versioned.licence, None)
         self.assertNotEqual(versioned.slug, slug)
 
@@ -920,13 +920,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                'title': random,
-                'introduction': random,
-                'conclusion': random,
-                'type': 'TUTORIAL',
-                'licence': new_licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': versioned.compute_hash()
+                "title": random,
+                "introduction": random,
+                "conclusion": random,
+                "type": "TUTORIAL",
+                "licence": new_licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": versioned.compute_hash(),
             },
             follow=False,
         )
@@ -1277,12 +1277,12 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:create-tutorial"),
             {
-                'title': given_title,
-                'introduction': some_text,
-                'conclusion': some_text,
-                'type': 'TUTORIAL',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
+                "title": given_title,
+                "introduction": some_text,
+                "conclusion": some_text,
+                "type": "TUTORIAL",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
             },
             follow=False,
         )
@@ -1436,11 +1436,11 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:create-tutorial"),
             {
-                'title': given_title,
-                'introduction': some_text,
-                'conclusion': some_text,
-                'type': 'TUTORIAL',
-                'subcategory': self.subcategory.pk,
+                "title": given_title,
+                "introduction": some_text,
+                "conclusion": some_text,
+                "type": "TUTORIAL",
+                "subcategory": self.subcategory.pk,
             },
             follow=False,
         )
@@ -1551,12 +1551,12 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:create-tutorial"),
             {
-                'title': given_title,
-                'introduction': some_text,
-                'conclusion': some_text,
-                'type': 'TUTORIAL',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
+                "title": given_title,
+                "introduction": some_text,
+                "conclusion": some_text,
+                "type": "TUTORIAL",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
             },
             follow=False,
         )
@@ -1939,14 +1939,14 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                'title': 'new title so that everything explode',
-                'introduction': tuto.load_version().get_introduction(),
-                'conclusion': tuto.load_version().get_conclusion(),
-                'type': 'ARTICLE',
-                'licence': tuto.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': tuto.load_version(tuto.sha_draft).compute_hash(),
-                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
+                "title": "new title so that everything explode",
+                "introduction": tuto.load_version().get_introduction(),
+                "conclusion": tuto.load_version().get_conclusion(),
+                "type": "ARTICLE",
+                "licence": tuto.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": tuto.load_version(tuto.sha_draft).compute_hash(),
+                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
             },
             follow=False,
         )
@@ -2861,13 +2861,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                'title': tuto.title,
-                'introduction': random,
-                'conclusion': random,
-                'type': 'TUTORIAL',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': ''
+                "title": tuto.title,
+                "introduction": random,
+                "conclusion": random,
+                "type": "TUTORIAL",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": "",
             },
             follow=True,
         )
@@ -2887,13 +2887,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                'title': tuto.title,
-                'introduction': random,
-                'conclusion': random,
-                'type': 'TUTORIAL',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': versioned.compute_hash()  # good hash
+                "title": tuto.title,
+                "introduction": random,
+                "conclusion": random,
+                "type": "TUTORIAL",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": versioned.compute_hash(),  # good hash
             },
             follow=True,
         )
@@ -3488,12 +3488,12 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.client.force_login(self.user_author)
 
         dic = {
-            'title': '',
-            'introduction': 'une intro',
-            'conclusion': 'une conclusion',
-            'type': 'TUTORIAL',
-            'licence': self.licence.pk,
-            'subcategory': self.subcategory.pk,
+            "title": "",
+            "introduction": "une intro",
+            "conclusion": "une conclusion",
+            "type": "TUTORIAL",
+            "licence": self.licence.pk,
+            "subcategory": self.subcategory.pk,
         }
 
         # empty title not disallowed because it is converted to the default title
@@ -4669,14 +4669,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                'title': '{} ({})'.format(self.tuto.title, 'modified'),  # will change slug
-                'introduction': random,
-                'conclusion': random,
-                'type': 'TUTORIAL',
-                'licence': self.tuto.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': tuto.load_version().compute_hash(),
-                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
+                "title": "{} ({})".format(self.tuto.title, "modified"),  # will change slug
+                "introduction": random,
+                "conclusion": random,
+                "type": "TUTORIAL",
+                "licence": self.tuto.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": tuto.load_version().compute_hash(),
+                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
             },
             follow=False,
         )
@@ -4771,13 +4771,13 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                'title': new_title,
-                'introduction': 'a',
-                'conclusion': 'b',
-                'type': 'TUTORIAL',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': tuto.sha_draft,
+                "title": new_title,
+                "introduction": "a",
+                "conclusion": "b",
+                "type": "TUTORIAL",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": tuto.sha_draft,
             },
             follow=False,
         )
@@ -4815,14 +4815,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[article.pk, article.slug]),
             {
-                'title': 'new title so that everything explode',
-                'introduction': article.load_version().get_introduction(),
-                'conclusion': article.load_version().get_conclusion(),
-                'type': 'ARTICLE',
-                'licence': article.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': article.load_version(article.sha_draft).compute_hash(),
-                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
+                "title": "new title so that everything explode",
+                "introduction": article.load_version().get_introduction(),
+                "conclusion": article.load_version().get_conclusion(),
+                "type": "ARTICLE",
+                "licence": article.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": article.load_version(article.sha_draft).compute_hash(),
+                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
             },
             follow=False,
         )
@@ -4871,13 +4871,13 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[published.pk, published.slug]),
             {
-                'title': published.title,
-                'introduction': 'crappy crap',
-                'conclusion': 'crappy crap',
-                'type': 'TUTORIAL',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': published.load_version().compute_hash()  # good hash
+                "title": published.title,
+                "introduction": "crappy crap",
+                "conclusion": "crappy crap",
+                "type": "TUTORIAL",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": published.load_version().compute_hash(),  # good hash
             },
             follow=True,
         )
@@ -4944,14 +4944,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[content_draft.pk, content_draft.slug]),
             {
-                'title': content_draft.title + '2',
-                'introduction': content_draft.introduction,
-                'conclusion': content_draft.conclusion,
-                'type': content_draft.type,
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': content_draft.compute_hash(),
-                'image': content_draft.image or 'None'
+                "title": content_draft.title + "2",
+                "introduction": content_draft.introduction,
+                "conclusion": content_draft.conclusion,
+                "type": content_draft.type,
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": content_draft.compute_hash(),
+                "image": content_draft.image or "None",
             },
             follow=False,
         )

--- a/zds/tutorialv2/tests/tests_views/tests_edgecases.py
+++ b/zds/tutorialv2/tests/tests_views/tests_edgecases.py
@@ -38,14 +38,14 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[opinion.pk, opinion.slug]),
             {
-                'title': 'new title',
-                'introduction': 'introduction',
-                'conclusion': 'conclusion',
-                'type': 'OPINION',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': opinion.load_version().compute_hash(),
-                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
+                "title": "new title",
+                "introduction": "introduction",
+                "conclusion": "conclusion",
+                "type": "OPINION",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": opinion.load_version().compute_hash(),
+                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
             },
             follow=False,
         )
@@ -57,14 +57,14 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[article.pk, article.slug]),
             {
-                'title': 'title',
-                'introduction': 'introduction',
-                'conclusion': 'conclusion',
-                'type': 'ARTICLE',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': article.load_version().compute_hash(),
-                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
+                "title": "title",
+                "introduction": "introduction",
+                "conclusion": "conclusion",
+                "type": "ARTICLE",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": article.load_version().compute_hash(),
+                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
             },
             follow=True,
         )

--- a/zds/tutorialv2/tests/tests_views/tests_edgecases.py
+++ b/zds/tutorialv2/tests/tests_views/tests_edgecases.py
@@ -38,15 +38,14 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[opinion.pk, opinion.slug]),
             {
-                "title": "new title",
-                "description": "subtitle",
-                "introduction": "introduction",
-                "conclusion": "conclusion",
-                "type": "OPINION",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": opinion.load_version().compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
+                'title': 'new title',
+                'introduction': 'introduction',
+                'conclusion': 'conclusion',
+                'type': 'OPINION',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': opinion.load_version().compute_hash(),
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False,
         )
@@ -58,15 +57,14 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[article.pk, article.slug]),
             {
-                "title": "title",
-                "description": "subtitle",
-                "introduction": "introduction",
-                "conclusion": "conclusion",
-                "type": "ARTICLE",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": article.load_version().compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
+                'title': 'title',
+                'introduction': 'introduction',
+                'conclusion': 'conclusion',
+                'type': 'ARTICLE',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': article.load_version().compute_hash(),
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=True,
         )

--- a/zds/tutorialv2/tests/tests_views/tests_editcontentsubtitle.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontentsubtitle.py
@@ -24,11 +24,11 @@ class EditContentSubtitlePermissionTests(TutorialTestMixin, TestCase):
         self.content = PublishableContentFactory(author_list=[self.author])
 
         # Get information to be reused in tests
-        self.form_url = reverse('content:edit-subtitle', kwargs={'pk': self.content.pk})
-        self.form_data = {'subtitle': 'Pretty standard subtitle'}
-        self.content_data = {'pk': self.content.pk, 'slug': self.content.slug}
-        self.content_url = reverse('content:view', kwargs=self.content_data)
-        self.login_url = reverse('member-login') + '?next=' + self.form_url
+        self.form_url = reverse("content:edit-subtitle", kwargs={"pk": self.content.pk})
+        self.form_data = {"subtitle": "Pretty standard subtitle"}
+        self.content_data = {"pk": self.content.pk, "slug": self.content.slug}
+        self.content_url = reverse("content:view", kwargs=self.content_data)
+        self.login_url = reverse("member-login") + "?next=" + self.form_url
 
     def test_not_authenticated(self):
         """Test that on form submission, unauthenticated users are redirected to the login page."""
@@ -38,21 +38,21 @@ class EditContentSubtitlePermissionTests(TutorialTestMixin, TestCase):
 
     def test_authenticated_author(self):
         """Test that on form submission, authors are redirected to the content page."""
-        login_success = self.client.login(username=self.author.username, password='hostel77')
+        login_success = self.client.login(username=self.author.username, password="hostel77")
         self.assertTrue(login_success)
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_staff(self):
         """Test that on form submission, staffs are redirected to the content page."""
-        login_success = self.client.login(username=self.staff.username, password='hostel77')
+        login_success = self.client.login(username=self.staff.username, password="hostel77")
         self.assertTrue(login_success)
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_outsider(self):
         """Test that on form submission, unauthorized users get a 403."""
-        login_success = self.client.login(username=self.outsider.username, password='hostel77')
+        login_success = self.client.login(username=self.outsider.username, password="hostel77")
         self.assertTrue(login_success)
         response = self.client.post(self.form_url, self.form_data)
         self.assertEquals(response.status_code, 403)
@@ -70,41 +70,32 @@ class EditContentSubtitleWorkflowTests(TutorialTestMixin, TestCase):
         self.content = PublishableContentFactory(author_list=[self.author.user])
 
         # Get information to be reused in tests
-        self.form_url = reverse('content:edit-subtitle', kwargs={'pk': self.content.pk})
-        self.error_messages = EditContentSubtitleForm.declared_fields['subtitle'].error_messages
+        self.form_url = reverse("content:edit-subtitle", kwargs={"pk": self.content.pk})
+        self.error_messages = EditContentSubtitleForm.declared_fields["subtitle"].error_messages
         self.success_message = EditContentSubtitle.success_message
 
         # Log in with an authorized user (e.g the author of the content) to perform the tests
-        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        login_success = self.client.login(username=self.author.user.username, password="hostel77")
         self.assertTrue(login_success)
 
     def get_test_cases(self):
-        subtitle_too_long = 's' * (PublishableContent._meta.get_field('description').max_length + 1)
+        subtitle_too_long = "s" * (PublishableContent._meta.get_field("description").max_length + 1)
         return {
-            'empty_form': {
-                'inputs': {},
-                'expected_outputs': [self.success_message]
+            "empty_form": {"inputs": {}, "expected_outputs": [self.success_message]},
+            "empty_fields": {"inputs": {"subtitle": ""}, "expected_outputs": [self.success_message]},
+            "too_long": {
+                "inputs": {"subtitle": subtitle_too_long},
+                "expected_outputs": [self.error_messages["max_length"]],
             },
-            'empty_fields': {
-                'inputs': {'subtitle': ''},
-                'expected_outputs': [self.success_message]
-            },
-            'too_long': {
-                'inputs': {'subtitle': subtitle_too_long},
-                'expected_outputs': [self.error_messages['max_length']]
-            },
-            'success': {
-                'inputs': {'subtitle': 'Pretty standard subtitle'},
-                'expected_outputs': [self.success_message]
-            },
+            "success": {"inputs": {"subtitle": "Pretty standard subtitle"}, "expected_outputs": [self.success_message]},
         }
 
     def test_form_workflow(self):
         test_cases = self.get_test_cases()
         for case_name, case in test_cases.items():
             with self.subTest(msg=case_name):
-                response = self.client.post(self.form_url, case['inputs'], follow=True)
-                for msg in case['expected_outputs']:
+                response = self.client.post(self.form_url, case["inputs"], follow=True)
+                for msg in case["expected_outputs"]:
                     self.assertContains(response, escape(msg))
 
 
@@ -119,20 +110,20 @@ class EditContentSubtitleFunctionalTests(TutorialTestMixin, TestCase):
         # Create a content
         self.content = PublishableContentFactory(author_list=[self.author.user])
         self.initial_subtitle = self.content.description
-        self.new_subtitle = 'The other subtitle, definitely different from the other'
+        self.new_subtitle = "The other subtitle, definitely different from the other"
 
         # Get information to be reused in tests
-        self.form_url = reverse('content:edit-subtitle', kwargs={'pk': self.content.pk})
+        self.form_url = reverse("content:edit-subtitle", kwargs={"pk": self.content.pk})
 
         # Log in with an authorized user (e.g the author of the content) to perform the tests
-        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        login_success = self.client.login(username=self.author.user.username, password="hostel77")
         self.assertTrue(login_success)
 
     def test_basic_functionality(self):
         """Test main use case for the form."""
 
         # Send the form
-        form_data = {'subtitle': self.new_subtitle}
+        form_data = {"subtitle": self.new_subtitle}
         self.client.post(self.form_url, form_data)
 
         # Check updating of the database

--- a/zds/tutorialv2/tests/tests_views/tests_editcontentsubtitle.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontentsubtitle.py
@@ -1,0 +1,144 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.html import escape
+
+from zds.tutorialv2.models.database import PublishableContent
+from zds.tutorialv2.views.contents import EditContentSubtitle
+from zds.tutorialv2.forms import EditContentSubtitleForm
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.tutorialv2.factories import PublishableContentFactory
+
+
+@override_for_contents()
+class EditContentSubtitlePermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author])
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-subtitle', kwargs={'pk': self.content.pk})
+        self.form_data = {'subtitle': 'Pretty standard subtitle'}
+        self.content_data = {'pk': self.content.pk, 'slug': self.content.slug}
+        self.content_url = reverse('content:view', kwargs=self.content_data)
+        self.login_url = reverse('member-login') + '?next=' + self.form_url
+
+    def test_not_authenticated(self):
+        """Test that on form submission, unauthenticated users are redirected to the login page."""
+        self.client.logout()  # ensure no user is authenticated
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_author(self):
+        """Test that on form submission, authors are redirected to the content page."""
+        login_success = self.client.login(username=self.author.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff(self):
+        """Test that on form submission, staffs are redirected to the content page."""
+        login_success = self.client.login(username=self.staff.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_outsider(self):
+        """Test that on form submission, unauthorized users get a 403."""
+        login_success = self.client.login(username=self.outsider.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEquals(response.status_code, 403)
+
+
+@override_for_contents()
+class EditContentSubtitleWorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author.user])
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-subtitle', kwargs={'pk': self.content.pk})
+        self.error_messages = EditContentSubtitleForm.declared_fields['subtitle'].error_messages
+        self.success_message = EditContentSubtitle.success_message
+
+        # Log in with an authorized user (e.g the author of the content) to perform the tests
+        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        self.assertTrue(login_success)
+
+    def get_test_cases(self):
+        subtitle_too_long = 's' * (PublishableContent._meta.get_field('description').max_length + 1)
+        return {
+            'empty_form': {
+                'inputs': {},
+                'expected_outputs': [self.success_message]
+            },
+            'empty_fields': {
+                'inputs': {'subtitle': ''},
+                'expected_outputs': [self.success_message]
+            },
+            'too_long': {
+                'inputs': {'subtitle': subtitle_too_long},
+                'expected_outputs': [self.error_messages['max_length']]
+            },
+            'success': {
+                'inputs': {'subtitle': 'Pretty standard subtitle'},
+                'expected_outputs': [self.success_message]
+            },
+        }
+
+    def test_form_workflow(self):
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                response = self.client.post(self.form_url, case['inputs'], follow=True)
+                for msg in case['expected_outputs']:
+                    self.assertContains(response, escape(msg))
+
+
+@override_for_contents()
+class EditContentSubtitleFunctionalTests(TutorialTestMixin, TestCase):
+    """Test the detailed behavior of the feature, such as updates of the database or repositories."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author.user])
+        self.initial_subtitle = self.content.description
+        self.new_subtitle = 'The other subtitle, definitely different from the other'
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-subtitle', kwargs={'pk': self.content.pk})
+
+        # Log in with an authorized user (e.g the author of the content) to perform the tests
+        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        self.assertTrue(login_success)
+
+    def test_basic_functionality(self):
+        """Test main use case for the form."""
+
+        # Send the form
+        form_data = {'subtitle': self.new_subtitle}
+        self.client.post(self.form_url, form_data)
+
+        # Check updating of the database
+        updated_content = PublishableContent.objects.get(pk=self.content.pk)
+        self.assertEqual(updated_content.description, self.new_subtitle)
+
+        # Check updating of the repository
+        versioned = updated_content.load_version()
+        self.assertEqual(versioned.description, self.new_subtitle)

--- a/zds/tutorialv2/tests/tests_views/tests_editcontenttitle.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontenttitle.py
@@ -24,11 +24,11 @@ class EditContentTitlePermissionTests(TutorialTestMixin, TestCase):
         self.content = PublishableContentFactory(author_list=[self.author])
 
         # Get information to be reused in tests
-        self.form_url = reverse('content:edit-title', kwargs={'pk': self.content.pk})
-        self.form_data = {'title': 'This very title is bidonné but valid'}
-        self.content_data = {'pk': self.content.pk, 'slug': self.content.slug}
-        self.content_url = reverse('content:view', kwargs=self.content_data)
-        self.login_url = reverse('member-login') + '?next=' + self.form_url
+        self.form_url = reverse("content:edit-title", kwargs={"pk": self.content.pk})
+        self.form_data = {"title": "This very title is bidonné but valid"}
+        self.content_data = {"pk": self.content.pk, "slug": self.content.slug}
+        self.content_url = reverse("content:view", kwargs=self.content_data)
+        self.login_url = reverse("member-login") + "?next=" + self.form_url
 
     def test_not_authenticated(self):
         """Test that on form submission, unauthenticated users are redirected to the login page."""
@@ -38,21 +38,21 @@ class EditContentTitlePermissionTests(TutorialTestMixin, TestCase):
 
     def test_authenticated_author(self):
         """Test that on form submission, authors are redirected to the content page."""
-        login_success = self.client.login(username=self.author.username, password='hostel77')
+        login_success = self.client.login(username=self.author.username, password="hostel77")
         self.assertTrue(login_success)
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_staff(self):
         """Test that on form submission, staffs are redirected to the content page."""
-        login_success = self.client.login(username=self.staff.username, password='hostel77')
+        login_success = self.client.login(username=self.staff.username, password="hostel77")
         self.assertTrue(login_success)
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_outsider(self):
         """Test that on form submission, unauthorized users get a 403."""
-        login_success = self.client.login(username=self.outsider.username, password='hostel77')
+        login_success = self.client.login(username=self.outsider.username, password="hostel77")
         self.assertTrue(login_success)
         response = self.client.post(self.form_url, self.form_data)
         self.assertEquals(response.status_code, 403)
@@ -70,37 +70,28 @@ class EditContentTitleWorkflowTests(TutorialTestMixin, TestCase):
         self.content = PublishableContentFactory(author_list=[self.author.user])
 
         # Get information to be reused in tests
-        self.form_url = reverse('content:edit-title', kwargs={'pk': self.content.pk})
-        self.error_messages = EditContentTitleForm.declared_fields['title'].error_messages
+        self.form_url = reverse("content:edit-title", kwargs={"pk": self.content.pk})
+        self.error_messages = EditContentTitleForm.declared_fields["title"].error_messages
         self.success_message = EditContentTitle.success_message
 
         # Log in with an authorized user (e.g the author of the content) to perform the tests
-        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        login_success = self.client.login(username=self.author.user.username, password="hostel77")
         self.assertTrue(login_success)
 
     def get_test_cases(self):
-        title_with_invalid_slug = '?'
-        title_too_long = 't' * (PublishableContent._meta.get_field('title').max_length + 1)
+        title_with_invalid_slug = "?"
+        title_too_long = "t" * (PublishableContent._meta.get_field("title").max_length + 1)
         return {
-            'empty_form': {
-                'inputs': {},
-                'expected_outputs': [self.error_messages['required']]
+            "empty_form": {"inputs": {}, "expected_outputs": [self.error_messages["required"]]},
+            "empty_fields": {"inputs": {"title": ""}, "expected_outputs": [self.error_messages["required"]]},
+            "invalid_title_slug": {
+                "inputs": {"title": title_with_invalid_slug},
+                "expected_outputs": [self.error_messages["invalid_slug"]],
             },
-            'empty_fields': {
-                'inputs': {'title': ''},
-                'expected_outputs': [self.error_messages['required']]
-            },
-            'invalid_title_slug': {
-                'inputs': {'title': title_with_invalid_slug},
-                'expected_outputs': [self.error_messages['invalid_slug']]
-            },
-            'too_long': {
-                'inputs': {'title': title_too_long},
-                'expected_outputs': [self.error_messages['max_length']]
-            },
-            'success': {
-                'inputs': {'title': 'Titre bien bidonné mais valide'},
-                'expected_outputs': [self.success_message]
+            "too_long": {"inputs": {"title": title_too_long}, "expected_outputs": [self.error_messages["max_length"]]},
+            "success": {
+                "inputs": {"title": "Titre bien bidonné mais valide"},
+                "expected_outputs": [self.success_message],
             },
         }
 
@@ -108,8 +99,8 @@ class EditContentTitleWorkflowTests(TutorialTestMixin, TestCase):
         test_cases = self.get_test_cases()
         for case_name, case in test_cases.items():
             with self.subTest(msg=case_name):
-                response = self.client.post(self.form_url, case['inputs'], follow=True)
-                for msg in case['expected_outputs']:
+                response = self.client.post(self.form_url, case["inputs"], follow=True)
+                for msg in case["expected_outputs"]:
                     self.assertContains(response, escape(msg))
 
 
@@ -124,20 +115,20 @@ class EditContentTitleFunctionalTests(TutorialTestMixin, TestCase):
         # Create a content
         self.content = PublishableContentFactory(author_list=[self.author.user])
         self.initial_title = self.content.title
-        self.new_title = 'The other title, definitely different from the other'
+        self.new_title = "The other title, definitely different from the other"
 
         # Get information to be reused in tests
-        self.form_url = reverse('content:edit-title', kwargs={'pk': self.content.pk})
+        self.form_url = reverse("content:edit-title", kwargs={"pk": self.content.pk})
 
         # Log in with an authorized user (e.g the author of the content) to perform the tests
-        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        login_success = self.client.login(username=self.author.user.username, password="hostel77")
         self.assertTrue(login_success)
 
     def test_basic_functionality(self):
         """Test main use case for the form."""
 
         # Send the form
-        form_data = {'title': self.new_title}
+        form_data = {"title": self.new_title}
         self.client.post(self.form_url, form_data)
 
         # Check updating of the database

--- a/zds/tutorialv2/tests/tests_views/tests_editcontenttitle.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontenttitle.py
@@ -1,0 +1,149 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.html import escape
+
+from zds.tutorialv2.models.database import PublishableContent
+from zds.tutorialv2.views.contents import EditContentTitle
+from zds.tutorialv2.forms import EditContentTitleForm
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.tutorialv2.factories import PublishableContentFactory
+
+
+@override_for_contents()
+class EditContentTitlePermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author])
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-title', kwargs={'pk': self.content.pk})
+        self.form_data = {'title': 'This very title is bidonné but valid'}
+        self.content_data = {'pk': self.content.pk, 'slug': self.content.slug}
+        self.content_url = reverse('content:view', kwargs=self.content_data)
+        self.login_url = reverse('member-login') + '?next=' + self.form_url
+
+    def test_not_authenticated(self):
+        """Test that on form submission, unauthenticated users are redirected to the login page."""
+        self.client.logout()  # ensure no user is authenticated
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_author(self):
+        """Test that on form submission, authors are redirected to the content page."""
+        login_success = self.client.login(username=self.author.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff(self):
+        """Test that on form submission, staffs are redirected to the content page."""
+        login_success = self.client.login(username=self.staff.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_outsider(self):
+        """Test that on form submission, unauthorized users get a 403."""
+        login_success = self.client.login(username=self.outsider.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEquals(response.status_code, 403)
+
+
+@override_for_contents()
+class EditContentTitleWorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author.user])
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-title', kwargs={'pk': self.content.pk})
+        self.error_messages = EditContentTitleForm.declared_fields['title'].error_messages
+        self.success_message = EditContentTitle.success_message
+
+        # Log in with an authorized user (e.g the author of the content) to perform the tests
+        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        self.assertTrue(login_success)
+
+    def get_test_cases(self):
+        title_with_invalid_slug = '?'
+        title_too_long = 't' * (PublishableContent._meta.get_field('title').max_length + 1)
+        return {
+            'empty_form': {
+                'inputs': {},
+                'expected_outputs': [self.error_messages['required']]
+            },
+            'empty_fields': {
+                'inputs': {'title': ''},
+                'expected_outputs': [self.error_messages['required']]
+            },
+            'invalid_title_slug': {
+                'inputs': {'title': title_with_invalid_slug},
+                'expected_outputs': [self.error_messages['invalid_slug']]
+            },
+            'too_long': {
+                'inputs': {'title': title_too_long},
+                'expected_outputs': [self.error_messages['max_length']]
+            },
+            'success': {
+                'inputs': {'title': 'Titre bien bidonné mais valide'},
+                'expected_outputs': [self.success_message]
+            },
+        }
+
+    def test_form_workflow(self):
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                response = self.client.post(self.form_url, case['inputs'], follow=True)
+                for msg in case['expected_outputs']:
+                    self.assertContains(response, escape(msg))
+
+
+@override_for_contents()
+class EditContentTitleFunctionalTests(TutorialTestMixin, TestCase):
+    """Test the detailed behavior of the feature, such as updates of the database or repositories."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author.user])
+        self.initial_title = self.content.title
+        self.new_title = 'The other title, definitely different from the other'
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-title', kwargs={'pk': self.content.pk})
+
+        # Log in with an authorized user (e.g the author of the content) to perform the tests
+        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        self.assertTrue(login_success)
+
+    def test_basic_functionality(self):
+        """Test main use case for the form."""
+
+        # Send the form
+        form_data = {'title': self.new_title}
+        self.client.post(self.form_url, form_data)
+
+        # Check updating of the database
+        updated_content = PublishableContent.objects.get(pk=self.content.pk)
+        self.assertEqual(updated_content.title, self.new_title)
+
+        # Check updating of the repository
+        versioned = updated_content.load_version()
+        self.assertEqual(versioned.title, self.new_title)

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -1190,14 +1190,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                'title': '{} ({})'.format(self.tuto.title, 'modified'),  # will change slug
-                'introduction': random,
-                'conclusion': random,
-                'type': 'TUTORIAL',
-                'licence': self.tuto.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': tuto.load_version().compute_hash(),
-                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
+                "title": "{} ({})".format(self.tuto.title, "modified"),  # will change slug
+                "introduction": random,
+                "conclusion": random,
+                "type": "TUTORIAL",
+                "licence": self.tuto.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": tuto.load_version().compute_hash(),
+                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
             },
             follow=False,
         )
@@ -1296,13 +1296,13 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                'title': new_title,
-                'introduction': 'a',
-                'conclusion': 'b',
-                'type': 'TUTORIAL',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': tuto.sha_draft,
+                "title": new_title,
+                "introduction": "a",
+                "conclusion": "b",
+                "type": "TUTORIAL",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": tuto.sha_draft,
             },
             follow=False,
         )
@@ -1340,14 +1340,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[article.pk, article.slug]),
             {
-                'title': 'new title so that everything explode',
-                'introduction': article.load_version().get_introduction(),
-                'conclusion': article.load_version().get_conclusion(),
-                'type': 'ARTICLE',
-                'licence': article.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': article.load_version(article.sha_draft).compute_hash(),
-                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
+                "title": "new title so that everything explode",
+                "introduction": article.load_version().get_introduction(),
+                "conclusion": article.load_version().get_conclusion(),
+                "type": "ARTICLE",
+                "licence": article.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": article.load_version(article.sha_draft).compute_hash(),
+                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
             },
             follow=False,
         )
@@ -1396,13 +1396,13 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[published.pk, published.slug]),
             {
-                'title': published.title,
-                'introduction': 'crappy crap',
-                'conclusion': 'crappy crap',
-                'type': 'TUTORIAL',
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': published.load_version().compute_hash()  # good hash
+                "title": published.title,
+                "introduction": "crappy crap",
+                "conclusion": "crappy crap",
+                "type": "TUTORIAL",
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": published.load_version().compute_hash(),  # good hash
             },
             follow=True,
         )
@@ -1469,14 +1469,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[content_draft.pk, content_draft.slug]),
             {
-                'title': content_draft.title + '2',
-                'introduction': content_draft.introduction,
-                'conclusion': content_draft.conclusion,
-                'type': content_draft.type,
-                'licence': self.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': content_draft.compute_hash(),
-                'image': content_draft.image or 'None'
+                "title": content_draft.title + "2",
+                "introduction": content_draft.introduction,
+                "conclusion": content_draft.conclusion,
+                "type": content_draft.type,
+                "licence": self.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": content_draft.compute_hash(),
+                "image": content_draft.image or "None",
             },
             follow=False,
         )
@@ -1988,14 +1988,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[self.tuto.pk, self.tuto.slug]),
             {
-                'title': self.tuto.title,
-                'introduction': '',
-                'conclusion': '',
-                'type': 'TUTORIAL',
-                'licence': self.tuto.licence.pk,
-                'subcategory': self.subcategory.pk,
-                'last_hash': self.tuto.load_version().compute_hash(),
-                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
+                "title": self.tuto.title,
+                "introduction": "",
+                "conclusion": "",
+                "type": "TUTORIAL",
+                "licence": self.tuto.licence.pk,
+                "subcategory": self.subcategory.pk,
+                "last_hash": self.tuto.load_version().compute_hash(),
+                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
             },
             follow=True,
         )

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -1190,15 +1190,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                "title": "{} ({})".format(self.tuto.title, "modified"),  # will change slug
-                "description": random,
-                "introduction": random,
-                "conclusion": random,
-                "type": "TUTORIAL",
-                "licence": self.tuto.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": tuto.load_version().compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
+                'title': '{} ({})'.format(self.tuto.title, 'modified'),  # will change slug
+                'introduction': random,
+                'conclusion': random,
+                'type': 'TUTORIAL',
+                'licence': self.tuto.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': tuto.load_version().compute_hash(),
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False,
         )
@@ -1297,14 +1296,13 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[tuto.pk, tuto.slug]),
             {
-                "title": new_title,
-                "description": tuto.description,
-                "introduction": "a",
-                "conclusion": "b",
-                "type": "TUTORIAL",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": tuto.sha_draft,
+                'title': new_title,
+                'introduction': 'a',
+                'conclusion': 'b',
+                'type': 'TUTORIAL',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': tuto.sha_draft,
             },
             follow=False,
         )
@@ -1342,15 +1340,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[article.pk, article.slug]),
             {
-                "title": "new title so that everything explode",
-                "description": article.description,
-                "introduction": article.load_version().get_introduction(),
-                "conclusion": article.load_version().get_conclusion(),
-                "type": "ARTICLE",
-                "licence": article.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": article.load_version(article.sha_draft).compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
+                'title': 'new title so that everything explode',
+                'introduction': article.load_version().get_introduction(),
+                'conclusion': article.load_version().get_conclusion(),
+                'type': 'ARTICLE',
+                'licence': article.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': article.load_version(article.sha_draft).compute_hash(),
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=False,
         )
@@ -1399,14 +1396,13 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[published.pk, published.slug]),
             {
-                "title": published.title,
-                "description": published.description,
-                "introduction": "crappy crap",
-                "conclusion": "crappy crap",
-                "type": "TUTORIAL",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": published.load_version().compute_hash(),  # good hash
+                'title': published.title,
+                'introduction': 'crappy crap',
+                'conclusion': 'crappy crap',
+                'type': 'TUTORIAL',
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': published.load_version().compute_hash()  # good hash
             },
             follow=True,
         )
@@ -1473,15 +1469,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[content_draft.pk, content_draft.slug]),
             {
-                "title": content_draft.title + "2",
-                "description": content_draft.description,
-                "introduction": content_draft.introduction,
-                "conclusion": content_draft.conclusion,
-                "type": content_draft.type,
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": content_draft.compute_hash(),
-                "image": content_draft.image or "None",
+                'title': content_draft.title + '2',
+                'introduction': content_draft.introduction,
+                'conclusion': content_draft.conclusion,
+                'type': content_draft.type,
+                'licence': self.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': content_draft.compute_hash(),
+                'image': content_draft.image or 'None'
             },
             follow=False,
         )
@@ -1993,15 +1988,14 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.post(
             reverse("content:edit", args=[self.tuto.pk, self.tuto.slug]),
             {
-                "title": self.tuto.title,
-                "description": self.tuto.description,
-                "introduction": "",
-                "conclusion": "",
-                "type": "TUTORIAL",
-                "licence": self.tuto.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": self.tuto.load_version().compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
+                'title': self.tuto.title,
+                'introduction': '',
+                'conclusion': '',
+                'type': 'TUTORIAL',
+                'licence': self.tuto.licence.pk,
+                'subcategory': self.subcategory.pk,
+                'last_hash': self.tuto.load_version().compute_hash(),
+                'image': (settings.BASE_DIR / 'fixtures' / 'logo.png').open('rb')
             },
             follow=True,
         )

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -1,7 +1,9 @@
 from django.urls import path, re_path
 from django.views.generic.base import RedirectView
 
-from zds.tutorialv2.views.contents import DisplayContent, CreateContent, EditContent, EditContentLicense, DeleteContent
+from zds.tutorialv2.views.contents import (DisplayContent, CreateContent, EditContent,
+                                           EditContentLicense, EditContentTitle, EditContentSubtitle,
+                                           DeleteContent)
 from zds.tutorialv2.views.validations_contents import ActivateJSFiddleInContent
 from zds.tutorialv2.views.containers_extracts import (
     CreateContainer,
@@ -154,7 +156,12 @@ urlpatterns = [
     re_path(r"^ajouter-auteur/(?P<pk>\d+)/$", AddAuthorToContent.as_view(), name="add-author"),
     re_path(r"^enlever-auteur/(?P<pk>\d+)/$", RemoveAuthorFromContent.as_view(), name="remove-author"),
     # Modify the license
-    re_path(r"^modifier-licence/(?P<pk>\d+)/$", EditContentLicense.as_view(), name="edit-license"),
+    re_path(r'^modifier-licence/(?P<pk>\d+)/$', EditContentLicense.as_view(), name='edit-license'),
+    # Modify the title
+    re_path(r'^modifier-titre/(?P<pk>\d+)/$', EditContentTitle.as_view(), name='edit-title'),
+    # Modify the subtitle
+    re_path(r'^modifier-sous-titre/(?P<pk>\d+)/$', EditContentSubtitle.as_view(), name='edit-subtitle'),
+
     # Modify the tags
     re_path(r"^modifier-tags/(?P<pk>\d+)/$", EditContentTags.as_view(), name="edit-tags"),
     # beta:

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -1,9 +1,15 @@
 from django.urls import path, re_path
 from django.views.generic.base import RedirectView
 
-from zds.tutorialv2.views.contents import (DisplayContent, CreateContent, EditContent,
-                                           EditContentLicense, EditContentTitle, EditContentSubtitle,
-                                           DeleteContent)
+from zds.tutorialv2.views.contents import (
+    DisplayContent,
+    CreateContent,
+    EditContent,
+    EditContentLicense,
+    EditContentTitle,
+    EditContentSubtitle,
+    DeleteContent,
+)
 from zds.tutorialv2.views.validations_contents import ActivateJSFiddleInContent
 from zds.tutorialv2.views.containers_extracts import (
     CreateContainer,
@@ -156,12 +162,11 @@ urlpatterns = [
     re_path(r"^ajouter-auteur/(?P<pk>\d+)/$", AddAuthorToContent.as_view(), name="add-author"),
     re_path(r"^enlever-auteur/(?P<pk>\d+)/$", RemoveAuthorFromContent.as_view(), name="remove-author"),
     # Modify the license
-    re_path(r'^modifier-licence/(?P<pk>\d+)/$', EditContentLicense.as_view(), name='edit-license'),
+    re_path(r"^modifier-licence/(?P<pk>\d+)/$", EditContentLicense.as_view(), name="edit-license"),
     # Modify the title
-    re_path(r'^modifier-titre/(?P<pk>\d+)/$', EditContentTitle.as_view(), name='edit-title'),
+    re_path(r"^modifier-titre/(?P<pk>\d+)/$", EditContentTitle.as_view(), name="edit-title"),
     # Modify the subtitle
-    re_path(r'^modifier-sous-titre/(?P<pk>\d+)/$', EditContentSubtitle.as_view(), name='edit-subtitle'),
-
+    re_path(r"^modifier-sous-titre/(?P<pk>\d+)/$", EditContentSubtitle.as_view(), name="edit-subtitle"),
     # Modify the tags
     re_path(r"^modifier-tags/(?P<pk>\d+)/$", EditContentTags.as_view(), name="edit-tags"),
     # beta:

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -16,12 +16,30 @@ from zds.gallery.mixins import ImageCreateMixin, NotAnImage
 from zds.gallery.models import Gallery, Image
 from zds.member.decorator import LoggedWithReadWriteHability, LoginRequiredMixin
 from zds.member.models import Profile
-from zds.tutorialv2.forms import ContentForm, JsFiddleActivationForm, AskValidationForm, AcceptValidationForm, \
-    RejectValidationForm, RevokeValidationForm, WarnTypoForm, CancelValidationForm, PublicationForm, \
-    UnpublicationForm, ContributionForm, SearchSuggestionForm, EditContentLicenseForm, EditContentTagsForm, \
-    EditContentTitleForm, EditContentSubtitleForm
-from zds.tutorialv2.mixins import SingleContentDetailViewMixin, SingleContentFormViewMixin, SingleContentViewMixin, \
-    FormWithPreview
+from zds.tutorialv2.forms import (
+    ContentForm,
+    JsFiddleActivationForm,
+    AskValidationForm,
+    AcceptValidationForm,
+    RejectValidationForm,
+    RevokeValidationForm,
+    WarnTypoForm,
+    CancelValidationForm,
+    PublicationForm,
+    UnpublicationForm,
+    ContributionForm,
+    SearchSuggestionForm,
+    EditContentLicenseForm,
+    EditContentTagsForm,
+    EditContentTitleForm,
+    EditContentSubtitleForm,
+)
+from zds.tutorialv2.mixins import (
+    SingleContentDetailViewMixin,
+    SingleContentFormViewMixin,
+    SingleContentViewMixin,
+    FormWithPreview,
+)
 from zds.tutorialv2.models.database import PublishableContent, Validation, ContentContribution, ContentSuggestion
 from zds.tutorialv2.utils import init_new_repo
 from zds.tutorialv2.views.authors import RemoveAuthorFromContent
@@ -69,8 +87,8 @@ class CreateContent(LoggedWithReadWriteHability, FormWithPreview):
 
         # create the object:
         self.content = PublishableContent()
-        self.content.title = form.cleaned_data['title']
-        self.content.type = form.cleaned_data['type']
+        self.content.title = form.cleaned_data["title"]
+        self.content.type = form.cleaned_data["type"]
         self.content.licence = self.request.user.profile.licence  # Use the preferred license of the user if it exists
         self.content.source = form.cleaned_data["source"]
         self.content.creation_date = datetime.now()
@@ -154,12 +172,12 @@ class DisplayContent(LoginRequiredMixin, SingleContentDetailViewMixin):
         if self.versioned_object.is_beta:
             context["formWarnTypo"] = WarnTypoForm(self.versioned_object, self.versioned_object, public=False)
 
-        context['validation'] = validation
-        context['formJs'] = form_js
-        context['form_edit_license'] = EditContentLicenseForm(self.versioned_object)
-        context['form_edit_title'] = EditContentTitleForm(self.versioned_object)
-        context['form_edit_subtitle'] = EditContentSubtitleForm(self.versioned_object)
-        context['form_edit_tags'] = EditContentTagsForm(self.versioned_object, self.object)
+        context["validation"] = validation
+        context["formJs"] = form_js
+        context["form_edit_license"] = EditContentLicenseForm(self.versioned_object)
+        context["form_edit_title"] = EditContentTitleForm(self.versioned_object)
+        context["form_edit_subtitle"] = EditContentSubtitleForm(self.versioned_object)
+        context["form_edit_tags"] = EditContentTagsForm(self.versioned_object, self.object)
 
         if self.versioned_object.requires_validation:
             context["formPublication"] = PublicationForm(self.versioned_object, initial={"source": self.object.source})
@@ -205,13 +223,13 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         initial = super().get_initial()
         versioned = self.versioned_object
 
-        initial['title'] = versioned.title
-        initial['type'] = versioned.type
-        initial['introduction'] = versioned.get_introduction()
-        initial['conclusion'] = versioned.get_conclusion()
-        initial['source'] = versioned.source
-        initial['subcategory'] = self.object.subcategory.all()
-        initial['last_hash'] = versioned.compute_hash()
+        initial["title"] = versioned.title
+        initial["type"] = versioned.type
+        initial["introduction"] = versioned.get_introduction()
+        initial["conclusion"] = versioned.get_conclusion()
+        initial["source"] = versioned.source
+        initial["subcategory"] = self.object.subcategory.all()
+        initial["last_hash"] = versioned.compute_hash()
 
         return initial
 
@@ -245,9 +263,9 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
             return self.form_invalid(form)
 
         # first, update DB (in order to get a new slug if needed)
-        title_is_changed = publishable.title != form.cleaned_data['title']
-        publishable.title = form.cleaned_data['title']
-        publishable.source = form.cleaned_data['source']
+        title_is_changed = publishable.title != form.cleaned_data["title"]
+        publishable.title = form.cleaned_data["title"]
+        publishable.source = form.cleaned_data["source"]
 
         publishable.update_date = datetime.now()
 
@@ -270,15 +288,17 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
             publishable.image = img
 
         publishable.save(force_slug_update=title_is_changed)
-        logger.debug('content %s updated, slug is %s', publishable.pk, publishable.slug)
+        logger.debug("content %s updated, slug is %s", publishable.pk, publishable.slug)
 
         # now, update the versioned information
-        sha = versioned.repo_update_top_container(form.cleaned_data['title'],
-                                                  publishable.slug,
-                                                  form.cleaned_data['introduction'],
-                                                  form.cleaned_data['conclusion'],
-                                                  form.cleaned_data['msg_commit'])
-        logger.debug('slug consistency after repo update repo=%s db=%s', versioned.slug, publishable.slug)
+        sha = versioned.repo_update_top_container(
+            form.cleaned_data["title"],
+            publishable.slug,
+            form.cleaned_data["introduction"],
+            form.cleaned_data["conclusion"],
+            form.cleaned_data["msg_commit"],
+        )
+        logger.debug("slug consistency after repo update repo=%s db=%s", versioned.slug, publishable.slug)
         # update relationships :
         publishable.sha_draft = sha
 
@@ -342,16 +362,16 @@ class EditContentTitle(LoginRequiredMixin, SingleContentFormViewMixin):
     modal_form = True
     model = PublishableContent
     form_class = EditContentTitleForm
-    success_message = _('Le titre a bien été changé.')
+    success_message = _("Le titre a bien été changé.")
 
     def get_form_kwargs(self):
         kwargs = super(EditContentTitle, self).get_form_kwargs()
-        kwargs['versioned_content'] = self.versioned_object
+        kwargs["versioned_content"] = self.versioned_object
         return kwargs
 
     def form_valid(self, form):
         publishable = self.object
-        title = form.cleaned_data['title']
+        title = form.cleaned_data["title"]
 
         # Update title in database
         publishable.title = title
@@ -365,7 +385,7 @@ class EditContentTitle(LoginRequiredMixin, SingleContentFormViewMixin):
             publishable.slug,
             self.versioned_object.get_introduction(),
             self.versioned_object.get_conclusion(),
-            f'Changement du titre ({title})'
+            f"Changement du titre ({title})",
         )
 
         # Update relationships in database
@@ -381,16 +401,16 @@ class EditContentSubtitle(LoginRequiredMixin, SingleContentFormViewMixin):
     modal_form = True
     model = PublishableContent
     form_class = EditContentSubtitleForm
-    success_message = _('Le sous-titre a bien été changé.')
+    success_message = _("Le sous-titre a bien été changé.")
 
     def get_form_kwargs(self):
         kwargs = super(EditContentSubtitle, self).get_form_kwargs()
-        kwargs['versioned_content'] = self.versioned_object
+        kwargs["versioned_content"] = self.versioned_object
         return kwargs
 
     def form_valid(self, form):
         publishable = self.object
-        subtitle = form.cleaned_data['subtitle']
+        subtitle = form.cleaned_data["subtitle"]
 
         # Update subtitle in database
         publishable.description = subtitle
@@ -404,7 +424,7 @@ class EditContentSubtitle(LoginRequiredMixin, SingleContentFormViewMixin):
             publishable.slug,
             self.versioned_object.get_introduction(),
             self.versioned_object.get_conclusion(),
-            'Changement du sous-titre'
+            "Changement du sous-titre",
         )
 
         # Update relationships in database


### PR DESCRIPTION
Fix #5796.

Ça ressemble à ça :

![image](https://user-images.githubusercontent.com/35631001/82704487-ec6e9c00-9c75-11ea-82c1-e1e43936c8f1.png)


Et quand on clique pour afficher le formulaire :

![image](https://user-images.githubusercontent.com/35631001/82704518-00b29900-9c76-11ea-9129-c6f2fc153bfb.png)

![image](https://user-images.githubusercontent.com/35631001/82704560-1d4ed100-9c76-11ea-8906-b585eb3751be.png)



### Contrôle qualité

En tant que simple visiteur ou simple membre (ni auteur, ni staff) :

* regarder l'affichage correct des titres et sous-titres sur tout le site (tutoriels, articles, billets, forums, et pages classiques (dans le profil, les listes de contenus, etc.)
* vérifier l'absence des boutons de modification des tutos/articles/billets quand on est publié ou en bêta ;
* vérifier qu'on se prend les erreurs adéquates quand on tente de se servir malicieusement des formulaires ;

En tant qu'auteur ou staff :

* vérifier la présence des boutons de modification ;
* vérifier que le bouton de la description change entre le petit stylo et "Ajouter un sous-titre" selon la présence ou non d'un sous-titre ;
* vérifier le bon affichage/désaffichage des formulaires quand on joue avec les boutons modifier/annuler ;
* vérifier la fonctionnalité nominale des formulaires (bon changement du titre et de la description, messages de confirmation, etc.)
* vérifier la fonctionnalité des formulaires pour les erreurs quand on a les droits pour s'en servir (slug invalide, etc.)