### PR TITLE
Simplifie le watchdog de publication

### DIFF
--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -418,18 +418,15 @@ class ZMarkdownRebberLatexPublicator(Publicator):
         with open(latex_file_path, mode='w', encoding='utf-8') as latex_file:
             latex_file.write(content)
 
-        try:
-            self.full_tex_compiler_call(latex_file_path, draftmode='-draftmode')
-            self.full_tex_compiler_call(latex_file_path, draftmode='-draftmode')
-            self.make_glossary(base_name.split('/')[-1], latex_file_path)
-            self.full_tex_compiler_call(latex_file_path)
-        except FailureDuringPublication:
-            logging.getLogger(self.__class__.__name__).exception('could not publish %s', base_name + self.extension)
-        else:
-            shutil.copy2(latex_file_path, published_content_entity.get_extra_contents_directory())
-            shutil.copy2(pdf_file_path, published_content_entity.get_extra_contents_directory())
-            logging.info('published latex=%s, pdf=%s', published_content_entity.has_type('tex'),
-                         published_content_entity.has_type(self.doc_type))
+        self.full_tex_compiler_call(latex_file_path, draftmode='-draftmode')
+        self.full_tex_compiler_call(latex_file_path, draftmode='-draftmode')
+        self.make_glossary(base_name.split('/')[-1], latex_file_path)
+        self.full_tex_compiler_call(latex_file_path)
+
+        shutil.copy2(latex_file_path, published_content_entity.get_extra_contents_directory())
+        shutil.copy2(pdf_file_path, published_content_entity.get_extra_contents_directory())
+        logging.info('published latex=%s, pdf=%s', published_content_entity.has_type('tex'),
+                     published_content_entity.has_type(self.doc_type))
 
     def full_tex_compiler_call(self, latex_file, draftmode: str = ''):
         success_flag = self.tex_compiler(latex_file, draftmode)

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -417,16 +417,14 @@ class ZMarkdownRebberLatexPublicator(Publicator):
             shutil.copy(str(default_logo_original_path), str(base_directory / 'default_logo.png'))
         with open(latex_file_path, mode='w', encoding='utf-8') as latex_file:
             latex_file.write(content)
+        shutil.copy2(latex_file_path, published_content_entity.get_extra_contents_directory())
 
         self.full_tex_compiler_call(latex_file_path, draftmode='-draftmode')
         self.full_tex_compiler_call(latex_file_path, draftmode='-draftmode')
         self.make_glossary(base_name.split('/')[-1], latex_file_path)
         self.full_tex_compiler_call(latex_file_path)
 
-        shutil.copy2(latex_file_path, published_content_entity.get_extra_contents_directory())
         shutil.copy2(pdf_file_path, published_content_entity.get_extra_contents_directory())
-        logging.info('published latex=%s, pdf=%s', published_content_entity.has_type('tex'),
-                     published_content_entity.has_type(self.doc_type))
 
     def full_tex_compiler_call(self, latex_file, draftmode: str = ''):
         success_flag = self.tex_compiler(latex_file, draftmode)


### PR DESCRIPTION
Voici un petit nettoyage du watchdog de publication qui le simplifie et ça devrait régler nos soucis. Auparavant on lançait plusieurs générations d'export en parallèle mais on s'est rendu compte que ça causait pas mal d'erreurs "MySQL has gone away" donc on est ne parallélise plus. Plus besoin donc de `concurrent.futures` que j'ai enlevé.

Si jamais on voit l'erreur `FailureDuringPublication`, le *watchdog* continue de tourner. Si jamais on a une autre erreur (du style "MySQL has gone away") alors normalement le *watchdog* devrait planter et être redémarrer par systemd.

On regarde s'il y a des exports en attente toutes les minutes au lieu de 10 secondes pour ne pas surcharger inutilement le serveur MySQL.

N'hésitez pas à donner vos avis !

**Instructions de QA :**

- Console 1 :  `source zdsenv/bin/activate` puis `make zmd-start` et `make run-back`
- Console 2 : `source zdsenv/bin/activate` puis `python manage.py publication_watchdog` (si des exportations se lancent c'est normal, il faut attendre qu'elles finissent)
- Onglet du navigateur 1 : Se connecter avec `admin`
- Onglet du navigateur 2 : Aller sur http://127.0.0.1:8000/admin/tutorialv2/publicationevent/
- Onglet du navigateur 1 : Aller sur un contenu et cliquer sur "Exporter le contenu"
- Onglet du navigateur 2 : Vérifier que de nouveaux événements ont été créés et sont en état "Export demandé"
- Console 2 : Vérifier qu'au bout d'une minute (ou moins), les exportations se lancent une par une (à la suite)
- Console 2 : Vérifier qu'il y a bien un message au lancement que chaque exportation et une à la fin (*failed* ou *succeed*)
- Onglet du navigateur 2 : Vérifier que les nouveaux événements apparaissent bien en "Export demandé" ou "Export échoué"
- Onglet du navigateur 1 : Aller sur un contenu et cliquer sur "Exporter le contenu"
- Console 2 : Lorsque les exportations se lancent, tuer le processus avec CTRL+C
- Onglet du navigateur 2 : Vérifier qu'un des nouveaux événements apparaît bien en "Export en cours"
- Console 2 : Relancer la commande
- Onglet du navigateur 2 : Vérifier que l'événement qui apparaissait en "Export en cours" apparaît maintenant en "Export échoué"
