### PR TITLE
Corrige la modale de publication d'un billet (lien vers la licence)

### DIFF
--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1197,15 +1197,14 @@ class PublicationForm(forms.Form):
         self.no_subcategories = content.subcategory.count() == 0
         no_category_msg = HTML(_("""<p><strong>Votre publication n'est dans aucune catégorie.
                                     Vous devez <a href="{}#{}">choisir une catégorie</a>
-                                    avant de demander la validation.</strong></p>"""
+                                    avant de publier.</strong></p>"""
                                  .format(reverse('content:edit', kwargs={'pk': content.pk, 'slug': content.slug}),
                                          'div_id_subcategory')))
 
         self.no_license = not content.licence
         no_license_msg = HTML(_("""<p><strong>Vous n'avez pas choisi de licence pour votre publication.
-                                   Vous devez <a href="{}">choisir une licence</a>
-                                   avant de demander la validation.</strong></p>"""
-                                .format('#edit-license')))
+                                   Vous devez <a href="#edit-license" class="open-modal">choisir une licence</a>
+                                   avant de publier.</strong></p>"""))
 
         self.helper.layout = Layout(
             no_category_msg if self.no_subcategories else None,


### PR DESCRIPTION
Fix #5821.

### Contrôle qualité

La liste des étapes qui permet de vérifier que c'est corrigé :

1. Allez sur le site en local
2. Connectez vous avec le compte admin (ou n'importe quel compte *sans* licence préférée dans les paramètres)
3. Créez un billet (en ne renseignant que son titre)
4. Essayez de publier ce billet (en cliquant dans la sidebar `Actions > Publier`)

La modale suivante s'affiche :

![Capture d’écran de 2020-06-10 10-01-53](https://user-images.githubusercontent.com/6066015/84242993-df6cfc00-ab01-11ea-9be3-2213573233cc.png)

1. cliquez ensuite sur le lien "choisir une licence"
2. constatez que ça renvoie vers une modale "choix de licence".