### PR TITLE
SCSS : mixins pour les media-queries adaptatives

### DIFF
--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -153,7 +153,7 @@ nav {
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     html,
     body {
         height: 100%;
@@ -165,7 +165,7 @@ nav {
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     body {
         background: #222;
 

--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -165,7 +165,7 @@ nav {
     }
 }
 
-@include touch {
+@include until-desktop {
     body {
         background: #222;
 

--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -334,7 +334,7 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .content-container,
     .modals-container {
         form.content-wrapper {

--- a/assets/scss/base/_helpers.scss
+++ b/assets/scss/base/_helpers.scss
@@ -73,7 +73,7 @@ hr.clearfix {
     display: none;
 }
 
-@media only screen and #{$media-extra-wide} {
+@include wide {
     .wide {
         display: inline;
     }
@@ -82,7 +82,7 @@ hr.clearfix {
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .screen {
         display: inline;
     }

--- a/assets/scss/base/_high-pixel-ratio.scss
+++ b/assets/scss/base/_high-pixel-ratio.scss
@@ -40,12 +40,12 @@
     }
 }
 
-@media only screen and (-webkit-min-device-pixel-ratio: 1.3) and #{$media-mobile-tablet},
-       only screen and (min--moz-device-pixel-ratio: 1.3) and #{$media-mobile-tablet},
-       only screen and (-o-min-device-pixel-ratio: 4/3) and #{$media-mobile-tablet},
-       only screen and (min-device-pixel-ratio: 1.3) and #{$media-mobile-tablet},
-       only screen and (min-resolution: 192dpi) and #{$media-mobile-tablet},
-       only screen and (min-resolution: 2dppx) and #{$media-mobile-tablet} {
+@media only screen and (-webkit-min-device-pixel-ratio: 1.3) and (max-width: $desktop - 1px),
+       only screen and (min--moz-device-pixel-ratio: 1.3) and (max-width: $desktop - 1px),
+       only screen and (-o-min-device-pixel-ratio: 4/3) and (max-width: $desktop - 1px),
+       only screen and (min-device-pixel-ratio: 1.3) and (max-width: $desktop - 1px),
+       only screen and (min-resolution: 192dpi) and (max-width: $desktop - 1px),
+       only screen and (min-resolution: 2dppx) and (max-width: $desktop - 1px) {
 
     .enable-mobile-menu .mobile-menu-hide .page-container .mobile-menu-btn:after {
         @include sprite-2x();

--- a/assets/scss/components/_alert-box.scss
+++ b/assets/scss/components/_alert-box.scss
@@ -123,7 +123,7 @@
     }
 }
 
-@media only screen and #{$media-tablet} {
+@include tablet {
     .alert-box .alert-box-text {
         display: inline;
     }
@@ -132,7 +132,7 @@
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .alert-box {
         .alert-box-btn {
             &,

--- a/assets/scss/components/_breadcrumb.scss
+++ b/assets/scss/components/_breadcrumb.scss
@@ -2,7 +2,7 @@
     display: none;
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .breadcrumb {
         position: relative;
         display: flex;

--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -317,7 +317,7 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .full-content-wrapper .content-item {
         .content-info {
             h3 {
@@ -330,7 +330,7 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .content-item {
         &.write-tutorial {
             display: none;

--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -317,7 +317,7 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
     }
 }
 
-@include touch {
+@include until-desktop {
     .full-content-wrapper .content-item {
         .content-info {
             h3 {

--- a/assets/scss/components/_featured-item.scss
+++ b/assets/scss/components/_featured-item.scss
@@ -97,7 +97,7 @@
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .featured-resource-edit-form {
         flex-direction: column;
         align-items: unset;

--- a/assets/scss/components/_header-dropdown.scss
+++ b/assets/scss/components/_header-dropdown.scss
@@ -116,7 +116,7 @@
     display: block;
 }
 
-@media only screen and #{$media-tablet} {
+@include tablet {
     .dropdown {
         box-shadow: 0 5px 7px rgba(0, 0, 0, .3);
     }
@@ -160,7 +160,7 @@
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     html.dropdown-active {
         overflow: hidden;
 
@@ -200,7 +200,7 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .dropdown {
         top: 60px;
     }

--- a/assets/scss/components/_header-search.scss
+++ b/assets/scss/components/_header-search.scss
@@ -79,7 +79,7 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .search {
         &:before {
             content: " ";

--- a/assets/scss/components/_linkbox.scss
+++ b/assets/scss/components/_linkbox.scss
@@ -26,7 +26,7 @@ $color-linkbox-default: #777;
             width: calc(25% - 20px);
         }
 
-        @include touch {
+        @include until-desktop {
             width: 50%;
             width: calc(50% - 20px);
         }

--- a/assets/scss/components/_linkbox.scss
+++ b/assets/scss/components/_linkbox.scss
@@ -21,17 +21,17 @@ $color-linkbox-default: #777;
         width: 33.33%;
         width: calc(33.33% - 20px);
 
-        @media only screen and #{$media-extra-wide} {
+        @include wide {
             width: 25%;
             width: calc(25% - 20px);
         }
 
-        @media only screen and #{$media-mobile-tablet} {
+        @include touch {
             width: 50%;
             width: calc(50% - 20px);
         }
 
-        @media only screen and #{$media-mobile} {
+        @include mobile {
             width: 100%;
             width: calc(100% - 20px);
         }

--- a/assets/scss/components/_mobile-menu.scss
+++ b/assets/scss/components/_mobile-menu.scss
@@ -3,13 +3,13 @@
     display: none;
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .mobile-menu-only {
         display: none;
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .js .page-container {
         position: relative;
         z-index: 10;

--- a/assets/scss/components/_mobile-menu.scss
+++ b/assets/scss/components/_mobile-menu.scss
@@ -9,7 +9,7 @@
     }
 }
 
-@include touch {
+@include until-desktop {
     .js .page-container {
         position: relative;
         z-index: 10;

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -144,7 +144,7 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .enable-mobile-menu .modals-container .modal {
         box-shadow: 0 2px 7px rgba(0, 0, 0, .7);
 

--- a/assets/scss/components/_more-link.scss
+++ b/assets/scss/components/_more-link.scss
@@ -16,7 +16,7 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
     text-decoration: none;
 }
 
-@include touch {
+@include until-desktop {
 }
 
 @include mobile {

--- a/assets/scss/components/_more-link.scss
+++ b/assets/scss/components/_more-link.scss
@@ -16,8 +16,8 @@ $content-reaction-offset: -14px; // -30px to not offset the meta
     text-decoration: none;
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
 }

--- a/assets/scss/components/_notification-list.scss
+++ b/assets/scss/components/_notification-list.scss
@@ -123,7 +123,7 @@
     }
 }
 
-@include touch {
+@include until-desktop {
     .notification-list {
         .notification {
             background: none !important;

--- a/assets/scss/components/_notification-list.scss
+++ b/assets/scss/components/_notification-list.scss
@@ -115,7 +115,7 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .notification-list {
         .notification-last-answer-short-date {
             display: none;
@@ -123,7 +123,7 @@
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .notification-list {
         .notification {
             background: none !important;
@@ -143,7 +143,7 @@
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .notification-list {
         .notification-infos .ico-after:after {
             margin: 4px 0 0 2px;

--- a/assets/scss/components/_pagination.scss
+++ b/assets/scss/components/_pagination.scss
@@ -101,13 +101,13 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .pagination {
         border: 1px solid #d2d5d6;
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .pagination {
         li {
             &.prev a,
@@ -121,7 +121,7 @@
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .pagination {
         li {
             &.summary-button {

--- a/assets/scss/components/_pagination.scss
+++ b/assets/scss/components/_pagination.scss
@@ -121,7 +121,7 @@
     }
 }
 
-@include touch {
+@include until-desktop {
     .pagination {
         li {
             &.summary-button {

--- a/assets/scss/components/_search-box.scss
+++ b/assets/scss/components/_search-box.scss
@@ -139,7 +139,7 @@
     }
 }
 
-@include touch {
+@include until-desktop {
     .search-box {
         margin: 30px 40px 0;
     }

--- a/assets/scss/components/_search-box.scss
+++ b/assets/scss/components/_search-box.scss
@@ -114,7 +114,7 @@
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .search-box {
         margin: 30px 0 0!important;
 
@@ -139,7 +139,7 @@
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .search-box {
         margin: 30px 40px 0;
     }

--- a/assets/scss/components/_topic-list.scss
+++ b/assets/scss/components/_topic-list.scss
@@ -261,7 +261,7 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .topic-list {
         .topic-members-short-date {
             display: none;
@@ -289,7 +289,7 @@
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .topic-list {
         .topic {
             background: none !important;
@@ -325,7 +325,7 @@
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .topic-list {
         .topic-infos .ico-after:after {
             margin: 4px 0 0 2px;

--- a/assets/scss/components/_topic-list.scss
+++ b/assets/scss/components/_topic-list.scss
@@ -289,7 +289,7 @@
     }
 }
 
-@include touch {
+@include until-desktop {
     .topic-list {
         .topic {
             background: none !important;

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -500,7 +500,7 @@ form.topic-message {
     margin-top: 50px;
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .topic-message {
         padding: 20px 0;
 
@@ -596,7 +596,7 @@ form.topic-message {
     margin: 10px;
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .topic-message {
         margin: 25px 0;
 
@@ -671,7 +671,7 @@ form.topic-message {
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .topic-message .message {
         .message-actions a {
             width: 0px;

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -500,7 +500,7 @@ form.topic-message {
     margin-top: 50px;
 }
 
-@include touch {
+@include until-desktop {
     .topic-message {
         padding: 20px 0;
 

--- a/assets/scss/components/_user-profile.scss
+++ b/assets/scss/components/_user-profile.scss
@@ -23,7 +23,7 @@ body.userprofilepage {
         }
     }
 
-    @media only screen and #{$media-mobile} {
+    @include mobile {
         .flexpage-wrapper {
             padding-top: 0;
         }
@@ -65,7 +65,7 @@ body.userprofilepage {
 
         margin: 2.2rem -1.2rem 2.2rem 0;
 
-        @media only screen and #{$media-mobile} {
+        @include mobile {
             flex-direction: column;
             margin-top: 1.8rem;
         }
@@ -102,7 +102,7 @@ body.userprofilepage {
                     font-size: 2rem;
                     font-weight: 300;
 
-                    @media only screen and #{$media-mobile} {
+                    @include mobile {
                         margin-bottom: 1rem;
                     }
 
@@ -117,7 +117,7 @@ body.userprofilepage {
                 flex-direction: row;
                 align-items: center;
 
-                @media only screen and #{$media-mobile} {
+                @include mobile {
                     flex-direction: column;
                     align-items: baseline;
                 }
@@ -142,7 +142,7 @@ body.userprofilepage {
                         margin-left: 0;
                         margin-right: 10px;
 
-                        @media only screen and #{$media-mobile} {
+                        @include mobile {
                             margin-right: 4px;
                             margin-bottom: 4px;
                         }
@@ -235,7 +235,7 @@ body.userprofilepage {
             flex: 4;
             padding-right: 3.2rem;
 
-            @media only screen and #{$media-mobile} {
+            @include mobile {
                 margin-top: 20px;
 
                 .head-profile-links {
@@ -262,7 +262,7 @@ html.js body.userprofilepage .user-bio-and-activity .bio-container {
         max-height: 64rem;
         overflow: hidden;
 
-        @media only screen and #{$media-mobile} {
+        @include mobile {
             max-height: 16rem;
         }
     }

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -108,7 +108,7 @@
     }
 }
 
-@media only screen and #{$media-extra-wide} {
+@include wide {
     .full-content-wrapper .tutorial-list article {
         width: 29.3%;
     }
@@ -124,7 +124,7 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .content-wrapper,
     .full-content-wrapper {
         margin: 0 0 0 4%;
@@ -140,7 +140,7 @@
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .main .content-container {
         .taglist,
         .pubdate {
@@ -200,7 +200,7 @@
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .main .content-container .article-content .btn {
         float: none;
         text-align: center;

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -140,7 +140,7 @@
     }
 }
 
-@include touch {
+@include until-desktop {
     .main .content-container {
         .taglist,
         .pubdate {

--- a/assets/scss/layout/_footer.scss
+++ b/assets/scss/layout/_footer.scss
@@ -98,7 +98,7 @@
         }
     }
 
-    @include touch {
+    @include until-desktop {
         text-align: center;
         height: auto;
 

--- a/assets/scss/layout/_footer.scss
+++ b/assets/scss/layout/_footer.scss
@@ -98,7 +98,7 @@
         }
     }
 
-    @media only screen and #{$media-mobile-tablet} {
+    @include touch {
         text-align: center;
         height: auto;
 

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -407,7 +407,7 @@ $logo-width: 240px;
     }
 }
 
-@include touch {
+@include until-desktop {
     .header-container {
         .header-logo {
             width: 40px;

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -9,7 +9,7 @@ $logo-width: 240px;
     header, .sub-header {
         display: flex;
 
-        @media only screen and #{$media-wide} {
+        @include desktop {
             padding: 0 2rem;
 
             .header-right .dropdown {
@@ -118,7 +118,7 @@ $logo-width: 240px;
         background: url("../images/logo.png") no-repeat center center;
         background-size: $logo-width auto;
 
-        @media only screen and #{$media-wide} {
+        @include desktop {
             &:hover,
             &:focus {
                 background-color: $color-header-hover;
@@ -141,7 +141,7 @@ $logo-width: 240px;
         margin: 0 0.5em;
         line-height: 50px;
         font-size: 1.7rem;
-        @media only screen and #{$media-wide} {
+        @include desktop {
             display: none;
         }
     }
@@ -407,7 +407,7 @@ $logo-width: 240px;
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .header-container {
         .header-logo {
             width: 40px;
@@ -498,7 +498,7 @@ $logo-width: 240px;
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .header-container {
         z-index: 1;
         position: relative;

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -174,7 +174,7 @@
     clear: both;
 }
 
-@include fullhd {
+@include extra-wide {
     .main .content-container {
         .content-wrapper {
             max-width: 960px;
@@ -328,7 +328,7 @@
     }
 }
 
-@include touch {
+@include until-desktop {
     .main .content-container .new-btn-container {
         display: block;
         margin: 30px 0;

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -174,7 +174,7 @@
     clear: both;
 }
 
-@media only screen and #{$media-mega-wide} {
+@include fullhd {
     .main .content-container {
         .content-wrapper {
             max-width: 960px;
@@ -183,7 +183,7 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     body.no-sidebar .main {
         .content-container {
             width: 100%;
@@ -311,7 +311,7 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .content-cols .main {
         .content-container {
             width: 79%;
@@ -328,7 +328,7 @@
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .main .content-container .new-btn-container {
         display: block;
         margin: 30px 0;

--- a/assets/scss/pages/_flexpage.scss
+++ b/assets/scss/pages/_flexpage.scss
@@ -231,7 +231,7 @@ $content-width: 1145px;
                 line-height: 50px;
                 border: none;
 
-                @media only screen and #{$media-mobile} {
+                @include mobile {
                     display: flex;
                     align-items: baseline;
 
@@ -364,7 +364,7 @@ $content-width: 1145px;
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .flexpage-title-tool .actions {
         & ~ .title,
         & ~ .aside {
@@ -373,13 +373,13 @@ $content-width: 1145px;
     }
 }
 
-@media only screen and #{$media-under-extra-wide} {
+@include until-wide {
    .flexpage .flexpage-wrapper {
         padding: 20px 10px;
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .flexpage {
         .flexpage-wrapper {
             padding: 20px 10px;
@@ -412,7 +412,7 @@ $content-width: 1145px;
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .flexpage {
         .flexpage-title-tool {
             padding: 15px 0;

--- a/assets/scss/pages/_flexpage.scss
+++ b/assets/scss/pages/_flexpage.scss
@@ -379,7 +379,7 @@ $content-width: 1145px;
     }
 }
 
-@include touch {
+@include until-desktop {
     .flexpage {
         .flexpage-wrapper {
             padding: 20px 10px;

--- a/assets/scss/pages/_gallery.scss
+++ b/assets/scss/pages/_gallery.scss
@@ -111,7 +111,7 @@
     float: left !important;
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .gallery-col-image {
         float: left;
         width: 50%;

--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -210,7 +210,7 @@
     }
 }
 
-@include touch {
+@include until-desktop {
     .home {
         .flexpage-header {
             padding-top: 10px;

--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -157,7 +157,7 @@
     }
 }
 
-@media only screen and #{$media-mobile} {
+@include mobile {
     .home {
         .home-description:not(.connected):not(.short) {
             display: none;
@@ -210,7 +210,7 @@
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .home {
         .flexpage-header {
             padding-top: 10px;
@@ -246,7 +246,7 @@
     }
 }
 
-@media only screen and #{$media-wide} {
+@include desktop {
     .home {
         $gap: 20px;
         .home-row {

--- a/assets/scss/pages/_search.scss
+++ b/assets/scss/pages/_search.scss
@@ -7,7 +7,7 @@
     }
 }
 
-@media only screen and #{$media-mobile-tablet} {
+@include touch {
     .pagination-top {
         margin-top: 10px;
     }

--- a/assets/scss/pages/_search.scss
+++ b/assets/scss/pages/_search.scss
@@ -7,7 +7,7 @@
     }
 }
 
-@include touch {
+@include until-desktop {
     .pagination-top {
         margin-top: 10px;
     }

--- a/assets/scss/variables/_media-queries.scss
+++ b/assets/scss/variables/_media-queries.scss
@@ -2,7 +2,7 @@
 $tablet: 769px;
 $desktop: 1024px;
 $wide: 1216px;
-$fullhd: 1408px;
+$extra-wide: 1408px;
 
 // Some inspiration for names & concepts from the Bulma CSS framework
 
@@ -27,8 +27,8 @@ $fullhd: 1408px;
   }
 }
 
-// Tablets and mobules: touchscreens
-@mixin touch {
+// Tablets and mobiles (touchscreens)
+@mixin until-desktop {
   @media screen and (max-width: $desktop - 1px) {
     @content;
   }
@@ -64,21 +64,21 @@ $fullhd: 1408px;
 
 // Wide screen only
 @mixin wide-only {
-  @media screen and (min-width: $wide) and (max-width: $fullhd - 1px) {
+  @media screen and (min-width: $wide) and (max-width: $extra-wide - 1px) {
     @content;
   }
 }
 
 // Mobile, tablet, desktop and wide screen
-@mixin until-fullhd {
-  @media screen and (max-width: $fullhd - 1px) {
+@mixin until-extra-wide {
+  @media screen and (max-width: $extra-wide - 1px) {
     @content;
   }
 }
 
 // Full HD screen
-@mixin fullhd {
-  @media screen and (min-width: $fullhd) {
+@mixin extra-wide {
+  @media screen and (min-width: $extra-wide) {
     @content;
   }
 }

--- a/assets/scss/variables/_media-queries.scss
+++ b/assets/scss/variables/_media-queries.scss
@@ -1,7 +1,84 @@
-$media-mega-wide: "(min-width: 1360px)";
-$media-extra-wide: "(min-width: 1140px)";
-$media-wide: "(min-width: 960px)";
-$media-tablet: "(min-width: 760px)";
-$media-mobile-tablet: "(max-width: 959px)";
-$media-under-extra-wide: "(max-width: 1140px)";
-$media-mobile: "(max-width: 759px)";
+// Breakpoints between each screen category
+$tablet: 769px;
+$desktop: 1024px;
+$wide: 1216px;
+$fullhd: 1408px;
+
+// Some inspiration for names & concepts from the Bulma CSS framework
+
+// Mobile and below (well, mobile)
+@mixin mobile {
+  @media screen and (max-width: $tablet - 1px) {
+    @content;
+  }
+}
+
+// Tablet and above (also print)
+@mixin tablet {
+  @media screen and (min-width: $tablet), print {
+    @content;
+  }
+}
+
+// Tablet
+@mixin tablet-only {
+  @media screen and (min-width: $tablet) and (max-width: $desktop - 1px) {
+    @content;
+  }
+}
+
+// Tablets and mobules: touchscreens
+@mixin touch {
+  @media screen and (max-width: $desktop - 1px) {
+    @content;
+  }
+}
+
+// Desktop and above
+@mixin desktop {
+  @media screen and (min-width: $desktop) {
+    @content;
+  }
+}
+
+// Desktop only
+@mixin desktop-only {
+  @media screen and (min-width: $desktop) and (max-width: $wide - 1px) {
+    @content;
+  }
+}
+
+// Mobile, tablet and desktop
+@mixin until-wide {
+  @media screen and (max-width: $wide - 1px) {
+     @content;
+  }
+}
+
+// Wide screen and above
+@mixin wide {
+  @media screen and (min-width: $wide) {
+    @content;
+  }
+}
+
+// Wide screen only
+@mixin wide-only {
+  @media screen and (min-width: $wide) and (max-width: $fullhd - 1px) {
+    @content;
+  }
+}
+
+// Mobile, tablet, desktop and wide screen
+@mixin until-fullhd {
+  @media screen and (max-width: $fullhd - 1px) {
+    @content;
+  }
+}
+
+// Full HD screen
+@mixin fullhd {
+  @media screen and (min-width: $fullhd) {
+    @content;
+  }
+}

--- a/doc/source/front-end/helpers-scss.rst
+++ b/doc/source/front-end/helpers-scss.rst
@@ -1,0 +1,112 @@
+==================
+Helpers CSS
+==================
+
+Des *mixins* SCSS sont disponibles pour faciliter le développement.
+
+CSS adaptatif (responsive)
+=============
+
+Une série de *mixins* existe pour faciliter l'insertion de *media-queries*
+afin d'adapter l'interface du site aux différents appareils du marché.
+
+Variables
+-------------------
+
+Tout d'abord, des variables SCSS définissent différents points d'arrêt entre
+plusieurs types d'écran :
+
+- ``$tablet`` : largeur minimale des tablettes (769 pixels) ;
+- ``$desktop`` : largeur minimale d'un écran d'ordinateur classique (1024 pixels) ;
+- ``$wide`` : largeur minimale d'un écran large (1216 pixels) ;
+- ``$fullhd`` : largeur minimale d'un écran full-HD (1408 pixels).
+
+*Mixins*
+-------------------
+
+Mais concrètement, vous utiliserez surtout les *mixins* permettant d'inclure
+automatiquement les *media-queries* correspondantes à différentes catégories
+ou ensembles de catégories d'écran. Par exemple, pour écrire du SCSS qui ne sera
+que pris en compte pour les mobiles, écrivez :
+
+.. sourcecode:: scss
+
+  @include mobile {
+    // Votre code SCSS…
+  }
+
+ou encore, en SASS :
+
+.. sourcecode:: sass
+
+  +mobile
+    // Votre code SASS…
+
+Il est tout aussi possible d'utiliser ceci pour définir tous les CSS spécifiques
+à une catégorie d'écran d'un coup, ou au fur et à mesure en spécifiant propriété
+par propriété. Ainsi, ces deux façons de faire sont valides :
+
+.. sourcecode:: scss
+
+  .something {
+    font-weight: bold;
+
+    @include mobile {
+      font-weight: normal;
+    }
+  }
+
+  // -- ou --
+
+  .something {
+    font-weight: bold;
+  }
+
+  @include mobile {
+    .something {
+      font-weight: normal;
+    }
+  }
+
+Voici les différentes *mixins* disponibles. Les noms des *mixins* reprennent
+ceux des points d'arrêt plus haut.
+
+- ``mobile`` : les appareils mobiles.
+- ``tablet`` : les tablettes, et toutes les tailles au dessus.
+- ``tablet-only`` : les tablettes, uniquement.
+- ``touch`` : les mobiles et les tablettes.
+- ``desktop`` : les ordinateurs, toutes tailles d'écran.
+- ``desktop-only`` : les ordinateurs, mais pas ceux de grande taille.
+- ``until-wide`` : les mobiles, tablettes, et ordinateurs pas trop grands.
+- ``wide`` : les ordinateurs, à partir de ceux ayant un grand écran.
+- ``wide-only`` : les ordinateurs ayant un grand écran, mais pas un écran full-HD.
+- ``until-fullhd`` : tous les appareils, sauf ceux ayant un écran full-HD.
+- ``fullhd`` : les ordinateurs ayant un écran full-HD. Les téléviseurs, aussi.
+
+Si vous étiez habitué⋅e à l'ancien système…
+-------------------
+
+Auparavant, des variables existaient contenant la partie des ``@media``
+changeante en fonction des largeurs d'écran, et on écrivait les *media-queries*
+en entier à chaque fois. Les noms des variables n'étaient pas exactement les
+mêmes non plus.
+
+.. list-table:: Voici donc une correspondance.
+  :header-rows: 1
+
+  * - Ancienne variable
+    - *Mixin* équivalente
+  * - ``$media-mobile``
+    - ``mobile``
+  * - ``$media-mobile-tablet``
+    - ``touch``
+  * - ``$media-tablet``
+    - ``tablet``
+  * - ``$media-wide``
+    - ``desktop``
+  * - ``$media-under-extra-wide``
+    - ``until-wide``
+  * - ``$media-extra-wide``
+    - ``wide``
+  * - ``$media-mega-wide``
+    - ``fullhd``

--- a/doc/source/front-end/helpers-scss.rst
+++ b/doc/source/front-end/helpers-scss.rst
@@ -1,17 +1,17 @@
 ==================
-Helpers CSS
+Mixins SCSS
 ==================
 
 Des *mixins* SCSS sont disponibles pour faciliter le développement.
 
 CSS adaptatif (responsive)
-=============
+==========================
 
 Une série de *mixins* existe pour faciliter l'insertion de *media-queries*
 afin d'adapter l'interface du site aux différents appareils du marché.
 
 Variables
--------------------
+---------
 
 Tout d'abord, des variables SCSS définissent différents points d'arrêt entre
 plusieurs types d'écran :
@@ -19,10 +19,10 @@ plusieurs types d'écran :
 - ``$tablet`` : largeur minimale des tablettes (769 pixels) ;
 - ``$desktop`` : largeur minimale d'un écran d'ordinateur classique (1024 pixels) ;
 - ``$wide`` : largeur minimale d'un écran large (1216 pixels) ;
-- ``$fullhd`` : largeur minimale d'un écran full-HD (1408 pixels).
+- ``$extra-wide`` : largeur minimale d'un écran full-HD (1408 pixels).
 
 *Mixins*
--------------------
+--------
 
 Mais concrètement, vous utiliserez surtout les *mixins* permettant d'inclure
 automatiquement les *media-queries* correspondantes à différentes catégories
@@ -68,23 +68,40 @@ par propriété. Ainsi, ces deux façons de faire sont valides :
     }
   }
 
-Voici les différentes *mixins* disponibles. Les noms des *mixins* reprennent
-ceux des points d'arrêt plus haut.
+Voici les différentes *mixins* disponibles, avec la largeur de l'écran
+correspondante. Les noms des *mixins* reprennent ceux des points d'arrêt plus
+haut.
 
-- ``mobile`` : les appareils mobiles.
-- ``tablet`` : les tablettes, et toutes les tailles au dessus.
-- ``tablet-only`` : les tablettes, uniquement.
-- ``touch`` : les mobiles et les tablettes.
-- ``desktop`` : les ordinateurs, toutes tailles d'écran.
-- ``desktop-only`` : les ordinateurs, mais pas ceux de grande taille.
-- ``until-wide`` : les mobiles, tablettes, et ordinateurs pas trop grands.
-- ``wide`` : les ordinateurs, à partir de ceux ayant un grand écran.
-- ``wide-only`` : les ordinateurs ayant un grand écran, mais pas un écran full-HD.
-- ``until-fullhd`` : tous les appareils, sauf ceux ayant un écran full-HD.
-- ``fullhd`` : les ordinateurs ayant un écran full-HD. Les téléviseurs, aussi.
+.. note::
+
+	Pour des raisons de cohérence, et sauf si vous avez une bonne raison de faire autrement (par exemple, en cas de besoin d'un point d'arrêt très spécifique), utilisez toujours ces *mixins* pour insérer un code CSS spécifique à une largeur d'écran.
+
+
+- | ``mobile`` : les appareils mobiles.
+  | *0 → 768 pixels*
+- | ``tablet`` : les tablettes, et toutes les tailles au dessus.
+  | *769 pixels → ∞*
+- | ``tablet-only`` : les tablettes, uniquement.
+  | *769 → 1023 pixels*
+- | ``until-desktop`` : les mobiles et les tablettes.
+  | *0 → 1023 pixels*
+- | ``desktop`` : les ordinateurs, toutes tailles d'écran.
+  | *1024 pixels → ∞*
+- | ``desktop-only`` : les ordinateurs, mais pas ceux de grande taille.
+  | *1024 → 1215 pixels*
+- | ``until-wide`` : les mobiles, tablettes, et ordinateurs pas trop grands.
+  | *0 → 1215 pixels*
+- | ``wide`` : les ordinateurs, à partir de ceux ayant un grand écran.
+  | *1216 pixels → ∞*
+- | ``wide-only`` : les ordinateurs ayant un grand écran, mais pas *très* grand.
+  | *1216 → 1407 pixels*
+- | ``until-extra-wide`` : tous les appareils n'ayant pas un très grand écran.
+  | *0 → 1407 pixels*
+- | ``extra-wide`` : les ordinateurs ayant un écran très grand. Les téléviseurs, aussi.
+  | *1408 pixels → ∞*
 
 Si vous étiez habitué⋅e à l'ancien système…
--------------------
+-------------------------------------------
 
 Auparavant, des variables existaient contenant la partie des ``@media``
 changeante en fonction des largeurs d'écran, et on écrivait les *media-queries*
@@ -99,7 +116,7 @@ mêmes non plus.
   * - ``$media-mobile``
     - ``mobile``
   * - ``$media-mobile-tablet``
-    - ``touch``
+    - ``until-desktop``
   * - ``$media-tablet``
     - ``tablet``
   * - ``$media-wide``
@@ -109,4 +126,4 @@ mêmes non plus.
   * - ``$media-extra-wide``
     - ``wide``
   * - ``$media-mega-wide``
-    - ``fullhd``
+    - ``extra-wide``


### PR DESCRIPTION
Cette PR ajoute plusieurs _mixins_ permettant d'inclure les _media-queries_ servant à adapter le site à divers appareils. Elle met également à jour les points d'arrêt des différentes tailles d'écran, ainsi que leurs noms qui n'étaient, à mon humble avis, pas très pertinents.

Elle s'inscrit dans un objectif d'amélioration globale du code source de l'interface de Zeste de Savoir.

### Pourquoi ce changement ?

L'objectif est double : **clarifier le code** et **simplifier le développement**.

On passe de ceci : 

```scss
@media screen and #{$media-mobile-tablet} {
  // ...
}
```

à ceci : 

```scss
@include until-desktop {
  // ...
}
```

Le code est beaucoup plus clair : on voit immédiatement sans avoir à scanner la _media-query_ que l'on a affaire à un bloc concernant les appareils mobiles et tablettes (plus petits qu'un ordinateur de bureau). Il est également plus simple à écrire, car il n'est plus nécessaire de taper toute la _media-query_ et de se souvenir des noms des variables, à entourer de `#{}` pour que ce soit interprété littéralement par SCSS… non, un `@include mobile` et basta.

Il est également plus représentatif de la réalité, car j'ai renommé les points d'arrêt : 
- `mobile-tablet` devient `touch`, afin d'expliciter le fait que cette règle va concrètement viser les appareils tactiles, pour lesquels la réflexion d'interface n'est pas forcément la même que pour un appareil utilisé à l'aide d'une souris ;
- la série des `wide`, `extra-wide`, `mega-wide` est remplacée par des noms plus explicites et moins _dramatiques_ : `desktop`, `wide` et `fullhd` ;
- vu que les _mixins_ inutilisées disparaissent totalement une fois compilées, j'en ai ajouté quelques unes de plus afin de simplifier d'avance les futurs développements. Chaque intervalle est plus ou moins sélectionnable : pour chaque type d'écran, le type uniquement (par exemple `tablet-only`), le type plus toutes les tailles supérieures (par exemple `desktop`), et le type plus toutes les tailles inférieures (par exemple `until-wide` ou le cas particulier `touch`, qui serait équivalent à `until-desktop`).

Enfin dans l'objectif de simplification, **tout ceci est désormais documenté** — ce n'était pas le cas avant.

Les valeurs des points d'arrêt ont été légèrement modifiées (chacune gagne une centaine de pixels, selon les standards les plus utilisés aujourd'hui), afin de suivre l'évolution des différentes tailles d'écran. Ce point peut être trivialement annulé, afin de profiter du confort des _mixins_ avec les anciens points d'arrêt.

_Les styles d'erreur (`errors/scss/*.scss`) ne sont pas concernées par ce changement, étant isolées du reste des feuilles de style. J'ai également laissé deux media-queries aux valeurs très spécifiques dans `layout/_header`, car elles ne rentraient de toute façon pas dans un point d'arrêt._

### Les points d'arrêt et _mixins_ ajoutées

_(Extrait de la documentation écrite pour l'occasion.)_

#### Points d'arrêt

- ``$tablet`` : largeur minimale des tablettes (769 pixels, auparavant 760).
- ``$desktop`` : largeur minimale d'un écran d'ordinateur classique (1024 pixels, auparavant 960).
- ``$wide`` : largeur minimale d'un écran large (1216 pixels, auparavant 1140).
- ``$fullhd`` : largeur minimale d'un écran full-HD (1408 pixels, auparavant 1360).

#### _Mixins_

- ``mobile`` : les appareils mobiles.
- ``tablet`` : les tablettes, et toutes les tailles au dessus.
- ``tablet-only`` : les tablettes, uniquement.
- ``touch`` : les mobiles et les tablettes.
- ``desktop`` : les ordinateurs, toutes tailles d'écran.
- ``desktop-only`` : les ordinateurs, mais pas ceux de grande taille.
- ``until-wide`` : les mobiles, tablettes, et ordinateurs pas trop grands.
- ``wide`` : les ordinateurs, à partir de ceux ayant un grand écran.
- ``wide-only`` : les ordinateurs ayant un grand écran, mais pas un écran full-HD.
- ``until-fullhd`` : tous les appareils, sauf ceux ayant un écran full-HD.
- ``fullhd`` : les ordinateurs ayant un écran full-HD. Les téléviseurs, aussi.

### Contrôle qualité

Vérifier que le site s'affiche toujours correctement dans toutes les tailles d'écran.

L'usage de _mixins_ ne change pas le code CSS généré ; par contre, la modification des points d'arrêt pourrait avoir des effets secondaires imprévus, même si j'ai regardé un peu partout et que je n'ai rien vu de particulier.