### PR TITLE
Corrige le problème de sauvegarde avec plusieurs onglets ouverts + l'actualisation du pied de page

### DIFF
--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -379,7 +379,6 @@
       autosave: {
         enabled: true,
         uniqueId: mdeUniqueKey,
-        submit_delay: 10000,
         delay: 1000
       },
       indentWithTabs: false,

--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -401,6 +401,7 @@
       spellChecker: false,
       inputStyle: 'contenteditable',
       nativeSpellcheck: true,
+      sideBySideFullscreen: false,
       promptAbbrv: true,
       theme: 'idea',
       previewRender: customMarkdownParser,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cookies-eu-banner": "2.0.1",
     "cssnano": "4.1.10",
     "del": "5.1.0",
-    "easymde": "2.9.1-299.0",
+    "easymde": "2.10.2-360.0",
     "gulp": "4.0.2",
     "gulp-concat": "2.6.1",
     "gulp-if": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1646,14 +1646,14 @@ each-props@^1.3.0:
     is-plain-object "^2.0.1"
     object.defaults "^1.1.0"
 
-easymde@2.9.1-299.0:
-  version "2.9.1-299.0"
-  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.9.1-299.0.tgz#0b039343294908021ca88059940aab51ea09adb9"
-  integrity sha512-pV0gfX1iWFvfxP35iYXJfb0iKgS45XT+l7fvJ9jq06rIhJDx/DlSp6GJy9P8fdY8ouHAiUZyvALIfn/kuCy6uQ==
+easymde@2.10.2-360.0:
+  version "2.10.2-360.0"
+  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.10.2-360.0.tgz#da4e22df3aa1916ae547d84467260fa5d28d1afb"
+  integrity sha512-Mbh9iYATsDHNBmVZviwmIGjJncF+wc1CPQyaovzXNWRUX/K4ToJV9a3hBZmcKeQVYRWPVp6J3cMhuEDWMyZPeg==
   dependencies:
-    codemirror "^5.51.0"
+    codemirror "^5.53.2"
     codemirror-spell-checker "1.1.2"
-    marked "^0.8.0"
+    marked "^1.0.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"


### PR DESCRIPTION
Cette PR permet de corriger deux problèmes au sein du nouvel éditeur par le simple fait d'une mise à jour de la version de easymde (c'est vrai que les PRs coté upstream viennent des contributeurs de zds).

- Ticket #5616 : l'affichage de la ligne/colonne sur laquelle on est se fait désormais même si on clique ailleurs avec la souris.
- Ticket : #5607 : on ne perd plus la sauvegarde même si on a plusieurs onglets ouverts sur la même page (grace au fait que la sauvegarde se fait maintenant uniquement si l'on modifie le texte, et non toute les `x` secondes comme c'était le cas avant).
- Ticket : #5566 : le mode side by side n'exige plus d'être en plein écran.

### Contrôle qualité

- Assurez vous d'avoir buildé le front `make install-front` + `make build-front`
- Allez dans une zone de texte markdown avec le nouvel éditeur

#### Ticket 5616

- Tapez du texte sur plusieurs lignes
- Cliquez quelque part dans le texte et constatez que dans le pied de page de la zone de texte la ligne et la colonne s'actualise bien au clic.

#### Ticket 5607

- Ouvrez deux onglets d'édition sur le même lien
- Tapez du texte dans l'onglet 1, allez dans l'onglet 2, rafraîchissez votre page et constatez que le texte de l'onglet 1 est bien présent dans l'onglet 2
- Faite l'inverse, tapez du texte dans l'onglet 2, allez dans l'onglet 1, rafraîchissez votre page et constatez que le texte de l'onglet 2 est bien présent dans l'onglet 1.
- N'hésitez pas a tester des cas qui vous viennent en tête.

#### Ticket 5566

- Ouvrez une zone de rédaction
- Cliquez sur le bouton "side-by-side" en mode "pas plein écran" et vérifiez que la zone s'affiche bien
- Passez en plein écran et cliquez sur le bouton "side-by-side" et vérifiez que la zone s'affiche bien.