### PR TITLE
Passage à zmarkdown 9.1

### DIFF
--- a/assets/js/markdown-help.js
+++ b/assets/js/markdown-help.js
@@ -25,9 +25,9 @@
     'Le langage d’un bloc de code peut être spécifié après les <code>```</code> ouvrants. La liste des langages supportés <a href="' + linkToPygments + '">est disponible ici</a>.',
     'Vous pouvez <a href="' + linkToMathsTutorial + '">écrire des formules mathématiques</a> en encadrant ces dernières du signe dollar <code>$</code>.',
     'Pour ajouter une image, vous pouvez simplement la glisser-déposer depuis votre explorateur.',
-    'vous pouvez préciser à quel numéro commencent les lignes avec cette syntaxe : <code>```python linenostart=42</code> au début d\'un bloc de code. Pratique pour faire coïncider les numéros de ligne à une erreur, par exemple.',
-    'vous pouvez surligner des lignes avec cette syntaxe : <code>```rust hl_lines=2,4-7</code> au début d\'un bloc de code.',
-    'vous pouvez à la fois choisir à quel numéro démarrent les lignes et en surligner avec <code>```lisp linenostart=244 hl_lines=247,252</code> au début d\'un bloc de code.'
+    'Vous pouvez préciser à quel numéro commencent les lignes avec cette syntaxe : <code>```python linenostart=42</code> au début d\'un bloc de code. Pratique pour faire coïncider les numéros de ligne à une erreur, par exemple.',
+    'Vous pouvez surligner des lignes avec cette syntaxe : <code>```rust hl_lines=2,4-7</code> au début d\'un bloc de code.',
+    'Vous pouvez à la fois choisir à quel numéro démarrent les lignes et en surligner avec <code>```lisp linenostart=244 hl_lines=247,252</code> au début d\'un bloc de code.'
   ]
 
   function addDocMD($elem) {

--- a/assets/js/markdown-help.js
+++ b/assets/js/markdown-help.js
@@ -24,7 +24,10 @@
     'Pour écrire un bout de code au milieu d’une phrase, utilisez la syntaxe <code>`un bout de code`</code>.',
     'Le langage d’un bloc de code peut être spécifié après les <code>```</code> ouvrants. La liste des langages supportés <a href="' + linkToPygments + '">est disponible ici</a>.',
     'Vous pouvez <a href="' + linkToMathsTutorial + '">écrire des formules mathématiques</a> en encadrant ces dernières du signe dollar <code>$</code>.',
-    'Pour ajouter une image, vous pouvez simplement la glisser-déposer depuis votre explorateur.'
+    'Pour ajouter une image, vous pouvez simplement la glisser-déposer depuis votre explorateur.',
+    'vous pouvez préciser à quel numéro commencent les lignes avec cette syntaxe : <code>```python linenostart=42</code> au début d\'un bloc de code. Pratique pour faire coïncider les numéros de ligne à une erreur, par exemple.',
+    'vous pouvez surligner des lignes avec cette syntaxe : <code>```rust hl_lines=2,4-7</code> au début d\'un bloc de code.',
+    'vous pouvez à la fois choisir à quel numéro démarrent les lignes et en surligner avec <code>```lisp linenostart=244 hl_lines=247,252</code> au début d\'un bloc de code.'
   ]
 
   function addDocMD($elem) {

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -333,43 +333,7 @@ samp {
 }
 
 // code
-.hljs-code-div {
-  font-family: $font-monospace;
-  background-color: #fff;
-  margin: 0 auto;
-  padding: 0.5em;
-  border-radius: .25em;
-  display: flex;
-
-  line-height: 18px;
-  font-family: $font-monospace;
-  font-style: normal;
-  font-size: 14px;
-
-  + .hljs-code-div {
-    margin-top: 14px;
-  }
-
-  .hljs-line-numbers {
-    counter-reset: line;
-    border-right: 1px solid #ddd;
-    margin: 0;
-    padding: .5em;
-    color: #888;
-    text-align: right;
-
-    span::before {
-      counter-increment: line;
-      content: counter(line);
-      display: block;
-    }
-  }
-  pre {
-    margin: 0;
-    width: 100%;
-    overflow-x: auto;
-  }
-}
+@import "base/source-code";
 
 // touche
 kbd {

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -437,16 +437,6 @@ div.align-left, figure pre code.hljs {
     text-align: left;
 }
 
-.language-console {
-    color: $color-console-text;
-    background-color: $color-console-bg;
-    font-family: Source Code Pro,monospace,serif;
-    display: block;
-    overflow-x: auto;
-    padding: .5em;
-
-}
-
 // checkbox menu
 
 ul li p {

--- a/assets/scss/base/_source-code.scss
+++ b/assets/scss/base/_source-code.scss
@@ -1,4 +1,5 @@
 // ZMD source code
+
 .hljs-code-div {
   display: flex;
 
@@ -29,10 +30,10 @@
     margin: 0;
     padding: .5em;
 
-    border-right: 1px solid #ddd;
+    border-right: 1px solid hsl(180, 7.7%, 94.9%);  // TODO $grey-100
 
     text-align: right;
-    color: #888;
+    color: hsl(192, 2%, 52%);  // TODO $grey-500
 
     z-index: 1;
 
@@ -50,6 +51,7 @@
       content: counter(line);
     }
 
+    // Support for content generated after zmd 9.1.
     span[data-count]:after {
       content: attr(data-count);
     }
@@ -58,7 +60,7 @@
     span.hll {
       &:after {
         font-weight: bold;
-        color: hsl(25.8, 95.9%, 19%);  // TODO $accent-900
+        color: hsl(15.1, 85.6%, 30%);  // TODO $accent-900
       }
 
       &:before {
@@ -71,16 +73,18 @@
         width: 100%;
         height: 1.3em;
 
-        background-color: transparentize(hsl(39.2, 78.8%, 87.1%), .6);  // TODO transparentize($accent-200, .6)
+        background-color: transparentize(hsl(38.2, 86.3%, 80%), .66);  // TODO transparentize($accent-300, .66)
       }
     }
   }
 
+  // Code part
   pre {
     margin: 0;
     width: 100%;
     overflow-x: auto;
 
+    // Required for highlight to work (same for the other one below)
     background-color: transparent;
 
     z-index: 2;
@@ -90,25 +94,32 @@
     }
   }
 
+  // This applies only to console codes rendered with zmd 9.1.2+, as previous
+  // versions were missing the possibility to style them as full console blocks.
+  // Old blocs only have a bkack background on the content, not the line numbers,
+  // and they get a degraded support for line highlight.
   &.hljs-code-console {
-    background-color: black;  // TODO $black
+    background-color: hsl(0, 0%, 6%);  // TODO $black
 
     .hljs-line-numbers {
       border-right-color: hsl(192, 2.6%, 62.9%);  // TODO $grey-400
 
       span {
         &:after , &.hll:after{
-          color: white;  // TODO $white
+          color: hsl(0, 0%, 98%);  // TODO $white
         }
       }
     }
 
+    // Required for highlight to work
     pre code.language-console {
-      background-color: transparent !important;
+      background-color: transparent;
     }
   }
 }
 
+// The code part of the console codes (shared for legacy and new versions,
+// the background-color being overrided for new versions).
 .language-console {
   display: block;
   padding: .5em;

--- a/assets/scss/base/_source-code.scss
+++ b/assets/scss/base/_source-code.scss
@@ -1,0 +1,90 @@
+// ZMD source code
+.hljs-code-div {
+  display: flex;
+
+  // Required for line highlights
+  position: relative;
+
+  margin: 0 auto;
+  padding: 0.5em;
+
+  border-radius: .25em;
+
+  background-color: #fff;  // TODO $white
+  font-family: $font-monospace;
+  font-style: normal;
+  font-size: 14px;
+
+  line-height: 1.3em;
+
+  z-index: 0;
+
+  + .hljs-code-div {
+    margin-top: 14px;
+  }
+
+  .hljs-line-numbers {
+    counter-reset: line;
+
+    margin: 0;
+    padding: .5em;
+
+    border-right: 1px solid #ddd;
+
+    text-align: right;
+    color: #888;
+
+    z-index: 1;
+
+    span:after {
+      display: block;
+    }
+
+    // LEGACY
+    // Support for content generated before zmd 9.1, without explicit
+    // line numbers.
+    span:not([data-count]):after {
+      counter-increment: line;
+      content: counter(line);
+    }
+
+    span[data-count]:after {
+      content: attr(data-count);
+    }
+
+    // Highlighted lines
+    span.hll {
+      &:after {
+        font-weight: bold;
+        color: hsl(25.8, 95.9%, 19%);  // TODO $accent-900
+      }
+
+      &:before {
+        display: block;
+        content: '';
+
+        position: absolute;
+        left: 0;
+
+        width: 100%;
+        height: 1.3em;
+
+        background-color: transparentize(hsl(39.2, 78.8%, 87.1%), .6);  // TODO transparentize($accent-200, .6)
+      }
+    }
+  }
+
+  pre {
+    margin: 0;
+    width: 100%;
+    overflow-x: auto;
+
+    background-color: transparent;
+
+    z-index: 2;
+
+    .hljs {
+      background-color: transparent;
+    }
+  }
+}

--- a/assets/scss/base/_source-code.scss
+++ b/assets/scss/base/_source-code.scss
@@ -38,6 +38,8 @@
 
     span:after {
       display: block;
+      position: relative;
+      top: -1px;
     }
 
     // LEGACY
@@ -87,4 +89,34 @@
       background-color: transparent;
     }
   }
+
+  &.hljs-code-console {
+    background-color: black;  // TODO $black
+
+    .hljs-line-numbers {
+      border-right-color: hsl(192, 2.6%, 62.9%);  // TODO $grey-400
+
+      span {
+        &:after , &.hll:after{
+          color: white;  // TODO $white
+        }
+      }
+    }
+
+    pre code.language-console {
+      background-color: transparent !important;
+    }
+  }
+}
+
+.language-console {
+  display: block;
+  padding: .5em;
+
+  color: $color-console-text;
+  background-color: $color-console-bg;
+
+  font-family: $font-monospace;
+
+  overflow-x: auto;
 }

--- a/assets/scss/base/_source-code.scss
+++ b/assets/scss/base/_source-code.scss
@@ -96,7 +96,7 @@
 
   // This applies only to console codes rendered with zmd 9.1.2+, as previous
   // versions were missing the possibility to style them as full console blocks.
-  // Old blocs only have a bkack background on the content, not the line numbers,
+  // Old blocs only have a black background on the content, not the line numbers,
   // and they get a degraded support for line highlight.
   &.hljs-code-console {
     background-color: hsl(0, 0%, 6%);  // TODO $black
@@ -119,7 +119,7 @@
 }
 
 // The code part of the console codes (shared for legacy and new versions,
-// the background-color being overrided for new versions).
+// the background-color being overridden for new versions).
 .language-console {
   display: block;
   padding: .5em;

--- a/assets/scss/variables/_colors.scss
+++ b/assets/scss/variables/_colors.scss
@@ -19,7 +19,7 @@ $color-hat: #6F6F6F;
 $color-staff-hat: $color-primary;
 
 $color-console-bg: #000;
-$color-console-text: #DDD;
+$color-console-text: #EEE;
 
 $color-not-ready-content: #D0D0D0;
 $color-badge-sanction: #b71c1c;

--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "8.3.0",
+    "zmarkdown": "9.1.0",
     "pm2": "^4.2.3"
   },
   "engines": {

--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,8 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "9.1.0",
-    "pm2": "^4.2.3"
+    "zmarkdown": "9.1.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "9.1.0"
+    "zmarkdown": "9.1.2"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
Passage à zmarkdown 9.1

**QA :**

- `make zmd-install && make zmd-start && make run-back`
- Vérifier que le markdown n'est pas cassé
- Si aucune régression évidente n'est trouvée, merger