### PR TITLE
Amélioration de l'intégration du lien de modification de la licence d'un contenu

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -213,3 +213,4 @@ exports.errors = errors
 exports.prepareZmd = prepareZmd
 exports.prepareEasyMde = prepareEasyMde
 exports.default = gulp.parallel(watch, jsLint)
+

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -213,4 +213,3 @@ exports.errors = errors
 exports.prepareZmd = prepareZmd
 exports.prepareEasyMde = prepareEasyMde
 exports.default = gulp.parallel(watch, jsLint)
-

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -85,6 +85,7 @@
         select,
         textarea {
             margin: 0 0 15px;
+            width: 100%;
         }
     }
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -92,6 +92,7 @@
 @import "pages/stats";
 @import "pages/tutorial-help";
 @import "pages/tutorial-history";
+@import "pages/content-editor";
 
 /*-------------------------
 10. High pixel ratio (retina)

--- a/assets/scss/pages/_content-editor.scss
+++ b/assets/scss/pages/_content-editor.scss
@@ -1,0 +1,56 @@
+.editable-element {
+  display: flex;
+  align-items: center;
+
+  > :not(.edit-button) {
+    flex: 21;
+    margin: 0;
+  }
+}
+
+.edit-button {
+  position: relative;
+
+  margin: 0 .4rem;
+
+  width: 24px;
+  height: 24px;
+
+  border-radius: 100%;
+
+  transition: background-color .1s ease-in-out;
+
+  &:hover {
+    background-color: $color-primary;
+
+    &:after {
+      @include sprite-position($edit-light);
+    }
+  }
+
+  &:first-child {
+    margin-left: 0;
+  }
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  &:after {
+    content: " ";
+    display: block;
+
+    position: absolute;
+
+    top: 4px;
+    left: 4px;
+
+    width: 16px;
+    height: 16px;
+
+    background-repeat: no-repeat;
+
+    @include sprite;
+    @include sprite-position($edit-blue);
+  }
+}

--- a/assets/scss/variables/_colors.scss
+++ b/assets/scss/variables/_colors.scss
@@ -1,4 +1,4 @@
-// If you want to change this, you may want to do it also in templates/base.html. Particulary in the meta tag named theme-color and msapplication-navbutton-color. 
+// If you want to change this, you may want to do it also in templates/base.html. Particulary in the meta tag named theme-color and msapplication-navbutton-color.
 $color-primary: #084561;
 $color-secondary: #F8AD32;
 

--- a/doc/source/front-end/interface-utilisateur.rst
+++ b/doc/source/front-end/interface-utilisateur.rst
@@ -73,7 +73,7 @@ Ajoutez une icône sur un bouton comme sur n'importe quel autre élément :
 Le style général du site se veut épuré, on évitera les icônes sur les boutons de soumission de formulaire. On les utilisera pour illustrer les boutons d'action : déplacer, supprimer, renommer, éditer, etc.
 
 Icône d'aide
--------------
+------------
 
 Il existe une classe, ``help-question-mark``, à appliquer sur un lien, affichant
 un petit cercle coloré autour du texte du lien. Avec ``?`` comme texte de lien,
@@ -86,6 +86,57 @@ N'oubliez pas d'ajouter un attribut ``title`` (ou si l'infobulle gêne,
 .. sourcecode:: html
 
   <a href="#" class="help-question-mark" title="Titre du lien">?</a>
+
+Bouton de modification
+----------------------
+
+Pour afficher un petit bouton permettant de modifier un élément, et *seulement si
+l'élément modifié est clairement identifié pour l'utilisateur*, il existe une
+classe ``edit-button`` à ajouter à un lien. Le texte de ce lien doit être masqué
+afin de ne pas briser son affichage. Le rendu sera un crayon bleu, virant au blanc
+sur fond bleu circulaire lorsque survolé.
+
+Il est important de tout de même spécifier *et* un texte dans le bouton (masqué),
+*et* une infobulle, afin d'être très clair sur le rôle du bouton tant pour un
+utilisateur normal (le bouton n'ayant pas de nom visuel, l'infobulle permet de
+confirmer ce qu'il fait) que pour un utilisateur usant d'un lecteur d'écran (le
+texte alternatif étant alors indispensable, l'icône crayon ne pouvant être vue).
+
+Aussi, si le lien ouvre une boîte modale, celle-ci sera sans titre si le lien est
+vide.
+
+Voici un exemple.
+
+.. sourcecode:: html
+
+  <a href="#modal" class="open-modal edit-button" title="{% trans "Modifier la licence" %}">
+    <span class="visuallyhidden">{% trans "Modifier la licence" %}</span>
+  </a>
+
+Pour s'assurer que le bouton de modification et ce qu'il permet de modifier
+soient correctement alignés verticalement et espacés, il existe une seconde
+classe à appliquer à un conteneur des deux éléments : ``editable-element``.
+
+Cet élément doit avoir deux enfants : l'un d'entre eux sera l'élément
+visuellement modifié, et l'autre le bouton de modification, avec la classe
+``edit-button``. S'il a plus de deux enfants, le bouton de modification prendra
+toujours le moins d'espace possible, et les autres se partageront équitablement
+la place disponible, tout en restant alignés verticalement.
+
+Le bouton peut être placé avant ou après l'élément : l'alignement et
+l'espacement seront correctement gérés.
+
+Si on prend l'exemple d'une licence d'un contenu à côté de laquelle on place un
+bouton de modification, l'on pourrait utiliser le code HTML suivant.
+
+.. sourcecode:: html
+
+  <div class="editable-element">
+    <p>{{ content.licence }}</p>
+    <a href="#edit-license" class="open-modal edit-button" title="{% trans "Modifier la licence" %}">
+      <span class="visuallyhidden">{% trans "Modifier la licence" %}</span>
+    </a>
+  </div>
 
 
 Formulaires
@@ -215,4 +266,3 @@ Vous pouvez combiner icône et texte comme ceci :
       <span class="alert-box-text">Croix + texte.</span>
       <button class="close-alert-box close-alert-box-text ico-after cross white">Masquer l'alerte</button>
   </div>
-

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -22,15 +22,18 @@
 
 {% block headline %}
     {% if content.licence %}
-        <p class="license">
-            {{ content.licence }}
-            <a href="#edit-license" class="open-modal">{% trans "Modifier la licence" %}</a>
-        </p>
+      <div class="editable-element license">
+        <p>{{ content.licence }}</p>
+        <a href="#edit-license" class="open-modal edit-button" title="{% trans "Modifier la licence" %}">
+          <span class="visuallyhidden">{% trans "Modifier la licence" %}</span>
+        </a>
+      </div>
     {% else %}
         <p class="license">
             <a href="#edit-license" class="open-modal">Choisissez la licence de votre publication !</a>
         </p>
     {% endif %}
+
     {% crispy form_edit_license %}
 
     <h1 {% if content.image %}class="illu"{% endif %}>


### PR DESCRIPTION
Auparavant un lien textuel, le lien permettant d'ouvrir la boîte de dialogue de modification de la licence d'un contenu est désormais un bouton avec une icône de crayon.

Cette PR ajoute plus généralement deux outils pour gérer ce genre de cas de figure (ainsi que leur documentation) : 
- une classe CSS à appliquer à un lien, permettant d'en faire  un bouton de modification cohérent avec les autres ;
- une autre classe CSS conteneur permettant d'abriter l'élément modifié ainsi que son bouton, pour s'assurer que les deux restent verticalement centrés et correctement espacés.

Une modification mineure dans les modales améliore également l'intégration des formulaires dans ces derniers, les rendant systématiquement en pleine largeur.

Voici un aperçu. Bien entendu, comme pour tout, je reste ouvert si autrui a des propositions d'amélioration sur le style choisi.

![image](https://user-images.githubusercontent.com/1417570/84607525-12badc80-aeae-11ea-99f5-a079b227cc3d.png)

![image](https://user-images.githubusercontent.com/1417570/84607509-06cf1a80-aeae-11ea-95d7-f82ae34d3bd7.png)

Numéro ~~du ticket~~ de la PR concernée (optionnel) : #5784.
PR demandée (gentiment) par @Arnaud-D.


### Contrôle qualité

- Lancez le site, en prenant soin de lancer la construction du _front-end_ à un moment afin de le reconstruire.
- Rendez-vous sur un contenu en cours de rédaction, en sa version brouillon, ou à défaut, créez-en un.
- Concernant le bouton : vérifiez qu'il s'affiche correctement à côté de la licence, en haut à droite de la page et  en regard du site, et que sa réalisation est satisfaisante.
- Concernant la boîte de dialogue : vérifiez qu'elle s'affiche correctement lorsque l'on clique sur le bouton, qu'elle a toujours un titre, et que son formulaire est en pleine largeur.
