### PR TITLE
Gestion des exports d'un contenu

### DIFF
--- a/assets/js/content-export.js
+++ b/assets/js/content-export.js
@@ -104,17 +104,6 @@
             headerDownloadLink.setAttribute('title', t.trDownloadTitle)
           } else if (state === 'running' || state === 'requested') {
             headerDownloadLink.setAttribute('title', t.trDownloadUnavailableTitle)
-          } else {
-            headerDownloadLink.setAttribute('title', t.trRestartTitle)
-            let restarRequestClicked = false
-            headerDownloadLink.addEventListener('click', () => {
-              if (restarRequestClicked) return
-
-              headerDownloadLink.innerText = t.trGenerationWaiting
-              restarRequestClicked = true
-
-              requestExports()
-            })
           }
 
           if (state !== 'failure') {
@@ -124,7 +113,7 @@
 
           footer.innerText = t[`trState${state}`]
 
-          headerP.appendChild(headerDownloadLink)
+          if (state !== 'failure') headerP.appendChild(headerDownloadLink)
           header.appendChild(headerH4)
           header.appendChild(headerP)
 

--- a/assets/js/content-export.js
+++ b/assets/js/content-export.js
@@ -1,27 +1,199 @@
-(function($) {
-  $('[data-export-button]').click(function(e) {
-    e.preventDefault()
-    const $button = $(e.target)
-    const url = $button.data('export-button')
-    const csrf = $('input[name=csrfmiddlewaretoken]').val()
-    $button.prop('disabled', true)
-    $button.prop('aria-busy', true)
-    $.ajax(url, {
-      method: 'POST',
-      headers: {
-        'X-CSRFToken': csrf
-      },
-      data: {}
-    }).done(() => {
-      $button.prop('disabled', false)
-      $button.text($button.attr('data-success-text'))
-      $button.prop('aria-busy', false)
-      setTimeout(() => $button.text($button.attr('data-base-text')), 5000)
-    }).fail(() => {
-      $button.prop('disabled', false)
-      $button.text($button.attr('data-error-text'))
-      $button.prop('aria-busy', false)
-      setTimeout(() => $button.text($button.attr('data-base-text')), 5000)
+(function() {
+    const exportsModal = document.getElementById('exports-modal')
+
+    // Not on a tutorial page
+    if (!exportsModal) return
+
+    const exportsModalHandle = document.querySelector('[data-exports-api]')
+
+    const exportsSection = exportsModal.querySelector('section.exports')
+    const exportsRequestButton = exportsModal.querySelector('footer button.btn')
+
+    const exportsAPI = exportsModalHandle.dataset.exportsApi
+    const exportRequestAPI = exportsModalHandle.dataset.requestExportApi
+
+    const t = exportsSection.dataset
+
+    const formatter = new Intl.DateTimeFormat('fr-FR', {
+        weekday: "long", year: "numeric", month: "long", day: "numeric"
     })
-  })
-})(jQuery)
+
+    const formatterLong = new Intl.DateTimeFormat('fr-FR', {
+        weekday: "long", year: "numeric", month: "long", day: "numeric",
+        hour: "numeric", minute: "numeric", second: "numeric"
+    })
+
+    let updateTaskID = null
+
+    exportsRequestButton.dataset.initialLabel = exportsRequestButton.innerText
+
+    function displayError(message) {
+        exportsSection.classList.add('is-empty')
+
+        let p = document.createElement('p');
+        p.innerHTML = message;
+
+        exportsSection.innerHTML = ''
+        exportsSection.appendChild(p)
+    }
+
+    function updateExports() {
+        return fetch(exportsAPI)
+            .then(response => response.json())
+            .then(content_exports => {
+                if (content_exports.length === 0) {
+                    displayError(t.trNoExports)
+                    return
+                }
+
+                // We want PDF and ePub first, in this order
+                const firstFormats = ['pdf', 'epub']
+
+                content_exports.sort((a, b) => {
+                    const aIndex = firstFormats.indexOf(a.format_requested)
+                    const bIndex = firstFormats.indexOf(b.format_requested)
+                    const aIn = aIndex !== -1
+                    const bIn = bIndex !== -1
+
+                    if (aIn && !bIn) return -1
+                    else if (!aIn && bIn) return 1
+                    else if (aIn && bIn) return aIndex - bIndex
+                    else return a.format_requested.localeCompare(b.format_requested)
+                })
+
+                exportsSection.classList.remove('is-empty')
+                exportsSection.innerHTML = ''
+
+                for (const content_export of content_exports) {
+                    const article = document.createElement('article')
+                    const header = document.createElement('header')
+                    const headerH4 = document.createElement('h4')
+                    const headerP = document.createElement('p')
+                    const headerDownloadLink = document.createElement('a')
+                    const footer = document.createElement('footer')
+
+                    const state = content_export.state_of_processing.toLowerCase()
+                    const date = new Date(content_export.date)
+
+                    article.classList.add('export')
+                    article.classList.add(`is-${state}`)
+
+                    headerH4.innerText = t['trFormat' + content_export.format_requested] || content_export.format_requested
+
+                    headerP.setAttribute('title', formatterLong.format(date))
+                    headerP.innerText = formatter.format(date) + ' – '
+
+                    if (state === 'success') {
+                        headerDownloadLink.setAttribute('title', t.trDownloadTitle)
+                    }
+                    else if (state === 'running' || state === 'requested') {
+                        headerDownloadLink.setAttribute('title', t.trDownloadUnavailableTitle)
+                    }
+                    else {
+                        headerDownloadLink.setAttribute('title', t.trRestartTitle)
+                        let restarRequestClicked = false
+                        headerDownloadLink.addEventListener('click', () => {
+                            if (restarRequestClicked) return;
+
+                            headerDownloadLink.innerText = t.trGenerationWaiting
+                            restarRequestClicked = true
+
+                            requestExports()
+                        })
+                    }
+
+                    if (state === 'failure') {
+                        headerDownloadLink.innerText = t.trRestart
+                        headerDownloadLink.setAttribute('href', '#')
+                    }
+                    else {
+                        headerDownloadLink.innerText = t.trDownload
+                        headerDownloadLink.setAttribute('href', content_export.url)
+                    }
+
+                    footer.innerText = t[`trState${state}`]
+
+                    headerP.appendChild(headerDownloadLink)
+                    header.appendChild(headerH4)
+                    header.appendChild(headerP)
+
+                    article.appendChild(header)
+                    article.appendChild(footer)
+
+                    exportsSection.appendChild(article)
+                }
+
+                scheduleNextUpdate(content_exports)
+            })
+            .catch(() => {
+                displayError(t.trErrorLoading)
+                scheduleNextUpdate()
+            })
+    }
+
+    /**
+     * Starts/stops the update task if required.
+     * The task should run:
+     * - if the modale is open;
+     * - if there is at least one export with state `REQUESTED` or `RUNNING`.
+     */
+    function scheduleNextUpdate(content_exports) {
+        let shouldRun = exportsModal.classList.contains('open')
+        if (content_exports) {
+            shouldRun &= content_exports
+                .filter(exp => exp.state_of_processing === 'REQUESTED' || exp.state_of_processing === 'RUNNING')
+                .length > 0
+        }
+
+        if (shouldRun) {
+            setTimeout(updateExports, 4000)
+        }
+    }
+
+    function requestExports() {
+        exportsRequestButton.setAttribute('disabled', 'disabled')
+        exportsRequestButton.classList.add('disabled')
+        exportsRequestButton.classList.add('submitted')
+        exportsRequestButton.innerText = t.trGenerationWaiting
+
+        const line = document.createElement('div')
+        line.classList.add('line-loading')
+
+        exportsRequestButton.appendChild(line)
+
+        function messageOnButton(message, timeout) {
+            exportsRequestButton.classList.remove('disabled')
+            exportsRequestButton.classList.remove('submitted')
+
+            exportsRequestButton.setAttribute('disabled', 'disabled')
+            exportsRequestButton.innerText = message
+
+            setTimeout(() => {
+                exportsRequestButton.removeAttribute('disabled')
+                exportsRequestButton.innerText = exportsRequestButton.dataset.initialLabel
+            }, 1000 * timeout)
+        }
+
+        let headers = new Headers()
+
+        fetch(exportRequestAPI, {
+            method: 'POST',
+            headers: new Headers({
+                'X-CSRFToken': exportsRequestButton.dataset.csrf
+            })
+        }).then(() => {
+            messageOnButton(t.trGenerationRequested, 120)
+            updateExports()
+        }).catch(e => {
+            console.error('Cannot request exports update', e)
+            messageOnButton(t.trGenerationErrored, 5)
+        })
+    }
+
+    exportsModalHandle.addEventListener('click', () => {
+        updateExports()
+        exportsModalHandle.blur()
+    })
+
+    exportsRequestButton.addEventListener('click', requestExports)
+})()

--- a/assets/js/content-export.js
+++ b/assets/js/content-export.js
@@ -1,199 +1,221 @@
+/* ===== Zeste de Savoir ====================================================
+   Exports modale: opening and live-update.
+   ---------------------------------
+   Author: Amaury Carrade
+   ========================================================================== */
+
 (function() {
-    const exportsModal = document.getElementById('exports-modal')
+  const exportsModal = document.getElementById('exports-modal')
 
-    // Not on a tutorial page
-    if (!exportsModal) return
+  // Not on a tutorial page
+  if (!exportsModal) return
 
-    const exportsModalHandle = document.querySelector('[data-exports-api]')
+  const exportsModalHandle = document.querySelector('[data-exports-api]')
 
-    const exportsSection = exportsModal.querySelector('section.exports')
-    const exportsRequestButton = exportsModal.querySelector('footer button.btn')
+  const exportsSection = exportsModal.querySelector('section.exports')
+  const exportsRequestButton = exportsModal.querySelector('footer button.btn')
 
-    const exportsAPI = exportsModalHandle.dataset.exportsApi
-    const exportRequestAPI = exportsModalHandle.dataset.requestExportApi
+  const exportsAPI = exportsModalHandle.dataset.exportsApi
+  const exportRequestAPI = exportsModalHandle.dataset.requestExportApi
 
-    const t = exportsSection.dataset
+  const t = exportsSection.dataset
 
-    const formatter = new Intl.DateTimeFormat('fr-FR', {
-        weekday: "long", year: "numeric", month: "long", day: "numeric"
-    })
+  const formatter = new Intl.DateTimeFormat('fr-FR', {
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
+  })
 
-    const formatterLong = new Intl.DateTimeFormat('fr-FR', {
-        weekday: "long", year: "numeric", month: "long", day: "numeric",
-        hour: "numeric", minute: "numeric", second: "numeric"
-    })
+  const formatterLong = new Intl.DateTimeFormat('fr-FR', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric'
+  })
 
-    let updateTaskID = null
+  exportsRequestButton.dataset.initialLabel = exportsRequestButton.innerText
 
-    exportsRequestButton.dataset.initialLabel = exportsRequestButton.innerText
+  /**
+   * Displays a message where the exports list stands (removing the list),
+   * e.g. to display an error message, or if the list is empty.
+   */
+  function displayError(message) {
+    exportsSection.classList.add('is-empty')
 
-    function displayError(message) {
-        exportsSection.classList.add('is-empty')
+    const p = document.createElement('p')
+    p.innerHTML = message
 
-        let p = document.createElement('p');
-        p.innerHTML = message;
+    exportsSection.innerHTML = ''
+    exportsSection.appendChild(p)
+  }
 
-        exportsSection.innerHTML = ''
-        exportsSection.appendChild(p)
-    }
-
-    function updateExports() {
-        return fetch(exportsAPI)
-            .then(response => response.json())
-            .then(content_exports => {
-                if (content_exports.length === 0) {
-                    displayError(t.trNoExports)
-                    return
-                }
-
-                // We want PDF and ePub first, in this order
-                const firstFormats = ['pdf', 'epub']
-
-                content_exports.sort((a, b) => {
-                    const aIndex = firstFormats.indexOf(a.format_requested)
-                    const bIndex = firstFormats.indexOf(b.format_requested)
-                    const aIn = aIndex !== -1
-                    const bIn = bIndex !== -1
-
-                    if (aIn && !bIn) return -1
-                    else if (!aIn && bIn) return 1
-                    else if (aIn && bIn) return aIndex - bIndex
-                    else return a.format_requested.localeCompare(b.format_requested)
-                })
-
-                exportsSection.classList.remove('is-empty')
-                exportsSection.innerHTML = ''
-
-                for (const content_export of content_exports) {
-                    const article = document.createElement('article')
-                    const header = document.createElement('header')
-                    const headerH4 = document.createElement('h4')
-                    const headerP = document.createElement('p')
-                    const headerDownloadLink = document.createElement('a')
-                    const footer = document.createElement('footer')
-
-                    const state = content_export.state_of_processing.toLowerCase()
-                    const date = new Date(content_export.date)
-
-                    article.classList.add('export')
-                    article.classList.add(`is-${state}`)
-
-                    headerH4.innerText = t['trFormat' + content_export.format_requested] || content_export.format_requested
-
-                    headerP.setAttribute('title', formatterLong.format(date))
-                    headerP.innerText = formatter.format(date) + ' – '
-
-                    if (state === 'success') {
-                        headerDownloadLink.setAttribute('title', t.trDownloadTitle)
-                    }
-                    else if (state === 'running' || state === 'requested') {
-                        headerDownloadLink.setAttribute('title', t.trDownloadUnavailableTitle)
-                    }
-                    else {
-                        headerDownloadLink.setAttribute('title', t.trRestartTitle)
-                        let restarRequestClicked = false
-                        headerDownloadLink.addEventListener('click', () => {
-                            if (restarRequestClicked) return;
-
-                            headerDownloadLink.innerText = t.trGenerationWaiting
-                            restarRequestClicked = true
-
-                            requestExports()
-                        })
-                    }
-
-                    if (state === 'failure') {
-                        headerDownloadLink.innerText = t.trRestart
-                        headerDownloadLink.setAttribute('href', '#')
-                    }
-                    else {
-                        headerDownloadLink.innerText = t.trDownload
-                        headerDownloadLink.setAttribute('href', content_export.url)
-                    }
-
-                    footer.innerText = t[`trState${state}`]
-
-                    headerP.appendChild(headerDownloadLink)
-                    header.appendChild(headerH4)
-                    header.appendChild(headerP)
-
-                    article.appendChild(header)
-                    article.appendChild(footer)
-
-                    exportsSection.appendChild(article)
-                }
-
-                scheduleNextUpdate(content_exports)
-            })
-            .catch(() => {
-                displayError(t.trErrorLoading)
-                scheduleNextUpdate()
-            })
-    }
-
-    /**
-     * Starts/stops the update task if required.
-     * The task should run:
-     * - if the modale is open;
-     * - if there is at least one export with state `REQUESTED` or `RUNNING`.
-     */
-    function scheduleNextUpdate(content_exports) {
-        let shouldRun = exportsModal.classList.contains('open')
-        if (content_exports) {
-            shouldRun &= content_exports
-                .filter(exp => exp.state_of_processing === 'REQUESTED' || exp.state_of_processing === 'RUNNING')
-                .length > 0
+  /**
+   * Calls the exports API and update the view with the current exports and
+   * their statuts.
+   */
+  function updateExports() {
+    return fetch(exportsAPI)
+      .then(response => response.json())
+      .then(contentExports => {
+        if (contentExports.length === 0) {
+          displayError(t.trNoExports)
+          return
         }
 
-        if (shouldRun) {
-            setTimeout(updateExports, 4000)
-        }
-    }
+        // We want PDF and ePub first, in this order
+        const firstFormats = ['pdf', 'epub']
 
-    function requestExports() {
-        exportsRequestButton.setAttribute('disabled', 'disabled')
-        exportsRequestButton.classList.add('disabled')
-        exportsRequestButton.classList.add('submitted')
-        exportsRequestButton.innerText = t.trGenerationWaiting
+        contentExports.sort((a, b) => {
+          const aIndex = firstFormats.indexOf(a.format_requested)
+          const bIndex = firstFormats.indexOf(b.format_requested)
+          const aIn = aIndex !== -1
+          const bIn = bIndex !== -1
 
-        const line = document.createElement('div')
-        line.classList.add('line-loading')
-
-        exportsRequestButton.appendChild(line)
-
-        function messageOnButton(message, timeout) {
-            exportsRequestButton.classList.remove('disabled')
-            exportsRequestButton.classList.remove('submitted')
-
-            exportsRequestButton.setAttribute('disabled', 'disabled')
-            exportsRequestButton.innerText = message
-
-            setTimeout(() => {
-                exportsRequestButton.removeAttribute('disabled')
-                exportsRequestButton.innerText = exportsRequestButton.dataset.initialLabel
-            }, 1000 * timeout)
-        }
-
-        let headers = new Headers()
-
-        fetch(exportRequestAPI, {
-            method: 'POST',
-            headers: new Headers({
-                'X-CSRFToken': exportsRequestButton.dataset.csrf
-            })
-        }).then(() => {
-            messageOnButton(t.trGenerationRequested, 120)
-            updateExports()
-        }).catch(e => {
-            console.error('Cannot request exports update', e)
-            messageOnButton(t.trGenerationErrored, 5)
+          if (aIn && !bIn) return -1
+          else if (!aIn && bIn) return 1
+          else if (aIn && bIn) return aIndex - bIndex
+          else return a.format_requested.localeCompare(b.format_requested)
         })
+
+        exportsSection.classList.remove('is-empty')
+        exportsSection.innerHTML = ''
+
+        for (const contentExport of contentExports) {
+          const article = document.createElement('article')
+          const header = document.createElement('header')
+          const headerH4 = document.createElement('h4')
+          const headerP = document.createElement('p')
+          const headerDownloadLink = document.createElement('a')
+          const footer = document.createElement('footer')
+
+          const state = contentExport.state_of_processing.toLowerCase()
+          const date = new Date(contentExport.date)
+
+          article.classList.add('export')
+          article.classList.add(`is-${state}`)
+
+          headerH4.innerText = t['trFormat' + contentExport.format_requested] || contentExport.format_requested
+
+          headerP.setAttribute('title', formatterLong.format(date))
+          headerP.innerText = formatter.format(date) + ' – '
+
+          if (state === 'success') {
+            headerDownloadLink.setAttribute('title', t.trDownloadTitle)
+          } else if (state === 'running' || state === 'requested') {
+            headerDownloadLink.setAttribute('title', t.trDownloadUnavailableTitle)
+          } else {
+            headerDownloadLink.setAttribute('title', t.trRestartTitle)
+            let restarRequestClicked = false
+            headerDownloadLink.addEventListener('click', () => {
+              if (restarRequestClicked) return
+
+              headerDownloadLink.innerText = t.trGenerationWaiting
+              restarRequestClicked = true
+
+              requestExports()
+            })
+          }
+
+          if (state === 'failure') {
+            headerDownloadLink.innerText = t.trRestart
+            headerDownloadLink.setAttribute('href', '#')
+          } else {
+            headerDownloadLink.innerText = t.trDownload
+            headerDownloadLink.setAttribute('href', contentExport.url)
+          }
+
+          footer.innerText = t[`trState${state}`]
+
+          headerP.appendChild(headerDownloadLink)
+          header.appendChild(headerH4)
+          header.appendChild(headerP)
+
+          article.appendChild(header)
+          article.appendChild(footer)
+
+          exportsSection.appendChild(article)
+        }
+
+        scheduleNextUpdate(contentExports)
+      })
+      .catch(() => {
+        displayError(t.trErrorLoading)
+        scheduleNextUpdate()
+      })
+  }
+
+  /**
+   * Schedules the next update task, if it should run.
+   * The task should run:
+   * - if the modale is open; and
+   * - if there is at least one export with state `REQUESTED` or `RUNNING`.
+   */
+  function scheduleNextUpdate(contentExports) {
+    let shouldRun = exportsModal.classList.contains('open')
+    if (contentExports) {
+      shouldRun &= contentExports
+        .filter(exp => exp.state_of_processing === 'REQUESTED' || exp.state_of_processing === 'RUNNING')
+        .length > 0
     }
 
-    exportsModalHandle.addEventListener('click', () => {
-        updateExports()
-        exportsModalHandle.blur()
-    })
+    if (shouldRun) {
+      setTimeout(updateExports, 4000)
+    }
+  }
 
-    exportsRequestButton.addEventListener('click', requestExports)
+  /**
+   * Displays a message on the “request all exports” button, and disables said
+   * button, during the given timeout. After this timeout, the button is
+   * restored to its original state.
+   */
+  function messageOnButton(message, timeout) {
+    exportsRequestButton.classList.remove('disabled')
+    exportsRequestButton.classList.remove('submitted')
+
+    exportsRequestButton.setAttribute('disabled', 'disabled')
+    exportsRequestButton.innerText = message
+
+    setTimeout(() => {
+      exportsRequestButton.removeAttribute('disabled')
+      exportsRequestButton.innerText = exportsRequestButton.dataset.initialLabel
+    }, 1000 * timeout)
+  }
+
+  /**
+   * Requests the exports to be generated.
+   * Sends the POST request, then update the exports list to reflect the
+   * request.
+   */
+  function requestExports() {
+    exportsRequestButton.setAttribute('disabled', 'disabled')
+    exportsRequestButton.classList.add('disabled')
+    exportsRequestButton.classList.add('submitted')
+    exportsRequestButton.innerText = t.trGenerationWaiting
+
+    const line = document.createElement('div')
+    line.classList.add('line-loading')
+
+    exportsRequestButton.appendChild(line)
+
+    fetch(exportRequestAPI, {
+      method: 'POST',
+      headers: new Headers({
+        'X-CSRFToken': exportsRequestButton.dataset.csrf
+      })
+    }).then(() => {
+      messageOnButton(t.trGenerationRequested, 120)
+      updateExports()
+    }).catch(e => {
+      console.error('Cannot request exports update', e)
+      messageOnButton(t.trGenerationErrored, 5)
+    })
+  }
+
+  exportsModalHandle.addEventListener('click', () => {
+    updateExports()
+    exportsModalHandle.blur()
+  })
+
+  exportsRequestButton.addEventListener('click', requestExports)
 })()

--- a/assets/js/content-export.js
+++ b/assets/js/content-export.js
@@ -98,7 +98,7 @@
           headerH4.innerText = t['trFormat' + contentExport.format_requested] || contentExport.format_requested
 
           headerP.setAttribute('title', formatterLong.format(date))
-          headerP.innerText = formatter.format(date) + ' – '
+          headerP.innerText = formatter.format(date) + (state !== 'failure' ? ' – ' : '')
 
           if (state === 'success') {
             headerDownloadLink.setAttribute('title', t.trDownloadTitle)
@@ -117,10 +117,7 @@
             })
           }
 
-          if (state === 'failure') {
-            headerDownloadLink.innerText = t.trRestart
-            headerDownloadLink.setAttribute('href', '#')
-          } else {
+          if (state !== 'failure') {
             headerDownloadLink.innerText = t.trDownload
             headerDownloadLink.setAttribute('href', contentExport.url)
           }

--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -191,7 +191,7 @@
             }
         }
     }
-    @mixin addBtnColorProperties($bg, $color, $bg_hover, $color_hover, $bg_loading) {  
+    @mixin addBtnColorProperties($bg, $color, $bg_hover, $color_hover, $bg_loading) {
         &:not(.link) {
             background: $bg;
             color: $color;

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -136,6 +136,12 @@
     &.modal-large {
         width: 800px;
     }
+
+    &.modal-flex, &.modal-large {
+        p {
+            width: 100%;
+        }
+    }
 }
 
 @media only screen and #{$media-wide} {

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -93,6 +93,7 @@
 @import "pages/tutorial-help";
 @import "pages/tutorial-history";
 @import "pages/content-editor";
+@import "pages/content-exports";
 
 /*-------------------------
 10. High pixel ratio (retina)

--- a/assets/scss/pages/_content-exports.scss
+++ b/assets/scss/pages/_content-exports.scss
@@ -57,7 +57,6 @@
                     color: #6c6c6c;
 
                     a {
-                        //color: $color-primary;
                         text-decoration: none;
 
                         &:hover {

--- a/assets/scss/pages/_content-exports.scss
+++ b/assets/scss/pages/_content-exports.scss
@@ -1,0 +1,136 @@
+#exports-modal {
+    width: 500px;
+
+    p {
+        text-align: justify;
+    }
+
+    section.exports {
+        margin-top: 3.6rem;
+        margin-bottom: 4rem;
+
+        &.is-empty {
+
+            p {
+                margin: 0;
+                text-align: center;
+            }
+        }
+
+        article.export {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+
+            margin: 0 1rem 1.5rem 0;
+
+            header {
+                flex: 2;
+                margin-left: 4rem;
+
+                position: relative;
+
+                &:before {
+                    content: '';
+
+                    position: absolute;
+                    left: -3rem;
+                    top: calc(50% - 8px);
+
+                    width: 16px;
+                    height: 16px;
+
+                    background-repeat: no-repeat;
+
+                    @include sprite();
+                }
+
+                h4 {
+                    margin: 0;
+                    font-size: 1.2em;
+                }
+
+                p {
+                    font-size: .9em;
+                    margin-bottom: 0;
+
+                    color: #6c6c6c;
+
+                    a {
+                        //color: $color-primary;
+                        text-decoration: none;
+
+                        &:hover {
+                            text-decoration: underline;
+                        }
+                    }
+                }
+            }
+
+            &:not(.is-success):not(.is-failure) {
+                header p a {
+                    &, &:hover {
+                        color: #999;
+                    }
+                }
+            }
+
+            &.is-requested {
+                header:before {
+                    @include sprite-position($radio)
+                }
+            }
+
+            &.is-running {
+                header:before {
+                    @include sprite-position($radio)
+                }
+
+                footer {
+                    color: $color-primary;
+                }
+            }
+
+            &.is-success {
+                header:before {
+                    @include sprite-position($tick-green);
+                }
+
+                footer {
+                    color: $color-success;
+                }
+            }
+
+            &.is-failure {
+                header:before {
+                    @include sprite-position($cross-red)
+                }
+
+                footer {
+                    color: $color-danger;
+                }
+            }
+        }
+    }
+
+    footer {
+        h3 {
+            margin-bottom: 1rem;
+        }
+
+        p {
+            margin-bottom: 1.5rem;
+        }
+
+        button.btn {
+            margin: .4rem 1rem 1.5rem;
+            float: none;
+            width: calc(100% - 2rem);
+
+            &[disabled] {
+                background-color: transparent !important;
+                color: #6c6c6c !important;
+            }
+        }
+    }
+}

--- a/templates/tutorialv2/includes/exports.part.html
+++ b/templates/tutorialv2/includes/exports.part.html
@@ -1,0 +1,56 @@
+{% load i18n %}
+
+<a href="#exports-modal" class="open-modal ico-after gear blue"
+   data-exports-id="{{ content.pk }}"
+   data-exports-api="{% url "api:content:list_exports" content.pk %}"
+   data-request-export-api="{% url "api:content:generate_export" content.pk %}">
+  {% trans "Exports du contenu (PDF, ePub, LaTeX…)" %}
+</a>
+
+<div class="modal modal-flex" id="exports-modal" data-modal-close="Fermer">
+    {% blocktrans %}
+        <p>
+            En plus de leur version web, <strong>vos contenus sont exportés
+            automatiquement en différents formats</strong> (PDF, ePub pour
+            liseuses, LaTeX, HTML…) par Zeste de Savoir, ce qui permet notamment
+            de les diffuser plus facilement hors-ligne.
+        </p>
+    {% endblocktrans %}
+
+    <section class="exports is-empty"
+             data-tr-no-exports="{% trans "<strong>Ce contenu n'a jamais été exporté.</strong><br />Cliquez sur le bouton vert ci-dessous pour générer des version PDF, ePub, etc. !" %}"
+             data-tr-error-loading="{% trans "Impossible de charger la liste des exports." %}"
+             data-tr-formatpdf="{% trans "PDF" %}"
+             data-tr-formatepub="{% trans "ePub" %}"
+             data-tr-formathtml="{% trans "HTML" %}"
+             data-tr-formatzip="{% trans "ZIP" %}"
+             data-tr-download="{% trans "Télécharger" %}"
+             data-tr-download-title="{% trans "Télécharger cet export" %}"
+             data-tr-download-unavailable-title="{% trans "Cet export est en cours de traitement ; ce lien ne fonctionnera pas ou sera obsolète." %}"
+             data-tr-restart="{% trans "Relancer" %}"
+             data-tr-restart-title="{% trans "Relancer la génération de cet export" %}"
+             data-tr-statesuccess="{% trans "Terminé" %}"
+             data-tr-staterunning="{% trans "En cours de traitement" %}"
+             data-tr-statefailure="{% trans "Échoué" %}"
+             data-tr-staterequested="{% trans "En attente" %}"
+             data-tr-generation-waiting="{% trans "Traitement…" %}"
+             data-tr-generation-requested="{% trans "La génération a été demandée." %}"
+             data-tr-generation-errored="{% trans "Impossible de demander la génération… Réessayez ?" %}"
+    >
+        <p>
+            {% trans "Chargement en cours…" %}
+        </p>
+    </section>
+
+    <footer>
+        <h3>{% trans "Exporter dans tous les formats" %}</h3>
+        {% blocktrans %}
+            <p>
+                Si pour quelque raison, les exports ne sont pas disponibles, ou
+                si vous voulez les actualiser, cliquez sur le bouton ci-dessous
+                pour re-lancer leur génération.
+            </p>
+        {% endblocktrans %}
+        <button class="btn btn-submit btn-holder modal-inner" data-csrf="{{ csrf_token }}">Demander la génération de tous les exports</button>
+    </footer>
+</div>

--- a/templates/tutorialv2/includes/exports.part.html
+++ b/templates/tutorialv2/includes/exports.part.html
@@ -31,7 +31,6 @@
              data-tr-staterunning="{% trans "En cours de traitement" %}"
              data-tr-statefailure="{% trans "Échoué" %}"
              data-tr-staterequested="{% trans "En attente" %}"
-             data-tr-generation-waiting="{% trans "Traitement…" %}"
              data-tr-generation-requested="{% trans "La génération a été demandée." %}"
              data-tr-generation-errored="{% trans "Impossible de demander la génération… Réessayez ?" %}"
     >

--- a/templates/tutorialv2/includes/exports.part.html
+++ b/templates/tutorialv2/includes/exports.part.html
@@ -27,8 +27,6 @@
              data-tr-download="{% trans "Télécharger" %}"
              data-tr-download-title="{% trans "Télécharger cet export" %}"
              data-tr-download-unavailable-title="{% trans "Cet export est en cours de traitement ; ce lien ne fonctionnera pas ou sera obsolète." %}"
-             data-tr-restart="{% trans "Relancer" %}"
-             data-tr-restart-title="{% trans "Relancer la génération de cet export" %}"
              data-tr-statesuccess="{% trans "Terminé" %}"
              data-tr-staterunning="{% trans "En cours de traitement" %}"
              data-tr-statefailure="{% trans "Échoué" %}"
@@ -43,11 +41,11 @@
     </section>
 
     <footer>
-        <h3>{% trans "Exporter dans tous les formats" %}</h3>
+        <h3>{% trans "Regénérer les exports de votre contenu" %}</h3>
         {% blocktrans %}
             <p>
-                Si pour quelque raison, les exports ne sont pas disponibles, ou
-                si vous voulez les actualiser, cliquez sur le bouton ci-dessous
+                Si pour quelque raison, tous les exports ne sont pas disponibles,
+                ou si vous voulez les actualiser, cliquez sur le bouton ci-dessous
                 pour re-lancer leur génération.
             </p>
         {% endblocktrans %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -486,9 +486,7 @@
                 </a>
             </li>
             <li>
-                <button data-export-button="{% url "api:content:generate_export" content.pk %}" class="ico-after gear blue">
-                    {% trans "Exporter le contenu (epub, pdf, latex...)" %}
-                </button>
+                {% include "tutorialv2/includes/exports.part.html" %}
             </li>
         {% endif %}
         {# END ONLINE VERSION #}

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -273,12 +273,7 @@
                     </a>
                 </li>
                 <li>
-                    <button data-export-button="{% url "api:content:generate_export" content.pk %}" class="ico-after gear blue"
-                    data-success-text="{% trans "Export en cours, veuillez attendre quelques minutes" %}"
-                    data-error-text="{% trans "La demande d'export a échoué" %}"
-                    data-base-text="{% trans "Exporter le contenu (epub, pdf, latex...)" %}">
-                        {% trans "Exporter le contenu (epub, pdf, latex...)" %}
-                    </button>
+                    {% include "tutorialv2/includes/exports.part.html" %}
                 </li>
                 {% if is_staff %}
                     {% if content.requires_validation %}

--- a/zds/tutorialv2/api/serializers.py
+++ b/zds/tutorialv2/api/serializers.py
@@ -1,5 +1,5 @@
 from dry_rest_permissions.generics import DRYPermissions
-from rest_framework.serializers import ModelSerializer, URLField
+from rest_framework.serializers import ModelSerializer
 
 from zds.tutorialv2.models.database import PublicationEvent
 
@@ -11,5 +11,5 @@ class PublicationEventSerializer(ModelSerializer):
 
     class Meta:
         model = PublicationEvent
-        fields = ('state_of_processing', 'format_requested', 'date', 'url')
+        fields = ("state_of_processing", "format_requested", "date", "url")
         permissions_classes = DRYPermissions

--- a/zds/tutorialv2/api/serializers.py
+++ b/zds/tutorialv2/api/serializers.py
@@ -11,5 +11,5 @@ class PublicationEventSerializer(ModelSerializer):
 
     class Meta:
         model = PublicationEvent
-        fields = ("state_of_processing", "format_requested", "date", "url")
+        fields = ('state_of_processing', 'format_requested', 'date', 'url')
         permissions_classes = DRYPermissions

--- a/zds/tutorialv2/api/serializers.py
+++ b/zds/tutorialv2/api/serializers.py
@@ -1,0 +1,15 @@
+from dry_rest_permissions.generics import DRYPermissions
+from rest_framework.serializers import ModelSerializer, URLField
+
+from zds.tutorialv2.models.database import PublicationEvent
+
+
+class PublicationEventSerializer(ModelSerializer):
+    """
+    Serializer of a subscription object.
+    """
+
+    class Meta:
+        model = PublicationEvent
+        fields = ('state_of_processing', 'format_requested', 'date', 'url')
+        permissions_classes = DRYPermissions

--- a/zds/tutorialv2/api/tests.py
+++ b/zds/tutorialv2/api/tests.py
@@ -198,13 +198,12 @@ class ContentExportsAPITest(TutorialTestMixin, APITestCase):
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
 
     def tearDown(self):
-        pass
-        # if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):
-        #     shutil.rmtree(settings.ZDS_APP['content']['repo_private_path'])
-        # if os.path.isdir(settings.ZDS_APP['content']['repo_public_path']):
-        #     shutil.rmtree(settings.ZDS_APP['content']['repo_public_path'])
-        # if os.path.isdir(settings.MEDIA_ROOT):
-        #     shutil.rmtree(settings.MEDIA_ROOT)
+        if os.path.isdir(settings.ZDS_APP['content']['repo_private_path']):
+            shutil.rmtree(settings.ZDS_APP['content']['repo_private_path'])
+        if os.path.isdir(settings.ZDS_APP['content']['repo_public_path']):
+            shutil.rmtree(settings.ZDS_APP['content']['repo_public_path'])
+        if os.path.isdir(settings.MEDIA_ROOT):
+            shutil.rmtree(settings.MEDIA_ROOT)
 
     def test_request_content_exports_generation(self):
         author = ProfileFactory()

--- a/zds/tutorialv2/api/urls.py
+++ b/zds/tutorialv2/api/urls.py
@@ -9,15 +9,15 @@ from zds.tutorialv2.api.views import (
 
 urlpatterns = [
     path(
-        "reactions/<int:pk>/karma/",
+        'reactions/<int:pk>/karma/',
         ContentReactionKarmaView.as_view(),
-        name="reaction-karma",
+        name='reaction-karma',
     ),
     path(
-        "publication/preparation/<int:pk>/",
+        'publication/preparation/<int:pk>/',
         ContainerPublicationReadinessView.as_view(),
-        name="readiness",
+        name='readiness',
     ),
-    path("export/<int:pk>/", ExportView.as_view(), name="generate_export"),
-    path("exports/<int:pk>/", ExportsView.as_view(), name="list_exports"),
+    path('export/<int:pk>/', ExportView.as_view(), name='generate_export'),
+    path('exports/<int:pk>/', ExportsView.as_view(), name='list_exports'),
 ]

--- a/zds/tutorialv2/api/urls.py
+++ b/zds/tutorialv2/api/urls.py
@@ -1,11 +1,12 @@
-from django.urls import re_path
+from django.urls import path, re_path
 
-from zds.tutorialv2.api.views import ContentReactionKarmaView, ContainerPublicationReadinessView, ExportView
+from zds.tutorialv2.api.views import ContentReactionKarmaView, ContainerPublicationReadinessView, ExportView, ExportsView
 
 urlpatterns = [
     re_path(r'^reactions/(?P<pk>\d+)/karma/?$',
             ContentReactionKarmaView.as_view(), name='reaction-karma'),
     re_path(r'^publication/preparation/(?P<pk>[0-9]+)/',
             ContainerPublicationReadinessView.as_view(), name='readiness'),
-    re_path(r'^export/(?P<pk>[0-9]+)/', ExportView.as_view(), name='generate_export')
+    re_path(r'^export/(?P<pk>[0-9]+)/', ExportView.as_view(), name='generate_export'),
+    path('exports/<int:pk>/', ExportsView.as_view(), name='list_exports')
 ]

--- a/zds/tutorialv2/api/urls.py
+++ b/zds/tutorialv2/api/urls.py
@@ -1,12 +1,23 @@
-from django.urls import path, re_path
+from django.urls import path
 
-from zds.tutorialv2.api.views import ContentReactionKarmaView, ContainerPublicationReadinessView, ExportView, ExportsView
+from zds.tutorialv2.api.views import (
+    ContentReactionKarmaView,
+    ContainerPublicationReadinessView,
+    ExportView,
+    ExportsView,
+)
 
 urlpatterns = [
-    re_path(r'^reactions/(?P<pk>\d+)/karma/?$',
-            ContentReactionKarmaView.as_view(), name='reaction-karma'),
-    re_path(r'^publication/preparation/(?P<pk>[0-9]+)/',
-            ContainerPublicationReadinessView.as_view(), name='readiness'),
-    re_path(r'^export/(?P<pk>[0-9]+)/', ExportView.as_view(), name='generate_export'),
-    path('exports/<int:pk>/', ExportsView.as_view(), name='list_exports')
+    path(
+        "reactions/<int:pk>/karma/",
+        ContentReactionKarmaView.as_view(),
+        name="reaction-karma",
+    ),
+    path(
+        "publication/preparation/<int:pk>/",
+        ContainerPublicationReadinessView.as_view(),
+        name="readiness",
+    ),
+    path("export/<int:pk>/", ExportView.as_view(), name="generate_export"),
+    path("exports/<int:pk>/", ExportsView.as_view(), name="list_exports"),
 ]

--- a/zds/tutorialv2/api/views.py
+++ b/zds/tutorialv2/api/views.py
@@ -38,8 +38,8 @@ class ContainerReadinessSerializer(Serializer):
         init = super().run_validation(data)
         if not init:
             return init
-        if not data.get("parent_container_slug", ""):
-            init.pop("parent_container_slug", "")
+        if not data.get('parent_container_slug', ''):
+            init.pop('parent_container_slug', '')
         return init
 
     def save(self, **kwargs):
@@ -47,14 +47,14 @@ class ContainerReadinessSerializer(Serializer):
             self.is_valid(True)
         versioned = self.instance.load_version()
         container = search_container_or_404(versioned, self.validated_data)
-        container.ready_to_publish = self.validated_data["ready_to_publish"]
+        container.ready_to_publish = self.validated_data['ready_to_publish']
         sha = versioned.repo_update(
             versioned.title,
             versioned.get_introduction(),
             versioned.get_conclusion(),
-            commit_message=_("{} est {} à la publication.").format(
+            commit_message=_('{} est {} à la publication.').format(
                 container.get_path(True),
-                _("prêt") if container.ready_to_publish else _("ignoré"),
+                _('prêt') if container.ready_to_publish else _('ignoré'),
             ),
         )
         PublishableContent.objects.filter(pk=self.instance.pk).update(sha_draft=sha)
@@ -78,8 +78,8 @@ class ContainerPublicationReadinessView(UpdateAPIView):
 
     def get_object(self):
         content = (
-            PublishableContent.objects.prefetch_related("authors")
-            .filter(pk=int(self.kwargs.get("pk", 0)))
+            PublishableContent.objects.prefetch_related('authors')
+            .filter(pk=int(self.kwargs.get('pk', 0)))
             .first()
         )
         if not content:
@@ -95,14 +95,14 @@ class ExportView(APIView):
     def get_object(self):  # required by IsAuthorOrStaff
         if not self._object:
             self._object = get_object_or_404(
-                PublishableContent.objects, pk=int(self.kwargs.get("pk", 0))
+                PublishableContent.objects, pk=int(self.kwargs.get('pk', 0))
             )
         return self._object
 
     def ensure_directories(self, content: PublishableContent):
         final_directory = Path(content.public_version.get_extra_contents_directory())
         building_directory = Path(
-            str(final_directory.parent) + "__building", final_directory.name
+            str(final_directory.parent) + '__building', final_directory.name
         )
         with contextlib.suppress(FileExistsError):
             final_directory.mkdir(parents=True)
@@ -114,20 +114,20 @@ class ExportView(APIView):
         try:
             publishable_content = self.get_object()
             if not publishable_content.public_version:
-                raise Http404("Not public content")
+                raise Http404('Not public content')
 
             tmp_dir, _ = self.ensure_directories(publishable_content)
             versioned = publishable_content.load_version(public=True)
             base_name = str(Path(tmp_dir, versioned.slug))
-            md_file_path = str(Path(tmp_dir, versioned.slug + ".md"))
+            md_file_path = str(Path(tmp_dir, versioned.slug + '.md'))
 
-            PublicatorRegistry.get("md").publish(
+            PublicatorRegistry.get('md').publish(
                 md_file_path,
                 base_name,
                 versioned=versioned,
                 cur_language=translation.get_language(),
             )
-            PublicatorRegistry.get("watchdog").publish_from_published_content(
+            PublicatorRegistry.get('watchdog').publish_from_published_content(
                 publishable_content.public_version
             )
         except ValueError:
@@ -166,9 +166,9 @@ class ExportsView(ListAPIView):
                 WHERE published.content_id = %s
             )
             SELECT * FROM latest_events WHERE row = 1""",
-            [int(self.kwargs.get("pk", 0))],
+            [int(self.kwargs.get('pk', 0))],
         )
 
-        prefetch_related_objects(exports, "published_object")
+        prefetch_related_objects(exports, 'published_object')
 
         return exports

--- a/zds/tutorialv2/api/views.py
+++ b/zds/tutorialv2/api/views.py
@@ -111,10 +111,11 @@ class ExportView(APIView):
             return Response({}, status=status.HTTP_201_CREATED, headers={})
 
 
-"""
-Lists the most recent exports for this content, and their status.
-"""
 class ExportsView(ListAPIView):
+    """
+    Lists the most recent exports for this content, and their status.
+    """
+
     serializer_class = PublicationEventSerializer
     pagination_class = None
 

--- a/zds/tutorialv2/api/views.py
+++ b/zds/tutorialv2/api/views.py
@@ -1,10 +1,7 @@
 import contextlib
 from pathlib import Path
 
-from django.db.models.expressions import Window
-from django.db.models.functions import RowNumber
 from django.db.models.query import prefetch_related_objects
-from django.db.models import F, Q, Subquery
 from django.http import Http404
 from django.utils import translation
 from django.utils.translation import gettext as _
@@ -16,12 +13,20 @@ from rest_framework.response import Response
 from rest_framework.serializers import Serializer, CharField, BooleanField
 from rest_framework.views import APIView
 
-from zds.member.api.permissions import CanReadAndWriteNowOrReadOnly, IsNotOwnerOrReadOnly, IsAuthorOrStaff
+from zds.member.api.permissions import (
+    CanReadAndWriteNowOrReadOnly,
+    IsNotOwnerOrReadOnly,
+    IsAuthorOrStaff,
+)
 from zds.tutorialv2.publication_utils import PublicatorRegistry
 from zds.tutorialv2.utils import search_container_or_404
 from zds.utils.api.views import KarmaView
 from zds.tutorialv2.api.serializers import PublicationEventSerializer
-from zds.tutorialv2.models.database import ContentReaction, PublishableContent, PublicationEvent
+from zds.tutorialv2.models.database import (
+    ContentReaction,
+    PublishableContent,
+    PublicationEvent,
+)
 
 
 class ContainerReadinessSerializer(Serializer):
@@ -33,8 +38,8 @@ class ContainerReadinessSerializer(Serializer):
         init = super().run_validation(data)
         if not init:
             return init
-        if not data.get('parent_container_slug', ''):
-            init.pop('parent_container_slug', '')
+        if not data.get("parent_container_slug", ""):
+            init.pop("parent_container_slug", "")
         return init
 
     def save(self, **kwargs):
@@ -42,11 +47,16 @@ class ContainerReadinessSerializer(Serializer):
             self.is_valid(True)
         versioned = self.instance.load_version()
         container = search_container_or_404(versioned, self.validated_data)
-        container.ready_to_publish = self.validated_data['ready_to_publish']
-        sha = versioned.repo_update(versioned.title, versioned.get_introduction(), versioned.get_conclusion(),
-                                    commit_message=_('{} est {} à la publication.').format(
-                                        container.get_path(True),
-                                        _('prêt') if container.ready_to_publish else _('ignoré')))
+        container.ready_to_publish = self.validated_data["ready_to_publish"]
+        sha = versioned.repo_update(
+            versioned.title,
+            versioned.get_introduction(),
+            versioned.get_conclusion(),
+            commit_message=_("{} est {} à la publication.").format(
+                container.get_path(True),
+                _("prêt") if container.ready_to_publish else _("ignoré"),
+            ),
+        )
         PublishableContent.objects.filter(pk=self.instance.pk).update(sha_draft=sha)
 
     def to_representation(self, instance):
@@ -55,17 +65,23 @@ class ContainerReadinessSerializer(Serializer):
 
 class ContentReactionKarmaView(KarmaView):
     queryset = ContentReaction.objects.all()
-    permission_classes = (IsAuthenticatedOrReadOnly, CanReadAndWriteNowOrReadOnly, IsNotOwnerOrReadOnly)
+    permission_classes = (
+        IsAuthenticatedOrReadOnly,
+        CanReadAndWriteNowOrReadOnly,
+        IsNotOwnerOrReadOnly,
+    )
 
 
 class ContainerPublicationReadinessView(UpdateAPIView):
-    permission_classes = (IsAuthorOrStaff, )
+    permission_classes = (IsAuthorOrStaff,)
     serializer_class = ContainerReadinessSerializer
 
     def get_object(self):
-        content = PublishableContent.objects.prefetch_related('authors')\
-            .filter(pk=int(self.kwargs.get('pk', 0)))\
+        content = (
+            PublishableContent.objects.prefetch_related("authors")
+            .filter(pk=int(self.kwargs.get("pk", 0)))
             .first()
+        )
         if not content:
             raise Http404()
         self.check_object_permissions(self.request, object)
@@ -78,12 +94,16 @@ class ExportView(APIView):
 
     def get_object(self):  # required by IsAuthorOrStaff
         if not self._object:
-            self._object = get_object_or_404(PublishableContent.objects, pk=int(self.kwargs.get('pk', 0)))
+            self._object = get_object_or_404(
+                PublishableContent.objects, pk=int(self.kwargs.get("pk", 0))
+            )
         return self._object
 
     def ensure_directories(self, content: PublishableContent):
         final_directory = Path(content.public_version.get_extra_contents_directory())
-        building_directory = Path(str(final_directory.parent) + '__building', final_directory.name)
+        building_directory = Path(
+            str(final_directory.parent) + "__building", final_directory.name
+        )
         with contextlib.suppress(FileExistsError):
             final_directory.mkdir(parents=True)
         with contextlib.suppress(FileExistsError):
@@ -94,17 +114,22 @@ class ExportView(APIView):
         try:
             publishable_content = self.get_object()
             if not publishable_content.public_version:
-                raise Http404('Not public content')
+                raise Http404("Not public content")
 
             tmp_dir, _ = self.ensure_directories(publishable_content)
             versioned = publishable_content.load_version(public=True)
             base_name = str(Path(tmp_dir, versioned.slug))
-            md_file_path = str(Path(tmp_dir, versioned.slug + '.md'))
+            md_file_path = str(Path(tmp_dir, versioned.slug + ".md"))
 
-            PublicatorRegistry.get('md').publish(md_file_path, base_name,
-                                                 versioned=versioned,
-                                                 cur_language=translation.get_language())
-            PublicatorRegistry.get('watchdog').publish_from_published_content(publishable_content.public_version)
+            PublicatorRegistry.get("md").publish(
+                md_file_path,
+                base_name,
+                versioned=versioned,
+                cur_language=translation.get_language(),
+            )
+            PublicatorRegistry.get("watchdog").publish_from_published_content(
+                publishable_content.public_version
+            )
         except ValueError:
             return Response({}, status=status.HTTP_400_BAD_REQUEST, headers={})
         else:
@@ -132,15 +157,18 @@ class ExportsView(ListAPIView):
         #
         # This uses raw SQL because even if Django supports windowed requests, it does not allow
         # to select _from_ a subrequest (« SELECT * FROM (SELECT … ) WHERE … »).
-        exports = PublicationEvent.objects.raw("""
+        exports = PublicationEvent.objects.raw(
+            """
             WITH latest_events AS (
                 SELECT p.*, ROW_NUMBER() OVER (PARTITION BY format_requested ORDER BY date DESC) AS row
                 FROM tutorialv2_publicationevent AS p
                 INNER JOIN tutorialv2_publishedcontent published ON (p.published_object_id = published.id)
                 WHERE published.content_id = %s
             )
-            SELECT * FROM latest_events WHERE row = 1""", [int(self.kwargs.get('pk', 0))])
+            SELECT * FROM latest_events WHERE row = 1""",
+            [int(self.kwargs.get("pk", 0))],
+        )
 
-        prefetch_related_objects(exports, 'published_object')
+        prefetch_related_objects(exports, "published_object")
 
         return exports

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -1344,6 +1344,9 @@ class PublicationEvent(models.Model):
     def __str__(self):
         return '{}: {} - {}'.format(self.published_object.title(), self.format_requested, self.state_of_processing)
 
+    def url(self):
+        return self.published_object.get_absolute_url_to_extra_content(self.format_requested)
+
 
 class ContentContributionRole(models.Model):
     """


### PR DESCRIPTION
Ce commit ajoute une interface pour gérer les exports d'un contenu, en connaître l'état de traitement, et relancer, en cas de nécessité, leur traitement.

Il ajoute également une API pour lister les exports d'un contenu et leurs URLs.

Numéro du ticket concerné (optionnel) : closes #5830.

Le ticket d'origine parlait d'une page listant _toutes les demandes d'export passées_, mais après discussion avec @Situphen son auteur, nous sommes parvenus à la conclusion que ce n'était pas si pertinent que cela. À la place, cette proposition ajoute une interface listant uniquement la dernière demande d'export pour chaque type, ainsi que son statut (en attente, en cours de traitement, traitée, ou échouée), ainsi qu'un moyen de relancer la génération si nécessaire (ce que faisait initialement le lien dans la barre latérale).

L'interface étant dynamique (dans une modale, sans rechargement de la page), cette PR ajoute également une API pour récupérer les derniers exports d'un contenu. Cette API est _publique_, car j'estime qu'il n'est pas nécessaire de la protéger, mais ça pourrait se discuter.

![L'interface de gestion des exports](https://user-images.githubusercontent.com/1417570/85011145-6e60c080-b161-11ea-872f-3d31532add21.png)

L'interface se met à jour en temps réel lorsque nécessaire (i.e. lorsqu'elle est ouverte _et_ qu'il y a au moins un export en cours).

Des tests ont été ajoutés — bien entendu —, mais également pour l'API pré-existante de demande d'exports, car elle n'était pas testée jusqu'à présent.

#### Cette PR ajoute une requête SQL brute

L'API listant les derniers exports par type utilise une requête SQL brute (`PublicationEvent.objects.raw('…')`), car Django ne supporte pas la sélection depuis une sous-requête (`SELECT * FROM (SELECT …) WHERE …`).

### Contrôle qualité

Il y a deux points à tester : le fonctionnement correct de l'interface, et le fonctionnement de l'optimisation des requêtes de mise à jour.

Comme pré-requis à tous les tests, vous devez avoir une installation de ZdS et deux terminaux : un pour lancer le site et un pour le _watchdog_.

#### Notes préliminaires

Si vous n'avez jamais lancé le watchdog sur votre instance et qu'elle est relativement récente, il est possible que vous ayez une grande quantité de contenus en attente de traitement par ce dernier. Afin d'éviter d'attendre une heure qu'ils soient tous traités, vous pouvez éliminer toutes ces demandes avant de commencer la QA. Ouvrez un _shell_ Django avec la commande `python manage.py shell` depuis l'environnement virtuel, puis : 

```py
Python 3.8.3 (default, May 17 2020, 18:15:42) 
[GCC 10.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from zds.tutorialv2.models.database import PublicationEvent
>>> PublicationEvent.objects.all().delete()
(0, {'tutorialv2.PublicationEvent': 0})
```

Cette suppression n'a aucune incidence nocive sur votre instance ni sur ses exports : elle supprime uniquement l'historique des _demandes d'export_, mais les éventuels fichiers restent toujours là.

Autre point : il est probable que sur votre instance locale, l'export PDF échoue. Cela se produit car vous n'avez pas tous les fichiers LaTeX (et notamment le _template_) pour générer ce dernier. Ce n'est absolument pas grave, car nous ne testons pas ici le fonctionnement du système d'export, mais uniquement son interface. C'est même bien, car cela permet de s'assurer que ce dernier réagit bien en cas d'erreur.

#### Test de l'interface

- Lancez le site avec `make run`, ce qui aura pour effet de reconstruire le _front_ au passage. Pour l'instant, ne lancez pas le _watchdog_.
- Créez et publiez un contenu. Vous pouvez également utiliser un contenu existant généré par les _fixtures_, peu importe.
- Sur la version brouillon du contenu publié, **cliquez sur le lien « Gérer les exports »** dans la barre latérale. Une interface modale doit s'ouvrir tel que montré plus haut.
   - _**Note** – Selon si vous avez ou non supprimé les demandes d'export et si vous utilisez un contenu fraîchement publié ou anciennement présent, et supposant que vous n'avez jamais lancé le _watchdog_ avant, vous verrez ou bien tous les exports comme étant « En attente », ou bien aucun export du tout.)_
- **Cliquez sur le bouton vert « Demander la génération de tous les exports ».** Après un temps de chargement, tous les exports doivent passer « En attente », et la date indiquée est actualisée (pour vérifier que la minute est bonne, la date complète apparaît au survol).
- Maintenant, **lancez le _watchdog_**, sans quitter la page ni la modale, ni l'actualiser ou quoique ce soit. Vous devriez observer que l'interface se met à jour en temps réel au fur et à mesure du traitement par le _watchdog_ : les exports passent à l'état _en traitement_, puis _terminé_ ou _échoué_, le cas échéant.
   - _**Note** – Il est très possible que l'interface n'affiche occasionnellement plus les exports quand le watchdog est en train de traiter des fichiers. Ce n'est **pas** un problème : ça vient du fait qu'une base SQLite supporte moins bien les accès concurrents que le SGBD que l'on utilise en production (si vous regardez les erreurs remontées, il s'agit de « database is locked »). Il est également possible que le watchdog plante à cause de cela : dans ce cas, relancez-le._
- Si un export échoue, le lien de téléchargement se transforme en un lien de relancement. Cliquer dessus relance tous les exports.
   - _**Note** – Ce test peut être combiné avec la section suivante, qui impliquera également de relancer un export à un moment, afin de gagner du temps._
- Maintenant, allez sur la version publique du contenu. Le lien de gestion des exports doit être présent et l'interface doit s'afficher à l'identique. (Inutile de re-tester le reste.)

#### Tests de l'optimisation de la mise à jour en temps réel

L'interface se met à jour à l'aide d'un système de requêtes régulières à l'API. Ce système ne tourne que lorsque strictement nécessaire, pour éviter toute requête superflue.

Pour cette partie de la QA, je vous invite à couper le _watchdog_ : ce sera plus simple.

- Rendez-vous sur la page d'un contenu pour lequel vous avez accès à la gestion des exports. Assurez-vous que les exports sont tous traités (ce qui devrait être le cas si vous faites cette QA dans l'ordre).
- **Ouvrez les outils de développement de votre navigateur**, à la section « Réseau » (`F12` ou `Ctrl + Maj + I`, généralement, ou `Ctrl + Maj + E` sous Firefox pour accéder directement à l'onglet réseau).
- **Ouvrez l'interface de gestion des exports.** Dans la console réseau, vous voyez une seule requête.
- **Cliquez sur le bouton de demande de tous les exports.** En plus de la requête `POST` d'envoi de la demande, vous constatez qu'il y a une requête `GET` envoyée toutes les quelques secondes.
- **Fermez l'interface de gestion des exports** (sans quitter la page pour autant). Vous observez que même si le traitement est toujours en cours, les requêtes cessent.
- Maintenant, **relancez le _watchdog_ et rouvrez l'interface**. Vous constatez que les requêtes régulières reprennent (même si certaines échouent peut-être).
- Dés que le traitement est achevé (tous les exports sont à « Terminé » ou « Échoué »), les requêtes cessent.