### PR TITLE
Il s'agit de demander à Travis de tester avec MariaDB 10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ python:
 
 services:
   - memcached
-  - mysql
 
 
 addons:
   firefox: "latest"
+  mariadb: 10.4
   apt:
     packages:
       - language-pack-fr

--- a/scripts/ci_mysql_setup.sh
+++ b/scripts/ci_mysql_setup.sh
@@ -10,6 +10,10 @@ sudo mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRAN
 sudo mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
 sudo mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
 
+# Ensures correct charset and collation
+sudo mysql -u root -e "SET GLOBAL character_set_server = 'utf8mb4';"
+sudo mysql -u root -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci';"
+
 # Ensures the root user is able to connect without password
 sudo mysql -u root -e "SET Password=PASSWORD('')"
 

--- a/scripts/ci_mysql_setup.sh
+++ b/scripts/ci_mysql_setup.sh
@@ -10,8 +10,12 @@ sudo mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRAN
 sudo mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
 sudo mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
 
+# Ensures correct charset and collation
+sudo mysql -u root -e "SET GLOBAL character_set_server = 'utf8mb4';"
+sudo mysql -u root -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci';"
+
 # Ensures the root user is able to connect without password
 sudo mysql -u root -e "SET Password=PASSWORD('')"
 
 # Create database with the correct charset and collation
-sudo mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"
+sudo mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_unicode_ci';"

--- a/scripts/ci_mysql_setup.sh
+++ b/scripts/ci_mysql_setup.sh
@@ -4,10 +4,14 @@ sudo sed -i'' 's/\[mysqld\]/\[mysqld\]\ninnodb_file_per_table=on\ninnodb_file_fo
 sudo systemctl restart mysql
 
 # Travis should fail as soon as possible
-sudo mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';"
+mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';"
+
 # Avoid "mysql has gone away" errors
-sudo mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
-sudo mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
+mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
+mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
+
+# Ensures the root user is able to connect without password
+sudo mysql -u root -e "SET Password=PASSWORD('')"
 
 # Create database with the correct charset and collation
-sudo mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"
+mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"

--- a/scripts/ci_mysql_setup.sh
+++ b/scripts/ci_mysql_setup.sh
@@ -4,9 +4,10 @@ sudo sed -i'' 's/\[mysqld\]/\[mysqld\]\ninnodb_file_per_table=on\ninnodb_file_fo
 sudo systemctl restart mysql
 
 # Travis should fail as soon as possible
-mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';"
+sudo mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';"
 # Avoid "mysql has gone away" errors
-mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
-mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
+sudo mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
+sudo mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
+
 # Create database with the correct charset and collation
-mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"
+sudo mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"

--- a/scripts/ci_mysql_setup.sh
+++ b/scripts/ci_mysql_setup.sh
@@ -10,10 +10,6 @@ sudo mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRAN
 sudo mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
 sudo mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
 
-# Ensures correct charset and collation
-sudo mysql -u root -e "SET GLOBAL character_set_server = 'utf8mb4';"
-sudo mysql -u root -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci';"
-
 # Ensures the root user is able to connect without password
 sudo mysql -u root -e "SET Password=PASSWORD('')"
 

--- a/scripts/ci_mysql_setup.sh
+++ b/scripts/ci_mysql_setup.sh
@@ -4,14 +4,14 @@ sudo sed -i'' 's/\[mysqld\]/\[mysqld\]\ninnodb_file_per_table=on\ninnodb_file_fo
 sudo systemctl restart mysql
 
 # Travis should fail as soon as possible
-mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';"
+sudo mysql -u root -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';"
 
 # Avoid "mysql has gone away" errors
-mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
-mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
+sudo mysql -u root -e "SET GLOBAL wait_timeout = 36000;"
+sudo mysql -u root -e "SET GLOBAL max_allowed_packet = 134209536;"
 
 # Ensures the root user is able to connect without password
 sudo mysql -u root -e "SET Password=PASSWORD('')"
 
 # Create database with the correct charset and collation
-mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"
+sudo mysql -u root -e "CREATE DATABASE zds_test CHARACTER SET = utf8mb4 COLLATE utf8mb4_unicode_ci;"


### PR DESCRIPTION
En production, on utilise MariaDB 10.4 (similaire à MySQL 8). Mais Travis exécute les tests avec MySQL 5.7. Il est bien mieux de tester avec une configuration aussi proche de la production que possible.

De plus, jusqu'à présent, ça ne posait pas de problème (car concrètement, on n'utilisait pas de SQL récent), mais la PR #5832 utilise les clauses fenêtrées, intégrées dans MariaDB 10.2 / MySQL 8 — les tests échouent donc, alors qu'ils ne devraient pas et que tout fonctionnerait en production. Ce problème pourrait se reproduire si, pour quoique ce soit d'autre, on a besoin de SQL‌ plus moderne.

Cette PR change donc la configuration de Travis afin que ce dernier teste avec MariaDB 10.4.

### Contrôle qualité

- Ouvrir le log d'un des tests de Travis, et vérifier que la configuration système de Travis précise bien que la version 10.4 de MariaDB est utilisée.