### PR TITLE
fix #5684: Adapte l'affichage du forum pour les membres en lecture seule

### DIFF
--- a/templates/forum/category/forum.html
+++ b/templates/forum/category/forum.html
@@ -66,9 +66,11 @@
 
 
 {% block new_btn %}
-    <a href="{% url 'topic-new' %}?forum={{ forum.pk }}" class="new-btn ico-after more blue">
-        {% trans "Nouveau sujet" %}
-    </a>
+  {% if user.can_write_now %}
+      <a href="{% url 'topic-new' %}?forum={{ forum.pk }}" class="new-btn ico-after more blue">
+          {% trans "Nouveau sujet" %}
+      </a>
+  {% endif %}
 {% endblock %}
 
 

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -161,19 +161,19 @@
 {% endblock %}
 
 
-
 {% block new_btn %}
-    <a href="{% url 'topic-new' %}?forum={{ topic.forum.pk }}" class="new-btn ico-after more blue">
-        {% trans "Nouveau sujet" %}
-    </a>
+  {% if user.can_write_now %}
+      <a href="{% url 'topic-new' %}?forum={{ topic.forum.pk }}" class="new-btn ico-after more blue">
+          {% trans "Nouveau sujet" %}
+      </a>
 
-    {% if topic.author.pk == user.pk and topic.first_post.is_visible or is_staff %}
-        <a href="{% url 'topic-edit' %}?topic={{ topic.pk }}" class="new-btn ico-after edit blue">
-            {% trans "Éditer le sujet" %}
-        </a>
-    {% endif %}
+      {% if topic.author.pk == user.pk and topic.first_post.is_visible or is_staff %}
+          <a href="{% url 'topic-edit' %}?topic={{ topic.pk }}" class="new-btn ico-after edit blue">
+              {% trans "Éditer le sujet" %}
+          </a>
+      {% endif %}
+  {% endif %}
 {% endblock %}
-
 
 
 {% block sidebar_actions %}

--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -23,6 +23,10 @@
             <a href="{% url "register-member" %}" class="alert-box-btn">{% trans "Créer un compte" %}</a>
         </p>
     </div>
+{% elif not user.can_write_now %}
+<div class="alert-box ico-after ico-alert light">
+    {% trans "Vous êtes en lecture seule. Vous ne pouvez pas poster de messages." %}
+</div>
 {% elif topic.antispam or is_antispam %}
     <div class="alert-box ico-after ico-alert light">
         {% trans "Vous venez de poster. Merci de patienter au moins 15 minutes entre deux messages consécutifs afin de limiter le flood." %}


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) :
#5684


### Contrôle qualité
Mettre un utilisateur en Lecture Seule. Vérifier qu'il ne peut pas poster de messages et qu'il n'a pas le bouton "Nouveau sujet"

