### PR TITLE
Corrige le chargement de l'éditeur sur la page d'édition du profil

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -281,6 +281,7 @@ class ProfileForm(MiniProfileForm):
             self.fields['options'].initial += 'email_for_new_mp'
 
         layout = Layout(
+            IncludeEasyMDE(),
             Field('biography'),
             ButtonHolder(StrictButton(_('Aperçu'), type='preview', name='preview',
                                       css_class='btn btn-grey preview-btn'),),


### PR DESCRIPTION
Corrige le chargement de l'éditeur sur la page d'édition du profil

Closes #5838 

**QA**

- `source zdsenv/bin/activate && make run`
- Aller sur http://localhost:8000/membres/parametres/profil/
- Vérifier que l'éditeur est correctement chargé