### PR TITLE
Permet à l'auteur d'un message de préciser pourquoi il le masque

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -74,12 +74,12 @@
                                     </a>
                                     <form action="{{ hide_link|safe }}" method="post" id="hide-message-{{ message.id }}" class="modal modal-flex">
                                         {% csrf_token %}
-                                        {% if perms_change %}
-                                            <p>
-                                                {% trans "Pour quelle raison souhaitez-vous masquer ce message ?" %}
-                                            </p>
-                                            <input type="text" name="text_hidden" placeholder="Flood, Troll, Hors sujet, ..." >
-                                        {% else %}
+                                        <p>
+                                            {% trans "Pour quelle raison souhaitez-vous masquer ce message ?" %}
+                                        </p>
+                                        <input type="text" name="text_hidden" placeholder="{% if perms_change %}Flood, Troll, Hors sujet, ...{% else %}Erreur, mauvaise compréhension, changement d'avis, ...{% endif %}">
+
+                                        {% if not perms_change  %}
                                             <p>
                                                 {% trans "Attention, en masquant ce message, vous ne pourrez plus l’afficher vous-même. Êtes-vous certain de vouloir le faire ?" %}
                                             </p>

--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -104,9 +104,7 @@ class PostEditMixin(object):
                 alert.solve(user, _('Le message a été masqué.'))
             post.is_visible = False
             post.editor = user
-
-            if is_staff:
-                post.text_hidden = data.get('text_hidden', '')
+            post.text_hidden = data.get('text_hidden', '')
 
             messages.success(request, _('Le message est désormais masqué.'))
             for user in Notification.objects.get_users_for_unread_notification_on(post):


### PR DESCRIPTION
Ticket concerné: closes #5831 


### Contrôle qualité

- Se connecter en simple membre, aller voir un message qu'on a posté sur un sujet du forum. Si on souhaite le masquer, on peut maintenant préciser une raison. La raison doit bien s'afficher à la place du message masqué.
- Faire la même chose, en tant que staff sur un message qui n'a pas été rédigé par staff.
- Répéter ces deux tests sur un commentaire posté sous un article / un billet / un tutoriel.