### PR TITLE
Inclusivité de l'interface de rédaction de message

### DIFF
--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -11,12 +11,12 @@
     </div>
 {% elif not user.is_authenticated %}
     <div class="alert-box info alert-box-not-closable">
-        {% trans "Vous devez être connecté pour pouvoir poster un message." %}
+        {% trans "Connectez-vous pour pouvoir poster un message." %}
         <br>
         <a href="{% url "member-login" %}?next={{ request.path }}" class="alert-box-btn alert-box-btn-right">Connexion</a>
     </div>
     <div class="alert-box not-member alert-box-not-closable">
-        <h4 class="alert-box-title">Pas encore inscrit ?</h4>
+        <h4 class="alert-box-title">Pas encore membre ?</h4>
         <p>
             {% trans "Créez un compte en une minute pour profiter pleinement de toutes les fonctionnalités de Zeste de Savoir. Ici, tout est gratuit et sans publicité." %}
             <br>
@@ -29,7 +29,7 @@
     </div>
 {% elif topic.one_participant_remaining %}
     <div class="alert-box info cross light">
-        {% trans "Vous êtes seul dans cette conversation." %}
+        {% trans "Il n'y a personne d'autre que vous dans cette conversation." %}
     </div>
 {% else %}
     {% if topic.old_post_warning %}
@@ -44,7 +44,7 @@
 
     {% if page_obj.has_next %}
         <div class="alert-box warning ico-after alert light">
-            {% trans "<strong>Attention</strong>, vous n’êtes pas sur la dernière page de ce sujet, assurez-vous de l’avoir lu dans son intégralité avant d’y répondre." %}
+            {% trans "<strong>Attention</strong>, vous n’êtes pas sur la dernière page de ce sujet. Assurez-vous de l’avoir lu dans son intégralité avant d’y répondre." %}
         </div>
     {% endif %}
 

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -861,7 +861,7 @@ class ForumMemberTests(TestCase):
         profiles = [ProfileFactory(), ProfileFactory()]
         topic = TopicFactory(forum=forum, author=profiles[1].user)
         expected = '<strong>Attention</strong>, vous n’êtes pas sur la dernière page de '
-        expected += 'ce sujet, assurez-vous de l’avoir lu dans son intégralité avant d’y'
+        expected += 'ce sujet. Assurez-vous de l’avoir lu dans son intégralité avant d’y'
         expected += ' répondre.'
 
         for i in range(settings.ZDS_APP['forum']['posts_per_page'] + 2):


### PR DESCRIPTION
Reprise de la formulation des messages des interfaces permettant de rédiger un commentaire ou un message sur le forum, afin de privilégier des formulations neutres et inclusives, et non uniquement masculines.

### Contrôle qualité

Travis (modification de textes uniquement) et approbation morale des changements.