### PR TITLE
🚸 Ajout du bouton « Signaler une faute » sur la page de partie

### DIFF
--- a/templates/tutorialv2/includes/warn_typo.part.html
+++ b/templates/tutorialv2/includes/warn_typo.part.html
@@ -14,7 +14,11 @@
                     {% trans "ce billet" %}
                 {% endif %}
             {% else %}
-                {% trans "ce chapitre" %}
+                {% if container.is_chapter %}
+                    {% trans "ce chapitre" %}
+                {% else %}
+                    {% trans "cette partie" %}
+                {% endif %}
             {% endif %}
         </a>
 

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -98,10 +98,7 @@
         {% include "tutorialv2/includes/chapter_pager.part.html" with position="bottom" online=True %}
     {% endif %}
 
-    {% if container.has_extracts %}
-        {# possibility to signal a mistake to the author is only available on chapter #}
-        {% include "tutorialv2/includes/warn_typo.part.html" with content=content %}
-    {% endif %}
+    {% include "tutorialv2/includes/warn_typo.part.html" with content=content %}
 {% endblock %}
 
 {% block sidebar_actions %}


### PR DESCRIPTION
fix #5694 

### Contrôle qualité

Il suffit de vérifier si les boutons « Signaler une faute » ont toujours la bonne valeur, quelque soit le conteneur ou le contenu et si le bouton est bien apparu sur la page de partie.