### PR TITLE
Met à jour typographie et liens des astuces Markdown

### DIFF
--- a/assets/js/markdown-help.js
+++ b/assets/js/markdown-help.js
@@ -10,24 +10,24 @@
 
   var linkToMathsTutorial = '//zestedesavoir.com/tutoriels/244/comment-rediger-des-maths-sur-zeste-de-savoir/'
   var linkToMarkdownHelp = '//zestedesavoir.com/tutoriels/221/rediger-sur-zds/'
-  var linkToPygments = 'http://pygments.org/languages'
+  var linkToSupportedLanguages = 'https://github.com/highlightjs/highlight.js/blob/master/SUPPORTED_LANGUAGES.md'
 
   var tips = [
-    'Les simples retours à la ligne ne sont pas pris en compte. Pour créer un nouveau paragraphe, pensez à <em>sauter une ligne</em> !',
-    'Encadrez votre texte par une astérisque pour écrire en italique ou deux pour du gras.',
-    'Pour écrire un lien, utilisez la syntaxe <code>[texte de lien](url du lien)</code>',
-    'Les blocs de code sont délimités par trois accents graves <code>```</code>.',
-    'Pour créer une liste à puces, sautez une ligne et commencez chaque élément de la liste par <code>+</code>, <code>-</code> ou <code>*</code>.',
-    "Pour citer quelqu'un, utilisez le symbole <code>></code>.",
-    'Pour tracer une ligne, utilisez <code>---</code>, <code>+++</code> ou <code>***</code>.',
-    'Pour aller à la ligne sans changer de paragraphe, finissez votre première ligne par deux espaces.',
-    'Pour écrire un bout de code au milieu d’une phrase, utilisez la syntaxe <code>`un bout de code`</code>.',
-    'Le langage d’un bloc de code peut être spécifié après les <code>```</code> ouvrants. La liste des langages supportés <a href="' + linkToPygments + '">est disponible ici</a>.',
-    'Vous pouvez <a href="' + linkToMathsTutorial + '">écrire des formules mathématiques</a> en encadrant ces dernières du signe dollar <code>$</code>.',
-    'Pour ajouter une image, vous pouvez simplement la glisser-déposer depuis votre explorateur.',
-    'Vous pouvez préciser à quel numéro commencent les lignes avec cette syntaxe : <code>```python linenostart=42</code> au début d\'un bloc de code. Pratique pour faire coïncider les numéros de ligne à une erreur, par exemple.',
-    'Vous pouvez surligner des lignes avec cette syntaxe : <code>```rust hl_lines=2,4-7</code> au début d\'un bloc de code.',
-    'Vous pouvez à la fois choisir à quel numéro démarrent les lignes et en surligner avec <code>```lisp linenostart=244 hl_lines=247,252</code> au début d\'un bloc de code.'
+    'les simples retours à la ligne ne sont pas pris en compte. Pour créer un nouveau paragraphe, pensez à <em>sauter une ligne</em> !',
+    'encadrez votre texte par une astérisque pour écrire en italique ou deux pour du gras.',
+    'pour écrire un lien, utilisez la syntaxe <code>[texte de lien](url du lien)</code>',
+    'les blocs de code sont délimités par trois accents graves <code>```</code>.',
+    'pour créer une liste à puces, sautez une ligne et commencez chaque élément de la liste par <code>+</code>, <code>-</code> ou <code>*</code>.',
+    "pour citer quelqu'un, utilisez le symbole <code>></code>.",
+    'pour tracer une ligne, utilisez <code>---</code>, <code>+++</code> ou <code>***</code>.',
+    'pour aller à la ligne sans changer de paragraphe, finissez votre première ligne par deux espaces.',
+    'pour écrire un bout de code au milieu d’une phrase, utilisez la syntaxe <code>`un bout de code`</code>.',
+    'le langage d’un bloc de code peut être spécifié après les <code>```</code> ouvrants. <a href="' + linkToSupportedLanguages + '">La liste des langages supportés est disponible ici.</a>',
+    'vous pouvez <a href="' + linkToMathsTutorial + '">écrire des formules mathématiques</a> en encadrant ces dernières du signe dollar <code>$</code>.',
+    'pour ajouter une image, vous pouvez simplement la glisser-déposer depuis votre explorateur.',
+    'vous pouvez préciser à quel numéro commencent les lignes avec cette syntaxe : <code>```python linenostart=42</code> au début d\'un bloc de code. Pratique pour faire coïncider les numéros de ligne à une erreur, par exemple.',
+    'vous pouvez surligner des lignes avec cette syntaxe : <code>```rust hl_lines=2,4-7</code> au début d\'un bloc de code.',
+    'vous pouvez à la fois choisir à quel numéro démarrent les lignes et en surligner avec <code>```lisp linenostart=244 hl_lines=247,252</code> au début d\'un bloc de code.'
   ]
 
   function addDocMD($elem) {


### PR DESCRIPTION
- La première lettre des astuces Markdown passe en minuscule, afin d'avoir une phrase générée typographiquement correcte, celle-ci débutant par « Astuce : ».
- Le lien de la liste des langages pointait toujours vers celle de Pygments, que l'on utilise plus depuis zmd ; ce lien a donc été mis à jour pour pointer vers la liste d'highlight.js réellement utilisée (par lowlight).

### Contrôle qualité

1. Démarrer le site avec `make run` (ce qui a pour effet de reconstruire le front au passage).
2. Aller sur une page avec un formulaire de composition Markdown ; actualiser cette page de force (`Ctrl + F5`) pour être sûr d'avoir la dernière version du JS.
3. Vérifier que les astuces s'affichent toujours correctement, et que leur typographie est correcte (pas de majuscule au milieu de la phrase). Si vous tombez sur celle indiquant que l'on peut spécifier le langage d'un bloc de code, vérifiez que le lien pointe vers une page contenant une telle liste ([celle-ci](https://github.com/highlightjs/highlight.js/blob/master/SUPPORTED_LANGUAGES.md)).