### PR TITLE
Empêche de poster des alertes en apparence vides

### DIFF
--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -120,15 +120,18 @@ class PostEditMixin(object):
 
     @staticmethod
     def perform_alert_message(request, post, user, alert_text):
-        alert = Alert(
-            author=user,
-            comment=post,
-            scope='FORUM',
-            text=alert_text,
-            pubdate=datetime.now())
-        alert.save()
+        if len(alert_text.strip()) == 0:
+            messages.error(request, _('La raison du signalement ne peut pas être vide.'))
+        else:
+            alert = Alert(
+                author=user,
+                comment=post,
+                scope='FORUM',
+                text=alert_text,
+                pubdate=datetime.now())
+            alert.save()
 
-        messages.success(request, _("Une alerte a été envoyée à l'équipe concernant ce message."))
+            messages.success(request, _("Une alerte a été envoyée à l'équipe concernant ce message."))
 
     @staticmethod
     def perform_useful(post):

--- a/zds/tutorialv2/views/published.py
+++ b/zds/tutorialv2/views/published.py
@@ -874,18 +874,22 @@ class SendContentAlert(FormView, LoginRequiredMixin):
             raise Http404('Identifiant manquant ou conversion en entier impossible.')
         content = get_object_or_404(PublishableContent, pk=content_pk)
 
-        alert = Alert(
-            author=request.user,
-            content=content,
-            scope='CONTENT',
-            text=request.POST['signal_text'],
-            pubdate=datetime.now())
-        alert.save()
+        if len(request.POST['signal_text'].strip()) == 0:
+            messages.error(request, _('La raison du signalement ne peut pas être vide.'))
+        else:
+            alert = Alert(
+                author=request.user,
+                content=content,
+                scope='CONTENT',
+                text=request.POST['signal_text'],
+                pubdate=datetime.now())
+            alert.save()
 
-        human_content_type = TYPE_CHOICES_DICT[content.type].lower()
-        messages.success(
-            self.request,
-            _('Ce {} a bien été signalé aux modérateurs.').format(human_content_type))
+            human_content_type = TYPE_CHOICES_DICT[content.type].lower()
+            messages.success(
+                self.request,
+                _('Ce {} a bien été signalé aux modérateurs.').format(human_content_type))
+
         return redirect(content.get_absolute_url_online())
 
 
@@ -942,15 +946,19 @@ class SendNoteAlert(FormView, LoginRequiredMixin):
             raise Http404("Impossible de convertir l'identifiant en entier.")
         reaction = get_object_or_404(ContentReaction, pk=reaction_pk)
 
-        alert = Alert(
-            author=request.user,
-            comment=reaction,
-            scope=reaction.related_content.type,
-            text=request.POST['signal_text'],
-            pubdate=datetime.now())
-        alert.save()
+        if len(request.POST['signal_text'].strip()) == 0:
+            messages.error(request, _('La raison du signalement ne peut pas être vide.'))
+        else:
+            alert = Alert(
+                author=request.user,
+                comment=reaction,
+                scope=reaction.related_content.type,
+                text=request.POST['signal_text'],
+                pubdate=datetime.now())
+            alert.save()
 
-        messages.success(self.request, _('Ce commentaire a bien été signalé aux modérateurs.'))
+            messages.success(self.request, _('Ce commentaire a bien été signalé aux modérateurs.'))
+
         return redirect(reaction.get_absolute_url())
 
 


### PR DESCRIPTION
Fix #5764


### Contrôle qualité

Tenter d'alerter avec un message de motif en apparence vide (uniquement des espaces ou des retours à la ligne). Tester pour:
- les messages sur le forum
- les commentaires sur les articles, les billets ou les tutoriaux
- les billets (le bouton est sous le contenu du billet, à côté du bouton pour signaler une faute)

Il faut tester les trois cas, c'est à chaque fois un code différent. Un message d'erreur doit apparaître en haut de la page si le message du motif d'alerte est vide. Vérifier aussi que ça fonctionne toujours avec un motif non vide.

Note: pour les amateurs de refactoring, je pense qu'il y a matière à amélioration pour signaler les messages ou les contenus (cf les trois fonctions où j'ai apporté des modifications, il doit être possible d'en faire une seule fonction, idem pour les templates correspondant aux modales de signalement).