### PR TITLE
Utilise la même police pour les boutons sous les billets

### DIFF
--- a/templates/tutorialv2/includes/alert.html
+++ b/templates/tutorialv2/includes/alert.html
@@ -3,9 +3,11 @@
 
 {% if user.is_authenticated and user not in content.authors.all %}
     {% if current_content_type == 'OPINION' %}
-        <a href="#signal-content-{{ content.pk }}" class="open-modal btn btn-grey ico-after alert blue">
-            {% trans "Signaler le contenu" %}
-        </a>
+        <div>
+            <a href="#signal-content-{{ content.pk }}" class="open-modal btn btn-grey ico-after alert blue">
+                {% trans "Signaler le contenu" %}
+            </a>
+        </div>
         <form action="{% url 'content:alert-content' content.pk %}" method="post" id="signal-content-{{ content.pk }}" class="modal modal-flex">
             {% csrf_token %}
             <label for="signal-content-{{ content.pk }}-field">


### PR DESCRIPTION
Corrige la police utilisée par le bouton "Signaler le contenu" sous le contenu des billets, à côté du bouton "Signaler une faute"


### Contrôle qualité

Vérifier que les polices des deux boutons sous le contenu des billets sont identiques.

(observé/testé avec Firefox)
