### PR TITLE
Affichage et utilisation des bonnes versions

### DIFF
--- a/doc/source/install/extra-install-es.rst
+++ b/doc/source/install/extra-install-es.rst
@@ -48,9 +48,9 @@ La procédure d'installation, si vous souhaitez utiliser Elasticsearch sans l'in
 
 .. sourcecode:: bash
 
-    wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.zip
-    unzip elasticsearch-5.5.2.zip
-    cd elasticsearch-5.5.2/
+    wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.3.zip
+    unzip elasticsearch-5.5.3.zip
+    cd elasticsearch-5.5.3/
 
 Pour démarrer Elasticsearch, utilisez
 
@@ -93,9 +93,9 @@ Sous Windows
 
 Elasticsearch requiert **la version 8** de Java, que vous pouvez trouver `sur la page officielle de java <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_. Prenez la version correspondante à votre système d'exploitation.
 
-Téléchargez ensuite Elasticsearch à l'adresse suivante : `https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.zip <https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.zip>`_, puis extrayez le dossier ``elasticsearch-5.5.2`` du zip à l'aide de votre outil préféré.
+Téléchargez ensuite Elasticsearch à l'adresse suivante : `https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.3.zip <https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.3.zip>`_, puis extrayez le dossier ``elasticsearch-5.5.3`` du zip à l'aide de votre outil préféré.
 
-Pour démarer Elasticsearch, ouvrez un *shell* (ou un *powershell*) et rendez-vous dans le dossier ``elasticsearch-5.5.2``.
+Pour démarer Elasticsearch, ouvrez un *shell* (ou un *powershell*) et rendez-vous dans le dossier ``elasticsearch-5.5.3``.
 Exécutez ensuite la commande suivante :
 
 .. sourcecode:: bash

--- a/doc/source/install/extra-install-frontend.rst
+++ b/doc/source/install/extra-install-frontend.rst
@@ -8,7 +8,7 @@ Vous voulez nous aider au développement du frontend ? Installez Node.js et Yarn
 Installation de Node.js et Yarn
 ===============================
 
-Le frontend de Zeste de Savoir repose sur la version actuelle de Node.js supportée à long terme, la version 8. Vous pouvez installer Node.js 8 via `votre gestionnaire de paquet <https://nodejs.org/en/download/package-manager/>`_ (``apt``, ``yum``, …) ou en téléchargeant une `archive <https://nodejs.org/en/download/>`_.
+Le frontend de Zeste de Savoir repose sur la version actuelle de Node.js supportée à long terme, la version 12. Vous pouvez installer Node.js 12 via `votre gestionnaire de paquet <https://nodejs.org/en/download/package-manager/>`_ (``apt``, ``yum``, …) ou en téléchargeant une `archive <https://nodejs.org/en/download/>`_.
 
 Dans le cas où vous avez besoin de faire cohabiter sur votre système différentes versions de Node.js pour des projets différents, à l’instar de virtualenv ou rvm, il existe `nvm <https://github.com/creationix/nvm>`_ (Node Version Manager) qui permet d’installer plusieurs version de Node.js et de basculer d’une version à l’autre facilement.
 
@@ -22,9 +22,9 @@ Pour vérifier que Node.js et yarn sont installés (et que vous avez les bonnes 
 .. sourcecode:: bash
 
     $ node -v
-    v8.x.x
+    v12.x.x
     $ yarn -v
-    0.27.x
+    1.22.x
 
 Si ``yarn`` n’est pas installé ou pas à jour, utilisez ``npm i -g yarn``.
 

--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -154,7 +154,7 @@ Composant ``elastic-local``
 
 Installe une version **locale** d'Elasticsearch dans un dossier ``.local`` situé dans le dossier de ZdS.
 La commande ``elasticsearch`` est ensuite ajoutée dans le *virtualenv*, de telle sorte à ce que ce soit cette version locale qui soit utilisée.
-La version d'Elasticsearch installée est controlée par la variable d'environement ``ZDS_ELASTIC_VERSION`` (dont la valeur est par défaut ``5.5.2``).
+La version d'Elasticsearch installée est controlée par la variable d'environement ``ZDS_ELASTIC_VERSION`` (dont la valeur est par défaut ``5.5.3``).
 
 Notez que vous pouvez choisir d'installer Elasticsearch manuellement, `comme décrit ici <./extra-install-es.html#sous-linux>`_.
 

--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -95,7 +95,7 @@ Composant ``node``
 
 Installe ``nvm`` et l'utilise pour installer ``node``, puis ``yarn``.
 Ajoute ensuite un ``.nvmrc`` dans le dossier et ajoute ``node use`` au script d'activation du *virtualenv* (pour qu'il soit automatiquement utilisé au chargement).
-La version de node installée est controlée par la variable d'environement ``ZDS_NODE_VERSION`` (dont la valeur est par défaut ``10.8.0``).
+La version de node installée est controlée par la variable d'environement ``ZDS_NODE_VERSION`` (dont la valeur est par défaut ``12``).
 
 Si vous ne souhaitez pas utiliser ce composant, il vous faut tout de même installer les outils du front-end manuellement. Pour cela, rendez-vous sur `la documentation dédiée <frontend-install.html>`_.
 

--- a/doc/source/install/install-osx.rst
+++ b/doc/source/install/install-osx.rst
@@ -38,7 +38,7 @@ Pré-requis
 
 .. sourcecode:: bash
 
-  brew install gettext cairo --without-x11 py2cairo node && \
+  brew install gettext cairo --without-x11 py2cairo node@12 && \
   pip3 install virtualenv virtualenvwrapper
 
 Une fois les pré-requis terminés, vous pouvez vous lancer dans l'installaton de l'environnement de zds.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "doc": "doc"
   },
   "engines": {
-    "node": ">=10.x <=12.x"
+    "node": "12.x"
   },
   "scripts": {
     "gulp": "node ./node_modules/gulp/bin/gulp.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zds-site",
-  "version": "0.2.0",
-  "description": "Site internet communautaire codé à l'aide du Framework Django 1.10",
+  "version": "30.0.0",
+  "description": "Site internet communautaire codé à l'aide du Framework Django 2.2",
   "directories": {
     "doc": "doc"
   },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   },
   "browserslist": [
     "last 2 versions",
-    "> 1%",
-    "ie >= 9"
+    "> 1%"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "doc": "doc"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": "12.x"
   },
   "scripts": {
     "gulp": "node ./node_modules/gulp/bin/gulp.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "doc": "doc"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">=10.x <=12.x"
   },
   "scripts": {
     "gulp": "node ./node_modules/gulp/bin/gulp.js",

--- a/scripts/win/install_zds.ps1
+++ b/scripts/win/install_zds.ps1
@@ -94,8 +94,8 @@ if (-not (_in "-node") -and ((_in "+node") -or (_in "+base") -or (_in "+full")))
 
   mkdir temp_download | Out-Null
 
-  $node_filename = "node-v10.18.0-win-x64"
-  $node_url="https://nodejs.org/dist/v10.18.0/$node_filename.zip"
+  $node_filename = "node-v12.18.2-win-x64"
+  $node_url="https://nodejs.org/dist/v12.18.2/$node_filename.zip"
 
   PrintInfo " | -> Downloading NodeJS..."
   (new-object System.Net.WebClient).DownloadFile($node_url, "temp_download/node.zip")


### PR DESCRIPTION
Mise à jour des versions des technologies utilisés par zds-site dans la doc et package.json et du script Windows.

Numéro du ticket concerné (optionnel) : #5851, #5860

### Contrôle qualité

- Tester si le nouveau `package.json` fonctionne avec Node.js v12
- Tester si l'installation de Node.js  sur macOS via la commande `brew install node@12` ([normalement oui](https://formulae.brew.sh/formula/node), sinon, installation de la v14)
- Tester le script Windows (il fonctionne si la version globale de Node.js est la v12, si supérieure, il faut utiliser [cette procédure](https://github.com/zestedesavoir/zds-site/issues/5850))