### PR TITLE
Corrige l'affichage de l'élément sous le champ de recherche sous Safari.

### DIFF
--- a/assets/scss/pages/_flexpage.scss
+++ b/assets/scss/pages/_flexpage.scss
@@ -95,7 +95,7 @@ $content-width: 1145px;
                 }
             }
         }
-        
+
         .avatar {
             flex: 4;
             align-self: start;
@@ -123,7 +123,7 @@ $content-width: 1145px;
                 }
             }
         }
-        
+
         .actions {
             flex: 4;
 
@@ -139,11 +139,11 @@ $content-width: 1145px;
                 text-transform: uppercase;
                 font-size: 0.7em;
                 font-weight: 400;
-                
+
                 #subscriber_count, #subscriber_count_combined {
                     margin-left: 10px;
                 }
-                
+
                 &:hover,
                 &:focus {
                     color: white !important;
@@ -289,7 +289,6 @@ $content-width: 1145px;
             flex-direction: column;
             margin-top: 10px;
             margin-right: 20px;
-            height: 50px;
 
             .search {
                 display: flex;


### PR DESCRIPTION
Dans le bandeau bleu (`flexpage`), l'élément affiché sous le champ de recherche n'apparaît plus par dessus ce dernier, sur Safari et autres navigateurs utilisant WebKit.

Numéro du ticket concerné (optionnel) : fixes #5862.

### Contrôle qualité

- Lancez le site en reconstruisant le _front_ (`make run`)
- Sur un navigateur avec WebKit comme moteur de rendu (par exemple Safari ou GNOME Web), vérifiez sur une page de profil que le texte affiché sous le champ de recherche (indiquant la date d'inscription et de dernière connexion, ainsi que la dernière IP si votre compte de test a les droits) n'est pas par dessus le champ de recherche. Dans le doute, n'hésitez pas à actualiser sans le cache (`Ctrl/Cmd + F5` généralement), afin d'avoir la dernière version du CSS.