### PR TITLE
Corrige l'affichage du bouton du petit champ de recherche sur WebKit

### DIFF
--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -436,8 +436,8 @@ $logo-width: 240px;
             }
 
 
-            .notifs-links .ico-link, 
-            #my-account, 
+            .notifs-links .ico-link,
+            #my-account,
             #my-account .avatar{
                 height: 50px;
                 width: 50px;
@@ -545,5 +545,9 @@ $logo-width: 240px;
         display: flex;
         flex-shrink: 0;
         justify-content: flex-end;
+
+        form {
+          display: flex;
+        }
     }
 }


### PR DESCRIPTION
Le bouton du petit champ de recherche était sous le champ de recherche, dans la barre du fil d'Ariane, sur WebKit.

Numéro du ticket concerné (optionnel) : fixes #4956. (Il n'est jamais trop tard…)

### Contrôle qualité

1. Lancer le site en reconstruisant le _front-end_ (avec `make run`).
2. Sur un navigateur ayant WebKit comme moteur de rendu (Safari, GNOME Web…), se rendre sur une page qui n'a pas de bandeau bleu (sur laquelle le mini-champ de recherche est visible), par exemple une page d'un tutoriel ou d'un article.
3. Après actualisation sans cache de la page (`Cmd/Ctrl + F5` généralement), vérifier que le bouton d'envoi du champ de recherche est bien à côté du champ, et non dessous.
4. Sur un navigateur ayant un autre moteur de rendu (par exemple, Firefox ou Chrome), vérifier, également après un rafraîchissement sans cache, que le rendu est toujours bon.