### PR TITLE
Mise à jour des dépendances Python

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
 -r requirements.txt
 
-coverage==5.0.4
+coverage==5.2
 PyYAML==5.3.1
 django-debug-toolbar==2.2
-flake8==3.7.9
-flake8-quotes==2.1.1
-autopep8==1.5
+flake8==3.8.3
+flake8-quotes==3.2.0
+autopep8==1.5.3
 Sphinx==2.4.4
 selenium==3.141.0
-sphinx_rtd_theme==0.4.3
+sphinx_rtd_theme==0.5.0
 Faker==3.0.0
 mock==3.0.5
 colorlog==4.1.0
-django-extensions==2.2.8
+django-extensions==3.0.3

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
 gunicorn==20.0.4
-mysqlclient==1.4.6
+mysqlclient==2.0.1
 raven==6.10.0
-ujson==2.0.3
+ujson==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,33 +1,33 @@
 # Implicit dependencies (optional dependencies of dependencies)
-social-auth-app-django==3.1.0
+social-auth-app-django==4.0.0
 python-social-auth==0.3.6
 elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
 
 # Explicit dependencies (references in code)
-Django==2.2.13
-django-crispy-forms==1.9.0
+Django==2.2.14
+django-crispy-forms==1.9.2
 django-model-utils==4.0.0
 django-munin==0.2.1
 python-memcached==1.59
-lxml==4.5.0
+lxml==4.5.2
 factory-boy==2.8.1
 geoip2==3.0.0
-Pillow==7.0.0
-GitPython==3.1.0
+Pillow==7.2.0
+GitPython==3.1.7
 easy-thumbnails==2.7
-beautifulsoup4==4.8.2
+beautifulsoup4==4.9.1
 django-recaptcha==2.0.6
-google-api-python-client==1.8.0
-toml==0.10.0
-requests==2.23.0
-homoglyphs==1.3.5
+google-api-python-client==1.9.3
+toml==0.10.1
+requests==2.24.0
+homoglyphs==2.0.3
 
 # Api dependencies
 djangorestframework==3.11.0
-djangorestframework-xml==1.4.0
-django-filter==2.2.0
-django-oauth-toolkit==1.3.0
+djangorestframework-xml==2.0.0
+django-filter==2.3.0
+django-oauth-toolkit==1.3.2
 drf-extensions==0.6.0
 django-rest-swagger==2.2.0
 django-cors-middleware==1.5.0

--- a/scripts/generate_release_summary.py
+++ b/scripts/generate_release_summary.py
@@ -90,8 +90,8 @@ def parse_issues(req):
         # check closed issue
         elif issue['state'] == 'closed':
             labels = []
-            for l in issue['labels']:
-                labels.append(l['name'])
+            for label in issue['labels']:
+                labels.append(label['name'])
 
             if 'S-BUG' in labels or 'S-Régression' in labels:
                 closed_bug.append(issue)

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -1048,7 +1048,7 @@ class ForumGuestTests(TestCase):
         post2 = PostFactory(topic=topic1, author=user1, position=2)
         PostFactory(topic=topic1, author=user1, position=3)
 
-        result = self.client.get(reverse('post-new') + '?sujet={0}&cite={0}'.format(topic1.pk, post2.pk), follow=False)
+        result = self.client.get(reverse('post-new') + '?sujet={}&cite={}'.format(topic1.pk, post2.pk), follow=False)
 
         self.assertEqual(result.status_code, 302)
 

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -1823,10 +1823,10 @@ class FakeBackend(BaseEmailBackend):
 @override_settings(EMAIL_BACKEND='zds.member.tests.tests_views.FakeBackend')
 class RegisterTest(TestCase):
     def test_exception_on_mail(self):
-        def message(l):
+        def send_messages(messages):
             print('message sent')
-            raise SMTPException(l)
-        mail_backend.send_messages = message
+            raise SMTPException(messages)
+        mail_backend.send_messages = send_messages
 
         result = self.client.post(
             reverse('register-member'),

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -567,7 +567,7 @@ def handle_content_with_chapter_and_parts(container, current_size, fake, nb_avg_
         for k in range(random.randint(1, nb_avg_containers_in_content * 2)):
             subcontainer = ContainerFactory(parent=container, title=fake.text(max_nb_chars=60))
 
-            for l in range(random.randint(1, nb_avg_extracts_in_content * 2)):
+            for m in range(random.randint(1, nb_avg_extracts_in_content * 2)):
                 ExtractFactory(container=subcontainer, title=fake.text(max_nb_chars=60), light=False)
 
 


### PR DESCRIPTION
Mise à jour des dépendances Python, en prévision de la v29.2

**QA :**

- `source zdsenv/bin/activate && make install-back && make install-front && make migrate-db && make build-front && make zmd-start && make run-back`
- Vérifier que le site fonctionne normalement