### PR TITLE
[29.2] “Undefined” sur le bouton de demande d'export

### DIFF
--- a/templates/tutorialv2/includes/exports.part.html
+++ b/templates/tutorialv2/includes/exports.part.html
@@ -31,6 +31,7 @@
              data-tr-staterunning="{% trans "En cours de traitement" %}"
              data-tr-statefailure="{% trans "Échoué" %}"
              data-tr-staterequested="{% trans "En attente" %}"
+             data-tr-generation-waiting="{% trans "Envoi de la demande…" %}"
              data-tr-generation-requested="{% trans "La génération a été demandée." %}"
              data-tr-generation-errored="{% trans "Impossible de demander la génération… Réessayez ?" %}"
     >


### PR DESCRIPTION
Lors de l'envoi d'une demande d'export dans le dialogue concerné, pendant le chargement, il était inscrit “undefined” au lieu d'un texte d'attente.

### Contrôle qualité

1. Lancez le site en reconstruisant le _front-end_ au passage (`make run`).
2. Allez sur la page d'un contenu publié (brouillon ou non, peu importe), avec un compte _staff_ ou le compte de l'un des auteurs. Actualisez la-dite page sans le cache, afin d'être sûr d'avoir la dernière version du JS.
3. Ouvrez le dialogue de gestion d'exports en cliquant sur le bouton dans la barre latérale, et cliquez sur le bouton vert de demande d'exports. Pendant l'envoi de la demande (au moment où une animation de chargement est visible sur le bouton), il est inscrit un texte de chargement (« Envoi de la demande… »), et non « undefined ».