### PR TITLE
🚸 Suppression de la partie « Mon profil » de la barre latérale

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -332,7 +332,7 @@
                 {% with profile=user.profile %}
                     <a href="{% url "member-detail" user.username %}"
                        id="my-account"
-                       class="dont-click-if-sidebar"
+                       class="mobile-menu-hide"
                        title="{% trans 'Mon profil' %}"
                        data-title="{% trans 'Mon profil' %}"
 


### PR DESCRIPTION
Supprime la partie « Mon profil » de la barre latérale.

Numéro du ticket concerné (optionnel) : fix #2496

### Contrôle qualité

1. Vérifier si la partie « Mon profil » n'apparaît plus dans la barre latérale, en dessous de la barre de recherche sur mobile et tablette.
2. Vérifier que rien d'autre est impacté (en particulier le menu de droite (avatar), que ça soit sur mobile, tablette ou PC.