### PR TITLE
[29.2] Il n'était pas possible d'annuler la validation

### DIFF
--- a/zds/tutorialv2/views/validations.py
+++ b/zds/tutorialv2/views/validations.py
@@ -239,7 +239,7 @@ class CancelValidation(LoginRequiredMixin, ModalFormView):
         # reject validation:
         quote = '\n'.join(['> ' + line for line in form.cleaned_data['text'].split('\n')])
         validation.status = 'CANCEL'
-        validation.comment_authors += _('\n\nLa validation a été **annulée** pour la raison suivante :\n\n{}')\
+        validation.comment_authors = _('\n\nLa validation a été **annulée** pour la raison suivante :\n\n{}')\
             .format(quote)
         validation.date_validation = datetime.now()
         validation.save()
@@ -247,7 +247,7 @@ class CancelValidation(LoginRequiredMixin, ModalFormView):
         validation.content.sha_validation = None
         validation.content.save()
 
-        # warn the former validator that the all thing have been canceled
+        # warn the former validator that the whole thing has been cancelled
         if validation.validator:
             bot = get_object_or_404(User, username=settings.ZDS_APP['member']['bot_account'])
             msg = render_to_string(


### PR DESCRIPTION
Lorsque l'on cherchait à annuler la demande de validation, une `TypeError` était retournée (ou, sur la version de production, une erreur 500).

```
TypeError at /validations/annuler/15/
unsupported operand type(s) for +=: 'NoneType' and 'str'
```

### Contrôle qualité

1. Lancez le site avec `make run`.
2. Mettez un contenu en validation (ou, utilisez un contenu déjà en validation, peu importe). Réservez-le avec un compte staff.
3. Tentez d'annuler la validation. Constatez que ça fonctionne et que vous n'obtenez pas d'erreur. Constatez que le message privé envoyé au validateur en charge est bon.