### PR TITLE
[29.2] L'API des demandes d'aide ne fonctionne pas en prod/bêta.

### DIFF
--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -40,7 +40,7 @@ urlpatterns = [
     path('tribunes/<int:pk>/', RedirectOldContentOfAuthor.as_view(type='OPINION')),
 
     re_path(r'^aides/$', ContentsWithHelps.as_view(), name='helps'),
-    re_path(r'^aides/(?P<pk>\d+)/change$', ChangeHelp.as_view(), name='helps-change'),
+    re_path(r'^aides/(?P<pk>\d+)/change/$', ChangeHelp.as_view(), name='helps-change'),
     re_path(r'^(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/(?P<container_slug>.+)/$',
             DisplayContainer.as_view(public_is_prioritary=False),
             name='view-container'),


### PR DESCRIPTION
Ajout d'un `/` final à l'API pour éviter la redirection cassant l'URL.

Numéro du ticket concerné (optionnel) : fixes #5878.

### Contrôle qualité

**:warning: Ce problème ne se présente pas dans l'environnement de développement.** Il faudra probablement le tester en bêta.

1. Aller sur un contenu que l'on possède.
2. Essayer d'ajouter ou de supprimer une demande d'aide via le menu latéral. Constater que ça fonctionne.