### PR TITLE
[29.2] Les pinaillages de l'interface d'exports.

### DIFF
--- a/assets/js/content-export.js
+++ b/assets/js/content-export.js
@@ -86,7 +86,6 @@
           const header = document.createElement('header')
           const headerH4 = document.createElement('h4')
           const headerP = document.createElement('p')
-          const headerDownloadLink = document.createElement('a')
           const footer = document.createElement('footer')
 
           const state = contentExport.state_of_processing.toLowerCase()
@@ -98,22 +97,20 @@
           headerH4.innerText = t['trFormat' + contentExport.format_requested] || contentExport.format_requested
 
           headerP.setAttribute('title', formatterLong.format(date))
-          headerP.innerText = formatter.format(date) + (state !== 'failure' ? ' – ' : '')
+          headerP.innerText = formatter.format(date) + (state === 'success' ? ' – ' : '')
 
           if (state === 'success') {
-            headerDownloadLink.setAttribute('title', t.trDownloadTitle)
-          } else if (state === 'running' || state === 'requested') {
-            headerDownloadLink.setAttribute('title', t.trDownloadUnavailableTitle)
-          }
+            const headerDownloadLink = document.createElement('a')
 
-          if (state !== 'failure') {
+            headerDownloadLink.setAttribute('title', t.trDownloadTitle)
             headerDownloadLink.innerText = t.trDownload
             headerDownloadLink.setAttribute('href', contentExport.url)
+
+            headerP.appendChild(headerDownloadLink)
           }
 
           footer.innerText = t[`trState${state}`]
 
-          if (state !== 'failure') headerP.appendChild(headerDownloadLink)
           header.appendChild(headerH4)
           header.appendChild(headerP)
 

--- a/assets/scss/pages/_content-exports.scss
+++ b/assets/scss/pages/_content-exports.scss
@@ -1,10 +1,6 @@
 #exports-modal {
     width: 500px;
 
-    p {
-        text-align: justify;
-    }
-
     section.exports {
         margin-top: 3.6rem;
         margin-bottom: 4rem;
@@ -41,7 +37,9 @@
                     height: 16px;
 
                     background-repeat: no-repeat;
+                }
 
+                &:not(.is-requested):not(.is-running):before {
                     @include sprite();
                 }
 
@@ -74,15 +72,22 @@
                 }
             }
 
-            &.is-requested {
+            &.is-requested, &.is-running {
                 header:before {
-                    @include sprite-position($radio)
-                }
-            }
+                    content: '';
 
-            &.is-running {
-                header:before {
-                    @include sprite-position($radio)
+                    display: block;
+                    left: -2.6rem;
+
+                    width: 8px;
+                    height: 8px;
+
+                    background-color: $color-primary;
+                    border-radius: 100%;
+                }
+
+                &.is-running header:before {
+                    animation: pulse 2s infinite;
                 }
 
                 footer {
@@ -132,4 +137,18 @@
             }
         }
     }
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
 }

--- a/templates/tutorialv2/includes/exports.part.html
+++ b/templates/tutorialv2/includes/exports.part.html
@@ -26,7 +26,6 @@
              data-tr-formatzip="{% trans "ZIP" %}"
              data-tr-download="{% trans "Télécharger" %}"
              data-tr-download-title="{% trans "Télécharger cet export" %}"
-             data-tr-download-unavailable-title="{% trans "Cet export est en cours de traitement ; ce lien ne fonctionnera pas ou sera obsolète." %}"
              data-tr-statesuccess="{% trans "Terminé" %}"
              data-tr-staterunning="{% trans "En cours de traitement" %}"
              data-tr-statefailure="{% trans "Échoué" %}"


### PR DESCRIPTION
J'ai corrigé ce qui m'a été remonté.

- Le texte n'est plus justifié dans la modale.
- Les icônes d'état d'attente et de traitement n'ont plus d'artefact.
- Le lien de téléchargement n'est affiché que pour les exports traités avec succès.

Un autre ajout au passage.

- L'icône d'état “en cours de traitement” clignote doucement, pour donner un effet de traitement en cours renforcé, et pour différencier de l'état “en attente”.

Numéro du ticket concerné (optionnel) : fixes #5876.

### Contrôle qualité

- Lancer le site avec `make run`. Aller sur le site et actualiser sans le cache pour avoir les dernières versions du JS et du CSS.
- Aller sur un contenu publié que votre compte peut gérer (tous, si vous êtes connecté⋅e avec le compte `admin`). Cliquer sur le lien « Exports du contenu » dans la barre latérale pour ouvrir la modale.
- **Vérifier que le texte n'est pas justifié.**
- Demander la re-génération des contenus.
- **Vérifier que les icônes n'ont pas d'artefact.**
- **Vérifier que les liens de téléchargement ne s'affichent pas.**
- Lancer le _watchdog_ générant les contenus avec, dans un autre terminal, `make start-publication-watchdog`. Retournez sur la page où la modale est ouverte, sans l'actualiser (l'état se mettra à jour en temps réel).
- **Vérifier que pendant le traitement (du PDF, le reste vous n'aurez pas le temps), l'icône clignote.**
- **Vérifier que les icônes des états “réussi” et “échoué” sont toujours correctes.**
- **Vérifier que le lien de téléchargement apparaît bien sur les exports réussis.**