### PR TITLE
💄 Cohérence du fond des menu déroulants d'EasyMDE

### DIFF
--- a/assets/scss/components/_editor-new.scss
+++ b/assets/scss/components/_editor-new.scss
@@ -34,7 +34,13 @@
             }
             button.blocMenu {
                 border-color: #fcfcfc;
+                background-image: linear-gradient(to right bottom, rgb(253, 253, 253) 0px, rgb(253, 253, 253) 84%, rgb(51, 51, 51) 50%, rgb(51, 51, 51) 100%);
             }
+
+            .easymde-dropdown-content {
+                background-color: #fcfcfc;
+            }
+
             button.active,
             button:hover {
                 border: 1px solid transparent;


### PR DESCRIPTION
Le fond du bouton « i » de son menu déroulant sont de la même couleur que les autres boutons. Ça sera le cas pour les autres boutons de ce type si on en ajoute.

Il est a noté que tous les autres boutons n'ont pas de fond mais que celui-ci en pour permettre le triangle noir dans le coin du bas à gauche. Il s'agit d'un style d'EasyMDE. Si un thème alternatif est utilisé, il y a un risque que ce bouton reste clair.

Numéro du ticket concerné : #5792

### Contrôle qualité

1. Se connecter ;
2. Utiliser le nouvel éditeur ;
3. Vérifier si la couleur du bouton « i » et de son menu est de la même couleur que des autres boutons ;
4. Vérifier qu'il n'y a pas de répercussions.