### PR TITLE
🐛 Changement de classe de l'encadré « Signalement du profil »

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -878,7 +878,7 @@
                                 <em>{{ alert.text }}</em>
                             </span>
                             {% if alert.solved %}
-                                <span class="close-alert-box close-alert-box-text">
+                                <span class="view-alert-box close-alert-box-text">
                                     {% trans "Résolu par" %}
                                     {% include "misc/member_item.part.html" with member=alert.moderator %}
                                 </span>


### PR DESCRIPTION
Ne masque plus l'encadré quand on clique sur le pseudonyme du membre ayant résolu le signalement.

Numéro du ticket concerné (optionnel) : close #5813

### Contrôle qualité

1. Se connecter en tant qu'admin ;
2. Signaler le membre M ;
3. Résoudre le signalement ;
4. Accéder au profil du membre M ;
5. Cliquer sur le pseudonyme « admin » à droite de l'encadré gris ;
6. Vérifier qu'aucun problème n'a été engendré.
