### PR TITLE
[v29.2] Corrige l'affichage des demandes d'aide

### DIFF
--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -73,7 +73,7 @@
         </div>
     {% endif %}
 
-    {% if helps %}
+    {% if content_helps %}
         <div class="content-wrapper">
             <div class="alert-box info">
                 {% if content.authors.count > 1 %}
@@ -82,7 +82,7 @@
                     {% trans "L’auteur de ce contenu recherche" %}
                 {% endif %}
 
-                {% for help in helps.all %}{% if not forloop.first %}{% if forloop.last %}{% trans ' et ' %}{% else %}{% trans ', ' %}{% endif %}{% endif %}un {{ help.title|lower }}{% if forloop.last %}{% trans '.' %}{% endif %}{% endfor %}
+                {% for help in content_helps %}{% if not forloop.first %}{% if forloop.last %}{% trans ' et ' %}{% else %}{% trans ', ' %}{% endif %}{% endif %}un {{ help.title|lower }}{% if forloop.last %}{% trans '.' %}{% endif %}{% endfor %}
 
                 {% if not can_edit %}
                     {% blocktrans with plural=content.authors.count|pluralize_fr %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -115,7 +115,7 @@
             </div>
         </div>
 
-        {% if helps %}
+        {% if content_helps %}
             <div class="content-wrapper">
                 <div class="alert-box info">
                     {% if content.authors.count > 1 %}
@@ -124,7 +124,7 @@
                         {% trans "L’auteur de ce contenu recherche" %}
                     {% endif %}
 
-                    {% for help in content.helps.all %}{% if not forloop.first %}{% if forloop.last %}{% trans ' et ' %}{% else %}{% trans ', ' %}{% endif %}{% endif %}un {{ help.title|lower }}{% if forloop.last %}{% trans '.' %}{% endif %}{% endfor %}
+                    {% for help in content_helps %}{% if not forloop.first %}{% if forloop.last %}{% trans ' et ' %}{% else %}{% trans ', ' %}{% endif %}{% endif %}un {{ help.title|lower }}{% if forloop.last %}{% trans '.' %}{% endif %}{% endfor %}
 
                     {% if not can_edit %}
                         {% blocktrans with plural=content.authors.count|pluralize_fr %}
@@ -730,11 +730,11 @@
                     <li>
                         <form action="{% url 'content:helps-change' content.pk %}" method="POST">
                             {% csrf_token %}
-                            <input type="hidden" name="activated" value="{% if help.pk in content_helps %}false{% else %}true{% endif %}">
+                            <input type="hidden" name="activated" value="{% if help in content_helps %}false{% else %}true{% endif %}">
                             <input type="hidden" name="help_wanted" value="{{ help.title }}">
                             <button type="submit"
-                               class="help-toggle {% if help.pk in content_helps %}selected ico-after tick green{% endif %} help-{{ help.slug }}"
-                               data-activated="{% if help.pk in content_helps %}true{% else %}false{% endif %}">
+                               class="help-toggle {% if help in content_helps %}selected ico-after tick green{% endif %} help-{{ help.slug }}"
+                               data-activated="{% if help in content_helps %}true{% else %}false{% endif %}">
                                 {{ help.title }}
                             </button>
                         </form>

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -261,7 +261,7 @@ class SingleContentDetailViewMixin(SingleContentViewMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super(SingleContentDetailViewMixin, self).get_context_data(**kwargs)
         context['helps'] = list(HelpWriting.objects.all())
-        context['content_helps'] = self.object.helps.values_list('pk', flat=True)
+        context['content_helps'] = list(self.object.helps.all())
         context['content'] = self.versioned_object
         context['can_edit'] = self.is_author
         context['is_staff'] = self.is_staff

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -249,7 +249,6 @@ class DisplayBetaContent(DisplayContent):
 
     def get_context_data(self, **kwargs):
         context = super(DisplayBetaContent, self).get_context_data(**kwargs)
-        context['helps'] = list(self.object.helps.all())
         context['pm_link'] = self.object.get_absolute_contact_url()
         return context
 
@@ -1136,7 +1135,6 @@ class DisplayBetaContainer(DisplayContainer):
 
     def get_context_data(self, **kwargs):
         context = super(DisplayBetaContainer, self).get_context_data(**kwargs)
-        context['helps'] = list(self.object.helps.all())
         context['pm_link'] = self.object.get_absolute_contact_url()
         return context
 


### PR DESCRIPTION
Corrige l'affichage des demandes d'aide

Closes #5890 

**QA :**

- `source zdsenv/bin/activate && make zmd-start && make run-back`
- Aller sur un contenu en étant connecté avec un des auteurs du contenu
- Sélectionner un ou plusieurs demandes d'aide sur la barre latérale du contenu en version brouillon
- Mettre le contenu en bêta
- Vérifier que le texte « L’auteur de ce contenu recherche ... » mentionne bien les demandes d'aide sélectionnées
  - sur la page principale du contenu en bêta
  - sur une partie ou un chapitre du contenu en bêta