### PR TITLE
Correction d'une erreur de classe à l'origine du non-affichage de certains menus

### DIFF
--- a/templates/member/base.html
+++ b/templates/member/base.html
@@ -21,7 +21,7 @@
 
 
 {% block sidebar %}
-    <aside class="sidebar mobile-menu-only">
+    <aside class="sidebar mobile-menu-hide">
         {% block sidebar_actions %}{% endblock %}
     </aside>
 {% endblock %}


### PR DESCRIPTION
<!-- Veuillez décrire vos changements à l’emplacement de ce commentaire (inutile dans le cas de tout petits changements). -->

Cette pull request corrige une erreur de classe qui avait pour conséquence de n'afficher certaines sidebars de l'espace membre (demandes de casquettes et gestion des fournisseurs e-mail) que sur mobile alors qu'elles ne devaient l'être que sur ordinateur. Le résultat était le suivant :

- L'option apparaissait en double sur mobile ;
- Et nulle part sur ordinateur.

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné (optionnel) : aucun

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

Il s'agit de vérifier [ici](http://localhost:8000/membres/casquettes/demandes/) que le lien « Demandes résolues » apparaît une seule fois tant sur mobile que sur bureau.

<!-- Merci ! -->
