### PR TITLE
Restreint l'interface d'administration des MP au mode développement

### DIFF
--- a/zds/mp/admin.py
+++ b/zds/mp/admin.py
@@ -1,32 +1,28 @@
+from django.conf import settings
 from django.contrib import admin
 
 from .models import PrivatePost, PrivateTopic, PrivateTopicRead
 
 
-class PrivatePostAdmin(admin.ModelAdmin):
+if settings.DEBUG:
+    class PrivatePostAdmin(admin.ModelAdmin):
+        """Representation of PrivatePost model in the admin interface."""
 
-    """Representation of PrivatePost model in the admin interface."""
+        list_display = ('privatetopic', 'author', 'pubdate', 'update', 'position_in_topic')
+        raw_id_fields = ('privatetopic', 'author')
 
-    list_display = ('privatetopic', 'author', 'pubdate', 'update', 'position_in_topic')
-    raw_id_fields = ('privatetopic', 'author')
+    class PrivateTopicAdmin(admin.ModelAdmin):
+        """Representation of PrivateTopic model in the admin interface."""
 
+        list_display = ('title', 'subtitle', 'author', 'last_message', 'pubdate')
+        raw_id_fields = ('author', 'participants', 'last_message')
 
-class PrivateTopicAdmin(admin.ModelAdmin):
+    class PrivateTopicReadAdmin(admin.ModelAdmin):
+        """Representation of PrivateTopicRead model in the admin interface."""
 
-    """Representation of PrivateTopic model in the admin interface."""
+        list_display = ('privatetopic', 'privatepost', 'user')
+        raw_id_fields = ('privatetopic', 'privatepost', 'user')
 
-    list_display = ('title', 'subtitle', 'author', 'last_message', 'pubdate')
-    raw_id_fields = ('author', 'participants', 'last_message')
-
-
-class PrivateTopicReadAdmin(admin.ModelAdmin):
-
-    """Representation of PrivateTopicRead model in the admin interface."""
-
-    list_display = ('privatetopic', 'privatepost', 'user')
-    raw_id_fields = ('privatetopic', 'privatepost', 'user')
-
-
-admin.site.register(PrivatePost, PrivatePostAdmin)
-admin.site.register(PrivateTopic, PrivateTopicAdmin)
-admin.site.register(PrivateTopicRead, PrivateTopicReadAdmin)
+    admin.site.register(PrivatePost, PrivatePostAdmin)
+    admin.site.register(PrivateTopic, PrivateTopicAdmin)
+    admin.site.register(PrivateTopicRead, PrivateTopicReadAdmin)

--- a/zds/mp/admin.py
+++ b/zds/mp/admin.py
@@ -1,0 +1,32 @@
+from django.contrib import admin
+
+from .models import PrivatePost, PrivateTopic, PrivateTopicRead
+
+
+class PrivatePostAdmin(admin.ModelAdmin):
+
+    """Representation of PrivatePost model in the admin interface."""
+
+    list_display = ('privatetopic', 'author', 'pubdate', 'update', 'position_in_topic')
+    raw_id_fields = ('privatetopic', 'author')
+
+
+class PrivateTopicAdmin(admin.ModelAdmin):
+
+    """Representation of PrivateTopic model in the admin interface."""
+
+    list_display = ('title', 'subtitle', 'author', 'last_message', 'pubdate')
+    raw_id_fields = ('author', 'participants', 'last_message')
+
+
+class PrivateTopicReadAdmin(admin.ModelAdmin):
+
+    """Representation of PrivateTopicRead model in the admin interface."""
+
+    list_display = ('privatetopic', 'privatepost', 'user')
+    raw_id_fields = ('privatetopic', 'privatepost', 'user')
+
+
+admin.site.register(PrivatePost, PrivatePostAdmin)
+admin.site.register(PrivateTopic, PrivateTopicAdmin)
+admin.site.register(PrivateTopicRead, PrivateTopicReadAdmin)


### PR DESCRIPTION
L'interface d'administration des MP a été récemment supprimée pour des raisons de confidentialité. En ayant eu besoin en développement et après discussion avec @AmauryCarrade, cette PR la remet en mode développement.

Voir aussi #5889 et #5892 pour l'historique.

### Contrôle qualité

Vérifier que l'interface d'administration des MP s'affiche si et seulement si `DEBUG is True`.
