### PR TITLE
Corrige l'affichage de la page de profil et réorganise les templates d'administration

### DIFF
--- a/templates/member/admin/add_banned_email_provider.html
+++ b/templates/member/admin/add_banned_email_provider.html
@@ -1,4 +1,4 @@
-{% extends "member/base.html" %}
+{% extends "member/admin/base.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
 

--- a/templates/member/admin/banned_email_providers.html
+++ b/templates/member/admin/banned_email_providers.html
@@ -1,4 +1,4 @@
-{% extends "member/base.html" %}
+{% extends "member/admin/base.html" %}
 {% load date %}
 {% load i18n %}
 

--- a/templates/member/admin/base.html
+++ b/templates/member/admin/base.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title_base %}
+    &bull; {% trans "Administration des membres" %}
+{% endblock %}
+
+
+
+{% block mobile_title %}
+    {% trans "Administration des membres" %}
+{% endblock %}
+
+
+
+{% block breadcrumb_base %}
+    <li><a href="{% url 'member-list' %}">{% trans "Administration des membres" %}</a></li>
+{% endblock %}
+
+
+
+{% block sidebar %}
+    <aside class="sidebar mobile-menu-hide">
+        {% block sidebar_actions %}{% endblock %}
+    </aside>
+{% endblock %}

--- a/templates/member/admin/hat_request.html
+++ b/templates/member/admin/hat_request.html
@@ -1,4 +1,4 @@
-{% extends "member/base.html" %}
+{% extends "member/admin/base.html" %}
 {% load date %}
 {% load i18n %}
 {% load emarkdown %}

--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -1,4 +1,4 @@
-{% extends "member/base.html" %}
+{% extends "member/admin/base.html" %}
 {% load date %}
 {% load i18n %}
 {% load remove_url_scheme %}

--- a/templates/member/admin/members_with_provider.html
+++ b/templates/member/admin/members_with_provider.html
@@ -1,4 +1,4 @@
-{% extends "member/base.html" %}
+{% extends "member/admin/base.html" %}
 {% load date %}
 {% load i18n %}
 {% load remove_url_scheme %}

--- a/templates/member/admin/new_email_providers.html
+++ b/templates/member/admin/new_email_providers.html
@@ -1,4 +1,4 @@
-{% extends "member/base.html" %}
+{% extends "member/admin/base.html" %}
 {% load date %}
 {% load i18n %}
 

--- a/templates/member/admin/promote.html
+++ b/templates/member/admin/promote.html
@@ -1,4 +1,4 @@
-{% extends "member/settings/base.html" %}
+{% extends "member/admin/base.html" %}
 {% load crispy_forms_tags %}
 {% load i18n %}
 

--- a/templates/member/admin/requested_hats.html
+++ b/templates/member/admin/requested_hats.html
@@ -1,4 +1,4 @@
-{% extends "member/base.html" %}
+{% extends "member/admin/base.html" %}
 {% load date %}
 {% load i18n %}
 

--- a/templates/member/admin/solved_hat_requests.html
+++ b/templates/member/admin/solved_hat_requests.html
@@ -1,4 +1,4 @@
-{% extends "member/base.html" %}
+{% extends "member/admin/base.html" %}
 {% load date %}
 {% load i18n %}
 

--- a/templates/member/base.html
+++ b/templates/member/base.html
@@ -21,7 +21,7 @@
 
 
 {% block sidebar %}
-    <aside class="sidebar mobile-menu-hide">
+    <aside class="sidebar mobile-menu-only">
         {% block sidebar_actions %}{% endblock %}
     </aside>
 {% endblock %}

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -742,7 +742,7 @@ class NewEmailProvidersList(LoginRequiredMixin, PermissionRequiredMixin, ZdSPagi
 
     model = NewEmailProvider
     context_object_name = 'providers'
-    template_name = 'member/settings/new_email_providers.html'
+    template_name = 'member/admin/new_email_providers.html'
     queryset = NewEmailProvider.objects \
         .select_related('user') \
         .select_related('user__profile') \
@@ -773,7 +773,7 @@ class BannedEmailProvidersList(LoginRequiredMixin, PermissionRequiredMixin, ZdSP
 
     model = BannedEmailProvider
     context_object_name = 'providers'
-    template_name = 'member/settings/banned_email_providers.html'
+    template_name = 'member/admin/banned_email_providers.html'
     queryset = BannedEmailProvider.objects \
         .select_related('moderator') \
         .select_related('moderator__profile') \
@@ -788,7 +788,7 @@ class MembersWithProviderList(LoginRequiredMixin, PermissionRequiredMixin, ZdSPa
 
     model = User
     context_object_name = 'members'
-    template_name = 'member/settings/members_with_provider.html'
+    template_name = 'member/admin/members_with_provider.html'
 
     def get_object(self):
         return get_object_or_404(BannedEmailProvider, pk=self.kwargs['provider_pk'])
@@ -812,7 +812,7 @@ class AddBannedEmailProvider(LoginRequiredMixin, PermissionRequiredMixin, Create
     permissions = ['member.change_bannedemailprovider']
 
     model = BannedEmailProvider
-    template_name = 'member/settings/add_banned_email_provider.html'
+    template_name = 'member/admin/add_banned_email_provider.html'
     form_class = BannedEmailProviderForm
     success_url = reverse_lazy('banned-email-providers')
 
@@ -910,7 +910,7 @@ class RequestedHatsList(LoginRequiredMixin, PermissionRequiredMixin, ZdSPagingLi
 
     model = HatRequest
     context_object_name = 'requests'
-    template_name = 'member/settings/requested_hats.html'
+    template_name = 'member/admin/requested_hats.html'
     queryset = HatRequest.objects \
         .filter(is_granted__isnull=True) \
         .select_related('user') \
@@ -924,7 +924,7 @@ class SolvedHatRequestsList(LoginRequiredMixin, PermissionRequiredMixin, ZdSPagi
 
     model = HatRequest
     context_object_name = 'requests'
-    template_name = 'member/settings/solved_hat_requests.html'
+    template_name = 'member/admin/solved_hat_requests.html'
     queryset = (HatRequest.objects
                 .filter(is_granted__isnull=False)
                 .select_related('user')
@@ -937,7 +937,7 @@ class SolvedHatRequestsList(LoginRequiredMixin, PermissionRequiredMixin, ZdSPagi
 class HatRequestDetail(LoginRequiredMixin, DetailView):
     model = HatRequest
     context_object_name = 'hat_request'
-    template_name = 'member/settings/hat_request.html'
+    template_name = 'member/admin/hat_request.html'
 
     def get_object(self, queryset=None):
         request = super(HatRequestDetail, self).get_object()
@@ -1400,7 +1400,7 @@ def settings_promote(request, user_pk):
         'groups': user.groups.all(),
         'activation': user.is_active
     })
-    return render(request, 'member/settings/promote.html', {
+    return render(request, 'member/admin/promote.html', {
         'usr': user,
         'profile': profile,
         'form': form
@@ -1413,7 +1413,7 @@ def member_from_ip(request, ip_address):
     """List users connected from a particular IP."""
 
     members = Profile.objects.filter(last_ip_address=ip_address).order_by('-last_visit')
-    return render(request, 'member/settings/memberip.html', {
+    return render(request, 'member/admin/memberip.html', {
         'members': members,
         'ip': ip_address
     })


### PR DESCRIPTION
La pull request #5895 avait pour effet secondaire d'afficher une sidebar sur la page de profil, tout à fait indésirable en raison de son niveau design. Le fait est que la page de profil a un fonctionnement différent de celui des pages d'administration, et elles ne peuvent pas donc reposer sur le même `base.html`. Ainsi, cette pull request :

- Annule la modification d'hier (la classe `mobile-menu-only` revient dans `member/base.html`) ;
- Crée un nouveau sous-dossier `templates/member/admin` où figurent désormais les nouveaux templates d'administration des membres (ça permet de faire le tri dans `templates/member/settings`) ;
- Crée un `base.html` dans ce nouveau dossier, dans lequel la sidebar a pour classe `mobile-menu-hide`.

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

Vérifier le bon affichage de la page de profil, des demandes de casquettes, de la gestion des fournisseurs e-mail et de la gestion des groupes d'un membre.