### PR TITLE
Passage à zmd 9.1.3 pour pouvoir exporter les gros contenus

### DIFF
--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "9.1.2"
+    "zmarkdown": "9.1.3"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
Passage à zmd 9.1.3 pour pouvoir exporter les gros contenus

On augmente simplement la taille limite pour la génération du LaTeX