### PR TITLE
Harmonise les licences des fixtures avec celles de la prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ generate-pdf: ## Generate PDFs of published contents
 migrate-db: ## Create or update database schema
 	python manage.py migrate
 
-generate-fixtures: ## Generate fixtures (users, tutorials, articles, opinions, topics...)
+generate-fixtures: ## Generate fixtures (users, tutorials, articles, opinions, topics, licenses...)
 	@if curl -s $(ZMD_URL) > /dev/null; then \
 		python manage.py loaddata fixtures/*.yaml; \
 		python manage.py load_factory_data fixtures/advanced/aide_tuto_media.yaml; \

--- a/doc/source/utils/fixture_loaders.rst
+++ b/doc/source/utils/fixture_loaders.rst
@@ -13,9 +13,9 @@ Chargement du jeu de données standard
 En l'absence d'exigences particulières, le moyen le plus simple de charger un jeu de données est d'utiliser la
 commande suivante :
 
-```
-make generate-fixtures
-```
+.. sourcecode:: bash
+
+    make generate-fixtures
 
 ou si vous souhaitez purger les données existantes au préalable :
 

--- a/doc/source/utils/fixture_loaders.rst
+++ b/doc/source/utils/fixture_loaders.rst
@@ -19,9 +19,9 @@ commande suivante :
 
 ou si vous souhaitez purger les données existantes au préalable :
 
-```
-make new-db
-```
+.. sourcecode:: bash
+
+    make new-db
 
 Ces commandes chargent :
 

--- a/doc/source/utils/fixture_loaders.rst
+++ b/doc/source/utils/fixture_loaders.rst
@@ -5,22 +5,47 @@ Le chargement de jeux de données (fixtures)
 Zeste de Savoir étant un projet très complet il est nécessaire de pouvoir charger un ensemble de jeux de données
 de manière automatique pour créer une nouvelle instance à des fins de test ou pour forker le site.
 
-Pour faciliter la tâche, trois outils sont mis à disposition des développeurs, testeurs et utilisateurs.
+Pour faciliter la tâche, des outils sont mis à disposition des développeurs, testeurs et utilisateurs.
+
+Chargement du jeu de données standard
+-------------------------------------
+
+En l'absence d'exigences particulières, le moyen le plus simple de charger un jeu de données est d'utiliser la
+commande suivante :
+
+```
+make generate-fixtures
+```
+
+ou si vous souhaitez purger les données existantes au préalable :
+
+```
+make new-db
+```
+
+Ces commandes chargent :
+
+* un jeu de données simples ;
+* quelques données plus complexes ;
+* un jeu de données modérément massif.
+
+Ces trois opérations correspondent à des appels aux outils décrits ci-après. Les paramètres exacts sont
+disponibles dans le fichier `Makefile` à la racine de l'environnement de développement.
 
 Les données sérialisables pour une base fonctionnelle
 -----------------------------------------------------
 
 Un premier ensemble de données simples est accessible par la commande intégrée à django ``python manage.py loaddata``.
 
-Cette commande s'attend à une liste de fichier au format yaml et supporte les *wildcards*.
-Nous possédons un ensemble de données sérialisées dans le dossier fixtures:
+Cette commande s'attend à une liste de fichiers au format yaml et supporte les *wildcards*.
+Nous possédons un ensemble de données sérialisées dans le dossier fixtures :
 
-- ``categories.yaml`` : contient le chargement de 3 catégories de tutoriels, 2 sous catégories de tutoriels rangées dans les bonnes catégories parentes
-- ``forums.yaml`` : contient le chargment de 4 catégories de forum et de 10 forums dans ces catégories
-- ``licences.yaml`` : contient le chargement de 2 licences dont la licence par défaut (tous droit réservés)
-- ``mps.yaml`` : **nécessite le chargement des users**, contient la création d'un MP d'un membre à un admin
-- ``topics.yaml``: **nécessite le chargement des users**, contient la création de plusieurs topics dans les forums dont un résolu
-- ``users.yaml``: Crée 6 utilisateurs:
+- ``categories.yaml`` : contient le chargement de 3 catégories de tutoriels, 2 sous-catégories de tutoriels rangées dans les bonnes catégories parentes ;
+- ``forums.yaml`` : contient le chargement de 4 catégories de forum et de 10 forums dans ces catégories ;
+- ``licences.yaml`` : contient le chargement des licences, identiques à celles utilisées en production ;
+- ``mps.yaml`` : **nécessite le chargement des users**, contient la création d'un MP d'un membre à un admin ;
+- ``topics.yaml``: **nécessite le chargement des users**, contient la création de plusieurs topics dans les forums dont un résolu ;
+- ``users.yaml``: Crée 6 utilisateurs :
     - admin/admin avec les droits d'administration
     - staff/staff faisant partie du groupe staff
     - user/user un utilisateur normal et sans problème
@@ -31,9 +56,7 @@ Nous possédons un ensemble de données sérialisées dans le dossier fixtures:
 - ``oauth_applications.yaml``: crée une application de test `pour l'API <../api.html>`_:
     - ``client_id``: ``w14aIFqE7z90ti1rXE8hCRMRUOPBP4rXpfLZIKmT`` ;
     - ``client_secret``: ``0q4ee800NWs8cSHa0FIbkTLwEncMqYHOCAxNkt9zRmd10bRk1J18TkbviO5QHy2b66ggzyLADm79tJw5BQf2XfApPnk0nogcFaYhtNO33uNlzzT8sXfxu3zzBFu5Wejv``.
-- ``group.yaml``: crée les descriptions de deux groupes de la page d'accueil (staff et groupe technique)
-
-De ce fait, le moyen le plus simple de charger l'ensemble des données de base est la commande ``make fixtures``.
+- ``group.yaml``: crée les descriptions de deux groupes de la page d'accueil (staff et groupe technique).
 
 Les données complexes voire les scénarios
 -----------------------------------------
@@ -62,7 +85,7 @@ Le format du fichier est celui-ci:
             champ_string: "valeur2"
             champ_int: 1
 
-Les fichiers de factory déjà existant sont rangés dans le dossier ``fixtures/advanced``.
+Les fichiers de factory déjà existants sont rangés dans le dossier ``fixtures/advanced``.
 
 Pour utiliser un fichier yaml de factory, il vous suffit de lancer la commande ``python manage.py load_factory_data chemin_vers_vos_fichier.yaml``.
 Cette méthode est compatible avec les *wildcards*.
@@ -117,9 +140,7 @@ Ce coefficient sera à multiplier par le *coefficient de taille* dirrigé par :
 +---------------------------------+-----------------------------------+-----------------------------+
 |category_forum                   |forum.Category                     |4                            |
 +---------------------------------+-----------------------------------+-----------------------------+
-|category_content                 |Licence                            | Plusieurs [#lic]_           |
-|                                 +-----------------------------------+-----------------------------+
-|                                 |utils.Category                     |5                            |
+|category_content                 |utils.Category                     |5                            |
 |                                 +-----------------------------------+-----------------------------+
 |                                 |utils.SubCategory                  |10                           |
 +---------------------------------+-----------------------------------+-----------------------------+
@@ -137,7 +158,5 @@ Ce coefficient sera à multiplier par le *coefficient de taille* dirrigé par :
 +---------------------------------+-----------------------------------+-----------------------------+
 
 
-
-.. [#lic] Les licences suivantes seront créée : "CB-BY", "CC-BY-ND", "CC-BY-ND-SA", "CC-BY-SA", "CC", "CC-BY-IO" et "Tout-Droits"
-.. [#cv2] C'est à dire 60% en validation (dont 20% réservés) et 30% publiés. S'il sagit de tutoriels, 50% de petits, 30% de moyen et 20% de *bigs*.
-.. [#moy] Ce nombre est une moyenne, le nombre réel est choisi au hasard autour de cette moyenne
+.. [#cv2] C'est-à-dire 60% en validation (dont 20% réservés) et 30% publiés. S'il sagit de tutoriels, 50% de petits, 30% de moyen et 20% de *bigs*.
+.. [#moy] Ce nombre est une moyenne, le nombre réel est choisi au hasard autour de cette moyenne.

--- a/fixtures/licences.yaml
+++ b/fixtures/licences.yaml
@@ -1,24 +1,48 @@
 -   model: utils.Licence
-    pk: 1
-    fields:
-        code : Beerware
-        title : Licence Beerware
-        description : Si l'utilisateur rencontre l'auteur et considère que le logiciel de ce dernier est utile, il est encouragé à lui offrir une bière « en retour ».
--   model: utils.Licence
-    pk: 2
-    fields:
-        code : GNU GPL
-        title : Licence GNU GPL
-        description :  Chaque personne qui adhère aux termes et aux conditions de la GPL a la permission de modifier le travail, de l'étudier et de redistribuer le travail ou un travail dérivé.
--   model: utils.Licence
-    pk: 7
-    fields:
-        code : Tous droits réservés
-        title : Tous droits réservés
-        description :  Droit d'auteur pur et dur.
--   model: utils.Licence
-    pk: 42
+    pk: 8
     fields:
         code: CC 0
         title: Licence CC 0
-        description: Domaine public - Licence CC 0
+        description: Domaine public - Licence CC 0.
+-   model: utils.Licence
+    pk: 1
+    fields:
+        code: CC BY
+        title: Licence CC BY
+        description: Paternité - Licence CC BY.
+-   model: utils.Licence
+    pk: 4
+    fields:
+        code: CC BY-NC
+        title: Licence CC BY-NC
+        description: Paternité, non-commercial - Licence CC BY-NC.
+-   model: utils.Licence
+    pk: 6
+    fields:
+        code: CC BY-NC-ND
+        title: Licence CC BY-NC-ND
+        description: Paternité, non-commercial, pas de modification - Licence CC BY-NC-ND.
+-   model: utils.Licence
+    pk: 5
+    fields:
+        code: CC BY-NC-SA
+        title: Licence CC BY-NC-SA
+        description: Paternité, non-commercial, partage dans les mêmes conditions - Licence CC BY-NC-SA.
+-   model: utils.Licence
+    pk: 3
+    fields:
+        code: CC BY-ND
+        title: Licence CC BY-ND
+        description: Paternité, pas de modification - Licence CC BY-ND.
+-   model: utils.Licence
+    pk: 2
+    fields:
+        code: CC BY-SA
+        title: Licence CC BY-SA
+        description: Paternité, partage dans les mêmes conditions - Licence CC BY-SA.
+-   model: utils.Licence
+    pk: 7
+    fields:
+        code: Tous droits réservés
+        title: Tous droits réservés
+        description: Droit d'auteur pur et dur.

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -288,16 +288,16 @@ def __generate_topic_and_post(cli, fake, nb_avg_posts_in_topic, nb_topics, nb_us
 
 def load_categories_content(cli, size, fake, *_, **__):
     """
-    Load categories and subcategories for tutorial and article
+    Load categories, subcategories and licenses for tutorials and articles
     """
 
-    lics = ['CB-BY', 'CC-BY-ND', 'CC-BY-ND-SA', 'CC-BY-SA', 'CC', 'CC-BY-IO', 'Tout-Droits']
+    # Load a few licenses, while avoiding creating duplicates of what may have been loaded before
+    lics = ['Tous droits réservés', 'CC BY']
     for lic in lics:
-        ex = Licence.objects.filter(code=lic).all()
-        if len(ex) == 0:
+        if Licence.objects.filter(code=lic).count() == 0:
             licence = Licence(code=lic, title=lic, description='')
             licence.save()
-            cli.stdout.write('Note: ajout de la licence {}'.format(lic))
+            cli.stdout.write('Note : ajout de la licence `{}`'.format(lic))
     categories = []
     sub_categories = []
     nb_categories = size * 5


### PR DESCRIPTION
Fix #5844.

Cette PR harmonise les licences des fixtures pour avoir les mêmes que celles de la prod. En particulier :

* les fixtures contiennent les mêmes licences qu'en prod (avec les mêmes pk normalement) ;
* `load_categories_content` créer le minimum vital (deux licences qui existent en prod) et plus aucune licence bizarre;
* la documentation parle maintenant de la méthode la plus simple pour charger des fixtures plutôt que de parler directement des outils (et quelques améliorations orthographiques).

C'est aussi un travail préliminaire pour #5801.

### Contrôle qualité

- faire `make new-db` (ou `make generate-fixtures` après avoir nettoyé tout) ;
- se connecter avec un utilisateur quelconque ;
- vérifier que les licences sont bien les mêmes que celles de la prod (même ordre, même formulation, même pk si possible), soit dans un contenu, soit dans le profil.