### PR TITLE
Corrige l'affichage des statistiques de visite

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -258,10 +258,9 @@
 
     {# Javascript stuff start #}
     <script src="{% static "js/jquery.min.js" %}"></script>
-    <script src="{% static "js/script.js" %}"></script>
     {% block extra_js %}
     {% endblock %}
-
+    <script src="{% static "js/script.js" %}"></script>
 
 
     {# Google Analytics #}


### PR DESCRIPTION
Corrige l'affichage des statistiques de visite

Closes #5899 

**QA**

- `source zdsenv/bin/activate && make install-back && make install-front && make zmd-install && make migrate-db && make build-front && make zmd-start && make run-back` (je vais créer un alias pour ça je crois :D)
- Aller sur la page des statistiques d'un contenu
- Vérifier que le graphe s'affiche correctement et qu'aucune erreur n'est émise dans la console

Alternativement, j'ai mis la PR sur la bêta donc vous pouvez directement regarder là-bas sur un de vos contenus !