### PR TITLE
Cache des boutons non autorisés pour les membres lambda

### DIFF
--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -705,9 +705,11 @@
         </div>
     {% endif %}
 
-    <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Éditorialisation">
-        {%  include "tutorialv2/includes/editorialization.part.html"  %}
-    </div>
+    {% if is_staff or can_edit %}
+        <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Éditorialisation">
+            {%  include "tutorialv2/includes/editorialization.part.html"  %}
+        </div>
+    {% endif %}
 
     {% if can_edit and not content.is_opinion %}
         <div class="actions">

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -289,9 +289,11 @@
             {% trans "Importer une nouvelle version" %}
         </a>
     {% elif not version or version != content.sha_draft %}
-        <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
-            {% trans "Version brouillon" %}
-        </a>
+        {% if is_staff or can_edit %}
+            <a href="{{ object.get_absolute_url }}" class="ico-after arrow-right blue new-btn">
+                {% trans "Version brouillon" %}
+            </a>
+        {% endif %}
     {% endif %}
 {% endblock %}
 

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -21,20 +21,24 @@
 
 
 {% block headline %}
-    {% if content.licence %}
-      <div class="editable-element license">
-        <p>{{ content.licence }}</p>
-        <a href="#edit-license" class="open-modal edit-button" title="{% trans "Modifier la licence" %}">
-          <span class="visuallyhidden">{% trans "Modifier la licence" %}</span>
-        </a>
-      </div>
-    {% else %}
-        <p class="license">
-            <a href="#edit-license" class="open-modal">Choisissez la licence de votre publication !</a>
-        </p>
-    {% endif %}
+    {% if is_staff or can_edit %}
+        {% if content.licence %}
+          <div class="editable-element license">
+            <p>{{ content.licence }}</p>
+            <a href="#edit-license" class="open-modal edit-button" title="{% trans "Modifier la licence" %}">
+              <span class="visuallyhidden">{% trans "Modifier la licence" %}</span>
+            </a>
+          </div>
+        {% else %}
+            <p class="license">
+                <a href="#edit-license" class="open-modal">Choisissez la licence de votre publication !</a>
+            </p>
+        {% endif %}
 
-    {% crispy form_edit_license %}
+        {% crispy form_edit_license %}
+    {% elif content.licence %}
+        <span class="license">{{ content.licence }}</span>
+    {% endif %}
 
     <h1 {% if content.image %}class="illu"{% endif %}>
         {% if content.image %}


### PR DESCRIPTION
- Cache le bouton de modification de la licence pour les membres lambda
- Cache le bouton de modification des tags pour les membres lambda
- Cache le lien vers la version brouillon pour les membres lambda

Closes #5904 

Cette PR corrige ce bug pour qu'on puisse déployer un correctif en production, mais ce gabarit aurait bien besoin d'un nettoyage un peu plus profond je pense ! :)

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Trouver un contenu où la version en bêta est différente de la version en brouillon (sinon il y aura le bug #5906)
- Se connecter avec un utilisateur qui n'est ni staff, ni auteur du contenu
- Vérifier que la version brouillon est inaccessible
- Vérifier que les boutons de modifications et le lien vers la version brouillon n'apparaissent pas en version bêta