### PR TITLE
Corrige l'affichage de la liste des contenus d'un auteur

### DIFF
--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -2198,11 +2198,12 @@ class ContentOfAuthor(ZdSPagingListView):
 
     def get_queryset(self):
         profile = self.user.profile
-        if self.type not in list(TYPE_CHOICES_DICT.keys()):
-            raise Http404('Ce type de contenu est inconnu dans le système.')
-        _type = self.type
         if self.type == 'ALL':
             _type = None
+        elif self.type in list(TYPE_CHOICES_DICT.keys()):
+            _type = self.type
+        else:
+            raise Http404('Ce type de contenu est inconnu dans le système.')
 
         # Filter.
         if 'filter' in self.request.GET:


### PR DESCRIPTION
Corrige l'affichage de la liste des contenus d'un auteur

Closes #5912 

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que la liste des contenus (tous types mélangés) d'un auteur s'affiche correctement sans erreur 404