### PR TITLE
Déplace le choix des catégories dans un formulaire indépendant

### DIFF
--- a/templates/tutorialv2/includes/editorialization.part.html
+++ b/templates/tutorialv2/includes/editorialization.part.html
@@ -10,6 +10,13 @@
         {% crispy form_edit_tags %}
     </li>
 
+    <li>
+        <a href="#edit-categories" class="open-modal ico-after gear blue">
+            Modifier les catégories
+        </a>
+        {% crispy form_edit_categories %}
+    </li>
+
     {% if is_staff and not content.is_opinion %}
         <li>
             <a href="#add-suggestion" class="open-modal ico-after more blue">

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -261,22 +261,28 @@ class ContentForm(ContainerForm):
     def _create_layout(self):
         self.helper.layout = Layout(
             IncludeEasyMDE(),
-            Field('title'),
-            Field('description'),
-            Field('type'),
-            Field('image'),
-            Field('introduction', css_class='md-editor preview-source'),
-            ButtonHolder(StrictButton(_('Aperçu'), type='preview', name='preview',
-                                      css_class='btn btn-grey preview-btn'),),
-            HTML('{% if form.introduction.value %}{% include "misc/preview.part.html" \
-            with text=form.introduction.value %}{% endif %}'),
-            Field('conclusion', css_class='md-editor preview-source'),
-            ButtonHolder(StrictButton(_('Aperçu'), type='preview', name='preview',
-                                      css_class='btn btn-grey preview-btn'),),
-            HTML('{% if form.conclusion.value %}{% include "misc/preview.part.html" \
-            with text=form.conclusion.value %}{% endif %}'),
-            Field('last_hash'),
-            Field('source'),
+            Field("title"),
+            Field("description"),
+            Field("type"),
+            Field("image"),
+            Field("introduction", css_class="md-editor preview-source"),
+            ButtonHolder(
+                StrictButton(_("Aperçu"), type="preview", name="preview", css_class="btn btn-grey preview-btn"),
+            ),
+            HTML(
+                '{% if form.introduction.value %}{% include "misc/preview.part.html" \
+            with text=form.introduction.value %}{% endif %}'
+            ),
+            Field("conclusion", css_class="md-editor preview-source"),
+            ButtonHolder(
+                StrictButton(_("Aperçu"), type="preview", name="preview", css_class="btn btn-grey preview-btn"),
+            ),
+            HTML(
+                '{% if form.conclusion.value %}{% include "misc/preview.part.html" \
+            with text=form.conclusion.value %}{% endif %}'
+            ),
+            Field("last_hash"),
+            Field("source"),
         )
 
         self.helper.layout.append(Field("msg_commit"))
@@ -350,37 +356,39 @@ class EditContentTagsForm(forms.Form):
 
 class EditContentCategoriesForm(forms.Form):
     subcategory = forms.ModelMultipleChoiceField(
-        label=_('Sélectionnez les catégories qui correspondent à votre contenu.'),
-        queryset=SubCategory.objects.order_by('title').all(),
+        label=_("Sélectionnez les catégories qui correspondent à votre contenu."),
+        queryset=SubCategory.objects.order_by("title").all(),
         required=False,
         widget=forms.CheckboxSelectMultiple(),
         error_messages={
-            'invalid_choice': _('Merci de choisir un choix valide dans la liste.'),
-            'empty_when_published': _('Vous devez choisir au moins une catégorie, car ce contenu est déjà publié.')}
+            "invalid_choice": _("Merci de choisir un choix valide dans la liste."),
+            "empty_when_published": _("Vous devez choisir au moins une catégorie, car ce contenu est déjà publié."),
+        },
     )
 
     def __init__(self, versioned_content, db_content, *args, **kwargs):
         self.db_content = db_content
-        kwargs['initial'] = {'subcategory': db_content.subcategory.all()}
+        kwargs["initial"] = {"subcategory": db_content.subcategory.all()}
         super(forms.Form, self).__init__(*args, **kwargs)
 
         self.helper = FormHelper()
-        self.helper.form_class = 'content-wrapper'
-        self.helper.form_method = 'post'
-        self.helper.form_id = 'edit-categories'
-        self.helper.form_class = 'modal modal-flex'
-        self.helper.form_action = reverse('content:edit-categories', kwargs={'pk': versioned_content.pk})
+        self.helper.form_class = "content-wrapper"
+        self.helper.form_method = "post"
+        self.helper.form_id = "edit-categories"
+        self.helper.form_class = "modal modal-flex"
+        self.helper.form_action = reverse("content:edit-categories", kwargs={"pk": versioned_content.pk})
         self.helper.layout = Layout(
-            Field('subcategory', template='crispy/checkboxselectmultiple.html'),
-            ButtonHolder(StrictButton('Valider', type='submit'))
+            Field("subcategory", template="crispy/checkboxselectmultiple.html"),
+            ButtonHolder(StrictButton("Valider", type="submit")),
         )
-        self.previous_page_url = reverse('content:view', kwargs={'pk': versioned_content.pk,
-                                                                 'slug': versioned_content.slug})
+        self.previous_page_url = reverse(
+            "content:view", kwargs={"pk": versioned_content.pk, "slug": versioned_content.slug}
+        )
 
     def is_valid(self):
         # Forbid removing all categories of a validated content
-        if self.db_content.in_public() and 'subcategory' not in self.data:
-            self.add_error('subcategory', self.fields['subcategory'].error_messages['empty_when_published'])
+        if self.db_content.in_public() and "subcategory" not in self.data:
+            self.add_error("subcategory", self.fields["subcategory"].error_messages["empty_when_published"])
         return super(EditContentCategoriesForm, self).is_valid()
 
 
@@ -731,9 +739,13 @@ class AskValidationForm(forms.Form):
         self.helper.form_id = "ask-validation"
 
         self.no_subcategories = content.subcategory.count() == 0
-        no_category_msg = HTML(_("""<p><strong>Votre publication n'est dans aucune catégorie.
+        no_category_msg = HTML(
+            _(
+                """<p><strong>Votre publication n'est dans aucune catégorie.
                                     Vous devez <a href="#edit-categories" class="open-modal">choisir une catégorie</a>
-                                    avant de demander la validation.</strong></p>"""))
+                                    avant de demander la validation.</strong></p>"""
+            )
+        )
 
         self.no_license = not content.licence
         no_license_msg = HTML(

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -353,7 +353,11 @@ class EditContentCategoriesForm(forms.Form):
         label=_('Sélectionnez les catégories qui correspondent à votre contenu.'),
         queryset=SubCategory.objects.order_by('title').all(),
         required=False,
-        widget=forms.CheckboxSelectMultiple()
+        widget=forms.CheckboxSelectMultiple(),
+        error_messages={'invalid_choice':
+                            _('Merci de choisir un choix valide dans la liste.'),
+                        'empty_when_published':
+                            _('Vous devez choisir au moins une catégorie, car ce contenu est déjà publié.')}
     )
 
     def __init__(self, versioned_content, db_content, *args, **kwargs):
@@ -377,8 +381,7 @@ class EditContentCategoriesForm(forms.Form):
     def is_valid(self):
         # Forbid removing all categories of a validated content
         if self.db_content.in_public() and 'subcategory' not in self.data:
-            self.add_error('subcategory',
-                           _('Vous devez choisir au moins une catégorie, car ce contenu est déjà publié.'))
+            self.add_error('subcategory', self.fields['subcategory'].error_messages['empty_when_published'])
         return super(EditContentCategoriesForm, self).is_valid()
 
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -354,10 +354,9 @@ class EditContentCategoriesForm(forms.Form):
         queryset=SubCategory.objects.order_by('title').all(),
         required=False,
         widget=forms.CheckboxSelectMultiple(),
-        error_messages={'invalid_choice':
-                            _('Merci de choisir un choix valide dans la liste.'),
-                        'empty_when_published':
-                            _('Vous devez choisir au moins une catégorie, car ce contenu est déjà publié.')}
+        error_messages={
+            'invalid_choice': _('Merci de choisir un choix valide dans la liste.'),
+            'empty_when_published': _('Vous devez choisir au moins une catégorie, car ce contenu est déjà publié.')}
     )
 
     def __init__(self, versioned_content, db_content, *args, **kwargs):

--- a/zds/tutorialv2/tests/tests_front.py
+++ b/zds/tutorialv2/tests/tests_front.py
@@ -161,8 +161,8 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
 
         intro = find_element("div#div_id_introduction div.CodeMirror")
         action_chains = ActionChains(selenium)
-        action_chains.click(intro).perform()
-        action_chains.send_keys("Le cadavre exquis boira le vin nouveau.").perform()
+        action_chains.move_to_element(intro).click(intro).perform()
+        action_chains.send_keys('Le cadavre exquis boira le vin nouveau.').perform()
 
         find_element(".content-container button[type=submit]").click()
 

--- a/zds/tutorialv2/tests/tests_front.py
+++ b/zds/tutorialv2/tests/tests_front.py
@@ -162,7 +162,7 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
         intro = find_element("div#div_id_introduction div.CodeMirror")
         action_chains = ActionChains(selenium)
         action_chains.move_to_element(intro).click(intro).perform()
-        action_chains.send_keys('Le cadavre exquis boira le vin nouveau.').perform()
+        action_chains.send_keys("Le cadavre exquis boira le vin nouveau.").perform()
 
         find_element(".content-container button[type=submit]").click()
 

--- a/zds/tutorialv2/tests/tests_front.py
+++ b/zds/tutorialv2/tests/tests_front.py
@@ -156,9 +156,6 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
         selenium.execute_script('localStorage.setItem("editor_choice", "new")')  # we want the new editor
         new_article_url = self.live_server_url + reverse("content:create-article")
         selenium.get(new_article_url)
-        WebDriverWait(self.selenium, 10).until(
-            ec.element_to_be_clickable((By.CSS_SELECTOR, "input[type=checkbox][name=subcategory]"))
-        ).click()
 
         find_element("#id_title").send_keys("Oulipo")
 

--- a/zds/tutorialv2/tests/tests_views/tests_editcontentcategories.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontentcategories.py
@@ -28,11 +28,11 @@ class EditContentCategoriesPermissionTests(TutorialTestMixin, TestCase):
         self.content = PublishableContentFactory(author_list=[self.author])
 
         # Get information to be reused in tests
-        self.form_url = reverse('content:edit-categories', kwargs={'pk': self.content.pk})
-        self.form_data = {'categories': [self.category]}
-        self.content_data = {'pk': self.content.pk, 'slug': self.content.slug}
-        self.content_url = reverse('content:view', kwargs=self.content_data)
-        self.login_url = reverse('member-login') + '?next=' + self.form_url
+        self.form_url = reverse("content:edit-categories", kwargs={"pk": self.content.pk})
+        self.form_data = {"categories": [self.category]}
+        self.content_data = {"pk": self.content.pk, "slug": self.content.slug}
+        self.content_url = reverse("content:view", kwargs=self.content_data)
+        self.login_url = reverse("member-login") + "?next=" + self.form_url
 
     def test_not_authenticated(self):
         """Test that on form submission, unauthenticated users are redirected to the login page."""
@@ -42,21 +42,21 @@ class EditContentCategoriesPermissionTests(TutorialTestMixin, TestCase):
 
     def test_authenticated_author(self):
         """Test that on form submission, authors are redirected to the content page."""
-        login_success = self.client.login(username=self.author.username, password='hostel77')
+        login_success = self.client.login(username=self.author.username, password="hostel77")
         self.assertTrue(login_success)
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_staff(self):
         """Test that on form submission, staffs are redirected to the content page."""
-        login_success = self.client.login(username=self.staff.username, password='hostel77')
+        login_success = self.client.login(username=self.staff.username, password="hostel77")
         self.assertTrue(login_success)
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_outsider(self):
         """Test that on form submission, unauthorized users get a 403."""
-        login_success = self.client.login(username=self.outsider.username, password='hostel77')
+        login_success = self.client.login(username=self.outsider.username, password="hostel77")
         self.assertTrue(login_success)
         response = self.client.post(self.form_url, self.form_data)
         self.assertEquals(response.status_code, 403)
@@ -78,16 +78,17 @@ class EditContentCategoriesWorkflowTests(TutorialTestMixin, TestCase):
 
         # Create a published content
         self.published_content = PublishableContentFactory(author_list=[self.author.user], add_license=False)
-        publish_content(self.published_content,
-                        self.published_content.load_version_or_404(self.published_content.sha_draft))
+        publish_content(
+            self.published_content, self.published_content.load_version_or_404(self.published_content.sha_draft)
+        )
         self.published_content.save()  # update object info to take the publication into account
 
         # Get information to be reused in tests
-        self.error_messages = EditContentCategoriesForm.declared_fields['subcategory'].error_messages
+        self.error_messages = EditContentCategoriesForm.declared_fields["subcategory"].error_messages
         self.success_message = EditContentCategories.success_message
 
         # Log in with an authorized user (e.g the author of the content) to perform the tests
-        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        login_success = self.client.login(username=self.author.user.username, password="hostel77")
         self.assertTrue(login_success)
 
     def form_url(self, is_published):
@@ -95,39 +96,35 @@ class EditContentCategoriesWorkflowTests(TutorialTestMixin, TestCase):
             content = self.published_content
         else:
             content = self.content
-        return reverse('content:edit-categories', kwargs={'pk': content.pk})
+        return reverse("content:edit-categories", kwargs={"pk": content.pk})
 
     def get_test_cases(self):
         return {
-            'empty_form': {
-                'config': {'is_published': False},
-                'inputs': {},
-                'expected_outputs': [self.success_message]
+            "empty_form": {"config": {"is_published": False}, "inputs": {}, "expected_outputs": [self.success_message]},
+            "success_category_one": {
+                "config": {"is_published": False},
+                "inputs": {"subcategory": self.category.pk},
+                "expected_outputs": [self.success_message],
             },
-            'success_category_one': {
-                'config': {'is_published': False},
-                'inputs': {'subcategory': self.category.pk},
-                'expected_outputs': [self.success_message]
+            "invalid_category": {
+                "config": {"is_published": False},
+                "inputs": {"subcategory": "42"},  # valid form for a pk, but the value does not exist
+                "expected_outputs": [self.error_messages["invalid_choice"]],
             },
-            'invalid_category': {
-                'config': {'is_published': False},
-                'inputs': {'subcategory': '42'},  # valid form for a pk, but the value does not exist
-                'expected_outputs': [self.error_messages['invalid_choice']]
+            "invalid_category_pk": {
+                "config": {"is_published": False},
+                "inputs": {"subcategory": "valeur bidonnée"},  # value that fails to convert to a valid pk
+                "expected_outputs": [self.error_messages["invalid_pk_value"] % {"pk": "valeur bidonnée"}],
             },
-            'invalid_category_pk': {
-                'config': {'is_published': False},
-                'inputs': {'subcategory': 'valeur bidonnée'},  # value that fails to convert to a valid pk
-                'expected_outputs': [self.error_messages['invalid_pk_value'] % {'pk': 'valeur bidonnée'}]
+            "empty_when_published": {
+                "config": {"is_published": True},
+                "inputs": {},
+                "expected_outputs": [self.error_messages["empty_when_published"]],
             },
-            'empty_when_published': {
-                'config': {'is_published': True},
-                'inputs': {},
-                'expected_outputs': [self.error_messages['empty_when_published']]
-            },
-            'success_category_when_published': {
-                'config': {'is_published': True},
-                'inputs': {'subcategory': self.category.pk},
-                'expected_outputs': [self.success_message]
+            "success_category_when_published": {
+                "config": {"is_published": True},
+                "inputs": {"subcategory": self.category.pk},
+                "expected_outputs": [self.success_message],
             },
         }
 
@@ -135,9 +132,9 @@ class EditContentCategoriesWorkflowTests(TutorialTestMixin, TestCase):
         test_cases = self.get_test_cases()
         for case_name, case in test_cases.items():
             with self.subTest(msg=case_name):
-                form_url = self.form_url(case['config']['is_published'])
-                response = self.client.post(form_url, case['inputs'], follow=True)
-                for msg in case['expected_outputs']:
+                form_url = self.form_url(case["config"]["is_published"])
+                response = self.client.post(form_url, case["inputs"], follow=True)
+                for msg in case["expected_outputs"]:
                     self.assertContains(response, escape(msg))  # the response is escaped, so we escape the message too
 
 
@@ -157,10 +154,10 @@ class EditContentCategoriesFunctionalTests(TutorialTestMixin, TestCase):
         self.content = PublishableContentFactory(author_list=[self.author.user], add_license=False)
 
         # Get information to be reused in tests
-        self.form_url = reverse('content:edit-categories', kwargs={'pk': self.content.pk})
+        self.form_url = reverse("content:edit-categories", kwargs={"pk": self.content.pk})
 
         # Log in with an authorized user (e.g the author of the content) to perform the tests
-        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        login_success = self.client.login(username=self.author.user.username, password="hostel77")
         self.assertTrue(login_success)
 
     def test_form_function(self):
@@ -169,48 +166,48 @@ class EditContentCategoriesFunctionalTests(TutorialTestMixin, TestCase):
         for case_name, case in test_cases.items():
             with self.subTest(msg=case_name):
                 # Prepare the test environment to match given preconditions
-                self.content.subcategory.set(case['preconditions']['subcategory'])
-                self.assertEqual(list(self.content.subcategory.all()), case['preconditions']['subcategory'])
+                self.content.subcategory.set(case["preconditions"]["subcategory"])
+                self.assertEqual(list(self.content.subcategory.all()), case["preconditions"]["subcategory"])
 
                 # Post the form with given inputs
-                form_data = {'subcategory': [sc.pk for sc in case['inputs']['subcategory']]}
+                form_data = {"subcategory": [sc.pk for sc in case["inputs"]["subcategory"]]}
                 self.client.post(self.form_url, form_data)
 
                 # Check the effects of having sent the form
                 updated_content = PublishableContent.objects.get(pk=self.content.pk)
-                self.assertEqual(list(updated_content.subcategory.all()), case['expected_outputs']['subcategory'])
+                self.assertEqual(list(updated_content.subcategory.all()), case["expected_outputs"]["subcategory"])
 
     def get_test_cases(self):
         """List test cases for the categories editing form."""
         return {
-            'from blank to one category': {
-                'preconditions': {'subcategory': []},
-                'inputs': {'subcategory': [self.category1]},
-                'expected_outputs': {'subcategory': [self.category1]}
+            "from blank to one category": {
+                "preconditions": {"subcategory": []},
+                "inputs": {"subcategory": [self.category1]},
+                "expected_outputs": {"subcategory": [self.category1]},
             },
-            'from blank to two categories': {
-                'preconditions': {'subcategory': []},
-                'inputs': {'subcategory': [self.category1, self.category2]},
-                'expected_outputs': {'subcategory': [self.category1, self.category2]}
+            "from blank to two categories": {
+                "preconditions": {"subcategory": []},
+                "inputs": {"subcategory": [self.category1, self.category2]},
+                "expected_outputs": {"subcategory": [self.category1, self.category2]},
             },
-            'remove all categories (1)': {
-                'preconditions': {'subcategory': [self.category1]},
-                'inputs': {'subcategory': []},
-                'expected_outputs': {'subcategory': []}
+            "remove all categories (1)": {
+                "preconditions": {"subcategory": [self.category1]},
+                "inputs": {"subcategory": []},
+                "expected_outputs": {"subcategory": []},
             },
-            'remove all categories (2)': {
-                'preconditions': {'subcategory': [self.category1, self.category2]},
-                'inputs': {'subcategory': []},
-                'expected_outputs': {'subcategory': []}
+            "remove all categories (2)": {
+                "preconditions": {"subcategory": [self.category1, self.category2]},
+                "inputs": {"subcategory": []},
+                "expected_outputs": {"subcategory": []},
             },
-            'add one category': {
-                'preconditions': {'subcategory': [self.category1]},
-                'inputs': {'subcategory': [self.category1, self.category2]},
-                'expected_outputs': {'subcategory': [self.category1, self.category2]}
+            "add one category": {
+                "preconditions": {"subcategory": [self.category1]},
+                "inputs": {"subcategory": [self.category1, self.category2]},
+                "expected_outputs": {"subcategory": [self.category1, self.category2]},
             },
-            'remove one category': {
-                'preconditions': {'subcategory': [self.category1, self.category2]},
-                'inputs': {'subcategory': [self.category2]},
-                'expected_outputs': {'subcategory': [self.category2]}
+            "remove one category": {
+                "preconditions": {"subcategory": [self.category1, self.category2]},
+                "inputs": {"subcategory": [self.category2]},
+                "expected_outputs": {"subcategory": [self.category2]},
             },
         }

--- a/zds/tutorialv2/tests/tests_views/tests_editcontentcategories.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontentcategories.py
@@ -1,0 +1,216 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.html import escape
+
+from zds.tutorialv2.models.database import PublishableContent
+from zds.tutorialv2.publication_utils import publish_content
+from zds.tutorialv2.views.editorialization import EditContentCategories
+from zds.tutorialv2.forms import EditContentCategoriesForm
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.tutorialv2.factories import PublishableContentFactory, SubCategoryFactory
+
+
+@override_for_contents()
+class EditContentCategoriesPermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+
+        # Create a category
+        self.category = SubCategoryFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author])
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-categories', kwargs={'pk': self.content.pk})
+        self.form_data = {'categories': [self.category]}
+        self.content_data = {'pk': self.content.pk, 'slug': self.content.slug}
+        self.content_url = reverse('content:view', kwargs=self.content_data)
+        self.login_url = reverse('member-login') + '?next=' + self.form_url
+
+    def test_not_authenticated(self):
+        """Test that on form submission, unauthenticated users are redirected to the login page."""
+        self.client.logout()  # ensure no user is authenticated
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_author(self):
+        """Test that on form submission, authors are redirected to the content page."""
+        login_success = self.client.login(username=self.author.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff(self):
+        """Test that on form submission, staffs are redirected to the content page."""
+        login_success = self.client.login(username=self.staff.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_outsider(self):
+        """Test that on form submission, unauthorized users get a 403."""
+        login_success = self.client.login(username=self.outsider.username, password='hostel77')
+        self.assertTrue(login_success)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEquals(response.status_code, 403)
+
+
+@override_for_contents()
+class EditContentCategoriesWorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create a category
+        self.category = SubCategoryFactory()
+
+        # Create a draft content
+        self.content = PublishableContentFactory(author_list=[self.author.user], add_license=False)
+
+        # Create a published content
+        self.published_content = PublishableContentFactory(author_list=[self.author.user], add_license=False)
+        publish_content(self.published_content,
+                        self.published_content.load_version_or_404(self.published_content.sha_draft))
+        self.published_content.save()  # update object info to take the publication into account
+
+        # Get information to be reused in tests
+        self.error_messages = EditContentCategoriesForm.declared_fields['subcategory'].error_messages
+        self.success_message = EditContentCategories.success_message
+
+        # Log in with an authorized user (e.g the author of the content) to perform the tests
+        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        self.assertTrue(login_success)
+
+    def form_url(self, is_published):
+        if is_published:
+            content = self.published_content
+        else:
+            content = self.content
+        return reverse('content:edit-categories', kwargs={'pk': content.pk})
+
+    def get_test_cases(self):
+        return {
+            'empty_form': {
+                'config': {'is_published': False},
+                'inputs': {},
+                'expected_outputs': [self.success_message]
+            },
+            'success_category_one': {
+                'config': {'is_published': False},
+                'inputs': {'subcategory': self.category.pk},
+                'expected_outputs': [self.success_message]
+            },
+            'invalid_category': {
+                'config': {'is_published': False},
+                'inputs': {'subcategory': '42'},  # valid form for a pk, but the value does not exist
+                'expected_outputs': [self.error_messages['invalid_choice']]
+            },
+            'invalid_category_pk': {
+                'config': {'is_published': False},
+                'inputs': {'subcategory': 'valeur bidonnée'},  # value that fails to convert to a valid pk
+                'expected_outputs': [self.error_messages['invalid_pk_value'] % {'pk': 'valeur bidonnée'}]
+            },
+            'empty_when_published': {
+                'config': {'is_published': True},
+                'inputs': {},
+                'expected_outputs': [self.error_messages['empty_when_published']]
+            },
+            'success_category_when_published': {
+                'config': {'is_published': True},
+                'inputs': {'subcategory': self.category.pk},
+                'expected_outputs': [self.success_message]
+            },
+        }
+
+    def test_form_workflow(self):
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                form_url = self.form_url(case['config']['is_published'])
+                response = self.client.post(form_url, case['inputs'], follow=True)
+                for msg in case['expected_outputs']:
+                    self.assertContains(response, escape(msg))  # the response is escaped, so we escape the message too
+
+
+@override_for_contents()
+class EditContentCategoriesFunctionalTests(TutorialTestMixin, TestCase):
+    """Test the detailed behavior of the feature, such as updates of the database."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create some categories
+        self.category1 = SubCategoryFactory()
+        self.category2 = SubCategoryFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author.user], add_license=False)
+
+        # Get information to be reused in tests
+        self.form_url = reverse('content:edit-categories', kwargs={'pk': self.content.pk})
+
+        # Log in with an authorized user (e.g the author of the content) to perform the tests
+        login_success = self.client.login(username=self.author.user.username, password='hostel77')
+        self.assertTrue(login_success)
+
+    def test_form_function(self):
+        """Test many use cases for the form."""
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                # Prepare the test environment to match given preconditions
+                self.content.subcategory.set(case['preconditions']['subcategory'])
+                self.assertEqual(list(self.content.subcategory.all()), case['preconditions']['subcategory'])
+
+                # Post the form with given inputs
+                form_data = {'subcategory': [sc.pk for sc in case['inputs']['subcategory']]}
+                self.client.post(self.form_url, form_data)
+
+                # Check the effects of having sent the form
+                updated_content = PublishableContent.objects.get(pk=self.content.pk)
+                self.assertEqual(list(updated_content.subcategory.all()), case['expected_outputs']['subcategory'])
+
+    def get_test_cases(self):
+        """List test cases for the categories editing form."""
+        return {
+            'from blank to one category': {
+                'preconditions': {'subcategory': []},
+                'inputs': {'subcategory': [self.category1]},
+                'expected_outputs': {'subcategory': [self.category1]}
+            },
+            'from blank to two categories': {
+                'preconditions': {'subcategory': []},
+                'inputs': {'subcategory': [self.category1, self.category2]},
+                'expected_outputs': {'subcategory': [self.category1, self.category2]}
+            },
+            'remove all categories (1)': {
+                'preconditions': {'subcategory': [self.category1]},
+                'inputs': {'subcategory': []},
+                'expected_outputs': {'subcategory': []}
+            },
+            'remove all categories (2)': {
+                'preconditions': {'subcategory': [self.category1, self.category2]},
+                'inputs': {'subcategory': []},
+                'expected_outputs': {'subcategory': []}
+            },
+            'add one category': {
+                'preconditions': {'subcategory': [self.category1]},
+                'inputs': {'subcategory': [self.category1, self.category2]},
+                'expected_outputs': {'subcategory': [self.category1, self.category2]}
+            },
+            'remove one category': {
+                'preconditions': {'subcategory': [self.category1, self.category2]},
+                'inputs': {'subcategory': [self.category2]},
+                'expected_outputs': {'subcategory': [self.category2]}
+            },
+        }

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -19,12 +19,10 @@ from zds.tutorialv2.views.help import ContentsWithHelps, ChangeHelp
 from zds.tutorialv2.views.authors import AddAuthorToContent, RemoveAuthorFromContent
 from zds.tutorialv2.views.redirect import RedirectOldContentOfAuthor
 from zds.tutorialv2.views.archives import DownloadContent, UpdateContentWithArchive, CreateContentFromArchive
-from zds.tutorialv2.views.contributors import (
-    AddContributorToContent,
-    RemoveContributorFromContent,
-    ContentOfContributors,
-)
-from zds.tutorialv2.views.editorialization import RemoveSuggestion, AddSuggestion, EditContentTags
+from zds.tutorialv2.views.contributors import AddContributorToContent, RemoveContributorFromContent, \
+    ContentOfContributors
+from zds.tutorialv2.views.editorialization import RemoveSuggestion, AddSuggestion, EditContentTags, \
+    EditContentCategories
 
 from zds.tutorialv2.views.lists import TagsListView, ContentOfAuthor, ListContentReactions
 from zds.tutorialv2.views.alerts import SendContentAlert, SolveContentAlert
@@ -156,7 +154,11 @@ urlpatterns = [
     # Modify the license
     re_path(r"^modifier-licence/(?P<pk>\d+)/$", EditContentLicense.as_view(), name="edit-license"),
     # Modify the tags
-    re_path(r"^modifier-tags/(?P<pk>\d+)/$", EditContentTags.as_view(), name="edit-tags"),
+    re_path(r'^modifier-tags/(?P<pk>\d+)/$', EditContentTags.as_view(), name='edit-tags'),
+
+    # Modify the categories
+    re_path(r'^modifier-categories/(?P<pk>\d+)/$', EditContentCategories.as_view(), name='edit-categories'),
+
     # beta:
     re_path(r"^activer-beta/(?P<pk>\d+)/(?P<slug>.+)/$", ManageBetaContent.as_view(action="set"), name="set-beta"),
     re_path(

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -19,10 +19,17 @@ from zds.tutorialv2.views.help import ContentsWithHelps, ChangeHelp
 from zds.tutorialv2.views.authors import AddAuthorToContent, RemoveAuthorFromContent
 from zds.tutorialv2.views.redirect import RedirectOldContentOfAuthor
 from zds.tutorialv2.views.archives import DownloadContent, UpdateContentWithArchive, CreateContentFromArchive
-from zds.tutorialv2.views.contributors import AddContributorToContent, RemoveContributorFromContent, \
-    ContentOfContributors
-from zds.tutorialv2.views.editorialization import RemoveSuggestion, AddSuggestion, EditContentTags, \
-    EditContentCategories
+from zds.tutorialv2.views.contributors import (
+    AddContributorToContent,
+    RemoveContributorFromContent,
+    ContentOfContributors,
+)
+from zds.tutorialv2.views.editorialization import (
+    RemoveSuggestion,
+    AddSuggestion,
+    EditContentTags,
+    EditContentCategories,
+)
 
 from zds.tutorialv2.views.lists import TagsListView, ContentOfAuthor, ListContentReactions
 from zds.tutorialv2.views.alerts import SendContentAlert, SolveContentAlert
@@ -154,11 +161,9 @@ urlpatterns = [
     # Modify the license
     re_path(r"^modifier-licence/(?P<pk>\d+)/$", EditContentLicense.as_view(), name="edit-license"),
     # Modify the tags
-    re_path(r'^modifier-tags/(?P<pk>\d+)/$', EditContentTags.as_view(), name='edit-tags'),
-
+    re_path(r"^modifier-tags/(?P<pk>\d+)/$", EditContentTags.as_view(), name="edit-tags"),
     # Modify the categories
-    re_path(r'^modifier-categories/(?P<pk>\d+)/$', EditContentCategories.as_view(), name='edit-categories'),
-
+    re_path(r"^modifier-categories/(?P<pk>\d+)/$", EditContentCategories.as_view(), name="edit-categories"),
     # beta:
     re_path(r"^activer-beta/(?P<pk>\d+)/(?P<slug>.+)/$", ManageBetaContent.as_view(action="set"), name="set-beta"),
     re_path(

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -16,12 +16,29 @@ from zds.gallery.mixins import ImageCreateMixin, NotAnImage
 from zds.gallery.models import Gallery, Image
 from zds.member.decorator import LoggedWithReadWriteHability, LoginRequiredMixin
 from zds.member.models import Profile
-from zds.tutorialv2.forms import ContentForm, JsFiddleActivationForm, AskValidationForm, AcceptValidationForm, \
-    RejectValidationForm, RevokeValidationForm, WarnTypoForm, CancelValidationForm, PublicationForm, \
-    UnpublicationForm, ContributionForm, SearchSuggestionForm, EditContentLicenseForm, EditContentTagsForm, \
-    EditContentCategoriesForm
-from zds.tutorialv2.mixins import SingleContentDetailViewMixin, SingleContentFormViewMixin, SingleContentViewMixin, \
-    FormWithPreview
+from zds.tutorialv2.forms import (
+    ContentForm,
+    JsFiddleActivationForm,
+    AskValidationForm,
+    AcceptValidationForm,
+    RejectValidationForm,
+    RevokeValidationForm,
+    WarnTypoForm,
+    CancelValidationForm,
+    PublicationForm,
+    UnpublicationForm,
+    ContributionForm,
+    SearchSuggestionForm,
+    EditContentLicenseForm,
+    EditContentTagsForm,
+    EditContentCategoriesForm,
+)
+from zds.tutorialv2.mixins import (
+    SingleContentDetailViewMixin,
+    SingleContentFormViewMixin,
+    SingleContentViewMixin,
+    FormWithPreview,
+)
 from zds.tutorialv2.models.database import PublishableContent, Validation, ContentContribution, ContentSuggestion
 from zds.tutorialv2.utils import init_new_repo
 from zds.tutorialv2.views.authors import RemoveAuthorFromContent
@@ -160,7 +177,7 @@ class DisplayContent(LoginRequiredMixin, SingleContentDetailViewMixin):
         context["form_edit_license"] = EditContentLicenseForm(self.versioned_object)
         context["form_edit_tags"] = EditContentTagsForm(self.versioned_object, self.object)
 
-        context['form_edit_categories'] = EditContentCategoriesForm(self.versioned_object, self.object)
+        context["form_edit_categories"] = EditContentCategoriesForm(self.versioned_object, self.object)
 
         if self.versioned_object.requires_validation:
             context["formPublication"] = PublicationForm(self.versioned_object, initial={"source": self.object.source})
@@ -206,13 +223,13 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         initial = super().get_initial()
         versioned = self.versioned_object
 
-        initial['title'] = versioned.title
-        initial['description'] = versioned.description
-        initial['type'] = versioned.type
-        initial['introduction'] = versioned.get_introduction()
-        initial['conclusion'] = versioned.get_conclusion()
-        initial['source'] = versioned.source
-        initial['last_hash'] = versioned.compute_hash()
+        initial["title"] = versioned.title
+        initial["description"] = versioned.description
+        initial["type"] = versioned.type
+        initial["introduction"] = versioned.get_introduction()
+        initial["conclusion"] = versioned.get_conclusion()
+        initial["source"] = versioned.source
+        initial["last_hash"] = versioned.compute_hash()
 
         return initial
 

--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -7,16 +7,8 @@ from django.utils.translation import gettext_lazy as _
 from zds.featured.mixins import FeatureableMixin
 from zds.tutorialv2 import signals
 from zds.notification.models import ContentReactionAnswerSubscription
-from zds.tutorialv2.forms import (
-    RevokeValidationForm,
-    UnpublicationForm,
-    WarnTypoForm,
-    PickOpinionForm,
-    UnpickOpinionForm,
-    PromoteOpinionToArticleForm,
-    SearchSuggestionForm,
-    EditContentTagsForm,
-)
+from zds.tutorialv2.forms import RevokeValidationForm, UnpublicationForm, WarnTypoForm, PickOpinionForm, \
+    UnpickOpinionForm, PromoteOpinionToArticleForm, SearchSuggestionForm, EditContentTagsForm, EditContentCategoriesForm
 from zds.tutorialv2.mixins import SingleOnlineContentDetailViewMixin
 
 from zds.tutorialv2.models.database import (
@@ -115,6 +107,8 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
             )
 
         context["form_edit_tags"] = EditContentTagsForm(self.versioned_object, self.object)
+
+        context['form_edit_categories'] = EditContentCategoriesForm(self.versioned_object, self.object)
 
         # pagination of comments
         make_pagination(

--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -7,8 +7,17 @@ from django.utils.translation import gettext_lazy as _
 from zds.featured.mixins import FeatureableMixin
 from zds.tutorialv2 import signals
 from zds.notification.models import ContentReactionAnswerSubscription
-from zds.tutorialv2.forms import RevokeValidationForm, UnpublicationForm, WarnTypoForm, PickOpinionForm, \
-    UnpickOpinionForm, PromoteOpinionToArticleForm, SearchSuggestionForm, EditContentTagsForm, EditContentCategoriesForm
+from zds.tutorialv2.forms import (
+    RevokeValidationForm,
+    UnpublicationForm,
+    WarnTypoForm,
+    PickOpinionForm,
+    UnpickOpinionForm,
+    PromoteOpinionToArticleForm,
+    SearchSuggestionForm,
+    EditContentTagsForm,
+    EditContentCategoriesForm,
+)
 from zds.tutorialv2.mixins import SingleOnlineContentDetailViewMixin
 
 from zds.tutorialv2.models.database import (
@@ -108,7 +117,7 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
 
         context["form_edit_tags"] = EditContentTagsForm(self.versioned_object, self.object)
 
-        context['form_edit_categories'] = EditContentCategoriesForm(self.versioned_object, self.object)
+        context["form_edit_categories"] = EditContentCategoriesForm(self.versioned_object, self.object)
 
         # pagination of comments
         make_pagination(

--- a/zds/tutorialv2/views/editorialization.py
+++ b/zds/tutorialv2/views/editorialization.py
@@ -123,17 +123,17 @@ class EditContentCategories(LoggedWithReadWriteHability, SingleContentFormViewMi
     modal_form = True
     model = PublishableContent
     form_class = EditContentCategoriesForm
-    success_message = _('Les catégories ont bien été modifiées.')
+    success_message = _("Les catégories ont bien été modifiées.")
 
     def get_form_kwargs(self):
         kwargs = super(EditContentCategories, self).get_form_kwargs()
-        kwargs['versioned_content'] = self.versioned_object
-        kwargs['db_content'] = self.object
+        kwargs["versioned_content"] = self.versioned_object
+        kwargs["db_content"] = self.object
         return kwargs
 
     def form_valid(self, form):
         self.object.subcategory.clear()
-        for subcat in form.cleaned_data['subcategory']:
+        for subcat in form.cleaned_data["subcategory"]:
             self.object.subcategory.add(subcat)
         self.object.save(force_slug_update=False)
         messages.success(self.request, EditContentCategories.success_message)


### PR DESCRIPTION
Déplacement de la modification des catégories dans un formulaire dédié sous forme de modale.

Fix #5908.

### Contrôle qualité

* Vérifier l'affichage du bouton d'accès au formulaire (sur les tutos, sur les articles, sur les billets)
* Vérifier le non-affichage du bouton dans les conditions adéquates (quand on a pas les droits notamment)
* Vérifier qu'on se prend bien des erreurs de permissions si on essaie d'envoyer le formulaire sans les droits
* Vérifier que le formulaire marche pour des situations habituelles quand on a les droits
* Vérifier qu'on ne peut pas enlever toute les catégories d'un contenu publié
* Jouer un peu à maltraiter le formulaire pour vérifier la robustesse du traitement des erreurs.