### PR TITLE
Retire du code inutile de la gestion des tags

### DIFF
--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -343,7 +343,9 @@ class EditContentTagsForm(forms.Form):
         error_messages={'max_length': _('La liste de tags saisie dépasse la longueur maximale autorisée.')}
     )
 
-    def __init__(self, content, *args, **kwargs):
+    def __init__(self, content, db_content, *args, **kwargs):
+        self.db_content = db_content
+        kwargs['initial'] = {'tags': ', '.join(db_content.tags.values_list('title', flat=True))}
         super(forms.Form, self).__init__(*args, **kwargs)
 
         self.helper = FormHelper()

--- a/zds/tutorialv2/tests/tests_views/tests_editcontenttags.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontenttags.py
@@ -133,7 +133,6 @@ class EditContentTagsWorkflowTests(TutorialTestMixin, TestCase):
 
 @override_for_contents()
 class EditContentTagsFunctionalTests(TutorialTestMixin, TestCase):
-    # TODO
     """Test the detailed behavior of the feature, such as updates of the database or repositories."""
 
     def setUp(self):

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -150,8 +150,7 @@ class DisplayContent(LoginRequiredMixin, SingleContentDetailViewMixin):
             self.versioned_object,
             initial={'license': self.versioned_object.licence})
 
-        initial_tags_field = ', '.join(self.object.tags.values_list('title', flat=True))
-        context['form_edit_tags'] = EditContentTagsForm(self.versioned_object, initial={'tags': initial_tags_field})
+        context['form_edit_tags'] = EditContentTagsForm(self.versioned_object, self.object)
 
         if self.versioned_object.requires_validation:
             context['formPublication'] = PublicationForm(self.versioned_object, initial={'source': self.object.source})

--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -92,8 +92,7 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
             context['formAddSuggestion'] = SearchSuggestionForm(content=self.object,
                                                                 initial={'excluded_pk': ','.join(excluded_for_search)})
 
-        initial_tags_field = ', '.join(self.object.tags.values_list('title', flat=True))
-        context['form_edit_tags'] = EditContentTagsForm(self.versioned_object, initial={'tags': initial_tags_field})
+        context['form_edit_tags'] = EditContentTagsForm(self.versioned_object, self.object)
 
         # pagination of comments
         make_pagination(context,

--- a/zds/tutorialv2/views/editorialization.py
+++ b/zds/tutorialv2/views/editorialization.py
@@ -96,6 +96,7 @@ class EditContentTags(LoggedWithReadWriteHability, SingleContentFormViewMixin):
     def get_form_kwargs(self):
         kwargs = super(EditContentTags, self).get_form_kwargs()
         kwargs['content'] = self.versioned_object
+        kwargs['db_content'] = self.object
         return kwargs
 
     def form_valid(self, form):

--- a/zds/tutorialv2/views/editorialization.py
+++ b/zds/tutorialv2/views/editorialization.py
@@ -98,11 +98,6 @@ class EditContentTags(LoggedWithReadWriteHability, SingleContentFormViewMixin):
         kwargs['content'] = self.versioned_object
         return kwargs
 
-    def get_initial(self):
-        initial = super(EditContentTags, self).get_initial()
-        initial['tags'] = ', '.join(self.object.tags.values_list('title', flat=True))
-        return initial
-
     def form_valid(self, form):
         self.object.tags.clear()
         self.object.add_tags(form.cleaned_data['tags'].split(','))


### PR DESCRIPTION
En bossant sur une autre PR, je me suis rendu compte que j'avais du code inutile. Je pense qu'il vaut mieux l'enlever parce que ça complique la compréhension du code. Il y avait aussi un "TODO" inutile qui traînaît. J'ai aussi retravaillé légèrement l'interface d'un formulaire.

### Contrôle qualité

Les tests unitaires doivent passer et il faut vérifier rapidement que le formulaire de modification des tags d'un contenu/billet est toujours bien rempli automatiquement.