### PR TITLE
[29.3] Correction de l'affichage des casquettes du profil

### DIFF
--- a/assets/scss/components/_user-profile.scss
+++ b/assets/scss/components/_user-profile.scss
@@ -124,6 +124,7 @@ body.userprofilepage {
 
                 h3 {
                     flex: 2;
+                    min-width: 12.8rem;
 
                     a.title-link {
                         cursor: help;
@@ -136,15 +137,13 @@ body.userprofilepage {
                 }
 
                 .hatlist {
-                    justify-content: flex-start;
+                    justify-content: flex-end;
 
                     li {
-                        margin-left: 0;
-                        margin-right: 10px;
+                        margin: 4px 10px 4px 0;
 
                         @include mobile {
-                            margin-right: 4px;
-                            margin-bottom: 4px;
+                            margin: 2px 4px 2px 0;
                         }
                     }
                 }

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -232,17 +232,32 @@
                                                 <span>({{ app.site.literal_name }})</span>
                                             {% endif %}
                                         </a>
-                                        {% if perms.utils.change_hat and not hat.group %}
-                                            <a href="#remove-hat-{{ hat.pk }}" class="open-modal" title="{% trans "Retirer la casquette" %}" aria-haspopup="dialog">×</a>
-                                            <form action="{% url 'remove-hat' usr.pk hat.pk %}" method="post" id="remove-hat-{{ hat.pk }}" class="modal modal-flex" data-modal-title="{% trans "Retirer la casquette" %}">
-                                                {% csrf_token %}
-                                                <p>
-                                                    {% blocktrans with hat=hat.name username=usr.username %}
-                                                        Voulez-vous vraiment retirer la casquette « {{ hat }} » à {{ username }} ?
-                                                    {% endblocktrans %}
-                                                </p>
-                                                <button type="submit" class="btn btn-submit">{% trans 'Confirmer' %}</button>
-                                            </form>
+
+                                        {% if not hat.group %}
+                                            {% if perms.utils.change_hat or profile == user.profile %}
+                                                <a href="#remove-hat-{{ hat.pk }}" class="open-modal" title="{% trans "Retirer la casquette" %}" aria-haspopup="dialog">×</a>
+                                                <form action="{% url 'remove-hat' usr.pk hat.pk %}" method="post" id="remove-hat-{{ hat.pk }}" class="modal modal-flex" data-modal-title="{% trans "Retirer la casquette" %}">
+                                                    {% if profile == user.profile %}
+                                                        {% blocktrans with hat=hat.name username=usr.username %}
+                                                            <p>
+                                                                Voulez-vous vraiment vous retirer la casquette « <strong>{{ hat }}</strong> » ?
+                                                                Vous ne pourrez plus poster avec, mais vos anciens messages l'auront toujours,
+                                                                tant que vous ne les modifiez pas.
+                                                            </p>
+                                                            <p>
+                                                                Vous pourrez toujours re-demander la casquette à l'avenir.
+                                                            </p>
+                                                        {% endblocktrans %}
+                                                    {% else %}
+                                                        {% blocktrans with hat=hat.name username=usr.username %}
+                                                            <p>Voulez-vous vraiment retirer la casquette « <strong>{{ hat }}</strong> » à {{ username }} ?</p>
+                                                        {% endblocktrans %}
+                                                    {% endif %}
+
+                                                    {% csrf_token %}
+                                                    <button type="submit" class="btn btn-submit">{% trans 'Confirmer' %}</button>
+                                                </form>
+                                            {% endif %}
                                         {% endif %}
                                     </li>
                                 {% endfor %}

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -15,6 +15,7 @@ from zds.notification.models import TopicAnswerSubscription
 from zds.member import NEW_PROVIDER_USES
 from zds.member.managers import ProfileManager
 from zds.tutorialv2.models.database import PublishableContent
+from zds.utils import slugify
 from zds.utils.models import Alert, Licence, Hat
 
 from zds.forum.models import Forum
@@ -404,7 +405,11 @@ class Profile(models.Model):
         profile_hats = list(self.hats.all())
         groups_hats = list(Hat.objects.filter(group__in=self.user.groups.all()))
         hats = profile_hats + groups_hats
-        hats.sort(key=lambda hat: hat.name)
+
+        # We sort internal hats before the others, and we slugify for sorting to sort correctly
+        # with diatrics.
+        hats.sort(key=lambda hat: f'{"a" if hat.is_staff else "b"}-{slugify(hat.name)}')
+
         return hats
 
     def get_requested_hats(self):


### PR DESCRIPTION
Cette PR corrige quelques problèmes d'affichage divers des casquettes sur la page de profil d'un membre.

- Les casquettes ne sont plus affichées un peu en vrac quand il y en a plus d'une ligne.
- Les casquettes sont affichées avec un ordre plus logique : d'abord les casquettes internes au site, puis les autres, et par ordre alphabétique au sein d'un groupe (comme avant).
- L'ordre alphabétique a été amélioré afin que les accents soient correctement pris en compte.
- Le bouton de retrait d'une casquette a été ajouté sur la page de son propre profil, quand il ne s'agit pas d'une casquette de groupe, car n'importe qui peut se retirer une casquette indépendante sans passer par l'équipe du site.

### Contrôle qualité

1. Lancez le site avec `make run`. Assurez-vous d'actualiser une page de force afin d'avoir la dernière version du CSS (`Ctrl+F5` ou similaire).
2. Depuis un compte d'administration (qui peut gérer les casquettes), allez sur le profil d'un membre lambda et ajoutez-lui beaucoup de casquettes (ou des casquettes avec un texte un peu long), jusqu'à ce qu'il y ait au moins deux lignes de casquettes sur son profil. _Pour rappel, le formulaire pour créer une casquette est dans la page de profil, dans les blocs d'administration._
3. **Vérifiez que les casquettes s'affichent correctement** : alignées à droite (pas à gauche), elles n'écrasent pas le titre « Casquettes » ; les lignes ne sont pas collées.
4. **Vérifiez que vous pouvez toujours supprimer les casquettes non-liées à un groupe du membre** (via un bouton qui soit s'afficher en survolant la casquette), **et que le texte affiché dans la popup est bon** (il doit s'adresser à vous comme à un membre de l'équipe).
5. Allez sur le profil d'un membre staff (`admin` ou `staff`, par exemple), et ajoutez des casquettes classiques de la même façon qu'avant. **Vérifiez que les casquettes ajoutées sont bien toujours _après_ les casquettes de l'équipe**, même si elles devraient être avant si on ne regardait que l'ordre alphabétique.
5. Maintenant, connectez-vous avec le compte du premier utilisateur pour lequel plein de casquettes ont été créées. **Vérifiez que vous pouvez supprimer vos casquettes, et que le texte de la popup est bon** (il doit s'adresser à vous comme le propriétaire de la casquette, et vous prévenir des conséquences).