### PR TITLE
Autorise tous les domaines locaux en dev

### DIFF
--- a/zds/settings/dev.py
+++ b/zds/settings/dev.py
@@ -4,6 +4,13 @@ from .abstract_base import *
 
 DEBUG = True
 
+# NOTE: Can be removed once Django 3 is used
+ALLOWED_HOSTS = [
+    '.localhost',
+    '127.0.0.1',
+    '[::1]'
+]
+
 INSTALLED_APPS += (
     'debug_toolbar',
     'django_extensions',


### PR DESCRIPTION
Django 2.x n'autorisant pas les domaines `*.localhost` par défaut, j'ai ajouté un paramètre `ALLOWED_HOSTS` aux settings de dev.

À noter que Django 3 gèrera cela nativement, donc ça pourra être supprimé/nettoyé à l'occasion.


### Contrôle qualité

* `make run-back` devrait suffire à tester en accédant au front via un domaine local (j'ai par exemple un reverse-proxy sur `zestedesavoir.localhost` qui pointe vers `127.0.0.1:8000` chez moi)