### PR TITLE
Ajoute un paquet manquant dans les dépendances sur Debian

### DIFF
--- a/scripts/dependencies/debian.txt
+++ b/scripts/dependencies/debian.txt
@@ -25,3 +25,4 @@ build-essential
 imagemagick
 librsvg2-bin
 xzdec
+dh-autoreconf


### PR DESCRIPTION
Fix #5927



### Contrôle qualité

Réinstaller une instance de dev sur un Debian, idéalement fraîchement installé, et s'assurer que tout fonctionne bien, notamment la construction du front, comme rapporté dans le ticket.