### PR TITLE
Gére les espaces insécables dans l'aperçu de mise en une

### DIFF
--- a/assets/js/featured-resource-preview.js
+++ b/assets/js/featured-resource-preview.js
@@ -3,6 +3,18 @@
    ========================================================================== */
 
 (function($) {
+  function convertToNbsp(text) {
+    // Any change here should also be made in zds/utils/templatetags/french_typography.py
+    return text
+      .replace(' ;', '&#8239;;')
+      .replace(' ?', '&#8239;?')
+      .replace(' !', '&#8239;!')
+      .replace(' %', '&#8239;%')
+      .replace('« ', '«&nbsp;')
+      .replace(' »', '&nbsp;»')
+      .replace(' :', '&nbsp;:')
+  }
+
   function updatePreview(data, element) {
     var $el = $(element)
     if (data.image) {
@@ -11,7 +23,7 @@
       $el.find('.featured-resource-illu').hide()
     }
 
-    $el.find('h2').text(data.title)
+    $el.find('h2').html(data.title)
     $el.find('.featured-resource-description').html(data.description)
     $el.find('a').attr('href', data.link)
   }
@@ -25,10 +37,10 @@
   $('.featured-resource-edit-form form input').on('change input', function() {
     updatePreview({
       image: $('.featured-resource-edit-form input[name=image_url]').val(),
-      title: $('.featured-resource-edit-form input[name=title]').val(),
+      title: convertToNbsp($('.featured-resource-edit-form input[name=title]').val()),
       description: buildDescription(
         $('.featured-resource-edit-form input[name=authors]').val(),
-        $('.featured-resource-edit-form input[name=type]').val()
+        convertToNbsp($('.featured-resource-edit-form input[name=type]').val())
       ),
       link: $('.featured-edit-form input[name=url]').val()
     }, $('.featured-resource-edit-form .featured-resource-item'))

--- a/templates/featured/includes/featured_resource_item.part.html
+++ b/templates/featured/includes/featured_resource_item.part.html
@@ -7,7 +7,7 @@
         <img src="{{ featured_resource.image_url|remove_url_scheme }}" alt="Illustration {{ featured_resource.title }}" class="featured-resource-illu">
         <div class="featured-resource-meta">
             <h2>{{ featured_resource.title|french_typography }}</h2>
-            <p class="featured-resource-description">{{ featured_resource.type }} {% if featured_resource.authors %} {% trans "par" %} <i>{{ featured_resource.authors }}</i>{% endif %}</p>
+            <p class="featured-resource-description">{{ featured_resource.type|french_typography }} {% if featured_resource.authors %} {% trans "par" %} <i>{{ featured_resource.authors }}</i>{% endif %}</p>
         </div>
     </a>
 </article>

--- a/zds/utils/templatetags/french_typography.py
+++ b/zds/utils/templatetags/french_typography.py
@@ -13,6 +13,9 @@ def french_typography(str):
     before or after some symbols, according to French typography.
 
     This filter is naive and should not be used on Markdown content.
+
+
+    Any change here should also be made in assets/js/featured-resource-preview.js
     """
     return mark_safe(
         # Narrow non-breaking space: &#8239;


### PR DESCRIPTION
Fix #5903

Suite du commit 58c858452067ca14dcec3b5678e1fe85d4c0eb0e (voir la PR #5883)


### Contrôle qualité

Reconstruire le front: `make build-front`

1. Se connecter en tant qu'administrateur ;
2. Accéder à la page d'un contenu ;
3. Mettre ce contenu en Une ;
4. Mettre le titre suivant : « `Comment alerter les secours ?` »: le point d'interrogation reste sur la même ligne.
