### PR TITLE
Ne pas afficher `msg-are-hidden` pour 1er message

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -21,7 +21,7 @@
 {% endif %}
 
 {% ifchanged %}
-{% if message_is_hidden %}
+{% if message_is_hidden and message.pk != topic.first_post.pk %}
     <div class="msg-are-hidden hidden" aria-hidden="true"><a class="link" href="#show">{% trans "Un ou plusieurs messages ont été masqués" %}</a></div>
 {% endif %}
 {% endifchanged %}


### PR DESCRIPTION
Fixe #5916

Si le premier message d'une conversation est caché, il faut laisser le message apparent (avec les styles adéquats) au lieu du message raccourci.


### Contrôle qualité

Ouvrir un sujet dont le premier message est masqué. Il devrait être déplié, sans impacter le reste des messages cachés.

J'ai également testé le cas où les deux (ou plus) premiers messages sont masqués : le premier apparaît mais pas le second.