### PR TITLE
Fixe espacement `msg-are-hidden`

### DIFF
--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -1,9 +1,24 @@
 div.msg-are-hidden {
+    position: relative;
+    z-index: 1;
     text-align: center;
-    margin: -15px 0;
+    margin: 0;
+
     a {
         color: #999;
         font-size: 12px;
+    }
+
+    & ~ .topic-message.hidden + .topic-message:not(.hidden) {
+        margin-top: 10px;
+
+        @include until-desktop {
+            margin-top: 0;
+            padding-top: 5px;
+        }
+    }
+    .topic-message ~ & {
+        margin-top: -15px;
     }
 }
 

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -17,7 +17,7 @@ div.msg-are-hidden {
             padding-top: 5px;
         }
     }
-    .topic-message ~ & {
+    .topic-message + & {
         margin-top: -15px;
     }
 }

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -17,6 +17,9 @@ div.msg-are-hidden {
             padding-top: 5px;
         }
     }
+    & + .topic-message.hidden + .pagination {
+        margin-top: 10px;
+    }
     .topic-message + & {
         margin-top: -15px;
     }


### PR DESCRIPTION
Devrait fixer les issues #5799 et #5907

L'espacement négatif du bloc `msg-are-hidden` le rend parfois inaccessible ou invisible.


### Contrôle qualité

Construire le front et accéder à un des cas problématiques expliqués dans les issues liées.

Le message devrait être cliquable en toute circonstance et l'espacement devrait être cohérent.