### PR TITLE
Force affichage message si cible ancre

### DIFF
--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -123,6 +123,12 @@ div.msg-are-hidden {
         }
     }
 
+    &:target {
+        /* Force l'affichage des messages masqués s'ils sont la cible d'une ancre (par exemple en venant via une notification) */
+        display: block !important;
+        visibility: visible !important;
+    }
+
     .user {
         @include until-desktop {
             display: none;


### PR DESCRIPTION
Corrige le troisième point de [ce sujet](https://zestedesavoir.com/forums/sujet/14589/quelques-problemes-avec-les-messages-masques/?page=1).

Actuellement si un message caché est la cible d'un lien avec une ancre (par exemple lorsqu'on suit une notification), l'ancre ne mène à rien et le message est caché.

Cette PR corrige cela en forçant l'affichage du message en question si l'ancre de la page le cible directement.

### Contrôle qualité

  - Lancez `make build-front` ;
  - Suivez un lien vers un message caché (idéalement vraiment caché, avec un message `msg-are-hidden` qui va bien) ;
  - Le message doit être accessible et l'ancre doit fonctionner.

À noter que j'ai dû déplacer l'`id` qui sert pour l'ancre, cela peut risque de casser autre chose, par exemple si du JS l'utilise (ce qui a priori ne devrait pas être le cas).