### PR TITLE
[Django 3.x] Mise à jour des dépendances qui gèrent les slugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ drf-extensions==0.6.0
 dry-rest-permissions==0.1.10
 oauth2client==4.1.3
 
-# Zep 12 dependency
-# next versions of this libraries break previous behavior for slug generation from string with single quotes
-django-uuslug==1.0.3
-python-slugify==1.1.4
+# Dependencies for slug generation, please be extra careful with those
+django-uuslug==1.2.0
+python-slugify==4.0.1

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -14,7 +14,7 @@ from elasticsearch_dsl.field import Text, Keyword, Integer, Boolean, Float, Date
 from zds.forum.managers import TopicManager, ForumManager, PostManager, TopicReadManager
 from zds.notification import signals
 from zds.searchv2.models import AbstractESDjangoIndexable, delete_document_in_elasticsearch, ESIndexManager
-from zds.utils import get_current_user, slugify
+from zds.utils import get_current_user, old_slugify
 from zds.utils.models import Comment, Tag
 
 
@@ -245,7 +245,7 @@ class Topic(AbstractESDjangoIndexable):
         return reverse("topic-posts-list", args=[self.pk, self.slug()])
 
     def slug(self):
-        return slugify(self.title)
+        return old_slugify(self.title)
 
     def get_post_count(self):
         """

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -11,7 +11,7 @@ from zds.forum.factories import ForumCategoryFactory, ForumFactory, TopicFactory
 from zds.forum.models import Forum, TopicRead, Post, Topic, is_read
 from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.notification.models import TopicAnswerSubscription
-from zds.utils import slugify
+from zds.utils import old_slugify
 from zds.utils.forums import get_tag_by_title
 from zds.utils.models import Alert, Tag
 
@@ -742,7 +742,7 @@ class ForumMemberTests(TestCase):
         PostFactory(topic=topic1, author=self.user, position=3)
 
         # simple member can read public topic
-        result = self.client.get(reverse("topic-posts-list", args=[topic1.pk, slugify(topic1.title)]), follow=True)
+        result = self.client.get(reverse("topic-posts-list", args=[topic1.pk, old_slugify(topic1.title)]), follow=True)
         self.assertEqual(result.status_code, 200)
 
     def test_failing_unread_post(self):
@@ -992,7 +992,7 @@ class ForumGuestTests(TestCase):
         PostFactory(topic=topic1, author=self.user, position=3)
 
         # guest can read public topic
-        result = self.client.get(reverse("topic-posts-list", args=[topic1.pk, slugify(topic1.title)]), follow=True)
+        result = self.client.get(reverse("topic-posts-list", args=[topic1.pk, old_slugify(topic1.title)]), follow=True)
         self.assertEqual(result.status_code, 200)
 
     def test_filter_topic(self):

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -25,7 +25,7 @@ from zds.member.models import user_readable_forums
 from zds.notification import signals
 from zds.notification.models import NewTopicSubscription, TopicAnswerSubscription
 from zds.featured.mixins import FeatureableMixin
-from zds.utils import slugify
+from zds.utils import old_slugify
 from zds.utils.forums import create_topic, send_post, CreatePostView
 from zds.utils.mixins import FilterMixin
 from zds.utils.models import Alert, Tag, CommentVote
@@ -173,7 +173,7 @@ class TopicPostsListView(ZdSPagingListView, FeatureableMixin, SingleObjectMixin)
         self.object = self.get_object()
         if not self.object.forum.can_read(request.user):
             raise PermissionDenied
-        if not self.kwargs.get("topic_slug") == slugify(self.object.title):
+        if not self.kwargs.get("topic_slug") == old_slugify(self.object.title):
             return redirect(self.object.get_absolute_url())
         return super(TopicPostsListView, self).get(request, *args, **kwargs)
 

--- a/zds/gallery/factories.py
+++ b/zds/gallery/factories.py
@@ -3,7 +3,7 @@ import contextlib
 import factory
 
 from zds.gallery.models import Image, Gallery, UserGallery
-from zds.utils import slugify
+from zds.utils import old_slugify
 
 
 # Don't try to directly use UserFactory, this didn't create Profile then
@@ -13,7 +13,7 @@ class ImageFactory(factory.DjangoModelFactory):
         model = Image
 
     title = factory.Sequence("titre de l'image {0}".format)
-    slug = factory.LazyAttribute(lambda o: "{0}".format(slugify(o.title)))
+    slug = factory.LazyAttribute(lambda o: "{0}".format(old_slugify(o.title)))
     legend = factory.Sequence("legende de l'image {0}".format)
     physical = factory.django.ImageField(color="blue")
 
@@ -33,7 +33,7 @@ class GalleryFactory(factory.DjangoModelFactory):
 
     title = factory.Sequence("titre de la gallerie {0}".format)
     subtitle = factory.Sequence("Sous-titre de la gallerie {0}".format)
-    slug = factory.LazyAttribute(lambda o: "{0}".format(slugify(o.title)))
+    slug = factory.LazyAttribute(lambda o: "{0}".format(old_slugify(o.title)))
 
     @classmethod
     def _prepare(cls, create, **kwargs):

--- a/zds/gallery/mixins.py
+++ b/zds/gallery/mixins.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import tempfile
 import zipfile
-from uuslug import slugify
 
 from PIL import Image as ImagePIL
 from easy_thumbnails.files import get_thumbnailer
@@ -12,6 +11,7 @@ from django.conf import settings
 
 from zds.gallery.models import Gallery, UserGallery, GALLERY_WRITE, GALLERY_READ, Image
 from zds.tutorialv2.models.database import PublishableContent
+from zds.utils.uuslug_wrapper import slugify
 
 
 class GalleryMixin:

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -15,7 +15,7 @@ from zds.notification.models import TopicAnswerSubscription
 from zds.member import NEW_PROVIDER_USES
 from zds.member.managers import ProfileManager
 from zds.tutorialv2.models.database import PublishableContent
-from zds.utils import slugify
+from zds.utils import old_slugify
 from zds.utils.models import Alert, Licence, Hat
 
 from zds.forum.models import Forum
@@ -399,7 +399,7 @@ class Profile(models.Model):
 
         # We sort internal hats before the others, and we slugify for sorting to sort correctly
         # with diatrics.
-        hats.sort(key=lambda hat: f'{"a" if hat.is_staff else "b"}-{slugify(hat.name)}')
+        hats.sort(key=lambda hat: f'{"a" if hat.is_staff else "b"}-{old_slugify(hat.name)}')
 
         return hats
 

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -7,7 +7,7 @@ from django.db import models
 
 from zds.mp.managers import PrivateTopicManager, PrivatePostManager
 from zds.mp import signals
-from zds.utils import get_current_user, slugify
+from zds.utils import get_current_user, old_slugify
 
 
 class NotReachableError(Exception):
@@ -82,7 +82,7 @@ class PrivateTopic(models.Model):
         with older private topic, the slug is always re-calculated when we need one.
         :return: title slugify.
         """
-        return slugify(self.title)
+        return old_slugify(self.title)
 
     def get_post_count(self):
         """

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -31,7 +31,7 @@ from zds.tutorialv2.factories import (
 )
 from zds.tutorialv2.models.database import ContentReaction, PublishableContent
 from zds.tutorialv2.publication_utils import publish_content
-from zds.utils import slugify
+from zds.utils import old_slugify
 from zds.utils.mps import send_mp, send_message_mp
 
 
@@ -167,7 +167,7 @@ class NotificationForumTest(TestCase):
         self.client.logout()
         self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"), True)
 
-        result = self.client.get(reverse("topic-posts-list", args=[topic1.pk, slugify(topic1.title)]), follow=True)
+        result = self.client.get(reverse("topic-posts-list", args=[topic1.pk, old_slugify(topic1.title)]), follow=True)
         self.assertEqual(result.status_code, 200)
 
         notification = Notification.objects.get(subscription__user=self.user2)

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -393,7 +393,7 @@ class ContentNotification(TestCase, TutorialTestMixin):
         content.sha_draft = versioned.repo_update(
             introduction="new intro", conclusion="new conclusion", title=versioned.title
         )
-        content.save(force_slug_update=False)
+        content.save()
         publish_content(content, content.load_version(), True)
         notify_update(content, True, False)
         notifs = get_header_notifications(self.user1)["general_notifications"]["list"]
@@ -407,7 +407,7 @@ class ContentNotification(TestCase, TutorialTestMixin):
         content.sha_draft = versioned.repo_update(
             introduction="new intro", conclusion="new conclusion", title=versioned.title
         )
-        content.save(force_slug_update=False)
+        content.save()
         publish_content(content, content.load_version(), True)
         notify_update(content, True, True)
         notifs = get_header_notifications(self.user1)["general_notifications"]["list"]

--- a/zds/searchv2/tests/tests_models.py
+++ b/zds/searchv2/tests/tests_models.py
@@ -313,7 +313,7 @@ class ESIndexManagerTests(TutorialTestMixin, TestCase):
         versioned = tuto.load_version(sha=tuto.sha_draft)
 
         tuto.title = "un titre complètement différent!"
-        tuto.save()
+        tuto.save(force_slug_update=True)
 
         versioned.repo_update_top_container(tuto.title, tuto.slug, "osef", "osef")
         second_publication = publish_content(tuto, versioned, True)

--- a/zds/tutorialv2/epub_utils.py
+++ b/zds/tutorialv2/epub_utils.py
@@ -13,7 +13,7 @@ from django.template.loader import render_to_string
 from django.conf import settings
 
 from zds.tutorialv2.publish_container import publish_container
-from zds.utils import slugify
+from zds.utils import old_slugify
 
 
 def __build_mime_type_conf():
@@ -77,7 +77,7 @@ def build_html_chapter_file(published_object, versioned_object, working_dir, roo
     )
     for container_path, title in path_to_title_dict.items():
         # TODO: check if a function exists in the std lib to get rid of `root_dir + '/'`
-        yield container_path.replace(str(root_dir.absolute()) + "/", ""), "chapter-" + slugify(title), title
+        yield container_path.replace(str(root_dir.absolute()) + "/", ""), "chapter-" + old_slugify(title), title
 
 
 def build_toc_ncx(chapters, tutorial, working_dir):

--- a/zds/tutorialv2/management/commands/adjust_slugs.py
+++ b/zds/tutorialv2/management/commands/adjust_slugs.py
@@ -1,10 +1,10 @@
 import os
-from uuslug import slugify
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from zds.tutorialv2.models.database import PublishableContent
+from zds.utils.uuslug_wrapper import slugify
 
 
 class Command(BaseCommand):

--- a/zds/tutorialv2/management/commands/upgrade_manifest_to_v2.py
+++ b/zds/tutorialv2/management/commands/upgrade_manifest_to_v2.py
@@ -1,7 +1,7 @@
 from zds.tutorialv2.models.versioned import Extract, VersionedContent, Container
 from django.core.management.base import BaseCommand
 from zds.utils.models import Licence
-from uuslug import slugify
+from zds.utils.uuslug_wrapper import slugify
 import os
 from zds import json_handler
 

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -167,14 +167,14 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
         self.refresh_from_db(fields=list(fields.keys()))
         return self
 
-    def save(self, *args, force_slug_update=True, update_date=True, **kwargs):
+    def save(self, *args, force_slug_update=False, update_date=True, **kwargs):
         """
         Rewrite the ``save()``  function to handle slug uniqueness
 
         :param update_date: if ``True`` will assign "update_date" property to now
-        :param force_slug_update: if set to ``False`` do not try to update the slug
+        :param force_slug_update: if ``True`` will try to update the slug
         """
-        if force_slug_update:
+        if self.slug == "" or force_slug_update:
             self.slug = uuslug(self.title, instance=self, max_length=80)
         if update_date:
             self.update_date = datetime.now()
@@ -593,7 +593,7 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
             except ValueError as e:
                 logger.warning(e)
         logger.debug("Initial number of tags=%s, after filtering=%s", len(tag_collection), len(self.tags.all()))
-        self.save(force_slug_update=False)
+        self.save()
 
     def requires_validation(self):
         """

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -20,7 +20,6 @@ from elasticsearch_dsl import Mapping, Q as ES_Q
 from elasticsearch_dsl.field import Text, Keyword, Date, Boolean
 from git import Repo, BadObject
 from gitdb.exc import BadName
-from uuslug import uuslug
 
 from zds import json_handler
 from zds.forum.models import Topic
@@ -41,6 +40,7 @@ from zds.utils import get_current_user
 from zds.utils.models import SubCategory, Licence, HelpWriting, Comment, Tag
 from zds.utils.templatetags.emarkdown import render_markdown_stats
 from zds.utils.tutorials import get_blob
+from zds.utils.uuslug_wrapper import uuslug
 
 ALLOWED_TYPES = ["pdf", "md", "html", "epub", "zip", "tex"]
 logger = logging.getLogger(__name__)

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -7,7 +7,6 @@ from git import Repo
 import os
 import shutil
 import codecs
-from uuslug import slugify
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
@@ -16,11 +15,12 @@ from django.utils.translation import ugettext_lazy as _
 from django.template.loader import render_to_string
 
 from zds.tutorialv2.models.mixins import TemplatableContentModelMixin
-from zds.tutorialv2.utils import default_slug_pool, export_content, get_commit_author, InvalidOperationError
-from zds.utils.misc import compute_hash
 from zds.tutorialv2.models import SINGLE_CONTAINER_CONTENT_TYPES, CONTENT_TYPES_BETA, CONTENT_TYPES_REQUIRING_VALIDATION
+from zds.tutorialv2.utils import default_slug_pool, export_content, get_commit_author, InvalidOperationError
 from zds.tutorialv2.utils import get_blob, InvalidSlugError, check_slug
+from zds.utils.misc import compute_hash
 from zds.utils.templatetags.emarkdown import emarkdown
+from zds.utils.uuslug_wrapper import slugify
 
 
 class Container:

--- a/zds/tutorialv2/tests/tests_lists.py
+++ b/zds/tutorialv2/tests/tests_lists.py
@@ -102,7 +102,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto_1.save()
         tuto_1_draft = tuto_1.load_version()
         tuto_1.public_version = publish_content(tuto_1, tuto_1_draft, is_major_update=True)
-        tuto_1.save(force_slug_update=False)
+        tuto_1.save()
 
     def test_list_categories(self):
         category_1 = ContentCategoryFactory()

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -548,7 +548,7 @@ class UtilsTests(TutorialTestMixin, TestCase):
             "(/media/galleries/4410/c1016bf1-a1de-48a1-9ef1-144308e8725d.jpg)"
         )
         article.sha_draft = article.load_version().repo_update(article.title, image_string, "", update_slug=False)
-        article.save(force_slug_update=False)
+        article.save()
         publish_content(article, article.load_version())
         self.assertTrue(PublishedContent.objects.filter(content_id=article.pk).exists())
 

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -6,15 +6,14 @@ from django.contrib.auth.models import User
 from django.http import Http404
 from django.utils.translation import ugettext_lazy as _
 from git import Repo, Actor
-from uuslug import slugify
 
 from django.conf import settings
 from zds.notification import signals
 from zds.tutorialv2 import VALID_SLUG
 from zds.tutorialv2.models import CONTENT_TYPE_LIST
-from zds.utils import get_current_user
-from zds.utils import slugify as old_slugify
+from zds.utils import get_current_user, old_slugify
 from zds.utils.models import Licence
+from zds.utils.uuslug_wrapper import slugify
 
 logger = logging.getLogger(__name__)
 

--- a/zds/tutorialv2/views/archives.py
+++ b/zds/tutorialv2/views/archives.py
@@ -13,7 +13,6 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import FormView
 from easy_thumbnails.files import get_thumbnailer
-from uuslug import slugify
 
 from zds import json_handler
 from zds.gallery.models import Image, Gallery
@@ -30,6 +29,7 @@ from zds.tutorialv2.utils import (
     default_slug_pool,
     init_new_repo,
 )
+from zds.utils.uuslug_wrapper import slugify
 
 
 class DownloadContent(LoginRequiredMixin, SingleContentDownloadViewMixin):

--- a/zds/tutorialv2/views/archives.py
+++ b/zds/tutorialv2/views/archives.py
@@ -423,7 +423,7 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
                 # of course, need to update sha
                 self.object.sha_draft = sha
                 self.object.update_date = datetime.now()
-                self.object.save(force_slug_update=False)
+                self.object.save()
 
                 self.success_url = reverse("content:view", args=[versioned.pk, versioned.slug])
 
@@ -484,7 +484,7 @@ class CreateContentFromArchive(LoggedWithReadWriteHability, FormView):
 
                 # Attach user to gallery
                 self.object.gallery = gal
-                self.object.save(force_slug_update=False)
+                self.object.save()
 
                 # Add subcategories on tutorial
                 for subcat in form.cleaned_data["subcategory"]:
@@ -492,7 +492,7 @@ class CreateContentFromArchive(LoggedWithReadWriteHability, FormView):
 
                 # We need to save the tutorial before changing its author list since it's a many-to-many relationship
                 self.object.authors.add(self.request.user)
-                self.object.save(force_slug_update=False)
+                self.object.save()
                 self.object.ensure_author_gallery()
                 # ok, now we can import
                 introduction = ""
@@ -547,7 +547,7 @@ class CreateContentFromArchive(LoggedWithReadWriteHability, FormView):
                 # of course, need to update sha
                 self.object.sha_draft = sha
                 self.object.update_date = datetime.now()
-                self.object.save(force_slug_update=False)
+                self.object.save()
 
                 self.success_url = reverse("content:view", args=[versioned.pk, versioned.slug])
 

--- a/zds/tutorialv2/views/archives.py
+++ b/zds/tutorialv2/views/archives.py
@@ -352,11 +352,12 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
                     )
 
                 # first, update DB object (in order to get a new slug if needed)
+                title_is_changed = self.object.title != new_version.title
                 self.object.title = new_version.title
                 self.object.description = new_version.description
                 self.object.licence = new_version.licence
                 self.object.type = new_version.type  # change of type is then allowed !!
-                self.object.save()
+                self.object.save(force_slug_update=title_is_changed)
 
                 new_version.slug = self.object.slug  # new slug if any !!
 

--- a/zds/tutorialv2/views/authors.py
+++ b/zds/tutorialv2/views/authors.py
@@ -66,7 +66,7 @@ class AddAuthorToContent(LoggedWithReadWriteHability, SingleContentFormViewMixin
                         hat=get_hat_from_settings("validation"),
                     )
                 UserGallery(gallery=self.object.gallery, user=user, mode=GALLERY_WRITE).save()
-        self.object.save(force_slug_update=False)
+        self.object.save()
         self.success_url = self.object.get_absolute_url()
 
         return super(AddAuthorToContent, self).form_valid(form)
@@ -130,7 +130,7 @@ class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormView
                 )
                 return redirect(self.object.get_absolute_url())
 
-        self.object.save(force_slug_update=False)
+        self.object.save()
 
         authors_list = ""
 

--- a/zds/tutorialv2/views/beta.py
+++ b/zds/tutorialv2/views/beta.py
@@ -140,7 +140,7 @@ class ManageBetaContent(LoggedWithReadWriteHability, SingleContentFormViewMixin)
                             leave=True,
                             hat=get_hat_from_settings("validation"),
                         )
-                        self.object.save(force_slug_update=False)
+                        self.object.save()
                     else:
                         send_message_mp(
                             bot, self.object.validation_private_message, msg, hat=get_hat_from_settings("validation")
@@ -189,7 +189,7 @@ class ManageBetaContent(LoggedWithReadWriteHability, SingleContentFormViewMixin)
                     topic.tags.add(tag)
                 topic.save()
 
-        self.object.save(force_slug_update=False)  # we should prefer .update but it needs a uge refactoring
+        self.object.save()  # we should prefer .update but it needs a huge refactoring
 
         self.success_url = self.versioned_object.get_absolute_url(version=sha_beta)
 

--- a/zds/tutorialv2/views/comments.py
+++ b/zds/tutorialv2/views/comments.py
@@ -164,7 +164,7 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
 
         if is_new:  # we first need to save the reaction
             self.object.last_note = self.reaction
-            self.object.save(update_date=False, force_slug_update=False)
+            self.object.save(update_date=False)
 
         self.success_url = self.reaction.get_absolute_url()
         return super(SendNoteFormView, self).form_valid(form)

--- a/zds/tutorialv2/views/containers_extracts.py
+++ b/zds/tutorialv2/views/containers_extracts.py
@@ -64,7 +64,7 @@ class CreateContainer(LoggedWithReadWriteHability, SingleContentFormViewMixin, F
         # then save:
         self.object.sha_draft = sha
         self.object.update_date = datetime.now()
-        self.object.save(force_slug_update=False)
+        self.object.save()
 
         self.success_url = parent.children[-1].get_absolute_url()
 
@@ -183,7 +183,7 @@ class EditContainer(LoggedWithReadWriteHability, SingleContentFormViewMixin, For
         # then save
         self.object.sha_draft = sha
         self.object.update_date = datetime.now()
-        self.object.save(force_slug_update=False)
+        self.object.save()
 
         self.success_url = container.get_absolute_url()
 
@@ -221,7 +221,7 @@ class CreateExtract(LoggedWithReadWriteHability, SingleContentFormViewMixin, For
         # then save
         self.object.sha_draft = sha
         self.object.update_date = datetime.now()
-        self.object.save(force_slug_update=False)
+        self.object.save()
 
         self.success_url = parent.children[-1].get_absolute_url()
 
@@ -400,8 +400,7 @@ class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
                 update_slug=False,
             )
             content.sha_draft = versioned.sha_draft
-            content.save(force_slug_update=False)  # we do not want the save routine to update the slug in case
-            # of slug algorithm conflict (for pre-zep-12 or imported content)
+            content.save()
             messages.info(self.request, _("L'élément a bien été déplacé."))
         except TooDeepContainerError:
             messages.error(

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -11,7 +11,6 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DeleteView
-from uuslug import slugify
 
 from zds.gallery.models import Gallery, Image
 from zds.member.decorator import LoggedWithReadWriteHability, LoginRequiredMixin
@@ -43,6 +42,7 @@ from zds.tutorialv2.utils import init_new_repo
 from zds.tutorialv2.views.authors import RemoveAuthorFromContent
 from zds.utils.models import get_hat_from_settings
 from zds.utils.mps import send_mp, send_message_mp
+from zds.utils.uuslug_wrapper import slugify
 
 logger = logging.getLogger(__name__)
 

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -102,18 +102,18 @@ class CreateContent(LoggedWithReadWriteHability, FormWithPreview):
             img.save()
             self.content.image = img
 
-        self.content.save(force_slug_update=False)
+        self.content.save()
 
         # We need to save the content before changing its author list since it's a many-to-many relationship
         self.content.authors.add(self.request.user)
 
         self.content.ensure_author_gallery()
-        self.content.save(force_slug_update=False)
+        self.content.save()
         # Add subcategories on tutorial
         for subcat in form.cleaned_data["subcategory"]:
             self.content.subcategory.add(subcat)
 
-        self.content.save(force_slug_update=False)
+        self.content.save()
 
         # create a new repo :
         init_new_repo(
@@ -297,7 +297,7 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         for subcat in form.cleaned_data["subcategory"]:
             publishable.subcategory.add(subcat)
 
-        publishable.save(force_slug_update=False)
+        publishable.save()
 
         self.success_url = reverse("content:view", args=[publishable.pk, publishable.slug])
         return super().form_valid(form)
@@ -321,7 +321,7 @@ class EditContentLicense(LoginRequiredMixin, SingleContentFormViewMixin):
         # Update license in database
         publishable.licence = form.cleaned_data["license"]
         publishable.update_date = datetime.now()
-        publishable.save(force_slug_update=False)
+        publishable.save()
 
         # Update license in repository
         self.versioned_object.licence = form.cleaned_data["license"]
@@ -335,7 +335,7 @@ class EditContentLicense(LoginRequiredMixin, SingleContentFormViewMixin):
 
         # Update relationships in database
         publishable.sha_draft = sha
-        publishable.save(force_slug_update=False)
+        publishable.save()
 
         messages.success(self.request, EditContentLicense.success_message_license)
 
@@ -406,7 +406,7 @@ class DeleteContent(LoginRequiredMixin, SingleContentViewMixin, DeleteView):
                             hat=get_hat_from_settings("validation"),
                             automatically_read=validation.validator,
                         )
-                        validation.content.save(force_slug_update=False)
+                        validation.content.save()
                     else:
                         send_message_mp(
                             bot,

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -102,7 +102,7 @@ class CreateContent(LoggedWithReadWriteHability, FormWithPreview):
             img.save()
             self.content.image = img
 
-        self.content.save()
+        self.content.save(force_slug_update=False)
 
         # We need to save the content before changing its author list since it's a many-to-many relationship
         self.content.authors.add(self.request.user)

--- a/zds/tutorialv2/views/editorialization.py
+++ b/zds/tutorialv2/views/editorialization.py
@@ -114,6 +114,6 @@ class EditContentTags(LoggedWithReadWriteHability, SingleContentFormViewMixin):
     def form_valid(self, form):
         self.object.tags.clear()
         self.object.add_tags(form.cleaned_data["tags"].split(","))
-        self.object.save(force_slug_update=False)
+        self.object.save()
         messages.success(self.request, EditContentTags.success_message)
         return redirect(form.previous_page_url)

--- a/zds/tutorialv2/views/help.py
+++ b/zds/tutorialv2/views/help.py
@@ -81,7 +81,7 @@ class ChangeHelp(LoggedWithReadWriteHability, SingleContentFormViewMixin):
             self.object.helps.add(data["help_wanted"])
         else:
             self.object.helps.remove(data["help_wanted"])
-        self.object.save(force_slug_update=False)
+        self.object.save()
         if self.request.is_ajax():
             return HttpResponse(
                 json.dumps({"result": "ok", "help_wanted": data["activated"]}), content_type="application/json"

--- a/zds/tutorialv2/views/lists.py
+++ b/zds/tutorialv2/views/lists.py
@@ -1,5 +1,4 @@
 from collections import defaultdict, OrderedDict
-from uuslug import slugify
 
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
@@ -19,6 +18,7 @@ from zds.tutorialv2.models.database import PublishedContent, PublishableContent,
 from zds.utils.models import Tag, Category, SubCategory, CategorySubCategory
 from zds.utils.paginator import make_pagination, ZdSPagingListView
 from zds.utils.templatetags.topbar import topbar_publication_categories
+from zds.utils.uuslug_wrapper import slugify
 
 
 class ListOnlineContents(ContentTypeMixin, ZdSPagingListView):

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -182,7 +182,7 @@ class AskValidationForContent(LoggedWithReadWriteHability, SingleContentFormView
         # update the content with the source and the version of the validation
         self.object.source = self.versioned_object.source
         self.object.sha_validation = validation.version
-        self.object.save()
+        self.object.save(force_slug_update=False)
 
         messages.success(self.request, _("Votre demande de validation a été transmise à l'équipe."))
 
@@ -237,7 +237,7 @@ class CancelValidation(LoginRequiredMixin, ModalFormView):
         validation.save()
 
         validation.content.sha_validation = None
-        validation.content.save()
+        validation.content.save(force_slug_update=False)
 
         # warn the former validator that the whole thing has been cancelled
         if validation.validator:
@@ -391,7 +391,7 @@ class RejectValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
         validation.save()
 
         validation.content.sha_validation = None
-        validation.content.save()
+        validation.content.save(force_slug_update=False)
 
         # send PM
         versioned = validation.content.load_version(sha=validation.version)
@@ -528,7 +528,7 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
         self.object.sha_public = None
         self.object.sha_validation = validation.version
         self.object.pubdate = None
-        self.object.save()
+        self.object.save(force_slug_update=False)
 
         # send PM
         msg = render_to_string(
@@ -582,7 +582,7 @@ class MarkObsolete(LoginRequiredMixin, PermissionRequiredMixin, FormView):
         else:
             content.is_obsolete = True
             messages.info(request, _("Le contenu est maintenant marqué comme obsolète."))
-        content.save()
+        content.save(force_slug_update=False)
         return redirect(content.get_absolute_url_online())
 
 

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -182,7 +182,7 @@ class AskValidationForContent(LoggedWithReadWriteHability, SingleContentFormView
         # update the content with the source and the version of the validation
         self.object.source = self.versioned_object.source
         self.object.sha_validation = validation.version
-        self.object.save(force_slug_update=False)
+        self.object.save()
 
         messages.success(self.request, _("Votre demande de validation a été transmise à l'équipe."))
 
@@ -237,7 +237,7 @@ class CancelValidation(LoginRequiredMixin, ModalFormView):
         validation.save()
 
         validation.content.sha_validation = None
-        validation.content.save(force_slug_update=False)
+        validation.content.save()
 
         # warn the former validator that the whole thing has been cancelled
         if validation.validator:
@@ -262,7 +262,7 @@ class CancelValidation(LoginRequiredMixin, ModalFormView):
                     send_by_mail=False,
                     hat=get_hat_from_settings("validation"),
                 )
-                validation.content.save(force_slug_update=False)
+                validation.content.save()
             else:
                 send_message_mp(bot, validation.content.validation_private_message, msg)
 
@@ -323,7 +323,7 @@ class ReserveValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
                         mark_as_read=True,
                         hat=get_hat_from_settings("validation"),
                     )
-                    validation.content.save(force_slug_update=False)
+                    validation.content.save()
                 else:
                     send_message_mp(validation.validator, validation.content.validation_private_message, msg)
                 mark_read(validation.content.validation_private_message, validation.validator)
@@ -391,7 +391,7 @@ class RejectValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
         validation.save()
 
         validation.content.sha_validation = None
-        validation.content.save(force_slug_update=False)
+        validation.content.save()
 
         # send PM
         versioned = validation.content.load_version(sha=validation.version)
@@ -417,7 +417,7 @@ class RejectValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
                 direct=False,
                 hat=get_hat_from_settings("validation"),
             )
-            validation.content.save(force_slug_update=False)
+            validation.content.save()
         else:
             send_message_mp(
                 bot, validation.content.validation_private_message, msg, no_notification_for=[self.request.user]
@@ -528,7 +528,7 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
         self.object.sha_public = None
         self.object.sha_validation = validation.version
         self.object.pubdate = None
-        self.object.save(force_slug_update=False)
+        self.object.save()
 
         # send PM
         msg = render_to_string(
@@ -553,7 +553,7 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
                 direct=False,
                 hat=get_hat_from_settings("validation"),
             )
-            self.object.save(force_slug_update=False)
+            self.object.save()
         else:
             send_message_mp(
                 bot, validation.content.validation_private_message, msg, no_notification_for=[self.request.user]
@@ -582,7 +582,7 @@ class MarkObsolete(LoginRequiredMixin, PermissionRequiredMixin, FormView):
         else:
             content.is_obsolete = True
             messages.info(request, _("Le contenu est maintenant marqué comme obsolète."))
-        content.save(force_slug_update=False)
+        content.save()
         return redirect(content.get_absolute_url_online())
 
 

--- a/zds/tutorialv2/views/validations_opinions.py
+++ b/zds/tutorialv2/views/validations_opinions.py
@@ -67,7 +67,7 @@ class PublishOpinion(LoggedWithReadWriteHability, DoesNotRequireValidationFormVi
             db_object.source = db_object.source
             db_object.sha_validation = None
             db_object.public_version = published
-            db_object.save(force_slug_update=False)
+            db_object.save()
 
             # if only ignore, we remove it from history
             PickListOperation.objects.filter(content=db_object, operation__in=["NO_PICK", "PICK"]).update(
@@ -132,7 +132,7 @@ class UnpublishOpinion(LoginRequiredMixin, SingleOnlineContentFormViewMixin, Doe
                     direct=False,
                     hat=get_hat_from_settings("moderation"),
                 )
-                self.object.save(force_slug_update=False)
+                self.object.save()
             else:
                 send_message_mp(
                     bot,
@@ -222,7 +222,7 @@ class DoNotPickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormView
                         direct=False,
                         hat=get_hat_from_settings("moderation"),
                     )
-                    self.object.save(force_slug_update=False)
+                    self.object.save()
                 else:
                     send_message_mp(
                         bot,
@@ -294,7 +294,7 @@ class PickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMixin
 
         db_object.sha_picked = form.cleaned_data["version"]
         db_object.picked_date = datetime.now()
-        db_object.save(force_slug_update=False)
+        db_object.save()
 
         # mark to reindex to boost correctly in the search
         self.public_content_object.es_flagged = True
@@ -326,7 +326,7 @@ class PickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMixin
                 direct=False,
                 hat=get_hat_from_settings("moderation"),
             )
-            self.object.save(force_slug_update=False)
+            self.object.save()
         else:
             send_message_mp(
                 bot,
@@ -370,7 +370,7 @@ class UnpickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMix
             raise PermissionDenied("Impossible de retirer des billets choisis un billet pas choisi.")
 
         db_object.sha_picked = None
-        db_object.save(force_slug_update=False)
+        db_object.save()
         PickListOperation.objects.filter(operation="PICK", is_effective=True, content=self.object).first().cancel(
             self.request.user
         )
@@ -400,7 +400,7 @@ class UnpickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMix
                 direct=False,
                 hat=get_hat_from_settings("moderation"),
             )
-            self.object.save(force_slug_update=False)
+            self.object.save()
         else:
             send_message_mp(bot, self.object.validation_private_message, msg)
 
@@ -479,10 +479,10 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
             article.subcategory.add(subcat)
         for tag in tags:
             article.tags.add(tag)
-        article.save(force_slug_update=False)
+        article.save()
         # add information about the conversion to the original opinion
         db_object.converted_to = article
-        db_object.save(force_slug_update=False)
+        db_object.save()
 
         # clone the repo
         clone_repo(old_git_path, article.get_repo_path())
@@ -493,7 +493,7 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
             versionned_article.title, versionned_article.get_introduction(), versionned_article.get_conclusion()
         )
         article.sha_draft = article.sha_validation
-        article.save(force_slug_update=False)
+        article.save()
         # ask for validation
         validation = Validation()
         validation.content = article
@@ -516,7 +516,7 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
         gal.save()
         article.gallery = gal
         # save updates
-        article.save(force_slug_update=False)
+        article.save()
         article.ensure_author_gallery()
 
         # send message to user
@@ -540,7 +540,7 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
             direct=False,
             hat=get_hat_from_settings("validation"),
         )
-        article.save(force_slug_update=False)
+        article.save()
 
         self.success_url = db_object.get_absolute_url()
 

--- a/zds/tutorialv2/views/validations_opinions.py
+++ b/zds/tutorialv2/views/validations_opinions.py
@@ -67,7 +67,7 @@ class PublishOpinion(LoggedWithReadWriteHability, DoesNotRequireValidationFormVi
             db_object.source = db_object.source
             db_object.sha_validation = None
             db_object.public_version = published
-            db_object.save()
+            db_object.save(force_slug_update=False)
 
             # if only ignore, we remove it from history
             PickListOperation.objects.filter(content=db_object, operation__in=["NO_PICK", "PICK"]).update(
@@ -294,7 +294,7 @@ class PickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMixin
 
         db_object.sha_picked = form.cleaned_data["version"]
         db_object.picked_date = datetime.now()
-        db_object.save()
+        db_object.save(force_slug_update=False)
 
         # mark to reindex to boost correctly in the search
         self.public_content_object.es_flagged = True
@@ -370,7 +370,7 @@ class UnpickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMix
             raise PermissionDenied("Impossible de retirer des billets choisis un billet pas choisi.")
 
         db_object.sha_picked = None
-        db_object.save()
+        db_object.save(force_slug_update=False)
         PickListOperation.objects.filter(operation="PICK", is_effective=True, content=self.object).first().cancel(
             self.request.user
         )
@@ -479,10 +479,10 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
             article.subcategory.add(subcat)
         for tag in tags:
             article.tags.add(tag)
-        article.save()
+        article.save(force_slug_update=False)
         # add information about the conversion to the original opinion
         db_object.converted_to = article
-        db_object.save()
+        db_object.save(force_slug_update=False)
 
         # clone the repo
         clone_repo(old_git_path, article.get_repo_path())
@@ -493,7 +493,7 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
             versionned_article.title, versionned_article.get_introduction(), versionned_article.get_conclusion()
         )
         article.sha_draft = article.sha_validation
-        article.save()
+        article.save(force_slug_update=False)
         # ask for validation
         validation = Validation()
         validation.content = article
@@ -516,7 +516,7 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
         gal.save()
         article.gallery = gal
         # save updates
-        article.save()
+        article.save(force_slug_update=False)
         article.ensure_author_gallery()
 
         # send message to user

--- a/zds/utils/__init__.py
+++ b/zds/utils/__init__.py
@@ -30,7 +30,7 @@ class ThreadLocals:
         _thread_locals.request = request
 
 
-def slugify(text):
+def old_slugify(text):
     if not defaultfilters.slugify(text).strip():
         return "--"
     else:

--- a/zds/utils/factories.py
+++ b/zds/utils/factories.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 from zds.utils.models import HelpWriting, Category
-from zds.utils import slugify
+from zds.utils import old_slugify
 from shutil import copyfile
 from os.path import basename, join
 
@@ -13,7 +13,7 @@ class HelpWritingFactory(factory.DjangoModelFactory):
         model = HelpWriting
 
     title = factory.Sequence("titre de l'image {0}".format)
-    slug = factory.LazyAttribute(lambda o: "{0}".format(slugify(o.title)))
+    slug = factory.LazyAttribute(lambda o: "{0}".format(old_slugify(o.title)))
     tablelabel = factory.LazyAttribute(lambda n: "Besoin de " + n.title)
 
     @classmethod

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -19,7 +19,7 @@ from django.contrib.auth.models import User, Permission
 from zds.member.models import Profile
 from zds.forum.models import Forum, Topic, ForumCategory
 from zds.utils.models import Tag, Category as TCategory, CategorySubCategory, SubCategory, Licence
-from zds.utils import slugify
+from zds.utils import old_slugify
 from django.conf import settings
 from django.db import transaction, IntegrityError
 from zds.tutorialv2.factories import (
@@ -326,7 +326,9 @@ def load_categories_content(cli, size, fake, *_, **__):
     tps1 = time.time()
     for i in range(0, nb_categories):
         ttl = str(i) + " " + fake.job()
-        cat = TCategory(title=ttl, description=fake.sentence(nb_words=15, variable_nb_words=True), slug=slugify(ttl))
+        cat = TCategory(
+            title=ttl, description=fake.sentence(nb_words=15, variable_nb_words=True), slug=old_slugify(ttl)
+        )
         cat.save()
         categories.append(cat)
         sys.stdout.write(" Cat. {}/{}  \r".format(i + 1, nb_categories))
@@ -336,7 +338,7 @@ def load_categories_content(cli, size, fake, *_, **__):
         with contextlib.suppress(IntegrityError):
             ttl = str(i * 10) + str(i) + " " + fake.word()
             subcat = SubCategory(
-                title=ttl, subtitle=fake.sentence(nb_words=5, variable_nb_words=True), slug=slugify(ttl)
+                title=ttl, subtitle=fake.sentence(nb_words=5, variable_nb_words=True), slug=old_slugify(ttl)
             )
             subcat.save()
             sub_categories.append(subcat)

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -3,7 +3,6 @@ import os
 import string
 import uuid
 import logging
-from uuslug import uuslug
 
 from django.conf import settings
 
@@ -22,9 +21,10 @@ from zds.notification import signals
 from zds.mp.models import PrivateTopic
 from zds.tutorialv2.models import TYPE_CHOICES, TYPE_CHOICES_DICT
 from zds.utils.mps import send_mp
-from zds.utils import slugify
+from zds.utils import old_slugify
 from zds.utils.misc import contains_utf8mb4
 from zds.utils.templatetags.emarkdown import render_markdown
+from zds.utils.uuslug_wrapper import uuslug
 
 from model_utils.managers import InheritanceManager
 
@@ -687,7 +687,7 @@ class Tag(models.Model):
 
     def save(self, *args, **kwargs):
         self.title = self.title.strip()
-        if not self.title or not slugify(self.title.replace("-", "")):
+        if not self.title or not old_slugify(self.title.replace("-", "")):
             raise ValueError('Tag "{}" is not correct'.format(self.title))
         self.title = smart_text(self.title).lower()
         self.slug = uuslug(self.title, instance=self, max_length=Tag._meta.get_field("slug").max_length)
@@ -724,5 +724,5 @@ class HelpWriting(models.Model):
         return self.title
 
     def save(self, *args, **kwargs):
-        self.slug = slugify(self.title)
+        self.slug = old_slugify(self.title)
         super(HelpWriting, self).save(*args, **kwargs)

--- a/zds/utils/uuslug_wrapper.py
+++ b/zds/utils/uuslug_wrapper.py
@@ -1,0 +1,23 @@
+from uuslug import uuslug as uuslug_uuslug
+from uuslug import slugify as uuslug_slugify
+
+
+def wrapper(text):
+    """
+    Wrapper that removes single quotes from text.
+    """
+    return text.replace("'", "")
+
+
+def slugify(text, *args, **kwargs):
+    """
+    Wrapper around django-uuslug's slugify function
+    """
+    return uuslug_slugify(wrapper(text), *args, **kwargs)
+
+
+def uuslug(text, *args, **kwargs):
+    """
+    Wrapper around django-uuslug's uuslug function
+    """
+    return uuslug_uuslug(wrapper(text), *args, **kwargs)


### PR DESCRIPTION
Depuis la ZEP 12, les dépendances qui gèrent les slugs (`django-uuslug` et `python-slugify`) n'ont pas été mises à jour. Cela va nous poser soucis lorsqu'on passera à Django 3.x car les versions utilisées actuellement ne sont pas compatible avec cette version.

Actuellement lors de la génération des slugs, les apostrophes sont supprimées. Si on met à jour ces dépendances telles quelles, les apostrophes seront remplacées par un tiret. Actuellement, « C'est la vie » devient « cest-la-vie » mais après la mise à jour ce sera « c-est-la-vie ».

La solution retenue que j'ai retenu est de ne pas utiliser directement les fonctions `slugify` et `uuslug` proposées par `django-uuslug` mais de créer deux fonctions *wrapper* qui suppriment les apostrophes avant d'envoyer le texte à `slugify` et `uuslug`. J'ai découvert qu'en dehors des contenus une autre fonction nommée `slugify` et définie dans `zds/utils` est utilisée pour les slugs des tags, galeries, catégories de forum, etc. Pour éviter toute confusion j'ai décidé de la renommer `old_slugify` (choix arbitraire, n'hésitez pas à proposer autre chose).

Quitte à faire de la QA sur tout ce qui touche aux slugs, j'en ai profité pour vérifier que tous les appels à `content.save()` dans le code spécifient bien la valeur de `force_slug_update`. Ensuite, j'ai inversé la logique : appeler `content.save()` ne met pas à jour le slug sauf lorsque le slug est vide (c'est-à-dire à la création du contenu) ou lorsque `force_slug_update=True` est spécifié.

Closes #6000 
Closes #3553 (qui a mon avis est identique à #6000)

**QA :**

- Github Actions
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que le site web tourne correctement, notamment tout ce qui touche aux slugs

Merci de penser à utiliser le bouton **« Rebase and merge »** pour garder les commits séparés (et non pas « Squash and merge ») au cas où il faudrait revenir en arrière sur un commit en particulier (étant donné la criticité de ce qui touche aux slugs)