### PR TITLE
Mise à jour mineure des dépendances Python

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 -r requirements.txt
 
-coverage==5.2.1
+coverage==5.3
 PyYAML==5.3.1
-django-debug-toolbar==2.2
-flake8==3.8.3
+django-debug-toolbar==3.1.1
+flake8==3.8.4
 flake8-quotes==3.2.0
 autopep8==1.5.4
 Sphinx==2.4.4
@@ -12,4 +12,4 @@ sphinx_rtd_theme==0.5.0
 Faker==3.0.0
 mock==3.0.5
 colorlog==4.2.1
-django-extensions==3.0.7
+django-extensions==3.0.9

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -3,4 +3,4 @@
 gunicorn==20.0.4
 mysqlclient==2.0.1
 raven==6.10.0
-ujson==3.1.0
+ujson==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,21 +12,21 @@ django-munin==0.2.1
 python-memcached==1.59
 lxml==4.5.2
 factory-boy==2.8.1
-geoip2==3.0.0
+geoip2==4.1.0
 Pillow==7.2.0
-GitPython==3.1.7
+GitPython==3.1.9
 easy-thumbnails==2.7
-beautifulsoup4==4.9.1
+beautifulsoup4==4.9.3
 django-recaptcha==2.0.6
-google-api-python-client==1.11.0
+google-api-python-client==1.12.3
 toml==0.10.1
 requests==2.24.0
 homoglyphs==2.0.3
 
 # Api dependencies
-djangorestframework==3.11.0
+djangorestframework==3.12.1
 djangorestframework-xml==2.0.0
-django-filter==2.3.0
+django-filter==2.4.0
 django-oauth-toolkit==1.3.2
 drf-extensions==0.6.0
 django-rest-swagger==2.2.0


### PR DESCRIPTION
Mise à jour des dépendances Python qui sont très simples à mettre à jour

**QA :**

- Travis
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que le site web tourne correctement