### PR TITLE
On utilise Mock depuis la bibliothèque standard

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,5 @@ Sphinx==3.2.1
 selenium==3.141.0
 sphinx_rtd_theme==0.5.0
 Faker==3.0.0
-mock==3.0.5
 colorlog==4.2.1
 django-extensions==3.0.9

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from smtplib import SMTPException
 
 from django.core.mail.backends.base import BaseEmailBackend
-from mock import Mock
+from unittest.mock import Mock
 from oauth2_provider.models import AccessToken, Application
 
 from django.conf import settings

--- a/zds/tutorialv2/tests/tests_views/tests_stats.py
+++ b/zds/tutorialv2/tests/tests_views/tests_stats.py
@@ -1,8 +1,8 @@
 import datetime
 from copy import deepcopy
 from random import randint, uniform, shuffle
+from unittest import mock
 
-import mock
 from django.conf import settings
 from django.urls import reverse
 from django.test import TestCase


### PR DESCRIPTION
On utilise Mock depuis la bibliothèque standard

> mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.

**QA :**
- Travis
- (Optionnel) `source zdsenv/bin/activate && make update` puis vérifier que `make test-back` fonctionne bien en local (aussi bien que sur `upstream/dev` à minima)