### PR TITLE
Migration vers ElasticSearch 7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ zmd-stop: ## Stop the zmarkdown server
 ## ~ Elastic Search
 
 run-elasticsearch: ## Run the Elastic Search server
-	elasticsearch || echo 'No Elastic Search installed (you can add it locally with `./scripts/install_zds.sh +elastic-local`)'
+	.local/elasticsearch/bin/elasticsearch || echo 'No Elastic Search installed (you can add it locally with `./scripts/install_zds.sh +elastic-local`)'
 
 index-all: ## Index the database in a new Elastic Search index
 	python manage.py es_manager index_all

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Implicit dependencies (optional dependencies of dependencies)
 social-auth-app-django==4.0.0
 python-social-auth==0.3.6
-elasticsearch==5.5.3
-elasticsearch-dsl==5.4.0
+elasticsearch==7.9.1
+elasticsearch-dsl==7.3.0
 
 # Explicit dependencies (references in code)
 Django==2.2.16

--- a/scripts/define_variable.sh
+++ b/scripts/define_variable.sh
@@ -11,7 +11,7 @@ if [[ $ZDS_NVM_VERSION == "" ]]; then
 fi
 
 if [[ $ZDS_ELASTIC_VERSION == "" ]]; then
-    ZDS_ELASTIC_VERSION="5.5.2"
+    ZDS_ELASTIC_VERSION="7.9.2"
 fi
 
 if [[ $ZDS_LATEX_REPO == "" ]]; then
@@ -27,4 +27,3 @@ fi
 if [[ $ZMD_URL == "" ]]; then
     ZMD_URL="http://localhost:27272"
 fi
-

--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -260,7 +260,7 @@ if ! $(_in "--force-skip-activating" $@) && [[ ( $VIRTUAL_ENV == "" || $(realpat
     fi
 
     zds_fold_end
-else 
+else
     print_info "!! Add \`$(realpath $ZDS_VENV)\` in your PATH."
 
     if [ ! -d $ZDS_VENV ]; then
@@ -273,7 +273,7 @@ fi
 export ZDS_ENV=$(realpath $ZDS_VENV)
 
 
-# local jdk 
+# local jdk
 if  ! $(_in "-jdk-local" $@) && ( $(_in "+jdk-local" $@) || $(_in "+full" $@) ); then
     zds_fold_start "jdk" "* [+jdk-local] installing a local version of JDK (v$ZDS_JDK_VERSION)"
 
@@ -334,18 +334,23 @@ if  ! $(_in "-elastic-local" $@) && ( $(_in "+elastic-local" $@) || $(_in "+full
         rm -r "$es_path"
     fi
 
-    wget_nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ZDS_ELASTIC_VERSION}.zip
+    # TODO - Check how to deal with other architectures and such.
+    wget_nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ZDS_ELASTIC_VERSION}-linux-x86_64.tar.gz
     if [[ $? == 0 ]]; then
-        unzip -q elasticsearch-${ZDS_ELASTIC_VERSION}.zip 
-        rm elasticsearch-${ZDS_ELASTIC_VERSION}.zip
+        tar -xzf elasticsearch-${ZDS_ELASTIC_VERSION}-linux-x86_64.tar.gz
+        rm elasticsearch-${ZDS_ELASTIC_VERSION}-linux-x86_64.tar.gz
         mv elasticsearch-${ZDS_ELASTIC_VERSION} elasticsearch
 
         # add options to reduce memory consumption
-        print_info "#Options added by install_zds.sh" >> "$es_path/config/jvm.options"
-        print_info "-Xms512m" >> "$es_path/config/jvm.options"
-        print_info "-Xmx512m" >> "$es_path/config/jvm.options"
+        options_file="$es_path/config/jvm.options.d/zds.options"
+        echo "# Options added by install_zds.sh" >> "$options_file"
+        echo "-Xms512m" >> "$options_file"
+        echo "-Xmx512m" >> "$options_file"
 
         # symbolic link to elastic start script
+        if [ -e $ZDS_ENV/bin/elasticsearch ]; then # remove previous symlink
+            rm "$ZDS_ENV/bin/elasticsearch"
+        fi
         ln -s "$es_path/bin/elasticsearch" $ZDS_ENV/bin/
     else
         print_error "!! Cannot get elasticsearch ${ZDS_ELASTIC_VERSION}"

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -41,7 +41,7 @@ class SimilarTopicsView(CreateView, SingleObjectMixin):
             self.authorized_forums = get_authorized_forums(self.request.user)
 
             search_queryset = Search()
-            query = Match(_type='topic') \
+            query = Match(type='topic') \
                 & Terms(forum_pk=self.authorized_forums) \
                 & MultiMatch(query=self.search_query, fields=['title', 'subtitle', 'tags'])
 
@@ -92,8 +92,8 @@ class SuggestionContentView(CreateView, SingleObjectMixin):
             search_queryset = Search()
             if len(excluded_content_ids) > 0 and excluded_content_ids != ['']:
                 search_queryset = search_queryset.exclude('terms', content_pk=excluded_content_ids)
-            query = Match(_type='publishedcontent') & MultiMatch(query=self.search_query,
-                                                                 fields=['title', 'description'])
+            query = Match(type='publishedcontent') & MultiMatch(query=self.search_query,
+                                                                fields=['title', 'description'])
 
             functions_score = [
                 {
@@ -210,7 +210,7 @@ class SearchView(ZdSPagingListView):
             weight_functions = []
             for _type, weights in list(settings.ZDS_APP['search']['boosts'].items()):
                 if _type in models:
-                    weight_functions.append({'filter': Match(_type=_type), 'weight': weights['global']})
+                    weight_functions.append({'filter': Match(type=_type), 'weight': weights['global']})
 
             scored_queryset = FunctionScore(query=queryset, boost_mode='multiply', functions=weight_functions)
             search_queryset = search_queryset.query(scored_queryset)
@@ -272,7 +272,7 @@ class SearchView(ZdSPagingListView):
     def get_queryset_chapters(self):
         """Search in content chapters."""
 
-        query = Match(_type='chapter') \
+        query = Match(type='chapter') \
             & MultiMatch(query=self.search_query, fields=['title', 'text'])
 
         if self.content_category:
@@ -293,7 +293,7 @@ class SearchView(ZdSPagingListView):
         + topic is locked.
         """
 
-        query = Match(_type='topic') \
+        query = Match(type='topic') \
             & Terms(forum_pk=self.authorized_forums) \
             & MultiMatch(query=self.search_query, fields=['title', 'subtitle', 'tags'])
 
@@ -317,7 +317,7 @@ class SearchView(ZdSPagingListView):
         + post has a like/dislike ratio above (has more likes than dislikes) or below (the other way around) 1.0.
         """
 
-        query = Match(_type='post') \
+        query = Match(type='post') \
             & Terms(forum_pk=self.authorized_forums) \
             & Term(is_visible=True) \
             & MultiMatch(query=self.search_query, fields=['text_html'])

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -924,7 +924,7 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
 
     @classmethod
     def get_es_mapping(cls):
-        mapping = Mapping(cls.get_es_document_type())
+        mapping = Mapping()
 
         mapping.field('content_pk', 'integer')
         mapping.field('publication_date', Date())
@@ -1128,7 +1128,7 @@ class FakeChapter(AbstractESIndexable):
         """Define mapping and parenting
         """
 
-        mapping = Mapping(cls.get_es_document_type())
+        mapping = Mapping()
         mapping.meta('parent', type='publishedcontent')
 
         mapping.field('title', Text(boost=1.5))

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -16,8 +16,7 @@ from django.http import Http404
 from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
-from elasticsearch_dsl import Mapping, Q as ES_Q
-from elasticsearch_dsl.field import Text, Keyword, Date, Boolean
+from elasticsearch_dsl import Mapping, Text, Keyword, Date, Boolean, Q as ES_Q
 from git import Repo, BadObject
 from gitdb.exc import BadName
 from uuslug import uuslug
@@ -1125,11 +1124,11 @@ class FakeChapter(AbstractESIndexable):
         return 'chapter'
 
     @classmethod
-    def get_es_mapping(self):
+    def get_es_mapping(cls):
         """Define mapping and parenting
         """
 
-        mapping = Mapping(self.get_es_document_type())
+        mapping = Mapping(cls.get_es_document_type())
         mapping.meta('parent', type='publishedcontent')
 
         mapping.field('title', Text(boost=1.5))


### PR DESCRIPTION
L'objectif de cette PR est de mettre à jour notre moteur de recherche, qui utilise actuellement ElasticSearch 5.5, vers ES 7.

ES 6 et 7 ont apporté plusieurs changements, le plus notable étant [la suppression des types de documents](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html) que nous utilisons en interne pour différencier dans un même index les différents… types de documents (contenus, messages, …).

Cette PR devra donc : 
- [x] mettre à jour le script d'installation ainsi que le `Makefile` afin d'installer et de lancer ElasticSearch 7 ;
- [ ] mettre à jour `searchv2` afin de ne plus utiliser les types de documents (il faudra décider de comment faire : on peut ou utiliser un index par type, ou émuler nous-même un type de documents et filtrer dessus lorsqu'on fait les recherches).

Numéro du ticket concerné (optionnel) : #5554 

Si les tests échouent, c'est totalement normal pour le moment.

### Mise en production

Cette PR nécessitera la mise à jour d'ElasticSearch vers la version 7.9.2 (ou supérieur si une autre version sort entre temps) sur le serveur de production, ou bien en [effectuant une mise à jour sans interruption de service](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html), ou en remplaçant à froid ES 5.5 par ES 7.9 puis en réindexant totalement le site.

Il faudra également [mettre à jour la configuration d'Ansible](https://github.com/zestedesavoir/ansible-zestedesavoir/blob/550ccb107a6242a161729baa60460f0443418195/roles/elasticsearch/tasks/main.yml#L19-L23) pour copier le sous-dossier `jvm.options.d` en plus du fichier `jvm.options`.

### Contrôle qualité

Aucun de pertinent pour le moment. Voici ce qu'il faudra faire à terme.

- Mettre à jour (ou installer) ES sur votre instance locale : `make install-back && ./scripts/install_zds.sh +jdk-local +elastic-local`.
- Démarrer ElasticSearch : `make run-elasticsearch`.
- Vérifier que l'indexation totale fonctionne correctement : `make index-all`.
- Tester que la recherche fonctionne correctement sur le site.
- Modifier des contenus (republiés), ajouter des messages, bref, changer des trucs qu'on peut chercher sur le site.
- Vérifier que l'indexation partielle fonctionne correctement : `make index-flagged`.
- Tester que les modifications effectuées à l'avant-dernier point sont bien disponibles dans les résultats de recherche.