### PR TITLE
Ajoute le profil de Clem dans les fixtures

### DIFF
--- a/fixtures/users.yaml
+++ b/fixtures/users.yaml
@@ -151,6 +151,11 @@
     fields:
         user: 8
         last_ip_address: 192.168.0.1
+-   model: member.Profile
+    pk: 9
+    fields:
+        user: 9
+        last_ip_address: 192.168.0.1
 
 -   model: utils.Hat
     pk: 1


### PR DESCRIPTION
Lorsque @Arnaud-D a ajouté le compte Clem dans les fixtures, il a oublié d'ajouter le profil correspondant. Cela cause une erreur lors que l'on génère les fixtures : 

```
Traceback (most recent call last):
  [...]
  File "/home/situphen/Code/zds-site/zds/utils/management/commands/load_fixtures.py", line 126, in load_gallery
    UserGalleryFactory(user=profiles[user_index].user, gallery=gal)
IndexError: list index out of range
```

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make new-db`
- Vérifier que la commande `make new-db` n'échoue pas