### PR TITLE
Distingue les sujets lus et non-lus sur la page des derniers sujets

### DIFF
--- a/zds/forum/urls.py
+++ b/zds/forum/urls.py
@@ -3,7 +3,7 @@ from django.urls import re_path
 from zds.forum import feeds
 from zds.forum.views import CategoriesForumsListView, ForumCategoryForumsDetailView, ForumTopicsListView, \
     TopicPostsListView, TopicNew, TopicEdit, FindTopic, FindTopicByTag, PostNew, PostEdit, PostSignal, \
-    PostPotentialSpam, PostUseful, PostUnread, FindPost, solve_alert, ManageGitHubIssue, LastTopicsViewTests, \
+    PostPotentialSpam, PostUseful, PostUnread, FindPost, solve_alert, ManageGitHubIssue, LastTopicsListView, \
     FindFollowedTopic
 
 urlpatterns = [
@@ -57,7 +57,7 @@ urlpatterns = [
 
     # Last subjects.
     re_path(r'^derniers-sujets/$',
-            LastTopicsViewTests.as_view(), name='last-subjects'),
+            LastTopicsListView.as_view(), name='last-subjects'),
 
     # Categories and forums list.
     re_path(r'^$', CategoriesForumsListView.as_view(), name='cats-forums-list'),

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -75,6 +75,15 @@ class LastTopicsViewTests(ListView):
             .order_by(query_order)[:settings.ZDS_APP['forum']['topics_per_page']]
         return topics
 
+    def get_context_data(self, **kwargs):
+        context = super(LastTopicsViewTests, self).get_context_data(**kwargs)
+
+        context.update({
+            'topic_read': TopicRead.objects.list_read_topic_pk(self.request.user, context['topics'])
+        })
+
+        return context
+
 
 class ForumTopicsListView(FilterMixin, ForumEditMixin, ZdSPagingListView, UpdateView, SingleObjectMixin):
 

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -57,7 +57,7 @@ class ForumCategoryForumsDetailView(DetailView):
         return context
 
 
-class LastTopicsViewTests(ListView):
+class LastTopicsListView(ListView):
 
     context_object_name = 'topics'
     template_name = 'forum/last_topics.html'
@@ -76,7 +76,7 @@ class LastTopicsViewTests(ListView):
         return topics
 
     def get_context_data(self, **kwargs):
-        context = super(LastTopicsViewTests, self).get_context_data(**kwargs)
+        context = super(LastTopicsListView, self).get_context_data(**kwargs)
 
         context.update({
             'topic_read': TopicRead.objects.list_read_topic_pk(self.request.user, context['topics'])


### PR DESCRIPTION
Fix #5748

### Contrôle qualité

Aller sur la page http://127.0.0.1:8000/forums/derniers-sujets/ en étant connecté et s'assurer qu'on distingue les sujets lus et ceux qui ne sont pas lus.

Question subsidiaire: pourquoi la classe de la vue pour la liste des derniers sujets s'appelle `LastTopicViewTests` ? Pourquoi `Tests` dans le nom ?