### PR TITLE
Fix #4539 : problème de duplication lors de la souscription à un forum

### DIFF
--- a/zds/notification/managers.py
+++ b/zds/notification/managers.py
@@ -80,7 +80,7 @@ class SubscriptionManager(models.Manager):
         # boolean creation flag is useless for us. Use default method because of its robustness
         subscription = self.get_or_create(
             object_id=content_object.pk,
-            content_type__pk=content_type.pk,
+            content_type=content_type,
             user=user)
         if not subscription.is_active:
             subscription.activate()

--- a/zds/notification/managers.py
+++ b/zds/notification/managers.py
@@ -77,16 +77,13 @@ class SubscriptionManager(models.Manager):
         :return: subscription
         """
         content_type = ContentType.objects.get_for_model(content_object)
-        try:
-            subscription = self.get(
-                object_id=content_object.pk,
-                content_type__pk=content_type.pk,
-                user=user)
-            if not subscription.is_active:
-                subscription.activate()
-        except ObjectDoesNotExist:
-            subscription = self.model(user=user, content_object=content_object)
-            subscription.save()
+        # boolean creation flag is useless for us. Use default method because of its robustness
+        subscription = self.get_or_create(
+            object_id=content_object.pk,
+            content_type__pk=content_type.pk,
+            user=user)
+        if not subscription.is_active:
+            subscription.activate()
 
         return subscription
 

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -440,3 +440,13 @@ class SubscriptionsTest(TestCase):
         send_message_mp(self.userOAuth2, topic, '', send_by_mail=True)
 
         self.assertEqual(1, len(mail.outbox))
+
+    def test_follow_by_email_after_normal(self):
+        forum = ForumFactory(category=ForumCategoryFactory())
+        user = ProfileFactory()
+        subsription = NewTopicSubscription.objects.toggle_follow(forum, user)
+        self.assertIsNotNone(subsription)
+        new_subsription = NewTopicSubscription.objects.toggle_follow(forum, user, by_email=True)
+        self.assertIsNotNone(new_subsription)
+        self.assertEqual(subsription.pk, new_subsription.pk)
+        self.assertTrue(new_subsription.by_email)

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -443,7 +443,7 @@ class SubscriptionsTest(TestCase):
 
     def test_follow_by_email_after_normal(self):
         forum = ForumFactory(category=ForumCategoryFactory())
-        user = ProfileFactory()
+        user = ProfileFactory().user
         subsription = NewTopicSubscription.objects.toggle_follow(forum, user)
         self.assertIsNotNone(subsription)
         new_subsription = NewTopicSubscription.objects.toggle_follow(forum, user, by_email=True)


### PR DESCRIPTION
# QA 

- Souscrire à un forum sans activer la souscription par email
- Souscrire avec email sans désactiver la précédente souscription


