### PR TITLE
suppression de jquery du fichier d'accessibilité et correction de bugs

### DIFF
--- a/assets/js/accessibility-links.js
+++ b/assets/js/accessibility-links.js
@@ -6,29 +6,29 @@
 
 (function() {
   function isHidden(el) {
-    var style = window.getComputedStyle(el)
+    const style = window.getComputedStyle(el)
     return (style.display === 'none')
   }
 
   function accessibility(element) {
-    element.addEventListener('focus', function() {
+    element.addEventListener('focus', () => {
       Array.from(document.querySelectorAll('.dropdown'))
         .filter(item => !isHidden(item))
         .forEach(item => item.parentElement.querySelector('.active').classList.remove('active'))
       document.querySelector('#accessibility').classList.add('focused')
     })
-    element.addEventListener('blur', function() {
+    element.addEventListener('blur', () => {
       document.querySelector('#accessibility').classList.remove('focused')
     })
-    element.addEventListener('click', function() {
-      var link = this.getAttribute('href')
-      setTimeout(function() { // Forces the focus on next tick
+    element.addEventListener('click', () => {
+      const link = this.getAttribute('href')
+      setTimeout(() => { // Forces the focus on next tick
         document.querySelectorAll(link).item(0).focus() // Focus the first focusable element
       })
     })
   }
 
-  window.addEventListener('DOMContentLoaded', function() {
+  window.addEventListener('DOMContentLoaded', () => {
     Array.from(document.querySelectorAll('#accessibility a')).forEach(item => accessibility(item))
   })
 })()

--- a/assets/js/accessibility-links.js
+++ b/assets/js/accessibility-links.js
@@ -1,21 +1,34 @@
 /* ===== Zeste de Savoir ====================================================
    Managment of accessibility links
    ---------------------------------
-   Author: Alex-D / Alexandre Demode
+   Author: Alex-D / Alexandre Demode, firm1
    ========================================================================== */
 
-(function($) {
-  'use strict'
+(function() {
+  function isHidden(el) {
+    var style = window.getComputedStyle(el)
+    return (style.display === 'none')
+  }
 
-  $('#accessibility a').on('focus', function() {
-    $('.dropdown:visible').parent().find('.active').removeClass('active')
-    $('#accessibility').addClass('focused')
-  }).on('blur', function() {
-    $('#accessibility').removeClass('focused')
-  }).on('click', function() {
-    var link = $(this).attr('href')
-    setTimeout(function() { // Forces the focus on next tick
-      $(link).find(':tabbable').first().focus() // Focus the first focusable element
+  function accessibility(element) {
+    element.addEventListener('focus', function() {
+      Array.from(document.querySelectorAll('.dropdown'))
+        .filter(item => !isHidden(item))
+        .forEach(item => item.parentElement.querySelector('.active').classList.remove('active'))
+      document.querySelector('#accessibility').classList.add('focused')
     })
+    element.addEventListener('blur', function() {
+      document.querySelector('#accessibility').classList.remove('focused')
+    })
+    element.addEventListener('click', function() {
+      var link = this.getAttribute('href')
+      setTimeout(function() { // Forces the focus on next tick
+        document.querySelectorAll(link).item(0).focus() // Focus the first focusable element
+      })
+    })
+  }
+
+  window.addEventListener('DOMContentLoaded', function() {
+    Array.from(document.querySelectorAll('#accessibility a')).forEach(item => accessibility(item))
   })
-})(jQuery)
+})()

--- a/templates/base.html
+++ b/templates/base.html
@@ -171,7 +171,7 @@
                 <a href="#content" accesskey="s">{% trans "Aller au contenu" %}</a>
             </li>
             <li>
-                <a href="#{% block searchbox_id %}search{% endblock %}" accesskey="4">{% trans "Aller à la recherche" %}</a>
+                <a href="#{% block searchbox_id %}search-top{% endblock %}" accesskey="4">{% trans "Aller à la recherche" %}</a>
             </li>
         </ul>
 
@@ -201,7 +201,7 @@
                 </div>
                 <div class="search header-right" id="search">
                     <form action="{% url "search:query" %}">
-                        <input type="text" name="q" placeholder="{% trans "Rechercher" %}" title="{% trans "Contenu de la recherche" %}">
+                        <input id="search-top" type="text" name="q" placeholder="{% trans "Rechercher" %}" title="{% trans "Contenu de la recherche" %}">
                         <button type="submit" class="ico-after search-submit" title="{% trans "Lancer la recherche" %}">{% trans "OK" %}</button>
                     </form>
                     <a href="{% url "search:query" %}" title="{% trans "Recherche avancée" %}" class="search-more"></a>

--- a/templates/tutorialv2/view/base_categories.html
+++ b/templates/tutorialv2/view/base_categories.html
@@ -52,7 +52,7 @@
 
 {% block body_class %}flexpage{% endblock %}
 
-
+{% block searchbox_id %}search-content{% endblock %}
 
 {% block content_out %}
     <section class="flexpage-header">
@@ -116,8 +116,8 @@
                     {% if level < 4 %}
                         <div class="aside">
                             <form action="{% url 'search:query' %}" id="search-form" class="search" method="get">
-                                <label for="id_q" class="control-label">{% trans 'Recherche' %}</label>
-                                <input id="id_q" maxlength="150" name="q" required="required" type="search" placeholder="{% trans 'dans' %} {% if subcategory %}{{ subcategory.title }}{% elif category %}{{ category.title }}{% else %}{% trans 'la bibliothèque' %}{% endif %}">
+                                <label for="search-content" class="control-label">{% trans 'Recherche' %}</label>
+                                <input id="search-content" maxlength="150" name="q" required="required" type="search" placeholder="{% trans 'dans' %} {% if subcategory %}{{ subcategory.title }}{% elif category %}{{ category.title }}{% else %}{% trans 'la bibliothèque' %}{% endif %}">
                                 <input type="hidden" name="models" value="content">
                                 <input type="hidden" name="from_library" value="on">
                                 {% if category %}

--- a/zds/searchv2/forms.py
+++ b/zds/searchv2/forms.py
@@ -18,7 +18,8 @@ class SearchForm(forms.Form):
         widget=forms.TextInput(
             attrs={
                 'type': 'search',
-                'required': 'required'
+                'required': 'required',
+                'id': "search-home"
             }
         )
     )

--- a/zds/searchv2/forms.py
+++ b/zds/searchv2/forms.py
@@ -19,7 +19,7 @@ class SearchForm(forms.Form):
             attrs={
                 'type': 'search',
                 'required': 'required',
-                'id': "search-home"
+                'id': 'search-home'
             }
         )
     )


### PR DESCRIPTION
Cette PR permet de retirer la dépendance jquery sur le fichier `accessibility-links.js`, et en profite pour corriger les bugs découverts qui est : si on essaye d'acceder à la zone de recherche de la page d'accueil ou la page de la bibliothèque depuis le menu d'accessibilité, on est pas renvoyé au bon endroit.

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné (optionnel) : #5786 

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

Par exemple :

- Avant de lancer le site `make run-back` assurez-vous d'avoir buildé le front `make build-front`
- Lancez le site `make run-back`
- Allez sur la page d'accueil et tenter d'acceder au menu d'accessibilité (appuyer sur la touche tab après avoir raffraichi votre fenêtre) et vérifiez que les 3 liens fonctionnent bien.

Ci-dessous une capture du menu d'accessibilité 

![Capture d’écran de 2020-10-11 17-40-21](https://user-images.githubusercontent.com/6066015/95683029-fe32ea80-0be8-11eb-832f-07ffb595843e.png)

<!-- Merci ! -->
