### PR TITLE
Ajoute la commande format-front au Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,10 @@ build-front: ## Build the frontend assets (CSS, JS, images)
 watch-front: ## Build the frontend assets when they are modified
 	yarn run watch --speed
 
-lint-front: ## Lint the frontend's Javascript
+format-front: ## Format the Javascript code
+	yarn run lint --fix
+
+lint-front: ## Lint the Javascript code
 	yarn run lint
 
 clean-front: ## Clean the frontend builds


### PR DESCRIPTION
Ajoute la commande format-front au Makefile

**QA :**

- `source zdsenv/bin/activate`
- modifier un fichier javascript en ne respectant pas les règles de ESLint
- vérifier que `make lint-front` retourne bien une erreur
- vérifier que `make format-front` se lance bien
- vérifier que `make lint-front` ne retourne plus d'erreur
