### PR TITLE
Découple le module de MP des notifications

### DIFF
--- a/zds/mp/commons.py
+++ b/zds/mp/commons.py
@@ -6,7 +6,7 @@ from django.shortcuts import get_object_or_404
 
 from zds.mp.models import PrivateTopicRead, PrivatePost
 from zds.utils.templatetags.emarkdown import emarkdown
-from zds.notification import signals
+from zds.mp import signals
 
 
 class LeavePrivateTopic(object):
@@ -63,7 +63,7 @@ class UpdatePrivatePost(object):
             except PrivateTopicRead.DoesNotExist:  # record already removed, nothing to do
                 pass
 
-        signals.answer_unread.send(sender=post.privatetopic.__class__, instance=post, user=user)
+        signals.message_unread.send(sender=post.privatetopic.__class__, instance=post, user=user)
 
 
 class SinglePrivatePostObjectMixin(SingleObjectMixin):

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from django.db import models
 
 from zds.mp.managers import PrivateTopicManager, PrivatePostManager
-from zds import notification
 from zds.mp import signals
 from zds.utils import get_current_user, slugify
 
@@ -468,4 +467,4 @@ def mark_read(privatetopic, user=None):
         topic = PrivateTopicRead(privatepost=privatetopic.last_message, privatetopic=privatetopic, user=user)
 
     topic.save()
-    notification.signals.content_read.send(sender=privatetopic.__class__, instance=privatetopic, user=user)
+    signals.topic_read.send(sender=privatetopic.__class__, instance=privatetopic, user=user)

--- a/zds/mp/signals.py
+++ b/zds/mp/signals.py
@@ -1,4 +1,12 @@
 from django.dispatch import Signal
 
+# New message management
+message_added = Signal(providing_args=['instance', 'user', 'by_email'])
+
+# Read/Unread management
+topic_read = Signal(providing_args=['instance', 'user', 'target'])
+message_unread = Signal(providing_args=['instance', 'user'])
+
+# Participant management
 participant_added = Signal(providing_args=['instance'])
 participant_removed = Signal(providing_args=['instance'])

--- a/zds/mp/tests/tests_models.py
+++ b/zds/mp/tests/tests_models.py
@@ -1,4 +1,5 @@
 from math import ceil
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.urls import reverse
@@ -307,7 +308,8 @@ class FunctionTest(TestCase):
         mark_read(self.topic1, self.profile1.user)
         self.assertFalse(is_privatetopic_unread(self.topic1, self.profile1.user))
 
-    def test_mark_read(self):
+    @patch('zds.mp.signals.topic_read')
+    def test_mark_read(self, topic_read):
         self.assertTrue(self.topic1.is_unread(self.profile1.user))
 
         # scenario - topic1 :
@@ -315,6 +317,7 @@ class FunctionTest(TestCase):
         # post2 - user2 - read
         mark_read(self.topic1, self.profile1.user)
         self.assertFalse(self.topic1.is_unread(self.profile1.user))
+        self.assertEqual(topic_read.send.call_count, 1)
 
         # scenario - topic1 :
         # post1 - user1 - read

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch
+
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import Group
 
 from zds.member.factories import ProfileFactory, UserFactory
+from zds.mp import signals
 from zds.mp.factories import PrivateTopicFactory, PrivatePostFactory
 from zds.mp.models import PrivateTopic, PrivatePost, PrivateTopicRead, mark_read
 from zds.utils.models import Hat
@@ -1175,6 +1178,7 @@ class PrivatePostUnreadTest(TestCase):
             author=self.participant.user,
             position_in_topic=2)
 
+
     def test_denies_anonymous(self):
         """Test the case of an unauthenticated user trying to unread a private post."""
         self.client.logout()
@@ -1213,7 +1217,8 @@ class PrivatePostUnreadTest(TestCase):
         result = self.client.get(reverse('private-post-unread') + '?message=' + str(self.post2.pk), follow=False)
         self.assertEqual(result.status_code, 403)
 
-    def test_unread_first_post(self):
+    @patch('zds.mp.signals.message_unread')
+    def test_unread_first_post(self, message_unread):
         self.assertTrue(self.client.login(username=self.participant.user.username, password='hostel77'))
         result = self.client.get(
             reverse('private-post-unread') + '?message=' + str(self.post1.pk),
@@ -1221,8 +1226,10 @@ class PrivatePostUnreadTest(TestCase):
         self.assertRedirects(result, reverse('mp-list'))
         with self.assertRaises(PrivateTopicRead.DoesNotExist):
             PrivateTopicRead.objects.get(privatetopic=self.post1.privatetopic, user=self.participant.user)
+        self.assertEqual(message_unread.send.call_count, 1)
 
-    def test_unread_normal_post(self):
+    @patch('zds.mp.signals.message_unread')
+    def test_unread_normal_post(self, message_unread):
         self.assertTrue(self.client.login(username=self.participant.user.username, password='hostel77'))
         self.client.get(
             reverse('private-post-unread') + '?message=' + str(self.post2.pk),
@@ -1231,8 +1238,10 @@ class PrivatePostUnreadTest(TestCase):
         self.assertEqual(topic_read.privatetopic, self.topic1)
         self.assertEqual(topic_read.user, self.participant.user)
         self.assertEqual(topic_read.privatepost, self.post1)
+        self.assertEqual(message_unread.send.call_count, 1)
 
-    def test_multiple_unread1(self):
+    @patch('zds.mp.signals.message_unread')
+    def test_multiple_unread1(self, message_unread):
         self.assertTrue(self.client.login(username=self.participant.user.username, password='hostel77'))
         self.client.get(
             reverse('private-post-unread') + '?message=' + str(self.post1.pk),
@@ -1244,8 +1253,10 @@ class PrivatePostUnreadTest(TestCase):
         self.assertEqual(topic_read.privatetopic, self.topic1)
         self.assertEqual(topic_read.user, self.participant.user)
         self.assertEqual(topic_read.privatepost, self.post1)
+        self.assertEqual(message_unread.send.call_count, 2)
 
-    def test_multiple_unread2(self):
+    @patch('zds.mp.signals.message_unread')
+    def test_multiple_unread2(self, message_unread):
         self.assertTrue(self.client.login(username=self.participant.user.username, password='hostel77'))
         self.client.get(
             reverse('private-post-unread') + '?message=' + str(self.post1.pk),
@@ -1255,6 +1266,7 @@ class PrivatePostUnreadTest(TestCase):
             follow=True)
         with self.assertRaises(PrivateTopicRead.DoesNotExist):
             PrivateTopicRead.objects.get(privatetopic=self.post1.privatetopic, user=self.participant.user)
+        self.assertEqual(message_unread.send.call_count, 2)
 
     def test_no_interference(self):
         mark_read(self.topic1, self.author.user)

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from django.contrib.auth.models import Group
 
 from zds.member.factories import ProfileFactory, UserFactory
-from zds.mp import signals
 from zds.mp.factories import PrivateTopicFactory, PrivatePostFactory
 from zds.mp.models import PrivateTopic, PrivatePost, PrivateTopicRead, mark_read
 from zds.utils.models import Hat
@@ -1177,7 +1176,6 @@ class PrivatePostUnreadTest(TestCase):
             privatetopic=self.topic1,
             author=self.participant.user,
             position_in_topic=2)
-
 
     def test_denies_anonymous(self):
         """Test the case of an unauthenticated user trying to unread a private post."""

--- a/zds/utils/mps.py
+++ b/zds/utils/mps.py
@@ -6,7 +6,7 @@ from django.template.loader import render_to_string
 import logging
 
 from zds.mp.models import PrivateTopic, PrivatePost, mark_read
-from zds.notification import signals
+from zds.mp import signals
 from zds.utils.templatetags.emarkdown import emarkdown
 
 logger = logging.getLogger(__name__)
@@ -110,8 +110,8 @@ def send_message_mp(
     n_topic.save()
 
     if not direct:
-        signals.new_content.send(sender=post.__class__, instance=post, by_email=send_by_mail,
-                                 no_notification_for=no_notification_for)
+        signals.message_added.send(sender=post.__class__, instance=post, by_email=send_by_mail,
+                                   no_notification_for=no_notification_for)
 
     if send_by_mail and direct:
         subject = '{} : {}'.format(settings.ZDS_APP['site']['literal_name'], n_topic.title)


### PR DESCRIPTION
## Contexte

Pour #5940, je vais avoir besoin d'utiliser le module de notification, mais la manière dont il est fait à tendance à créer des imbroglio avec les dépendances. La solution que j'envisage est de découpler mieux le module de notification des modules qui envoie des signaux.

## Le problème

Actuellement, on a :

- le module de notification qui _définit_ des signaux ;
- les autres modules qui _importent_ ces signaux pour les envoyer au moment opportun (et parfois _importent_ carrément le module de notification pour créer des abonnements) ;
- le module de notification qui _reçoit_ ces signaux et _importe_ ce qu'il faut des autres modules pour gérer les notifications associées.

On a donc des imports dans les deux sens, ce qui fait un couplage assez fort. 

## Une solution

Un design plus pratique est de rendre le module de notification entièrement invisible pour tous les autres modules. Seul le module de notification aurait connaissance des autres modules. Les autres modules se contentent d'envoyer des signaux pour informer les récepteurs de ce qu'ils sont entrain de faire.

Mon but est d'aller vers cette architecture :

- chaque module définit lui-même les signaux qui sont utiles pour observer son comportement (création, ajout de message, suppression, ajout ou retrait de participants, etc.) ;
- le module de notification écoute ces signaux et gère tout ce qui concerne les notif (abonnements et notif elles-mêmes).

---

## La présente PR

Cette PR est une première étape, qui s'occupe *uniquement du module de MP*. Les autres viendront plus tard.

On a ici :

- la création de signaux directement dans le module de MP pour remplacer ceux précédemment importés du module de notification ;
- la mise à jour des tests existants pour vérifier le bon envoi des signaux ;
- la mise à jour du module de notification pour écouter les signaux du module de MP au lieu de ses propres signaux comme auparavant.

 Notez que certaines choses ne sont pas vraiment testées dans les MP (les grosses fonctions utilitaires par exemple), et que je ne souhaite pas ajouter de tests pour les signaux afférants dans le cadre de cette PR.

### Contrôle qualité

- vérifier que toutes les notifications marchent correctement pour les MP (réception de MP, marquage non lu, ...)
- test unitaires