### PR TITLE
Personalise le message d'envoi d'image trop lourde

### DIFF
--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -325,7 +325,7 @@
         error = resp.responseJSON[0]
       } else if (resp.responseText !== undefined) {
         if (parseInt(resp.status) === 400) {
-          error = 'Quelque chose s\'est mal passé lors de l\'envoi. Votre image est peut-être trop lourde'
+          error = 'Quelque chose s\'est mal passé lors de l\'envoi. Votre image est peut-être trop lourde.'
         } else {
           error = 'Erreur ' + resp.status + ' ' + resp.statusText + ' : ' + "'" + resp.responseText.split('\n')[0] + "'"
         }

--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -299,7 +299,7 @@
   }
 
   var uploadImage = function(file, onSuccess, onError) {
-    var galleryUrl = '/api/galeries/' + document.body.getAttribute('data-gallery') + '/images/'
+    const galleryUrl = '/api/galeries/' + document.body.getAttribute('data-gallery') + '/images/'
 
     var formData = new FormData()
     formData.append('physical', file)
@@ -324,7 +324,11 @@
       } else if (resp.responseJSON !== undefined) {
         error = resp.responseJSON[0]
       } else if (resp.responseText !== undefined) {
-        error = 'Erreur ' + resp.status + ' ' + resp.statusText + ' : ' + "'" + resp.responseText.split('\n')[0] + "'"
+        if (parseInt(resp.status) === 400) {
+          error = 'Quelque chose s\'est mal passé lors de l\'envoi. Votre image est peut-être trop lourde'
+        } else {
+          error = 'Erreur ' + resp.status + ' ' + resp.statusText + ' : ' + "'" + resp.responseText.split('\n')[0] + "'"
+        }
       } else if (resp.readyState === 0 && resp.statusText === 'error') {
         error = 'Oups ! Impossible de se connecter au serveur.'
       }


### PR DESCRIPTION
Cette PR corrige le problème des images tellement lourdes que nginx les refuse avant même d'arriver à l'api.

Numéro du ticket concerné (optionnel) : #5818

### Contrôle qualité

Cette PR doit être **testée sur la beta**, car le souci arrive quand on a nginx en frontal.

Donc, en allant sur la beta, il faut : 

- Aller sur un sujet de forum ou un contenu (sur le nouvel éditeur) et essayer de glisser/deposer une image de plus de 5 Mb et constatez que le message d'erreur renvoyé est plutôt clair.