### PR TITLE
Correction du retour de plein écran

### DIFF
--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -2,8 +2,6 @@ html {
     height: 100%;
     width: 100%;
     font-size: 62.5%;
-    overflow-x: hidden;
-    word-wrap: break-word;
 }
 
 body {


### PR DESCRIPTION
Cette pull request permet de corrige un problème d'ancrage. En effet, depuis le nouvel éditeur, lorsqu'on revenait du mode plein écran, on se retrouvait systématiquement en haut de la page. Cette PR corrige ce problème.


### Contrôle qualité

- Assurez vous que vous avez buildé le front `make build-front`
- Lancer le site et rendez vous sur une zone d'édition markdown (forum ou contenu) avec le nouvel éditeur
- Passez en plein écran, et appuez sur la tocuhe "Echap" pour revenir au mode normal, et constatez que vous êtes toujours sur la zone de texte, et non en haut de page.