### PR TITLE
Afficher la liste des commentaires d'un membre

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -340,7 +340,7 @@
                                     </div>
                                 {% endif %}
 
-                                {% if public_tutos_count > 0 or articles_public_count > 0 or opinions_public_count > 0 %}
+                                {% if public_tutos_count > 0 or articles_public_count > 0 or opinions_public_count > 0 or content_reactions_count > 0 %}
                                     <div class="linkbox-item primary">
                                         <div class="head">
                                             <h3>{% trans 'Contenus' %}</h3>

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -381,6 +381,17 @@
                                                 </p>
                                             </a>
                                         {% endif %}
+                                        {% if content_reactions_count > 0 %}
+                                            <a href="{% url "content:list-content-reactions" usr.pk %}" class="tail">
+                                                <p>
+                                                    {% blocktrans count content_reactions_count=content_reactions_count %}
+                                                        <span class="bold">{{ content_reactions_count }}</span> commentaire publié
+                                                    {% plural %}
+                                                        <span class="bold">{{ content_reactions_count }}</span> commentaires publiés
+                                                    {% endblocktrans %}
+                                                </p>
+                                            </a>
+                                        {% endif %}
                                     </div>
                                 {% endif %}
                                 {% if contribution_tutorials_count > 0 or contribution_articles_count > 0 %}

--- a/templates/tutorialv2/comment/list.html
+++ b/templates/tutorialv2/comment/list.html
@@ -7,13 +7,13 @@
 
 
 {% block title %}
-    {% trans "Messages postés par" %} {{ usr.username }}
+    {% trans "Commentaires postés par" %} {{ usr.username }}
 {% endblock %}
 
 
 
 {% block headline %}
-    {% trans "Messages postés par" %} "{{ usr.username }}"
+    {% trans "Commentaires postés par" %} "{{ usr.username }}"
 {% endblock %}
 
 
@@ -22,7 +22,7 @@
     {% with profile=usr|profile %}
         <li><a href="{{ profile.get_absolute_url }}">{{ usr.username }}</a></li>
     {% endwith %}
-    <li><a href="{% url 'post-find' usr.pk %}">{% trans "Messages postés" %}</a></li>
+    <li><a href="{% url 'content:list-content-reactions' usr.pk %}">{% trans "Commentaires postés" %}</a></li>
     <li>{% trans "Recherche" %}</li>
 {% endblock %}
 
@@ -30,47 +30,47 @@
 
 {% block content %}
 
-    {% if hidden_posts_count %}
+    {% if hidden_content_reactions_count %}
         <p class="alert-box info">
-            {% blocktrans count counter=hidden_posts_count %}
-                {{ counter }} message est invisible car dans un sujet inaccessible.
+            {% blocktrans count counter=hidden_content_reactions_count %}
+                {{ counter }} commentaire est invisible car dans une publication inaccessible.
             {% plural %}
-                {{ counter }} messages sont invisibles car dans un sujet inaccessible.
+                {{ counter }} commentaires sont invisibles car dans une publication inaccessible.
             {% endblocktrans %}
         </p>
     {% endif %}
 
     {% include "misc/paginator.html" with position="top" %}
 
-    {% if posts %}
+    {% if content_reactions %}
         <div class="table-wrapper">
             <table>
                 <thead>
                     <tr>
-                        <th width="15%">{% trans "Sujet" %}</th>
+                        <th width="15%">{% trans "Publication" %}</th>
                         <th width="10%">{% trans "Date" %}</th>
                         <th width="30%">{% trans "Extrait" %}</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {% for post in posts %}
+                    {% for content_reaction in content_reactions %}
                         <tr>
                             <td>
-                                <div class="forum-entry-title {% if user.is_authenticated %} {% if topic.is_unread %} unread {% endif %} {% endif %}">
-                                    <a href="{{ post.get_absolute_url }}">{{ post.topic.title }} </a>
-                                    {% if post.topic.subtitle %} <p> {{ post.topic.subtitle }} </p> {% endif %}
+                                <div class="forum-entry-title">
+                                    <a href="{{ content_reaction.get_absolute_url }}">{{ content_reaction.related_content.title }} </a>
+                                    {% if content_reaction.related_content.description %} <p> {{ content_reaction.related_content.description }} </p> {% endif %}
                                 </div>
                             </td>
                             <td>
-                                {{ post.pubdate|format_date }}
+                                {{ content_reaction.pubdate|format_date }}
                             </td>
                             <td>
-                                {% if post.is_visible %}
-                                    {{ post.text|truncatechars:200 }}
+                                {% if content_reaction.is_visible %}
+                                    {{ content_reaction.text|truncatechars:200 }}
                                 {% else %}
-                                    {% if post.text_hidden %}
-                                        {% trans "Masqué par" %} {{ post.editor }}
-                                        : {{ post.text_hidden }}
+                                    {% if content_reaction.text_hidden %}
+                                        {% trans "Masqué par" %} {{ content_reaction.editor }}
+                                        : {{ content_reaction.text_hidden }}
                                     {% endif %}
                                 {% endif %}
                             </td>
@@ -81,7 +81,7 @@
         </div>
     {% else %}
         <p>
-            {% trans "Aucun message n’a été posté par" %} {{ usr.username }}.
+            {% trans "Aucun commentaire n’a été content_reactioné par" %} {{ usr.username }}.
         </p>
     {% endif %}
 

--- a/templates/tutorialv2/comment/list.html
+++ b/templates/tutorialv2/comment/list.html
@@ -1,0 +1,89 @@
+{% extends "forum/base.html" %}
+{% load date %}
+{% load profile %}
+{% load emarkdown %}
+{% load i18n %}
+
+
+
+{% block title %}
+    {% trans "Messages postés par" %} {{ usr.username }}
+{% endblock %}
+
+
+
+{% block headline %}
+    {% trans "Messages postés par" %} "{{ usr.username }}"
+{% endblock %}
+
+
+
+{% block breadcrumb %}
+    {% with profile=usr|profile %}
+        <li><a href="{{ profile.get_absolute_url }}">{{ usr.username }}</a></li>
+    {% endwith %}
+    <li><a href="{% url 'post-find' usr.pk %}">{% trans "Messages postés" %}</a></li>
+    <li>{% trans "Recherche" %}</li>
+{% endblock %}
+
+
+
+{% block content %}
+
+    {% if hidden_posts_count %}
+        <p class="alert-box info">
+            {% blocktrans count counter=hidden_posts_count %}
+                {{ counter }} message est invisible car dans un sujet inaccessible.
+            {% plural %}
+                {{ counter }} messages sont invisibles car dans un sujet inaccessible.
+            {% endblocktrans %}
+        </p>
+    {% endif %}
+
+    {% include "misc/paginator.html" with position="top" %}
+
+    {% if posts %}
+        <div class="table-wrapper">
+            <table>
+                <thead>
+                    <tr>
+                        <th width="15%">{% trans "Sujet" %}</th>
+                        <th width="10%">{% trans "Date" %}</th>
+                        <th width="30%">{% trans "Extrait" %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for post in posts %}
+                        <tr>
+                            <td>
+                                <div class="forum-entry-title {% if user.is_authenticated %} {% if topic.is_unread %} unread {% endif %} {% endif %}">
+                                    <a href="{{ post.get_absolute_url }}">{{ post.topic.title }} </a>
+                                    {% if post.topic.subtitle %} <p> {{ post.topic.subtitle }} </p> {% endif %}
+                                </div>
+                            </td>
+                            <td>
+                                {{ post.pubdate|format_date }}
+                            </td>
+                            <td>
+                                {% if post.is_visible %}
+                                    {{ post.text|truncatechars:200 }}
+                                {% else %}
+                                    {% if post.text_hidden %}
+                                        {% trans "Masqué par" %} {{ post.editor }}
+                                        : {{ post.text_hidden }}
+                                    {% endif %}
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% else %}
+        <p>
+            {% trans "Aucun message n’a été posté par" %} {{ usr.username }}.
+        </p>
+    {% endif %}
+
+    {% include "misc/paginator.html" with position="bottom" %}
+{% endblock %}

--- a/templates/tutorialv2/comment/list.html
+++ b/templates/tutorialv2/comment/list.html
@@ -81,7 +81,7 @@
         </div>
     {% else %}
         <p>
-            {% trans "Aucun commentaire n’a été content_reactioné par" %} {{ usr.username }}.
+            {% trans "Aucun commentaire n’a été posté par" %} {{ usr.username }}.
         </p>
     {% endif %}
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -42,7 +42,7 @@ from zds.mp.models import PrivatePost, PrivateTopic
 from zds.notification.models import TopicAnswerSubscription, NewPublicationSubscription
 from zds.pages.models import GroupContact
 from zds.tutorialv2.models import CONTENT_TYPES
-from zds.tutorialv2.models.database import PublishedContent, PickListOperation, ContentContribution
+from zds.tutorialv2.models.database import PublishedContent, PickListOperation, ContentContribution, ContentReaction
 from zds.utils.models import Comment, CommentVote, Alert, CommentEdit, Hat, HatRequest, get_hat_from_settings, \
     get_hat_to_add
 from zds.utils.mps import send_mp
@@ -191,6 +191,7 @@ class MemberDetail(DetailView):
             .values_list('content', flat=True)\
             .distinct()\
             .count()
+        context['content_reactions_count'] = ContentReaction.objects.filter(author=usr).count()
 
         if self.request.user.has_perm('member.change_profile'):
             sanctions = list(Ban.objects.filter(user=usr).select_related('moderator'))

--- a/zds/tutorialv2/managers.py
+++ b/zds/tutorialv2/managers.py
@@ -4,6 +4,7 @@ from django.db.models import Count, F
 from django.utils.translation import ugettext_lazy as _
 
 from zds.utils.models import Tag
+from model_utils.managers import InheritanceManager
 
 
 class PublishedContentManager(models.Manager):
@@ -271,3 +272,18 @@ class PublishableContentManager(models.Manager):
             content.public_version.content = content
             published.append(content.public_version)
         return published
+
+
+class ReactionManager(InheritanceManager):
+    """
+    Custom reaction manager.
+    """
+
+    def get_all_messages_of_a_user(self, target):
+        queryset = self.filter(author=target).distinct()
+
+        queryset = queryset\
+            .prefetch_related('author')\
+            .order_by('-pubdate')
+
+        return queryset

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -28,7 +28,7 @@ from zds.gallery.models import Image, Gallery, UserGallery, GALLERY_WRITE
 from zds.mp.models import PrivateTopic
 from zds.searchv2.models import AbstractESDjangoIndexable, AbstractESIndexable, delete_document_in_elasticsearch, \
     ESIndexManager
-from zds.tutorialv2.managers import PublishedContentManager, PublishableContentManager
+from zds.tutorialv2.managers import PublishedContentManager, PublishableContentManager, ReactionManager
 from zds.tutorialv2.models import TYPE_CHOICES, STATUS_CHOICES, CONTENT_TYPES_REQUIRING_VALIDATION, PICK_OPERATIONS
 from zds.tutorialv2.models.mixins import TemplatableContentModelMixin, OnlineLinkableContentMixin
 from zds.tutorialv2.models.versioned import NotAPublicVersion
@@ -1166,6 +1166,8 @@ class ContentReaction(Comment):
     related_content = models.ForeignKey(PublishableContent, verbose_name='Contenu',
                                         on_delete=models.CASCADE,
                                         related_name='related_content_note', db_index=True)
+
+    objects = ReactionManager()
 
     def __str__(self):
         return "<Réaction pour '{0}', #{1}>".format(self.related_content, self.pk)

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -17,7 +17,7 @@ from zds.tutorialv2.views.contributors import AddContributorToContent, RemoveCon
     ContentOfContributors
 from zds.tutorialv2.views.editorialization import RemoveSuggestion, AddSuggestion, EditContentTags
 
-from zds.tutorialv2.views.lists import (TagsListView, ContentOfAuthor)
+from zds.tutorialv2.views.lists import (TagsListView, ContentOfAuthor, ListContentReactions)
 from zds.tutorialv2.views.alerts import SendContentAlert, SolveContentAlert
 from zds.tutorialv2.views.misc import RequestFeaturedContent, FollowNewContent, WarnTypo
 from zds.tutorialv2.views.statistics import ContentStatisticsView
@@ -39,6 +39,7 @@ urlpatterns = [
          ContentOfContributors.as_view(
              type='ALL', context_object_name='contribution_contents'),
          name='find-contribution-all'),
+    path('commentaires/<str:username>/', ListContentReactions.as_view(), name='list-content-reactions')
 
     path('tutoriels/<int:pk>/', RedirectOldContentOfAuthor.as_view(type='TUTORIAL')),
     path('articles/<int:pk>/', RedirectOldContentOfAuthor.as_view(type='ARTICLE')),

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -39,7 +39,7 @@ urlpatterns = [
          ContentOfContributors.as_view(
              type='ALL', context_object_name='contribution_contents'),
          name='find-contribution-all'),
-    path('commentaires/<str:username>/', ListContentReactions.as_view(), name='list-content-reactions')
+    path('commentaires/<int:pk>/', ListContentReactions.as_view(), name='list-content-reactions'),
 
     path('tutoriels/<int:pk>/', RedirectOldContentOfAuthor.as_view(type='TUTORIAL')),
     path('articles/<int:pk>/', RedirectOldContentOfAuthor.as_view(type='ARTICLE')),

--- a/zds/tutorialv2/views/lists.py
+++ b/zds/tutorialv2/views/lists.py
@@ -15,7 +15,7 @@ from zds.forum.models import Forum
 from zds.notification.models import NewPublicationSubscription
 from zds.tutorialv2.mixins import ContentTypeMixin
 from zds.tutorialv2.models import TYPE_CHOICES_DICT, CONTENT_TYPE_LIST
-from zds.tutorialv2.models.database import PublishedContent, PublishableContent
+from zds.tutorialv2.models.database import PublishedContent, PublishableContent, ContentReaction
 from zds.utils.models import Tag, Category, SubCategory, CategorySubCategory
 from zds.utils.paginator import make_pagination, ZdSPagingListView
 from zds.utils.templatetags.topbar import topbar_publication_categories
@@ -408,27 +408,26 @@ class ContentOfAuthor(ZdSPagingListView):
 
 class ListContentReactions(ZdSPagingListView):
 
-    context_object_name = 'content_reaction'
+    context_object_name = 'content_reactions'
     template_name = 'tutorialv2/comment/list.html'
     paginate_by = settings.ZDS_APP['forum']['posts_per_page']
     model = ContentReaction
     user = None
 
     def dispatch(self, request, *args, **kwargs):
-        self.user = get_object_or_404(User, username=self.kwargs['username'])
+        self.user = get_object_or_404(User, pk=self.kwargs['pk'])
         return super(ListContentReactions, self).dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
-        return ContentReaction.objects.get_all_messages_of_a_user(self.request.user, self.object)
+        return ContentReaction.objects.get_all_messages_of_a_user(self.user)
 
     def get_context_data(self, **kwargs):
         context = super(ListContentReactions, self).get_context_data(**kwargs)
 
         context.update({
             'usr': self.user,
-            'hidden_reactions_count':
-                ContentReaction.objects.filter(author=self.object).distinct().count() - context['paginator'].count,
+            'hidden_content_reactions_count':
+                ContentReaction.objects.filter(author=self.user).distinct().count() - context['paginator'].count,
         })
 
         return context
-

--- a/zds/tutorialv2/views/lists.py
+++ b/zds/tutorialv2/views/lists.py
@@ -404,3 +404,31 @@ class ContentOfAuthor(ZdSPagingListView):
                 continue
             context['filters'].append({'key': filter_, 'text': authorized_filter[1], 'icon': authorized_filter[3]})
         return context
+
+
+class ListContentReactions(ZdSPagingListView):
+
+    context_object_name = 'content_reaction'
+    template_name = 'tutorialv2/comment/list.html'
+    paginate_by = settings.ZDS_APP['forum']['posts_per_page']
+    model = ContentReaction
+    user = None
+
+    def dispatch(self, request, *args, **kwargs):
+        self.user = get_object_or_404(User, username=self.kwargs['username'])
+        return super(ListContentReactions, self).dispatch(request, *args, **kwargs)
+
+    def get_queryset(self):
+        return ContentReaction.objects.get_all_messages_of_a_user(self.request.user, self.object)
+
+    def get_context_data(self, **kwargs):
+        context = super(ListContentReactions, self).get_context_data(**kwargs)
+
+        context.update({
+            'usr': self.user,
+            'hidden_reactions_count':
+                ContentReaction.objects.filter(author=self.object).distinct().count() - context['paginator'].count,
+        })
+
+        return context
+


### PR DESCRIPTION
Cette PR (qui reprend la base commencée par @Situphen ) permet d'afficher la liste des commentaires d'un membre. C'était déjà le cas pour le forum, mais ça n'a jamais été le cas pour les commentaires de publications.

Numéro du ticket concerné (optionnel) : #5963 


### Contrôle qualité

- Démarrez le site
- Allez sur la page de profil d'un membre ayant posté des commentaires sur un contenu (`user` par exemple) et vérifiez que vous avez le bouton "X commentaires publiés" (cf. capture ci-dessous)

![Capture d’écran de 2020-10-18 08-08-13](https://user-images.githubusercontent.com/6066015/96360012-37071e00-1119-11eb-8094-98875db94dc2.png)

- Cliquez sur ce fameux bouton, et vérifiez que vous avez accès à la page qui liste effectivement les commentaires (cf. capture ci-dessous)

![Capture d’écran de 2020-10-18 08-10-33](https://user-images.githubusercontent.com/6066015/96360036-6c137080-1119-11eb-95ac-bda9825dfd5a.png)

