### PR TITLE
Adapte le type d'une note de karma (pour eviter les erreur 500)

### DIFF
--- a/zds/member/migrations/0020_auto_20201018_0841.py
+++ b/zds/member/migrations/0020_auto_20201018_0841.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('member', '0019_profile_username_skeleton'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='karmanote',
+            name='note',
+            field=models.TextField(verbose_name='Commentaire'),
+        ),
+    ]

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -665,7 +665,7 @@ class KarmaNote(models.Model):
     user = models.ForeignKey(User, related_name='karmanote_user', db_index=True, on_delete=models.CASCADE)
     moderator = models.ForeignKey(User, related_name='karmanote_staff', db_index=True, on_delete=models.SET_NULL,
                                   null=True)
-    note = models.CharField('Commentaire', max_length=150)
+    note = models.TextField('Commentaire')
     karma = models.IntegerField('Valeur')
     pubdate = models.DateTimeField('Date d\'ajout', auto_now_add=True)
 


### PR DESCRIPTION
Cette PR adapte le type du champ note de karma pour éviter de generer une erreur 500 quand le pseudo d'un membre change (le pseudo étant utilisé pour mettre à jour le message de karma).
On ne peut pas toujours prévoir la taille d'un commentaire, on ne devrait pas limiter cette zone. Etant donné qu'il s'agit d'une valeur mise à jour uniquement par la modération (comme le commentaire de ban par exemple), on a l'assurance qu'il n y aura pas de spam par là.

Numéro du ticket concerné (optionnel) : fix #5779 


### Contrôle qualité

**NB** : Ce bug n'est reproductible que si vous utilisez mysql/mariadb comme base de donnée, et il faudrait donc faire la QA sur l'une de ces bases (sqlite la bd par defaut en local est trop permissive pour voir ce bug).

- Assurez vous d'avoir réalisé les migrations sur le site `make migrate-db`
- Connectez vous avec un utilisateur (`user` par exemple)
- Changez votre pseudo en quelque chose de très long : (`useruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruseruser` par exemple) 
- Vérifiez que vous n'avez pas d'erreur 500 

**NB2** : On pourrait se poser la question de l'autorisation d'un pseudo aussi long, c'est une autre question à traiter en dehors de cette PR je pense. Ici on traite surtout le fait que le commentaire de la note de karma est limité by design (donc je ne peux pas poster une citation trop longue du commentaire d'un membre pour alerter les modérateurs de ces propos).