### PR TITLE
Supprime l'héritage explicite depuis object

### DIFF
--- a/zds/api/validators.py
+++ b/zds/api/validators.py
@@ -1,4 +1,4 @@
-class Validator(object):
+class Validator:
     """
     Super class must be extend by classes which wants validate a model field.
     """

--- a/zds/api/views.py
+++ b/zds/api/views.py
@@ -1,7 +1,7 @@
 from rest_framework import exceptions
 
 
-class NoPatchView(object):
+class NoPatchView:
     """Raise HTTP 405 if one try to use the patch method"""
     def patch(self, request, *args, **kwargs):
         raise exceptions.MethodNotAllowed(method='PATCH')

--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -16,7 +16,7 @@ from zds.notification.models import TopicAnswerSubscription, Notification, NewTo
 from zds.utils.models import Alert, CommentEdit, get_hat_from_request
 
 
-class ForumEditMixin(object):
+class ForumEditMixin:
     @staticmethod
     def perform_follow(forum_or_tag, user):
         return NewTopicSubscription.objects.toggle_follow(forum_or_tag, user).is_active
@@ -26,7 +26,7 @@ class ForumEditMixin(object):
         return NewTopicSubscription.objects.toggle_follow(forum_or_tag, user, True).is_active
 
 
-class TopicEditMixin(object):
+class TopicEditMixin:
     @staticmethod
     def perform_follow(topic, user):
         return TopicAnswerSubscription.objects.toggle_follow(topic, user)
@@ -97,7 +97,7 @@ class TopicEditMixin(object):
         return topic
 
 
-class PostEditMixin(object):
+class PostEditMixin:
     @staticmethod
     def perform_hide_message(request, post, user, data):
         is_staff = user.has_perm('forum.change_post')

--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -14,7 +14,7 @@ from zds.utils.models import get_hat_from_settings
 from zds.utils.mps import send_mp
 
 
-class ProfileCreate(object):
+class ProfileCreate:
     def create_profile(self, data):
         """
         Creates an inactive profile in the database.
@@ -47,7 +47,7 @@ class ProfileCreate(object):
         profile.user.save()
 
 
-class TokenGenerator(object):
+class TokenGenerator:
     def generate_token(self, user):
         """
         Generates a token for member registration.
@@ -91,7 +91,7 @@ class TokenGenerator(object):
         msg.send()
 
 
-class MemberSanctionState(object):
+class MemberSanctionState:
     """
     Super class of the enumeration to know which sanction it is.
     """

--- a/zds/member/decorator.py
+++ b/zds/member/decorator.py
@@ -27,7 +27,7 @@ def can_write_and_read_now(func):
     return _can_write_and_read_now
 
 
-class PermissionRequiredMixin(object):
+class PermissionRequiredMixin:
     """
     Represent the basic code that a Generic Class Based View has to use when one or more
     permissions are required simultaneously to execute the view
@@ -43,7 +43,7 @@ class PermissionRequiredMixin(object):
         return super(PermissionRequiredMixin, self).dispatch(*args, **kwargs)
 
 
-class LoginRequiredMixin(object):
+class LoginRequiredMixin:
     """
     Represent the basic code that a Generic Class Based View has to use when
     the required action needs the user to be logged in.

--- a/zds/mp/commons.py
+++ b/zds/mp/commons.py
@@ -9,7 +9,7 @@ from zds.utils.templatetags.emarkdown import emarkdown
 from zds.mp import signals
 
 
-class LeavePrivateTopic(object):
+class LeavePrivateTopic:
     """
     Leave a private topic.
     """
@@ -25,7 +25,7 @@ class LeavePrivateTopic(object):
         raise NotImplementedError('`get_current_user()` must be implemented.')
 
 
-class UpdatePrivatePost(object):
+class UpdatePrivatePost:
     """
     Updates a private topic.
     """

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -123,7 +123,7 @@ class Subscription(models.Model):
         return Subscription.has_read_permission(request) and self.user == request.user
 
 
-class SingleNotificationMixin(object):
+class SingleNotificationMixin:
     """
     Mixin for the subscription that can only have one active notification at a time
     """
@@ -180,7 +180,7 @@ class SingleNotificationMixin(object):
             Notification.objects.filter(pk=self.last_notification.pk).update(is_read=True)
 
 
-class MultipleNotificationsMixin(object):
+class MultipleNotificationsMixin:
 
     def send_notification(self, content=None, send_email=True, sender=None):
         """

--- a/zds/searchv2/models.py
+++ b/zds/searchv2/models.py
@@ -20,7 +20,7 @@ def es_document_mapper(force_reindexing, index, obj):
     return obj.get_es_document_as_bulk_action(index, action)
 
 
-class AbstractESIndexable(object):
+class AbstractESIndexable:
     """Mixin for indexable objects.
 
     Define a number of different functions that can be overridden to tune the behavior of indexing into elasticsearch.
@@ -249,7 +249,7 @@ class NeedIndex(Exception):
     pass
 
 
-class ESIndexManager(object):
+class ESIndexManager:
     """Manage a given index with different taylor-made functions"""
 
     def __init__(self, name, shards=5, replicas=0, connection_alias='default'):

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -14,7 +14,7 @@ from zds.tutorialv2.utils import mark_read
 from zds.utils.models import HelpWriting
 
 
-class SingleContentViewMixin(object):
+class SingleContentViewMixin:
     """
     Base mixin to get only one content, and its corresponding versioned content
 
@@ -283,7 +283,7 @@ class SingleContentDetailViewMixin(SingleContentViewMixin, DetailView):
         return context
 
 
-class ContentTypeMixin(object):
+class ContentTypeMixin:
     """This class deals with the type of contents and fill context according to that"""
 
     current_content_type = None

--- a/zds/tutorialv2/models/mixins.py
+++ b/zds/tutorialv2/models/mixins.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 
-class TemplatableContentModelMixin(object):
+class TemplatableContentModelMixin:
     content_type_attribute = 'content_type'
 
     @property
@@ -72,7 +72,7 @@ class TemplatableContentModelMixin(object):
             return _('Le Contenu')
 
 
-class OnlineLinkableContentMixin(object):
+class OnlineLinkableContentMixin:
     content_type_attribute = 'content_type'
 
     def get_absolute_url_online(self):

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -72,7 +72,7 @@ class CommonLayoutVersionEditor(Layout):
         )
 
 
-class TagValidator(object):
+class TagValidator:
     """
     validate tags
     """

--- a/zds/utils/mixins.py
+++ b/zds/utils/mixins.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from zds.utils.models import Comment
 
 
-class FilterMixin(object):
+class FilterMixin:
     """
     View mixin which provides filtering for ListView.
     """
@@ -41,7 +41,7 @@ class FilterMixin(object):
         return context
 
 
-class QuoteMixin(object):
+class QuoteMixin:
     model_quote = None
 
     def build_quote(self, post_pk, user):


### PR DESCRIPTION
En Python 2, on hérite explicitement depuis object. En Python 3, c'est autorisé, mais ça ne sert à rien car c'est implicite. En conséquence, j'ai fait le ménage dans notre code pour retirer tous ces héritages.

### Contrôle qualité

Les tests unitaires suffisent.