### PR TITLE
Découple le module de notification et le module de tuto

### DIFF
--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -135,7 +135,7 @@ def mark_topic_notifications_read(sender, *, instance, user, **__):
         notification.save(update_fields=["is_read"])
 
 
-@receiver(notification_signals.content_read, sender=PublishableContent)
+@receiver(tuto_signals.content_read, sender=PublishableContent)
 @receiver(tuto_signals.content_unpublished)
 def mark_content_reactions_read(sender, *, instance, user=None, target, **__):
     """
@@ -374,7 +374,7 @@ def answer_content_reaction_event(sender, *, instance, created=True, **__):
         ContentReactionAnswerSubscription.objects.get_or_create_active(author, publishable_content)
 
 
-@receiver(notification_signals.new_content, sender=PublishableContent)
+@receiver(tuto_signals.content_published, sender=PublishableContent)
 @disable_for_loaddata
 def content_published_event(*__, instance, by_email, **___):
     """

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -13,22 +13,11 @@ from zds.forum.models import Topic, is_read
 from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.mp.models import mark_read
-from zds.notification import signals
-from zds.notification.models import (
-    Notification,
-    TopicAnswerSubscription,
-    ContentReactionAnswerSubscription,
-    PrivateTopicAnswerSubscription,
-    NewTopicSubscription,
-    NewPublicationSubscription,
-)
-from zds.tutorialv2.factories import (
-    PublishableContentFactory,
-    LicenceFactory,
-    ContentReactionFactory,
-    SubCategoryFactory,
-    PublishedContentFactory,
-)
+from zds.tutorialv2 import signals
+from zds.notification.models import Notification, TopicAnswerSubscription, ContentReactionAnswerSubscription, \
+    PrivateTopicAnswerSubscription, NewTopicSubscription, NewPublicationSubscription
+from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory, ContentReactionFactory, \
+    SubCategoryFactory, PublishedContentFactory
 from zds.tutorialv2.models.database import ContentReaction, PublishableContent
 from zds.tutorialv2.publication_utils import publish_content
 from zds.utils import old_slugify

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -14,10 +14,21 @@ from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.mp.models import mark_read
 from zds.tutorialv2 import signals
-from zds.notification.models import Notification, TopicAnswerSubscription, ContentReactionAnswerSubscription, \
-    PrivateTopicAnswerSubscription, NewTopicSubscription, NewPublicationSubscription
-from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory, ContentReactionFactory, \
-    SubCategoryFactory, PublishedContentFactory
+from zds.notification.models import (
+    Notification,
+    TopicAnswerSubscription,
+    ContentReactionAnswerSubscription,
+    PrivateTopicAnswerSubscription,
+    NewTopicSubscription,
+    NewPublicationSubscription,
+)
+from zds.tutorialv2.factories import (
+    PublishableContentFactory,
+    LicenceFactory,
+    ContentReactionFactory,
+    SubCategoryFactory,
+    PublishedContentFactory,
+)
 from zds.tutorialv2.models.database import ContentReaction, PublishableContent
 from zds.tutorialv2.publication_utils import publish_content
 from zds.utils import old_slugify

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -519,7 +519,7 @@ class NotificationPublishableContentTest(TestCase):
         self.assertIsNone(subscription)
 
         # Signal call by the view at the publication.
-        signals.new_content.send(sender=self.tuto.__class__, instance=self.tuto, by_email=False)
+        signals.content_published.send(sender=self.tuto.__class__, instance=self.tuto, by_email=False)
 
         subscription = ContentReactionAnswerSubscription.objects.get_existing(user=self.user1, content_object=self.tuto)
         self.assertTrue(subscription.is_active)
@@ -617,7 +617,7 @@ class NotificationPublishableContentTest(TestCase):
         """
         subscription = NewPublicationSubscription.objects.toggle_follow(self.user1, self.user2)
 
-        signals.new_content.send(sender=self.tuto.__class__, instance=self.tuto, by_email=False)
+        signals.content_published.send(sender=self.tuto.__class__, instance=self.tuto, by_email=False)
 
         notifications = Notification.objects.filter(subscription=subscription, is_read=False).all()
         self.assertEqual(1, len(notifications))
@@ -639,7 +639,7 @@ class NotificationPublishableContentTest(TestCase):
     def test_no_error_on_multiple_subscription(self):
         subscription = NewPublicationSubscription.objects.toggle_follow(self.user1, self.user2)
 
-        signals.new_content.send(sender=self.tuto.__class__, instance=self.tuto, by_email=False)
+        signals.content_published.send(sender=self.tuto.__class__, instance=self.tuto, by_email=False)
 
         subscription1 = Notification.objects.filter(subscription=subscription, is_read=False).first()
         subscription2 = copy.copy(subscription1)
@@ -903,7 +903,7 @@ class NotificationTest(TestCase):
         author2 = ProfileFactory()
         NewPublicationSubscription.objects.toggle_follow(author2.user, author1.user)
         content = PublishedContentFactory(author_list=[author1.user, author2.user])
-        signals.new_content.send(sender=content.__class__, instance=content, by_email=False)
+        signals.content_published.send(sender=content.__class__, instance=content, by_email=False)
         auto_user_1_sub = NewPublicationSubscription.objects.get_existing(author1.user, author1.user, False)
         self.assertIsNotNone(auto_user_1_sub)
         notifs = list(Notification.objects.get_notifications_of(author1.user))

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -10,11 +10,21 @@ from zds.forum.factories import ForumCategoryFactory, ForumFactory
 from zds.forum.models import Topic
 from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import StaffProfileFactory, ProfileFactory
-from zds.notification.models import NewTopicSubscription, Notification, NewPublicationSubscription, \
-    ContentReactionAnswerSubscription, PingSubscription
+from zds.notification.models import (
+    NewTopicSubscription,
+    Notification,
+    NewPublicationSubscription,
+    ContentReactionAnswerSubscription,
+    PingSubscription,
+)
 from zds.tutorialv2 import signals
-from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory, SubCategoryFactory, \
-    PublishedContentFactory, ContentReactionFactory
+from zds.tutorialv2.factories import (
+    PublishableContentFactory,
+    LicenceFactory,
+    SubCategoryFactory,
+    PublishedContentFactory,
+    ContentReactionFactory,
+)
 from zds.tutorialv2.publication_utils import publish_content, notify_update
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 from zds.utils.mps import send_mp, send_message_mp
@@ -356,6 +366,7 @@ class ContentNotification(TestCase, TutorialTestMixin):
 
     def test_no_persistant_notif_on_revoke(self):
         from zds.tutorialv2.publication_utils import unpublish_content
+
         NewPublicationSubscription.objects.get_or_create_active(self.user1, self.user2)
         content = PublishedContentFactory(author_list=[self.user2])
 

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -10,21 +10,11 @@ from zds.forum.factories import ForumCategoryFactory, ForumFactory
 from zds.forum.models import Topic
 from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import StaffProfileFactory, ProfileFactory
-from zds.notification.models import (
-    NewTopicSubscription,
-    Notification,
-    NewPublicationSubscription,
-    ContentReactionAnswerSubscription,
-    PingSubscription,
-)
-from zds.notification import signals as notif_signals
-from zds.tutorialv2.factories import (
-    PublishableContentFactory,
-    LicenceFactory,
-    SubCategoryFactory,
-    PublishedContentFactory,
-    ContentReactionFactory,
-)
+from zds.notification.models import NewTopicSubscription, Notification, NewPublicationSubscription, \
+    ContentReactionAnswerSubscription, PingSubscription
+from zds.tutorialv2 import signals
+from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory, SubCategoryFactory, \
+    PublishedContentFactory, ContentReactionFactory
 from zds.tutorialv2.publication_utils import publish_content, notify_update
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 from zds.utils.mps import send_mp, send_message_mp
@@ -366,7 +356,6 @@ class ContentNotification(TestCase, TutorialTestMixin):
 
     def test_no_persistant_notif_on_revoke(self):
         from zds.tutorialv2.publication_utils import unpublish_content
-
         NewPublicationSubscription.objects.get_or_create_active(self.user1, self.user2)
         content = PublishedContentFactory(author_list=[self.user2])
 

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -370,7 +370,7 @@ class ContentNotification(TestCase, TutorialTestMixin):
         NewPublicationSubscription.objects.get_or_create_active(self.user1, self.user2)
         content = PublishedContentFactory(author_list=[self.user2])
 
-        notif_signals.new_content.send(sender=self.tuto.__class__, instance=content, by_email=False)
+        signals.content_published.send(sender=self.tuto.__class__, instance=content, by_email=False)
         self.assertEqual(1, len(Notification.objects.get_notifications_of(self.user1)))
         unpublish_content(content)
         self.assertEqual(0, len(Notification.objects.get_notifications_of(self.user1)))

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -15,7 +15,7 @@ from django.template.loader import render_to_string
 from django.utils import translation
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
-from zds.notification import signals
+from zds.tutorialv2 import signals
 from zds.tutorialv2.epub_utils import build_ebook
 from zds.tutorialv2.models.database import ContentReaction, PublishedContent, PublicationEvent
 from zds.tutorialv2.publish_container import publish_container
@@ -40,7 +40,7 @@ licences = {
 def notify_update(db_object, is_update, is_major):
     if not is_update or is_major:
         # Follow
-        signals.new_content.send(sender=db_object.__class__, instance=db_object, by_email=False)
+        signals.content_published.send(sender=db_object.__class__, instance=db_object, by_email=False)
 
 
 def publish_content(db_object, versioned, is_major_update=True):

--- a/zds/tutorialv2/signals.py
+++ b/zds/tutorialv2/signals.py
@@ -1,7 +1,7 @@
 from django.dispatch.dispatcher import Signal
 
 # Publication events
-content_published = Signal(providing_args=['instance', 'user', 'by_email'])
-content_unpublished = Signal(providing_args=['instance', 'target', 'moderator'])
+content_published = Signal(providing_args=["instance", "user", "by_email"])
+content_unpublished = Signal(providing_args=["instance", "target", "moderator"])
 
-content_read = Signal(providing_args=['instance', 'user', 'target'])
+content_read = Signal(providing_args=["instance", "user", "target"])

--- a/zds/tutorialv2/signals.py
+++ b/zds/tutorialv2/signals.py
@@ -1,4 +1,7 @@
 from django.dispatch.dispatcher import Signal
 
-# is sent whenever a content is unpublished
-content_unpublished = Signal(providing_args=["instance", "target", "moderator"])
+# Publication events
+content_published = Signal(providing_args=['instance', 'user', 'by_email'])
+content_unpublished = Signal(providing_args=['instance', 'target', 'moderator'])
+
+content_read = Signal(providing_args=['instance', 'user', 'target'])

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 from git import Repo, Actor
 
 from django.conf import settings
-from zds.notification import signals
+from zds.tutorialv2 import signals
 from zds.tutorialv2 import VALID_SLUG
 from zds.tutorialv2.models import CONTENT_TYPE_LIST
 from zds.utils import get_current_user, old_slugify

--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -5,7 +5,7 @@ from django.http import Http404
 from django.utils.translation import ugettext_lazy as _
 
 from zds.featured.mixins import FeatureableMixin
-from zds.notification import signals
+from zds.tutorialv2 import signals
 from zds.notification.models import ContentReactionAnswerSubscription
 from zds.tutorialv2.forms import (
     RevokeValidationForm,


### PR DESCRIPTION
Suite de #5976. Cette fois-ci, c'est le module de tuto qui se fait découpler du module de notification. C'est le dernier morceau facile de cette refacto ; après il y aura peut-être quelques subtilités à regarder.

### Contrôle qualité

Vérifier que tous les abonnements et notifications liés aux contenus fonctionnent :
- commentaires sur un contenu ;
- notification en cas de mise à jour majeure sur un contenu quand on est abonné
- suppression des notifs quand on se désabonne,
- peut être d'autres choses que j'ai oubliées.