### PR TITLE
Fix #5064 : Supprime du code fantôme

### DIFF
--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -215,8 +215,5 @@
 
   $(document).ready(function() {
     buildModals($('.modal'))
-    $('#content').on('DOMNodeInserted', '.modal', function(e) {
-      buildModals($(e.target))
-    })
   })
 })(jQuery)


### PR DESCRIPTION
Le code fantôme provoque certaine fois l'apparition en double du boutons "Annuler" sur certaines boites modales, je ne vois aucune explication concrète à la présence du code (voir commentaire de 2018 sur la PR #5064). (En plus l'event DOMNodeInserted est devenu déprécié).

<!-- Veuillez décrire vos changements à l’emplacement de ce commentaire (inutile dans le cas de tout petits changements). -->

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné (optionnel) : #5064

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

Tester plusieurs fois d'ouvrir la fenêtre modale des liens vérifier qu'elle s'affiche correctement dans toutes les situations.


Bon vol. ;)