### PR TITLE
Corrige le mode compatibilité

### DIFF
--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -800,7 +800,7 @@ function mirroringEasyMDE(easyMDE, textarea) {
     }, 12) // <-- after default trigger (I mean after browser trigger)
   })
 
-  $(easyMDE.element.parentElement).children('.editor-statusbar').before($twin)
+  $(easyMDE.element.parentElement).find('.editor-statusbar').before($twin)
 
   return $twin
 }

--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -659,8 +659,8 @@
             }
             easyMDE.codemirror.refresh()
           },
-          className: 'fas fa-broom',
-          title: 'Passe au mode compatibilité'
+          className: 'fas fa-remove-format',
+          title: 'Zone de texte sans mise en forme'
         },
         '|',
         {


### PR DESCRIPTION
Cette PR permet de corrige l'apparition de la zone de texte sans mise en forme depuis le nouvel éditeur. Autrefois appelé mode de compatibilité, on en profite pour lui donner un nom plus parlant.

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné (optionnel) : #5987

### Contrôle qualité


- Lancez le site et buildez le front `source zdsenv/bin/activate && make zmd-start && make build-front && make run-back` ;
- Aller sur une page où il y a l'éditeur
- Appuyez sur ce bouton : ![](https://user-images.githubusercontent.com/6066015/98467793-8bad2e80-21d7-11eb-8515-f8cc0e52eb22.png)
- Constatez que la zone de texte sans mise en forme apparaît et que l'on a bien perdu la mise en forme.
