### PR TITLE
Mise à jour du lien de la déclaration de l'association au JO

### DIFF
--- a/templates/pages/association.html
+++ b/templates/pages/association.html
@@ -30,7 +30,7 @@
             {{ asso_name }} est une association loi 1901 (association à but non lucratif) et joue le rôle de structure
             légale du site <a href="{{ site_url }}">{{ site_url }}</a>, dont le but est de promouvoir le partage de connaissances à travers des
             ressources pédagogiques gratuites et de préférence sous licence libre.
-            <a href="http://www.journal-officiel.gouv.fr/publications/assoc/pdf/2014/0016/JOAFE_PDF_Unitaire_20140016_01712.pdf">
+            <a href="https://www.journal-officiel.gouv.fr/associations/detail-annonce/associations_b/20140016/1712">
             Parue au Journal officiel le 19 avril 2014</a>, l’association a tenu sa première assemblée générale le 15 mars
             2014, au cours de laquelle ont été élus le bureau et le conseil d’administration en présence des <strong>quatorze</strong> membres fondateurs.
         {% endblocktrans %}


### PR DESCRIPTION
Ce patch est simplement une mise à jour du lien sur le JO pour remplacer l'ancien qui est cassé. La discussion relative se trouve sur le forum de ZdS [ici](https://zestedesavoir.com/forums/sujet/14740/page-lassociation-zeste-de-savoir-lien-du-jo-mort/).