### PR TITLE
Corrige le style et la semantique lors de la desinscription

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -455,6 +455,12 @@ kbd {
 
     color: $accent-900;
     text-shadow: 0 $length-1 0 $white;
+
+    &.is-red {
+            background-color: $red-200;
+            border: solid 1px $red-400;
+            color: $red-900;
+    }
 }
 
 // Code inline

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -131,16 +131,6 @@
         font-size: $font-size-6;
         font-weight: normal;
     }
-
-    kbd {
-        background-color: $color-keyboard; 
-        padding: 2px 6px; 
-        border-radius: 3px; 
-        border: solid 1px desaturate(darken($color-keyboard, 15%), 10%); 
-        border-bottom-width: 3px; 
-        text-shadow: 0 1px 0 #FFF; 
-        color: darken($color-keyboard, 70%); 
-    }
 }
 
 @include wide {

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -131,6 +131,16 @@
         font-size: $font-size-6;
         font-weight: normal;
     }
+
+    kbd {
+        background-color: $color-keyboard; 
+        padding: 2px 6px; 
+        border-radius: 3px; 
+        border: solid 1px desaturate(darken($color-keyboard, 15%), 10%); 
+        border-bottom-width: 3px; 
+        text-shadow: 0 1px 0 #FFF; 
+        color: darken($color-keyboard, 70%); 
+    }
 }
 
 @include wide {

--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -21,85 +21,87 @@
 
 
 {% block content %}
-    <p>
-        {% blocktrans with username=user.username %}
-            Attention {{ username }}, vous êtes sur le point de vous désinscrire de Zeste de Savoir. Voici ce qu’implique cette action <strong>qui ne peut être annulée</strong>.
-        {% endblocktrans %}
-    </p>
-
-    <ul>
-        <li>
-            {% trans "Toutes vos conversations privées (MP) seront perdues" %}.
-        </li>
-        <li>
-            {% trans "Tous vos messages de forums seront anonymisés" %}.
-        </li>
-        <li>
-            {% blocktrans with username=user.username email=user.email %}
-                Votre compte et tous ses détails seront supprimés, cela signifie que l’adresse courriel ({{ email }}) sera effacée du système et votre pseudo ({{ username }}) sera libéré et utilisable par un autre membre.
-            {% endblocktrans %}
-        </li>
-        <li>
-            {% trans "Vos tutoriels, billets et articles non publiés (brouillon, bêta ou en cours de validation) seront supprimés sans possibilité de récuperation (sauf si d’autres auteurs sont présents lors de la rédaction" %}).
-        </li>
-        <li>
-            {% trans "Vos tutoriels, articles et billets publiés subiront les modifications suivantes :" %}
-            <ul>
-                <li>
-                    {% blocktrans %}
-                        Si vous étiez seul, ils seront placés sous la gouvernance du compte « Auteur Externe », sauf demande contraire de votre part à un membre du staff <strong>avant</strong> votre désinscription.
-                    {% endblocktrans %}
-                </li>
-                <li>
-                    {% trans "Si vous étiez plusieurs auteurs, vous quitterez le groupe de rédacteurs. Les autres pourront dès lors continuer sans vous" %}.
-                </li>
-            </ul>
-        </li>
-        <li>
-            {% trans "Vos galeries d’images subiront les modifications suivantes :" %}
-            <ul>
-                <li>
-                    {% blocktrans %}
-                        Si la galerie est liée à un tutoriel, elle subira le même sort que ce dernier (attribution à « Auteur externe » ou aux autres auteurs du contenu).
-                    {% endblocktrans %}
-                </li>
-                <li>
-                    {% blocktrans %}
-                        Si vous êtes plusieurs possesseurs, vous serez simplement supprimé du groupe.
-                    {% endblocktrans %}
-                </li>
-                <li>
-                    {% blocktrans %}
-                        Sinon, elle sera supprimée (ainsi que son contenu).
-                    {% endblocktrans %}
-                </li>
-            </ul>
-        </li>
-        <li>
-            {% trans "Toutes vos clés API (si vous en possédez) seront supprimées" %}.
-        </li>
-    </ul>
-
-    <p>
-
-        {% blocktrans %} Si vous souhaitez poursuivre votre désinscription, cliquez sur le bouton <kbd><samp>Me désinscrire</samp></kbd> ci-dessous. Sinon, il n’est pas encore trop tard{% endblocktrans %}...
-    </p>
-
-    <p>
-        <a href="#unregister" class="open-modal btn btn-cancel">{% trans "Me désinscrire" %}</a>
-    </p>
-
-    <form
-        method="post"
-        action="{% url "member-unregister" %}"
-        id="unregister"
-        class="modal modal-flex"
-    >
+    <article class="message-content">
         <p>
-            {% trans "C’est votre dernière chance de rester parmi nous" %}...
+            {% blocktrans with username=user.username %}
+                Attention {{ username }}, vous êtes sur le point de vous désinscrire de Zeste de Savoir. Voici ce qu’implique cette action <strong>qui ne peut être annulée</strong>.
+            {% endblocktrans %}
         </p>
 
-        {% csrf_token %}
-        <button type="submit" class="btn btn-submit">{% trans "Me désinscrire" %}</button>
-    </form>
+        <ul>
+            <li>
+                {% trans "Toutes vos conversations privées (MP) seront perdues" %}.
+            </li>
+            <li>
+                {% trans "Tous vos messages de forums seront anonymisés" %}.
+            </li>
+            <li>
+                {% blocktrans with username=user.username email=user.email %}
+                    Votre compte et tous ses détails seront supprimés, cela signifie que l’adresse courriel ({{ email }}) sera effacée du système et votre pseudo ({{ username }}) sera libéré et utilisable par un autre membre.
+                {% endblocktrans %}
+            </li>
+            <li>
+                {% trans "Vos tutoriels, billets et articles non publiés (brouillon, bêta ou en cours de validation) seront supprimés sans possibilité de récuperation (sauf si d’autres auteurs sont présents lors de la rédaction" %}).
+            </li>
+            <li>
+                {% trans "Vos tutoriels, articles et billets publiés subiront les modifications suivantes :" %}
+                <ul>
+                    <li>
+                        {% blocktrans %}
+                            Si vous étiez seul, ils seront placés sous la gouvernance du compte « Auteur Externe », sauf demande contraire de votre part à un membre du staff <strong>avant</strong> votre désinscription.
+                        {% endblocktrans %}
+                    </li>
+                    <li>
+                        {% trans "Si vous étiez plusieurs auteurs, vous quitterez le groupe de rédacteurs. Les autres pourront dès lors continuer sans vous" %}.
+                    </li>
+                </ul>
+            </li>
+            <li>
+                {% trans "Vos galeries d’images subiront les modifications suivantes :" %}
+                <ul>
+                    <li>
+                        {% blocktrans %}
+                            Si la galerie est liée à un tutoriel, elle subira le même sort que ce dernier (attribution à « Auteur externe » ou aux autres auteurs du contenu).
+                        {% endblocktrans %}
+                    </li>
+                    <li>
+                        {% blocktrans %}
+                            Si vous êtes plusieurs possesseurs, vous serez simplement supprimé du groupe.
+                        {% endblocktrans %}
+                    </li>
+                    <li>
+                        {% blocktrans %}
+                            Sinon, elle sera supprimée (ainsi que son contenu).
+                        {% endblocktrans %}
+                    </li>
+                </ul>
+            </li>
+            <li>
+                {% trans "Toutes vos clés API (si vous en possédez) seront supprimées" %}.
+            </li>
+        </ul>
+
+        <p>
+
+            {% blocktrans %} Si vous souhaitez poursuivre votre désinscription, cliquez sur le bouton <kbd class="is-red"><samp>Me désinscrire</samp></kbd> ci-dessous. Sinon, il n’est pas encore trop tard{% endblocktrans %}...
+        </p>
+
+        <p>
+            <a href="#unregister" class="open-modal btn btn-cancel">{% trans "Me désinscrire" %}</a>
+        </p>
+
+        <form
+            method="post"
+            action="{% url "member-unregister" %}"
+            id="unregister"
+            class="modal modal-flex"
+        >
+            <p>
+                {% trans "C’est votre dernière chance de rester parmi nous" %}...
+            </p>
+
+            {% csrf_token %}
+            <button type="submit" class="btn btn-submit">{% trans "Me désinscrire" %}</button>
+        </form>
+    </article>
 {% endblock %}

--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -82,7 +82,7 @@
 
     <p>
 
-        {% blocktrans %} Si vous souhaitez poursuivre votre désinscription, cliquez sur le bouton <kbd>Me désinscrire</kbd> ci-dessous. Sinon, il n’est pas encore trop tard{% endblocktrans %}...
+        {% blocktrans %} Si vous souhaitez poursuivre votre désinscription, cliquez sur le bouton <kbd><samp>Me désinscrire</samp></kbd> ci-dessous. Sinon, il n’est pas encore trop tard{% endblocktrans %}...
     </p>
 
     <p>


### PR DESCRIPTION
Traite l'issue #5716 

J'ai ajouté une balise `<samp>` pour améliorer la sémantique de la page, et modifié le style de la balise `<kbd>`.

# Q/A

- Se connecter comme utilisateur lambda
- Se rendre dans les Paramètres -> Désinscription

Je m'y suis prise comme un bourrin avec le style, mais ça marche. Je ne sais pas si ça risque de casser quelque chose dans le reste du site, mais vu que c'est juste une modification du style de `<kbd>` je pense que les chances sont faibles.

Je souhaiterai avoir une couleur plus rougeâtre pour le texte, pour qu'il puisse bien correspondre au bouton auquel il fait référence, vous en pensez quoi ?

Merci pour votre temps !
