### PR TITLE
Retire l'export de contenu au format HTML

### DIFF
--- a/templates/tutorialv2/includes/list_of_exports.html
+++ b/templates/tutorialv2/includes/list_of_exports.html
@@ -16,18 +16,6 @@
                 </li>
             {% endif %}
         {% endif %}
-        {% if public_object.has_html %}
-            <li>
-                <a href="{{ public_object.get_absolute_url_html }}" class="ico-after download blue">
-                    {% trans "HTML" %}
-                    {% with size=public_object.get_size_html %}
-                        {% if size %}
-                            ({{ size|filesizeformat }})
-                        {% endif %}
-                    {% endwith %}
-                </a>
-            </li>
-        {% endif %}
         {% if public_object.has_pdf %}
             <li>
                 <a href="{{ public_object.get_absolute_url_pdf }}" class="ico-after download blue">

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -21,7 +21,7 @@ from zds.tutorialv2.models.database import ContentReaction, PublishedContent, Pu
 from zds.tutorialv2.publish_container import publish_container
 from zds.tutorialv2.signals import content_unpublished
 from zds.utils.forums import send_post, lock_topic
-from zds.utils.templatetags.emarkdown import render_markdown, MD_PARSING_ERROR
+from zds.utils.templatetags.emarkdown import render_markdown
 from zds.utils.templatetags.smileys_def import SMILEYS_BASE_PATH, LICENSES_BASE_PATH
 
 logger = logging.getLogger(__name__)

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -310,6 +310,7 @@ class ZipPublicator(Publicator):
         except (IOError, ValueError) as e:
             raise FailureDuringPublication('Zip could not be created', e)
 
+
 @PublicatorRegistry.register('pdf')
 class ZMarkdownRebberLatexPublicator(Publicator):
     """

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -310,27 +310,6 @@ class ZipPublicator(Publicator):
         except (IOError, ValueError) as e:
             raise FailureDuringPublication('Zip could not be created', e)
 
-
-@PublicatorRegistry.register('html')
-class ZmarkdownHtmlPublicator(Publicator):
-
-    def publish(self, md_file_path, base_name, **kwargs):
-        md_flat_content = _read_flat_markdown(md_file_path)
-        published_content_entity = self.get_published_content_entity(md_file_path)
-        html_flat_content, *_ = render_markdown(md_flat_content, disable_ping=True,
-                                                disable_js=True)
-        html_file_path = path.splitext(md_file_path)[0] + '.html'
-        if str(MD_PARSING_ERROR) in html_flat_content:
-            logging.getLogger(self.__class__.__name__).error('HTML could not be rendered')
-            return
-
-        with open(html_file_path, mode='w', encoding='utf-8') as final_file:
-            final_file.write(html_flat_content)
-        shutil.move(html_file_path, str(
-            Path(published_content_entity.get_extra_contents_directory(),
-                 published_content_entity.content_public_slug + '.html')))
-
-
 @PublicatorRegistry.register('pdf')
 class ZMarkdownRebberLatexPublicator(Publicator):
     """

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -3689,7 +3689,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertTrue(os.path.exists(published.get_extra_contents_directory()))
         self.assertTrue(os.path.exists(os.path.join(published.get_extra_contents_directory(), 'images')))
 
-        avail_extra = ['md', 'html', 'pdf', 'epub', 'zip']
+        avail_extra = ['md', 'pdf', 'epub', 'zip']
 
         # test existence and access for admin
         for extra in avail_extra:

--- a/zds/tutorialv2/urls/urls_articles.py
+++ b/zds/tutorialv2/urls/urls_articles.py
@@ -19,8 +19,6 @@ urlpatterns = [
     # Downloads
     re_path(r'^md/(?P<pk>\d+)/(?P<slug>.+)\.md$',
             DownloadOnlineArticle.as_view(requested_file='md'), name='download-md'),
-    re_path(r'^html/(?P<pk>\d+)/(?P<slug>.+)\.html$', DownloadOnlineArticle.as_view(requested_file='html'),
-            name='download-html'),
     re_path(r'^pdf/(?P<pk>\d+)/(?P<slug>.+)\.pdf$', DownloadOnlineArticle.as_view(requested_file='pdf'),
             name='download-pdf'),
     re_path(r'^tex/(?P<pk>\d+)/(?P<slug>.+)\.tex$', DownloadOnlineArticle.as_view(requested_file='tex'),

--- a/zds/tutorialv2/urls/urls_opinions.py
+++ b/zds/tutorialv2/urls/urls_opinions.py
@@ -17,8 +17,6 @@ urlpatterns = [
     # downloads:
     re_path(r'^md/(?P<pk>\d+)/(?P<slug>.+)\.md$',
             DownloadOnlineOpinion.as_view(requested_file='md'), name='download-md'),
-    re_path(r'^html/(?P<pk>\d+)/(?P<slug>.+)\.html$',
-            DownloadOnlineOpinion.as_view(requested_file='html'), name='download-html'),
     re_path(r'^pdf/(?P<pk>\d+)/(?P<slug>.+)\.pdf$',
             DownloadOnlineOpinion.as_view(requested_file='pdf'), name='download-pdf'),
     re_path(r'^epub/(?P<pk>\d+)/(?P<slug>.+)\.epub$',

--- a/zds/tutorialv2/urls/urls_tutorials.py
+++ b/zds/tutorialv2/urls/urls_tutorials.py
@@ -30,8 +30,6 @@ urlpatterns = [
     # downloads:
     re_path(r'^md/(?P<pk>\d+)/(?P<slug>.+)\.md$',
             DownloadOnlineTutorial.as_view(requested_file='md'), name='download-md'),
-    re_path(r'^html/(?P<pk>\d+)/(?P<slug>.+)\.html$',
-            DownloadOnlineTutorial.as_view(requested_file='html'), name='download-html'),
     re_path(r'^pdf/(?P<pk>\d+)/(?P<slug>.+)\.pdf$',
             DownloadOnlineTutorial.as_view(requested_file='pdf'), name='download-pdf'),
     re_path(r'^epub/(?P<pk>\d+)/(?P<slug>.+)\.epub$',


### PR DESCRIPTION
Retire l'export de contenu au format HTML, comme discuté dans l'issue #5806 .

## Q/A

- Ajouter un tutoriel, article et billet au site de test
- Vérifier l'absence du lien vers le fichier HTML

J'ai remarqué que l'URL des fichiers au format markdown est toujours en place alors que l'export de contenu dans ce format ne semble pas être possible en prod, est ce que je devrais en faire une issue (et potentiellement m'en occuper) ?

Merci !
