### PR TITLE
Découple le module utils et le module de notifications

### DIFF
--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -29,6 +29,7 @@ from zds.notification.models import (
 import zds.notification.signals as notification_signals
 from zds.tutorialv2.models.database import PublishableContent, ContentReaction
 import zds.tutorialv2.signals as tuto_signals
+import zds.utils.signals as utils_signals
 from zds.utils.models import Tag
 
 logger = logging.getLogger(__name__)
@@ -401,8 +402,8 @@ def content_published_event(*__, instance, by_email, **___):
             subscription.send_notification(content=content, sender=user, send_email=by_email)
 
 
-@receiver(notification_signals.new_content, sender=ContentReaction)
-@receiver(notification_signals.new_content, sender=Post)
+@receiver(utils_signals.ping, sender=ContentReaction)
+@receiver(utils_signals.ping, sender=Post)
 @disable_for_loaddata
 def answer_comment_event(sender, *, instance, user, **__):
     comment = instance
@@ -504,7 +505,7 @@ def cleanup_notification_for_unpublished_content(sender, instance, **__):
         logger.exception("Error while saving %s, %s", instance, e)
 
 
-@receiver(notification_signals.unsubscribe)
+@receiver(utils_signals.unping)
 def unsubscripte_unpinged_user(sender, instance, user, **_):
     if user:
         PingSubscription.objects.deactivate_subscriptions(user, instance)

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -226,7 +226,7 @@ def clean_subscriptions(sender, *, topic, **__):
             subscription.deactivate()
 
 
-@receiver(notification_signals.content_read, sender=ContentReaction)
+@receiver(tuto_signals.content_read, sender=ContentReaction)
 @receiver(forum_signals.post_read, sender=Post)
 def mark_comment_read(sender, *, instance, user, **__):
     comment = instance

--- a/zds/notification/signals.py
+++ b/zds/notification/signals.py
@@ -3,9 +3,6 @@ from django.dispatch import Signal
 # is sent whenever a resource is created.
 new_content = Signal(providing_args=["instance", "user", "by_email"])
 
-# is sent whenever a content is edited.
-edit_content = Signal(providing_args=["instance", "action"])
-
 # is sent when a content is read (topic, article or tutorial)
 content_read = Signal(providing_args=["instance", "user", "target"])
 

--- a/zds/notification/signals.py
+++ b/zds/notification/signals.py
@@ -1,9 +1,5 @@
 from django.dispatch import Signal
 
-
-# is sent whenever an answer is set as unread
-answer_unread = Signal(providing_args=["instance", "user"])
-
 # is sent whenever a resource is created.
 new_content = Signal(providing_args=["instance", "user", "by_email"])
 

--- a/zds/notification/signals.py
+++ b/zds/notification/signals.py
@@ -1,9 +1,4 @@
 from django.dispatch import Signal
 
-# is sent whenever a resource is created.
-new_content = Signal(providing_args=["instance", "user", "by_email"])
-
 # is sent when a content is read (topic, article or tutorial)
 content_read = Signal(providing_args=["instance", "user", "target"])
-
-unsubscribe = Signal(providing_args=["instance", "user"])

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -17,7 +17,7 @@ from django.template.loader import render_to_string
 
 from easy_thumbnails.fields import ThumbnailerImageField
 
-from zds.notification import signals
+from zds.utils import signals
 from zds.mp.models import PrivateTopic
 from zds.tutorialv2.models import TYPE_CHOICES, TYPE_CHOICES_DICT
 from zds.utils.mps import send_mp
@@ -435,12 +435,12 @@ class Comment(models.Model):
         pinged_usernames = set(pinged_usernames_from_new_text) - set(pinged_usernames_from_old_text)
         pinged_users = User.objects.filter(username__in=pinged_usernames)
         for pinged_user in pinged_users:
-            signals.new_content.send(sender=self.__class__, instance=self, user=pinged_user)
+            signals.ping.send(sender=self.__class__, instance=self, user=pinged_user)
 
         unpinged_usernames = set(pinged_usernames_from_old_text) - set(pinged_usernames_from_new_text)
         unpinged_users = User.objects.filter(username__in=unpinged_usernames)
         for unpinged_user in unpinged_users:
-            signals.unsubscribe.send(self.author, instance=self, user=unpinged_user)
+            signals.unping.send(self.author, instance=self, user=unpinged_user)
 
     def hide_comment_by_user(self, user, text_hidden):
         """Hide a comment and save it

--- a/zds/utils/signals.py
+++ b/zds/utils/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+ping = Signal(providing_args=["instance", "user", "by_email"])
+unping = Signal(providing_args=["instance", "user"])


### PR DESCRIPTION
Suite de #5982, #5976, #5971 (et j'espère que ce sera la fin). Pour rappel, le but est de refactoriser le module de notification pour rendre possible les notifications dans #5940.

Il restait encore des signaux définis par le module de notification, alors que l'objectif est que le module de notification se contente d'écouter les signaux émis par les autres modules (et définis en leur sein). En vérité, il reste bien un signal définit par le module et qu'il écoute lui-même, mais ça ne pose pas de problème (et c'est même plutôt l'inverse).

La présente PR :

- supprime deux signaux désormais inutilisés suite aux refactorisations précédentes ;
- déplace la définition de deux signaux utilisés par `Comment` (la classe commune aux commentaires de contenu et messages du forum) dans le module `utils`.

### Contrôle qualité

Tester le bon comportement des pings :

- quand on fait un nouveau message (notification des membres) ;
- quand on édite un message en ajoutant et enlevant des pings (notifications des nouveaux, notifications supprimées pour ceux enelever et pas de double notif pour ceux qui sont inchangés).