### PR TITLE
Préparation du passage à Django 3.0 et 3.1

### DIFF
--- a/zds/api/bits.py
+++ b/zds/api/bits.py
@@ -1,6 +1,6 @@
 import datetime
 from django.core.cache import cache
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from rest_framework_extensions.key_constructor.bits import QueryParamsKeyBit, KeyBitBase
 
 
@@ -51,4 +51,4 @@ class UpdatedAtKeyBit(KeyBitBase):
         if value is None:
             value = datetime.datetime.utcnow()
             cache.set(self.update_key, value=value)
-        return force_text(value)
+        return force_str(value)

--- a/zds/featured/forms.py
+++ b/zds/featured/forms.py
@@ -3,7 +3,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Field, ButtonHolder
 from django import forms
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.featured.models import FeaturedResource, FeaturedMessage
 

--- a/zds/featured/models.py
+++ b/zds/featured/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.featured.managers import FeaturedResourceManager, FeaturedMessageManager, FeaturedRequestedManager
 from zds.member.models import User

--- a/zds/featured/tests.py
+++ b/zds/featured/tests.py
@@ -2,7 +2,7 @@ from datetime import datetime, date
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.test import TestCase
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from zds.member.factories import StaffProfileFactory, ProfileFactory
 from zds.featured.factories import FeaturedResourceFactory

--- a/zds/featured/views.py
+++ b/zds/featured/views.py
@@ -5,7 +5,7 @@ from django.db.models import Count
 from django.urls import reverse
 from django.shortcuts import redirect
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic import CreateView, RedirectView, UpdateView, FormView, DeleteView
 from django.views.generic.list import MultipleObjectMixin
 from django.http import HttpResponse

--- a/zds/forum/commons.py
+++ b/zds/forum/commons.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic.detail import SingleObjectMixin
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.models import User

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Field, Hidden, HTML

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -12,7 +12,7 @@ from django.http import Http404, HttpResponse, StreamingHttpResponse
 from django.shortcuts import redirect, get_object_or_404, render
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST, require_GET
 from django.views.generic import ListView, DetailView, CreateView, UpdateView
 from django.views.generic.detail import SingleObjectMixin

--- a/zds/gallery/api/serializers.py
+++ b/zds/gallery/api/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers, exceptions
 from dry_rest_permissions.generics import DRYPermissionsField
 
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.api.serializers import ZdSModelSerializer
 from zds.gallery.models import Gallery, Image, UserGallery

--- a/zds/gallery/api/views.py
+++ b/zds/gallery/api/views.py
@@ -6,7 +6,7 @@ from rest_framework_extensions.etag.decorators import etag
 from rest_framework_extensions.key_constructor import bits
 from dry_rest_permissions.generics import DRYPermissions
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.api.bits import UpdatedAtKeyBit
 from zds.api.key_constructor import PagingListKeyConstructor, DetailKeyConstructor

--- a/zds/gallery/auto_upload_gallery.py
+++ b/zds/gallery/auto_upload_gallery.py
@@ -1,5 +1,5 @@
 from django.http.request import HttpRequest
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from zds.gallery.models import Gallery, UserGallery, GALLERY_WRITE
 from zds.tutorialv2.models.database import PublishableContent
 

--- a/zds/gallery/forms.py
+++ b/zds/gallery/forms.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper

--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from django.contrib.auth.models import User
 from django.db import models
 from django.dispatch import receiver
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.gallery.managers import GalleryManager
 

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.http import Http404, HttpResponseRedirect
 from django.views.generic import DeleteView, FormView, View
 from django.shortcuts import redirect, get_object_or_404
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.mixins import LoginRequiredMixin
 
 from zds.gallery.forms import (

--- a/zds/member/__init__.py
+++ b/zds/member/__init__.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 NEW_PROVIDER_USES = [("NEW_ACCOUNT", _("Nouveau compte")), ("EMAIL_EDIT", _("Édition de l'adresse e-mail"))]

--- a/zds/member/api/views.py
+++ b/zds/member/api/views.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.core.cache import cache
 from django.db.models.signals import post_save, post_delete
 from dry_rest_permissions.generics import DRYPermissions

--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -7,7 +7,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from django.template.defaultfilters import pluralize
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.member.models import Profile, TokenRegister, Ban
 from zds.utils.models import get_hat_from_settings
@@ -108,7 +108,7 @@ class MemberSanctionState:
         Gets the type of a sanction.
 
         :return: type of the sanction.
-        :rtype: ugettext_lazy
+        :rtype: gettext_lazy
         """
         raise NotImplementedError("`get_type()` must be implemented.")
 
@@ -126,7 +126,7 @@ class MemberSanctionState:
         Gets detail of a sanction.
 
         :return: detail of the sanction.
-        :rtype: ugettext_lazy
+        :rtype: gettext_lazy
         """
         raise NotImplementedError("`get_detail()` must be implemented.")
 
@@ -168,7 +168,7 @@ class MemberSanctionState:
         Gets the message for an un-sanction.
 
         :return: message of the un-sanction.
-        :rtype: ugettext_lazy
+        :rtype: gettext_lazy
         """
         return _(
             "Bonjour **{0}**,\n\n"
@@ -184,7 +184,7 @@ class MemberSanctionState:
         Gets the message for a sanction.
 
         :return: message of the sanction.
-        :rtype: ugettext_lazy
+        :rtype: gettext_lazy
         """
         return _(
             "Bonjour **{0}**,\n\n"

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User, Group
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from captcha.fields import ReCaptchaField
 from crispy_forms.bootstrap import StrictButton

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -8,7 +8,7 @@ from django.contrib.gis.geoip2 import GeoIP2
 from django.urls import reverse
 from django.db import models
 from django.dispatch import receiver
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.forum.models import Post, Topic
 from zds.notification.models import TopicAnswerSubscription

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -12,7 +12,7 @@ from django.core import mail
 from django.urls import reverse
 from django.test import TestCase, override_settings
 from django.utils.html import escape
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.notification.models import TopicAnswerSubscription
 from zds.member.factories import (

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -11,6 +11,7 @@ from django.contrib.auth.models import User, Group
 from django.core import mail
 from django.urls import reverse
 from django.test import TestCase, override_settings
+from django.utils.html import escape
 from django.utils.translation import ugettext_lazy as _
 
 from zds.notification.models import TopicAnswerSubscription
@@ -1709,4 +1710,4 @@ class RegisterTest(TestCase):
             follow=False,
         )
         self.assertEqual(result.status_code, 200)
-        self.assertIn("Impossible d&#39;envoyer l&#39;email.", result.content.decode("utf-8"))
+        self.assertIn(escape("Impossible d'envoyer l'email."), result.content.decode("utf-8"))

--- a/zds/member/utils.py
+++ b/zds/member/utils.py
@@ -1,6 +1,6 @@
 from social_django.middleware import SocialAuthExceptionMiddleware
 from django.contrib import messages
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
 import logging
 

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator
 from django.utils.encoding import force_str
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.utils.misc import contains_utf8mb4
 from zds.member.models import BannedEmailProvider, Profile

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import ugettext_lazy as _
 
 from zds.utils.misc import contains_utf8mb4
@@ -32,7 +32,7 @@ class ZdSEmailValidator(EmailValidator):
     message = _("Utilisez une adresse de courriel valide.")
 
     def __call__(self, value, check_username_available=True):
-        value = force_text(value)
+        value = force_str(value)
 
         if not value or "@" not in value:
             raise ValidationError(self.message, code=self.code)

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -20,8 +20,8 @@ from django.shortcuts import redirect, render, get_object_or_404
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.utils.text import format_lazy
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ugettext as __
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as __
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, UpdateView, CreateView, FormView, View
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
+from urllib.parse import unquote
 
 from oauth2_provider.models import AccessToken
 
@@ -18,7 +19,6 @@ from django.http import Http404, HttpResponseBadRequest, StreamingHttpResponse
 from django.shortcuts import redirect, render, get_object_or_404
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
-from django.utils.http import urlunquote
 from django.utils.text import format_lazy
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext as __
@@ -108,9 +108,9 @@ class MemberDetail(DetailView):
     template_name = "member/profile.html"
 
     def get_object(self, queryset=None):
-        # Use urlunquote to accept twicely quoted URLs (for instance in MPs
+        # Use unquote to accept twicely quoted URLs (for instance in MPs
         # sent through emarkdown parser).
-        return get_object_or_404(User, username=urlunquote(self.kwargs["user_name"]))
+        return get_object_or_404(User, username=unquote(self.kwargs["user_name"]))
 
     def get_summaries(self, profile):
         """

--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -4,7 +4,7 @@ from crispy_forms.bootstrap import StrictButton
 
 from django import forms
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.mp.models import PrivateTopic
 from zds.mp.validators import ParticipantsStringValidator, TitleValidator, TextValidator

--- a/zds/mp/validators.py
+++ b/zds/mp/validators.py
@@ -1,6 +1,6 @@
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from zds.api.validators import Validator
 from zds.member.models import Profile
 

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -9,7 +9,7 @@ from django.db import transaction
 from django.http import Http404, StreamingHttpResponse
 from django.shortcuts import redirect, get_object_or_404, render
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import CreateView, RedirectView, UpdateView
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.list import MultipleObjectMixin

--- a/zds/notification/models.py
+++ b/zds/notification/models.py
@@ -8,7 +8,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.validators import validate_email, ValidationError
 from django.db import models, IntegrityError, transaction
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
 from zds.forum.models import Topic, Post

--- a/zds/notification/views.py
+++ b/zds/notification/views.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils.decorators import method_decorator
 from django.contrib import messages
 from django.views.decorators.http import require_POST
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.shortcuts import redirect
 from django.urls import reverse
 

--- a/zds/pages/models.py
+++ b/zds/pages/models.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import Group, User
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class GroupContact(models.Model):

--- a/zds/pages/tests.py
+++ b/zds/pages/tests.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.forum.models import Post
 from zds.forum.factories import create_category_and_forum, create_topic_in_forum

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -6,7 +6,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView, DetailView
 from django.core.exceptions import PermissionDenied
 from django.views.decorators.http import require_POST

--- a/zds/search/constant.py
+++ b/zds/search/constant.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 MODEL_TOPIC = "sujets"
 MODEL_POST = "messages"

--- a/zds/searchv2/forms.py
+++ b/zds/searchv2/forms.py
@@ -2,7 +2,7 @@ import random
 
 from django import forms
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.contrib import messages
 from django.http import HttpResponse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.generic import CreateView

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -1,7 +1,7 @@
 from os.path import join
+from urllib.parse import quote
 
 from django.contrib.messages import constants as message_constants
-from django.utils.http import urlquote
 from django.utils.translation import gettext_lazy as _
 
 from .config import config
@@ -295,7 +295,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 LOGIN_URL = "member-login"
 LOGIN_REDIRECT_URL = "/"
 
-ABSOLUTE_URL_OVERRIDES = {"auth.user": lambda u: "/membres/voir/{0}/".format(urlquote(u.username.encode("utf-8")))}
+ABSOLUTE_URL_OVERRIDES = {"auth.user": lambda u: "/membres/voir/{0}/".format(quote(u.username.encode("utf-8")))}
 
 # Django fileserve settings (set to True for local dev version only)
 SERVE = False

--- a/zds/tutorialv2/feeds.py
+++ b/zds/tutorialv2/feeds.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
 from django.utils.feedgenerator import Atom1Feed
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.utils.models import Category, SubCategory
 from zds.tutorialv2.models.database import PublishedContent

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -12,7 +12,7 @@ from zds.utils.models import SubCategory, Licence
 from zds.tutorialv2.models import TYPE_CHOICES
 from zds.utils.models import HelpWriting
 from zds.tutorialv2.models.database import PublishableContent, ContentContributionRole
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from zds.member.models import Profile
 from zds.tutorialv2.utils import slugify_raise_on_invalid, InvalidSlugError
 from zds.utils.forms import TagValidator, IncludeEasyMDE

--- a/zds/tutorialv2/management/commands/generate_epub.py
+++ b/zds/tutorialv2/management/commands/generate_epub.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from zds.tutorialv2.models.database import PublishedContent
 from zds.tutorialv2.models.versioned import NotAPublicVersion

--- a/zds/tutorialv2/management/commands/generate_markdown.py
+++ b/zds/tutorialv2/management/commands/generate_markdown.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from django.core.management import BaseCommand
 from django.utils import translation
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.tutorialv2.models.database import PublishedContent
 from zds.tutorialv2.models.versioned import NotAPublicVersion

--- a/zds/tutorialv2/management/commands/generate_pdf.py
+++ b/zds/tutorialv2/management/commands/generate_pdf.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from zds.tutorialv2.models.database import PublishedContent
 from zds.tutorialv2.models.versioned import NotAPublicVersion

--- a/zds/tutorialv2/managers.py
+++ b/zds/tutorialv2/managers.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.db.models import Count, F
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.utils.models import Tag
 from model_utils.managers import InheritanceManager

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from django.http import Http404, HttpResponse, HttpResponsePermanentRedirect, StreamingHttpResponse
 from django.template.loader import render_to_string
 from django.shortcuts import redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView, FormView
 from django.views.generic import View
 

--- a/zds/tutorialv2/models/__init__.py
+++ b/zds/tutorialv2/models/__init__.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 CONTENT_TYPES = (

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -15,7 +15,7 @@ from django.dispatch import receiver
 from django.http import Http404
 from django.urls import reverse
 from django.utils.http import urlencode
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from elasticsearch_dsl import Mapping, Q as ES_Q
 from elasticsearch_dsl.field import Text, Keyword, Date, Boolean
 from git import Repo, BadObject

--- a/zds/tutorialv2/models/mixins.py
+++ b/zds/tutorialv2/models/mixins.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class TemplatableContentModelMixin:

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -11,7 +11,7 @@ import codecs
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.template.loader import render_to_string
 
 from zds.tutorialv2.models.mixins import TemplatableContentModelMixin

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -13,7 +13,7 @@ import requests
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
 from django.utils import translation
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from zds.tutorialv2 import signals
 from zds.tutorialv2.epub_utils import build_ebook

--- a/zds/tutorialv2/publish_container.py
+++ b/zds/tutorialv2/publish_container.py
@@ -7,7 +7,7 @@ from os import path, makedirs
 from pathlib import Path
 import copy
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.utils.templatetags.emarkdown import emarkdown
 

--- a/zds/tutorialv2/receivers.py
+++ b/zds/tutorialv2/receivers.py
@@ -3,7 +3,7 @@ import logging
 
 from django.db.models.signals import post_delete
 from django.dispatch.dispatcher import receiver
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.tutorialv2.models.database import PublishableContent, ContentReaction
 from zds.tutorialv2.signals import content_unpublished

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -1,7 +1,7 @@
 import datetime
 from django.urls import reverse
 from django.test import TestCase
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -13,7 +13,7 @@ from django.contrib.auth.models import Group
 from django.core import mail
 from django.urls import reverse
 from django.test import TestCase
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.forum.factories import ForumFactory, ForumCategoryFactory
 from zds.forum.models import Topic, Post, TopicRead

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -6,7 +6,7 @@ from django.core import mail
 from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.forum.factories import ForumFactory, ForumCategoryFactory
 from zds.gallery.factories import UserGalleryFactory

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -4,7 +4,7 @@ import logging
 from urllib.parse import urlsplit, urlunsplit, quote
 from django.contrib.auth.models import User
 from django.http import Http404
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from git import Repo, Actor
 
 from django.conf import settings

--- a/zds/tutorialv2/views/alerts.py
+++ b/zds/tutorialv2/views/alerts.py
@@ -7,7 +7,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 
 from zds.member.decorator import LoginRequiredMixin

--- a/zds/tutorialv2/views/archives.py
+++ b/zds/tutorialv2/views/archives.py
@@ -10,7 +10,7 @@ from PIL import Image as ImagePIL
 from django.conf import settings
 from django.contrib import messages
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 from easy_thumbnails.files import get_thumbnailer
 

--- a/zds/tutorialv2/views/authors.py
+++ b/zds/tutorialv2/views/authors.py
@@ -5,7 +5,7 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.text import format_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.gallery.models import UserGallery, GALLERY_WRITE
 from zds.member.decorator import LoggedWithReadWriteHability

--- a/zds/tutorialv2/views/beta.py
+++ b/zds/tutorialv2/views/beta.py
@@ -5,7 +5,7 @@ from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.forum.models import Topic, Forum, mark_read
 from zds.member.decorator import LoggedWithReadWriteHability

--- a/zds/tutorialv2/views/comments.py
+++ b/zds/tutorialv2/views/comments.py
@@ -9,7 +9,7 @@ from django.shortcuts import render, get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 
 from zds import json_handler

--- a/zds/tutorialv2/views/containers_extracts.py
+++ b/zds/tutorialv2/views/containers_extracts.py
@@ -6,7 +6,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import JsonResponse, Http404
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import DeleteView, FormView
 
 from zds.member.decorator import LoggedWithReadWriteHability, LoginRequiredMixin

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -9,7 +9,7 @@ from django.shortcuts import redirect, get_object_or_404
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import DeleteView
 
 from zds.gallery.models import Gallery, Image

--- a/zds/tutorialv2/views/contributors.py
+++ b/zds/tutorialv2/views/contributors.py
@@ -9,7 +9,7 @@ from django.shortcuts import redirect, get_object_or_404
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.text import format_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.member.decorator import LoggedWithReadWriteHability
 from zds.notification.models import NewPublicationSubscription

--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import settings
 from django.http import Http404
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.featured.mixins import FeatureableMixin
 from zds.tutorialv2 import signals

--- a/zds/tutorialv2/views/editorialization.py
+++ b/zds/tutorialv2/views/editorialization.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.member.decorator import LoggedWithReadWriteHability
 from zds.tutorialv2.forms import RemoveSuggestionForm, EditContentTagsForm

--- a/zds/tutorialv2/views/help.py
+++ b/zds/tutorialv2/views/help.py
@@ -3,7 +3,7 @@ import json
 from django.conf import settings
 from django.db.models import Count, Q
 from django.http import HttpResponse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.member.decorator import LoggedWithReadWriteHability
 from zds.tutorialv2.forms import ToggleHelpForm

--- a/zds/tutorialv2/views/lists.py
+++ b/zds/tutorialv2/views/lists.py
@@ -2,7 +2,7 @@ from collections import defaultdict, OrderedDict
 
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from django.db.models import Count
 from django.http import Http404

--- a/zds/tutorialv2/views/misc.py
+++ b/zds/tutorialv2/views/misc.py
@@ -5,7 +5,7 @@ from django.db import transaction
 from django.http import HttpResponse, Http404
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 
 from zds import json_handler

--- a/zds/tutorialv2/views/statistics.py
+++ b/zds/tutorialv2/views/statistics.py
@@ -4,7 +4,7 @@ from datetime import timedelta, datetime, date
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 
 import googleapiclient

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -10,7 +10,7 @@ from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView, FormView
 
 from zds.member.decorator import LoginRequiredMixin, PermissionRequiredMixin, LoggedWithReadWriteHability

--- a/zds/tutorialv2/views/validations_opinions.py
+++ b/zds/tutorialv2/views/validations_opinions.py
@@ -10,7 +10,7 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, ListView
 
 from zds.gallery.models import Gallery

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -2,7 +2,7 @@ import logging
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.layout import Layout, ButtonHolder, Field, Div, HTML
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.template import defaultfilters
 from zds.utils.models import Tag
 from zds.utils.misc import contains_utf8mb4

--- a/zds/utils/header_notifications.py
+++ b/zds/utils/header_notifications.py
@@ -1,5 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from zds.forum.models import Post
 from zds.mp.models import PrivateTopic

--- a/zds/utils/mixins.py
+++ b/zds/utils/mixins.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.conf import settings
 from zds.utils.models import Comment
 

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from django.utils.encoding import smart_str
 from django.db import models
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.dispatch import receiver
 from django.template.loader import render_to_string
 

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.db.models.signals import post_save
 from django.urls import reverse
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.db import models
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
@@ -782,7 +782,7 @@ class Tag(models.Model):
         self.title = self.title.strip()
         if not self.title or not old_slugify(self.title.replace("-", "")):
             raise ValueError('Tag "{}" is not correct'.format(self.title))
-        self.title = smart_text(self.title).lower()
+        self.title = smart_str(self.title).lower()
         self.slug = uuslug(self.title, instance=self, max_length=Tag._meta.get_field("slug").max_length)
         super(Tag, self).save(*args, **kwargs)
 

--- a/zds/utils/templatetags/append_query_params.py
+++ b/zds/utils/templatetags/append_query_params.py
@@ -1,6 +1,7 @@
-from django import template
-from django.utils.http import urlquote
 from functools import wraps
+from urllib.parse import quote
+
+from django import template
 
 register = template.Library()
 
@@ -82,7 +83,7 @@ class AppendGetNode(template.Node):
 
         if len(get) > 0:
             list_arg = [
-                "{0}={1}".format(key, urlquote(str(value))) for key in list(get.keys()) for value in get.getlist(key)
+                "{0}={1}".format(key, quote(str(value))) for key in list(get.keys()) for value in get.getlist(key)
             ]
             path += "?" + "&".join(list_arg)
 

--- a/zds/utils/templatetags/date.py
+++ b/zds/utils/templatetags/date.py
@@ -4,7 +4,7 @@ from django import template
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.template.defaultfilters import date
 from django.utils.timezone import get_default_timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 register = template.Library()
 

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -7,7 +7,7 @@ from django import template
 from django.conf import settings
 from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger(__name__)
 register = template.Library()

--- a/zds/utils/templatetags/feminize.py
+++ b/zds/utils/templatetags/feminize.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 register = template.Library()
 articles = {_("le"): _("la"), _("un"): _("une"), _("Nouveau"): _("Nouvelle"), _("Ce"): _("Cette")}

--- a/zds/utils/templatetags/htmldiff.py
+++ b/zds/utils/templatetags/htmldiff.py
@@ -2,7 +2,7 @@ from difflib import HtmlDiff
 from django import template
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 register = template.Library()

--- a/zds/utils/templatetags/interventions.py
+++ b/zds/utils/templatetags/interventions.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from django import template
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.db.models import F
 
 from zds.forum.models import is_read as topic_is_read

--- a/zds/utils/templatetags/joinby.py
+++ b/zds/utils/templatetags/joinby.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 register = template.Library()
 

--- a/zds/utils/templatetags/minute_to_duration.py
+++ b/zds/utils/templatetags/minute_to_duration.py
@@ -1,6 +1,6 @@
 from django import template
 from django.template import defaultfilters as filters
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 import datetime
 
 register = template.Library()

--- a/zds/utils/tests/tests_append_query_params.py
+++ b/zds/utils/tests/tests_append_query_params.py
@@ -1,5 +1,6 @@
 from django.test import TestCase, RequestFactory
-from django.template.base import TemplateSyntaxError, Token, TokenType, Context, VariableDoesNotExist, Template
+from django.template import TemplateSyntaxError, Context, VariableDoesNotExist, Template
+from django.template.base import Token, TokenType
 
 from zds.utils.templatetags.append_query_params import easy_tag, AppendGetNode
 

--- a/zds/utils/tests/tests_interventions.py
+++ b/zds/utils/tests/tests_interventions.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from django.urls import reverse
+from django.utils.html import escape
 from django.template import Context, Template
 from django.test import TestCase
 
@@ -103,7 +104,7 @@ class InterventionsTest(TestCase):
 
     def test_interventions_humane_delta(self):
         tr = Template("{% load interventions %}" "{{ date_today|humane_delta }}").render(self.context)
-        self.assertEqual("Aujourd&#39;hui", tr)
+        self.assertEqual(escape("Aujourd'hui"), tr)
 
         tr = Template("{% load interventions %}" "{{ date_yesterday|humane_delta }}").render(self.context)
         self.assertEqual("Hier", tr)


### PR DESCRIPTION
Préparation du passage à Django 3.0 et 3.1 à partir des notes de version

- Quelques modifications dans les tests pour qu'ils fonctionnent avec Django 3.0 et (pas encore entièrement) 3.1
- Quelques modifications dans le code (principalement du renommage) en prévision de future dépréciation de fonctions

[**Django 3.0**](https://docs.djangoproject.com/en/3.1/releases/3.0/)

- Utilise la fonction django.utils.html.escape() pour échapper les apostrophes dans les tests
  - En prévision d'un prochain changement dans Django 3.0, j'utilise la fonction `escape()` dans les tests au lieu d'échapper à la main les apostrophes
  - > `django.utils.html.escape()` now uses `html.escape()` to escape HTML. This converts `'` to `&#x27;` instead of the previous equivalent decimal code `&#39;`.
- Renomme force_text() en force_str()
  - `force_text()` déprécié à partir de Django 3.0 donc je fais le changement dès maintenant
  - > The `smart_text()` and `force_text()` aliases (since Django 2.0) of `smart_str()` and `force_str()` are deprecated. Ignore this deprecation if your code supports Python 2 as the behavior of `smart_str()` and `force_str()` is different there.
- Renomme smart_text() en smart_str()
  - `smart_text()` déprécié à partir de Django 3.0 donc je fais le changement dès maintenant
  - > The `smart_text()` and `force_text()` aliases (since Django 2.0) of `smart_str()` and `force_str()` are deprecated. Ignore this deprecation if your code supports Python 2 as the behavior of `smart_str()` and `force_str()` is different there.
- Renomme `django.utils.http.urlquote()` en `urllib.parse.quote()`
  - `django.utils.http.urlquote()` déprécié à partir de Django 3.0 donc je fais le changement dès maintenant
  - > `django.utils.http.urlquote()`, `urlquote_plus()`, `urlunquote()`, and `urlunquote_plus()` are deprecated in favor of the functions that they’re aliases for: `urllib.parse.quote()`, `quote_plus()`, `unquote()`, and `unquote_plus()`.
- Renomme `django.utils.http.urlunquote()` en `urllib.parse.unquote()`
  - `django.utils.http.urlunquote()` déprécié à partir de Django 3.0 donc je fais le changement dès maintenant
  - > `django.utils.http.urlquote()`, `urlquote_plus()`, `urlunquote()`, and `urlunquote_plus()` are deprecated in favor of the functions that they’re aliases for: `urllib.parse.quote()`, `quote_plus()`, `unquote()`, and `unquote_plus()`.
- Renomme les fonctions `ugettext()` en `gettext()`
  - `django.utils.translation.ugettext()` déprécié à partir de Django 3.0 donc je fais le changement dès maintenant
  - > `django.utils.translation.ugettext()`, `ugettext_lazy()`, `ugettext_noop()`, `ungettext()`, and `ungettext_lazy()` are deprecated in favor of the functions that they’re aliases for: `django.utils.translation.gettext()`, `gettext_lazy()`, `gettext_noop()`, `ngettext()`, and `ngettext_lazy()`.

[**Django 3.1**](https://docs.djangoproject.com/en/3.1/releases/3.1/)

- Renomme `from django.template.base import Context` en `from django.template import Context`
  - `from django.template.base import Context` est déprécié en faveur de `from django.template import Context` et sera supprimé avec Django 3.1 donc je fais le changement dès maintenant
  - > The compatibility imports of `Context`, `ContextPopException`, and `RequestContext` in `django.template.base` are removed.
 
- (**À faire plus tard dans une autre PR**) Corriger les erreurs liées à `ModelChoiceField` et `ModelMultipleChoiceField`
  - À mon avis, ce serait lié au gabarit `templates/crispy/checkboxselectmultiple.html` qui est ancien et n'est pas probablement compatible Django 3.1
  - > `ModelChoiceIterator`, used by `ModelChoiceField` and `ModelMultipleChoiceField`, now yields 2-tuple choices containing `ModelChoiceIteratorValue` instances as the first `value` element in each choice. In most cases this proxies transparently, but if you need the `field` value itself, use the `ModelChoiceIteratorValue.value` attribute instead. 

**QA :** 

- Github Actions
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que le site web fonctionne correctement

**Merci de fusionner cette PR avec le bouton « Rebase and merge »** pour conserver les commits unitaires et avoir un bel historique !