### PR TITLE
Thème de coloration syntaxique accessible et aux couleurs de ZdS

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -182,7 +182,7 @@ function prepareZmd() {
 
 // Prepares files for easy mde
 function prepareEasyMde() {
-  return gulp.src(['node_modules/easymde/dist/easymde.min.css', 'node_modules/codemirror/theme/idea.css'])
+  return gulp.src(['node_modules/easymde/dist/easymde.min.css'])
     .pipe(gulp.dest('dist/css/'))
 }
 

--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -406,7 +406,7 @@
       nativeSpellcheck: true,
       sideBySideFullscreen: false,
       promptAbbrv: true,
-      theme: 'idea',
+      theme: 'zest',
       previewRender: customMarkdownParser,
       syncSideBySidePreviewScroll: false,
       toolbar: [

--- a/assets/scss/base/_source-code.scss
+++ b/assets/scss/base/_source-code.scss
@@ -102,11 +102,14 @@
     background-color: $black;
 
     .hljs-line-numbers {
-      border-right-color: $grey-400;
+      border-right-color: $grey-600;
 
       span {
-        &:after , &.hll:after{
-          color: $white;
+        &:after {
+          color: $grey-400;
+        }
+        &.hll:after {
+          color: $grey-200;
         }
       }
     }

--- a/assets/scss/highlight/_zest-codemirror.scss
+++ b/assets/scss/highlight/_zest-codemirror.scss
@@ -91,6 +91,11 @@
 
     span.cm-link {
         color: $primary-600;
+        text-decoration: none;
+    }
+
+    span.cm-formatting-strikethrough {
+        text-decoration: none;
     }
 
     span.cm-quote {
@@ -101,8 +106,8 @@
         color: $purple-600;
     }
 
-    span.cm-formatting-header {
-        color: $accent-700;
+    span.cm-header {
+        color: $accent-800;
     }
 
     .CodeMirror-activeline-background {

--- a/assets/scss/highlight/_zest-codemirror.scss
+++ b/assets/scss/highlight/_zest-codemirror.scss
@@ -1,0 +1,131 @@
+/* Zeste de Savoir CodeMirror theme */
+/* Based on a11y-light theme by ericwbailey: https://github.com/highlightjs/highlight.js/blob/35cd46312bf3e898471617c47d52f9528fedd763/src/styles/a11y-light.css */
+/* Itself based on the Tomorrow Night Eighties theme: https://github.com/isagalaev/highlight.js/blob/master/src/styles/tomorrow-night-eighties.css */
+/* @author: Amaury Carrade */
+
+.cm-s-zest {
+    font-family: $font-monospace;
+
+    span.cm-meta {
+        color: $green-900;
+    }
+
+    span.cm-formatting {
+        color: $grey-700;
+    }
+
+    span.cm-builtin {
+        color: $accent-700;
+    }
+
+    span.cm-number {
+        color: $blue-800;
+    }
+
+    span.cm-keyword {
+        line-height: 1em;
+        font-weight: bold;
+        color: $blue-900;
+    }
+
+    span.cm-atom {
+        font-weight: bold;
+        color: $blue-900;
+    }
+
+    span.cm-def {
+        color: $black;
+    }
+
+    span.cm-variable {
+        color: $black;
+    }
+
+    span.cm-variable-2 {
+        color: $black;
+    }
+
+    span.cm-variable-3, span.cm-type {
+        color: $black;
+    }
+
+    span.cm-formatting-list {
+        color: $primary-600;
+    }
+
+    span.cm-property {
+        color: $black;
+    }
+
+    span.cm-operator {
+        color: $accent-800;
+    }
+
+    span.cm-comment {
+        color: $grey-800;
+    }
+
+    span.cm-string {
+        color: $green-700;
+    }
+
+    span.cm-string-2 {
+        color: $green-700;
+    }
+
+    span.cm-qualifier {
+        color: $grey-600;
+    }
+
+    span.cm-error {
+        color: $red-600;
+    }
+
+    span.cm-attribute {
+        color: $blue-600;
+    }
+
+    span.cm-tag {
+        color: $blue-900;
+    }
+
+    span.cm-link {
+        color: $primary-600;
+    }
+
+    span.cm-quote {
+        color: $purple-900;
+    }
+
+    span.cm-formatting-quote {
+        color: $purple-600;
+    }
+
+    span.cm-formatting-header {
+        color: $accent-700;
+    }
+
+    .CodeMirror-activeline-background {
+        background: $primary-000;
+    }
+
+    span.cm-bracket {
+        color: $green-300;
+    }
+
+    .CodeMirror-matchingbracket {
+        outline: 1px solid grey;
+        color: $green-800 !important;
+    }
+}
+
+.CodeMirror-hints.zest {
+    font-family: $font-monospace;
+    color: $grey-500;
+    background-color: $blue-000 !important;
+
+    .CodeMirror-hint-active {
+        color: $grey-600 !important;
+        background-color: $blue-100 !important;
+    }
+}

--- a/assets/scss/highlight/_zest-hljs.scss
+++ b/assets/scss/highlight/_zest-hljs.scss
@@ -33,7 +33,8 @@
 }
 
 // Yellow
-.hljs-attribute {
+.hljs-attribute,
+.hljs-selector-pseudo {
   color: $accent-800;
 }
 
@@ -41,7 +42,8 @@
 .hljs-string,
 .hljs-symbol,
 .hljs-bullet,
-.hljs-addition {
+.hljs-addition,
+.hljs-selector-attr {
   color: $green-700;
 }
 
@@ -56,6 +58,15 @@
 .hljs-keyword,
 .hljs-selector-tag {
   color: $purple-800;
+}
+
+// Emphasis on these
+.hljs-attribute,
+.hljs-keyword,
+.hljs-selector-class,
+.hljs-selector-tag,
+.hljs-string {
+  font-weight: 700;
 }
 
 // The whole code

--- a/assets/scss/highlight/_zest-hljs.scss
+++ b/assets/scss/highlight/_zest-hljs.scss
@@ -6,7 +6,7 @@
 // Comment
 .hljs-comment,
 .hljs-quote {
-  color: $grey-600;
+  color: $grey-500;
 }
 
 // Red

--- a/assets/scss/highlight/_zest-hljs.scss
+++ b/assets/scss/highlight/_zest-hljs.scss
@@ -22,7 +22,6 @@
 }
 
 /* Orange */
-.hljs-number,
 .hljs-built_in,
 .hljs-builtin-name,
 .hljs-literal,
@@ -47,9 +46,10 @@
 }
 
 /* Blue */
+.hljs-number,
 .hljs-title,
 .hljs-section {
-  color: $primary-500;
+  color: $primary-600;
 }
 
 /* Purple */

--- a/assets/scss/highlight/_zest-hljs.scss
+++ b/assets/scss/highlight/_zest-hljs.scss
@@ -48,10 +48,13 @@
 }
 
 // Blue
-.hljs-number,
 .hljs-title,
 .hljs-section {
   color: $primary-600;
+}
+
+.hljs-number {
+  color: $blue-400;
 }
 
 // Purple

--- a/assets/scss/highlight/_zest-hljs.scss
+++ b/assets/scss/highlight/_zest-hljs.scss
@@ -3,13 +3,13 @@
 /* Itself based on the Tomorrow Night Eighties theme: https://github.com/isagalaev/highlight.js/blob/master/src/styles/tomorrow-night-eighties.css */
 /* @author: Amaury Carrade */
 
-/* Comment */
+// Comment
 .hljs-comment,
 .hljs-quote {
   color: $grey-600;
 }
 
-/* Red */
+// Red
 .hljs-variable,
 .hljs-template-variable,
 .hljs-tag,
@@ -21,7 +21,7 @@
   color: $red-600;
 }
 
-/* Orange */
+// Orange
 .hljs-built_in,
 .hljs-builtin-name,
 .hljs-literal,
@@ -32,12 +32,12 @@
   color: $accent-900;
 }
 
-/* Yellow */
+// Yellow
 .hljs-attribute {
   color: $accent-800;
 }
 
-/* Green */
+// Green
 .hljs-string,
 .hljs-symbol,
 .hljs-bullet,
@@ -45,25 +45,29 @@
   color: $green-700;
 }
 
-/* Blue */
+// Blue
 .hljs-number,
 .hljs-title,
 .hljs-section {
   color: $primary-600;
 }
 
-/* Purple */
+// Purple
 .hljs-keyword,
 .hljs-selector-tag {
   color: $purple-800;
 }
 
+// The whole code
 .hljs {
   display: block;
   overflow-x: auto;
-  background: #fefefe;
-  color: #545454;
   padding: 0.5em;
+
+  background: $true-white;
+  color: $grey-800;
+
+  font-weight: 500;
 }
 
 .hljs-emphasis {

--- a/assets/scss/highlight/_zest-hljs.scss
+++ b/assets/scss/highlight/_zest-hljs.scss
@@ -65,6 +65,7 @@
 .hljs-keyword,
 .hljs-selector-class,
 .hljs-selector-tag,
+.hljs-selector-id,
 .hljs-string {
   font-weight: 700;
 }
@@ -76,11 +77,12 @@
   padding: 0.5em;
 
   background: $true-white;
-  color: $grey-800;
+  color: $black;
 
   font-weight: 500;
 }
 
+// Markdown
 .hljs-emphasis {
   font-style: italic;
 }

--- a/assets/scss/highlight/_zest-hljs.scss
+++ b/assets/scss/highlight/_zest-hljs.scss
@@ -1,0 +1,100 @@
+/* Zeste de Savoir syntax theme */
+/* Based on a11y-light theme by ericwbailey: https://github.com/highlightjs/highlight.js/blob/35cd46312bf3e898471617c47d52f9528fedd763/src/styles/a11y-light.css */
+/* Itself based on the Tomorrow Night Eighties theme: https://github.com/isagalaev/highlight.js/blob/master/src/styles/tomorrow-night-eighties.css */
+/* @author: Amaury Carrade */
+
+/* Comment */
+.hljs-comment,
+.hljs-quote {
+  color: $grey-600;
+}
+
+/* Red */
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-regexp,
+.hljs-deletion {
+  color: $red-600;
+}
+
+/* Orange */
+.hljs-number,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-literal,
+.hljs-type,
+.hljs-params,
+.hljs-meta,
+.hljs-link {
+  color: $accent-900;
+}
+
+/* Yellow */
+.hljs-attribute {
+  color: $accent-800;
+}
+
+/* Green */
+.hljs-string,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition {
+  color: $green-700;
+}
+
+/* Blue */
+.hljs-title,
+.hljs-section {
+  color: $primary-500;
+}
+
+/* Purple */
+.hljs-keyword,
+.hljs-selector-tag {
+  color: $purple-800;
+}
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  background: #fefefe;
+  color: #545454;
+  padding: 0.5em;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .hljs-addition,
+  .hljs-attribute,
+  .hljs-built_in,
+  .hljs-builtin-name,
+  .hljs-bullet,
+  .hljs-comment,
+  .hljs-link,
+  .hljs-literal,
+  .hljs-meta,
+  .hljs-number,
+  .hljs-params,
+  .hljs-string,
+  .hljs-symbol,
+  .hljs-type,
+  .hljs-quote {
+        color: highlight;
+    }
+
+    .hljs-keyword,
+    .hljs-selector-tag {
+        font-weight: bold;
+    }
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -39,6 +39,7 @@
 6. Syntax highlighting theme
 ------------------------*/
 @import "highlight/zest-hljs";
+@import "highlight/zest-codemirror";
 
 /*------------------------
 7. Header

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -12,7 +12,6 @@
 1. External dependencies
 ------------------------*/
 @import "normalize.css/normalize";
-@import "highlight.js/styles/idea";
 
 /*------------------------
 2. Base
@@ -37,7 +36,12 @@
 @import "base/helpers";
 
 /*------------------------
-6. Header
+6. Syntax highlighting theme
+------------------------*/
+@import "highlight/zest-hljs";
+
+/*------------------------
+7. Header
 ------------------------*/
 @import "layout/header";
 @import "components/header-dropdown";
@@ -46,7 +50,7 @@
 @import "components/cookies-banner";
 
 /*------------------------
-7. Layout
+8. Layout
 ------------------------*/
 @import "layout/sidebar";
 @import "layout/main";
@@ -54,7 +58,7 @@
 @import "layout/footer";
 
 /*------------------------
-8. Components
+9. Components
 ------------------------*/
 @import "components/alert-box";
 @import "components/aside-meta";
@@ -85,7 +89,7 @@
 @import "components/more-link";
 
 /*------------------------
-9. Pages
+10. Pages
 ------------------------*/
 @import "pages/flexpage";
 @import "pages/home";
@@ -99,6 +103,6 @@
 @import "pages/content-exports";
 
 /*-------------------------
-10. High pixel ratio (retina)
+11. High pixel ratio (retina)
 -------------------------*/
 @import "base/high-pixel-ratio";

--- a/assets/scss/zmd.scss
+++ b/assets/scss/zmd.scss
@@ -5,7 +5,7 @@
 // FIXME: high-dpi support for icons?
 @import "variables/variables";
 @import "sprite";
-@import "highlight.js/styles/idea";
+@import "highlight/zest-hljs";
 @import "components/alert-box";
 @import "base/icons";
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "gulp-postcss": "9.0.0",
     "gulp-terser-js": "5.1.2",
     "gulp.spritesmith": "6.11.0",
-    "highlight.js": "10.4.1",
     "jquery": "3.5.1",
     "katex": "0.11.1",
     "moment": "2.29.1",

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,7 +99,7 @@
     {% block canonical %}{% endblock %}
 
     {# Webfont async loading #}
-    <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700|Source+Code+Pro:400,700|Merriweather:400,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700|Source+Code+Pro:400,500,700|Merriweather:400,700' rel='stylesheet' type='text/css'>
 
 
     {% block extra_css %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -93,7 +93,6 @@
         integrity="sha384-v8BU367qNbs/aIZIxuivaU55N5GPF89WBerHoGA4QTcbUjYiLQtKdrfXnqAcXyTv"
         crossorigin="anonymous">
     <link rel="stylesheet" href="{% static "css/easymde.min.css" %}">
-    <link rel="stylesheet" href="{% static "css/idea.css" %}">
     <link rel="stylesheet" href="{% static "css/katex.min.css" %}">
     <link rel="stylesheet" href="{% static "css/main.css" %}">
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,11 +2998,6 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@10.4.1:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
-  integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
-
 homedir-polyfill@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"


### PR DESCRIPTION
Cette PR _propose_ un thème de coloration syntaxique basé sur le thème a11y-light, [que l'on peut retrouver par ici](https://highlightjs.org/static/demo/) (le sélectionner à gauche), mais adapté aux couleurs de ZdS.

L'objectif est de l'adapter également pour CodeMirror — ça ne devrait pas être trop compliqué — et éventuellement d'en faire un paquet npm externe, afin que d'autres projets de ZdS (par exemple, Zeste de Code) puissent en profiter.

### Aperçu

_N'hésitez pas à cliquer sur les images pour les ouvrir en bonne qualité._

_**Ces captures d'écran ne sont plus à jour.**_

![Lisp](https://user-images.githubusercontent.com/1417570/103250000-19a0cc80-4972-11eb-83bd-a7d105d3ea6d.png)

![Python](https://user-images.githubusercontent.com/1417570/103250008-29201580-4972-11eb-8adf-7fed1d7ac8e5.png)

![Rust](https://user-images.githubusercontent.com/1417570/103250021-32a97d80-4972-11eb-9808-0e33644fc83e.png)

![INI](https://user-images.githubusercontent.com/1417570/103250037-43f28a00-4972-11eb-8f9f-bb875abd0aed.png)

![C](https://user-images.githubusercontent.com/1417570/103250047-4f45b580-4972-11eb-9d62-808417f6b664.png)

### Contrôle qualité

1. Lancer le site avec `make run`.
2. Aller sur un contenu ou en créer un contenant du code source. On pourra utiliser [ce fichier Markdown contenant plein de code sources dans plein de langages](https://gist.githubusercontent.com/AmauryCarrade/c6459874f2e4981afaef7a546d983c9b/raw/376a19e686f2083a74275ad43ad27e521c8d2ded/que-de-couleurs.md).
3. Vérifier que le rendu est bon, lisible, et accessible.