### PR TITLE
Passage de django-cors-middleware à django-cors-headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ requests==2.25.0
 toml==0.10.2
 
 # Api dependencies
-django-cors-middleware==1.5.0
+django-cors-headers==3.7.0
 django-filter==2.4.0
 django-oauth-toolkit==1.3.3
 django-rest-swagger==2.2.0


### PR DESCRIPTION
Il y a quelques années, `django-cors-headers` n'était plus maintenu donc on avait créé notre petit fork `django-cors-middleware`. Aujourd'hui, `django-cors-headers` est de nouveau maintenu et normalement les quelques modifications de notre fork ont été reprises donc je propose de repasser à `django-cors-headers` ce qui nous fait une chose de moins à maintenir.

**QA :** Je ne vois pas trop ce qu'il y a en dehors des tests Github Actions. Peut-être vérifier manuellement que l'API fonctionne correctement ?