### PR TITLE
Billets : les boutons précédents et suivants ne donnent accès qu'aux billets validés

### DIFF
--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -1,7 +1,7 @@
 import logging
 
-from django.db.models import F
 from django.conf import settings
+from django.db.models import F
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 

--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.db.models import F
 from django.conf import settings
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
@@ -84,6 +85,9 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
             queryset_pagination = PublishedContent.objects.filter(
                 content_type=self.current_content_type, must_redirect=False
             )
+            
+        if self.current_content_type == 'OPINION':
+            queryset_pagination = queryset_pagination.filter(content__sha_picked=F('sha_public'))
 
             context["previous_content"] = (
                 queryset_pagination.filter(publication_date__lt=self.public_content_object.publication_date)

--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -86,8 +86,8 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
                 content_type=self.current_content_type, must_redirect=False
             )
             
-        if self.current_content_type == 'OPINION':
-            queryset_pagination = queryset_pagination.filter(content__sha_picked=F('sha_public'))
+            if self.current_content_type == 'OPINION':
+                queryset_pagination = queryset_pagination.filter(content__sha_picked=F("sha_public"))
 
             context["previous_content"] = (
                 queryset_pagination.filter(publication_date__lt=self.public_content_object.publication_date)


### PR DESCRIPTION
Ajout faisant en sorte que les boutons Précédents et Suivants dans la bibliothèque de billets, proposent que les billets validé par le Staff.
Lignes ajoutées : 88-90
Issue lien : https://github.com/zestedesavoir/zds-site/issues/5793

<!-- Veuillez décrire vos changements à l’emplacement de ce commentaire (inutile dans le cas de tout petits changements). -->

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné (optionnel) :

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

<!-- Écrivez éventuellement ici quelques instructions pour nous aider à vérifier vos changement.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

<!-- Merci ! -->
