### PR TITLE
Corrige l'affichage des alertes sur les billets (#6011)

### DIFF
--- a/zds/utils/header_notifications.py
+++ b/zds/utils/header_notifications.py
@@ -20,7 +20,7 @@ def _get_alert_info(alert):
         return post.topic.title, post.get_absolute_url()
     elif alert.scope == "CONTENT":
         published = PublishableContent.objects.select_related("public_version").get(pk=alert.content.pk)
-        title = (published.public_version.title if published.public_version else published.title,)
+        title = published.public_version.title if published.public_version else published.title
         url = published.get_absolute_url_online() if published.public_version else ""
         return title, url
     elif alert.scope == "PROFILE":


### PR DESCRIPTION
Fix #6011.

Apparemment, laisser traîner une virgule n'est pas un bon plan. :D
D'ailleurs, la normalisation avec black a rendu le problème plus visible grâce aux parenthèses.

### Contrôle qualité

- Vérifier que l'affichage des alertes sur un billet est correct et pas comme décrit dans #6011.
- Vérifier que l'affichage des autres types d'alertes est toujours correct.
