### PR TITLE
Éditeur: Barre d'outil sticky sur tablette+

### DIFF
--- a/assets/scss/components/_editor-new.scss
+++ b/assets/scss/components/_editor-new.scss
@@ -9,6 +9,18 @@
         .editor-toolbar {
             border: 0;
 
+            @include tablet {
+                position: sticky;
+                top: 0;
+                z-index: 2;
+                background-color: $color-body-background;
+                border-bottom: $length-1 solid $grey-200;
+                
+                ~ .CodeMirror {
+                    border-top: 0;
+                }
+            }
+
             &.disabled-for-textarea-mode {
                 button {
                     &.disable-for-textarea-mode {


### PR DESCRIPTION
Proposition basique, il y a de la marge pour améliorer, mais je voulais avant tout proposer l'idée 🙂 

### Contrôle qualité

- `make build-front`
- Aller sur une page avec un éditeur de texte (idéalement avec beaucoup de texte, sinon insérer plusieurs retours à la ligne pour forcer une zone plus haute que le viewport
- La barre d'outils de l'éditeur devrait rester collée en haut de l'écran pendant le scroll au-dessus de l'éditeur, sur écrans `tablet` et au-dessus

