### PR TITLE
Les boutons ne s'empilent plus sur les titres des parties d'un contenu

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -52,12 +52,18 @@ h2 {
     }
 
     .actions-title {
+        display: flex;
+
         margin: 0 $length-10;
+
+        @include mobile {
+            flex-direction: column;
+        }
 
         .btn {
             height: $length-32;
 
-            margin-left: $length-4;
+            margin: $length-2;
 
             background-color: $grey-100;
             color: $grey-600;


### PR DESCRIPTION
Les boutons ne s'empilent plus sur les titres des parties d'un contenu

Closes #6033 

**QA :**

- `source zdsenv/bin/activate && make zmd-start && make update`
- Aller sur le site
- Se connecter avec `admin`
- Aller sur un contenu
- Cliquer sur "Voir la version brouillon"
- Vérifier que les boutons s'affichent correctement dans les titres des parties (à l'horizontal sur ordinateur et tablette, puis vertical sur mobile) en redimensionnant la fenêtre du navigateur