### PR TITLE
N'affiche que les trois points du menu des message sur mobile

### DIFF
--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -379,11 +379,11 @@ div.msg-are-hidden {
                         transition: $transition-duration ease-in-out;
                         transition-property: min-width, width, box-shadow;
 
-                        @include tiny {
+                        @include mobile {
                             width: 0;
                             min-width: $length-64;
 
-                            span {
+                            span, a:after {
                                 display: none;
                             }
                         }
@@ -492,9 +492,13 @@ div.msg-are-hidden {
                         li {
                             min-width: $length-192;
 
-                            @include tiny {
+                            @include mobile {
                                 span {
                                     display: inline;
+                                }
+
+                                a:after {
+                                    display: block;
                                 }
                             }
 

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -448,6 +448,7 @@ div.msg-are-hidden {
 
                                 color: $grey-500;
                                 font-size: $font-size-9;
+                                font-weight: bold;
 
                                 line-height: .8;
                             }


### PR DESCRIPTION
Tout est dans le titre.

### Contrôle qualité

1. `make run`
2. Vérifier sur un affichage mobile (sur un vrai téléphone ou sur la vue mobile du navigateur) que le bouton est réduit à trois points.
3. Vérifier que sur un ordi, le bouton est toujours complet.
