### PR TITLE
Ressuscite l'icône de Github

### DIFF
--- a/assets/scss/base/_icons.scss
+++ b/assets/scss/base/_icons.scss
@@ -191,6 +191,18 @@
         }
     }
 
+    &.github {
+        &:after {
+            @include sprite-position($github);
+        }
+        &.blue:after {
+            @include sprite-position($github-blue);
+        }
+        &.light:after {
+            @include sprite-position($github-light);
+        }
+    }
+
     &.help {
         &:after {
             @include sprite-position($help);


### PR DESCRIPTION
Ressuscite l'icône de Github

Closes #6038 

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Se connecter avec `dev`
- Aller sur un sujet
- Vérifier que l'icône de Github apparait bien à côté du bouton « Créer un ticket »