### PR TITLE
Dropdown actions messages

### DIFF
--- a/assets/js/accessibility-links.js
+++ b/assets/js/accessibility-links.js
@@ -12,7 +12,7 @@
 
   function accessibility(element) {
     element.addEventListener('focus', () => {
-      Array.from(document.querySelectorAll('.dropdown'))
+      Array.from(document.querySelectorAll('.header-dropdown'))
         .filter(item => !isHidden(item))
         .forEach(item => item.parentElement.querySelector('.active').classList.remove('active'))
       document.querySelector('#accessibility').classList.add('focused')

--- a/assets/js/dropdown-menu.js
+++ b/assets/js/dropdown-menu.js
@@ -14,7 +14,7 @@
     return $('.header-menu').is('[data-hovering-mode]')
   }
 
-  var handlers = $('.dropdown')
+  var handlers = $('.header-dropdown')
     .map(function(_, dropdown) {
       return setupDropdown($(dropdown))
     })

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -1,3 +1,5 @@
+$dropdown-offset-right: 6px;
+
 details.dropdown {
 	position: relative;
 
@@ -41,11 +43,9 @@ details.dropdown {
 	}
 
 	.dropdown-content {
-		$message-option-offset-right: 6px;
-
 		position: absolute;
 		top: $length-32;
-		right: $message-option-offset-right;
+		right: $dropdown-offset-right;
 
 		margin: 0;
 		padding: 0;
@@ -66,14 +66,14 @@ details.dropdown {
 		}
 		&::before {
 			top: -10px;
-			right: #{14px - $message-option-offset-right};
+			right: #{14px - $dropdown-offset-right};
 			border-width: 10px;
 			border-top: 0;
 			border-bottom-color: hsla(0, 0%, 0%, .04);
 		}
 		&::after {
 			top: -9px;
-			right: #{15px - $message-option-offset-right};
+			right: #{15px - $dropdown-offset-right};
 			border-width: 9px;
 			border-top: 0;
 			border-bottom-color: #fff;

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -44,7 +44,8 @@ details.dropdown {
         z-index: 21;
 
         background-color: $true-white;
-        @include shadow-4;
+        border-top: 1px solid rgba($true-black, .1);
+        @include shadow-2;
 
         &::before,
         &::after {

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -1,0 +1,82 @@
+details.dropdown {
+	position: relative;
+
+	summary {
+		height: $length-32;
+		padding-right: $length-16;
+		padding-left: $length-16;
+
+		appearance: none;
+
+		&::marker {
+			content: '…';
+
+			position: absolute;
+
+			top: 0;
+			right: 0;
+
+			padding: $length-6;
+			padding-right: $length-16;
+
+			color: $grey-500;
+			font-size: $font-size-9;
+			font-weight: bold;
+
+			line-height: .8;
+		}
+	}
+
+	&[open] {
+		summary {
+			&::before {
+				content: '';
+				position: fixed;
+				top: 0;
+				right: 0;
+				bottom: 0;
+				left: 0;
+			}
+		}
+	}
+
+	.dropdown-content {
+		$message-option-offset-right: 6px;
+
+		position: absolute;
+		top: $length-32;
+		right: $message-option-offset-right;
+
+		margin: 0;
+		padding: 0;
+
+		z-index: 21;
+
+		@include shadow-2;
+
+		&::before,
+		&::after {
+			content: " ";
+			position: absolute;
+			display: block;
+			width: 0;
+			height: 0;
+			border: 10px solid transparent;
+			border-top: 0;
+		}
+		&::before {
+			top: -10px;
+			right: #{14px - $message-option-offset-right};
+			border-width: 10px;
+			border-top: 0;
+			border-bottom-color: hsla(0, 0%, 0%, .04);
+		}
+		&::after {
+			top: -9px;
+			right: #{15px - $message-option-offset-right};
+			border-width: 9px;
+			border-top: 0;
+			border-bottom-color: #fff;
+		}
+	}
+}

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -57,22 +57,20 @@ details.dropdown {
             display: block;
             width: 0;
             height: 0;
-            border: 10px solid transparent;
-            border-top: 0;
         }
         &::before {
             top: -10px;
             right: #{14px - $dropdown-offset-right};
-            border-width: 10px;
+            border: 10px solid transparent;
             border-top: 0;
-            border-bottom-color: hsla(0, 0%, 0%, .04);
+            border-bottom-color: rgba($true-black, .04);
         }
         &::after {
             top: -9px;
             right: #{15px - $dropdown-offset-right};
-            border-width: 9px;
+            border: 9px solid transparent;
             border-top: 0;
-            border-bottom-color: #fff;
+            border-bottom-color: $true-white;
         }
     }
 }

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -42,14 +42,14 @@ details.dropdown {
         }
         &::before {
             top: -10px;
-            right: #{$length-14 - $dropdown-offset-right};
+            right: calc(14px - #{$dropdown-offset-right});
             border: 10px solid transparent;
             border-top: 0;
             border-bottom-color: rgba($true-black, .1);
         }
         &::after {
             top: -9px;
-            right: #{$length-15 - $dropdown-offset-right};
+            right: calc(15px - #{$dropdown-offset-right});
             border: 9px solid transparent;
             border-top: 0;
             border-bottom-color: $true-white;

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -1,10 +1,14 @@
-$dropdown-offset-right: $length-6;
+$dropdown-arrow-height: 10px;
 
 details.dropdown {
+    --dropdown-offset-right: 0;
+    --dropdown-arrow-offset-right: #{$length-4};
+
     position: relative;
 
     summary {
         appearance: none;
+        cursor: pointer;
     }
 
     &[open] {
@@ -22,14 +26,15 @@ details.dropdown {
 
     .dropdown-content {
         position: absolute;
-        top: $length-32;
-        right: $dropdown-offset-right;
+        top: 100%;
+        right: var(--dropdown-offset-right);
 
         margin: 0;
         padding: 0;
 
         z-index: 21;
 
+        background-color: $true-white;
         @include shadow-4;
 
         &::before,
@@ -41,16 +46,16 @@ details.dropdown {
             height: 0;
         }
         &::before {
-            top: -10px;
-            right: calc(14px - #{$dropdown-offset-right});
-            border: 10px solid transparent;
+            top: -#{$dropdown-arrow-height};
+            right: var(--dropdown-arrow-offset-right);
+            border: #{$dropdown-arrow-height} solid transparent;
             border-top: 0;
             border-bottom-color: rgba($true-black, .1);
         }
         &::after {
-            top: -9px;
-            right: calc(15px - #{$dropdown-offset-right});
-            border: 9px solid transparent;
+            top: -#{$dropdown-arrow-height - 1px};
+            right: calc(var(--dropdown-arrow-offset-right) + 1px);
+            border: #{$dropdown-arrow-height - 1px} solid transparent;
             border-top: 0;
             border-bottom-color: $true-white;
         }

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -1,82 +1,78 @@
 $dropdown-offset-right: 6px;
 
 details.dropdown {
-	position: relative;
+    position: relative;
 
-	summary {
-		height: $length-32;
-		padding-right: $length-16;
-		padding-left: $length-16;
+    summary {
+        height: $length-32;
+        padding-right: $length-16;
+        padding-left: $length-16;
 
-		appearance: none;
+        appearance: none;
 
-		&::marker {
-			content: '…';
+        &::marker {
+            content: '…';
 
-			position: absolute;
+            position: absolute;
 
-			top: 0;
-			right: 0;
+            top: 0;
+            right: 0;
 
-			padding: $length-6;
-			padding-right: $length-16;
+            padding: $length-6;
+            padding-right: $length-16;
 
-			color: $grey-500;
-			font-size: $font-size-9;
-			font-weight: bold;
+            color: $grey-500;
+            font-size: $font-size-9;
+            font-weight: bold;
 
-			line-height: .8;
-		}
-	}
+            line-height: .8;
+        }
+    }
 
-	&[open] {
-		summary {
-			&::before {
-				content: '';
-				position: fixed;
-				top: 0;
-				right: 0;
-				bottom: 0;
-				left: 0;
-			}
-		}
-	}
+    &[open] summary::before {
+        content: '';
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+    }
 
-	.dropdown-content {
-		position: absolute;
-		top: $length-32;
-		right: $dropdown-offset-right;
+    .dropdown-content {
+        position: absolute;
+        top: $length-32;
+        right: $dropdown-offset-right;
 
-		margin: 0;
-		padding: 0;
+        margin: 0;
+        padding: 0;
 
-		z-index: 21;
+        z-index: 21;
 
-		@include shadow-2;
+        @include shadow-2;
 
-		&::before,
-		&::after {
-			content: " ";
-			position: absolute;
-			display: block;
-			width: 0;
-			height: 0;
-			border: 10px solid transparent;
-			border-top: 0;
-		}
-		&::before {
-			top: -10px;
-			right: #{14px - $dropdown-offset-right};
-			border-width: 10px;
-			border-top: 0;
-			border-bottom-color: hsla(0, 0%, 0%, .04);
-		}
-		&::after {
-			top: -9px;
-			right: #{15px - $dropdown-offset-right};
-			border-width: 9px;
-			border-top: 0;
-			border-bottom-color: #fff;
-		}
-	}
+        &::before,
+        &::after {
+            content: " ";
+            position: absolute;
+            display: block;
+            width: 0;
+            height: 0;
+            border: 10px solid transparent;
+            border-top: 0;
+        }
+        &::before {
+            top: -10px;
+            right: #{14px - $dropdown-offset-right};
+            border-width: 10px;
+            border-top: 0;
+            border-bottom-color: hsla(0, 0%, 0%, .04);
+        }
+        &::after {
+            top: -9px;
+            right: #{15px - $dropdown-offset-right};
+            border-width: 9px;
+            border-top: 0;
+            border-bottom-color: #fff;
+        }
+    }
 }

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -8,15 +8,24 @@ details.dropdown {
 
     summary {
         appearance: none;
+        display: inline-block;
         cursor: pointer;
+
+        &::-webkit-details-marker {
+            display: none;
+        }
+        &::marker {
+            display: none;
+        }
     }
 
     &[open] {
         z-index: 10;
     }
 
-    &[open] summary::before {
+    &[open] summary::after {
         content: '';
+        cursor: default;
         position: fixed;
         top: 0;
         right: 0;

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -1,32 +1,14 @@
-$dropdown-offset-right: 6px;
+$dropdown-offset-right: $length-6;
 
 details.dropdown {
     position: relative;
 
     summary {
-        height: $length-32;
-        padding-right: $length-16;
-        padding-left: $length-16;
-
         appearance: none;
+    }
 
-        &::marker {
-            content: '…';
-
-            position: absolute;
-
-            top: 0;
-            right: 0;
-
-            padding: $length-6;
-            padding-right: $length-16;
-
-            color: $grey-500;
-            font-size: $font-size-9;
-            font-weight: bold;
-
-            line-height: .8;
-        }
+    &[open] {
+        z-index: 10;
     }
 
     &[open] summary::before {
@@ -48,7 +30,7 @@ details.dropdown {
 
         z-index: 21;
 
-        @include shadow-2;
+        @include shadow-4;
 
         &::before,
         &::after {
@@ -60,14 +42,14 @@ details.dropdown {
         }
         &::before {
             top: -10px;
-            right: #{14px - $dropdown-offset-right};
+            right: #{$length-14 - $dropdown-offset-right};
             border: 10px solid transparent;
             border-top: 0;
-            border-bottom-color: rgba($true-black, .04);
+            border-bottom-color: rgba($true-black, .1);
         }
         &::after {
             top: -9px;
-            right: #{15px - $dropdown-offset-right};
+            right: #{$length-15 - $dropdown-offset-right};
             border: 9px solid transparent;
             border-top: 0;
             border-bottom-color: $true-white;

--- a/assets/scss/components/_header-dropdown.scss
+++ b/assets/scss/components/_header-dropdown.scss
@@ -1,4 +1,4 @@
-.dropdown {
+.header-dropdown {
     display: none;
 
     position: absolute;
@@ -122,17 +122,17 @@
         }
     }
 }
-.active + .dropdown {
+.active + .header-dropdown {
     display: block;
 }
 
 @include tablet {
-    .dropdown {
+    .header-dropdown {
         box-shadow: 0 $length-6 $length-8 rgba($black, .3);
     }
 
     .header-right {
-        .dropdown {
+        .header-dropdown {
             width: $length-384;
             left: auto;
             padding: 0;
@@ -187,7 +187,7 @@
         display: none !important;
     }
 
-    .dropdown {
+    .header-dropdown {
         width: 100%;
         top: 180px;
         bottom: 0;
@@ -212,7 +212,7 @@
 }
 
 @include desktop {
-    .dropdown {
+    .header-dropdown {
         top: $header-height;
     }
 }

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -362,7 +362,23 @@ div.msg-are-hidden {
                     padding-right: $length-16;
                     padding-left: $length-16;
 
-                    appearance: none;
+                    &::marker {
+                        content: '…';
+
+                        position: absolute;
+
+                        top: 0;
+                        right: 0;
+
+                        padding: $length-6;
+                        padding-right: $length-16;
+
+                        color: $grey-500;
+                        font-size: $font-size-9;
+                        font-weight: bold;
+
+                        line-height: .8;
+                    }
                 }
 
                 ul {

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -355,12 +355,15 @@ div.msg-are-hidden {
             }
 
             details.message-actions {
+                margin-top: $length-4;
+                margin-right: $length-4;
                 margin-bottom: $length-8;
 
                 summary {
                     height: $length-32;
-                    padding-right: $length-16;
-                    padding-left: $length-16;
+                    padding-right: $length-8;
+                    padding-left: $length-8;
+                    color: $grey-500;
 
                     &::marker {
                         content: '…';
@@ -370,10 +373,11 @@ div.msg-are-hidden {
                         top: 0;
                         right: 0;
 
+                        width: $length-6;
+
                         padding: $length-6;
                         padding-right: $length-16;
 
-                        color: $grey-500;
                         font-size: $font-size-9;
                         font-weight: bold;
 
@@ -381,7 +385,9 @@ div.msg-are-hidden {
                     }
                 }
 
-                ul {
+                .dropdown-content {
+                    --dropdown-arrow-offset-right: #{$length-6};
+
                     li {
                         display: flex;
                         align-items: center;

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -365,28 +365,28 @@ div.msg-are-hidden {
                     padding-left: $length-8;
                     color: $grey-500;
 
-                    &::marker {
+                    &::before {
                         content: '…';
-
-                        position: absolute;
-
-                        top: 0;
-                        right: 0;
 
                         width: $length-6;
 
                         padding: $length-6;
-                        padding-right: $length-16;
 
                         font-size: $font-size-9;
                         font-weight: bold;
 
                         line-height: .8;
                     }
+
+                    &:hover,
+                    &:focus {
+                        color: $grey-700;
+                        outline: none;
+                    }
                 }
 
                 .dropdown-content {
-                    --dropdown-arrow-offset-right: #{$length-6};
+                    --dropdown-arrow-offset-right: #{$length-12};
 
                     li {
                         display: flex;

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -354,18 +354,18 @@ div.msg-are-hidden {
                 }
             }
 
-            aside.message-actions {
-                position: relative;
+            details.message-actions {
                 margin-bottom: $length-8;
 
+                summary {
+                    height: $length-32;
+                    padding-right: $length-16;
+                    padding-left: $length-16;
+
+                    appearance: none;
+                }
+
                 ul {
-                    position: absolute;
-                    top: 0;
-                    right: 0;
-
-                    margin: 0;
-                    padding: 0;
-
                     li {
                         display: flex;
                         align-items: center;
@@ -428,32 +428,6 @@ div.msg-are-hidden {
                             }
                         }
 
-                        &:not(:first-child) {
-                            display: none;
-                        }
-
-                        &:first-child {
-                            padding-right: $length-32;
-
-                            &:after {
-                                content: '…';
-
-                                position: absolute;
-
-                                top: 0;
-                                right: 0;
-
-                                padding: $length-6;
-                                padding-right: $length-16;;
-
-                                color: $grey-500;
-                                font-size: $font-size-9;
-                                font-weight: bold;
-
-                                line-height: .8;
-                            }
-                        }
-
                         &.is-separator {
                             // display: flex in :hover
                             align-items: center;
@@ -481,47 +455,41 @@ div.msg-are-hidden {
                         }
                     }
 
-                    &:hover, &:focus, &.is-active {
-                        z-index: 21;
+                    &, li, a, button {
+                        background-color: $true-white;
+                    }
 
-                        @include shadow-2;
+                    li {
+                        min-width: $length-192;
 
-                        &, li, a, button {
-                            background-color: $true-white;
-                        }
-
-                        li {
-                            min-width: $length-192;
-
-                            @include mobile {
-                                span {
-                                    display: inline;
-                                }
-
-                                a:after {
-                                    display: block;
-                                }
+                        @include mobile {
+                            span {
+                                display: inline;
                             }
 
-                            &:first-child {
-                                padding-right: 0;
-
-                                &:after {
-                                    display: none;
-                                }
-                            }
-
-                            &:not(:first-child) {
+                            a:after {
                                 display: block;
                             }
+                        }
 
-                            &.is-separator {
-                                display: flex;
-                            }
+                        &:first-child {
+                            padding-right: 0;
 
-                            a, button, button[type=submit] {
-                                color: $grey-900;
+                            &:after {
+                                display: none;
                             }
+                        }
+
+                        &:not(:first-child) {
+                            display: block;
+                        }
+
+                        &.is-separator {
+                            display: flex;
+                        }
+
+                        a, button, button[type=submit] {
+                            color: $grey-900;
                         }
                     }
                 }

--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -387,6 +387,8 @@ div.msg-are-hidden {
 
                 .dropdown-content {
                     --dropdown-arrow-offset-right: #{$length-12};
+                    padding-top: $length-4;
+                    padding-bottom: $length-4;
 
                     li {
                         display: flex;

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -12,7 +12,7 @@ $logo-width: 24rem;
         @include desktop {
             padding: 0 $length-20;
 
-            .header-right .dropdown {
+            .header-right .header-dropdown {
                 right: $length-20;
             }
         }
@@ -268,14 +268,14 @@ $logo-width: 24rem;
         }
     }
 
-    .dropdown {
+    .header-dropdown {
         overflow: hidden;
 
         @include mobile {
             top: $length-48;
             height: calc(100vh - #{$length-48});
 
-            @at-root body.has-top-banner .logbox .dropdown {
+            @at-root body.has-top-banner .logbox .header-dropdown {
                 height: calc(100vh - #{$length-48 + $length-24});
             }
         }
@@ -455,7 +455,7 @@ $logo-width: 24rem;
         }
     }
 
-    .dropdown.my-account-dropdown {
+    .header-dropdown.my-account-dropdown {
         @include tablet-only {
             .dropdown-list {
                 max-height: unset;
@@ -543,7 +543,7 @@ $logo-width: 24rem;
                 width: 100%;
             }
 
-            .dropdown {
+            .header-dropdown {
                 top: $length-48 - $length-1;
             }
 
@@ -554,7 +554,7 @@ $logo-width: 24rem;
                 width: $length-48;
             }
 
-            .dropdown.my-account-dropdown .dropdown-list {
+            .header-dropdown.my-account-dropdown .dropdown-list {
                 bottom: 0;
 
                 li {
@@ -635,11 +635,11 @@ $logo-width: 24rem;
         text-align: left;
     }
 
-    .dropdown {
+    .header-dropdown {
         top: $header-height;
     }
 
-    .logbox .dropdown.my-account-dropdown ul li {
+    .logbox .header-dropdown.my-account-dropdown ul li {
         height: $length-32;
         line-height: $length-32;
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -66,6 +66,7 @@
 @import "components/autocomplete";
 @import "components/breadcrumb";
 @import "components/content-item";
+@import "components/dropdown";
 @import "components/editor-new";
 @import "components/editor-old";
 @import "components/featured-item";

--- a/assets/scss/variables/_lengths.scss
+++ b/assets/scss/variables/_lengths.scss
@@ -6,7 +6,6 @@ $length-8: .8rem;
 $length-10: 1rem;
 $length-12: 1.2rem;
 $length-14: 1.4rem;
-$length-15: 1.5rem;
 $length-16: 1.6rem;
 $length-18: 1.8rem;
 $length-20: 2.0rem;

--- a/assets/scss/variables/_lengths.scss
+++ b/assets/scss/variables/_lengths.scss
@@ -6,6 +6,7 @@ $length-8: .8rem;
 $length-10: 1rem;
 $length-12: 1.2rem;
 $length-14: 1.4rem;
+$length-15: 1.5rem;
 $length-16: 1.6rem;
 $length-18: 1.8rem;
 $length-20: 2.0rem;

--- a/doc/source/front-end/elements-specifiques-au-site.rst
+++ b/doc/source/front-end/elements-specifiques-au-site.rst
@@ -177,6 +177,27 @@ S'il vous faut afficher un texte un peu long sur l'infobulle, qui ne rentre pas 
 
    Ce module est une reprise adaptée de ``bulma-tooltip`` `de Wikiki <https://wikiki.github.io/elements/tooltip/>`_.
 
+Les menus déroulants (ou dropdown)
+==================
+
+À ne pas confondre avec `header-dropdown`, ces menus déroulants ne requièrent aucun JS pour fonctionner mais se reposent sur la balise ``<details>``
+
+Pour créer un menu déroulant, utilisez simplement la classe ``dropdown`` à l'élément ``<details>``, en utilisant la balise ``<summary>`` pour fournir un texte alternatif au ``…`` affiché par défaut.
+
+La class ``.dropdown-content`` permet de grouper le contenu pour le positionner.
+
+Par exemple :
+
+.. sourcecode:: html
+
+   <details class="dropdown">
+      <summary><span class="sr-only">Menu déroulant</span></summary>
+
+      <div class="dropdown-content"></div>
+   </details>
+
+Note : Il y a par défaut un léger décalage vers la gauche via la variable ``$dropdown-offset-right``.
+
 La lecture zen
 ==============
 

--- a/doc/source/front-end/elements-specifiques-au-site.rst
+++ b/doc/source/front-end/elements-specifiques-au-site.rst
@@ -178,13 +178,13 @@ S'il vous faut afficher un texte un peu long sur l'infobulle, qui ne rentre pas 
    Ce module est une reprise adaptée de ``bulma-tooltip`` `de Wikiki <https://wikiki.github.io/elements/tooltip/>`_.
 
 Les menus déroulants (ou dropdown)
-==================
+==================================
 
-À ne pas confondre avec `header-dropdown`, ces menus déroulants ne requièrent aucun JS pour fonctionner mais se reposent sur la balise ``<details>``
+À ne pas confondre avec ``header-dropdown``, ces menus déroulants ne requièrent aucun JS pour fonctionner mais se reposent sur la balise ``<details>``.
 
 Pour créer un menu déroulant, utilisez simplement la classe ``dropdown`` à l'élément ``<details>``, en utilisant la balise ``<summary>`` pour fournir un texte alternatif au ``…`` affiché par défaut.
 
-La class ``.dropdown-content`` permet de grouper le contenu pour le positionner.
+La classe ``.dropdown-content`` permet de grouper le contenu pour le positionner.
 
 Par exemple :
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -43,7 +43,7 @@
                 </a>
 
                 {% cache 1800 menu_publications user|groups %}
-                    <div class="dropdown header-menu-dropdown">
+                    <div class="header-dropdown header-menu-dropdown">
                         <a href="{% url "publication:list" %}" class="dropdown-link-all">
                             {% trans "Accéder à tous les contenus de la bibliothèque" %}
                         </a>
@@ -101,7 +101,7 @@
                     <span class="arrow"></span>
                 </a>
                 {% cache 1800 menu_opinion user|groups %}
-                    <div class="dropdown header-menu-dropdown">
+                    <div class="header-dropdown header-menu-dropdown">
                         <a href="{% url "opinion:list" %}" class="dropdown-link-all">
                             {% trans "Tous les billets" %}
                         </a>
@@ -156,7 +156,7 @@
                     <span class="arrow"></span>
                 </a>
                 {% cache 1800 menu_forum user|groups %}
-                    <div class="dropdown header-menu-dropdown">
+                    <div class="header-dropdown header-menu-dropdown">
                         <a href="{% url "cats-forums-list" %}" class="dropdown-link-all">
                             {% trans "Tous les forums" %}
                         </a>
@@ -226,7 +226,7 @@
                         <span class="notif-text ico ico-messages">{% trans "Messagerie privée" %}</span>
                     </a>
 
-                    <div class="dropdown">
+                    <div class="header-dropdown">
                         <span class="dropdown-title dropdown-pm">
                             <h1>{% trans "Messagerie privée" %}</h1>
                             <a href="{% url "mp-new" %}" class="ico-after pm-new white" title="{% trans 'Envoyer un nouveau message privé' %}"></a>
@@ -267,7 +267,7 @@
                         <span class="notif-text ico ico-notifs">{% trans "Notifications" %}</span>
                     </a>
 
-                    <div class="dropdown">
+                    <div class="header-dropdown">
                         <h1 class="dropdown-title">{% trans "Notifications" %}</h1>
 
                         <ul class="dropdown-list">
@@ -306,7 +306,7 @@
                             {% endif %}
                         </a>
 
-                        <div class="dropdown staff-only">
+                        <div class="header-dropdown staff-only">
                             <h1 class="dropdown-title">{% trans "Alertes de modération" %}</h1>
                             <ul class="dropdown-list">
                                 {% for alert in header_alerts.list %}
@@ -350,7 +350,7 @@
                     </a>
                 {% endwith %}
 
-                <div class="dropdown my-account-dropdown mobile-all-links" data-title="{% trans 'Mon compte' %}">
+                <div class="header-dropdown my-account-dropdown mobile-all-links" data-title="{% trans 'Mon compte' %}">
                     <h1 class="dropdown-title">{{ user.username|truncatechars:25 }}</h1>
 
                     <ul class="dropdown-list">

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -108,7 +108,7 @@
             {% if user.is_authenticated %}
                 {% spaceless %}
                     <details class="message-actions dropdown">
-                        <summary title="Options du message"><span class="sr-only">Options du message</span></summary>
+                        <summary aria-label="Options du message"><span class="sr-only">Options du message</span></summary>
                         <ul class="dropdown-content" tabindex="0">
                             {# User actions on their own message #}
 

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -107,8 +107,9 @@
 
             {% if user.is_authenticated %}
                 {% spaceless %}
-                    <aside class="message-actions">
-                        <ul tabindex="0">
+                    <details class="message-actions dropdown">
+                        <summary title="Options du message"><span class="sr-only">Options du message</span></summary>
+                        <ul class="dropdown-content" tabindex="0">
                             {# User actions on their own message #}
 
                             {% if message.author == user %}
@@ -254,7 +255,7 @@
                                 {% endif %}
                             {% endif %}
                         </ul>
-                    </aside>
+                    </details>
                 {% endspaceless %}
 
                 {# Hide message modale #}

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -108,7 +108,7 @@
             {% if user.is_authenticated %}
                 {% spaceless %}
                     <details class="message-actions dropdown">
-                        <summary aria-label="Options du message"><span class="sr-only">Options du message</span></summary>
+                        <summary><span class="sr-only">Options du message</span></summary>
                         <ul class="dropdown-content" tabindex="0">
                             {# User actions on their own message #}
 


### PR DESCRIPTION
Plusieurs changements pour un même résultat : utilisation d'un dropdown classique (via `<details>` et `<summary`) pour les actions de messages

Création d'un composant `.dropdown` au passage. Renommage du `header-dropdown` qui créait un conflit.


### Contrôle qualité

  - `make build-front`
  - Aller sur un message avec des options (avec et sans modération activée)
  - Un dropdown devrait s'ouvrir, avec fermeture lors du clic à l'extérieur
  - Les dropdowns du header devraient fonctionner comme d'habitude
  - Documentation à vérifier aussi (je connais absolument pas `rts` donc j'ai improvisé à vue de nez)
