### PR TITLE
On enlève un peu de graisse aux blocs de code

### DIFF
--- a/assets/scss/highlight/_zest-hljs.scss
+++ b/assets/scss/highlight/_zest-hljs.scss
@@ -81,8 +81,6 @@
 
   background: $true-white;
   color: $black;
-
-  font-weight: 500;
 }
 
 // Markdown

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,7 +99,7 @@
     {% block canonical %}{% endblock %}
 
     {# Webfont async loading #}
-    <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700|Source+Code+Pro:400,500,700|Merriweather:400,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700|Source+Code+Pro:400,700|Merriweather:400,700' rel='stylesheet' type='text/css'>
 
 
     {% block extra_css %}


### PR DESCRIPTION
On enlève un peu de graisse aux blocs de code

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que le texte principal des blocs de code a un peu moins de graisse qu'avant