### PR TITLE
Ajout d'un filtre par tag sur les flux RSS/Atom des contenus

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -126,13 +126,15 @@
     {% endwith %}
 
     {# RSS links #}
-    <link rel="alternate" type="application/rss+xml" title="Forum" href="{% url "post-feed-rss" %}">
-    <link rel="alternate" type="application/rss+xml" title="Nouveaux tutoriels (RSS)" href="{% url "tutorial:feed-rss" %}">
-    <link rel="alternate" type="application/atom+xml" title="Nouveaux tutoriels (ATOM)" href="{% url "tutorial:feed-atom" %}">
-    <link rel="alternate" type="application/rss+xml" title="Nouveaux articles (RSS)" href="{% url "article:feed-rss" %}">
-    <link rel="alternate" type="application/atom+xml" title="Nouveaux articles (ATOM)" href="{% url "article:feed-atom" %}">
-    <link rel="alternate" type="application/rss+xml" title="Nouveaux billets (RSS)" href="{% url "opinion:feed-rss" %}">
-    <link rel="alternate" type="application/atom+xml" title="Nouveaux billets (ATOM)" href="{% url "opinion:feed-atom" %}">
+    {% with request.GET|yesno:'?,'|add:request.GET.urlencode as rss_params %}
+    <link rel="alternate" type="application/rss+xml" title="Forum" href="{% url "post-feed-rss" %}{{ rss_params | safe }}">
+    <link rel="alternate" type="application/rss+xml" title="Nouveaux tutoriels (RSS)" href="{% url "tutorial:feed-rss" %}{{ rss_params | safe }}">
+    <link rel="alternate" type="application/atom+xml" title="Nouveaux tutoriels (ATOM)" href="{% url "tutorial:feed-atom" %}{{ rss_params | safe }}">
+    <link rel="alternate" type="application/rss+xml" title="Nouveaux articles (RSS)" href="{% url "article:feed-rss" %}{{ rss_params | safe }}">
+    <link rel="alternate" type="application/atom+xml" title="Nouveaux articles (ATOM)" href="{% url "article:feed-atom" %}{{ rss_params | safe }}">
+    <link rel="alternate" type="application/rss+xml" title="Nouveaux billets (RSS)" href="{% url "opinion:feed-rss" %}{{ rss_params | safe }}">
+    <link rel="alternate" type="application/atom+xml" title="Nouveaux billets (ATOM)" href="{% url "opinion:feed-atom" %}{{ rss_params | safe }}">
+    {% endwith %}
     {# OpenSearch plugin autodiscovery #}
     <link rel="search" type="application/opensearchdescription+xml" title="{{ app.site.literal_name }}" href="{% url "search:opensearch" %}">
 

--- a/zds/tutorialv2/feeds.py
+++ b/zds/tutorialv2/feeds.py
@@ -35,11 +35,10 @@ class LastContentFeedRSS(Feed):
         if "subcategory" in self.query_params:
             subcategories = [get_object_or_404(SubCategory, slug=self.query_params.get("subcategory"))]
 
+        tags = None
         tag = self.query_params.get("tag", "").strip()
         if tag:
             tags = [get_object_or_404(Tag, slug=slugify(self.query_params.get("tag")))]
-        else:
-            tags = None
 
         feed_length = settings.ZDS_APP["content"]["feed_length"]
 

--- a/zds/tutorialv2/feeds.py
+++ b/zds/tutorialv2/feeds.py
@@ -35,7 +35,8 @@ class LastContentFeedRSS(Feed):
         if "subcategory" in self.query_params:
             subcategories = [get_object_or_404(SubCategory, slug=self.query_params.get("subcategory"))]
 
-        if "tag" in self.query_params:
+        tag = self.query_params.get("tag", "").strip()
+        if tag:
             tags = [get_object_or_404(Tag, slug=slugify(self.query_params.get("tag")))]
         else:
             tags = None

--- a/zds/tutorialv2/feeds.py
+++ b/zds/tutorialv2/feeds.py
@@ -4,7 +4,8 @@ from django.shortcuts import get_object_or_404
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.translation import gettext_lazy as _
 
-from zds.utils.models import Category, SubCategory
+from zds.utils.models import Category, SubCategory, Tag
+from zds.utils.uuslug_wrapper import slugify
 from zds.tutorialv2.models.database import PublishedContent
 
 
@@ -34,10 +35,15 @@ class LastContentFeedRSS(Feed):
         if "subcategory" in self.query_params:
             subcategories = [get_object_or_404(SubCategory, slug=self.query_params.get("subcategory"))]
 
+        if "tag" in self.query_params:
+            tags = [get_object_or_404(Tag, slug=slugify(self.query_params.get("tag")))]
+        else:
+            tags = None
+
         feed_length = settings.ZDS_APP["content"]["feed_length"]
 
         contents = PublishedContent.objects.last_contents(
-            content_type=[self.content_type], subcategories=subcategories
+            content_type=[self.content_type], subcategories=subcategories, tags=tags
         )[:feed_length]
 
         return contents

--- a/zds/tutorialv2/feeds.py
+++ b/zds/tutorialv2/feeds.py
@@ -29,11 +29,13 @@ class LastContentFeedRSS(Feed):
         :return: The last (typically 5) contents (sorted by publication date).
         """
         subcategories = None
-        if "category" in self.query_params:
-            category = get_object_or_404(Category, slug=self.query_params.get("category"))
+        category = self.query_params.get("category", "").strip()
+        if category:
+            category = get_object_or_404(Category, slug=category)
             subcategories = category.get_subcategories()
-        if "subcategory" in self.query_params:
-            subcategories = [get_object_or_404(SubCategory, slug=self.query_params.get("subcategory"))]
+        subcategory = self.query_params.get("subcategory", "").strip()
+        if subcategory:
+            subcategories = [get_object_or_404(SubCategory, slug=subcategory)]
 
         tags = None
         tag = self.query_params.get("tag", "").strip()

--- a/zds/tutorialv2/tests/tests_feeds.py
+++ b/zds/tutorialv2/tests/tests_feeds.py
@@ -174,6 +174,10 @@ class LastTutorialsFeedRSSTest(TutorialTestMixin, TestCase):
         ret = [item.content for item in self.tutofeed.items()]
         self.assertEqual(ret, [self.tuto])
 
+        self.tutofeed.query_params = {"subcategory": f" {self.subcategory.slug} "}
+        ret = [item.content for item in self.tutofeed.items()]
+        self.assertEqual(ret, [self.tuto])
+
         self.tutofeed.query_params = {"subcategory": subcategory2.slug}
         ret = [item.content for item in self.tutofeed.items()]
         self.assertEqual(ret, [tuto2])
@@ -350,6 +354,10 @@ class LastArticlesFeedRSSTest(TutorialTestMixin, TestCase):
         # Filter by subcategory
 
         self.articlefeed.query_params = {"subcategory": self.subcategory.slug}
+        ret = [item.content for item in self.articlefeed.items()]
+        self.assertEqual(ret, [self.article])
+
+        self.articlefeed.query_params = {"subcategory": f" {self.subcategory.slug} "}
         ret = [item.content for item in self.articlefeed.items()]
         self.assertEqual(ret, [self.article])
 

--- a/zds/tutorialv2/tests/tests_feeds.py
+++ b/zds/tutorialv2/tests/tests_feeds.py
@@ -195,6 +195,10 @@ class LastTutorialsFeedRSSTest(TutorialTestMixin, TestCase):
         ret = [item.content for item in self.tutofeed.items()]
         self.assertEqual(ret, [tuto2])
 
+        self.tutofeed.query_params = {"tag": f" {tag2.slug} "}
+        ret = [item.content for item in self.tutofeed.items()]
+        self.assertEqual(ret, [tuto2])
+
         self.tutofeed.query_params = {"tag": tag3.slug}
         ret = [item.content for item in self.tutofeed.items()]
         self.assertEqual(ret, [])
@@ -367,6 +371,10 @@ class LastArticlesFeedRSSTest(TutorialTestMixin, TestCase):
         self.assertEqual(ret, [article2, self.article])
 
         self.articlefeed.query_params = {"tag": tag2.slug}
+        ret = [item.content for item in self.articlefeed.items()]
+        self.assertEqual(ret, [article2])
+
+        self.articlefeed.query_params = {"tag": f" {tag2.slug} "}
         ret = [item.content for item in self.articlefeed.items()]
         self.assertEqual(ret, [article2])
 


### PR DESCRIPTION
Salut,

Juste un petit changement pour ajouter des filtres par tag sur les flux des contenus, par exemple http://zds/billets/flux/rss/?tag=python
Ce qui semble [être attendu par certaines personnes](https://discuss.afpy.org/t/blogs-francais-sur-python/88/11).