### PR TITLE
Ajoute une commande pour vider le cache

### DIFF
--- a/zds/utils/management/commands/clear_cache.py
+++ b/zds/utils/management/commands/clear_cache.py
@@ -1,0 +1,8 @@
+from django.core.management.base import BaseCommand
+from django.core.cache import cache
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        cache.clear()
+        self.stdout.write("Cleared cache.")


### PR DESCRIPTION
Ajoute une commande pour vider le cache

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que le site web fonctionne bien
- Dans une deuxième console, `source zdsenv/bin/activate` puis `python manage.py clear_cache`
- Vérifier que le site web fonctionne bien