### PR TITLE
Retire hauteur fixe éléments menu messages

### DIFF
--- a/assets/scss/components/_topic-message.scss
+++ b/assets/scss/components/_topic-message.scss
@@ -396,7 +396,6 @@ div.msg-are-hidden {
                         box-sizing: border-box;
 
                         min-width: $length-128;
-                        height: $length-32;
 
                         user-select: none;
 


### PR DESCRIPTION
Corrige un bug potentiel du menu des messages lorsque le texte est trop long ou que la police le rend trop grand pour passer dans une hauteur fixe : on supprime la hauteur fixe, l'élément s'adapte au contenu.

### Contrôle qualité

  - `make build-front` ;
  - Ouvrir le menu d'un message
  - Tester avec différentes taille de texte, différentes polices éventuellement