### PR TITLE
Outils editeur sticky

### DIFF
--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -1,6 +1,4 @@
 html {
-    height: 100%;
-    width: 100%;
     font-size: 62.5%;
 }
 
@@ -9,7 +7,7 @@ body {
     font-size: $font-size-10;
     line-height: 1.5;
     width: 100%;
-    height: 100%;
+    min-height: 100%;
 }
 
 @mixin normal-selection {
@@ -42,7 +40,7 @@ body {
     display: flex;
     flex-direction: column;
 
-    min-height: 100%;
+    min-height: 100vh;
 
     .main-container {
         display: flex;
@@ -141,9 +139,8 @@ nav {
 }
 
 @include desktop {
-    html,
     body {
-        height: 100%;
+        min-height: 100%;
     }
 
     .wrapper {

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -612,7 +612,7 @@ $logo-width: 24rem;
         position: relative;
 
         box-shadow: 0 0 $length-4 rgba($black, 0.3);
-        z-index: 1;
+        z-index: 3;
 
         header {
             background-image: linear-gradient(


### PR DESCRIPTION
Suite de #6051 

Quelques bugs ont été relevés, notamment le passage au-dessus des éléments du header (d'où le changement de z-index) et un bug au scroll (lié au fait que `body` ne faisait que `100vh`).

### Contrôle qualité

Par exemple :

  - Générer le CSS (`make build-front`)
  - Observer la barre d'outils de l'éditeur dans différentes situations (en ouvrant des menus du header, en scrollant, etc.)