### PR TITLE
Nouveau SDK pour Sentry

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -2,5 +2,5 @@
 
 gunicorn==20.1.0
 mysqlclient==2.0.3
-raven==6.10.0
+sentry-sdk==1.1.0
 ujson==4.0.2

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -471,9 +471,9 @@ class ZMarkdownRebberLatexPublicator(Publicator):
         # let's put 10 min of timeout because we do not generate latex everyday
         command_process.communicate(timeout=600)
         with contextlib.suppress(ImportError):
-            from raven import breadcrumbs
+            import sentry_sdk
 
-            breadcrumbs.record(message="lualatex call", data=command, type="cmd")
+            sentry_sdk.add_breadcrumb(message="lualatex call", data=command, type="cmd")
 
         pdf_file_path = path.splitext(texfile)[0] + self.extension
         return path.exists(pdf_file_path)
@@ -485,9 +485,9 @@ class ZMarkdownRebberLatexPublicator(Publicator):
         )
         std_out, std_err = command_process.communicate()
         with contextlib.suppress(ImportError):
-            from raven import breadcrumbs
+            import sentry_sdk
 
-            breadcrumbs.record(message="makeglossaries call", data=command, type="cmd")
+            sentry_sdk.add_breadcrumb(message="makeglossaries call", data=command, type="cmd")
         # TODO: check makeglossary exit codes to see if we can enhance error detection
         if "fatal" not in std_out.decode("utf-8").lower() and "fatal" not in std_err.decode("utf-8").lower():
             return True
@@ -515,9 +515,9 @@ def handle_tex_compiler_error(latex_file_path, ext):
             errors = "\n".join(lines)
     logger.debug("%s ext=%s", errors, ext)
     with contextlib.suppress(ImportError):
-        from raven import breadcrumbs
+        import sentry_sdk
 
-        breadcrumbs.record(message="luatex call", data=errors, type="cmd")
+        sentry_sdk.add_breadcrumb(message="luatex call", data=errors, type="cmd")
 
     raise FailureDuringPublication(errors)
 


### PR DESCRIPTION
Nouveau SDK pour Sentry, car l'ancien n'est plus maintenu

[Documentation pour la configuration](https://docs.sentry.io/platforms/python/guides/django/)

- [x] Configuration de base d'après la documentation
- [x] Remplacer les appels à Raven avec la nouvelle façon de faire dans `zds/tutorialv2/publication_utils.py`
- [x] Tester sur la bêta et adapter la configuration

**QA :** Github Actions seulement, étant donné que ça fonctionne bien sur la bêta