### PR TITLE
Change l'URL de la page de profil en /@pseudo

### DIFF
--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -69,7 +69,7 @@
             {% spaceless %}
                 <ul class="message-metadata">
                     <li>
-                        <a href="{{ message.author.get_absolute_url }}" class="username" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                        <a href="{{ message.author.profile.get_absolute_url }}" class="username" itemprop="author" itemscope itemtype="http://schema.org/Person">
                             <span itemprop="name">{{ message.author.username }}</span>
                         </a><span class="username-date-separator">, </span>
                         <a href="#p{{ message.pk }}" class="date" title="{{ message.pubdate|tooltip_date|capfirst }}">

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -27,7 +27,7 @@ class MemberModelsTest(TutorialTestMixin, TestCase):
         self.forumtopic = TopicFactory(forum=self.forum, author=self.staff.user)
 
     def test_get_absolute_url_for_details_of_member(self):
-        self.assertEqual(self.user1.get_absolute_url(), "/membres/voir/{0}/".format(self.user1.user.username))
+        self.assertEqual(self.user1.get_absolute_url(), f"/@{self.user1.user.username}")
 
     def test_get_avatar_url(self):
         # if no url was specified -> gravatar !

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -142,6 +142,23 @@ class MemberTests(TutorialTestMixin, TestCase):
         result = self.client.get(reverse("member-detail", args=["unknown_user"]), follow=False)
         self.assertEqual(result.status_code, 404)
 
+    def test_redirection_when_using_old_detail_member_url(self):
+        """
+        To test the redirection when accessing the member profile through the old url
+        """
+        user = ProfileFactory().user
+        result = self.client.get(reverse("member-detail-redirect", args=[user.username]), follow=False)
+
+        self.assertEqual(result.status_code, 301)
+
+    def test_old_detail_member_url_with_unexistant_member(self):
+        """
+        To test wether a 404 error is raised when the user in the old url does not exist
+        """
+        response = self.client.get(reverse("member-detail-redirect", args=["tartempion"]), follow=False)
+
+        self.assertEqual(response.status_code, 404)
+
     def test_moderation_history(self):
         user = ProfileFactory().user
 

--- a/zds/member/urls.py
+++ b/zds/member/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import re_path, path
 
 from zds.member.views import (
     MemberList,
@@ -41,13 +41,15 @@ from zds.member.views import (
     SolvedHatRequestsList,
     CreateProfileReportView,
     SolveProfileReportView,
+    redirect_old_profile_to_new,
 )
 
 urlpatterns = [
     # list
     re_path(r"^$", MemberList.as_view(), name="member-list"),
     # details
-    re_path(r"^voir/(?P<user_name>.+)/$", MemberDetail.as_view(), name="member-detail"),
+    # re_path(r"^voir/(?P<user_name>.+)/$", MemberDetail.as_view(), name="member-detail"),
+    path("voir/<str:user_name>/", redirect_old_profile_to_new, name="member-detail-redirect"),
     # modification
     re_path(r"^parametres/profil/$", UpdateMember.as_view(), name="update-member"),
     re_path(r"^parametres/github/$", UpdateGitHubToken.as_view(), name="update-github"),

--- a/zds/member/urls.py
+++ b/zds/member/urls.py
@@ -48,7 +48,6 @@ urlpatterns = [
     # list
     re_path(r"^$", MemberList.as_view(), name="member-list"),
     # details
-    # re_path(r"^voir/(?P<user_name>.+)/$", MemberDetail.as_view(), name="member-detail"),
     path("voir/<str:user_name>/", redirect_old_profile_to_new, name="member-detail-redirect"),
     # modification
     re_path(r"^parametres/profil/$", UpdateMember.as_view(), name="update-member"),

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -250,6 +250,11 @@ class MemberDetail(DetailView):
         return context
 
 
+def redirect_old_profile_to_new(request, user_name):
+    user = get_object_or_404(User, username=user_name)
+    return redirect(user.profile, permanent=True)
+
+
 class UpdateMember(UpdateView):
     """Update a profile."""
 

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -293,7 +293,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 LOGIN_URL = "member-login"
 LOGIN_REDIRECT_URL = "/"
 
-ABSOLUTE_URL_OVERRIDES = {"auth.user": lambda u: "/membres/voir/{0}/".format(quote(u.username.encode("utf-8")))}
+ABSOLUTE_URL_OVERRIDES = {"auth.user": lambda u: "/@{0}".format(quote(u.username.encode("utf-8")))}
 
 # Django fileserve settings (set to True for local dev version only)
 SERVE = False

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -6,6 +6,7 @@ from django.urls import include, re_path, path, get_resolver, reverse
 
 from zds.forum.models import ForumCategory, Forum, Topic, Tag
 from zds.pages.views import home as home_view
+from zds.member.views import MemberDetail
 from zds.tutorialv2.models.database import PublishedContent
 
 from django.conf import settings
@@ -97,6 +98,7 @@ urlpatterns = [
     re_path(r"^$", home_view, name="homepage"),
     re_path(r"^api/", include(("zds.api.urls", "zds.api"), namespace="api")),
     re_path(r"^oauth2/", include(("oauth2_provider.urls", "oauth2_provider"), namespace="oauth2_provider")),
+    path("@<str:user_name>", MemberDetail.as_view(), name="member-detail"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 # SiteMap URLs


### PR DESCRIPTION
<!-- Veuillez décrire vos changements à l’emplacement de ce commentaire (inutile dans le cas de tout petits changements). -->
Changement de l'url utilisée pour accéder au profil de l'utilisateur : zestedesavoir.com/@pseudo

- Création d'une nouvelle url dans le fichier `urls.py` principal
- Modification de l'ancienne url pour rediriger vers la nouvelle
- Création d'une vue de redirection

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné (optionnel) : #6047 

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

<!-- Écrivez éventuellement ici quelques instructions pour nous aider à vérifier vos changement.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

<!-- Merci ! -->
- Essayez d'accéder au profil d'un utilisateur existant via /@pseudo
- Essayez d'accéder au profil via l'ancienne adresse /membres/voir/pseudo : redirection vers la nouvelle adresse
