### PR TITLE
(v30) Petites corrections graphiques

### DIFF
--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -79,10 +79,6 @@ $content-item-padding-vertical: $length-14;
         header {
             flex: 2;
 
-            &:hover .content-title {
-                text-decoration: underline;
-            }
-
             .content-title {
                 margin: 0;
                 padding: 0;
@@ -102,6 +98,10 @@ $content-item-padding-vertical: $length-14;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
+
+                    &:hover {
+                        text-decoration: underline;
+                    }
                 }
             }
 
@@ -112,10 +112,6 @@ $content-item-padding-vertical: $length-14;
                 &, a {
                     font-size: $font-size-9;
                     color: $grey-600;
-
-                    &:hover {
-                        text-decoration: none;
-                    }
                 }
 
                 &.is-long {
@@ -297,6 +293,10 @@ $content-item-padding-vertical: $length-14;
                 text-decoration: underline;
             }
         }
+    }
+
+    &:not(.topic-item) .content-info header:hover .content-title {
+        text-decoration: underline;
     }
 }
 

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -131,6 +131,10 @@
         font-size: $font-size-6;
         font-weight: normal;
     }
+
+    p.is-dimmed {
+        color: $grey-500;
+    }
 }
 
 @include wide {

--- a/templates/member/hat.html
+++ b/templates/member/hat.html
@@ -45,10 +45,10 @@
                     <li>{% include "misc/member_item.part.html" with avatar=True %}</li>
                 {% endfor %}
             </ul>
-            <p>
-                {% trans "Remarque : cette liste correspond aux membres possédant actuellement la casquette. Si vous voyez un message avec cette casquette mais que son auteur n'apparaît pas ici, cela signifie qu'il l'avait en postant. Des messages privés automatiques peuvent également être envoyés avec une casquette." %}
-            </p>
         </div>
+        <p>
+            {% trans "Remarque : cette liste correspond aux membres possédant actuellement la casquette. Si vous voyez un message avec cette casquette mais que son auteur n'apparaît pas ici, cela signifie qu'il l'avait en postant. Des messages privés automatiques peuvent également être envoyés avec une casquette." %}
+        </p>
     {% else %}
         <p>{% trans "Aucun membre ne possède cette casquette." %}</p>
     {% endif %}

--- a/templates/member/hat.html
+++ b/templates/member/hat.html
@@ -46,7 +46,7 @@
                 {% endfor %}
             </ul>
         </div>
-        <p>
+        <p class="is-dimmed">
             {% trans "Remarque : cette liste correspond aux membres possédant actuellement la casquette. Si vous voyez un message avec cette casquette mais que son auteur n'apparaît pas ici, cela signifie qu'il l'avait en postant. Des messages privés automatiques peuvent également être envoyés avec une casquette." %}
         </p>
     {% else %}

--- a/templates/member/hats.html
+++ b/templates/member/hats.html
@@ -45,13 +45,14 @@
                         </td>
                         <td class="wide">
                             {% if hat.get_users %}
-                                {% for user in hat.get_users_preview %}
-                                    {% include 'misc/member_item.part.html' with member=user avatar=True %}
-                                {% endfor %}
-
+                                <div class="members">
+                                    <ul>
+                                        {% for user in hat.get_users_preview %}
+                                            <li>{% include "misc/member_item.part.html" with member=user avatar=True %}</li>
+                                        {% endfor %}
+                                    </ul>
+                                </div>
                                 {% if hat.get_users_count > app.member.users_in_hats_list %}
-                                    –
-
                                     <a href="{{ hat.get_absolute_url }}">
                                         {% blocktrans with users_count=hat.get_users_count %}
                                             Voir les {{ users_count }} membres


### PR DESCRIPTION
Petites corrections graphiques

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Aller sur la page d'une casquette et vérifier que la phrase « Remarque : cette liste... » s'affiche en dessous de la liste des membres et non plus à côté
- Avec le compte `admin`, aller sur les profils d'au moins 6 membres (par exemple `user1` jusqu'à `user6` inclus) et leur ajouter *la même casquette*
- Aller sur la page listant les casquettes et vérifier que le lien « Voir les X membres » s'affiche en dessous de la liste des membres et non plus à côté
- Aller sur la page d'accueil puis vérifier que : 
  - sur un encart de sujet du forum, le titre est souligné lors du survol du titre mais pas du sous-titre ;
  - sur un encart de contenu, le titre est souligné lors du survol du titre et du sous-titre.