### PR TITLE
Met à jour factory-boy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-munin==0.2.1
 django-recaptcha==2.0.6
 Django==2.2.19
 easy-thumbnails==2.7.1
-factory-boy==2.8.1
+factory-boy==3.2.0
 geoip2==4.1.0
 GitPython==3.1.13
 google-api-python-client==1.12.8

--- a/zds/featured/factories.py
+++ b/zds/featured/factories.py
@@ -5,7 +5,7 @@ import factory
 from zds.featured.models import FeaturedResource, FeaturedMessage
 
 
-class FeaturedResourceFactory(factory.DjangoModelFactory):
+class FeaturedResourceFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = FeaturedResource
 
@@ -13,7 +13,7 @@ class FeaturedResourceFactory(factory.DjangoModelFactory):
     pubdate = datetime.now()
 
 
-class FeaturedMessageFactory(factory.DjangoModelFactory):
+class FeaturedMessageFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = FeaturedMessage
 

--- a/zds/forum/factories.py
+++ b/zds/forum/factories.py
@@ -1,9 +1,10 @@
 import factory
+
 from zds.forum.models import ForumCategory, Forum, Topic, Post
 from zds.utils.models import Tag
 
 
-class ForumCategoryFactory(factory.DjangoModelFactory):
+class ForumCategoryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ForumCategory
 
@@ -11,7 +12,7 @@ class ForumCategoryFactory(factory.DjangoModelFactory):
     slug = factory.Sequence("category{}".format)
 
 
-class ForumFactory(factory.DjangoModelFactory):
+class ForumFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Forum
 
@@ -20,7 +21,7 @@ class ForumFactory(factory.DjangoModelFactory):
     slug = factory.Sequence("forum{}".format)
 
 
-class TagFactory(factory.DjangoModelFactory):
+class TagFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Tag
 
@@ -28,7 +29,7 @@ class TagFactory(factory.DjangoModelFactory):
     slug = factory.Sequence("tag{}".format)
 
 
-class TopicFactory(factory.DjangoModelFactory):
+class TopicFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Topic
 
@@ -36,7 +37,7 @@ class TopicFactory(factory.DjangoModelFactory):
     subtitle = factory.Sequence("Sous Titre du sujet No{}".format)
 
 
-class PostFactory(factory.DjangoModelFactory):
+class PostFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Post
 
@@ -45,9 +46,9 @@ class PostFactory(factory.DjangoModelFactory):
     text_html = text
 
     @classmethod
-    def _prepare(cls, create, **kwargs):
-        post = super()._prepare(create, **kwargs)
-        topic = kwargs.pop("topic", None)
+    def _generate(cls, create, attrs):
+        post = super()._generate(create, attrs)
+        topic = attrs.get("topic", None)
         if topic:
             post.save()
             topic.last_message = post

--- a/zds/gallery/factories.py
+++ b/zds/gallery/factories.py
@@ -1,14 +1,11 @@
 import contextlib
-
 import factory
 
 from zds.gallery.models import Image, Gallery, UserGallery
 from zds.utils import old_slugify
 
 
-# Don't try to directly use UserFactory, this didn't create Profile then
-# don't work!
-class ImageFactory(factory.DjangoModelFactory):
+class ImageFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Image
 
@@ -18,16 +15,17 @@ class ImageFactory(factory.DjangoModelFactory):
     physical = factory.django.ImageField(color="blue")
 
     @classmethod
-    def _prepare(cls, create, **kwargs):
-        gallery = kwargs.pop("gallery", None)
+    def _generate(cls, create, attrs):
+        # Only creates the Image if a Gallery is associated
+        gallery = attrs.get("gallery", None)
         if gallery is not None:
-            image = super()._prepare(create, gallery=gallery, **kwargs)
+            image = super()._generate(create, attrs)
         else:
             image = None
         return image
 
 
-class GalleryFactory(factory.DjangoModelFactory):
+class GalleryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Gallery
 
@@ -36,25 +34,26 @@ class GalleryFactory(factory.DjangoModelFactory):
     slug = factory.LazyAttribute(lambda o: "{}".format(old_slugify(o.title)))
 
     @classmethod
-    def _prepare(cls, create, **kwargs):
-        gal = super()._prepare(create, **kwargs)
+    def _generate(cls, create, attrs):
+        gallery = super()._generate(create, attrs)
         with contextlib.suppress(OSError):
-            gal.get_gallery_path().mkdir(parents=True)
-        return gal
+            gallery.get_gallery_path().mkdir(parents=True)
+        return gallery
 
 
-class UserGalleryFactory(factory.DjangoModelFactory):
+class UserGalleryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = UserGallery
 
     mode = "W"
 
     @classmethod
-    def _prepare(cls, create, **kwargs):
-        user = kwargs.pop("user", None)
-        gallery = kwargs.pop("gallery", None)
+    def _generate(cls, create, attrs):
+        # Only creates the UserGallery if a User and a Gallery are associated
+        user = attrs.get("user", None)
+        gallery = attrs.get("gallery", None)
         if user is not None and gallery is not None:
-            user_gal = super()._prepare(create, user=user, gallery=gallery, **kwargs)
+            user_gallery = super()._generate(create, attrs)
         else:
-            user_gal = None
-        return user_gal
+            user_gallery = None
+        return user_gallery

--- a/zds/member/factories.py
+++ b/zds/member/factories.py
@@ -7,10 +7,11 @@ from zds.member.models import Profile
 from zds.utils.models import Hat
 
 
-class UserFactory(factory.DjangoModelFactory):
+class UserFactory(factory.django.DjangoModelFactory):
     """
-    This factory creates User.
-    WARNING: Don't try to directly use `UserFactory`, this didn't create associated Profile then don't work!
+    Factory that creates a standard User.
+
+    WARNING: Don't try to directly use `UserFactory` because it won't create the associated Profile.
     Use `ProfileFactory` instead.
     """
 
@@ -19,46 +20,26 @@ class UserFactory(factory.DjangoModelFactory):
 
     username = factory.Sequence("firm{}".format)
     email = factory.Sequence("firm{}@zestedesavoir.com".format)
-    password = "hostel77"
+    password = factory.PostGenerationMethodCall("set_password", "hostel77")
 
     is_active = True
 
-    @classmethod
-    def _prepare(cls, create, **kwargs):
-        password = kwargs.pop("password", None)
-        user = super()._prepare(create, **kwargs)
-        if password:
-            user.set_password(password)
-            if create:
-                user.save()
-        return user
 
-
-class StaffFactory(factory.DjangoModelFactory):
+class StaffFactory(UserFactory):
     """
-    This factory creates staff User.
-    WARNING: Don't try to directly use `StaffFactory`, this didn't create associated Profile then don't work!
+    Factory that creates a Staff User (within the Staff group and with change_* permissions).
+
+    WARNING: Don't try to directly use `StaffFactory` because it won't create the associated Profile.
     Use `StaffProfileFactory` instead.
     """
 
-    class Meta:
-        model = User
-
     username = factory.Sequence("firmstaff{}".format)
     email = factory.Sequence("firmstaff{}@zestedesavoir.com".format)
-    password = "hostel77"
 
-    is_active = True
-
-    @classmethod
-    def _prepare(cls, create, **kwargs):
-        password = kwargs.pop("password", None)
-        user = super()._prepare(create, **kwargs)
-        if password:
-            user.set_password(password)
-            if create:
-                user.save()
+    @factory.post_generation
+    def groups(self, create, extracted, **kwargs):
         group_staff = Group.objects.filter(name="staff").first()
+
         if group_staff is None:
             group_staff = Group(name="staff")
             group_staff.save()
@@ -69,50 +50,46 @@ class StaffFactory(factory.DjangoModelFactory):
         perms = Permission.objects.filter(codename__startswith="change_").all()
         for perm in perms:
             group_staff.permissions.add(perm)
-        user.groups.add(group_staff)
 
-        user.save()
-        return user
+        self.groups.add(group_staff)
 
 
-class DevFactory(factory.DjangoModelFactory):
+class DevFactory(UserFactory):
     """
-    This factory creates dev User.
-    WARNING: Don't try to directly use `DevFactory`, this didn't create associated Profile then don't work!
+    Factory that creates a Dev User (within the Dev group).
+
+    WARNING: Don't try to directly use `DevFactory` because it won't create the associated Profile.
     Use `DevProfileFactory` instead.
     """
 
-    class Meta:
-        model = User
-
     username = factory.Sequence("firmdev{}".format)
     email = factory.Sequence("firmdev{}@zestedesavoir.com".format)
-    password = "hostel77"
 
-    is_active = True
-
-    @classmethod
-    def _prepare(cls, create, **kwargs):
-        password = kwargs.pop("password", None)
-        user = super()._prepare(create, **kwargs)
-        if password:
-            user.set_password(password)
-            if create:
-                user.save()
+    @factory.post_generation
+    def groups(self, create, extracted, **kwargs):
         group_dev = Group.objects.filter(name=settings.ZDS_APP["member"]["dev_group"]).first()
+
         if group_dev is None:
             group_dev = Group(name=settings.ZDS_APP["member"]["dev_group"])
             group_dev.save()
 
-        user.groups.add(group_dev)
-
-        user.save()
-        return user
+        self.groups.add(group_dev)
 
 
-class ProfileFactory(factory.DjangoModelFactory):
+class NonAsciiUserFactory(UserFactory):
     """
-    Use this factory when you need a complete Profile for a standard user.
+    Factory that creates a User with non-ASCII characters in their username.
+
+    WARNING: Don't try to directly use `NonAsciiUserFactory` because it won't create the associated Profile.
+    Use `NonAsciiProfileFactory` instead.
+    """
+
+    username = factory.Sequence("ïéàçÊÀ{}".format)
+
+
+class ProfileFactory(factory.django.DjangoModelFactory):
+    """
+    Use this factory when you need a complete Profile for a standard User.
     """
 
     class Meta:
@@ -132,71 +109,31 @@ class ProfileFactory(factory.DjangoModelFactory):
 
 class ProfileNotSyncFactory(ProfileFactory):
     """
-    Use this factory when you want a user with wrong identifiers.
+    Use this factory when you need a complete Profile for a User with wrong identifiers.
     """
 
     id = factory.Sequence(lambda n: n + 99999)
 
 
-class StaffProfileFactory(factory.DjangoModelFactory):
+class StaffProfileFactory(ProfileFactory):
     """
-    Use this factory when you need a complete Profile for a staff user.
+    Use this factory when you need a complete Profile for a Staff User.
     """
-
-    class Meta:
-        model = Profile
 
     user = factory.SubFactory(StaffFactory)
 
-    last_ip_address = "192.168.2.1"
-    site = "www.zestedesavoir.com"
 
-    @factory.lazy_attribute
-    def biography(self):
-        return f"My name is {self.user.username.lower()} and I i'm the guy who kill the bad guys "
-
-    sign = "Please look my flavour"
-
-
-class DevProfileFactory(factory.DjangoModelFactory):
+class DevProfileFactory(ProfileFactory):
     """
-    Use this factory when you need a complete Profile for a dev user.
+    Use this factory when you need a complete Profile for a Dev User.
     """
-
-    class Meta:
-        model = Profile
 
     user = factory.SubFactory(DevFactory)
-
-    last_ip_address = "192.168.2.1"
-    site = "www.zestedesavoir.com"
-
-    @factory.lazy_attribute
-    def biography(self):
-        return f"My name is {self.user.username.lower()} and I i'm the guy who kill the bad guys "
-
-    sign = "Please look my flavour"
-
-
-class NonAsciiUserFactory(UserFactory):
-    """
-    This factory creates standard user with non-ASCII characters in its username.
-    WARNING: Don't try to directly use `NonAsciiUserFactory`, this didn't create associated Profile then don't work!
-    Use `NonAsciiProfileFactory` instead.
-    """
-
-    class Meta:
-        model = User
-
-    username = factory.Sequence("ïéàçÊÀ{}".format)
 
 
 class NonAsciiProfileFactory(ProfileFactory):
     """
-    Use this factory to create a standard user with non-ASCII characters in its username.
+    Use this factory when you need a complete Profile for a User with non-ASCII characters in their username.
     """
-
-    class Meta:
-        model = Profile
 
     user = factory.SubFactory(NonAsciiUserFactory)

--- a/zds/mp/factories.py
+++ b/zds/mp/factories.py
@@ -3,7 +3,7 @@ import factory
 from zds.mp.models import PrivateTopic, PrivatePost
 
 
-class PrivateTopicFactory(factory.DjangoModelFactory):
+class PrivateTopicFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = PrivateTopic
 
@@ -11,17 +11,18 @@ class PrivateTopicFactory(factory.DjangoModelFactory):
     subtitle = factory.Sequence("Sous Titre du sujet No{}".format)
 
 
-class PrivatePostFactory(factory.DjangoModelFactory):
+class PrivatePostFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = PrivatePost
 
     text = "Bonjour, je me présente, je m'appelle l'homme au texte bidonné"
 
     @classmethod
-    def _prepare(cls, create, **kwargs):
-        ppost = super()._prepare(create, **kwargs)
-        ptopic = kwargs.pop("privatetopic", None)
+    def _generate(cls, create, attrs):
+        ppost = super()._generate(create, attrs)
+        ptopic = attrs.get("privatetopic", None)
         if ptopic:
+            ppost.save()
             ptopic.last_message = ppost
             ptopic.save()
         return ppost

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -24,14 +24,13 @@ from zds.notification.models import (
 )
 from zds.tutorialv2.factories import (
     PublishableContentFactory,
-    LicenceFactory,
     ContentReactionFactory,
-    SubCategoryFactory,
     PublishedContentFactory,
 )
 from zds.tutorialv2.models.database import ContentReaction, PublishableContent
 from zds.tutorialv2.publication_utils import publish_content
 from zds.utils import old_slugify
+from zds.utils.factories import SubCategoryFactory, LicenceFactory
 from zds.utils.mps import send_mp, send_message_mp
 
 

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -20,13 +20,12 @@ from zds.notification.models import (
 from zds.tutorialv2 import signals
 from zds.tutorialv2.factories import (
     PublishableContentFactory,
-    LicenceFactory,
-    SubCategoryFactory,
     PublishedContentFactory,
     ContentReactionFactory,
 )
 from zds.tutorialv2.publication_utils import publish_content, notify_update
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.utils.factories import SubCategoryFactory, LicenceFactory
 from zds.utils.mps import send_mp, send_message_mp
 from zds.utils.header_notifications import get_header_notifications
 

--- a/zds/tutorialv2/factories.py
+++ b/zds/tutorialv2/factories.py
@@ -4,7 +4,8 @@ import factory
 
 from zds.forum.factories import PostFactory, TopicFactory
 from zds.gallery.factories import GalleryFactory, UserGalleryFactory
-from zds.utils.models import SubCategory, Licence, CategorySubCategory
+from zds.utils.factories import LicenceFactory, SubCategoryFactory
+from zds.utils.models import Licence
 from zds.tutorialv2.models.database import PublishableContent, Validation, ContentReaction
 from zds.tutorialv2.models.versioned import Container, Extract
 from zds.tutorialv2.publication_utils import publish_content
@@ -238,33 +239,6 @@ class PublishedContentFactory(PublishableContentFactory):
         return content
 
 
-class SubCategoryFactory(factory.django.DjangoModelFactory):
-    """
-    Factory that creates a SubCategory.
-    """
-
-    class Meta:
-        model = SubCategory
-
-    title = factory.Sequence(lambda n: f"Sous-Categorie {n} pour Tuto")
-    subtitle = factory.Sequence(lambda n: f"Sous titre de Sous-Categorie {n} pour Tuto")
-    slug = factory.Sequence(lambda n: f"sous-categorie-{n}")
-
-    @classmethod
-    def _generate(cls, create, attrs):
-        # This parameter is only used inside _generate() and won't be saved in the database,
-        # which is why we use attrs.pop() (it is removed from attrs).
-        category = attrs.pop("category", None)
-
-        subcategory = super()._generate(create, attrs)
-
-        if category is not None:
-            relation = CategorySubCategory(category=category, subcategory=subcategory)
-            relation.save()
-
-        return subcategory
-
-
 class ValidationFactory(factory.django.DjangoModelFactory):
     """
     Factory that creates a Validation.
@@ -272,15 +246,3 @@ class ValidationFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Validation
-
-
-class LicenceFactory(factory.django.DjangoModelFactory):
-    """
-    Factory that creates a License.
-    """
-
-    class Meta:
-        model = Licence
-
-    code = factory.Sequence(lambda n: "bidon-no{}".format(n + 1))
-    title = factory.Sequence(lambda n: "Licence bidon no{}".format(n + 1))

--- a/zds/tutorialv2/factories.py
+++ b/zds/tutorialv2/factories.py
@@ -1,14 +1,14 @@
 from datetime import datetime
 
 import factory
-from zds.forum.factories import PostFactory, TopicFactory
 
+from zds.forum.factories import PostFactory, TopicFactory
+from zds.gallery.factories import GalleryFactory, UserGalleryFactory
+from zds.utils.models import SubCategory, Licence, CategorySubCategory
 from zds.tutorialv2.models.database import PublishableContent, Validation, ContentReaction
 from zds.tutorialv2.models.versioned import Container, Extract
-from zds.utils.models import SubCategory, Licence, CategorySubCategory
-from zds.gallery.factories import GalleryFactory, UserGalleryFactory
-from zds.tutorialv2.utils import init_new_repo
 from zds.tutorialv2.publication_utils import publish_content
+from zds.tutorialv2.utils import init_new_repo
 
 text_content = "Ceci est un texte bidon, **avec markown**"
 
@@ -34,7 +34,11 @@ tricky_text_content = (
 )
 
 
-class PublishableContentFactory(factory.DjangoModelFactory):
+class PublishableContentFactory(factory.django.DjangoModelFactory):
+    """
+    Factory that creates a PublishableContent.
+    """
+
     class Meta:
         model = PublishableContent
 
@@ -45,17 +49,18 @@ class PublishableContentFactory(factory.DjangoModelFactory):
     pubdate = datetime.now()
 
     @classmethod
-    def _prepare(
-        cls,
-        create,
-        *,
-        light=True,
-        author_list=None,
-        licence: Licence = None,
-        add_license=True,
-        add_category=True,
-        **kwargs,
-    ):
+    def _generate(cls, create, attrs):
+        # These parameters are only used inside _generate() and won't be saved in the database,
+        # which is why we use attrs.pop() (they are removed from attrs).
+        light = attrs.pop("light", True)
+        author_list = attrs.pop("author_list", None)
+        add_license = attrs.pop("add_license", True)
+        add_category = attrs.pop("add_category", True)
+
+        # This parameter will be saved in the database,
+        # which is why we use attrs.get() (it stays in attrs).
+        licence = attrs.get("licence", None)
+
         auths = author_list or []
         if add_license:
             given_licence = licence or Licence.objects.first()
@@ -67,7 +72,7 @@ class PublishableContentFactory(factory.DjangoModelFactory):
         if not light:
             text = tricky_text_content
 
-        publishable_content = super()._prepare(create, **kwargs)
+        publishable_content = super()._generate(create, attrs)
         publishable_content.gallery = GalleryFactory()
         publishable_content.licence = licence
         for auth in auths:
@@ -87,20 +92,34 @@ class PublishableContentFactory(factory.DjangoModelFactory):
 
 
 class ContainerFactory(factory.Factory):
+    """
+    Factory that creates a Container.
+    """
+
     class Meta:
         model = Container
 
     title = factory.Sequence(lambda n: "Mon container No{}".format(n + 1))
 
     @classmethod
-    def _prepare(cls, create, *, db_object=None, light=True, **kwargs):
-        parent = kwargs.pop("parent", None)
+    def _generate(cls, create, attrs):
+        # These parameters are only used inside _generate() and won't be saved in the database,
+        # which is why we use attrs.pop() (they are removed from attrs).
+        db_object = attrs.pop("db_object", None)
+        light = attrs.pop("light", True)
+
+        # This parameter will be saved in the database,
+        # which is why we use attrs.get() (it stays in attrs).
+        parent = attrs.get("parent", None)
+
+        # Needed because we use container.title later
+        container = super()._generate(create, attrs)
 
         text = text_content
         if not light:
             text = tricky_text_content
 
-        sha = parent.repo_add_container(kwargs["title"], text, text)
+        sha = parent.repo_add_container(container.title, text, text)
         container = parent.children[-1]
 
         if db_object:
@@ -111,19 +130,35 @@ class ContainerFactory(factory.Factory):
 
 
 class ExtractFactory(factory.Factory):
+    """
+    Factory that creates a Extract.
+    """
+
     class Meta:
         model = Extract
 
     title = factory.Sequence(lambda n: "Mon extrait No{}".format(n + 1))
 
     @classmethod
-    def _prepare(cls, create, *, light=True, container=None, db_object=None, **kwargs):
+    def _generate(cls, create, attrs):
+        # These parameters are only used inside _generate() and won't be saved in the database,
+        # which is why we use attrs.pop() (they are removed from attrs).
+        light = attrs.pop("light", True)
+        db_object = attrs.pop("db_object", None)
+
+        # This parameter will be saved in the database,
+        # which is why we use attrs.get() (it stays in attrs).
+        container = attrs.get("container", None)
+
+        # Needed because we use extract.title later
+        extract = super()._generate(create, attrs)
+
         parent = container
         text = text_content
         if not light:
             text = tricky_text_content
 
-        sha = parent.repo_add_extract(kwargs["title"], text)
+        sha = parent.repo_add_extract(extract.title, text)
         extract = parent.children[-1]
 
         if db_object:
@@ -133,7 +168,11 @@ class ExtractFactory(factory.Factory):
         return extract
 
 
-class ContentReactionFactory(factory.DjangoModelFactory):
+class ContentReactionFactory(factory.django.DjangoModelFactory):
+    """
+    Factory that creates a ContentReaction.
+    """
+
     class Meta:
         model = ContentReaction
 
@@ -141,8 +180,8 @@ class ContentReactionFactory(factory.DjangoModelFactory):
     text = "Bonjour, je me présente, je m'appelle l'homme au texte bidonné"
 
     @classmethod
-    def _prepare(cls, create, **kwargs):
-        note = super()._prepare(create, **kwargs)
+    def _generate(cls, create, attrs):
+        note = super()._generate(create, attrs)
         note.pubdate = datetime.now()
         note.save()
         note.related_content.last_note = note
@@ -151,10 +190,19 @@ class ContentReactionFactory(factory.DjangoModelFactory):
 
 
 class BetaContentFactory(PublishableContentFactory):
+    """
+    Factory that creates a PublishableContent with a beta version and a beta topic.
+    """
+
     @classmethod
-    def _prepare(cls, create, **kwargs):
-        beta_forum = kwargs.pop("forum", None)
-        publishable_content = super()._prepare(create, **kwargs)
+    def _generate(cls, create, attrs):
+        # This parameter is only used inside _generate() and won't be saved in the database,
+        # which is why we use attrs.pop() (it is removed from attrs).
+        beta_forum = attrs.pop("forum", None)
+
+        # Creates the PublishableContent (see PublishableContentFactory._generate() for more info)
+        publishable_content = super()._generate(create, attrs)
+
         if publishable_content.authors.count() > 0 and beta_forum is not None:
             beta_topic = TopicFactory(
                 title="[beta]" + publishable_content.title, author=publishable_content.authors.first(), forum=beta_forum
@@ -168,13 +216,19 @@ class BetaContentFactory(PublishableContentFactory):
 
 
 class PublishedContentFactory(PublishableContentFactory):
+    """
+    Factory that creates a PublishableContent and the publish it.
+    """
+
     @classmethod
-    def _prepare(cls, create, *, light=True, author_list=None, licence: Licence = None, **kwargs):
-        """create a new PublishableContent and then publish it."""
+    def _generate(cls, create, attrs):
+        # This parameter is only used inside _generate() and won't be saved in the database,
+        # which is why we use attrs.pop() (it is removed from attrs).
+        is_major_update = attrs.pop("is_major_update", True)
 
-        is_major_update = kwargs.pop("is_major_update", True)
+        # Creates the PublishableContent (see PublishableContentFactory._generate() for more info)
+        content = super()._generate(create, attrs)
 
-        content = super()._prepare(create, light=light, author_list=author_list, licence=licence, **kwargs)
         published = publish_content(content, content.load_version(), is_major_update)
         content.sha_public = content.sha_draft
         content.public_version = published
@@ -184,7 +238,11 @@ class PublishedContentFactory(PublishableContentFactory):
         return content
 
 
-class SubCategoryFactory(factory.DjangoModelFactory):
+class SubCategoryFactory(factory.django.DjangoModelFactory):
+    """
+    Factory that creates a SubCategory.
+    """
+
     class Meta:
         model = SubCategory
 
@@ -193,11 +251,12 @@ class SubCategoryFactory(factory.DjangoModelFactory):
     slug = factory.Sequence(lambda n: f"sous-categorie-{n}")
 
     @classmethod
-    def _prepare(cls, create, **kwargs):
+    def _generate(cls, create, attrs):
+        # This parameter is only used inside _generate() and won't be saved in the database,
+        # which is why we use attrs.pop() (it is removed from attrs).
+        category = attrs.pop("category", None)
 
-        category = kwargs.pop("category", None)
-
-        subcategory = super()._prepare(create, **kwargs)
+        subcategory = super()._generate(create, attrs)
 
         if category is not None:
             relation = CategorySubCategory(category=category, subcategory=subcategory)
@@ -206,19 +265,22 @@ class SubCategoryFactory(factory.DjangoModelFactory):
         return subcategory
 
 
-class ValidationFactory(factory.DjangoModelFactory):
+class ValidationFactory(factory.django.DjangoModelFactory):
+    """
+    Factory that creates a Validation.
+    """
+
     class Meta:
         model = Validation
 
 
-class LicenceFactory(factory.DjangoModelFactory):
+class LicenceFactory(factory.django.DjangoModelFactory):
+    """
+    Factory that creates a License.
+    """
+
     class Meta:
         model = Licence
 
     code = factory.Sequence(lambda n: "bidon-no{}".format(n + 1))
     title = factory.Sequence(lambda n: "Licence bidon no{}".format(n + 1))
-
-    @classmethod
-    def _prepare(cls, create, **kwargs):
-        licence = super()._prepare(create, **kwargs)
-        return licence

--- a/zds/tutorialv2/tests/tests_feeds.py
+++ b/zds/tutorialv2/tests/tests_feeds.py
@@ -10,14 +10,13 @@ from zds.forum.factories import ForumFactory, ForumCategoryFactory, TagFactory
 from zds.tutorialv2.models.database import PublishedContent
 from zds.tutorialv2.feeds import LastTutorialsFeedRSS, LastTutorialsFeedATOM, LastArticlesFeedRSS, LastArticlesFeedATOM
 from zds.tutorialv2.factories import (
-    LicenceFactory,
-    SubCategoryFactory,
     PublishableContentFactory,
     ContainerFactory,
     ExtractFactory,
 )
 from zds.tutorialv2.publication_utils import publish_content
 from zds.tutorialv2.tests import TutorialTestMixin
+from zds.utils.factories import SubCategoryFactory, LicenceFactory
 from copy import deepcopy
 
 overridden_zds_app = deepcopy(settings.ZDS_APP)

--- a/zds/tutorialv2/tests/tests_front.py
+++ b/zds/tutorialv2/tests/tests_front.py
@@ -15,15 +15,13 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 from zds.member.factories import StaffProfileFactory, ProfileFactory
 from zds.tutorialv2.factories import (
-    LicenceFactory,
-    SubCategoryFactory,
     PublishableContentFactory,
     ContainerFactory,
     ExtractFactory,
 )
 from zds.tutorialv2.models.database import PublishedContent, PublishableContent
 from zds.tutorialv2.tests import TutorialTestMixin, TutorialFrontMixin
-from zds.utils.factories import CategoryFactory
+from zds.utils.factories import CategoryFactory, SubCategoryFactory, LicenceFactory
 
 overridden_zds_app = deepcopy(settings.ZDS_APP)
 overridden_zds_app["content"]["repo_private_path"] = settings.BASE_DIR / "contents-private-test"

--- a/zds/tutorialv2/tests/tests_lists.py
+++ b/zds/tutorialv2/tests/tests_lists.py
@@ -10,8 +10,6 @@ from zds.tutorialv2.factories import (
     PublishableContentFactory,
     ContainerFactory,
     ExtractFactory,
-    LicenceFactory,
-    SubCategoryFactory,
     PublishedContentFactory,
     ValidationFactory,
 )
@@ -19,7 +17,7 @@ from zds.tutorialv2.publication_utils import publish_content
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 from zds.gallery.factories import UserGalleryFactory
 from zds.forum.factories import ForumFactory, ForumCategoryFactory
-from zds.utils.factories import CategoryFactory as ContentCategoryFactory
+from zds.utils.factories import CategoryFactory, SubCategoryFactory, LicenceFactory
 
 
 @override_for_contents()
@@ -105,7 +103,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto_1.save()
 
     def test_list_categories(self):
-        category_1 = ContentCategoryFactory()
+        category_1 = CategoryFactory()
         subcategory_1 = SubCategoryFactory(category=category_1)
         subcategory_2 = SubCategoryFactory(category=category_1)
         # Not in context if nothing published inside this subcategory

--- a/zds/tutorialv2/tests/tests_models.py
+++ b/zds/tutorialv2/tests/tests_models.py
@@ -14,14 +14,13 @@ from zds.tutorialv2.factories import (
     PublishableContentFactory,
     ContainerFactory,
     ExtractFactory,
-    LicenceFactory,
     PublishedContentFactory,
-    SubCategoryFactory,
 )
 from zds.gallery.factories import UserGalleryFactory
 from zds.tutorialv2.models.database import PublishableContent, PublishedContent
 from zds.tutorialv2.publication_utils import publish_content
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.utils.factories import SubCategoryFactory, LicenceFactory
 from zds.utils.models import Tag
 from django.template.defaultfilters import date
 

--- a/zds/tutorialv2/tests/tests_move.py
+++ b/zds/tutorialv2/tests/tests_move.py
@@ -10,14 +10,13 @@ from zds.tutorialv2.factories import (
     PublishableContentFactory,
     ContainerFactory,
     ExtractFactory,
-    LicenceFactory,
-    SubCategoryFactory,
 )
 from zds.tutorialv2.models.database import PublishableContent
 from zds.gallery.factories import UserGalleryFactory
 from zds.forum.factories import ForumFactory, ForumCategoryFactory
 from zds.tutorialv2.publication_utils import publish_content
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.utils.factories import SubCategoryFactory, LicenceFactory
 
 
 @override_for_contents()

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -8,12 +8,11 @@ from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.tutorialv2.factories import (
     PublishableContentFactory,
     ExtractFactory,
-    LicenceFactory,
     PublishedContentFactory,
-    SubCategoryFactory,
 )
 from zds.tutorialv2.models.database import PublishableContent, PublishedContent, PickListOperation
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.utils.factories import SubCategoryFactory, LicenceFactory
 from zds.utils.models import Alert
 
 

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -168,9 +168,9 @@ class UtilsTests(TutorialTestMixin, TestCase):
 
         # populate with 2 chapters (1 extract each)
         midsize_tuto_draft = midsize_tuto.load_version()
-        chapter1 = ContainerFactory(parent=midsize_tuto_draft, db_objet=midsize_tuto)
+        chapter1 = ContainerFactory(parent=midsize_tuto_draft, db_object=midsize_tuto)
         ExtractFactory(container=chapter1, db_object=midsize_tuto)
-        chapter2 = ContainerFactory(parent=midsize_tuto_draft, db_objet=midsize_tuto)
+        chapter2 = ContainerFactory(parent=midsize_tuto_draft, db_object=midsize_tuto)
         ExtractFactory(container=chapter2, db_object=midsize_tuto)
 
         # publish it
@@ -213,11 +213,11 @@ class UtilsTests(TutorialTestMixin, TestCase):
 
         # populate with 2 part (1 chapter with 1 extract each)
         bigtuto_draft = bigtuto.load_version()
-        part1 = ContainerFactory(parent=bigtuto_draft, db_objet=bigtuto)
-        chapter1 = ContainerFactory(parent=part1, db_objet=bigtuto)
+        part1 = ContainerFactory(parent=bigtuto_draft, db_object=bigtuto)
+        chapter1 = ContainerFactory(parent=part1, db_object=bigtuto)
         ExtractFactory(container=chapter1, db_object=bigtuto)
-        part2 = ContainerFactory(parent=bigtuto_draft, db_objet=bigtuto)
-        chapter2 = ContainerFactory(parent=part2, db_objet=bigtuto)
+        part2 = ContainerFactory(parent=bigtuto_draft, db_object=bigtuto)
+        chapter2 = ContainerFactory(parent=part2, db_object=bigtuto)
         ExtractFactory(container=chapter2, db_object=bigtuto)
 
         # publish it

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -11,7 +11,6 @@ from zds.member.factories import ProfileFactory, StaffProfileFactory
 from zds.tutorialv2.factories import (
     PublishableContentFactory,
     ContainerFactory,
-    LicenceFactory,
     ExtractFactory,
     PublishedContentFactory,
     ContentReactionFactory,
@@ -35,6 +34,7 @@ from django.core.management import call_command
 from zds.tutorialv2.publication_utils import Publicator, PublicatorRegistry
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 from zds import json_handler
+from zds.utils.factories import LicenceFactory
 from zds.utils.models import Alert
 from zds.utils.header_notifications import get_header_notifications
 

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -32,8 +32,6 @@ from zds.tutorialv2.factories import (
     PublishableContentFactory,
     ContainerFactory,
     ExtractFactory,
-    LicenceFactory,
-    SubCategoryFactory,
     PublishedContentFactory,
     tricky_text_content,
     BetaContentFactory,
@@ -54,7 +52,7 @@ from zds.tutorialv2.publication_utils import (
 )
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 from zds.utils.models import HelpWriting, Alert, Tag, Hat
-from zds.utils.factories import HelpWritingFactory, CategoryFactory
+from zds.utils.factories import HelpWritingFactory, CategoryFactory, SubCategoryFactory, LicenceFactory
 from zds.utils.header_notifications import get_header_notifications
 from zds import json_handler
 

--- a/zds/tutorialv2/tests/tests_views/tests_edgecases.py
+++ b/zds/tutorialv2/tests/tests_views/tests_edgecases.py
@@ -3,9 +3,10 @@ from django.test import TestCase
 from django.urls import reverse
 
 from zds.member.factories import ProfileFactory, StaffProfileFactory
-from zds.tutorialv2.factories import PublishedContentFactory, LicenceFactory, SubCategoryFactory
+from zds.tutorialv2.factories import PublishedContentFactory
 from zds.tutorialv2.models.database import PublishableContent
 from zds.tutorialv2.tests import override_for_contents, TutorialTestMixin
+from zds.utils.factories import LicenceFactory, SubCategoryFactory
 
 
 @override_for_contents()

--- a/zds/tutorialv2/tests/tests_views/tests_editcontentlicense.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontentlicense.py
@@ -7,7 +7,8 @@ from zds.tutorialv2.views.contents import EditContentLicense
 from zds.tutorialv2.forms import EditContentLicenseForm
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 from zds.member.factories import ProfileFactory, StaffProfileFactory
-from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory
+from zds.tutorialv2.factories import PublishableContentFactory
+from zds.utils.factories import LicenceFactory
 
 
 @override_for_contents()

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -17,8 +17,6 @@ from zds.tutorialv2.factories import (
     PublishableContentFactory,
     ContainerFactory,
     ExtractFactory,
-    LicenceFactory,
-    SubCategoryFactory,
     PublishedContentFactory,
 )
 from zds.tutorialv2.models.database import (
@@ -31,7 +29,7 @@ from zds.tutorialv2.models.database import (
 from zds.tutorialv2.publication_utils import publish_content
 from zds.tutorialv2.tests import TutorialTestMixin
 from zds.utils.models import Alert, Tag, Hat
-from zds.utils.factories import CategoryFactory
+from zds.utils.factories import CategoryFactory, SubCategoryFactory, LicenceFactory
 from zds.utils.header_notifications import get_header_notifications
 from copy import deepcopy
 from zds import json_handler

--- a/zds/tutorialv2/tests/tests_views/tests_stats.py
+++ b/zds/tutorialv2/tests/tests_views/tests_stats.py
@@ -10,9 +10,10 @@ from django.test.utils import override_settings
 
 from zds.gallery.factories import UserGalleryFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory
-from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory, LicenceFactory
+from zds.tutorialv2.factories import PublishableContentFactory, ContainerFactory, ExtractFactory
 from zds.tutorialv2.models.database import Validation, PublishedContent
 from zds.tutorialv2.tests import TutorialTestMixin
+from zds.utils.factories import LicenceFactory
 
 overridden_zds_app = deepcopy(settings.ZDS_APP)
 overridden_zds_app["content"]["repo_private_path"] = settings.BASE_DIR / "contents-private-test"

--- a/zds/utils/factories.py
+++ b/zds/utils/factories.py
@@ -1,14 +1,19 @@
+from os.path import basename, join
+from shutil import copyfile
+
+import factory
+
 from django.conf import settings
 
 from zds.utils.models import HelpWriting, Category
 from zds.utils import old_slugify
-from shutil import copyfile
-from os.path import basename, join
-
-import factory
 
 
-class HelpWritingFactory(factory.DjangoModelFactory):
+class HelpWritingFactory(factory.django.DjangoModelFactory):
+    """
+    Factory that creates a HelpWriting.
+    """
+
     class Meta:
         model = HelpWriting
 
@@ -17,10 +22,13 @@ class HelpWritingFactory(factory.DjangoModelFactory):
     tablelabel = factory.LazyAttribute(lambda n: "Besoin de " + n.title)
 
     @classmethod
-    def _prepare(cls, create, **kwargs):
-        help_writing = super()._prepare(create, **kwargs)
-        image_path = kwargs.pop("image_path", None)
-        fixture_image_path = kwargs.pop("fixture_image_path", None)
+    def _generate(cls, create, attrs):
+        # These parameters are only used inside _generate() and won't be saved in the database,
+        # which is why we use attrs.pop() (they are removed from attrs).
+        image_path = attrs.pop("image_path", None)
+        fixture_image_path = attrs.pop("fixture_image_path", None)
+
+        help_writing = super()._generate(create, attrs)
 
         if fixture_image_path is not None:
             image_path = join(settings.BASE_DIR, "fixtures", fixture_image_path)
@@ -40,7 +48,11 @@ class HelpWritingFactory(factory.DjangoModelFactory):
         return super()._create(target_class, *args, **kwargs)
 
 
-class CategoryFactory(factory.DjangoModelFactory):
+class CategoryFactory(factory.django.DjangoModelFactory):
+    """
+    Factory that creates a Category.
+    """
+
     class Meta:
         model = Category
 

--- a/zds/utils/factories.py
+++ b/zds/utils/factories.py
@@ -5,7 +5,7 @@ import factory
 
 from django.conf import settings
 
-from zds.utils.models import HelpWriting, Category
+from zds.utils.models import HelpWriting, Category, SubCategory, CategorySubCategory, Licence
 from zds.utils import old_slugify
 
 
@@ -58,3 +58,42 @@ class CategoryFactory(factory.django.DjangoModelFactory):
 
     title = factory.Sequence("Ma catégorie No{}".format)
     slug = factory.Sequence("category{}".format)
+
+
+class SubCategoryFactory(factory.django.DjangoModelFactory):
+    """
+    Factory that creates a SubCategory.
+    """
+
+    class Meta:
+        model = SubCategory
+
+    title = factory.Sequence(lambda n: f"Sous-Categorie {n} pour Tuto")
+    subtitle = factory.Sequence(lambda n: f"Sous titre de Sous-Categorie {n} pour Tuto")
+    slug = factory.Sequence(lambda n: f"sous-categorie-{n}")
+
+    @classmethod
+    def _generate(cls, create, attrs):
+        # This parameter is only used inside _generate() and won't be saved in the database,
+        # which is why we use attrs.pop() (it is removed from attrs).
+        category = attrs.pop("category", None)
+
+        subcategory = super()._generate(create, attrs)
+
+        if category is not None:
+            relation = CategorySubCategory(category=category, subcategory=subcategory)
+            relation.save()
+
+        return subcategory
+
+
+class LicenceFactory(factory.django.DjangoModelFactory):
+    """
+    Factory that creates a License.
+    """
+
+    class Meta:
+        model = Licence
+
+    code = factory.Sequence(lambda n: "bidon-no{}".format(n + 1))
+    title = factory.Sequence(lambda n: "Licence bidon no{}".format(n + 1))

--- a/zds/utils/tests/tests_interventions.py
+++ b/zds/utils/tests/tests_interventions.py
@@ -6,8 +6,9 @@ from django.template import Context, Template
 from django.test import TestCase
 
 from zds.tutorialv2.models.database import Validation
-from zds.tutorialv2.factories import PublishableContentFactory, LicenceFactory, SubCategoryFactory
+from zds.tutorialv2.factories import PublishableContentFactory
 from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.utils.factories import SubCategoryFactory, LicenceFactory
 from zds.utils.mps import send_message_mp, send_mp
 
 


### PR DESCRIPTION
- Met à jour factory-boy en 3.2.0 et adapte les classes `Factory` en conséquence (avec un peu plus d'explications du fonctionnement en commentaires)
- Corrige une typo dans les tests (`db_objet` => `db_object`)
- Déplace `SubCategoryFactory` et `LicenseFactory` de `zds/tutorialv2/factories.py` vers `zds/utils/factories.py` étant donné que `SubCategory` et `License` sont dans `zds/utils/models.py` (et adapte les importations en conséquence)

**QA :** Revue de code (incluant les commentaires) + Vérifier que les tests passent (Github Actions)

fix #5555 
fix #4656