### PR TITLE
Corrige un bug dans l'abonnement aux MP

### DIFF
--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -263,20 +263,21 @@ class PrivateTopic(models.Model):
         """
         return self.is_author(user) or user in self.participants.all()
 
-    def add_participant(self, user):
+    def add_participant(self, user, silent=False):
         """
         Add a participant to the private topic.
-        If the user is already participating, do not add it again.
+        If the user is already participating, do nothing.
         Send the `participant_added` signal if successful.
 
         :param user: the user to add to the private topic
+        :param silent: specify if the `participant_added` signal should be silent (e.g. no notification)
         :raise NotReachableError: if the user cannot receive private messages (e.g. a bot)
         """
         if not is_reachable(user):
             raise NotReachableError
-        if not self.is_participant(user):  # avoid adding the same participant twice
+        if not self.is_participant(user):
             self.participants.add(user)
-            signals.participant_added.send(sender=PrivateTopic, topic=self)
+            signals.participant_added.send(sender=PrivateTopic, topic=self, silent=silent)
 
     def remove_participant(self, user):
         """

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -67,8 +67,8 @@ class PrivateTopic(models.Model):
         topic.author = author
         topic.save()
 
-        for participants in recipients:
-            topic.add_participant(participants, silent=True)
+        for participant in recipients:
+            topic.add_participant(participant, silent=True)
         topic.save()
 
         return topic

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from math import ceil
 
 from django.conf import settings
@@ -12,8 +13,6 @@ from zds.utils import get_current_user, old_slugify
 
 class NotReachableError(Exception):
     """Raised when a user cannot be reached using private messages (e.g. bots)."""
-
-    pass
 
 
 class NotParticipatingError(Exception):
@@ -57,6 +56,22 @@ class PrivateTopic(models.Model):
     )
     pubdate = models.DateTimeField("Date de création", auto_now_add=True, db_index=True)
     objects = PrivateTopicManager()
+
+    @staticmethod
+    def create(title, subtitle, author, recipients):
+        limit = PrivateTopic._meta.get_field("title").max_length
+        topic = PrivateTopic()
+        topic.title = title[:limit]
+        topic.subtitle = subtitle
+        topic.pubdate = datetime.now()
+        topic.author = author
+        topic.save()
+
+        for participants in recipients:
+            topic.add_participant(participants, silent=True)
+        topic.save()
+
+        return topic
 
     def __str__(self):
         """

--- a/zds/mp/signals.py
+++ b/zds/mp/signals.py
@@ -1,14 +1,14 @@
 from django.dispatch import Signal
 
 # New message management
-message_added = Signal(providing_args=["instance", "user", "by_email"])
+message_added = Signal()  # providing_args=["post", "by_email", "no_notification_for"]
 
 # Read/Unread management
-topic_read = Signal(providing_args=["instance", "user", "target"])
-message_unread = Signal(providing_args=["instance", "user"])
+topic_read = Signal()  # providing_args=["instance", "user"]
+message_unread = Signal()  # providing_args=["instance", "user"]
 
 # Participant management
-participant_added = Signal(providing_args=["instance"])
-participant_removed = Signal(providing_args=["instance"])
+participant_added = Signal()  # providing_args=["topic", "silent"]
+participant_removed = Signal()  # providing_args=["topic"]
 
-topic_created = Signal(providing_args=["instance"])
+topic_created = Signal()  # providing_args=["topic", "by_email"]

--- a/zds/mp/signals.py
+++ b/zds/mp/signals.py
@@ -10,3 +10,5 @@ message_unread = Signal(providing_args=["instance", "user"])
 # Participant management
 participant_added = Signal(providing_args=["instance"])
 participant_removed = Signal(providing_args=["instance"])
+
+topic_created = Signal(providing_args=["instance"])

--- a/zds/mp/tests/tests_utils.py
+++ b/zds/mp/tests/tests_utils.py
@@ -59,7 +59,7 @@ class MpUtilTest(TestCase):
             follow=True,
         )
 
-        # Assert MP have been sent
+        # Assert MP have been sent
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, PrivateTopic.objects.all().count())
 

--- a/zds/notification/api/tests.py
+++ b/zds/notification/api/tests.py
@@ -100,6 +100,6 @@ class NotificationListAPITest(APITestCase):
 
     def create_notification_for_pm(self, sender, target):
         topic = PrivateTopicFactory(author=sender)
-        topic.participants.add(target)
+        topic.add_participant(target, silent=True)
         send_message_mp(author=sender, n_topic=topic, text="Testing")
         return topic

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -208,6 +208,7 @@ def notify_participants(sender, *, topic, silent, **__):
     """
     for participant in topic.participants.all():
         subscription = PrivateTopicAnswerSubscription.objects.get_or_create_active(participant, topic)
+        subscription.activate_email()
         if not silent:
             subscription.send_notification(
                 content=topic.last_message,

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -200,18 +200,20 @@ def unread_private_topic_event(sender, *, user, instance, **__):
 
 
 @receiver(mp_signals.participant_added, sender=PrivateTopic)
-def notify_participants(sender, *, topic, **__):
+def notify_participants(sender, *, topic, silent, **__):
     """
-    Show a notification to all participants of a private topic except the author.
+    Subscribe participants to the private topic if not already subscribed.
+    If not silent, send a notification to all participants except the author.
     The notification uses the last message of the private topic and respects email preferences.
     """
     for participant in topic.participants.all():
         subscription = PrivateTopicAnswerSubscription.objects.get_or_create_active(participant, topic)
-        subscription.send_notification(
-            content=topic.last_message,
-            sender=topic.last_message.author,
-            send_email=participant.profile.email_for_answer,
-        )
+        if not silent:
+            subscription.send_notification(
+                content=topic.last_message,
+                sender=topic.last_message.author,
+                send_email=participant.profile.email_for_answer,
+            )
 
 
 @receiver(mp_signals.participant_removed, sender=PrivateTopic)

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -406,19 +406,18 @@ def content_published_event(*__, instance, by_email, **___):
 
 @receiver(mp_signals.topic_created, sender=PrivateTopic)
 @disable_for_loaddata
-def answer_private_topic_event(sender, *, topic, by_email, **__):
+def create_private_topic_event(sender, *, topic, by_email, **__):
     """
-    Sends PrivateTopicAnswerSubscription to the subscribers to the topic and subscribe
-    the author to the following answers to the topic.
+    Subscribe the author to the answers to the topic.
 
     :param topic: the new post.
-    :param by_email: Send or not an email.
+    :param by_email: Send or not an email for this subscription.
     """
-
+    subscription = PrivateTopicAnswerSubscription.objects.get_or_create_active(topic.author, topic)
     if by_email:
-        PrivateTopicAnswerSubscription.objects.toggle_follow(topic.privatetopic, topic.author, by_email=by_email)
+        subscription.activate_email()
     else:
-        PrivateTopicAnswerSubscription.objects.toggle_follow(topic.privatetopic, topic.author)
+        subscription.deactivate_email()
 
 
 @receiver(mp_signals.message_added, sender=PrivatePost)

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -318,7 +318,6 @@ class ReserveValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
                         send_by_mail=True,
                         leave=False,
                         direct=False,
-                        mark_as_read=True,
                         hat=get_hat_from_settings("validation"),
                     )
                     validation.content.save()

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -288,7 +288,6 @@ class HatRequest(models.Model):
             "",
             message,
             leave=solved_by_bot,
-            mark_as_read=True,
             hat=get_hat_from_settings("hats_management"),
         )
 

--- a/zds/utils/mps.py
+++ b/zds/utils/mps.py
@@ -50,10 +50,12 @@ def send_mp(
     n_topic.pubdate = datetime.now()
     n_topic.author = author
     n_topic.save()
+    signals.topic_created.send(sender=PrivateTopic, topic=n_topic, by_email=send_by_mail)
 
     # Add all participants on the MP.
     for participants in users:
         n_topic.add_participant(participants, silent=True)
+    n_topic.save()
 
     topic = send_message_mp(author, n_topic, text, send_by_mail, direct, hat)
     if mark_as_read:
@@ -105,7 +107,7 @@ def send_message_mp(author, n_topic, text, send_by_mail=True, direct=False, hat=
 
     if not direct:
         signals.message_added.send(
-            sender=post.__class__, instance=post, by_email=send_by_mail, no_notification_for=no_notification_for
+            sender=post.__class__, post=post, by_email=send_by_mail, no_notification_for=no_notification_for
         )
 
     if send_by_mail and direct:

--- a/zds/utils/mps.py
+++ b/zds/utils/mps.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from datetime import datetime
 
 from django.conf import settings
@@ -118,12 +119,9 @@ def send_message_mp(author, n_topic, text, send_by_mail=True, direct=False, hat=
 
     # There's no need to inform of the new participant
     # because participants are already notified through the `message_added` signal.
-    try:
+    # If we tried to add the bot, that's fine (a better solution would be welcome though)
+    with suppress(NotReachableError):
         n_topic.add_participant(author, silent=True)
         n_topic.save()
-    except NotReachableError:
-        # we tried to add the bot, that's fine
-        # a better solution would be welcome though
-        pass
 
     return n_topic


### PR DESCRIPTION
Fix #6068. Et refactorise un peu le code des MP pour faciliter la gestion des notifs (qui change pas mal).

### Contrôle qualité

Faire la procédure du #6068 pour vérifier que c'est bien géré.

Jouer avec les MP dans tous les sens et vérifier qu'on a bien les notifs comme il faut.

Les notifs par mail sont normalement couvertes par les test auto.
