### PR TITLE
Passage à zmd 9.1.5 pour corriger les notes de bas de page

### DIFF
--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "9.1.4"
+    "zmarkdown": "9.1.5"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
Passage à zmd 9.1.5 pour corriger les notes de bas de page

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Poster un message avec des notes de bas de page
- Poster un deuxième message à la suite avec des notes de bas de page
- Vérifier que celles-ci fonctionnent correctement

Exemple de notes de bas de page : 

```md
Bonsoir,

Comment allez-vous[^al] très chère[^hehe] ?

J'espère que vous êtes chères[^hehe] ma chère[^hehe] !

[^al]:Alphabet que veux-tu ?
[^hehe]: hehe haha hoho huhu
```