### PR TITLE
Met à jour  de sécurité de Pillow en 8.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ GitPython==3.1.13
 google-api-python-client==1.12.8
 homoglyphs==2.0.4
 lxml==4.6.2
-Pillow==8.1.0
+Pillow==8.1.2
 python-memcached==1.59
 requests==2.25.1
 toml==0.10.2


### PR DESCRIPTION
Met à jour Pillow en 8.1.2

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier qu'on peut encore téléverser des images