### PR TITLE
Généralise l'usage de force_login dans les tests quand approprié

### DIFF
--- a/zds/featured/tests.py
+++ b/zds/featured/tests.py
@@ -22,8 +22,7 @@ stringof2001chars += "12.jpg"
 class FeaturedResourceListViewTest(TestCase):
     def test_success_list_of_featured(self):
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         response = self.client.get(reverse("featured-resource-list"))
 
@@ -36,8 +35,7 @@ class FeaturedResourceListViewTest(TestCase):
 
     def test_failure_list_of_featured_with_user_not_staff(self):
         profile = ProfileFactory()
-        login_check = self.client.login(username=profile.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(profile.user)
 
         response = self.client.get(reverse("featured-resource-list"))
 
@@ -48,9 +46,8 @@ class FeaturedResourceListViewTest(TestCase):
 class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
     def test_success_create_featured(self):
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
+        self.client.force_login(staff.user)
 
-        self.assertTrue(login_check)
         self.assertEqual(0, FeaturedResource.objects.all().count())
 
         pubdate = date(2016, 1, 1).strftime("%d/%m/%Y %H:%M:%S")
@@ -94,8 +91,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
 
     def test_failure_create_featured_with_user_not_staff(self):
         profile = ProfileFactory()
-        login_check = self.client.login(username=profile.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(profile.user)
 
         response = self.client.get(reverse("featured-resource-create"))
 
@@ -103,8 +99,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
 
     def test_failure_too_long_url(self):
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         self.assertEqual(0, FeaturedResource.objects.all().count())
         response = self.client.post(
@@ -146,8 +141,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         tutorial.image = image
         tutorial.save()
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
         response = self.client.get(
             "{}{}".format(
                 reverse("featured-resource-create"), f"?content_type=published_content&content_id={tutorial.pk}"
@@ -166,8 +160,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         forum = ForumFactory(category=category, position_in_category=1)
         topic = TopicFactory(forum=forum, author=author)
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
         response = self.client.get(
             "{}?content_type=topic&content_id={}".format(reverse("featured-resource-create"), topic.id)
         )
@@ -179,8 +172,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
 
     def test_failure_initial_content_not_found(self):
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         response = self.client.get(
             "{}?content_type=published_content&content_id=42".format(reverse("featured-resource-create"))
@@ -191,8 +183,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
 class FeaturedResourceUpdateViewTest(TestCase):
     def test_success_update_featured(self):
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         news = FeaturedResourceFactory()
         self.assertEqual(1, FeaturedResource.objects.all().count())
@@ -242,8 +233,7 @@ class FeaturedResourceUpdateViewTest(TestCase):
 
     def test_failure_create_featured_with_user_not_staff(self):
         profile = ProfileFactory()
-        login_check = self.client.login(username=profile.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(profile.user)
 
         response = self.client.get(reverse("featured-resource-update", args=[42]))
 
@@ -253,8 +243,7 @@ class FeaturedResourceUpdateViewTest(TestCase):
 class FeaturedResourceDeleteViewTest(TestCase):
     def test_success_delete_featured(self):
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         news = FeaturedResourceFactory()
         self.assertEqual(1, FeaturedResource.objects.all().count())
@@ -271,8 +260,7 @@ class FeaturedResourceDeleteViewTest(TestCase):
 
     def test_failure_delete_featured_with_user_not_staff(self):
         profile = ProfileFactory()
-        login_check = self.client.login(username=profile.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(profile.user)
 
         news = FeaturedResourceFactory()
         response = self.client.get(reverse("featured-resource-delete", args=[news.pk]))
@@ -283,8 +271,7 @@ class FeaturedResourceDeleteViewTest(TestCase):
 class FeaturedResourceListDeleteViewTest(TestCase):
     def test_success_list_delete_featured(self):
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         news = FeaturedResourceFactory()
         news2 = FeaturedResourceFactory()
@@ -304,8 +291,7 @@ class FeaturedResourceListDeleteViewTest(TestCase):
 
     def test_failure_list_delete_featured_with_user_not_staff(self):
         profile = ProfileFactory()
-        login_check = self.client.login(username=profile.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(profile.user)
 
         response = self.client.get(reverse("featured-resource-list-delete"))
 
@@ -315,8 +301,7 @@ class FeaturedResourceListDeleteViewTest(TestCase):
 class FeaturedMessageCreateUpdateViewTest(TestCase):
     def test_success_list_create_message(self):
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         response = self.client.post(
             reverse("featured-message-create"),
@@ -332,8 +317,7 @@ class FeaturedMessageCreateUpdateViewTest(TestCase):
 
     def test_create_only_one_message_in_system(self):
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         response = self.client.post(
             reverse("featured-message-create"),
@@ -364,8 +348,7 @@ class FeaturedMessageCreateUpdateViewTest(TestCase):
 class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
     def test_success_list(self):
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         response = self.client.get(reverse("featured-resource-requests"))
 
@@ -378,8 +361,7 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
 
     def test_failure_list_with_user_not_staff(self):
         profile = ProfileFactory()
-        login_check = self.client.login(username=profile.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(profile.user)
 
         response = self.client.get(reverse("featured-resource-requests"))
 
@@ -404,8 +386,7 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
 
         # without filter
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         response = self.client.get(reverse("featured-resource-requests"))
         self.assertEqual(200, response.status_code)
@@ -477,8 +458,7 @@ class FeaturedRequestUpdateViewTest(TestCase):
 
         # ignore
         staff = StaffProfileFactory()
-        login_check = self.client.login(username=staff.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(staff.user)
 
         content_type = ContentType.objects.get_for_model(topic)
         q = FeaturedRequested.objects.get(object_id=topic.pk, content_type__pk=content_type.pk)
@@ -517,8 +497,7 @@ class FeaturedRequestUpdateViewTest(TestCase):
 class FeaturedRequestToggleTest(TutorialTestMixin, TestCase):
     def test_toggle(self):
         author = ProfileFactory()
-        login_check = self.client.login(username=author.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(author.user)
 
         # create topic and toggle request
         category = ForumCategoryFactory(position=1)
@@ -608,8 +587,7 @@ class FeaturedRequestToggleTest(TutorialTestMixin, TestCase):
 
         # upvote with other user
         other = ProfileFactory()
-        login_check = self.client.login(username=other.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(other.user)
 
         response = self.client.post(
             reverse("content:request-featured", kwargs={"pk": tutorial.pk}),

--- a/zds/forum/api/tests.py
+++ b/zds/forum/api/tests.py
@@ -38,7 +38,7 @@ class ForumPostKarmaAPITest(APITestCase):
         profile.can_write = False
         profile.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:forum:post-karma", args=(post.pk,)))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -53,7 +53,7 @@ class ForumPostKarmaAPITest(APITestCase):
         category, forum = create_category_and_forum(group)
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:forum:post-karma", args=(topic.last_message.pk,)), {"vote": "like"})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -64,7 +64,7 @@ class ForumPostKarmaAPITest(APITestCase):
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:forum:post-karma", args=(post.pk,)), {"vote": "like"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(CommentVote.objects.filter(user=profile.user, comment=post, positive=True).exists())
@@ -76,7 +76,7 @@ class ForumPostKarmaAPITest(APITestCase):
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:forum:post-karma", args=(post.pk,)), {"vote": "dislike"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(CommentVote.objects.filter(user=profile.user, comment=post, positive=False).exists())
@@ -92,7 +92,7 @@ class ForumPostKarmaAPITest(APITestCase):
         vote.save()
 
         self.assertTrue(CommentVote.objects.filter(pk=vote.pk).exists())
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:forum:post-karma", args=(post.pk,)), {"vote": "neutral"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(CommentVote.objects.filter(pk=vote.pk).exists())
@@ -107,7 +107,7 @@ class ForumPostKarmaAPITest(APITestCase):
         vote = CommentVote(user=profile.user, comment=post, positive=False)
         vote.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:forum:post-karma", args=(post.pk,)), {"vote": "like"})
         vote.refresh_from_db()
 
@@ -141,7 +141,7 @@ class ForumPostKarmaAPITest(APITestCase):
         CommentVote.objects.create(user=profile.user, comment=equal_answer, positive=True)
         CommentVote.objects.create(user=profile2.user, comment=equal_answer, positive=False)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
 
         # on first message we should see 2 likes and 0 anonymous
         response = self.client.get(reverse("api:forum:post-karma", args=[upvoted_answer.pk]))

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -31,8 +31,7 @@ class ForumMemberTests(TestCase):
         self.forum22 = ForumFactory(category=self.category2, position_in_category=2)
         self.user = ProfileFactory().user
         self.user2 = ProfileFactory().user
-        log = self.client.login(username=self.user.username, password="hostel77")
-        self.assertEqual(log, True)
+        self.client.force_login(self.user)
 
         settings.ZDS_APP["member"]["bot_account"] = ProfileFactory().user.username
 
@@ -459,7 +458,7 @@ class ForumMemberTests(TestCase):
         self.assertEqual(result.status_code, 403)
         # login as staff
         staff1 = StaffProfileFactory().user
-        self.assertTrue(self.client.login(username=staff1.username, password="hostel77"))
+        self.client.force_login(staff1)
         # try again as staff
         resolve_reason = "Everything is OK kid"
         result = self.client.post(
@@ -500,7 +499,7 @@ class ForumMemberTests(TestCase):
         alert = Alert.objects.get(comment=post2.pk)
         # login as staff
         staff1 = StaffProfileFactory().user
-        self.assertEqual(self.client.login(username=staff1.username, password="hostel77"), True)
+        self.client.force_login(staff1)
         # try again as staff
         result = self.client.post(
             reverse("forum-solve-alert"),
@@ -549,8 +548,8 @@ class ForumMemberTests(TestCase):
         self.assertEqual(Post.objects.get(pk=post5.pk).is_useful, True)
 
         # useful if you are staff
-        StaffProfileFactory().user
-        self.assertEqual(self.client.login(username=self.user.username, password="hostel77"), True)
+        staff = StaffProfileFactory().user
+        self.client.force_login(staff)
         result = self.client.post(reverse("post-useful") + f"?message={post4.pk}", follow=False)
         self.assertNotEqual(result.status_code, 403)
         self.assertEqual(Post.objects.get(pk=post4.pk).is_useful, True)
@@ -591,7 +590,7 @@ class ForumMemberTests(TestCase):
 
         # test with staff
         staff1 = StaffProfileFactory().user
-        self.assertEqual(self.client.login(username=staff1.username, password="hostel77"), True)
+        self.client.force_login(staff1)
 
         result = self.client.post(
             reverse("topic-edit"), {"move": "", "forum": self.forum12.pk, "topic": topic1.pk}, follow=False
@@ -612,7 +611,7 @@ class ForumMemberTests(TestCase):
 
         # log as staff
         staff1 = StaffProfileFactory().user
-        self.assertEqual(self.client.login(username=staff1.username, password="hostel77"), True)
+        self.client.force_login(staff1)
 
         # missing parameter
         result = self.client.post(
@@ -769,7 +768,7 @@ class ForumMemberTests(TestCase):
 
         for i in range(settings.ZDS_APP["forum"]["posts_per_page"] + 2):
             PostFactory(topic=topic, author=profiles[i % 2].user, position=i + 2)
-        self.client.login(username=profiles[1].user.username, password="hostel77")
+        self.client.force_login(profiles[1].user)
 
         template_response = self.client.get(topic.get_absolute_url())
         self.assertIn(expected, template_response.content.decode("utf-8"))

--- a/zds/forum/tests/tests_feeds.py
+++ b/zds/forum/tests/tests_feeds.py
@@ -19,8 +19,7 @@ class LastTopicsFeedRSSTest(TestCase):
         self.forum2 = ForumFactory(category=self.category1, position_in_category=2)
 
         self.user = ProfileFactory().user
-        log = self.client.login(username=self.user.username, password="hostel77")
-        self.assertEqual(log, True)
+        self.client.force_login(self.user)
 
         self.tag = TagFactory()
         self.topic1 = TopicFactory(forum=self.forum, author=self.user)
@@ -153,8 +152,7 @@ class LastPostFeedTest(TestCase):
         self.forum3 = ForumFactory(category=self.category1, position_in_category=3)
 
         self.user = ProfileFactory().user
-        log = self.client.login(username=self.user.username, password="hostel77")
-        self.assertEqual(log, True)
+        self.client.force_login(self.user)
 
         self.tag = TagFactory()
         self.topic1 = TopicFactory(forum=self.forum, author=self.user)

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -18,7 +18,7 @@ from zds.utils.models import CommentEdit, Hat, Alert
 class LastTopicsViewTests(TestCase):
     def test_logged_user(self):
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         _, forum = create_category_and_forum()
         create_topic_in_forum(forum, profile)
         response = self.client.get(reverse("last-subjects"))
@@ -40,14 +40,14 @@ class LastTopicsViewTests(TestCase):
         create_topic_in_forum(forum, author_profile)
         # Tests with a user who cannot read the last topic.
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("last-subjects"))
         self.assertEqual(200, response.status_code)
         self.assertTrue(Topic.objects.last() not in response.context["topics"])
         # Adds to the user the right to read the last topic, and test again.
         profile.user.groups.add(group)
         profile.user.save()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("last-subjects"))
         self.assertEqual(200, response.status_code)
         self.assertTrue(Topic.objects.last() in response.context["topics"])
@@ -80,7 +80,7 @@ class CategoriesForumsListViewTests(TestCase):
 
         profile.user.groups.add(group)
         profile.user.save()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
 
         response = self.client.get(reverse("cats-forums-list"))
 
@@ -98,7 +98,7 @@ class CategoriesForumsListViewTests(TestCase):
 
         topics_nb = len(Topic.objects.get_last_topics())
 
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         data = {"lock": "true", "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -136,7 +136,7 @@ class CategoryForumsDetailViewTest(TestCase):
 
         profile.user.groups.add(group)
         profile.user.save()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
 
         response = self.client.get(reverse("cat-forums-list", args=[category.slug]))
 
@@ -289,7 +289,7 @@ class TopicNewTest(TestCase):
         profile.save()
         _, forum = create_category_and_forum()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("topic-new") + f"?forum={forum.pk}")
 
         self.assertEqual(403, response.status_code)
@@ -299,7 +299,7 @@ class TopicNewTest(TestCase):
         profile = ProfileFactory()
         _, forum = create_category_and_forum(group)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("topic-new") + f"?forum={forum.pk}")
 
         self.assertEqual(403, response.status_code)
@@ -307,7 +307,7 @@ class TopicNewTest(TestCase):
     def test_failure_create_topics_with_a_post_with_wrong_forum(self):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("topic-new") + "?forum=x")
 
         self.assertEqual(404, response.status_code)
@@ -316,7 +316,7 @@ class TopicNewTest(TestCase):
         profile = ProfileFactory()
         _, forum = create_category_and_forum()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("topic-new") + f"?forum={forum.pk}")
 
         self.assertEqual(200, response.status_code)
@@ -328,15 +328,15 @@ class TopicNewTest(TestCase):
         profile2 = ProfileFactory()
         notvisited = ProfileFactory()
         _, forum = create_category_and_forum()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"title": "Title of the topic", "subtitle": "Subtitle of the topic", "text": "A new post!", "tags": ""}
         self.client.post(reverse("topic-new") + f"?forum={forum.pk}", data, follow=False)
         self.client.logout()
-        self.assertTrue(self.client.login(username=profile2.user.username, password="hostel77"))
+        self.client.force_login(profile2.user)
         data = {"title": "Title of the topic", "subtitle": "Subtitle of the topic", "text": "A new post!", "tags": ""}
         self.client.post(reverse("topic-new") + f"?forum={forum.pk}", data, follow=False)
         self.client.logout()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         topic = Topic.objects.last()
         post = Post.objects.filter(topic__pk=topic.pk).first()
         # for user
@@ -347,14 +347,14 @@ class TopicNewTest(TestCase):
         self.client.logout()
         self.assertEqual(url, topic.get_absolute_url() + "?page=1#p" + str(post.pk))
         # for no visit
-        self.assertTrue(self.client.login(username=notvisited.user.username, password="hostel77"))
+        self.client.force_login(notvisited.user)
         self.assertEqual(url, topic.get_absolute_url() + "?page=1#p" + str(post.pk))
 
     def test_success_create_topic_with_post_in_preview_in_ajax(self):
         profile = ProfileFactory()
         _, forum = create_category_and_forum()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"preview": "", "text": "A new post!"}
         response = self.client.post(
             reverse("topic-new") + f"?forum={forum.pk}",
@@ -369,7 +369,7 @@ class TopicNewTest(TestCase):
         profile = ProfileFactory()
         _, forum = create_category_and_forum()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {
             "preview": "",
             "title": "Title of the topic",
@@ -384,7 +384,7 @@ class TopicNewTest(TestCase):
         profile = ProfileFactory()
         _, forum = create_category_and_forum()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"title": "Title of the topic", "subtitle": "Subtitle of the topic", "text": "A new post!", "tags": ""}
         response = self.client.post(reverse("topic-new") + f"?forum={forum.pk}", data, follow=False)
 
@@ -397,7 +397,7 @@ class TopicNewTest(TestCase):
         hat, _ = Hat.objects.get_or_create(name__iexact="A hat", defaults={"name": "A hat"})
         profile.hats.add(hat)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {
             "title": "Title of the topic",
             "subtitle": "Subtitle of the topic",
@@ -423,7 +423,7 @@ class TopicEditTest(TestCase):
         profile.can_write = False
         profile.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("topic-edit"))
 
         self.assertEqual(403, response.status_code)
@@ -431,7 +431,7 @@ class TopicEditTest(TestCase):
     def test_failure_edit_topic_with_wrong_topic_pk(self):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(
             reverse("topic-edit"),
             {
@@ -445,7 +445,7 @@ class TopicEditTest(TestCase):
     def test_failure_edit_topic_with_a_topic_not_found(self):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(
             reverse("topic-edit"),
             {
@@ -461,7 +461,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, HTTP_X_REQUESTED_WITH="XMLHttpRequest", follow=False)
 
@@ -472,7 +472,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -483,7 +483,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"follow": "1"}
         response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
@@ -504,7 +504,7 @@ class TopicEditTest(TestCase):
         first_post.is_visible = False
         first_post.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"follow": "1"}
         response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
@@ -521,7 +521,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"email": "1"}
         response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
@@ -544,7 +544,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, another_profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"solved": "", "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -555,7 +555,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"solved": "", "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -571,7 +571,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         data = {"solved": "", "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -587,7 +587,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, another_profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"lock": "true", "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -600,7 +600,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         data = {"lock": "true", "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -620,7 +620,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, another_profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"sticky": "true", "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -633,7 +633,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         data = {"sticky": "true", "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -654,7 +654,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, another_profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"move": "", "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -669,7 +669,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         data = {"move": "", "forum": "abc", "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -684,7 +684,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         data = {"move": "", "forum": 99999, "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -701,7 +701,7 @@ class TopicEditTest(TestCase):
 
         _, another_forum = create_category_and_forum()
 
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         data = {"move": "", "forum": another_forum.pk, "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -714,7 +714,7 @@ class TopicEditTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         another_profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=another_profile.user.username, password="hostel77"))
+        self.client.force_login(another_profile.user)
         response = self.client.get(reverse("topic-edit") + f"?topic={topic.pk}", follow=False)
         self.assertEqual(403, response.status_code)
 
@@ -729,7 +729,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         response = self.client.get(reverse("topic-edit") + f"?topic={topic.pk}", follow=False)
 
         self.assertEqual(200, response.status_code)
@@ -739,7 +739,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("topic-edit") + f"?topic={topic.pk}", follow=False)
 
         self.assertEqual(200, response.status_code)
@@ -749,7 +749,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {
             "preview": "",
             "title": "New title",
@@ -767,7 +767,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {
             "preview": "",
             "title": "New title",
@@ -788,7 +788,7 @@ class TopicEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {
             "title": "New title",
             "subtitle": "New subtitle",
@@ -840,7 +840,7 @@ class FindTopicTest(TestCase):
 
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("topic-find", args=[profile.user.pk]), follow=False)
 
         self.assertEqual(200, response.status_code)
@@ -858,7 +858,7 @@ class FindFollowedTopicTest(TestCase):
         profile = ProfileFactory()
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("followed-topic-find"), follow=False)
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context["topics"]))
@@ -878,7 +878,7 @@ class FindTopicByTagTest(TestCase):
         tag = TagFactory()
         topic.add_tags([tag.title])
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("topic-tag-find", args=[tag.slug]), follow=False)
 
         self.assertEqual(200, response.status_code)
@@ -907,7 +907,7 @@ class FindTopicByTagTest(TestCase):
         tag = TagFactory()
         topic.add_tags([tag.title])
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("topic-tag-find", args=[tag.slug]), follow=False)
 
         self.assertEqual(200, response.status_code)
@@ -988,7 +988,7 @@ class PostNewTest(TestCase):
         profile.can_write = False
         profile.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-new"))
 
         self.assertEqual(403, response.status_code)
@@ -996,7 +996,7 @@ class PostNewTest(TestCase):
     def test_failure_new_post_with_wrong_topic_pk(self):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-new") + "?sujet=abc", follow=False)
 
         self.assertEqual(404, response.status_code)
@@ -1004,7 +1004,7 @@ class PostNewTest(TestCase):
     def test_failure_new_post_with_a_topic_not_found(self):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-new") + "?sujet=99999", follow=False)
 
         self.assertEqual(404, response.status_code)
@@ -1015,7 +1015,7 @@ class PostNewTest(TestCase):
         _, forum = create_category_and_forum(group)
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-new") + f"?sujet={topic.pk}")
 
         self.assertEqual(403, response.status_code)
@@ -1025,7 +1025,7 @@ class PostNewTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile, is_locked=True)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-new") + f"?sujet={topic.pk}")
 
         self.assertEqual(403, response.status_code)
@@ -1037,7 +1037,7 @@ class PostNewTest(TestCase):
         topic.last_message.pubdate = datetime.now()
         topic.last_message.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-new") + f"?sujet={topic.pk}")
 
         self.assertEqual(403, response.status_code)
@@ -1048,7 +1048,7 @@ class PostNewTest(TestCase):
         topic = create_topic_in_forum(forum, another_profile)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-new") + f"?sujet={topic.pk}", follow=False)
 
         self.assertEqual(200, response.status_code)
@@ -1063,7 +1063,7 @@ class PostNewTest(TestCase):
         topic = create_topic_in_forum(forum, another_profile)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(
             reverse("post-new") + f"?sujet={topic.pk}&cite={topic.last_message.pk}",
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
@@ -1078,7 +1078,7 @@ class PostNewTest(TestCase):
         topic = create_topic_in_forum(forum, another_profile)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"preview": "", "text": "A new post!", "last_post": topic.last_message.pk}
         response = self.client.post(reverse("post-new") + f"?sujet={topic.pk}", data, follow=False)
 
@@ -1094,7 +1094,7 @@ class PostNewTest(TestCase):
         topic = create_topic_in_forum(forum, another_profile)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"preview": "", "text": "A new post!", "last_post": topic.last_message.pk}
         response = self.client.post(
             reverse("post-new") + f"?sujet={topic.pk}",
@@ -1111,7 +1111,7 @@ class PostNewTest(TestCase):
         topic = create_topic_in_forum(forum, another_profile)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"text": "A new post!", "last_post": topic.last_message.pk}
         response = self.client.post(reverse("post-new") + f"?sujet={topic.pk}", data, follow=False)
 
@@ -1124,7 +1124,7 @@ class PostNewTest(TestCase):
 
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
 
         hat, _ = Hat.objects.get_or_create(name__iexact="A hat", defaults={"name": "A hat"})
         other_hat, _ = Hat.objects.get_or_create(name__iexact="Another hat", defaults={"name": "Another hat"})
@@ -1197,7 +1197,7 @@ class PostEditTest(TestCase):
         profile.can_write = False
         profile.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-edit"))
 
         self.assertEqual(403, response.status_code)
@@ -1205,7 +1205,7 @@ class PostEditTest(TestCase):
     def test_failure_edit_post_with_wrong_post_pk(self):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-edit") + "?message=abc", follow=False)
 
         self.assertEqual(404, response.status_code)
@@ -1213,7 +1213,7 @@ class PostEditTest(TestCase):
     def test_failure_edit_post_with_a_topic_not_found(self):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-edit") + "?message=99999", follow=False)
 
         self.assertEqual(404, response.status_code)
@@ -1224,7 +1224,7 @@ class PostEditTest(TestCase):
         _, forum = create_category_and_forum(group)
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-edit") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(403, response.status_code)
@@ -1235,7 +1235,7 @@ class PostEditTest(TestCase):
         topic = create_topic_in_forum(forum, another_profile)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-edit") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(403, response.status_code)
@@ -1245,7 +1245,7 @@ class PostEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-edit") + f"?message={topic.last_message.pk}", follow=False)
 
         self.assertEqual(200, response.status_code)
@@ -1259,7 +1259,7 @@ class PostEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"preview": "", "text": "A new post!"}
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
 
@@ -1270,7 +1270,7 @@ class PostEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {
             "preview": "",
             "text": "A new post!",
@@ -1289,7 +1289,7 @@ class PostEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"text": "A new post!"}
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
 
@@ -1304,7 +1304,7 @@ class PostEditTest(TestCase):
         topic = create_topic_in_forum(forum, another_profile)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"delete_message": ""}
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
 
@@ -1315,7 +1315,7 @@ class PostEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         # WARNING : if author is not staff he can't send a delete message.
         data = {"delete_message": ""}
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
@@ -1333,7 +1333,7 @@ class PostEditTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         staff = StaffProfileFactory()
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         text_hidden_expected = "Bad guy!"
         data = {"delete_message": "", "text_hidden": text_hidden_expected}
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
@@ -1350,7 +1350,7 @@ class PostEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-useful") + f"?message={topic.last_message.pk}", follow=False)
         self.assertEqual(302, response.status_code)
 
@@ -1371,7 +1371,7 @@ class PostEditTest(TestCase):
         topic = create_topic_in_forum(forum, another_profile)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"show_message": ""}
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
 
@@ -1382,7 +1382,7 @@ class PostEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"show_message": ""}
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
 
@@ -1398,7 +1398,7 @@ class PostEditTest(TestCase):
         topic.last_message.save()
 
         staff = StaffProfileFactory()
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         data = {
             "show_message": "",
         }
@@ -1415,7 +1415,7 @@ class PostEditTest(TestCase):
         topic = create_topic_in_forum(forum, another_profile)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         text_expected = "Bad guy!"
         data = {"signal_message": "", "signal_text": text_expected}
         response = self.client.post(
@@ -1434,7 +1434,7 @@ class PostEditTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"delete_message": ""}
 
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
@@ -1457,7 +1457,7 @@ class PostEditTest(TestCase):
         topic = create_topic_in_forum(forum, ProfileFactory())
 
         # post a message with a hat
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {
             "text": "A new post!",
             "last_post": topic.last_message.pk,
@@ -1501,7 +1501,7 @@ class PostEditTest(TestCase):
         edits_count = CommentEdit.objects.count()
 
         # Edit post
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         data = {"text": "A new post!"}
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
         self.assertEqual(302, response.status_code)
@@ -1533,7 +1533,7 @@ class PostUsefulTest(TestCase):
         profile.can_write = False
         profile.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-useful"))
 
         self.assertEqual(403, response.status_code)
@@ -1541,7 +1541,7 @@ class PostUsefulTest(TestCase):
     def test_failure_post_useful_with_wrong_topic_pk(self):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-useful") + "?message=abc", follow=False)
 
         self.assertEqual(404, response.status_code)
@@ -1549,7 +1549,7 @@ class PostUsefulTest(TestCase):
     def test_failure_post_useful_with_a_topic_not_found(self):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-useful") + "?message=99999", follow=False)
 
         self.assertEqual(404, response.status_code)
@@ -1561,7 +1561,7 @@ class PostUsefulTest(TestCase):
         _, forum = create_category_and_forum(group)
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-useful") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(403, response.status_code)
@@ -1571,7 +1571,7 @@ class PostUsefulTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-useful") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(302, response.status_code)
@@ -1582,7 +1582,7 @@ class PostUsefulTest(TestCase):
         topic = create_topic_in_forum(forum, another_profile)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-useful") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(403, response.status_code)
@@ -1594,7 +1594,7 @@ class PostUsefulTest(TestCase):
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(
             reverse("post-useful") + f"?message={post.pk}", HTTP_X_REQUESTED_WITH="XMLHttpRequest", follow=False
         )
@@ -1609,7 +1609,7 @@ class PostUsefulTest(TestCase):
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("post-useful") + f"?message={post.pk}", follow=False)
 
         self.assertEqual(302, response.status_code)
@@ -1621,7 +1621,7 @@ class PostUsefulTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         staff = StaffProfileFactory()
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         response = self.client.post(reverse("post-useful") + f"?message={topic.last_message.pk}", follow=False)
 
         self.assertEqual(302, response.status_code)
@@ -1691,14 +1691,14 @@ class MessageActionTest(TestCase):
         self.assertNotContains(response, "Signaler")
 
         # authenticated, two 'Alert' buttons because we have two messages
-        self.client.login(username=profile.user.username, password="hostel77")
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
         alerts = [word for word in str(response.content).split() if word == "alert"]
         self.assertEqual(len(alerts), 2)
 
         # staff hides a message
         staff = StaffProfileFactory()
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         text_hidden_expected = "Bad guy!"
         data = {"delete_message": "", "text_hidden": text_hidden_expected}
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
@@ -1709,7 +1709,7 @@ class MessageActionTest(TestCase):
         self.assertContains(response, '<a href="#signal-message-', count=2)
 
         # authenticated, user can alert the hidden message too
-        self.client.login(username=profile.user.username, password="hostel77")
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertContains(response, '<a href="#signal-message-', count=2)
 
@@ -1730,14 +1730,14 @@ class MessageActionTest(TestCase):
         self.assertNotContains(response, "Masquer")
 
         # authenticated, only one 'Hide' buttons because our user only posted one of them
-        self.client.login(username=profile.user.username, password="hostel77")
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
         hide_buttons = [word for word in response.content.decode().split() if word == "hide"]
         self.assertEqual(len(hide_buttons), 1)
 
         # staff hides a message
         staff = StaffProfileFactory()
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         text_hidden_expected = "Bad guy!"
         data = {"delete_message": "", "text_hidden": text_hidden_expected}
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
@@ -1754,14 +1754,14 @@ class MessageActionTest(TestCase):
         self.assertContains(response, "Bad guy!")
 
         # user cannot show or re-enable their message
-        self.client.login(username=profile.user.username, password="hostel77")
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertNotContains(response, '<details class="message-text message-hidden-container">')
         self.assertNotContains(response, "Démasquer")
         self.assertContains(response, "Bad guy!")
 
         # staff can show or re-enable
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertContains(response, '<details class="message-text message-hidden-container">')
         self.assertContains(response, "Démasquer")
@@ -1800,7 +1800,7 @@ class PostUnreadTest(TestCase):
         profile.can_write = False
         profile.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-unread"))
 
         self.assertEqual(post_unread.send.call_count, 0)
@@ -1810,7 +1810,7 @@ class PostUnreadTest(TestCase):
     def test_failure_post_unread_with_wrong_topic_pk(self, post_unread):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-unread") + "?message=abc", follow=False)
 
         self.assertEqual(post_unread.send.call_count, 0)
@@ -1820,7 +1820,7 @@ class PostUnreadTest(TestCase):
     def test_failure_post_unread_with_a_topic_not_found(self, post_unread):
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-unread") + "?message=99999", follow=False)
 
         self.assertEqual(post_unread.send.call_count, 0)
@@ -1834,7 +1834,7 @@ class PostUnreadTest(TestCase):
         _, forum = create_category_and_forum(group)
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-unread") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(post_unread.send.call_count, 0)
@@ -1848,7 +1848,7 @@ class PostUnreadTest(TestCase):
         another_profile = ProfileFactory()
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-unread") + f"?message={post.pk}", follow=False)
 
         self.assertEqual(post_unread.send.call_count, 1)
@@ -1891,7 +1891,7 @@ class FindPostTest(TestCase):
 
         topic = create_topic_in_forum(forum, profile)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.get(reverse("post-find", args=[profile.user.pk]), follow=False)
 
         self.assertEqual(200, response.status_code)

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -20,8 +20,7 @@ class GalleryListViewTest(TestCase):
         GalleryFactory()
         UserGalleryFactory(user=profile.user, gallery=gallery)
 
-        login_check = self.client.login(username=profile.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(profile.user)
 
         response = self.client.get(reverse("gallery-list"), follow=True)
         self.assertEqual(200, response.status_code)
@@ -44,8 +43,7 @@ class GalleryDetailViewTest(TestCase):
         )
 
     def test_fail_gallery_no_exist(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
         response = self.client.get(reverse("gallery-details", args=["89", "test-gallery"]), follow=True)
 
         self.assertEqual(404, response.status_code)
@@ -55,8 +53,7 @@ class GalleryDetailViewTest(TestCase):
         gallery = GalleryFactory()
         UserGalleryFactory(gallery=gallery, user=self.profile1.user)
 
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         response = self.client.get(reverse("gallery-details", args=[gallery.pk, gallery.slug]))
         self.assertEqual(403, response.status_code)
@@ -66,8 +63,7 @@ class GalleryDetailViewTest(TestCase):
         UserGalleryFactory(gallery=gallery, user=self.profile1.user)
         UserGalleryFactory(gallery=gallery, user=self.profile2.user)
 
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         response = self.client.get(reverse("gallery-details", args=[gallery.pk, gallery.slug]))
         self.assertEqual(200, response.status_code)
@@ -86,15 +82,13 @@ class NewGalleryViewTest(TestCase):
 
     def test_access_member(self):
         """ just verify with get request that everythings is ok """
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.get(reverse("gallery-new"))
         self.assertEqual(200, response.status_code)
 
     def test_fail_new_gallery_with_missing_params(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
         self.assertEqual(0, Gallery.objects.count())
 
         response = self.client.post(reverse("gallery-new"), {"subtitle": "test"})
@@ -103,8 +97,7 @@ class NewGalleryViewTest(TestCase):
         self.assertEqual(0, Gallery.objects.filter(subtitle="test").count())
 
     def test_success_new_gallery(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
         self.assertEqual(0, Gallery.objects.count())
 
         response = self.client.post(
@@ -146,8 +139,7 @@ class ModifyGalleryViewTest(TestCase):
 
     def test_fail_delete_multi_read_permission(self):
         """ when user wants to delete a list of galleries just with a read permission """
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         self.assertEqual(4, Gallery.objects.all().count())
         self.assertEqual(5, UserGallery.objects.all().count())
@@ -163,8 +155,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual(3, Image.objects.all().count())
 
     def test_success_delete_multi_write_permission(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         self.assertEqual(4, Gallery.objects.all().count())
         self.assertEqual(5, UserGallery.objects.all().count())
@@ -182,8 +173,7 @@ class ModifyGalleryViewTest(TestCase):
 
     def test_fail_delete_read_permission(self):
         """ when user wants to delete a gallery just with a read permission """
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         self.assertEqual(4, Gallery.objects.all().count())
         self.assertEqual(5, UserGallery.objects.all().count())
@@ -199,8 +189,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual(3, Image.objects.all().count())
 
     def test_success_delete_write_permission(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         self.assertEqual(4, Gallery.objects.all().count())
         self.assertEqual(5, UserGallery.objects.all().count())
@@ -215,8 +204,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual(0, Image.objects.filter(gallery=self.gallery1).count())
 
     def test_fail_add_user_with_read_permission(self):
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         # gallery nonexistent
         response = self.client.post(
@@ -239,8 +227,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual(403, response.status_code)
 
     def test_fail_add_user_already_has_permission(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         # Same permission : read
         response = self.client.post(
@@ -274,8 +261,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual("R", permissions[0].mode)
 
     def test_success_add_user_read_permission(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.post(
             reverse("gallery-members", kwargs={"pk": self.gallery1.pk}),
@@ -292,8 +278,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual("R", permissions[0].mode)
 
     def test_success_add_user_write_permission(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.post(
             reverse("gallery-members", kwargs={"pk": self.gallery1.pk}),
@@ -310,8 +295,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual("W", permissions[0].mode)
 
     def test_success_modify_user_write_permission(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.post(
             reverse("gallery-members", kwargs={"pk": self.gallery1.pk}),
@@ -342,8 +326,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual("R", permissions[0].mode)
 
     def test_fail_user_modify_self(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.post(
             reverse("gallery-members", kwargs={"pk": self.gallery1.pk}),
@@ -360,8 +343,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual("W", permissions[0].mode)
 
     def test_success_user_leave_gallery(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         user_galleries = UserGallery.objects.filter(gallery=self.gallery1)
         self.assertEqual(user_galleries.count(), 2)
@@ -381,8 +363,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual(user_galleries.last().user, self.profile1.user)
 
     def test_error_last_user_with_write_leave_gallery(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         user_gallery = UserGallery.objects.filter(gallery=self.gallery1, user=self.profile1.user)
         self.assertEqual(user_gallery.count(), 1)
@@ -401,8 +382,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual(user_gallery.count(), 1)  # not gone
 
     def test_success_user_with_read_permission_leave_gallery(self):
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         user_galleries = UserGallery.objects.filter(gallery=self.gallery1)
         self.assertEqual(user_galleries.count(), 2)
@@ -422,8 +402,7 @@ class ModifyGalleryViewTest(TestCase):
         self.assertEqual(user_galleries.last().user, self.profile1.user)
 
     def test_fail_user_modify_user_has_permission(self):
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         user_galleries = UserGallery.objects.filter(gallery=self.gallery1)
         self.assertEqual(user_galleries.count(), 2)
@@ -467,8 +446,7 @@ class EditGalleryTestView(TestCase):
         self.user_gallery3 = UserGalleryFactory(user=self.profile3.user, gallery=self.gallery1, mode="R")
 
     def test_fail_member_no_permission_can_edit_gallery(self):
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         given_title = "Un nouveau titre"
         given_subtile = "Un nouveau sous-titre"
@@ -484,8 +462,7 @@ class EditGalleryTestView(TestCase):
         self.assertNotEqual(given_subtile, gallery.subtitle)
 
     def test_fail_member_read_permission_can_edit_gallery(self):
-        login_check = self.client.login(username=self.profile3.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile3.user)
 
         given_title = "Un nouveau titre"
         given_subtile = "Un nouveau sous-titre"
@@ -501,8 +478,7 @@ class EditGalleryTestView(TestCase):
         self.assertNotEqual(given_subtile, gallery.subtitle)
 
     def test_success_member_edit_gallery(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         given_title = "Un nouveau titre"
         given_subtile = "Un nouveau sous-titre"
@@ -532,8 +508,7 @@ class EditImageViewTest(TestCase):
         self.image.delete()
 
     def test_fail_member_no_permission_can_edit_image(self):
-        login_check = self.client.login(username=self.profile3.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile3.user)
 
         with (settings.BASE_DIR / "fixtures" / "logo.png").open("rb") as fp:
 
@@ -548,8 +523,7 @@ class EditImageViewTest(TestCase):
         image_test.delete()
 
     def test_success_member_edit_image(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         nb_files = len(os.listdir(self.gallery.get_gallery_path()))
 
@@ -570,8 +544,7 @@ class EditImageViewTest(TestCase):
         self.assertEqual(nb_files, len(os.listdir(self.gallery.get_gallery_path())))
 
     def test_access_permission(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.get(reverse("gallery-image-edit", args=[self.gallery.pk, self.image.pk]))
 
@@ -598,8 +571,7 @@ class ModifyImageTest(TestCase):
         self.image3.delete()
 
     def test_fail_modify_image_with_no_permission(self):
-        login_check = self.client.login(username=self.profile3.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile3.user)
 
         response = self.client.post(
             reverse("gallery-image-delete", kwargs={"pk_gallery": self.gallery1.pk}),
@@ -618,8 +590,7 @@ class ModifyImageTest(TestCase):
         UserGalleryFactory(user=profile4.user, gallery=gallery4)
         self.assertEqual(1, Image.objects.filter(pk=image4.pk).count())
 
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         self.client.post(
             reverse("gallery-image-delete", kwargs={"pk_gallery": self.gallery1.pk}),
@@ -631,8 +602,7 @@ class ModifyImageTest(TestCase):
         image4.delete()
 
     def test_success_delete_image_write_permission(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.post(
             reverse("gallery-image-delete", kwargs={"pk_gallery": self.gallery1.pk}),
@@ -644,8 +614,7 @@ class ModifyImageTest(TestCase):
         self.assertEqual(0, Image.objects.filter(pk=self.image1.pk).count())
 
     def test_success_delete_list_images_write_permission(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.post(
             reverse("gallery-image-delete", kwargs={"pk_gallery": self.gallery1.pk}),
@@ -658,8 +627,7 @@ class ModifyImageTest(TestCase):
         self.assertEqual(0, Image.objects.filter(pk=self.image2.pk).count())
 
     def test_fail_delete_image_read_permission(self):
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         response = self.client.post(
             reverse("gallery-image-delete", kwargs={"pk_gallery": self.gallery1.pk}),
@@ -681,8 +649,7 @@ class NewImageViewTest(TestCase):
         self.user_gallery2 = UserGalleryFactory(user=self.profile2.user, gallery=self.gallery, mode="R")
 
     def test_success_new_image_write_permission(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
         self.assertEqual(0, len(self.gallery.get_images()))
 
         with (settings.BASE_DIR / "fixtures" / "logo.png").open("rb") as fp:
@@ -698,8 +665,7 @@ class NewImageViewTest(TestCase):
         self.gallery.get_images()[0].delete()
 
     def test_fail_new_image_with_read_permission(self):
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
         self.assertEqual(0, len(self.gallery.get_images()))
 
         with (settings.BASE_DIR / "fixtures" / "logo.png").open("rb") as fp:
@@ -713,8 +679,7 @@ class NewImageViewTest(TestCase):
         self.assertEqual(0, len(self.gallery.get_images()))
 
     def test_fail_new_image_with_no_permission(self):
-        login_check = self.client.login(username=self.profile3.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile3.user)
         self.assertEqual(0, len(self.gallery.get_images()))
 
         with (settings.BASE_DIR / "fixtures" / "logo.png").open("rb") as fp:
@@ -728,8 +693,7 @@ class NewImageViewTest(TestCase):
         self.assertEqual(0, len(self.gallery.get_images()))
 
     def test_fail_gallery_not_exist(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         with (settings.BASE_DIR / "fixtures" / "logo.png").open("rb") as fp:
             response = self.client.post(
@@ -741,8 +705,7 @@ class NewImageViewTest(TestCase):
         self.assertEqual(404, response.status_code)
 
     def test_import_images_in_gallery(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         with (settings.BASE_DIR / "fixtures" / "archive-gallery.zip").open("rb") as fp:
             response = self.client.post(
@@ -760,8 +723,7 @@ class NewImageViewTest(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_import_images_in_gallery_no_archive(self):
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         with (settings.BASE_DIR / "fixtures" / "archive-gallery.zip").open("rb"):
             response = self.client.post(
@@ -777,8 +739,7 @@ class NewImageViewTest(TestCase):
         self.assertEqual(Image.objects.filter(gallery=self.gallery).count(), 0)
 
     def test_denies_import_images_in_gallery(self):
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         with (settings.BASE_DIR / "fixtures" / "archive-gallery.zip").open("rb") as fp:
             response = self.client.post(

--- a/zds/middlewares/tests/tests_setlastvisitmiddleware.py
+++ b/zds/middlewares/tests/tests_setlastvisitmiddleware.py
@@ -23,7 +23,7 @@ class SetLastVisitMiddlewareTest(TestCase):
         profile_pk = self.user.pk
 
         # login
-        self.assertEqual(self.client.login(username=self.user.user.username, password="hostel77"), True)
+        self.client.force_login(self.user.user)
 
         # set last login to a recent date
         self.user.last_visit = datetime.now() - timedelta(seconds=10)

--- a/zds/mp/tests/tests_utils.py
+++ b/zds/mp/tests/tests_utils.py
@@ -35,8 +35,7 @@ class MpUtilTest(TestCase):
         self.user5.profile.save()
 
         # Login as profile1
-        login_check = self.client.login(username=self.user1.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.user1)
 
         # Save bot group
         bot = Group(name=settings.ZDS_APP["member"]["bot_group"])
@@ -97,8 +96,7 @@ class MpUtilTest(TestCase):
 
         mail.outbox = []
         self.client.logout()
-        login_check = self.client.login(username=self.user2.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.user2)
 
         # Add an answer
         topic1 = PrivateTopic.objects.get()
@@ -123,5 +121,4 @@ class MpUtilTest(TestCase):
         PrivateTopic.objects.all().delete()
 
         self.client.logout()
-        login_check = self.client.login(username=self.user1.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.user1)

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -23,8 +23,7 @@ class IndexViewTest(TestCase):
 
     def test_success_delete_topic_no_participants(self):
         topic = PrivateTopicFactory(author=self.profile1.user)
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
         self.assertEqual(1, PrivateTopic.objects.filter(pk=topic.pk).count())
 
         response = self.client.post(reverse("mp-list-delete"), {"items": [topic.pk]})
@@ -34,8 +33,7 @@ class IndexViewTest(TestCase):
 
     def test_success_delete_topic_as_author(self):
 
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.post(reverse("mp-list-delete"), {"items": [self.topic1.pk]})
 
@@ -47,8 +45,7 @@ class IndexViewTest(TestCase):
 
     def test_success_delete_topic_as_participant(self):
 
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         response = self.client.post(reverse("mp-list-delete"), {"items": [self.topic1.pk]})
 
@@ -64,8 +61,7 @@ class IndexViewTest(TestCase):
 
         self.assertEqual(1, PrivateTopic.objects.filter(pk=topic.pk).count())
 
-        login_check = self.client.login(username=self.profile2.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile2.user)
 
         self.client.post(reverse("mp-list-delete"), {"items": [topic.pk]})
 
@@ -74,8 +70,7 @@ class IndexViewTest(TestCase):
     def test_topic_get_weird_page(self):
         """ get a page that can't exist (like page=abc)"""
 
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.get(reverse("mp-list") + "?page=abc")
         self.assertEqual(response.status_code, 404)
@@ -83,8 +78,7 @@ class IndexViewTest(TestCase):
     def test_topic_get_page_too_far(self):
         """ get a page that is too far yet"""
 
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         # create many subjects (at least two pages)
         for i in range(1, settings.ZDS_APP["forum"]["topics_per_page"] + 5):
@@ -109,8 +103,7 @@ class TopicViewTest(TestCase):
 
     def test_fail_topic_no_exist(self):
 
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.get(reverse("private-posts-list", args=[12, "private-topic"]))
         self.assertEqual(404, response.status_code)
@@ -118,8 +111,7 @@ class TopicViewTest(TestCase):
     def test_fail_topic_no_permission(self):
         """Check that a member not participating in a private topic is forbidden to view it."""
 
-        login_check = self.client.login(username=self.profile3.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile3.user)
 
         response = self.client.get(reverse("private-posts-list", args=[self.topic1.pk, self.topic1.slug]), follow=True)
 
@@ -128,8 +120,7 @@ class TopicViewTest(TestCase):
     def test_get_weird_page(self):
         """ get a page that can't exist (like page=abc)"""
 
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.get(
             reverse(
@@ -146,8 +137,7 @@ class TopicViewTest(TestCase):
     def test_get_page_too_far(self):
         """ get a page that can't exist (like page=42)"""
 
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         response = self.client.get(
             reverse(
@@ -164,7 +154,7 @@ class TopicViewTest(TestCase):
     def test_available_actions(self):
         """we should be able to cite, but not hide or alert"""
 
-        self.assertTrue(self.client.login(username=self.profile1.user.username, password="hostel77"))
+        self.client.force_login(self.profile1.user)
 
         response = self.client.get(
             reverse(
@@ -186,8 +176,7 @@ class TopicViewTest(TestCase):
     def test_more_than_one_message(self):
         """ test get second page """
 
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
         # create many subjects (at least two pages)
         post = None
@@ -219,8 +208,7 @@ class NewTopicViewTest(TestCase):
         self.hat, _ = Hat.objects.get_or_create(name__iexact="A hat", defaults={"name": "A hat"})
         self.profile1.hats.add(self.hat)
 
-        login_check = self.client.login(username=self.profile1.user.username, password="hostel77")
-        self.assertTrue(login_check)
+        self.client.force_login(self.profile1.user)
 
     def test_denies_anonymous(self):
 
@@ -393,7 +381,7 @@ class AnswerViewTest(TestCase):
 
         self.post2 = PrivatePostFactory(privatetopic=self.topic1, author=self.profile2.user, position_in_topic=2)
 
-        self.assertTrue(self.client.login(username=self.profile1.user.username, password="hostel77"))
+        self.client.force_login(self.profile1.user)
 
     def test_denies_anonymous(self):
 
@@ -486,7 +474,7 @@ class AnswerViewTest(TestCase):
     def test_fail_answer_with_no_right(self):
 
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.profile3.user.username, password="hostel77"))
+        self.client.force_login(self.profile3.user)
 
         response = self.client.post(
             reverse("private-posts-new", args=[self.topic1.pk, self.topic1.slug]),
@@ -537,7 +525,7 @@ class EditPostViewTest(TestCase):
 
         self.post2 = PrivatePostFactory(privatetopic=self.topic1, author=self.profile2.user, position_in_topic=2)
 
-        self.assertTrue(self.client.login(username=self.profile1.user.username, password="hostel77"))
+        self.client.force_login(self.profile1.user)
 
     def test_denies_anonymous(self):
 
@@ -550,7 +538,7 @@ class EditPostViewTest(TestCase):
 
     def test_succes_get_edit_post_page(self):
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.profile2.user.username, password="hostel77"))
+        self.client.force_login(self.profile2.user)
 
         response = self.client.get(
             reverse("private-posts-edit", args=[self.topic1.pk, self.topic1.slug, self.post2.pk])
@@ -581,7 +569,7 @@ class EditPostViewTest(TestCase):
     def test_success_edit_post(self):
 
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.profile2.user.username, password="hostel77"))
+        self.client.force_login(self.profile2.user)
 
         response = self.client.post(
             reverse("private-posts-edit", args=[self.topic1.pk, self.topic1.slug, self.post2.pk]),
@@ -638,7 +626,7 @@ class LeaveViewTest(TestCase):
 
         self.post2 = PrivatePostFactory(privatetopic=self.topic1, author=self.profile2.user, position_in_topic=2)
 
-        self.assertTrue(self.client.login(username=self.profile1.user.username, password="hostel77"))
+        self.client.force_login(self.profile1.user)
 
     def test_denies_anonymous(self):
 
@@ -677,7 +665,7 @@ class LeaveViewTest(TestCase):
     def test_success_leave_topic_as_participant(self):
 
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.profile2.user.username, password="hostel77"))
+        self.client.force_login(self.profile2.user)
 
         response = self.client.post(reverse("mp-delete", args=[self.topic1.pk, self.topic1.slug]), follow=True)
 
@@ -704,7 +692,7 @@ class AddParticipantViewTest(TestCase):
 
         self.post2 = PrivatePostFactory(privatetopic=self.topic1, author=self.profile2.user, position_in_topic=2)
 
-        self.assertTrue(self.client.login(username=self.profile1.user.username, password="hostel77"))
+        self.client.force_login(self.profile1.user)
 
     def test_denies_anonymous(self):
 
@@ -723,7 +711,7 @@ class AddParticipantViewTest(TestCase):
 
     def test_test_fail_add_bot_as_participant(self):
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.profile1.user.username, password="hostel77"))
+        self.client.force_login(self.profile1.user)
 
         self.client.post(
             reverse("mp-edit-participant", args=[self.topic1.pk, self.topic1.slug]),
@@ -747,7 +735,7 @@ class AddParticipantViewTest(TestCase):
         profile3 = ProfileFactory()
 
         self.client.logout()
-        self.assertTrue(self.client.login(username=profile3.user.username, password="hostel77"))
+        self.client.force_login(profile3.user)
 
         response = self.client.post(
             reverse("mp-edit-participant", args=[self.topic1.pk, self.topic1.slug]),
@@ -825,7 +813,7 @@ class PrivateTopicEditTest(TestCase):
         self.assertEqual("super subtitle", topic.subtitle)
 
     def test_success_edit_topic(self):
-        self.assertTrue(self.client.login(username=self.profile1.user.username, password="hostel77"))
+        self.client.force_login(self.profile1.user)
 
         response = self.client.post(
             reverse("mp-edit-topic", args=[self.topic1.pk, "private-topic"]),
@@ -845,7 +833,7 @@ class PrivateTopicEditTest(TestCase):
         self.topic1.subtitle = "super subtitle"
         self.topic1.save()
 
-        self.assertTrue(self.client.login(username=self.profile2.user.username, password="hostel77"))
+        self.client.force_login(self.profile2.user)
 
         response = self.client.get(reverse("mp-edit-topic", args=[self.topic1.pk, "private-topic"]), follow=True)
         self.assertEqual(403, response.status_code)
@@ -863,7 +851,7 @@ class PrivateTopicEditTest(TestCase):
         self.assertEqual("super subtitle", topic.subtitle)
 
     def test_fail_topic_doesnt_exist(self):
-        self.assertTrue(self.client.login(username=self.profile1.user.username, password="hostel77"))
+        self.client.force_login(self.profile1.user)
 
         response = self.client.get(reverse("mp-edit-topic", args=[91, "private-topic"]), follow=True)
         self.assertEqual(404, response.status_code)
@@ -879,7 +867,7 @@ class PrivateTopicEditTest(TestCase):
         self.topic1.subtitle = "super subtitle"
         self.topic1.save()
 
-        self.assertTrue(self.client.login(username=self.profile1.user.username, password="hostel77"))
+        self.client.force_login(self.profile1.user)
 
         response = self.client.post(
             reverse("mp-edit-topic", args=[self.topic1.pk, "private-topic"]),
@@ -918,7 +906,7 @@ class PrivatePostUnreadTest(TestCase):
 
     def test_failing_unread_post(self):
         """Test cases of invalid unread requests by an authenticated user."""
-        self.assertTrue(self.client.login(username=self.author.user.username, password="hostel77"))
+        self.client.force_login(self.author.user)
 
         # parameter is missing
         result = self.client.get(reverse("private-post-unread"), follow=False)
@@ -938,13 +926,13 @@ class PrivatePostUnreadTest(TestCase):
 
     def test_user_not_participating(self):
         """Test the case of a user not participating in a private topic attempting to unread a post. """
-        self.assertTrue(self.client.login(username=self.outsider.user.username, password="hostel77"))
+        self.client.force_login(self.outsider.user)
         result = self.client.get(reverse("private-post-unread") + "?message=" + str(self.post2.pk), follow=False)
         self.assertEqual(result.status_code, 403)
 
     @patch("zds.mp.signals.message_unread")
     def test_unread_first_post(self, message_unread):
-        self.assertTrue(self.client.login(username=self.participant.user.username, password="hostel77"))
+        self.client.force_login(self.participant.user)
         result = self.client.get(reverse("private-post-unread") + "?message=" + str(self.post1.pk), follow=True)
         self.assertRedirects(result, reverse("mp-list"))
         with self.assertRaises(PrivateTopicRead.DoesNotExist):
@@ -953,7 +941,7 @@ class PrivatePostUnreadTest(TestCase):
 
     @patch("zds.mp.signals.message_unread")
     def test_unread_normal_post(self, message_unread):
-        self.assertTrue(self.client.login(username=self.participant.user.username, password="hostel77"))
+        self.client.force_login(self.participant.user)
         self.client.get(reverse("private-post-unread") + "?message=" + str(self.post2.pk), follow=True)
         topic_read = PrivateTopicRead.objects.get(privatetopic=self.post2.privatetopic, user=self.participant.user)
         self.assertEqual(topic_read.privatetopic, self.topic1)
@@ -963,7 +951,7 @@ class PrivatePostUnreadTest(TestCase):
 
     @patch("zds.mp.signals.message_unread")
     def test_multiple_unread1(self, message_unread):
-        self.assertTrue(self.client.login(username=self.participant.user.username, password="hostel77"))
+        self.client.force_login(self.participant.user)
         self.client.get(reverse("private-post-unread") + "?message=" + str(self.post1.pk), follow=True)
         self.client.get(reverse("private-post-unread") + "?message=" + str(self.post2.pk), follow=True)
         topic_read = PrivateTopicRead.objects.get(privatetopic=self.post2.privatetopic, user=self.participant.user)
@@ -974,7 +962,7 @@ class PrivatePostUnreadTest(TestCase):
 
     @patch("zds.mp.signals.message_unread")
     def test_multiple_unread2(self, message_unread):
-        self.assertTrue(self.client.login(username=self.participant.user.username, password="hostel77"))
+        self.client.force_login(self.participant.user)
         self.client.get(reverse("private-post-unread") + "?message=" + str(self.post1.pk), follow=True)
         self.client.get(reverse("private-post-unread") + "?message=" + str(self.post1.pk), follow=True)
         with self.assertRaises(PrivateTopicRead.DoesNotExist):
@@ -984,7 +972,7 @@ class PrivatePostUnreadTest(TestCase):
     def test_no_interference(self):
         mark_read(self.topic1, self.author.user)
         topic_read_old = PrivateTopicRead.objects.filter(privatetopic=self.topic1, user=self.author.user)
-        self.assertTrue(self.client.login(username=self.participant.user.username, password="hostel77"))
+        self.client.force_login(self.participant.user)
         self.client.get(reverse("private-post-unread") + "?message=" + str(self.post2.pk), follow=True)
         topic_read_new = PrivateTopicRead.objects.filter(privatetopic=self.topic1, user=self.author.user)
         self.assertQuerysetEqual(topic_read_old, [repr(t) for t in topic_read_new])

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -46,7 +46,7 @@ class NotificationForumTest(TestCase):
         self.tag1 = TagFactory(title="Linux")
         self.tag2 = TagFactory(title="Windows")
 
-        self.assertTrue(self.client.login(username=self.user1.username, password="hostel77"))
+        self.client.force_login(self.user1)
 
     def test_creation_topic(self):
         """
@@ -164,7 +164,7 @@ class NotificationForumTest(TestCase):
         self.assertEqual(notification.is_read, False)
 
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"), True)
+        self.client.force_login(self.user2)
 
         result = self.client.get(reverse("topic-posts-list", args=[topic1.pk, old_slugify(topic1.title)]), follow=True)
         self.assertEqual(result.status_code, 200)
@@ -189,7 +189,7 @@ class NotificationForumTest(TestCase):
         forum_not_read = ForumFactory(category=self.category1, position_in_category=2)
         forum_not_read.groups.add(Group.objects.create(name="DummyGroup_1"))
 
-        self.assertTrue(self.client.login(username=StaffProfileFactory().user.username, password="hostel77"))
+        self.client.force_login(StaffProfileFactory().user)
         data = {"move": "", "forum": forum_not_read.pk, "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
 
@@ -230,7 +230,7 @@ class NotificationForumTest(TestCase):
 
         # hide last post
         data = {"delete_message": ""}
-        self.assertTrue(self.client.login(username=StaffProfileFactory().user.username, password="hostel77"))
+        self.client.force_login(StaffProfileFactory().user)
         response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
         self.assertEqual(302, response.status_code)
 
@@ -335,7 +335,7 @@ class NotificationForumTest(TestCase):
         # Move the topic to another forum.
         self.client.logout()
         staff = StaffProfileFactory()
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         data = {"move": "", "forum": self.forum12.pk, "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
         self.assertEqual(302, response.status_code)
@@ -345,7 +345,7 @@ class NotificationForumTest(TestCase):
         self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=False).all()))
 
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.user1.username, password="hostel77"))
+        self.client.force_login(self.user1)
         response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertEqual(200, response.status_code)
 
@@ -354,7 +354,7 @@ class NotificationForumTest(TestCase):
     def test_ping_on_tuto(self):
         """Error from #4904"""
         content = PublishedContentFactory(author_list=[self.user1])
-        self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"))
+        self.client.force_login(self.user2)
         result = self.client.post(
             reverse("content:add-reaction") + f"?pk={content.pk}",
             {
@@ -377,7 +377,7 @@ class NotificationForumTest(TestCase):
         # Move the topic to another forum.
         self.client.logout()
         staff = StaffProfileFactory()
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         data = {"move": "", "forum": self.forum12.pk, "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
         self.assertEqual(302, response.status_code)
@@ -387,7 +387,7 @@ class NotificationForumTest(TestCase):
         self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=False, is_dead=False).all()))
 
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.user1.username, password="hostel77"))
+        self.client.force_login(self.user1)
         response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertEqual(200, response.status_code)
 
@@ -506,7 +506,7 @@ class NotificationPublishableContentTest(TestCase):
         self.tuto.public_version = self.published
         self.tuto.save()
 
-        self.assertTrue(self.client.login(username=self.user1.username, password="hostel77"))
+        self.client.force_login(self.user1)
 
     def test_follow_content_at_publication(self):
         """
@@ -582,7 +582,7 @@ class NotificationPublishableContentTest(TestCase):
         self.assertEqual(result.status_code, 403)
 
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"), True)
+        self.client.force_login(self.user2)
 
         result = self.client.post(
             reverse("content:follow", args=[self.user1.pk]),
@@ -659,7 +659,7 @@ class NotificationPrivateTopicTest(TestCase):
         self.user2.profile.save()
         self.user3.profile.save()
 
-        self.assertTrue(self.client.login(username=self.user1.username, password="hostel77"))
+        self.client.force_login(self.user1)
 
     def test_creation_private_topic(self):
         """
@@ -840,7 +840,7 @@ class NotificationTest(TestCase):
         self.user1 = ProfileFactory().user
         self.user2 = ProfileFactory().user
 
-        self.assertTrue(self.client.login(username=self.user1.username, password="hostel77"))
+        self.client.force_login(self.user1)
 
     def test_reuse_old_notification(self):
         """
@@ -913,7 +913,7 @@ class NotificationTest(TestCase):
         PostFactory(topic=topic, author=self.user1, position=1)
         PostFactory(topic=topic, author=self.user2, position=2)
 
-        self.assertTrue(self.client.login(username=self.user1.username, password="hostel77"))
+        self.client.force_login(self.user1)
 
         notifications = Notification.objects.get_unread_notifications_of(self.user1)
         self.assertEqual(1, len(notifications))

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -49,7 +49,7 @@ class ForumNotification(TestCase):
 
     def test_ping_unknown(self):
         overridden_zds_app["comment"]["enable_pings"] = True
-        self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"))
+        self.client.force_login(self.user2)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",
             {
@@ -67,7 +67,7 @@ class ForumNotification(TestCase):
 
     def test_no_auto_ping(self):
         overridden_zds_app["comment"]["enable_pings"] = True
-        self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"))
+        self.client.force_login(self.user2)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",
             {
@@ -87,7 +87,7 @@ class ForumNotification(TestCase):
         overridden_zds_app["comment"]["max_pings"] = 2
         overridden_zds_app["comment"]["enable_pings"] = True
         pinged_users = [ProfileFactory(), ProfileFactory(), ProfileFactory(), ProfileFactory()]
-        self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"))
+        self.client.force_login(self.user2)
         self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",
             {
@@ -124,7 +124,7 @@ class ForumNotification(TestCase):
         to be more accurate : on edition, only ping **new** members
         """
         overridden_zds_app["comment"]["enable_pings"] = True
-        self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"))
+        self.client.force_login(self.user2)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",
             {
@@ -176,7 +176,7 @@ class ForumNotification(TestCase):
         to be more accurate : on edition, only ping **new** members
         """
         overridden_zds_app["comment"]["enable_pings"] = True
-        self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"))
+        self.client.force_login(self.user2)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",
             {
@@ -211,7 +211,7 @@ class ForumNotification(TestCase):
 
     def test_no_dead_notif_on_moving(self):
         NewTopicSubscription.objects.get_or_create_active(self.user1, self.forum11)
-        self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"))
+        self.client.force_login(self.user2)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",
             {
@@ -230,7 +230,7 @@ class ForumNotification(TestCase):
         self.assertIsNotNone(subscription.last_notification, "There must be a notification for now")
         self.assertFalse(subscription.last_notification.is_read)
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
         data = {"move": "", "forum": self.forum12.pk, "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
         self.assertEqual(302, response.status_code)
@@ -243,7 +243,7 @@ class ForumNotification(TestCase):
         self.assertTrue(subscription.last_notification.is_read, "As forum is not reachable, notification is read")
 
     def test_no_ping_on_private_forum(self):
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum12.pk}",
             {
@@ -261,7 +261,7 @@ class ForumNotification(TestCase):
         self.assertIsNone(subscription, "There must be no active subscription for now")
 
     def test_no_dead_ping_notif_on_moving_to_private_forum(self):
-        self.assertTrue(self.client.login(username=self.user2.username, password="hostel77"))
+        self.client.force_login(self.user2)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",
             {
@@ -280,7 +280,7 @@ class ForumNotification(TestCase):
         self.assertIsNotNone(subscription.last_notification, "There must be a notification for now")
         self.assertFalse(subscription.last_notification.is_read)
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
         data = {"move": "", "forum": self.forum12.pk, "topic": topic.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)
         self.assertEqual(302, response.status_code)
@@ -294,7 +294,7 @@ class ForumNotification(TestCase):
 
     def test_no_more_notif_on_losing_all_groups(self):
         NewTopicSubscription.objects.get_or_create_active(self.to_be_changed_staff, self.forum12)
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
         self.client.post(
             reverse("topic-new") + f"?forum={self.forum12.pk}",
             {
@@ -315,7 +315,7 @@ class ForumNotification(TestCase):
 
     def test_no_more_notif_on_losing_one_group(self):
         NewTopicSubscription.objects.get_or_create_active(self.to_be_changed_staff, self.forum12)
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
         self.client.post(
             reverse("topic-new") + f"?forum={self.forum12.pk}",
             {
@@ -361,7 +361,7 @@ class ContentNotification(TestCase, TutorialTestMixin):
         self.tuto.public_version = self.published
         self.tuto.save()
 
-        self.assertTrue(self.client.login(username=self.user1.username, password="hostel77"))
+        self.client.force_login(self.user1)
 
     def test_no_persistant_notif_on_revoke(self):
         from zds.tutorialv2.publication_utils import unpublish_content

--- a/zds/pages/tests.py
+++ b/zds/pages/tests.py
@@ -14,8 +14,7 @@ from zds.utils.templatetags.emarkdown import render_markdown
 class PagesMemberTests(TestCase):
     def setUp(self):
         self.user1 = ProfileFactory().user
-        log = self.client.login(username=self.user1.username, password="hostel77")
-        self.assertEqual(log, True)
+        self.client.force_login(self.user1)
 
     def test_url_home(self):
         """Test: check that home page is alive."""
@@ -75,8 +74,7 @@ class PagesMemberTests(TestCase):
 class PagesStaffTests(TestCase):
     def setUp(self):
         self.staff = StaffProfileFactory().user
-        log = self.client.login(username=self.staff.username, password="hostel77")
-        self.assertEqual(log, True)
+        self.client.force_login(self.staff)
 
     def test_url_home(self):
         """Test: check that home page is alive."""
@@ -206,14 +204,14 @@ class CommentEditsHistoryTests(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, self.user.profile)
 
-        self.assertTrue(self.client.login(username=self.user.username, password="hostel77"))
+        self.client.force_login(self.user)
         data = {"text": "A new post!"}
         self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
         self.post = topic.last_message
         self.edit = CommentEdit.objects.latest("date")
 
     def test_history_with_wrong_pk(self):
-        self.assertTrue(self.client.login(username=self.user.username, password="hostel77"))
+        self.client.force_login(self.user)
         response = self.client.get(reverse("comment-edits-history", args=[self.post.pk + 1]))
         self.assertEqual(response.status_code, 404)
         response = self.client.get(reverse("edit-detail", args=[self.edit.pk + 1]))
@@ -229,21 +227,21 @@ class CommentEditsHistoryTests(TestCase):
 
         # Login with another user and check that the history can't be displayed
         other_user = ProfileFactory().user
-        self.assertTrue(self.client.login(username=other_user.username, password="hostel77"))
+        self.client.force_login(other_user)
         response = self.client.get(reverse("comment-edits-history", args=[self.post.pk]))
         self.assertEqual(response.status_code, 403)
         response = self.client.get(reverse("edit-detail", args=[self.edit.pk]))
         self.assertEqual(response.status_code, 403)
 
         # Login as staff and check that the history can be displayed
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
         response = self.client.get(reverse("comment-edits-history", args=[self.post.pk]))
         self.assertEqual(response.status_code, 200)
         response = self.client.get(reverse("edit-detail", args=[self.edit.pk]))
         self.assertEqual(response.status_code, 200)
 
         # And finally, check that the post author can see the history
-        self.assertTrue(self.client.login(username=self.user.username, password="hostel77"))
+        self.client.force_login(self.user)
         response = self.client.get(reverse("comment-edits-history", args=[self.post.pk]))
         self.assertEqual(response.status_code, 200)
         response = self.client.get(reverse("edit-detail", args=[self.edit.pk]))
@@ -251,7 +249,7 @@ class CommentEditsHistoryTests(TestCase):
 
     def test_history_content(self):
         # Login as staff
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
 
         # Check that there is a row on the history
         response = self.client.get(reverse("comment-edits-history", args=[self.post.pk]))
@@ -263,13 +261,13 @@ class CommentEditsHistoryTests(TestCase):
 
         # And not when we're logged as author
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.user.username, password="hostel77"))
+        self.client.force_login(self.user)
         response = self.client.get(reverse("comment-edits-history", args=[self.post.pk]))
         self.assertNotContains(response, _("Supprimer"))
 
     def test_edit_detail(self):
         # Login as staff
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
 
         # Check that the original content is displayed
         response = self.client.get(reverse("edit-detail", args=[self.edit.pk]))
@@ -281,20 +279,20 @@ class CommentEditsHistoryTests(TestCase):
 
         # Test that this option is only available for author and staff
         other_user = ProfileFactory().user
-        self.assertTrue(self.client.login(username=other_user.username, password="hostel77"))
+        self.client.force_login(other_user)
         response = self.client.post(reverse("restore-edit", args=[self.edit.pk]))
         self.assertEqual(response.status_code, 403)
-        self.assertTrue(self.client.login(username=self.user.username, password="hostel77"))
+        self.client.force_login(self.user)
         response = self.client.post(reverse("restore-edit", args=[self.edit.pk]))
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
         response = self.client.post(reverse("restore-edit", args=[self.edit.pk]))
         self.assertEqual(response.status_code, 302)
 
         # Test that a sanctionned user can't do this
         self.user.profile.can_write = False
         self.user.profile.save()
-        self.assertTrue(self.client.login(username=self.user.username, password="hostel77"))
+        self.client.force_login(self.user)
         response = self.client.post(reverse("restore-edit", args=[self.edit.pk]))
         self.assertEqual(response.status_code, 403)
 
@@ -307,10 +305,10 @@ class CommentEditsHistoryTests(TestCase):
 
     def test_delete_original_content(self):
         # This option should only be available for staff
-        self.assertTrue(self.client.login(username=self.user.username, password="hostel77"))
+        self.client.force_login(self.user)
         response = self.client.post(reverse("delete-edit-content", args=[self.edit.pk]))
         self.assertEqual(response.status_code, 403)
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
         response = self.client.post(reverse("delete-edit-content", args=[self.edit.pk]))
         self.assertEqual(response.status_code, 302)
 

--- a/zds/searchv2/tests/tests_views.py
+++ b/zds/searchv2/tests/tests_views.py
@@ -247,7 +247,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.assertEqual(response.hits.total, 0)
 
         # 3. Connect with user (not a member of the group), search, and get no result
-        self.assertTrue(self.client.login(username=self.user.username, password="hostel77"))
+        self.client.force_login(self.user)
 
         result = self.client.get(reverse("search:query") + "?q=" + text, follow=False)
 
@@ -257,7 +257,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
 
         # 4. Connect with staff, search, and get the topic and the post
         self.client.logout()
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
 
         result = self.client.get(reverse("search:query") + "?q=" + text, follow=False)
 
@@ -618,7 +618,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.assertEqual(response[0].topic_title, topic_1.title)  # title was changed
 
         # 4. connect with staff and move topic
-        self.assertTrue(self.client.login(username=self.staff.username, password="hostel77"))
+        self.client.force_login(self.staff)
 
         data = {"move": "", "forum": hidden_forum.pk, "topic": topic_1.pk}
         response = self.client.post(reverse("topic-edit"), data, follow=False)

--- a/zds/tutorialv2/api/tests.py
+++ b/zds/tutorialv2/api/tests.py
@@ -52,7 +52,7 @@ class ContentReactionKarmaAPITest(TutorialTestMixin, APITestCase):
         profile.can_write = False
         profile.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:content:reaction-karma", args=(reaction.pk,)))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -65,7 +65,7 @@ class ContentReactionKarmaAPITest(TutorialTestMixin, APITestCase):
         reaction = ContentReactionFactory(author=author.user, position=1, related_content=self.content)
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:content:reaction-karma", args=(reaction.pk,)), {"vote": "like"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(CommentVote.objects.filter(user=profile.user, comment=reaction, positive=True).exists())
@@ -76,7 +76,7 @@ class ContentReactionKarmaAPITest(TutorialTestMixin, APITestCase):
 
         profile = ProfileFactory()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:content:reaction-karma", args=(reaction.pk,)), {"vote": "dislike"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(CommentVote.objects.filter(user=profile.user, comment=reaction, positive=False).exists())
@@ -91,7 +91,7 @@ class ContentReactionKarmaAPITest(TutorialTestMixin, APITestCase):
         vote.save()
 
         self.assertTrue(CommentVote.objects.filter(pk=vote.pk).exists())
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:content:reaction-karma", args=(reaction.pk,)), {"vote": "neutral"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(CommentVote.objects.filter(pk=vote.pk).exists())
@@ -105,7 +105,7 @@ class ContentReactionKarmaAPITest(TutorialTestMixin, APITestCase):
         vote = CommentVote(user=profile.user, comment=reaction, positive=False)
         vote.save()
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.put(reverse("api:content:reaction-karma", args=(reaction.pk,)), {"vote": "like"})
         vote.refresh_from_db()
 
@@ -138,7 +138,7 @@ class ContentReactionKarmaAPITest(TutorialTestMixin, APITestCase):
         CommentVote.objects.create(user=profile.user, comment=equal_reaction, positive=True)
         CommentVote.objects.create(user=profile2.user, comment=equal_reaction, positive=False)
 
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
 
         # on first message we should see 2 likes and 0 anonymous
         response = self.client.get(reverse("api:content:reaction-karma", args=[upvoted_reaction.pk]))
@@ -221,13 +221,13 @@ class ContentExportsAPITest(TutorialTestMixin, APITestCase):
         self.assertEqual(0, PublicationEvent.objects.filter(published_object=content).count())
 
         # An authenticated author but not an author should not either
-        self.assertTrue(self.client.login(username=not_author.user.username, password="hostel77"))
+        self.client.force_login(not_author.user)
         response = self.client.post(reverse("api:content:generate_export", args=[content.content.pk]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(0, PublicationEvent.objects.filter(published_object=content).count())
 
         # But if the user is staff, it should
-        self.assertTrue(self.client.login(username=staff.user.username, password="hostel77"))
+        self.client.force_login(staff.user)
         response = self.client.post(reverse("api:content:generate_export", args=[content.content.pk]))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -235,7 +235,7 @@ class ContentExportsAPITest(TutorialTestMixin, APITestCase):
         self.assertGreater(requests_count, 0)
 
         # And if the user is an author, it should too
-        self.assertTrue(self.client.login(username=author.user.username, password="hostel77"))
+        self.client.force_login(author.user)
         response = self.client.post(reverse("api:content:generate_export", args=[content.content.pk]))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -262,7 +262,7 @@ class ContentExportsAPITest(TutorialTestMixin, APITestCase):
             self.assertEqual(response.data, [])
 
         # Let's request some
-        self.assertTrue(self.client.login(username=author.user.username, password="hostel77"))
+        self.client.force_login(author.user)
         response = self.client.post(reverse("api:content:generate_export", args=[content.content.pk]))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -278,7 +278,7 @@ class ContentExportsAPITest(TutorialTestMixin, APITestCase):
         # Let's request some more. The API should only return the latest ones, so
         # even if there are some more records in the database, the count should stay
         # the same.
-        self.assertTrue(self.client.login(username=author.user.username, password="hostel77"))
+        self.client.force_login(author.user)
         response = self.client.post(reverse("api:content:generate_export", args=[content.content.pk]))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.client.logout()

--- a/zds/tutorialv2/tests/tests_lists.py
+++ b/zds/tutorialv2/tests/tests_lists.py
@@ -126,7 +126,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tutorial_unpublished = PublishableContentFactory(author_list=[self.user_author])
         article = PublishedContentFactory(author_list=[self.user_author], type="ARTICLE")
         article_unpublished = PublishableContentFactory(author_list=[self.user_author], type="ARTICLE")
-        self.client.login(username=self.user_author.username, password="hostel77")
+        self.client.force_login(self.user_author)
         resp = self.client.get(reverse("tutorial:find-tutorial", args=[self.user_author.username]))
         self.assertContains(resp, tutorial.title)
         self.assertContains(resp, tutorial_unpublished.title)
@@ -173,7 +173,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)  # get 302 → redirection to login
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.get(reverse("validation:list"), follow=False)
         self.assertEqual(result.status_code, 403)  # get 403 not allowed
@@ -181,7 +181,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.client.logout()
 
         # connect with staff:
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         response = self.client.get(reverse("validation:list"), follow=False)
         self.assertEqual(response.status_code, 200)  # OK

--- a/zds/tutorialv2/tests/tests_models.py
+++ b/zds/tutorialv2/tests/tests_models.py
@@ -449,7 +449,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         old_description = article.public_version.description()
         article.licence = LicenceFactory()
         article.save()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         self.client.post(
             reverse("content:edit", args=[article.pk, article.slug]),
             {

--- a/zds/tutorialv2/tests/tests_move.py
+++ b/zds/tutorialv2/tests/tests_move.py
@@ -59,7 +59,7 @@ class ContentMoveTests(TutorialTestMixin, TestCase):
 
     def test_move_up_extract(self):
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
         self.extract2 = ExtractFactory(container=self.chapter1, db_object=self.tuto)
         old_sha = tuto.sha_draft
@@ -105,7 +105,7 @@ class ContentMoveTests(TutorialTestMixin, TestCase):
         # test moving without permission
 
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.post(
             reverse("content:move-element"),
             {
@@ -122,7 +122,7 @@ class ContentMoveTests(TutorialTestMixin, TestCase):
     def test_move_extract_before(self):
         # test 1 : move extract after a sibling
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
         self.extract2 = ExtractFactory(container=self.chapter1, db_object=self.tuto)
         self.extract3 = ExtractFactory(container=self.chapter1, db_object=self.tuto)
@@ -243,7 +243,7 @@ class ContentMoveTests(TutorialTestMixin, TestCase):
 
     def test_move_container_before(self):
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
         self.chapter2 = ContainerFactory(parent=self.part1, db_object=self.tuto)
         self.chapter3 = ContainerFactory(parent=self.part1, db_object=self.tuto)
@@ -329,7 +329,7 @@ class ContentMoveTests(TutorialTestMixin, TestCase):
         # test moving without permission
 
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.post(
             reverse("content:move-element"),
             {
@@ -346,7 +346,7 @@ class ContentMoveTests(TutorialTestMixin, TestCase):
     def test_move_extract_after(self):
         # test 1 : move extract after a sibling
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
         self.extract2 = ExtractFactory(container=self.chapter1, db_object=self.tuto)
         self.extract3 = ExtractFactory(container=self.chapter1, db_object=self.tuto)
@@ -443,7 +443,7 @@ class ContentMoveTests(TutorialTestMixin, TestCase):
 
     def test_move_container_after(self):
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
         self.chapter2 = ContainerFactory(parent=self.part1, db_object=self.tuto)
         self.chapter3 = ContainerFactory(parent=self.part1, db_object=self.tuto)
@@ -507,7 +507,7 @@ class ContentMoveTests(TutorialTestMixin, TestCase):
         :return:
         """
         LicenceFactory(code="CC BY")
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         draft_zip_path = join(dirname(__file__), "fake_lasynchrone-et-le-multithread-en-net.zip")
         result = self.client.post(
             reverse("content:import-new"),

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -45,7 +45,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=opinion_draft, db_object=opinion)
         ExtractFactory(container=opinion_draft, db_object=opinion)
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("validation:publish-opinion", kwargs={"pk": opinion.pk, "slug": opinion.slug}),
@@ -65,17 +65,17 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         subcategory = SubCategoryFactory()
         opinion.subcategory.add(subcategory)
         opinion.save()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         resp = self.client.get(reverse("opinion:view", kwargs={"pk": opinion.pk, "slug": opinion.slug}))
         self.assertContains(resp, "Version brouillon", msg_prefix="Author must access their draft directly")
         self.assertNotContains(resp, "{}?subcategory=".format(reverse("publication:list")))
         self.assertContains(resp, "{}?category=".format(reverse("opinion:list")))
 
     def test_no_help_for_tribune(self):
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
     def test_help_for_article(self):
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         resp = self.client.get(reverse("content:create-article"))
         self.assertEqual(200, resp.status_code)
 
@@ -97,7 +97,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=opinion_draft, db_object=opinion)
         ExtractFactory(container=opinion_draft, db_object=opinion)
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.post(
             reverse("validation:publish-opinion", kwargs={"pk": opinion.pk, "slug": opinion.slug}),
@@ -130,7 +130,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=opinion_draft, db_object=opinion)
         ExtractFactory(container=opinion_draft, db_object=opinion)
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.post(
             reverse("validation:publish-opinion", kwargs={"pk": opinion.pk, "slug": opinion.slug}),
@@ -162,7 +162,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
         # author
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # publish
         result = self.client.post(
@@ -193,7 +193,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
         # staff
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         # publish
         result = self.client.post(
@@ -224,7 +224,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
         # guest => 403
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # publish with author
         result = self.client.post(
@@ -240,7 +240,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertIsNotNone(opinion.public_version)
         self.assertEqual(opinion.public_version.sha_public, opinion_draft.current_version)
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         # unpublish
         result = self.client.post(
@@ -270,7 +270,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=opinion_draft, db_object=opinion)
         ExtractFactory(container=opinion_draft, db_object=opinion)
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # publish
         result = self.client.post(
@@ -301,7 +301,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertIsNone(opinion.sha_picked)
         self.assertIsNone(opinion.picked_date)
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         # valid with staff
         result = self.client.post(
@@ -316,7 +316,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertIsNotNone(opinion.picked_date)
 
         # invalid with author => 403
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("validation:unpick-opinion", kwargs={"pk": opinion.pk, "slug": opinion.slug}),
@@ -329,7 +329,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(opinion.sha_picked, opinion_draft.current_version)
 
         # invalid with staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.post(
             reverse("validation:unpick-opinion", kwargs={"pk": opinion.pk, "slug": opinion.slug}),
@@ -361,7 +361,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=opinion_draft, db_object=opinion)
         ExtractFactory(container=opinion_draft, db_object=opinion)
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # publish
         result = self.client.post(
@@ -382,7 +382,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 403)
 
         # now, login as staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         # check that the opinion is displayed
         result = self.client.get(reverse("validation:list-opinion"))
@@ -448,7 +448,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=opinion_draft, db_object=opinion)
         ExtractFactory(container=opinion_draft, db_object=opinion)
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # publish
         result = self.client.post(
@@ -459,7 +459,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login as staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         # unpublish opinion
         result = self.client.post(
@@ -500,7 +500,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=opinion_draft, db_object=opinion)
         ExtractFactory(container=opinion_draft, db_object=opinion)
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # publish
         result = self.client.post(
@@ -511,7 +511,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login as staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         alerter = ProfileFactory().user
         Alert.objects.create(
             author=alerter,
@@ -565,7 +565,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=opinion_draft, db_object=opinion)
         ExtractFactory(container=opinion_draft, db_object=opinion)
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # publish
         result = self.client.post(
@@ -576,7 +576,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login as staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         # PICK
         result = self.client.post(
@@ -665,7 +665,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=opinion_draft, db_object=opinion)
         ExtractFactory(container=opinion_draft, db_object=opinion)
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # publish
         result = self.client.post(
@@ -689,7 +689,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         )
         self.assertEqual(result.status_code, 403)
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         # valid with staff
         result = self.client.post(
@@ -715,7 +715,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=opinion_draft, db_object=opinion)
         ExtractFactory(container=opinion_draft, db_object=opinion)
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("validation:publish-opinion", kwargs={"pk": opinion.pk, "slug": opinion.slug}),
@@ -733,7 +733,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         # Alert content
         random_user = ProfileFactory().user
 
-        self.assertEqual(self.client.login(username=random_user.username, password="hostel77"), True)
+        self.client.force_login(random_user)
 
         result = self.client.post(
             reverse("content:alert-content", kwargs={"pk": opinion.pk}), {"signal_text": "Yeurk !"}, follow=False
@@ -755,7 +755,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         alert = Alert.objects.get(pk=alert.pk)
         self.assertFalse(alert.solved)
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.post(
             reverse("content:resolve-content", kwargs={"pk": opinion.pk}),

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -478,7 +478,7 @@ class UtilsTests(TutorialTestMixin, TestCase):
         """
 
         # 1. With user connected
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # go to whatever page, if not, `get_current_user()` does not work at all
         result = self.client.get(reverse("pages-index"))

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -111,7 +111,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         """General access test for author, user, guest and staff"""
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
@@ -175,7 +175,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with guest
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
@@ -206,7 +206,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 403)
 
         # login with staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
@@ -240,7 +240,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         """General test on the basic workflow of a tutorial: creation, edition, deletion for the author"""
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # create tutorial
         intro = "une intro"
@@ -636,13 +636,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         """Test beta workflow (access and update)"""
 
         # login with guest and test the non-access
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(reverse("content:view", args=[self.tuto.pk, self.tuto.slug]), follow=False)
         self.assertEqual(result.status_code, 403)  # (get 403 since he is not part of the authors)
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         sometag = Tag(title="randomizeit")
         sometag.save()
         self.tuto.tags.add(sometag)
@@ -685,7 +685,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)  # (get 302: no access to beta for public)
 
         # test access for guest;
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         # get 200 everywhere :)
         result = self.client.get(
@@ -721,7 +721,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # change beta version
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse(
@@ -772,7 +772,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # then test for guest
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(
             reverse("content:view", args=[tuto.pk, tuto.slug]) + "?version=" + old_sha_beta, follow=False
@@ -786,7 +786,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # inactive beta
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("content:inactive-beta", kwargs={"pk": tuto.pk, "slug": tuto.slug}),
@@ -800,7 +800,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # then test for guest
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(
             reverse("content:view", args=[tuto.pk, tuto.slug]) + "?version=" + current_sha_beta, follow=False
@@ -809,7 +809,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # reactive beta
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("content:set-beta", kwargs={"pk": tuto.pk, "slug": tuto.slug}),
@@ -829,7 +829,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # then test for guest
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(
             reverse("content:view", args=[tuto.pk, tuto.slug]) + "?version=" + tuto.sha_draft, follow=False
@@ -845,7 +845,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         """Check that editorial helps are visible on the beta"""
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # create and add help
         help = HelpWritingFactory()
@@ -881,7 +881,7 @@ class ContentTests(TutorialTestMixin, TestCase):
     def test_history_navigation(self):
         """ensure that, if the title (and so the slug) of the content change, its content remain accessible"""
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
         versioned = tuto.load_version()
@@ -1189,7 +1189,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         """ensure that everything is ok if `None` is set"""
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         given_title = "Un titre que personne ne lira"
         some_text = "Tralalala !!"
@@ -1271,7 +1271,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         """Test if content is exported well"""
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         given_title = "Oh, le beau titre à lire !"
         some_text = "À lire à un moment ou un autre, Über utile"  # accentuated characters are important for the test
@@ -1431,7 +1431,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         """Test if the importation of a tuto is working"""
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         given_title = "Une autre histoire captivante"
         some_text = "Il était une fois ... La suite."
@@ -1547,7 +1547,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         """Test if the importation of a content into another is working"""
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         given_title = "Parce que le texte change à chaque fois"
         some_text = "Sinon, c'pas drôle"
@@ -1652,7 +1652,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         """Tests an error case that happen when someone sends an archive that modify the content title
         with a string that cannont be properly slugified"""
         new_article = PublishableContentFactory(type="ARTICLE", title="extension", authors=[self.user_author])
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         archive_path = settings.BASE_DIR / "fixtures" / "tuto" / "BadArchive.zip"
         answer = self.client.post(
             reverse("content:import", args=[new_article.pk, new_article.slug]),
@@ -1678,7 +1678,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         text2 = f"![Piège](img3.png) ![Image qui existe pas]({prefix}:img3.png) ![](mauvais:img3.png)"
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # create an article
         article = PublishableContentFactory(type="ARTICLE", licence=self.licence)
@@ -1787,19 +1787,19 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # login as guest and test the non-access
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.get(reverse("content:history", args=[tuto.pk, tuto.slug]), follow=False)
         self.assertEqual(result.status_code, 403)
 
         # staff access
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.get(reverse("content:history", args=[tuto.pk, tuto.slug]), follow=False)
         self.assertEqual(result.status_code, 200)
 
         # login as author and test the access
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.get(reverse("content:history", args=[tuto.pk, tuto.slug]), follow=False)
         self.assertEqual(result.status_code, 200)
 
@@ -1818,7 +1818,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         invalid_sha = "a" * 40
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # check 404 if missing parameters
         result = self.client.get(
@@ -1880,7 +1880,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         self.assertEqual(Validation.objects.count(), 0)
@@ -1902,7 +1902,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # validate with staff
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.get(
             reverse("content:view", kwargs={"pk": tuto.pk, "slug": tuto.slug}) + "?version=" + validation.version,
@@ -1938,7 +1938,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.client.logout()
 
         # Re-ask a new validation
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         tuto = PublishableContent.objects.get(pk=tuto.pk)
         versioned = tuto.load_version()
@@ -1975,7 +1975,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.client.logout()
 
         # validate with staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.get(
             reverse("content:view", kwargs={"pk": tuto.pk, "slug": tuto.slug}) + "?version=" + validation.version,
@@ -2022,7 +2022,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         self.assertEqual(Validation.objects.count(), 0)
@@ -2074,7 +2074,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         )
         self.assertEqual(result.status_code, 302)  # no, public cannot access a tutorial in validation ...
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(
             reverse("content:view", kwargs={"pk": tuto.pk, "slug": tuto.slug}) + "?version=" + validation.version,
@@ -2084,7 +2084,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # then try with staff
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.get(
             reverse("content:view", kwargs={"pk": tuto.pk, "slug": tuto.slug}) + "?version=" + validation.version,
@@ -2148,7 +2148,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(PrivateTopic.objects.last().author, self.user_staff)  # admin has received a PM
 
         # ensure that author cannot publish himself
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("validation:accept", kwargs={"pk": validation.pk}),
@@ -2160,7 +2160,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(Validation.objects.filter(content=tuto).last().status, "PENDING_V")
 
         # reject it with staff !
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.post(
             reverse("validation:reject", kwargs={"pk": validation.pk}), {"text": ""}, follow=False
@@ -2255,7 +2255,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         # ... another test cover the file creation and so all, lets skip this part
 
         # ensure that author cannot revoke his own publication
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("validation:revoke", kwargs={"pk": tuto.pk, "slug": tuto.slug}),
@@ -2266,7 +2266,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(Validation.objects.filter(content=tuto).last().status, "ACCEPT")
 
         # revoke publication with staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.post(
             reverse("validation:revoke", kwargs={"pk": tuto.pk, "slug": tuto.slug}),
@@ -2310,7 +2310,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         nb_messages = PrivatePost.objects.filter(
             privatetopic__pk=validation.content.validation_private_message.pk
         ).count()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("validation:cancel", kwargs={"pk": validation.pk}), {"text": text_cancel}, follow=False
@@ -2334,7 +2334,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto.authors.add(self.user_staff)
         tuto.save()
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         self.assertEqual(Validation.objects.count(), 0)
 
         result = self.client.post(
@@ -2371,7 +2371,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         self.assertEqual(Validation.objects.count(), 0)
@@ -2388,7 +2388,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # login with staff and reserve
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.post(
             reverse("validation:reserve", kwargs={"pk": validation.pk}), {"version": validation.version}, follow=False
@@ -2401,7 +2401,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # login with author, delete tuto
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # does not work without a text
         result = self.client.post(reverse("content:delete", args=[tuto.pk, tuto.slug]), follow=False)
@@ -2427,8 +2427,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
     def test_js_fiddle_activation(self):
 
-        login_check = self.client.login(username=self.staff.username, password="hostel77")
-        self.assertEqual(login_check, True)
+        self.client.force_login(self.staff)
         result = self.client.post(
             reverse("content:activate-jsfiddle"), {"pk": self.tuto.pk, "js_support": "on"}, follow=True
         )
@@ -2446,13 +2445,13 @@ class ContentTests(TutorialTestMixin, TestCase):
         updated = PublishableContent.objects.get(pk=self.tuto.pk)
         self.assertFalse(updated.js_support)
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(reverse("content:activate-jsfiddle"), {"pk": self.tuto.pk, "js_support": True})
         self.assertEqual(result.status_code, 403)
 
     def test_validate_unexisting(self):
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("validation:ask", kwargs={"pk": self.tuto.pk, "slug": self.tuto.slug}),
             {"text": "blaaaaa", "version": "unexistingversion"},
@@ -2482,7 +2481,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # then active the beta on tutorial :
         # first, login with author :
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         sha_draft = PublishableContent.objects.get(pk=self.tuto.pk).sha_draft
         response = self.client.post(
@@ -2617,7 +2616,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(contents[1], tutoriel_2)
 
     def test_add_author(self):
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("content:add-author", args=[self.tuto.pk]), {"username": self.user_guest.username}, follow=False
         )
@@ -2634,7 +2633,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(PublishableContent.objects.get(pk=self.tuto.pk).authors.count(), 2)
 
     def test_remove_author(self):
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         tuto = PublishableContentFactory(author_list=[self.user_author, self.user_guest])
         result = self.client.post(
             reverse("content:remove-author", args=[tuto.pk]), {"username": self.user_guest.username}, follow=False
@@ -2682,7 +2681,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         # create a tuto, populate, and set beta
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         sha_draft = PublishableContent.objects.get(pk=tuto.pk).sha_draft
         response = self.client.post(
@@ -2713,7 +2712,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         # login with normal user
         self.client.logout()
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         # check if user can warn typo in tutorial
         result = self.client.post(
@@ -2756,7 +2755,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertIn(self.chapter1.get_absolute_url_beta(), sent_pm.last_message.text)  # beta url is in message
 
         # now, induce change and publish
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         ExtractFactory(container=self.chapter1, db_object=tuto)  # new extract
 
@@ -2774,7 +2773,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content=tuto).last()
 
@@ -2798,7 +2797,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto = PublishableContent.objects.get(pk=tuto.pk)
         versioned = tuto.load_version()
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         # check if user can warn typo in tutorial
         result = self.client.post(
@@ -2863,7 +2862,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         random = "Il est minuit 30 et j'écris un test ;)"
         random_with_md = "un text contenant du **markdown** ."
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # no hash, no edition
         result = self.client.post(
@@ -3019,7 +3018,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(extract.get_text(), random)
 
     def test_malformed_url(self):
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.get(self.chapter1.get_absolute_url()[:-2] + "/")
         self.assertEqual(result.status_code, 404)
@@ -3041,7 +3040,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             published.get_absolute_url_online().replace(str(published.content.pk), "he-s-dead-jim")
         )
         self.assertEqual(result.status_code, 404)
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.post(
             reverse("content:add-reaction") + f"?pk={publishable.pk}",
@@ -3092,7 +3091,7 @@ class ContentTests(TutorialTestMixin, TestCase):
     def test_import_old_version(self):
         self.overridden_zds_app["content"]["default_licence_pk"] = LicenceFactory().pk
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         base = settings.BASE_DIR / "fixtures" / "tuto"
         old_contents = [
             base / "article_v1",
@@ -3115,7 +3114,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             self.assertEqual(json["title"], PublishableContent.objects.last().title)
 
     def test_import_bad_archive(self):
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         base = settings.BASE_DIR / "fixtures" / "tuto"
         old_path = base / "article_v1"
 
@@ -3178,7 +3177,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto.save()
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         result = self.client.post(
@@ -3189,7 +3188,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content=tuto).last()
 
@@ -3237,7 +3236,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             f.write("I rebuilt it to finish the test. Perhaps a funny quote would be a good thing?")
 
         # same test with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         for extra in avail_extra:
             result = self.client.get(published.get_absolute_url_to_extra_content(extra))
@@ -3258,7 +3257,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # same test with guest:
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         # get 404 on markdown:
         result = self.client.get(published.get_absolute_url_to_extra_content("md"))
@@ -3276,7 +3275,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         result = self.client.post(
@@ -3287,7 +3286,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content=tuto).last()
 
@@ -3316,7 +3315,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=self.chapter1, db_object=tuto)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         result = self.client.post(
@@ -3327,7 +3326,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content=tuto).last()
 
@@ -3358,7 +3357,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # create extract while there is already a part:
         result = self.client.get(reverse("content:create-extract", args=[tuto.pk, tuto.slug]), follow=False)
@@ -3408,7 +3407,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(1, Gallery.objects.filter(pk=self.tuto.gallery.pk).count())
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # try to delete gallery
         result = self.client.post(reverse("galleries-delete"), {"delete": "", "gallery": gallery.pk}, follow=True)
@@ -3447,7 +3446,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         new_author = ProfileFactory().user
 
         # login with author and add user
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("content:add-author", args=[self.tuto.pk]), {"username": new_author.username}, follow=False
@@ -3465,7 +3464,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         )
 
         # login with this new author, try to delete tuto
-        self.assertEqual(self.client.login(username=new_author.username, password="hostel77"), True)
+        self.client.force_login(new_author)
 
         # deleting
         result = self.client.post(reverse("content:delete", args=[tuto.pk, tuto.slug]), follow=False)
@@ -3480,7 +3479,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # login with author
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # now, will work
         result = self.client.post(reverse("content:delete", args=[tuto.pk, tuto.slug]), follow=False)
@@ -3492,7 +3491,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         """Test that invalid title (empty or wrong slugs) are not allowed"""
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         dic = {
             "title": "",
@@ -3592,7 +3591,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # test access for guest user
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(reverse("tutorial:view", kwargs={"pk": self.tuto.pk, "slug": self.tuto.slug}))
         self.assertEqual(result.status_code, 200)
@@ -3617,7 +3616,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=article_draft, db_object=article)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         self.assertEqual(Validation.objects.count(), 0)
@@ -3630,7 +3629,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content=article).last()
 
@@ -3660,7 +3659,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # test access for guest user
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.get(reverse("article:view", kwargs={"pk": article.pk, "slug": article_draft.slug}))
         self.assertEqual(result.status_code, 200)
 
@@ -3678,7 +3677,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=chapter1, db_object=midsize_tuto)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         result = self.client.post(
@@ -3689,7 +3688,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content=midsize_tuto).last()
 
@@ -3739,7 +3738,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # test access for guest user
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.get(
             reverse("tutorial:view", kwargs={"pk": midsize_tuto.pk, "slug": midsize_tuto_draft.slug})
         )
@@ -3768,7 +3767,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=chapter1, db_object=bigtuto)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         result = self.client.post(
@@ -3779,7 +3778,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content=bigtuto).last()
 
@@ -3853,7 +3852,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # test access for guest user
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.get(reverse("tutorial:view", kwargs={"pk": bigtuto.pk, "slug": bigtuto_draft.slug}))
         self.assertEqual(result.status_code, 200)
 
@@ -3879,7 +3878,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # just for the fun of it, lets then revoke publication
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.post(
             reverse("validation:revoke", kwargs={"pk": bigtuto.pk, "slug": bigtuto.slug}),
@@ -3940,7 +3939,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 404)
 
         # test access for guest user
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(reverse("tutorial:view", kwargs={"pk": bigtuto.pk, "slug": bigtuto_draft.slug}))
         self.assertEqual(result.status_code, 404)
@@ -3970,7 +3969,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
         message_to_post = "la ZEP-12"
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.post(
             reverse("content:add-reaction") + f"?pk={self.published.content.pk}",
@@ -4000,7 +3999,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 404)
 
         # visit the tutorial trigger the creation of a ContentRead
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         self.assertEqual(
             self.client.get(reverse("tutorial:view", args=[self.tuto.pk, self.tuto.slug])).status_code, 200
@@ -4015,7 +4014,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertTrue(reads.first().note.get_absolute_url() not in interventions)
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # test preview (without JS)
         result = self.client.post(
@@ -4088,7 +4087,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             "Ever notice how you come across somebody once in a while you shouldn't have fucked with? That's me."
         )
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         self.client.post(
             reverse("content:add-reaction") + f"?pk={self.tuto.pk}",
@@ -4096,7 +4095,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         reaction = ContentReaction.objects.filter(related_content__pk=self.tuto.pk).first()
 
@@ -4111,7 +4110,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(reaction.editor, self.user_staff)
 
         # test that someone else is not abble to quote the text
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(
             reverse("content:add-reaction") + f"?pk={self.tuto.pk}&cite={reaction.pk}", follow=False
@@ -4119,7 +4118,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 403)  # unable to quote a reaction if hidden
 
         # then, unhide it !
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.post(reverse("content:show-reaction", args=[reaction.pk]), follow=False)
 
@@ -4130,7 +4129,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_alert_reaction(self):
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         self.client.post(
             reverse("content:add-reaction") + f"?pk={self.tuto.pk}",
@@ -4138,7 +4137,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
         reaction = ContentReaction.objects.filter(related_content__pk=self.tuto.pk).first()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("content:alert-reaction", args=[reaction.pk]),
             {"signal_text": "No. Try not. Do... or do not. There is no try."},
@@ -4155,7 +4154,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=False,
         )
         self.assertEqual(result.status_code, 403)
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.post(
             reverse("content:resolve-reaction"),
             {
@@ -4171,7 +4170,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         reaction = ContentReaction.objects.filter(related_content__pk=self.tuto.pk).first()
 
         # test that edition of a comment with an alert by an admin also solve the alert
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("content:alert-reaction", args=[reaction.pk]),
             {"signal_text": "No. Try not. Do... or do not. There is no try."},
@@ -4182,7 +4181,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             Alert.objects.filter(author__pk=self.user_author.pk, comment__pk=reaction.pk, solved=False).first()
         )
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.post(
             reverse("content:update-reaction") + f"?message={reaction.pk}&pk={self.tuto.pk}",
             {"text": "Much to learn, you still have."},
@@ -4195,7 +4194,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_warn_typo_without_accessible_author(self):
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.post(
             reverse("content:warn-typo") + f"?pk={self.tuto.pk}",
             {
@@ -4237,7 +4236,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
     def test_find_tutorial_or_article(self):
         """test the behavior of `article:find-article` and `tutorial:find-tutorial` urls"""
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         tuto_in_beta = PublishableContentFactory(type="TUTORIAL")
         tuto_in_beta.authors.add(self.user_author)
@@ -4392,7 +4391,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         contents = response.context["articles"]
         self.assertEqual(len(contents), 0)  # no published article
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         response = self.client.get(reverse("tutorial:find-tutorial", args=[self.user_author.username]), follow=False)
         self.assertEqual(200, response.status_code)
@@ -4432,7 +4431,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         visited before, therefore this test will visit the index after each login (because :p)"""
 
         # login with guest
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(reverse("pages-index"))  # go to whatever page
         self.assertEqual(result.status_code, 200)
@@ -4468,7 +4467,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.logout()
 
         # login with author (could be staff, we don't care in this test)
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.get(reverse("pages-index"))  # go to whatever page
         self.assertEqual(result.status_code, 200)
@@ -4521,7 +4520,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(tuto.first_unread_note(), reactions[0])  # first unread note = first note
 
         # re-login with guest
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(reverse("pages-index"))  # go to whatever page
         self.assertEqual(result.status_code, 200)
@@ -4554,7 +4553,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(0, len(mail.outbox))
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("content:follow-reactions", args=[self.tuto.pk]), {"email": "1"})
         self.assertEqual(302, response.status_code)
 
@@ -4566,7 +4565,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
         self.client.logout()
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # post another reaction
         self.client.post(
@@ -4578,7 +4577,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(1, len(mail.outbox))
 
     def test_note_with_bad_param(self):
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         url_template = reverse("content:update-reaction") + "?pk={}&message={}"
         result = self.client.get(url_template.format(self.tuto.pk, 454545665895123))
         self.assertEqual(404, result.status_code)
@@ -4598,7 +4597,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         new_reaction.update_content("I will find you.")
 
         new_reaction.save()
-        self.assertEqual(self.client.login(username=new_user.username, password="hostel77"), True)
+        self.client.force_login(new_user)
         resp = self.client.get(reverse("content:update-reaction") + f"?message={new_reaction.pk}&pk={article.pk}")
         self.assertEqual(403, resp.status_code)
         resp = self.client.post(
@@ -4622,7 +4621,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         reaction.update_content(text)
         reaction.save()
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # cite note
         result = self.client.get(reverse("content:add-reaction") + f"?pk={tuto.pk}&cite={reaction.pk}", follow=True)
@@ -4653,7 +4652,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_cant_view_private_even_if_draft_is_equal_to_public(self):
         content = PublishedContentFactory(author_list=[self.user_author])
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         resp = self.client.get(reverse("content:view", args=[content.pk, content.slug]))
         self.assertEqual(403, resp.status_code)
 
@@ -4667,7 +4666,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertFalse(old_published.must_redirect)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # change title
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
@@ -4707,7 +4706,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content__pk=tuto.pk).last()
 
@@ -4769,7 +4768,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
     def test_validation_list_has_good_title(self):
         # aka fix 3172
         tuto = PublishableContentFactory(author_list=[self.user_author], type="TUTORIAL")
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("validation:ask", args=[tuto.pk, tuto.slug]),
             {"text": "something good", "version": tuto.sha_draft},
@@ -4792,7 +4791,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=False,
         )
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.get(reverse("validation:list") + "?type=tuto")
         self.assertIn(old_title, str(result.content))
         self.assertNotIn(new_title, str(result.content))
@@ -4821,7 +4820,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             date_validation=datetime.datetime.now(),
         )
         registered_validation.save()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         self.client.post(
             reverse("content:edit", args=[article.pk, article.slug]),
             {
@@ -4861,12 +4860,12 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         )
         registered_validation.save()
         subscriber = ProfileFactory().user
-        self.client.login(username=subscriber.username, password="hostel77")
+        self.client.force_login(subscriber)
         resp = self.client.post(reverse("content:follow-reactions", args=[article.pk]), {"follow": True})
         self.assertEqual(302, resp.status_code)
         public_count = PublishedContent.objects.count()
         self.client.logout()
-        self.client.login(username=self.user_staff.username, password="hostel77")
+        self.client.force_login(self.user_staff)
         result = self.client.post(
             reverse("validation:revoke", kwargs={"pk": article.pk, "slug": article.public_version.content_public_slug}),
             {"text": "This content was bad", "version": article.public_version.sha_public},
@@ -4878,7 +4877,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_validation_history(self):
         published = PublishedContentFactory(author_list=[self.user_author])
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("content:edit", args=[published.pk, published.slug]),
             {
@@ -4902,13 +4901,13 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Validation.objects.count(), 1)
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.get(reverse("validation:list") + "?type=tuto")
         self.assertIn('class="update_content"', str(result.content))
 
     def test_validation_history_for_new_content(self):
         publishable = PublishableContentFactory(author_list=[self.user_author])
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("validation:ask", kwargs={"pk": publishable.pk, "slug": publishable.slug}),
@@ -4918,7 +4917,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Validation.objects.count(), 1)
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.get(reverse("validation:list") + "?type=tuto")
         self.assertNotIn('class="update_content"', str(result.content))
 
@@ -4934,7 +4933,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(Validation.objects.count(), 0)
 
         # login with user and ask validation
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("validation:ask", kwargs={"pk": content_draft.pk, "slug": content_draft.slug}),
             {"text": text_validation, "version": content_draft.current_version},
@@ -4944,7 +4943,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(Validation.objects.count(), 1)
 
         # login with staff and reserve the content
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         validation = Validation.objects.filter(content=content).last()
         result = self.client.post(
             reverse("validation:reserve", kwargs={"pk": validation.pk}), {"version": validation.version}, follow=False
@@ -4952,7 +4951,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with user, edit content and ask validation for update
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("content:edit", args=[content_draft.pk, content_draft.slug]),
             {
@@ -4992,7 +4991,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         article_draft = article.load_version()
 
         # login with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # set beta
         result = self.client.post(
@@ -5012,7 +5011,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         # reserve the article
         validation = Validation.objects.filter(content=article).last()
@@ -5041,7 +5040,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertIsNotNone(last_message)
 
         # login with author to ensure that the beta is not closed if it was already closed (at a second validation).
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         result = self.client.post(
@@ -5052,7 +5051,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         # reserve the article
         validation = Validation.objects.filter(content=article).last()
@@ -5075,11 +5074,11 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_obsolete(self):
         # check that this function is only available for staff
-        self.client.login(username=self.user_author.username, password="hostel77")
+        self.client.force_login(self.user_author)
         result = self.client.post(reverse("validation:mark-obsolete", kwargs={"pk": self.tuto.pk}), follow=False)
         self.assertEqual(result.status_code, 403)
         # login as staff
-        self.client.login(username=self.user_staff.username, password="hostel77")
+        self.client.force_login(self.user_staff)
         # check that when the content is not marked as obsolete, the alert is not shown
         result = self.client.get(self.tuto.get_absolute_url_online(), follow=False)
         self.assertEqual(result.status_code, 200)
@@ -5364,7 +5363,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         tutorial_draft = tutorial.load_version()
 
         # ask validation
-        self.client.login(username=self.user_staff.username, password="hostel77")
+        self.client.force_login(self.user_staff)
         self.client.post(
             reverse("validation:ask", kwargs={"pk": tutorial.pk, "slug": tutorial.slug}),
             {"text": text_validation, "version": tutorial_draft.current_version},
@@ -5389,7 +5388,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         tutorial_draft = tutorial.load_version()
 
         # ask validation
-        self.client.login(username=self.user_staff.username, password="hostel77")
+        self.client.force_login(self.user_staff)
         self.client.post(
             reverse("validation:ask", kwargs={"pk": tutorial.pk, "slug": tutorial.slug}),
             {"text": text_validation, "version": tutorial_draft.current_version},
@@ -5410,7 +5409,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(tutorial.public_version.authors.count(), 1)
 
     def test_add_help_tuto(self):
-        self.client.login(username=self.user_author.username, password="hostel77")
+        self.client.force_login(self.user_author)
         tutorial = PublishableContentFactory(author_list=[self.user_author])
         help_wanted = HelpWritingFactory()
         resp = self.client.post(
@@ -5420,7 +5419,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(1, PublishableContent.objects.filter(pk=tutorial.pk).first().helps.count())
 
     def test_add_help_opinion(self):
-        self.client.login(username=self.user_author.username, password="hostel77")
+        self.client.force_login(self.user_author)
         tutorial = PublishableContentFactory(author_list=[self.user_author], type="OPINION")
         help_wanted = HelpWritingFactory()
         resp = self.client.post(
@@ -5430,7 +5429,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(0, PublishableContent.objects.filter(pk=tutorial.pk).first().helps.count())
 
     def test_save_no_redirect(self):
-        self.client.login(username=self.user_author.username, password="hostel77")
+        self.client.force_login(self.user_author)
         tutorial = PublishableContentFactory(author_list=[self.user_author])
         extract = ExtractFactory(db_object=tutorial, container=tutorial.load_version())
         tutorial = PublishableContent.objects.get(pk=tutorial.pk)

--- a/zds/tutorialv2/tests/tests_views/tests_edgecases.py
+++ b/zds/tutorialv2/tests/tests_views/tests_edgecases.py
@@ -34,7 +34,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             type="ARTICLE", title="title", author_list=[self.author.user], licence=self.licence
         )
         # login with author
-        self.assertEqual(self.client.login(username=self.author.user.username, password="hostel77"), True)
+        self.client.force_login(self.author.user)
         result = self.client.post(
             reverse("content:edit", args=[opinion.pk, opinion.slug]),
             {

--- a/zds/tutorialv2/tests/tests_views/tests_editcontentlicense.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontentlicense.py
@@ -42,22 +42,19 @@ class EditContentLicensePermissionTests(TutorialTestMixin, TestCase):
 
     def test_authenticated_author(self):
         """Test that on form submission, authors are redirected to the content page."""
-        login_success = self.client.login(username=self.author.username, password="hostel77")
-        self.assertTrue(login_success)
+        self.client.force_login(self.author)
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_staff(self):
         """Test that on form submission, staffs are redirected to the content page."""
-        login_success = self.client.login(username=self.staff.username, password="hostel77")
-        self.assertTrue(login_success)
+        self.client.force_login(self.staff)
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_outsider(self):
         """Test that on form submission, unauthorized users get a 403."""
-        login_success = self.client.login(username=self.outsider.username, password="hostel77")
-        self.assertTrue(login_success)
+        self.client.force_login(self.outsider)
         response = self.client.post(self.form_url, self.form_data)
         self.assertEquals(response.status_code, 403)
 
@@ -83,8 +80,7 @@ class EditContentLicenseWorkflowTests(TutorialTestMixin, TestCase):
         self.success_message_profile_update = EditContentLicense.success_message_profile_update
 
         # Log in with an authorized user (e.g the author of the content) to perform the tests
-        login_success = self.client.login(username=self.author.user.username, password="hostel77")
-        self.assertTrue(login_success)
+        self.client.force_login(self.author.user)
 
     def get_test_cases(self):
         return {
@@ -135,8 +131,7 @@ class EditContentLicenseFunctionalTests(TutorialTestMixin, TestCase):
         self.form_url = reverse("content:edit-license", kwargs={"pk": self.content.pk})
 
         # Log in with an authorized user (e.g the author of the content) to perform the tests
-        login_success = self.client.login(username=self.author.user.username, password="hostel77")
-        self.assertTrue(login_success)
+        self.client.force_login(self.author.user)
 
     def test_form_function(self):
         """Test many use cases for the form."""

--- a/zds/tutorialv2/tests/tests_views/tests_editcontenttags.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcontenttags.py
@@ -41,22 +41,19 @@ class EditContentTagsPermissionTests(TutorialTestMixin, TestCase):
 
     def test_authenticated_author(self):
         """Test that on form submission, authors are redirected to the content page."""
-        login_success = self.client.login(username=self.author.username, password="hostel77")
-        self.assertTrue(login_success)
+        self.client.force_login(self.author)
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_staff(self):
         """Test that on form submission, staffs are redirected to the content page."""
-        login_success = self.client.login(username=self.staff.username, password="hostel77")
-        self.assertTrue(login_success)
+        self.client.force_login(self.staff)
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_outsider(self):
         """Test that on form submission, unauthorized users get a 403."""
-        login_success = self.client.login(username=self.outsider.username, password="hostel77")
-        self.assertTrue(login_success)
+        self.client.force_login(self.outsider)
         response = self.client.post(self.form_url, self.form_data)
         self.assertEquals(response.status_code, 403)
 
@@ -78,8 +75,7 @@ class EditContentTagsWorkflowTests(TutorialTestMixin, TestCase):
         self.success_message = EditContentTags.success_message
 
         # Log in with an authorized user (e.g the author of the content) to perform the tests
-        login_success = self.client.login(username=self.author.user.username, password="hostel77")
-        self.assertTrue(login_success)
+        self.client.force_login(self.author.user)
 
     def get_test_cases(self):
         special_char_for_slug = "?"
@@ -142,8 +138,7 @@ class EditContentTagsFunctionalTests(TutorialTestMixin, TestCase):
         self.form_url = reverse("content:edit-tags", kwargs={"pk": self.content.pk})
 
         # Log in with an authorized user (e.g the author of the content) to perform the tests
-        login_success = self.client.login(username=self.author.user.username, password="hostel77")
-        self.assertTrue(login_success)
+        self.client.force_login(self.author.user)
 
     def test_form_function(self):
         """Test many use cases for the form."""

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -107,7 +107,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # test access for guest user
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(reverse("tutorial:view", kwargs={"pk": self.tuto.pk, "slug": self.tuto.slug}))
         self.assertEqual(result.status_code, 200)
@@ -132,7 +132,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=article_draft, db_object=article)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         self.assertEqual(Validation.objects.count(), 0)
@@ -145,7 +145,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content=article).last()
 
@@ -175,7 +175,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # test access for guest user
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.get(reverse("article:view", kwargs={"pk": article.pk, "slug": article_draft.slug}))
         self.assertEqual(result.status_code, 200)
 
@@ -193,7 +193,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=chapter1, db_object=midsize_tuto)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         result = self.client.post(
@@ -204,7 +204,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content=midsize_tuto).last()
 
@@ -254,7 +254,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # test access for guest user
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.get(
             reverse("tutorial:view", kwargs={"pk": midsize_tuto.pk, "slug": midsize_tuto_draft.slug})
         )
@@ -283,7 +283,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         ExtractFactory(container=chapter1, db_object=bigtuto)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         result = self.client.post(
@@ -294,7 +294,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content=bigtuto).last()
 
@@ -366,7 +366,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # test access for guest user
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.get(reverse("tutorial:view", kwargs={"pk": bigtuto.pk, "slug": bigtuto_draft.slug}))
         self.assertEqual(result.status_code, 200)
 
@@ -392,7 +392,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
         # just for the fun of it, lets then revoke publication
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         result = self.client.post(
             reverse("validation:revoke", kwargs={"pk": bigtuto.pk, "slug": bigtuto.slug}),
@@ -453,7 +453,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 404)
 
         # test access for guest user
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(reverse("tutorial:view", kwargs={"pk": bigtuto.pk, "slug": bigtuto_draft.slug}))
         self.assertEqual(result.status_code, 404)
@@ -483,7 +483,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
         message_to_post = "la ZEP-12"
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.post(
             reverse("content:add-reaction") + f"?pk={self.published.content.pk}",
@@ -513,7 +513,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 404)
 
         # visit the tutorial trigger the creation of a ContentRead
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         self.assertEqual(
             self.client.get(reverse("tutorial:view", args=[self.tuto.pk, self.tuto.slug])).status_code, 200
@@ -528,7 +528,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertTrue(reads.first().note.get_absolute_url() not in interventions)
 
         # login with author
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # test preview (without JS)
         result = self.client.post(
@@ -601,7 +601,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             "Ever notice how you come across somebody once in a while you shouldn't have fucked with? That's me."
         )
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         self.client.post(
             reverse("content:add-reaction") + f"?pk={self.tuto.pk}",
@@ -609,7 +609,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         reaction = ContentReaction.objects.filter(related_content__pk=self.tuto.pk).first()
 
@@ -624,7 +624,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(reaction.editor, self.user_staff)
 
         # test that someone else is not abble to quote the text
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(
             reverse("content:add-reaction") + f"?pk={self.tuto.pk}&cite={reaction.pk}", follow=False
@@ -632,7 +632,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 403)  # unable to quote a reaction if hidden
 
         # then, unhide it !
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.post(reverse("content:show-reaction", args=[reaction.pk]), follow=False)
 
@@ -643,7 +643,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_alert_reaction(self):
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         self.client.post(
             reverse("content:add-reaction") + f"?pk={self.tuto.pk}",
@@ -651,7 +651,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
         reaction = ContentReaction.objects.filter(related_content__pk=self.tuto.pk).first()
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("content:alert-reaction", args=[reaction.pk]),
             {"signal_text": "No. Try not. Do... or do not. There is no try."},
@@ -668,7 +668,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=False,
         )
         self.assertEqual(result.status_code, 403)
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.post(
             reverse("content:resolve-reaction"),
             {
@@ -684,7 +684,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         reaction = ContentReaction.objects.filter(related_content__pk=self.tuto.pk).first()
 
         # test that edition of a comment with an alert by an admin also solve the alert
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("content:alert-reaction", args=[reaction.pk]),
             {"signal_text": "No. Try not. Do... or do not. There is no try."},
@@ -695,7 +695,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             Alert.objects.filter(author__pk=self.user_author.pk, comment__pk=reaction.pk, solved=False).first()
         )
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.post(
             reverse("content:update-reaction") + f"?message={reaction.pk}&pk={self.tuto.pk}",
             {"text": "Much to learn, you still have."},
@@ -708,7 +708,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_warn_typo_without_accessible_author(self):
 
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         result = self.client.post(
             reverse("content:warn-typo") + f"?pk={self.tuto.pk}",
             {
@@ -750,7 +750,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
     def test_find_tutorial_or_article(self):
         """test the behavior of `article:find-article` and `content-find-tutorial` urls"""
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         tuto_in_beta = PublishableContentFactory(type="TUTORIAL")
         tuto_in_beta.authors.add(self.user_author)
@@ -905,7 +905,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         contents = response.context["articles"]
         self.assertEqual(len(contents), 0)  # no published article
 
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         response = self.client.get(reverse("tutorial:find-tutorial", args=[self.user_author.username]), follow=False)
         self.assertEqual(200, response.status_code)
@@ -945,7 +945,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         visited before, therefore this test will visit the index after each login (because :p)"""
 
         # login with guest
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(reverse("pages-index"))  # go to whatever page
         self.assertEqual(result.status_code, 200)
@@ -981,7 +981,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.client.logout()
 
         # login with author (could be staff, we don't care in this test)
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.get(reverse("pages-index"))  # go to whatever page
         self.assertEqual(result.status_code, 200)
@@ -1034,7 +1034,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(tuto.first_unread_note(), reactions[0])  # first unread note = first note
 
         # re-login with guest
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
 
         result = self.client.get(reverse("pages-index"))  # go to whatever page
         self.assertEqual(result.status_code, 200)
@@ -1067,7 +1067,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(0, len(mail.outbox))
 
         profile = ProfileFactory()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
         response = self.client.post(reverse("content:follow-reactions", args=[self.tuto.pk]), {"email": "1"})
         self.assertEqual(302, response.status_code)
 
@@ -1079,7 +1079,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
         self.client.logout()
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # post another reaction
         self.client.post(
@@ -1091,7 +1091,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(1, len(mail.outbox))
 
     def test_note_with_bad_param(self):
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         url_template = reverse("content:update-reaction") + "?pk={}&message={}"
         result = self.client.get(url_template.format(self.tuto.pk, 454545665895123))
         self.assertEqual(404, result.status_code)
@@ -1111,7 +1111,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         new_reaction.update_content("I will find you.")
 
         new_reaction.save()
-        self.assertEqual(self.client.login(username=new_user.username, password="hostel77"), True)
+        self.client.force_login(new_user)
         resp = self.client.get(reverse("content:update-reaction") + f"?message={new_reaction.pk}&pk={article.pk}")
         self.assertEqual(403, resp.status_code)
         resp = self.client.post(
@@ -1135,7 +1135,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         reaction.update_content(text)
         reaction.save()
 
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # cite note
         result = self.client.get(reverse("content:add-reaction") + f"?pk={tuto.pk}&cite={reaction.pk}", follow=True)
@@ -1166,7 +1166,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_cant_view_private_even_if_draft_is_equal_to_public(self):
         content = PublishedContentFactory(author_list=[self.user_author])
-        self.assertEqual(self.client.login(username=self.user_guest.username, password="hostel77"), True)
+        self.client.force_login(self.user_guest)
         resp = self.client.get(reverse("content:view", args=[content.pk, content.slug]))
         self.assertEqual(403, resp.status_code)
 
@@ -1180,7 +1180,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertFalse(old_published.must_redirect)
 
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # change title
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
@@ -1220,7 +1220,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff and publish
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         validation = Validation.objects.filter(content__pk=tuto.pk).last()
 
@@ -1286,7 +1286,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
     def test_validation_list_has_good_title(self):
         # aka fix 3172
         tuto = PublishableContentFactory(author_list=[self.user_author], type="TUTORIAL")
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("validation:ask", args=[tuto.pk, tuto.slug]),
             {"text": "something good", "source": "", "version": tuto.sha_draft},
@@ -1309,7 +1309,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             follow=False,
         )
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.get(reverse("validation:list") + "?type=tuto")
         self.assertIn(old_title, str(result.content))
         self.assertNotIn(new_title, str(result.content))
@@ -1338,7 +1338,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             date_validation=datetime.datetime.now(),
         )
         registered_validation.save()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         self.client.post(
             reverse("content:edit", args=[article.pk, article.slug]),
             {
@@ -1378,12 +1378,12 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         )
         registered_validation.save()
         subscriber = ProfileFactory().user
-        self.client.login(username=subscriber.username, password="hostel77")
+        self.client.force_login(subscriber)
         resp = self.client.post(reverse("content:follow-reactions", args=[article.pk]), {"follow": True})
         self.assertEqual(302, resp.status_code)
         public_count = PublishedContent.objects.count()
         self.client.logout()
-        self.client.login(username=self.user_staff.username, password="hostel77")
+        self.client.force_login(self.user_staff)
         result = self.client.post(
             reverse("validation:revoke", kwargs={"pk": article.pk, "slug": article.public_version.content_public_slug}),
             {"text": "This content was bad", "version": article.public_version.sha_public},
@@ -1395,7 +1395,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_validation_history(self):
         published = PublishedContentFactory(author_list=[self.user_author])
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("content:edit", args=[published.pk, published.slug]),
             {
@@ -1419,13 +1419,13 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Validation.objects.count(), 1)
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.get(reverse("validation:list") + "?type=tuto")
         self.assertIn('class="update_content"', str(result.content))
 
     def test_validation_history_for_new_content(self):
         publishable = PublishableContentFactory(author_list=[self.user_author])
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         result = self.client.post(
             reverse("validation:ask", kwargs={"pk": publishable.pk, "slug": publishable.slug}),
@@ -1435,7 +1435,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(Validation.objects.count(), 1)
         self.client.logout()
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         result = self.client.get(reverse("validation:list") + "?type=tuto")
         self.assertNotIn('class="update_content"', str(result.content))
 
@@ -1451,7 +1451,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(Validation.objects.count(), 0)
 
         # login with user and ask validation
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("validation:ask", kwargs={"pk": content_draft.pk, "slug": content_draft.slug}),
             {"text": text_validation, "source": "", "version": content_draft.current_version},
@@ -1461,7 +1461,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(Validation.objects.count(), 1)
 
         # login with staff and reserve the content
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
         validation = Validation.objects.filter(content=content).last()
         result = self.client.post(
             reverse("validation:reserve", kwargs={"pk": validation.pk}), {"version": validation.version}, follow=False
@@ -1469,7 +1469,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with user, edit content and ask validation for update
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("content:edit", args=[content_draft.pk, content_draft.slug]),
             {
@@ -1509,7 +1509,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         article_draft = article.load_version()
 
         # login with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # set beta
         result = self.client.post(
@@ -1529,7 +1529,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
         self.client.logout()
         # login with staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         # reserve the article
         validation = Validation.objects.filter(content=article).last()
@@ -1557,7 +1557,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertIsNotNone(last_message)
 
         # login with author to ensure that the beta is not closed if it was already closed (at a second validation).
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
 
         # ask validation
         result = self.client.post(
@@ -1568,7 +1568,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 302)
 
         # login with staff
-        self.assertEqual(self.client.login(username=self.user_staff.username, password="hostel77"), True)
+        self.client.force_login(self.user_staff)
 
         # reserve the article
         validation = Validation.objects.filter(content=article).last()
@@ -1591,11 +1591,11 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_obsolete(self):
         # check that this function is only available for staff
-        self.client.login(username=self.user_author.username, password="hostel77")
+        self.client.force_login(self.user_author)
         result = self.client.post(reverse("validation:mark-obsolete", kwargs={"pk": self.tuto.pk}), follow=False)
         self.assertEqual(result.status_code, 403)
         # login as staff
-        self.client.login(username=self.user_staff.username, password="hostel77")
+        self.client.force_login(self.user_staff)
         # check that when the content is not marked as obsolete, the alert is not shown
         result = self.client.get(self.tuto.get_absolute_url_online(), follow=False)
         self.assertEqual(result.status_code, 200)
@@ -1880,7 +1880,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         tutorial_draft = tutorial.load_version()
 
         # ask validation
-        self.client.login(username=self.user_staff.username, password="hostel77")
+        self.client.force_login(self.user_staff)
         self.client.post(
             reverse("validation:ask", kwargs={"pk": tutorial.pk, "slug": tutorial.slug}),
             {"text": text_validation, "source": "", "version": tutorial_draft.current_version},
@@ -1905,7 +1905,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         tutorial_draft = tutorial.load_version()
 
         # ask validation
-        self.client.login(username=self.user_staff.username, password="hostel77")
+        self.client.force_login(self.user_staff)
         self.client.post(
             reverse("validation:ask", kwargs={"pk": tutorial.pk, "slug": tutorial.slug}),
             {"text": text_validation, "source": "", "version": tutorial_draft.current_version},
@@ -1988,7 +1988,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         Check that all cards are produce for socials network
         """
         # connect with author:
-        self.assertEqual(self.client.login(username=self.user_author.username, password="hostel77"), True)
+        self.client.force_login(self.user_author)
         # add image to public tutorial
         self.client.post(
             reverse("content:edit", args=[self.tuto.pk, self.tuto.slug]),

--- a/zds/tutorialv2/tests/tests_views/tests_stats.py
+++ b/zds/tutorialv2/tests/tests_views/tests_stats.py
@@ -195,7 +195,7 @@ class StatTests(TestCase, TutorialTestMixin):
             "content:stats-content",
             kwargs={"pk": self.published.content_pk, "slug": self.published.content_public_slug},
         )
-        self.client.login(username=self.user_guest.username, password="hostel77")
+        self.client.force_login(self.user_guest)
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 403)
 
@@ -205,7 +205,7 @@ class StatTests(TestCase, TutorialTestMixin):
             "content:stats-content",
             kwargs={"pk": self.published.content_pk, "slug": self.published.content_public_slug},
         )
-        self.client.login(username=self.user_author.username, password="hostel77")
+        self.client.force_login(self.user_author)
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.context_data["display"], "global")
@@ -219,7 +219,7 @@ class StatTests(TestCase, TutorialTestMixin):
             "content:stats-content",
             kwargs={"pk": self.published.content_pk, "slug": self.published.content_public_slug},
         )
-        self.client.login(username=self.user_staff.username, password="hostel77")
+        self.client.force_login(self.user_staff)
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
 
@@ -263,7 +263,7 @@ class StatTests(TestCase, TutorialTestMixin):
         "zds.tutorialv2.views.statistics.ContentStatisticsView.config_ga_credentials", fake_config_ga_credentials
     )
     def test_query_date_parameter_duration(self):
-        self.client.login(username=self.user_author.username, password="hostel77")
+        self.client.force_login(self.user_author)
         # By default we only have the last 7 days
         self.check_success_result_by_duration()
         self.check_success_result_by_duration(0)
@@ -279,7 +279,7 @@ class StatTests(TestCase, TutorialTestMixin):
 
         # By default we only have the last 7 days
         default_duration = 7
-        self.client.login(username=self.user_author.username, password="hostel77")
+        self.client.force_login(self.user_author)
         url = reverse(
             "content:stats-content",
             kwargs={"pk": self.published.content_pk, "slug": self.published.content_public_slug},
@@ -297,7 +297,7 @@ class StatTests(TestCase, TutorialTestMixin):
         today = datetime.datetime.today()
         before_seven_days = today - datetime.timedelta(days=7)
 
-        self.client.login(username=self.user_author.username, password="hostel77")
+        self.client.force_login(self.user_author)
 
         resp = self.get_response_by_date(today, before_seven_days)
 
@@ -321,7 +321,7 @@ class StatTests(TestCase, TutorialTestMixin):
                     ExtractFactory(container=chapter, db_object=bigtuto)
 
         # connect with author:
-        self.client.login(username=author, password="hostel77")
+        self.client.force_login(author)
 
         # ask validation
         self.client.post(
@@ -331,7 +331,7 @@ class StatTests(TestCase, TutorialTestMixin):
         )
 
         # login with staff and publish
-        self.client.login(username=user_staff.username, password="hostel77")
+        self.client.force_login(user_staff)
 
         validation = Validation.objects.filter(content=bigtuto).last()
 

--- a/zds/utils/management/tests.py
+++ b/zds/utils/management/tests.py
@@ -57,7 +57,7 @@ class CommandsTestCase(TutorialTestMixin, TestCase):
         admin = ProfileFactory()
         admin.user.is_superuser = True
         admin.save()
-        self.assertTrue(self.client.login(username=admin.user.username, password="hostel77"))
+        self.client.force_login(admin.user)
 
         result = self.client.get("/?prof", follow=True)
         self.assertEqual(result.status_code, 200)

--- a/zds/utils/tests/tests_comments.py
+++ b/zds/utils/tests/tests_comments.py
@@ -35,8 +35,8 @@ class PotentialSpamTests(TutorialTestMixin, TestCase):
 
     def login(self, profile):
         self.logout()
-        self.assertTrue(self.client.login(username=profile.user.username, password="hostel77"))
-        self.assertTrue(self.client_api.login(username=profile.user.username, password="hostel77"))
+        self.client.force_login(profile.user)
+        self.client_api.force_login(profile.user)
 
     def test_mark_as_potential_spam_forum(self):
         author = ProfileFactory()

--- a/zds/utils/tests/tests_interventions.py
+++ b/zds/utils/tests/tests_interventions.py
@@ -60,14 +60,14 @@ class InterventionsTest(TestCase):
 
     def test_interventions_privatetopics(self):
 
-        self.assertTrue(self.client.login(username=self.author.user.username, password="hostel77"))
+        self.client.force_login(self.author.user)
         response = self.client.post(reverse("homepage"))
         self.assertEqual(200, response.status_code)
         self.assertContains(response, '<span class="notif-count">1</span>', html=True)
 
         self.client.logout()
 
-        self.assertTrue(self.client.login(username=self.user.user.username, password="hostel77"))
+        self.client.force_login(self.user.user)
         response = self.client.post(reverse("homepage"))
         self.assertEqual(200, response.status_code)
         self.assertContains(response, '<span class="notif-count">1</span>', html=True)
@@ -80,14 +80,14 @@ class InterventionsTest(TestCase):
         self.topic.participants.remove(move)
         self.topic.save()
 
-        self.assertTrue(self.client.login(username=self.user.user.username, password="hostel77"))
+        self.client.force_login(self.user.user)
         response = self.client.post(reverse("homepage"))
         self.assertEqual(200, response.status_code)
         self.assertContains(response, '<span class="notif-count">1</span>', html=True)
 
     def test_interventions_waiting_contents(self):
         # Login as staff
-        self.assertTrue(self.client.login(username=self.staff.user.username, password="hostel77"))
+        self.client.force_login(self.staff.user)
 
         # check that the number of waiting tutorials is correct
         response = self.client.post(reverse("homepage"))


### PR DESCRIPTION
Généralise l'usage de force_login dans les tests quand approprié. Dans la base actuelle, ça veut dire partout sauf sur un test particulier qui a besoin de vérifier l'authentification.

Les bénéfices principaux :

- code plus simple à la lecture
- l'intention est plus évidente (juste avoir un utilisateur logué vs. tester le login)
- force_login passe certains calculs de hash ce qui accélère les tests.

### Contrôle qualité

Les tests auto suffisent, mais vérifier tout de même dans le code que des `force_login` n'ont pas été utilisé dans des cas où on teste justement l'authentification.