### PR TITLE
Correction du lien vers Github

### DIFF
--- a/doc/source/workflow.rst
+++ b/doc/source/workflow.rst
@@ -24,7 +24,7 @@ La pré-production (ou bêta) est disponible sur `beta.zestedesavoir.com <https:
 Description
 -----------
 
-1. Les fonctionnalités et corrections de bugs se font via des *Pull Requests* (PR) depuis des *forks* via `GitHub <https://github.com/zestedesavoir.com/zds-site>`_.
+1. Les fonctionnalités et corrections de bugs se font via des *Pull Requests* (PR) depuis des *forks* via `GitHub <https://github.com/zestedesavoir/zds-site>`_.
 2. Ces PR sont unitaires. Aucune PR qui corrige plusieurs problèmes ou apporte plusieurs fonctionnalité ne sera acceptée; la règle est : une PR = une fonctionnalité ou une correction.
 3. Ces PR sont mergées dans la branche ``dev`` (appelée ``develop`` dans le git flow standard), après une *Quality Assurance* (QA) légère.
 4. La branche ``prod`` (appelée ``master`` dans le git flow standard) contient exclusivement le code en production, pas la peine d'essayer de faire le moindre *commit* dessus !


### PR DESCRIPTION
### Contrôle qualité

  - Se rendre dans la section  `Workflow de développement` de la documentation

*Ancien comportement:*
Le lien vers Github est cassé

*Nouveau comportement:*
Le lien fonctionne