### PR TITLE
Interdire l'utilisation de / dans le pseudo #5984

### DIFF
--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -176,6 +176,17 @@ class RegisterFormTest(TestCase):
         form = RegisterForm(data=data)
         self.assertFalse(form.is_valid())
 
+    def test_username_coma_register_form(self):
+        ProfileFactory()
+        data = {
+            "email": "test@gmail.com",
+            "username": "Ze/Tester",
+            "password": "ZePassword",
+            "password_confirm": "ZePassword",
+        }
+        form = RegisterForm(data=data)
+        self.assertFalse(form.is_valid())
+
 
 class MiniProfileFormTest(TestCase):
     """

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -176,7 +176,7 @@ class RegisterFormTest(TestCase):
         form = RegisterForm(data=data)
         self.assertFalse(form.is_valid())
 
-    def test_username_coma_register_form(self):
+    def test_username_slash_register_form(self):
         ProfileFactory()
         data = {
             "email": "test@gmail.com",
@@ -321,6 +321,15 @@ class ChangeUserFormTest(TestCase):
         ProfileFactory()
         data = {
             "username": "Ze,Tester",
+            "email": self.user1.user.email,
+        }
+        form = ChangeUserForm(data=data, user=self.user1.user)
+        self.assertFalse(form.is_valid())
+
+    def test_username_slash_changeuser_form(self):
+        ProfileFactory()
+        data = {
+            "username": "Ze/Tester",
             "email": self.user1.user.email,
         }
         form = ChangeUserForm(data=data, user=self.user1.user)

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -82,6 +82,8 @@ def validate_zds_username(value, check_username_available=True):
     skeleton_user_count = Profile.objects.filter(username_skeleton=Profile.find_username_skeleton(value)).count()
     if "," in value:
         msg = _("Le nom d'utilisateur ne peut contenir de virgules")
+    if "/" in value:
+        msg = _("Le nom d'utilisateur ne peut contenir de barre oblique")
     elif contains_utf8mb4(value):
         msg = _("Le nom d'utilisateur ne peut pas contenir des caractères utf8mb4")
     elif check_username_available and user_count > 0:

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -83,7 +83,7 @@ def validate_zds_username(value, check_username_available=True):
     if "," in value:
         msg = _("Le nom d'utilisateur ne peut contenir de virgules")
     if "/" in value:
-        msg = _("Le nom d'utilisateur ne peut contenir de barre oblique")
+        msg = _("Le nom d'utilisateur ne peut contenir de barres obliques")
     elif contains_utf8mb4(value):
         msg = _("Le nom d'utilisateur ne peut pas contenir des caractères utf8mb4")
     elif check_username_available and user_count > 0:


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) :
fix #5984


### Contrôle qualité

A.
  - Lancez `python manage.py runserver` ;
  - Créez un nouveau compte nommé `Mon/Nom` ;

*Ancien comportement:*
Le nouveau compte est crée avec succès mais son profil est inaccessible

*Nouveau comportement:*
La création du compte est bloquée à cause du symbole '/'

B.
  - Lancez `python manage.py runserver` ;
  - Connectez-vous avec un compte existant ;
  - Modifiez le nom d'utilisateur pour `Mon/Nom`;

*Ancien comportement:*
Le nom d'utilisateur est modifié avec succès mais son profil devientinaccessible

*Nouveau comportement:*
La modification est bloquée à cause du symbole '/'