### PR TITLE
Enlève la duplication d'id dans les formulaires de modale

### DIFF
--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -677,7 +677,9 @@ class AskValidationForm(forms.Form):
     text = forms.CharField(
         label="",
         required=False,
-        widget=forms.Textarea(attrs={"placeholder": _("Commentaire pour votre demande."), "rows": "3"}),
+        widget=forms.Textarea(
+            attrs={"placeholder": _("Commentaire pour votre demande."), "rows": "3", "id": "ask_validation_text"}
+        ),
     )
 
     version = forms.CharField(widget=forms.HiddenInput(), required=True)
@@ -810,7 +812,9 @@ class CancelValidationForm(forms.Form):
     text = forms.CharField(
         label="",
         required=True,
-        widget=forms.Textarea(attrs={"placeholder": _("Pourquoi annuler la validation ?"), "rows": "4"}),
+        widget=forms.Textarea(
+            attrs={"placeholder": _("Pourquoi annuler la validation ?"), "rows": "4", "id": "cancelçtext"}
+        ),
     )
 
     def __init__(self, validation, *args, **kwargs):

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -813,7 +813,7 @@ class CancelValidationForm(forms.Form):
         label="",
         required=True,
         widget=forms.Textarea(
-            attrs={"placeholder": _("Pourquoi annuler la validation ?"), "rows": "4", "id": "cancelçtext"}
+            attrs={"placeholder": _("Pourquoi annuler la validation ?"), "rows": "4", "id": "cancel_text"}
         ),
     )
 
@@ -860,7 +860,9 @@ class CancelValidationForm(forms.Form):
 class RejectValidationForm(forms.Form):
 
     text = forms.CharField(
-        label="", required=True, widget=forms.Textarea(attrs={"placeholder": _("Commentaire de rejet."), "rows": "6"})
+        label="",
+        required=True,
+        widget=forms.Textarea(attrs={"placeholder": _("Commentaire de rejet."), "rows": "6", "id": "reject_text"}),
     )
 
     def __init__(self, validation, *args, **kwargs):

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -912,7 +912,9 @@ class RevokeValidationForm(forms.Form):
     text = forms.CharField(
         label="",
         required=True,
-        widget=forms.Textarea(attrs={"placeholder": _("Pourquoi dépublier ce contenu ?"), "rows": "6"}),
+        widget=forms.Textarea(
+            attrs={"placeholder": _("Pourquoi dépublier ce contenu ?"), "rows": "6", "id": "up_text"}
+        ),
     )
 
     def __init__(self, content, *args, **kwargs):
@@ -1009,7 +1011,9 @@ class MoveElementForm(forms.Form):
 class WarnTypoForm(forms.Form):
 
     text = forms.CharField(
-        label="", required=True, widget=forms.Textarea(attrs={"placeholder": _("Expliquez la faute"), "rows": "3"})
+        label="",
+        required=True,
+        widget=forms.Textarea(attrs={"placeholder": _("Expliquez la faute"), "rows": "3", "id": "warn_text"}),
     )
 
     target = forms.CharField(widget=forms.HiddenInput(), required=False)
@@ -1154,7 +1158,9 @@ class UnpublicationForm(forms.Form):
     text = forms.CharField(
         label="",
         required=True,
-        widget=forms.Textarea(attrs={"placeholder": _("Pourquoi dépublier ce contenu ?"), "rows": "6"}),
+        widget=forms.Textarea(
+            attrs={"placeholder": _("Pourquoi dépublier ce contenu ?"), "rows": "6", "id": "up_reason"}
+        ),
     )
 
     def __init__(self, content, *args, **kwargs):

--- a/zds/tutorialv2/tests/__init__.py
+++ b/zds/tutorialv2/tests/__init__.py
@@ -79,7 +79,7 @@ class TutorialFrontMixin:
         find_element = self.selenium.find_element_by_css_selector
         self.selenium.get(self.live_server_url + self.content.get_absolute_url())
         find_element('a[href="#ask-validation"]').click()
-        find_element("#id_text").send_keys("Coucou.")
+        find_element("#ask-validation textarea").send_keys("Coucou.")
         find_element('#ask-validation button[type="submit"]').click()
 
     def take_reservation(self):
@@ -93,7 +93,7 @@ class TutorialFrontMixin:
         self.selenium.get(self.live_server_url + self.content.get_absolute_url())
         validation = Validation.objects.filter(content=self.content).first()
         find_element('a[href="#valid-publish"]').click()
-        find_element("form#valid-publish #id_text").send_keys("Coucou.")
+        find_element("form#valid-publish textarea").send_keys("Coucou.")
         find_element(f'form[action="/validations/accepter/{validation.pk}/"] button').click()
 
     def wait_element_attribute_change(self, locator, attribute, initial_value, time):


### PR DESCRIPTION
<!-- Veuillez décrire vos changements à l’emplacement de ce commentaire (inutile dans le cas de tout petits changements). -->

<!-- Indiquez ci-dessous les numéros des tickets (avec le # au début) corrigés par vos changements : -->
Numéro du ticket concerné (optionnel) :

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->
fix #5810 

### Contrôle qualité

- Ouvrir son inspecteur html
- Se connecter en tant que staff
- Ouvrir la version brouillon d'un tuto
- il n'y a qu'un seul champ (ou aucun) avec l'id "id_text", "up_text", "warn_text"
- demander la validation
- il n'y a qu'un seul champ (ou aucun) avec l'id "id_text", "up_text", "warn_text"
- publier
- il n'y a qu'un seul champ (ou aucun) avec l'id "id_text", "up_text", "warn_text"
- se connecter avec admin
- aller sur la page du tuto qui vient d'être publié et prévenez l'auteur qu'il y a une typo
- il n'y a qu'un seul champ (ou aucun) avec l'id "id_text", "up_text", "warn_text"
