### PR TITLE
Envoie un MP lorsqu'un membre est retiré des auteurs d'un contenu (#5778)

### DIFF
--- a/templates/tutorialv2/messages/remove_author_pm.md
+++ b/templates/tutorialv2/messages/remove_author_pm.md
@@ -1,0 +1,8 @@
+{% load i18n %}
+
+{% blocktrans with title=content.title|safe type=type|safe user=user|safe %}
+Bonjour {{ user }},
+
+Vous avez été retiré de la rédaction du contenu « {{ title }} ».
+
+{%  endblocktrans %}

--- a/zds/tutorialv2/views/authors.py
+++ b/zds/tutorialv2/views/authors.py
@@ -61,8 +61,6 @@ class AddAuthorToContent(LoggedWithReadWriteHability, SingleContentFormViewMixin
                                 "user": user.username,
                             },
                         ),
-                        send_by_mail=True,
-                        direct=False,
                         hat=get_hat_from_settings("validation"),
                     )
                 UserGallery(gallery=self.object.gallery, user=user, mode=GALLERY_WRITE).save()
@@ -135,8 +133,6 @@ class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormView
                                 "user": user.username,
                             },
                         ),
-                        send_by_mail=True,
-                        direct=False,
                         hat=get_hat_from_settings("validation"),
                     )
             else:  # if user is incorrect or alone

--- a/zds/tutorialv2/views/authors.py
+++ b/zds/tutorialv2/views/authors.py
@@ -111,22 +111,40 @@ class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormView
         current_user = False
         users = form.cleaned_data["users"]
 
-        _type = _("cet article")
+        _type = (_("cet article"), _("de l'article"))
         if self.object.is_tutorial:
-            _type = _("ce tutoriel")
+            _type = (_("ce tutoriel"), _("du tutoriel"))
         elif self.object.is_opinion:
-            _type = _("ce billet")
+            _type = (_("ce billet"), _("du billet"))
 
+        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
         for user in users:
             if RemoveAuthorFromContent.remove_author(self.object, user):
                 if user.pk == self.request.user.pk:
                     current_user = True
+                else:
+                    send_mp(
+                        bot,
+                        [user],
+                        format_lazy("{}{}", _("Retrait de la rédaction "), _type[1]),
+                        self.versioned_object.title,
+                        render_to_string(
+                            "tutorialv2/messages/remove_author_pm.md",
+                            {
+                                "content": self.object,
+                                "user": user.username,
+                            },
+                        ),
+                        send_by_mail=True,
+                        direct=False,
+                        hat=get_hat_from_settings("validation"),
+                    )
             else:  # if user is incorrect or alone
                 messages.error(
                     self.request,
                     _(
                         "Vous êtes le seul auteur de {} ou le membre sélectionné " "en a déjà quitté la rédaction."
-                    ).format(_type),
+                    ).format(_type[0]),
                 )
                 return redirect(self.object.get_absolute_url())
 
@@ -144,11 +162,11 @@ class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormView
 
         if not current_user:  # if the removed author is not current user
             messages.success(
-                self.request, _("Vous avez enlevé {} de la liste des auteurs de {}.").format(authors_list, _type)
+                self.request, _("Vous avez enlevé {} de la liste des auteurs de {}.").format(authors_list, _type[0])
             )
             self.success_url = self.object.get_absolute_url()
         else:  # if current user is leaving the content's redaction, redirect him to a more suitable page
-            messages.success(self.request, _("Vous avez bien quitté la rédaction de {}.").format(_type))
+            messages.success(self.request, _("Vous avez bien quitté la rédaction de {}.").format(_type[0]))
             self.success_url = reverse(
                 self.object.type.lower() + ":find-" + self.object.type.lower(), args=[self.request.user.username]
             )


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) :
#5778


### Contrôle qualité

**MP lors du retrait d'un autre membre:**

  - Créez un contenu (article, billet, tutoriel)
  - Ajoutez un membre à la liste d'auteurs
  - Retirez ce membre de la liste d'auteurs

**Ancien comportement:**
Aucun MP n'est envoyé lors du retrait du membre
**Nouveau comportement:**
Un MP est envoyé au membre lorsqu'il est supprimé de la liste d'auteurs

**Aucun MP lors du retrait de soi-même:**
  - Créez un contenu (article, billet, tutoriel)
  - Ajoutez un membre à la liste d'auteurs
  - Retirez-vous de la liste d'auteurs

**Ancien et nouveau comportement:**
Aucun MP n'est envoyé lors du retrait