### PR TITLE
Mise à jour des dépendances Python

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 -r requirements-dev.txt
 -r requirements-prod.txt
 
-coverage==5.4
+coverage==5.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,12 @@
 -r requirements.txt
 
 black==20.8b1
-colorlog==4.7.2
-coverage==5.4
+colorlog==4.8.0
 django-debug-toolbar==3.2
-django-extensions==3.1.1
-Faker==4.5.0
-pre-commit==2.10.1
+django-extensions==3.1.2
+Faker==8.0.0
+pre-commit==2.12.0
 PyYAML==5.4.1
 selenium==3.141.0
-Sphinx==3.5.1
-sphinx_rtd_theme==0.5.1
+Sphinx==3.5.3
+sphinx_rtd_theme==0.5.2

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-gunicorn==20.0.4
+gunicorn==20.1.0
 mysqlclient==2.0.3
 raven==6.10.0
 ujson==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,14 +10,14 @@ django-crispy-forms==1.11.1
 django-model-utils==4.1.1
 django-munin==0.2.1
 django-recaptcha==2.0.6
-Django==2.2.19
+Django==2.2.20
 easy-thumbnails==2.8rc0
 factory-boy==3.2.0
 geoip2==4.1.0
 GitPython==3.1.13
 google-api-python-client==1.12.8
 homoglyphs==2.0.4
-lxml==4.6.2
+lxml==4.6.3
 Pillow==8.1.2
 python-memcached==1.59
 requests==2.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ social-auth-app-django==4.0.0
 
 # Explicit dependencies (references in code)
 beautifulsoup4==4.9.3
-django-crispy-forms==1.11.1
+django-crispy-forms==1.11.2
 django-model-utils==4.1.1
 django-munin==0.2.1
 django-recaptcha==2.0.6
@@ -14,11 +14,11 @@ Django==2.2.20
 easy-thumbnails==2.8rc0
 factory-boy==3.2.0
 geoip2==4.1.0
-GitPython==3.1.13
+GitPython==3.1.14
 google-api-python-client==1.12.8
 homoglyphs==2.0.4
 lxml==4.6.3
-Pillow==8.1.2
+Pillow==8.2.0
 python-memcached==1.59
 requests==2.25.1
 toml==0.10.2
@@ -26,10 +26,10 @@ toml==0.10.2
 # Api dependencies
 django-cors-headers==3.7.0
 django-filter==2.4.0
-django-oauth-toolkit==1.4.0
+django-oauth-toolkit==1.5.0
 django-rest-swagger==2.2.0
 djangorestframework-xml==2.0.0
-djangorestframework==3.12.2
+djangorestframework==3.12.4
 drf-extensions==0.7.0
 dry-rest-permissions==0.1.10
 oauth2client==4.1.3


### PR DESCRIPTION
- Mise à jour de sécurité des dépendances Python (Django et lxml) pour pouvoir déployer une version corrective en production
- Mise à jour triviale des dépendances Python

Faker passe de 4.5.0 à 8.0.0 ce qui parait énorme mais c'est normal car maintenant ils font une version par commit fusionné.

Je n'ai pas mis à jour `google-api-python-client` car ils disent de faire très attention pour la migration vers la v2 donc ça se fera plus tard dans une autre PR.

**QA :** Github Actions + Vérification du fonctionnement du site web en local