### PR TITLE
Optimisation des requêtes SQL

### DIFF
--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -219,8 +219,8 @@ class TopicPostsListView(ZdSPagingListView, FeatureableMixin, SingleObjectMixin)
             context["user_can_modify"] = [post.pk for post in context["posts"] if post.author == self.request.user]
 
         if self.request.user.is_authenticated:
-            for post in posts:
-                signals.post_read.send(sender=post.__class__, instance=post, user=self.request.user)
+            if len(posts) > 0:
+                signals.post_read.send(sender=posts[0].__class__, instances=posts, user=self.request.user)
             if not self.object.is_read:
                 mark_read(self.object)
         return context

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -231,12 +231,14 @@ def clean_subscriptions(sender, *, topic, **__):
 
 @receiver(tuto_signals.content_read, sender=ContentReaction)
 @receiver(forum_signals.post_read, sender=Post)
-def mark_comment_read(sender, *, instance, user, **__):
-    comment = instance
+def mark_comments_read(sender, *, instances, user, **__):
+    comments = {}
+    for comment in instances:
+        comments[comment.pk] = comment
 
-    subscription = PingSubscription.objects.get_existing(user, comment, is_active=True)
-    if subscription:
-        subscription.mark_notification_read(comment)
+    subscriptions = PingSubscription.objects.filter(user=user, is_active=True, object_id__in=comments.keys())
+    for subscription in subscriptions:
+        subscription.mark_notification_read(comments[subscription.object_id])
 
 
 @receiver(forum_signals.topic_moved, sender=Topic)

--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -157,8 +157,10 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
             logger.warning("could not compute reading time: setting characters_per_minute is set to zero (error=%s)", e)
 
         if self.request.user.is_authenticated:
-            for reaction in context["reactions"]:
-                signals.content_read.send(sender=reaction.__class__, instance=reaction, user=self.request.user)
+            if len(context["reactions"]) > 0:
+                signals.content_read.send(
+                    sender=context["reactions"][0].__class__, instances=context["reactions"], user=self.request.user
+                )
             signals.content_read.send(
                 sender=self.object.__class__, instance=self.object, user=self.request.user, target=PublishableContent
             )


### PR DESCRIPTION
Optimisation des requêtes

- Deux requêtes en moins pour les commentaires des contenus
- N requêtes en moins pour les commentaires des contenus et les messages des forums

**Avant**

- Article avec deux pages de commentaires : 96 requêtes (2s) connecté et 29 requêtes (0,8s) anonyme
- Sujet avec deux pages de messages : 113 requêtes (2,3s) connecté et 18 requêtes (0,7s) anonyme

**Après**

- Article avec deux pages de commentaires : 69 requêtes (1,5s) connecté et 26 requêtes (0,8s) anonyme
- Sujet avec deux pages de messages : 93 requêtes (1,9s) connecté et 18 requêtes (0,7s) anonyme

**QA :**
- Vérifier que les pings fonctionnent correctement dans les commentaires des contenus et les messages du forum.