### PR TITLE
Supprime le paramètre enable_pings devenu inutile

### DIFF
--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -48,7 +48,6 @@ class ForumNotification(TestCase):
         self.forum12.save()
 
     def test_ping_unknown(self):
-        overridden_zds_app["comment"]["enable_pings"] = True
         self.client.force_login(self.user2)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",
@@ -66,7 +65,6 @@ class ForumNotification(TestCase):
         )
 
     def test_no_auto_ping(self):
-        overridden_zds_app["comment"]["enable_pings"] = True
         self.client.force_login(self.user2)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",
@@ -85,7 +83,6 @@ class ForumNotification(TestCase):
 
     def test_edit_with_more_than_max_ping(self):
         overridden_zds_app["comment"]["max_pings"] = 2
-        overridden_zds_app["comment"]["enable_pings"] = True
         pinged_users = [ProfileFactory(), ProfileFactory(), ProfileFactory(), ProfileFactory()]
         self.client.force_login(self.user2)
         self.client.post(
@@ -123,7 +120,6 @@ class ForumNotification(TestCase):
         """
         to be more accurate : on edition, only ping **new** members
         """
-        overridden_zds_app["comment"]["enable_pings"] = True
         self.client.force_login(self.user2)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",
@@ -175,7 +171,6 @@ class ForumNotification(TestCase):
         """
         to be more accurate : on edition, only ping **new** members
         """
-        overridden_zds_app["comment"]["enable_pings"] = True
         self.client.force_login(self.user2)
         result = self.client.post(
             reverse("topic-new") + f"?forum={self.forum11.pk}",

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -207,8 +207,6 @@ ZDS_APP = {
     },
     "comment": {
         "max_pings": 15,
-        # allow to mention (and notify) members in messages
-        "enable_pings": True,
     },
     "featured_resource": {
         "featured_per_page": 100,

--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -164,10 +164,6 @@ ZDS_APP["content"]["repo_private_path"] = "/opt/zds/data/contents-private"
 ZDS_APP["content"]["repo_public_path"] = "/opt/zds/data/contents-public"
 ZDS_APP["content"]["extra_content_generation_policy"] = "WATCHDOG"
 
-# allow to mention (and notify) members in messages
-# still a beta feature, keep it disabled for the time being
-ZDS_APP["comment"]["enable_pings"] = False
-
 ZDS_APP["visual_changes"] = zds_config.get("visual_changes", [])
 
 ZDS_APP["very_top_banner"] = config.get("very_top_banner", False)


### PR DESCRIPTION
Comme signalé par Amaury, le paramètre `enable_pings` n'est maintenant plus utilisé, cette PR supprime les différentes déclarations de ce paramètre.


### Contrôle qualité

Tests de la CI et vérifier que les pings fonctionnent.

