### PR TITLE
Corrige un bug graphique sur Firefox ESR

### DIFF
--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -147,7 +147,7 @@ $content-item-padding-vertical: $length-14;
 
                 // This width will not be respected but it will prevent the block
                 // to push against the other flex item (the comments bubble).
-                width: 10%;
+                min-width: 10%;
 
                 color: $accent-800;
 


### PR DESCRIPTION
Corrige un bug graphique sur Firefox ESR (version de Firefox dont le support est étendu sur plusieurs années, très utilisé en entreprises et dans les établissements scolaires)

**Avant**

![Capture d'écran du soucis](https://user-images.githubusercontent.com/6664636/115967685-433ebe80-a534-11eb-8129-a4095931ac62.png)

**Après**

![Capture d'écran une fois le soucis résolu](https://user-images.githubusercontent.com/6664636/115967704-50f44400-a534-11eb-91b3-36303fa24345.png)

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Créer un billet ou un article avec plusieurs auteurs et deux tags assez long
- Vérifier que la cartouche du billet s'affiche correctement sur Firefox ESR ([téléchargeable ici](https://www.mozilla.org/en-US/firefox/all/#product-desktop-esr)) ainsi que Firefox et Google Chrome