### PR TITLE
Mise en cache des requêtes vers les auteurs

### DIFF
--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -98,7 +98,7 @@
                                     {% endif %}
                                 </td>
                                 <td>
-                                    {% for author in validation.content.authors.all %}
+                                    {% for author in validation.content.redacting_authors %}
                                         {% include 'misc/member_item.part.html' with member=author avatar=True %}
                                     {% endfor %}
                                 </td>

--- a/templates/tutorialv2/validation/opinions.html
+++ b/templates/tutorialv2/validation/opinions.html
@@ -48,7 +48,7 @@
                                     </a>
                                 </td>
                                 <td>
-                                    {% for author in content.authors.all %}
+                                    {% for author in content.redacting_authors %}
                                         {% include 'misc/member_item.part.html' with member=author avatar=True %}
                                     {% endfor %}
                                 </td>

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -103,7 +103,7 @@
 
 {% block sidebar_actions %}
 
-    {% if not user in content.authors.all and user.is_authenticated %}
+    {% if not user in content.redacting_authors and user.is_authenticated %}
     <li>
         <a href="{{ pm_link }}" class="ico-after cite blue">
         {% blocktrans count counter=content.authors.all|length %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -122,7 +122,7 @@
         {% if content_helps %}
             <div class="content-wrapper">
                 <div class="alert-box info">
-                    {% if content.authors.count > 1 %}
+                    {% if content.redacting_authors|length > 1 %}
                         {% trans "Les auteurs de ce contenu recherchent" %}
                     {% else %}
                         {% trans "L’auteur de ce contenu recherche" %}
@@ -131,7 +131,7 @@
                     {% for help in content_helps %}{% if not forloop.first %}{% if forloop.last %}{% trans ' et ' %}{% else %}{% trans ', ' %}{% endif %}{% endif %}un {{ help.title|lower }}{% if forloop.last %}{% trans '.' %}{% endif %}{% endfor %}
 
                     {% if not can_edit %}
-                        {% blocktrans with plural=content.authors.count|pluralize_fr %}
+                        {% blocktrans with plural=content.redacting_authors|length|pluralize_fr %}
                             N’hésitez pas à <a href="{{ pm_link }}">le{{ plural }} contacter par MP</a> pour proposer votre aide !
                         {% endblocktrans %}
                     {% endif %}
@@ -325,7 +325,7 @@
                         <th width="100px">{% trans "Actions" %}</th>
                     </thead>
                     <tbody>
-                        {% for member in content.authors.all %}
+                        {% for member in content.redacting_authors %}
                             <tr>
                                 <td>{% include "misc/member_item.part.html" %}</td>
                                 <td>

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -112,7 +112,8 @@ class Forum(models.Model):
         try:
             return self.thread_count
         except AttributeError:
-            return Topic.objects.filter(forum=self).count()
+            setattr(self, "thread_count", Topic.objects.filter(forum=self).count())
+            return self.thread_count
 
     def get_post_count(self):
         """Retrieve or aggregate the number of posts in this forum. If this number already exists, it must be stored \

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -409,7 +409,9 @@ class Profile(models.Model):
         """
         Return all hats the user is allowed to use.
         """
-        profile_hats = list(self.hats.all())
+        if not hasattr(self, "_hats"):
+            setattr(self, "_hats", list(self.hats.all()))
+        profile_hats = getattr(self, "_hats")
         groups_hats = list(Hat.objects.filter(group__in=self.user.groups.all()))
         hats = profile_hats + groups_hats
 

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -159,7 +159,7 @@ def mark_content_reactions_read(sender, *, instance, user=None, target, **__):
             if subscription:
                 subscription.mark_notification_read()
     elif target == PublishableContent:
-        authors = list(instance.authors.all())
+        authors = instance.redacting_authors
         for author in authors:
             subscription = NewPublicationSubscription.objects.get_existing(user, author)
             # a subscription has to be handled only if it is active OR if it was triggered from the publication

--- a/zds/utils/templatetags/displayable_authors.py
+++ b/zds/utils/templatetags/displayable_authors.py
@@ -15,5 +15,5 @@ def displayable_authors(content, online):
     :rtype: iterable[zds.members.models.User]
     """
     if online:
-        return content.public_version.authors.all()
-    return content.authors.all()
+        return content.public_version.public_authors
+    return content.redacting_authors


### PR DESCRIPTION
Mise en cache des requêtes vers les auteurs

Je pense que ce serait plus propre d'utiliser `@cache_property` ([doc](https://docs.djangoproject.com/fr/2.2/ref/utils/#django.utils.functional.cached_property)) et de l'invalider si besoin comme précisé dans [ce message](https://stackoverflow.com/a/23490487).