### PR TITLE
Feature/multi sur meme reseau ipv6

### DIFF
--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -54,7 +54,7 @@
     </div>
 
     <p>
-        En IPV6, les adresses sont attribuées par bloc d'IP. Un bot de spam peut donc facilement changer d'adresse IP. Sont affichées ici tous les membres dont l'IPV6 fait partie du même bloc que l'IP demandée.
+        En IPv6, les adresses sont attribuées par bloc d'IP. Un bot de spam peut donc facilement changer d'adresse IP au sein de ce bloc. Sont affichées ici tous les membres dont l'IPv6 fait partie du même bloc que l'IP demandée.
     </p>
     {% endif %}
 {% endblock %}

--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -39,7 +39,7 @@
     </div>
 
     {# Checks if it's an IPV6 to show the members from the same IPV6 network #}
-    {% if ":" in ip %}Checks if it's an IPV6 to show the members from the same IPV6 network
+    {% if ":" in ip %}
     <p>
         {% blocktrans %}
             Liste des membres dont la dernière IP connue fait partie du bloc <code>{{ network_ip }}</code>

--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -38,7 +38,7 @@
         </ul>
     </div>
 
-    {% if ":" in ip %}
+    {% if ":" in ip %} <!--Checks if it's an IPV6 to show the members from the same IPV6 network-->
     <p>
         {% blocktrans %}
             Liste des membres dont la dernière IP connue fait partie du bloc <code>{{ network_ip }}</code>

--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -26,7 +26,7 @@
 {% block content %}
     <p>
         {% blocktrans %}
-            Liste des membres dont la dernière IP connue est {{ ip }}
+            Liste des membres dont la dernière IP connue est <code>{{ ip }}</code>
         {% endblocktrans %}
     </p>
 
@@ -41,7 +41,7 @@
     {% if ":" in ip %}
     <p>
         {% blocktrans %}
-            Liste des membres dont la dernière IP connue fait partie du bloc {{ network_ip }}
+            Liste des membres dont la dernière IP connue fait partie du bloc <code>{{ network_ip }}</code>
         {% endblocktrans %}
     </p>
 

--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -38,7 +38,8 @@
         </ul>
     </div>
 
-    {% if ":" in ip %} <!--Checks if it's an IPV6 to show the members from the same IPV6 network-->
+    {# Checks if it's an IPV6 to show the members from the same IPV6 network #}
+    {% if ":" in ip %}Checks if it's an IPV6 to show the members from the same IPV6 network
     <p>
         {% blocktrans %}
             Liste des membres dont la dernière IP connue fait partie du bloc <code>{{ network_ip }}</code>

--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -54,7 +54,7 @@
     </div>
 
     <p>
-        En IPv6, les adresses sont attribuées par bloc d'IP. Un bot de spam peut donc facilement changer d'adresse IP au sein de ce bloc. Sont affichées ici tous les membres dont l'IPv6 fait partie du même bloc que l'IP demandée.
+        En IPv6, les adresses sont attribuées par bloc d'IP. Un bot de spam peut donc facilement changer d'adresse IP au sein de ce bloc. Sont affichés ici tous les membres dont l'IPv6 fait partie du même bloc que l'IP demandée.
     </p>
     {% endif %}
 {% endblock %}

--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -37,4 +37,24 @@
             {% endfor %}
         </ul>
     </div>
+
+    {% if ":" in ip %}
+    <p>
+        {% blocktrans %}
+            Liste des membres dont la dernière IP connue fait partie du bloc {{ network_ip }}
+        {% endblocktrans %}
+    </p>
+
+    <div class="members">
+        <ul>
+            {% for member in network_members %}
+                <li>{% include "misc/member_item.part.html" with member=member info=member.last_visit|format_date:True avatar=True %}</li>
+            {% endfor %}
+        </ul>
+    </div>
+
+    <p>
+        En IPV6, les adresses sont attribuées par bloc d'IP. Un bot de spam peut donc facilement changer d'adresse IP. Sont affichées ici tous les membres dont l'IPV6 fait partie du même bloc que l'IP demandée.
+    </p>
+    {% endif %}
 {% endblock %}

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -1732,7 +1732,6 @@ class IpListingsTests(TestCase):
     def setUp(self) -> None:
         self.staff = StaffProfileFactory().user
         self.regular_user = ProfileFactory()
-        self.regular_user.user.save()
 
         self.user_ipv4_same_ip_1 = ProfileFactory(last_ip_address="155.128.92.54")
         self.user_ipv4_same_ip_1.user.username = "user_ipv4_same_ip_1"

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -1806,7 +1806,7 @@ class IpListingsTests(TestCase):
         response = self.client.get(reverse(member_from_ip, args=["0.0.0.0"]))
         self.assertEqual(response.status_code, 403)
 
-    def test_access_rights_to_ip_page_as_non_user(self) -> None:
+    def test_access_rights_to_ip_page_as_anonymous(self) -> None:
         response = self.client.get(reverse(member_from_ip, args=["0.0.0.0"]))
         self.assertEqual(response.status_code, 302)
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1468,7 +1468,8 @@ def member_from_ip(request, ip_address):
         # Remove the additional ":" at the end of the network adresse, so we can filter the IP adresses on this network
         network_ip = str(network_ip)[:-1]
         network_members = Profile.objects.filter(last_ip_address__startswith=network_ip).order_by("-last_visit")
-        members_and_ip.update({"network_members": network_members, "network_ip": network_ip})
+        members_and_ip["network_members"] = network_members
+        members_and_ip["network_ip"] = network_ip
 
     return render(request, "member/admin/memberip.html", members_and_ip)
 


### PR DESCRIPTION
J'ai (oups) effacé ma branche précédente, je la refais. Cf #6120 

Modification de la fonction member_from_ip afin qu'elle retourne tous les membres sur un même bloc IPV6. Adaptation du template associé. Ajout de tests fonctionnels et d'autorisation.

Numéro du ticket concerné :
closes #4103

### Contrôle qualité

- Se connecter en tant que staff
- Aller sur un profil utilisateur et cliquer sur son adresse IP ou se rendre directement sur membres/profil/multi/<adresse ip>/
- Vérifier que les utilisateurs soient bien affichés avec une IPV4
- Donner dans la base à 2 utilisateurs une adresse IPV6 sur le même réseau (par exemple en modifiant le dernier caractère)
- Vérifier qu'avec une IPV6, on a bien 2 blocs avec la liste utilisant l'adresse ip exacte et la liste utilisant le même réseau IPV6, contenant les deux utilisateurs modifiés précédemment
- Éventuellement (fonctionnait avant) : se connecter en utilisateur et vérifier que l'accès est verrouillé

Exemple, 2 comptes sur un même réseau IPV6 chez moi :
![image](https://user-images.githubusercontent.com/81959473/118635313-b950e100-b7d3-11eb-980e-1f1679e3b4cb.png)

