### PR TITLE
Redirige l'utilisateur vers la bonne page si déjà connecté (#6121)

### DIFF
--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -1166,6 +1166,8 @@ def login_view(request):
             return response
 
     if next_page is not None:
+        if request.user.is_authenticated:
+            return redirect(next_page)
         form.helper.form_action += "?next=" + next_page
     csrf_tk["error"] = error
     csrf_tk["form"] = form


### PR DESCRIPTION
Numéro du ticket concerné (optionnel) : #6121 

### Contrôle qualité
* Ne pas être connecté
* Tenter de se rendre vers une page de son propre contenu (billet, article, tuto). Cela vous redirigera vers une page de login avec un paramètre `next_page` dans l'url. Copier ce lien
* Se connecter
* Se rendre sur le lien copié lors de l'étape 2.

**Ancien comportement: **
Un message d'erreur est affiché: "Vous êtes déjà connecté."

**Nouveau comportement:**
Vous êtes automatiquement redirigé vers la bonne page
