### PR TITLE
Quelques modifications concernant Matomo

### DIFF
--- a/zds/middlewares/matomomiddleware.py
+++ b/zds/middlewares/matomomiddleware.py
@@ -9,9 +9,9 @@ from threading import Thread
 
 from zds.member.views import get_client_ip
 
-matomo_token_auth = settings.ZDS_APP["site"]["matomoTokenAuth"]
-matomo_api_url = "{}/matomo.php?token_auth={}".format(settings.ZDS_APP["site"]["matomoUrl"], matomo_token_auth)
-matomo_site_id = settings.ZDS_APP["site"]["matomoSiteID"]
+matomo_token_auth = settings.ZDS_APP["site"]["matomo_token_auth"]
+matomo_api_url = "{}/matomo.php?token_auth={}".format(settings.ZDS_APP["site"]["matomo_url"], matomo_token_auth)
+matomo_site_id = settings.ZDS_APP["site"]["matomo_site_id"]
 matomo_api_version = 1
 logger = logging.getLogger(__name__)
 tracked_status_code = [200]

--- a/zds/middlewares/matomomiddleware.py
+++ b/zds/middlewares/matomomiddleware.py
@@ -53,7 +53,7 @@ class MatomoMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
         self.queue = Queue()
-        if settings.ZDS_APP["site"].get("matomo_enabled", True):
+        if settings.ZDS_APP["site"]["matomo_tracking_enabled"]:
             self.worker = Thread(target=_background_process, args=(self.queue,))
             self.worker.setDaemon(True)
             self.worker.start()
@@ -66,7 +66,7 @@ class MatomoMiddleware:
         client_referer = request.META.get("HTTP_REFERER", "")
         client_accept_language = request.META.get("HTTP_ACCEPT_LANGUAGE", "")
         client_url = f"{request.scheme}://{request.get_host()}{request.path}"
-        if settings.ZDS_APP["site"].get("matomo_enabled", True):
+        if settings.ZDS_APP["site"]["matomo_tracking_enabled"]:
             self.queue.put(
                 {
                     "client_user_agent": client_user_agent,
@@ -95,6 +95,6 @@ class MatomoMiddleware:
         return response
 
     def __del__(self):
-        if settings.ZDS_APP["site"].get("matomo_enabled", True):
+        if settings.ZDS_APP["site"]["matomo_tracking_enabled"]:
             self.queue.put(False)
             self.worker.join(timeout=2)

--- a/zds/middlewares/matomomiddleware.py
+++ b/zds/middlewares/matomomiddleware.py
@@ -16,7 +16,7 @@ matomo_api_version = 1
 logger = logging.getLogger(__name__)
 tracked_status_code = [200]
 tracked_methods = ["GET"]
-excluded_paths = ["/contenus", "/mp", "/munin", "/api"]
+excluded_paths = ["/contenus", "/mp", "/munin", "/api", "/static", "/media"]
 
 
 def _background_process(queue: Queue):

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -66,6 +66,7 @@ ZDS_APP = {
         "sur lequel vous trouverez des tutoriels de tous niveaux, "
         "des articles et des forums d’entraide animés par et pour "
         "la communauté.",
+        "matomo_tracking_enabled": zds_config.get("matomo_tracking_enabled", False),
         "matomo_site_id": zds_config.get("matomo_site_id", 4),
         "matomo_url": zds_config.get("matomo_url", "https://matomo.zestedesavoir.com"),
         "matomo_token_auth": zds_config.get("matomo_token_auth", ""),

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -66,9 +66,9 @@ ZDS_APP = {
         "sur lequel vous trouverez des tutoriels de tous niveaux, "
         "des articles et des forums d’entraide animés par et pour "
         "la communauté.",
-        "matomoSiteID": zds_config.get("matomo_site_id", 4),
-        "matomoUrl": zds_config.get("matomo_url", "https://matomo.zestedesavoir.com"),
-        "matomoTokenAuth": zds_config.get("matomo_token_auth", ""),
+        "matomo_site_id": zds_config.get("matomo_site_id", 4),
+        "matomo_url": zds_config.get("matomo_url", "https://matomo.zestedesavoir.com"),
+        "matomo_token_auth": zds_config.get("matomo_token_auth", ""),
         "association": {
             "name": "Zeste de Savoir",
             "fee": zds_config.get("association_fee", "20 €"),

--- a/zds/tutorialv2/views/statistics.py
+++ b/zds/tutorialv2/views/statistics.py
@@ -18,9 +18,9 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
     template_name = "tutorialv2/stats/index.html"
     form_class = ContentCompareStatsURLForm
     urls = []
-    matomo_token_auth = settings.ZDS_APP["site"]["matomoTokenAuth"]
-    matomo_api_url = "{}/index.php?token_auth={}".format(settings.ZDS_APP["site"]["matomoUrl"], matomo_token_auth)
-    matomo_site_id = settings.ZDS_APP["site"]["matomoSiteID"]
+    matomo_token_auth = settings.ZDS_APP["site"]["matomo_token_auth"]
+    matomo_api_url = "{}/index.php?token_auth={}".format(settings.ZDS_APP["site"]["matomo_url"], matomo_token_auth)
+    matomo_site_id = settings.ZDS_APP["site"]["matomo_site_id"]
     logger = logging.getLogger(__name__)
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
- Exclut /static et /media du tracking de Matomo en local 
- Met les variables de Matomo en snake_case
- Désactive le tracking de Matomo par défaut

Il n'y a pas vraiment d'intérêt à laisser Matomo actif en local donc on le désactive par défaut. Lorsqu'il est activé pour faire des tests, les fichiers statiques et les médias servis en local ne sont pas suivis.

Fix #6128