### PR TITLE
Corrige la résolution des alertes multiples

### DIFF
--- a/doc/source/front-end/elements-specifiques-au-site.rst
+++ b/doc/source/front-end/elements-specifiques-au-site.rst
@@ -480,9 +480,9 @@ Pour afficher une liste d'alertes de modération, utilisez le gabari ``misc/aler
 ``alerts``, qui doit être un itérable d'``Alert`` à afficher, ainsi que l'un ou l'autre de ces paramètres pour préciser
 vers quoi le formulaire de résolution d'alerte doit être envoyé :
 
-- ``alert_solve_url`` : un **nom** d'URL (qui doit accepter un unique paramètre ``pk`` qui sera celui de l'alerte à
+- ``alerts_solve_url`` : un **nom** d'URL (qui doit accepter un unique paramètre ``pk`` qui sera celui de l'alerte à
   résoudre et qui doit être appelable en ``POST``) ; ou
-- ``alert_solve_link`` : une URL qui sera utilisée telle quelle pour toutes les alertes, et qui doit être appelable en
+- ``alerts_solve_link`` : une URL qui sera utilisée telle quelle pour toutes les alertes, et qui doit être appelable en
   ``POST`` également.
 
 Si aucun de ces paramètres n'est renseigné, le formulaire sera envoyé en ``POST`` vers la page courante.
@@ -496,7 +496,7 @@ Le formulaire transmettra les champs suivants :
 .. sourcecode:: html+django
 
    <h2>{% trans "Signalements du profil" %}</h2>
-   {% include "misc/alerts.part.html" with alerts=alerts alert_solve_url='solve-profile-alert' %}
+   {% include "misc/alerts.part.html" with alerts=alerts alerts_solve_url='solve-profile-alert' %}
 
 .. figure:: ../images/design/alerts.png
    :align: center

--- a/templates/forum/post/new.html
+++ b/templates/forum/post/new.html
@@ -66,7 +66,7 @@
                 {% url 'api:forum:post-karma' message.pk %}
             {% endcaptureas %}
 
-            {% captureas alert_solve_link %}
+            {% captureas alerts_solve_link %}
                 {% url "forum-solve-alert" %}
             {% endcaptureas %}
 

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -113,7 +113,7 @@
             {% url 'api:forum:post-karma' message.pk %}
         {% endcaptureas %}
 
-        {% captureas alert_solve_link %}
+        {% captureas alerts_solve_link %}
             {% url "forum-solve-alert" %}
         {% endcaptureas %}
 

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -909,7 +909,7 @@
             {% if perms.member.change_profile and alerts %}
                 <section id="alerts">
                     <h2 itemprop="name">{% trans "Signalements du profil" %}</h2>
-                    {% include "misc/alerts.part.html" with alerts=alerts alert_solve_url='solve-profile-alert' %}
+                    {% include "misc/alerts.part.html" with alerts=alerts alerts_solve_url='solve-profile-alert' %}
                 </section>
             {% endif %}
 

--- a/templates/misc/alerts.part.html
+++ b/templates/misc/alerts.part.html
@@ -1,16 +1,19 @@
 {% load date %}
 {% load i18n %}
+{% load set %}
 
 {# Parameters #}
 {# alerts - an iterable of alerts to display #}
 {# then one of: #}
-{# alert_solve_url - the *name* of the URL to solve the alert; must accept a single pk argument #}
-{# alert_solve_link - the link (already resolved) where the form should be sent (an hidden field with the alert pk will be available) #}
+{# alerts_solve_url - the *name* of the URL to solve the alert; must accept a single pk argument #}
+{# alerts_solve_link - the link (already resolved) where the form should be sent (an hidden field with the alert pk will be available) #}
 {# if none of them are set, the solve form action will be the current page #}
 
 {% for alert in alerts %}
-    {% if alert_solve_url and not alert_solve_link %}
-        {% url alert_solve_url alert.pk as alert_solve_link %}
+    {% if alerts_solve_url and not alerts_solve_link %}
+        {% url alerts_solve_url alert.pk as alert_solve_link %}
+    {% else %}
+        {% set alerts_solve_link as alert_solve_link %}
     {% endif %}
 
     <aside class="moderation-alert{% if alert.solved %} is-solved{% endif %}">

--- a/templates/misc/message.part.html
+++ b/templates/misc/message.part.html
@@ -331,7 +331,7 @@
         </div>
 
         {% if perms_change %}
-            {% include "misc/alerts.part.html" with alerts=message.alerts_on_this_comment.all alert_solve_link=alert_solve_link %}
+            {% include "misc/alerts.part.html" with alerts=message.alerts_on_this_comment.all alerts_solve_link=alerts_solve_link %}
         {% endif %}
 
         <div class="message-bottom">

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -108,7 +108,7 @@
 {% block content %}
     {% if is_staff %}
         <div class="opinion-alerts">
-            {% include "misc/alerts.part.html" with alerts=alerts alert_solve_url='content:resolve-content' %}
+            {% include "misc/alerts.part.html" with alerts=alerts alerts_solve_url='content:resolve-content' %}
         </div>
     {% endif %}
 
@@ -387,7 +387,7 @@
             {% url "api:content:reaction-karma" message.pk %}
         {% endcaptureas %}
 
-        {% captureas alert_solve_link %}
+        {% captureas alerts_solve_link %}
             {% url "content:resolve-reaction" %}
         {% endcaptureas %}
         {% captureas alert_link %}


### PR DESCRIPTION
Actuellement lorsqu'il y a deux alertes ou plus sur un profil, on ne peut résoudre que la première. Au premier tout de boucle, la variable `alert_solve_link` prend la valeur de `{% url alert_solve_url alert.pk %}`. Au deuxième tour de boucle, `alert_solve_link` existe déjà donc cette valeur ne change pas, ce qui rend impossible de résoudre les alertes suivantes. J'ai donc séparé la variable `alert_solve_link` en deux : 

- `alerts_solve_link` pour le lien qui permet de résoudre toutes les alertes et qui ne change pas à chaque tour de boucle ;
- `alert_solve_link` pour résoudre l'alerte en question, dont la valeur ne change pas si elle provient de `alerts_solve_link` mais change à chaque tour si elle provient de `alerts_solve_url`.

J'ai renommé `alert_solve_url` en `alerts_solve_url` pour rendre le code plus intelligible : les variables `alerts_*` sont fixées à chaque appel de `misc/alerts.part.html`, tandis que les variables `alert_*` sont fixées à chaque tour de boucle.

Fixes #6131 

**Reproduction du bogue en local**

- Créer deux alertes sur un profil
- Vérifier que la première peut se résoudre mais pas la seconde

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Créer deux alertes sur un profil
- Vérifier que les deux alertes peuvent bien se résoudre
- Vérifier que les alertes sur les autres pages fonctionnent bien (message, commentaire, contenu)