### PR TITLE
Corrige une marge sur une liste de tutos/articles de la bibliothèque

### DIFF
--- a/assets/scss/components/_pagination.scss
+++ b/assets/scss/components/_pagination.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-wrap: wrap;
 
-    margin: $length-20 0 0;
+    margin: $length-20 0 $length-20;
 
     padding: 0;
 

--- a/assets/scss/components/_pagination.scss
+++ b/assets/scss/components/_pagination.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-wrap: wrap;
 
-    margin: $length-20 0;
+    margin: $length-20 0 0;
 
     padding: 0;
 

--- a/assets/scss/pages/_flexpage.scss
+++ b/assets/scss/pages/_flexpage.scss
@@ -24,7 +24,7 @@ $content-width: 1145px;
 
     .flexpage-wrapper {
         max-width: $content-width;
-        margin: 0 auto;
+        margin: 0 auto $length-20;
     }
 
     .flexpage-header {


### PR DESCRIPTION
Fix #6109.

Cette PR corrige un petit bug graphique dans une liste de tuto/articles de la bilbiothèque quand on liste sur un type de contenu dans une sous-catégorie.

### Contrôle qualité

- s'arranger pour avoir une page de tutos dans la même sous-catégorie _sans_ pagination (possible de jouer avec le paramètre dans le backend `content_per_page`, le type d'URL concerné est le suivant :  `http://localhost:8000/bibliotheque/?subcategory=00-etude&type=tutorial`  ;
- vérifier que l'affichage est bon (pas de vignette collée en bas) ;
- s'arranger pour avoir de la pagination ;
- vérifier que l'affichage est identique à l'actuel (pas de marges supplémentaires introduite par cette PR).