### PR TITLE
Améliore la barre d'outils du nouvel éditeur

### DIFF
--- a/assets/scss/components/_editor-new.scss
+++ b/assets/scss/components/_editor-new.scss
@@ -8,21 +8,29 @@
 
         .editor-toolbar {
             border: 0;
+            background-color: $color-body-background;
 
+            /* Let the toolbar stay on screen when writing long texts */
+            /* Disabled on mobile or when the editor is fullscreen */
             @include tablet {
-                position: sticky;
-                top: 0;
-                z-index: 2;
-                background-color: $color-body-background;
-                border-bottom: $length-1 solid $grey-200;
+                &:not(.fullscreen) {
+                    position: sticky;
+                    z-index: 2;
 
-                @at-root body.has-top-banner & {
-                    top: $length-24;
-                }
+                    top: 0;
+                    @at-root body.has-top-banner & {
+                        top: $length-24;
+                    }
 
-                ~ .CodeMirror {
-                    border-top: 0;
+                    border-bottom: $length-1 solid $grey-200;
+                    ~ .CodeMirror {
+                        border-top: 0;
+                    }
                 }
+            }
+
+            &.fullscreen {
+                z-index: 22; /* needs to be above #very-top-banner (_very-top-banner.scss) */
             }
 
             &.disabled-for-textarea-mode {

--- a/assets/scss/components/_very-top-banner.scss
+++ b/assets/scss/components/_very-top-banner.scss
@@ -20,7 +20,7 @@
     border-color: var(--very-top-banner-border-color);
     color: var(--very-top-banner-color);
 
-    z-index: 21;
+    z-index: 21; /* needs to be below .editor-toolbar (_editor-new.scss) */
 
     span {
         flex: 12;


### PR DESCRIPTION
La barre d'outils est visible en plein écran et passe au dessus de la bannière d'information lorsqu'elle est présente. Lorsqu'elle n'est pas en plein écran et lorsqu'on n'est pas sur un téléphone, elle reste toujours à l'écran (sticky) même lorsqu'on écrit un texte très long.

Fixes #6137 

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que la barre d'outils est visible en plein écran
- Vérifier que la barre d'outils reste visible à l'écran même lorsqu'on écrit un texte très long