### PR TITLE
Utilise la même version de KaTeX que zmarkdown

### DIFF
--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "10.1.1"
+    "zmarkdown": "10.1.2"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
Utilise la même version de KaTeX que zmarkdown

[Sujet sur le forum](https://zestedesavoir.com/forums/sujet/15460/la-police-des-maths/)

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Écrire un message contenant `$a$` et vérifier que l'on obtient bien la lettre `a` en italique