### PR TITLE
Corrige le lien de contribution technique de la page « À propos »

### DIFF
--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -26,8 +26,8 @@
 {% block content %}
     {% set app.site.literal_name as site_name %}
     <p>
-        {% blocktrans with repository=app.site.repository.url %}
-            Si vous vous intéressez à tout cela, vous devriez songer à <a href="{{ repository }}">contribuer au développement du site</a> !
+        {% blocktrans %}
+            Si vous vous intéressez à tout cela, vous devriez songer à <a href="{{ default_repository_url }}">contribuer au développement du site</a> !
         {% endblocktrans %}
     </p>
 

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -17,6 +17,7 @@ from zds.member.decorator import can_write_and_read_now
 from zds.pages.models import GroupContact
 from zds.searchv2.forms import SearchForm
 from zds.tutorialv2.models.database import PublishableContent, PublishedContent
+from zds.utils.context_processor import get_repository_url
 from zds.utils.models import Alert, CommentEdit, Comment
 
 
@@ -58,7 +59,15 @@ def index(request):
 
 def about(request):
     """Display many informations about the website."""
-    return render(request, "pages/about.html")
+    return render(
+        request,
+        "pages/about.html",
+        {
+            "default_repository_url": get_repository_url(
+                settings.ZDS_APP["github_projects"]["default_repository"], "base_url"
+            ),
+        },
+    )
 
 
 def association(request):


### PR DESCRIPTION
Corrige le lien de contribution technique de la page « À propos »

[Bug reporté par romantik sur le forum](https://zestedesavoir.com/forums/sujet/15595/bug-lien-de-contribution-casse/)

Régression de #6084

**QA :**

- `source zdsenv/bin/activate && make update && make run-back`
- Aller sur la page « À propos » et vérifier que le lien « contribuer au développement du site » fonctionne correctement
