### PR TITLE
Vérifie que le champ CSRF existe avant de récupérer sa valeur

### DIFF
--- a/assets/js/common/ajax.js
+++ b/assets/js/common/ajax.js
@@ -5,13 +5,21 @@
  */
 class ZDSAjax {
   constructor() {
-    this._crsf = document.querySelector("input[name='csrfmiddlewaretoken']").getAttribute('value')
+    const csrfInput = document.querySelector("input[name='csrfmiddlewaretoken']")
+    if (csrfInput !== null) {
+      this._crsf = csrfInput.getAttribute('value')
+    }
+    else {
+      this._csrf = null
+    }
   }
 
   get(url, dataCallback, errorCallback = (error) => console.error(error)) {
     const headers = new Headers()
     headers.append('Accept', 'application/json')
-    headers.append('X-CSRFToken', this._crsf)
+    if (this._csrf !== null) {
+      headers.append('X-CSRFToken', this._crsf)
+    }
     headers.append('X-REQUESTED-WITH', 'XMLHttpRequest')
     const init = {
       method: 'GET',
@@ -38,7 +46,9 @@ class ZDSAjax {
   _sendRequestWithData(jsonOrFormData, method, url, dataCallback, errorCallback) {
     const headers = new Headers()
     headers.append('Accept', 'application/json')
-    headers.append('X-CSRFToken', this._crsf)
+    if (this._csrf !== null) {
+      headers.append('X-CSRFToken', this._crsf)
+    }
     headers.append('X-REQUESTED-WITH', 'XMLHttpRequest')
     const init = {
       method: method,


### PR DESCRIPTION
Les modifications apportées par le commit 20b81c14ba cherchent à récupérer la valeur du champ contenant le token CSRF. Si ce champ n'existe pas, comme c'est le cas lorsqu'on n'est pas connecté sur les pages ne contenant pas de formulaire en POST (par exemple: la page d'accueil), une erreur JavaScript est produite, empêchant l'exécution des autres scripts.

Cette PR corrige le problème.

## QA

- `make build-front`
- Sur la page d'accueil, en étant déconnecté, il n'y a pas d'erreur JavaScript
- Créer un tuto et jouer avec les bouton d'ajouts et de retraits des demandes d'aide (pour vérifier que le script JavaScript modifié fonctionne toujours, il me semble que c'est pour l'instant le seul endroit où il est utilisé).
