### PR TITLE
Réduit la verbosité des logs de l'environnement de dev

### DIFF
--- a/zds/settings/dev.py
+++ b/zds/settings/dev.py
@@ -66,7 +66,7 @@ LOGGING = {
             "propagate": False,
         },
         "zds": {
-            "level": "DEBUG",  # Important because the default level is 'WARNING' or something like that
+            "level": "INFO",
             "handlers": ["console"],
         },
     },


### PR DESCRIPTION
Utilise la valeur par défaut de verbosité au lieu de DEBUG, qui affiche les (trop) nombreux messages de conversion de zMarkdown.

## QA

Lancer le site et se balader dessus, constater que le niveau de verbosité des informations affichées sur la console est satisfaisant (les messages de conversion de zmd n’apparaissent plus).
