### PR TITLE
Crée toujours la catégorie mère d'une sous-categorie

### DIFF
--- a/zds/tutorialv2/tests/tests_lists.py
+++ b/zds/tutorialv2/tests/tests_lists.py
@@ -119,7 +119,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         context_categories = list(resp.context_data["categories"])
         self.assertEqual(context_categories[0].contents_count, 10)
         self.assertEqual(context_categories[0].subcategories, [subcategory_1, subcategory_2])
-        self.assertEqual(context_categories, [category_1])
+        self.assertIn(category_1, context_categories)
 
     def test_private_lists(self):
         tutorial = PublishedContentFactory(author_list=[self.user_author])

--- a/zds/utils/factories.py
+++ b/zds/utils/factories.py
@@ -80,9 +80,11 @@ class SubCategoryFactory(factory.django.DjangoModelFactory):
 
         subcategory = super()._generate(create, attrs)
 
-        if category is not None:
-            relation = CategorySubCategory(category=category, subcategory=subcategory)
-            relation.save()
+        if category is None:
+            category = CategoryFactory()
+
+        relation = CategorySubCategory(category=category, subcategory=subcategory)
+        relation.save()
 
         return subcategory
 


### PR DESCRIPTION
La classe qui construit les données de tests des sous-catégories ne construit pas de catégorie parente. Cela pose un problème quand on cherche à consulter une sous-catégorie orpheline. Cette PR corrige ce problème.

## QA

1. Générer un nouvelle base de données avec le jeu de données de test: `make new-db` (attention: cela efface toutes les données existantes du site !)
2. Consulter un tutoriel, article ou billet qui a comme sous-catégorie `Sous-Categorie n pour Tuto`
3. Cliquer sur le lien de cette sous-catégorie: il n'y a pas d'erreur, la page attendue s'affiche bien. (le comportement précédent était une erreur 500)
