### PR TITLE
Gère plus d'erreurs possibles venant de Matomo

### DIFF
--- a/templates/tutorialv2/stats/index.html
+++ b/templates/tutorialv2/stats/index.html
@@ -40,17 +40,19 @@
                     {% endblocktrans %}
             {% endif %}
         </h2>
-        <!-- Tab links -->
-        <div class="tab">
-            <span class="tablinks" tabindex="0" id="tab-view-graph">{% trans "Pages vues" %}</span>
-            <span class="tablinks" tabindex="0" id="tab-visit-time-graph">{% trans "Temps moyen de lecture" %}</span>
-            <span class="tablinks" tabindex="0" id="tab-users-graph">{% trans "Nombre de visiteurs uniques" %}</span>
-        </div>
-        <!-- Tab content -->
-        {% include "misc/graph.part.html" with tab_name="tab-view-graph-content" graph_title="Évolution des pages vues sur le contenu" canvas_id="view-graph" report_key="nb_hits" y_label="Nombre de pages" %}
-        {% include "misc/graph.part.html" with tab_name="tab-visit-time-graph-content" graph_title="Évolution du temps moyen lecture (en secondes)" canvas_id="visit-time-graph" report_key="avg_time_on_page" y_label="Secondes" %}
-        {% include "misc/graph.part.html" with tab_name="tab-users-graph-content" graph_title="Évolution du nombre de visiteurs uniques" canvas_id="users-graph" report_key="nb_uniq_visitors" y_label="Nombre de visiteurs" %}
 
+        {% if reports %}
+            <!-- Tab links -->
+            <div class="tab">
+                <span class="tablinks" tabindex="0" id="tab-view-graph">{% trans "Pages vues" %}</span>
+                <span class="tablinks" tabindex="0" id="tab-visit-time-graph">{% trans "Temps moyen de lecture" %}</span>
+                <span class="tablinks" tabindex="0" id="tab-users-graph">{% trans "Nombre de visiteurs uniques" %}</span>
+            </div>
+            <!-- Tab content -->
+            {% include "misc/graph.part.html" with tab_name="tab-view-graph-content" graph_title="Évolution des pages vues sur le contenu" canvas_id="view-graph" report_key="nb_hits" y_label="Nombre de pages" %}
+            {% include "misc/graph.part.html" with tab_name="tab-visit-time-graph-content" graph_title="Évolution du temps moyen lecture (en secondes)" canvas_id="visit-time-graph" report_key="avg_time_on_page" y_label="Secondes" %}
+            {% include "misc/graph.part.html" with tab_name="tab-users-graph-content" graph_title="Évolution du nombre de visiteurs uniques" canvas_id="users-graph" report_key="nb_uniq_visitors" y_label="Nombre de visiteurs" %}
+        {% endif %}
 
         {% if cumulative_stats %}
             {% if display == 'global' %}


### PR DESCRIPTION
Cette PR gère plus d'erreurs possibles retournées par Matomo.

Actuellement, sur l'environnement de dev, consulter les statistiques d'un contenu renvoie une erreur 500 `AttributeError 'str' object has no attribute 'items'`. Cela provient du fait que Matomo renvoie des erreurs `You can't access this resource as it requires 'view' access for the website id = 4.` (ce point devra être corrigé dans une autre PR, mais autant en profiter pour gérer correctement ce cas).

J'en ai profité pour corriger quelques détails dans le code auquel j'ai touché:
- faire `data = {}` juste avant de tenter `data.get("message", ...)` n'est pas une très bonne idée...
- pas besoin de f-strings lorsqu'il n'y a rien à formater dans les chaînes de caractères

Si quelqu'un a une idée comment factoriser les deux lignes `self.logger / message.error` qui se répètent (presque identiquement) trois fois, je suis preneur.


### Contrôle qualité

Sur l'environnement de dev, aller à la page des statistiques d'un contenu: la page s'affiche, sans erreur 500.

Comme toujours pour les statistiques, il faudra s'assurer sur la bêta que ça fonctionne bien, même lorsque des statistiques sont disponibles.
