### PR TITLE
Petites corrections pour l'installation de l'env de dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ install-back-with-prod:
 	pip install --upgrade -r requirements-dev.txt -r requirements-prod.txt
 
 run-back: zmd-check ## Run the backend server
-	python manage.py runserver --nostatic
+	python manage.py runserver --nostatic 0.0.0.0:8000
 
 run-back-fast: zmd-check ## Run the backend server in fast mode (no debug toolbar & full browser cache)
-	python manage.py runserver --settings zds.settings.dev_fast
+	python manage.py runserver --settings zds.settings.dev_fast 0.0.0.0:8000
 
 lint-back: ## Lint Python code
 	black . --check

--- a/doc/source/install/install-docker.rst
+++ b/doc/source/install/install-docker.rst
@@ -1,0 +1,51 @@
+========================
+Installation dans Docker
+========================
+
+
+.. note::
+
+    Par manque de développeurs utilisant Docker au sein de l'équipe de
+    développement de ZdS, cette section n'est guère fournie. Les instructions
+    données ici ne le sont qu'à titre indicatif. N'hésitez pas à signaler tout
+    problème ou proposer des améliorations !
+
+L'installation de l'environnement de développement dans Docker se base sur `l'installation sous Linux <install-linux.html>`_.
+
+Lancez un shell interactif dans un conteneur basé sur Debian :
+
+.. sourcecode:: bash
+
+    docker run -it -p 8000:8000 debian:buster
+
+
+Une fois dans le conteneur, saisissez les commandes suivantes :
+
+.. sourcecode:: bash
+
+    # On se place dans le $HOME
+    cd
+
+    # Permet d'utiliser correctement apt
+    DEBIAN_FRONTEND=noninteractive
+
+    # Installez les paquets minimaux requis
+    apt update
+    apt install sudo make vim git
+
+    # Clonez le dépôt de ZdS
+    git clone https://github.com/<votre login>/zds-site.git
+    cd zds-site/
+
+    # Installez ZdS
+    make install-linux
+
+    # Nécessaire pour avoir nvm dans le PATH
+    source ../.bashrc
+
+    # À partir de maintenant, les commandes ne sont plus spécifiques à l'utilisation de Docker.
+
+    # Lancement de ZdS
+    source zdsenv/bin/activate
+    make zmd-start
+    make run-back

--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -15,7 +15,10 @@ Pour installer une version locale de ZdS sur GNU/Linux, veuillez suivre les inst
     - Si malgré tout vous ne parvenez pas à installer ZdS, n'hésitez pas à ouvrir `un sujet sur le forum <https://zestedesavoir.com/forums/sujet/nouveau/?forum=2>`_
 
 
-Après avoir cloné, installer ZdS sous Linux est relativement simple. En effet, il suffit de lancer la commande suivante (qui se chargera d'installer ce qui est nécessaire, plus d'infos ci-dessous):
+Pour installer ZdS, vous aurez besoin d'abord des programmes ``make`` et ``sudo``. S'ils ne sont pas déjà installés sur votre système, ils sont généralement disponibles dans les gestionnaires de paquets sous le même nom.
+
+
+Après avoir cloné le dépôt du code source, installer ZdS sous Linux est relativement simple. En effet, il suffit de lancer la commande suivante (qui se chargera d'installer ce qui est nécessaire, plus d'infos ci-dessous):
 
 .. sourcecode:: bash
 

--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -222,7 +222,16 @@ if ! $(_in "--force-skip-activating" $@) && [[ ( $VIRTUAL_ENV == "" || $(realpat
         echo "   - If you don't have other choice, use \`--force-skip-activating\`."
         exit 1
     fi
-else 
+
+    # Some dependencies (like rust ones) require a recent pip:
+    print_info "* upgrading pip"
+    pip install --upgrade pip; exVal=$?
+
+    if [[ $exVal != 0 ]]; then
+        print_error "!! Failed to upgrade pip"
+        exit 1
+    fi
+
     print_info "!! Add \`$(realpath $ZDS_VENV)\` in your PATH."
 
     if [ ! -d $ZDS_VENV ]; then

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -7,8 +7,11 @@ from django.utils.translation import gettext_lazy as _
 from .config import config
 from .base_dir import BASE_DIR
 
-
-INTERNAL_IPS = ("127.0.0.1",)  # debug toolbar
+# especially for debug toolbar:
+INTERNAL_IPS = (
+    "127.0.0.1",
+    "172.17.0.1",  # to enable debug toolbar when executed in a Docker container
+)
 
 DATABASES = {
     "default": {

--- a/zds/settings/dev.py
+++ b/zds/settings/dev.py
@@ -4,8 +4,7 @@ from .abstract_base import *
 
 DEBUG = True
 
-# NOTE: Can be removed once Django 3 is used
-ALLOWED_HOSTS = [".localhost", "127.0.0.1", "[::1]"]
+ALLOWED_HOSTS = ["*"]  # allow everything in case we are in a Docker container
 
 INSTALLED_APPS += (
     "debug_toolbar",


### PR DESCRIPTION
Cette PR met à jour pip dans l'environnement virtuel après sa création, pour corriger le bug #6082 et ajoute une légère doc sur l'installation dans Docker (qui répond à #6118)


### Contrôle qualité

- Relire la doc ajoutée
- Tester les commandes que j'ai indiquées pour Docker. Ça validera en même temps la correction pour la mise à jour de pip.   
    - Utiliser `debian:buster` est important, le support de `debian` (= `debian:latest` = `debian:bullseye`) n'est pas encore assuré.
    - Lors du clonage du dépôt git, vous pouvez utiliser la commande `git clone https://github.com/philippemilink/zds-site.git -b install` pour avoir directement le code de cette PR.
