### PR TITLE
Supprime les propositions de mise en Une associées à un contenu supprimer #6153 

### DIFF
--- a/zds/featured/views.py
+++ b/zds/featured/views.py
@@ -255,7 +255,11 @@ class FeaturedRequestedList(FeaturedViewMixin, ZdSPagingListView):
         if type_featured_request in FEATUREABLES.keys():
             queryset = queryset.filter(type=FEATUREABLES[type_featured_request]["name"])
 
-        return [q for q in queryset.all() if isinstance(q.content_object, Topic) or not q.content_object.is_obsolete]
+        return [
+            q
+            for q in queryset.all()
+            if q == None and (isinstance(q.content_object, Topic) or not q.content_object.is_obsolete)
+        ]
 
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)

--- a/zds/featured/views.py
+++ b/zds/featured/views.py
@@ -255,11 +255,12 @@ class FeaturedRequestedList(FeaturedViewMixin, ZdSPagingListView):
         if type_featured_request in FEATUREABLES.keys():
             queryset = queryset.filter(type=FEATUREABLES[type_featured_request]["name"])
 
-        return [
-            q
-            for q in queryset.all()
-            if q == None and (isinstance(q.content_object, Topic) or not q.content_object.is_obsolete)
-        ]
+        featured_request_list = []
+        for q in queryset.all():
+            if q.content_object is not None:
+                if isinstance(q.content_object, Topic) or not q.content_object.is_obsolete:
+                    featured_request_list.append(q)
+        return featured_request_list
 
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
Teste si un Topic est vide avant d'aller chercher des infos dessus

Numéro du ticket concerné (optionnel) :
#6153


### Contrôle qualité

1. Aller sur un contenu publié
2. Cliquer sur le bouton « Proposer la mise en Une »
3. Dépublier le contenu
4. Supprimer le contenu
5. Constater que la page `/mise-en-avant/unes/requetes/` est fonctionnelle
