### PR TITLE
Compte les commentaires non masqués

### DIFF
--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -479,13 +479,13 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
         """Count all the reactions to this content. Warning, if you did not pre process this number, \
         a query will be sent
 
-        :return: number of notes in the tutorial.
+        :return: number of notes in the content.
         :rtype: int
         """
         try:
             return self.count_note
         except AttributeError:
-            self.count_note = ContentReaction.objects.filter(related_content__pk=self.pk).count()
+            self.count_note = ContentReaction.objects.filter(related_content__pk=self.pk, is_visible=True).count()
             return self.count_note
 
     def get_last_note(self):

--- a/zds/tutorialv2/views/lists.py
+++ b/zds/tutorialv2/views/lists.py
@@ -38,10 +38,12 @@ class ListOnlineContents(ContentTypeMixin, ZdSPagingListView):
         :return: list of contents with the right type
         :rtype: list of zds.tutorialv2.models.database.PublishedContent
         """
-        sub_query = "SELECT COUNT(*) FROM {} WHERE {}={}".format(
-            "tutorialv2_contentreaction",
+        sub_query = "SELECT COUNT(*) FROM {} WHERE {}={} AND {}={} AND utils_comment.is_visible=TRUE".format(
+            "tutorialv2_contentreaction,utils_comment",
             "tutorialv2_contentreaction.related_content_id",
             "tutorialv2_publishablecontent.id",
+            "utils_comment.id",
+            "tutorialv2_contentreaction.comment_ptr_id",
         )
         queryset = PublishedContent.objects.filter(must_redirect=False)
         # this condition got more complexe with development of zep13


### PR DESCRIPTION
Cette PR permet de compter uniquement les messages non masqués sur les commentaires de contenus.

Numéro du ticket concerné : #6145 

<!-- Si certains de vos commits corrigent des bugs, il est préférable de les indiquer également dans les messages de commit en suivant ces instructions : https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Si votre pull request nécessite d’effectuer des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->


### Contrôle qualité

- Demarrez le site `make run-back` et assurez vous d'avoir généré des fixtures `generate-fixtures`
- Connectez vous avec l'utilisateur admin
- Allez dans des commentaires de contenus (billet, article, tuto) et masquez un commentaire
- Assurez vous que sur la page d'accueil, la page de la bibliothèque et la page de la tribune, que le nombre de commentaire affiché dans la bulle adéquate correspond au nombre de commentaires non masqués.

<!-- Merci ! -->
