### PR TITLE
Mise à jour triviale des dépendances Python

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 -r requirements.txt
 
 black==21.4b1  # penser à mettre à jour aussi .github/workflows/ci.yml
-colorlog==5.0.1
-django-debug-toolbar==3.2.1
+colorlog==6.4.1
+django-debug-toolbar==3.2.2
 django-extensions==3.1.3
-Faker==8.2.1
-pre-commit==2.13.0
+Faker==8.12.1
+pre-commit==2.15.0
 PyYAML==5.4.1
 selenium==3.141.0
 Sphinx==3.5.3

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -2,5 +2,5 @@
 
 gunicorn==20.1.0
 mysqlclient==2.0.3
-sentry-sdk==1.1.0
-ujson==4.0.2
+sentry-sdk==1.3.1
+ujson==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.3
 python-social-auth==0.3.6
-social-auth-app-django==4.0.0
+social-auth-app-django==5.0.0
 
 # Explicit dependencies (references in code)
 beautifulsoup4==4.9.3
-django-crispy-forms==1.11.2
+django-crispy-forms==1.12.0
 django-model-utils==4.1.1
 django-munin==0.2.1
 django-recaptcha==2.0.6
@@ -18,19 +18,19 @@ GitPython==3.1.14
 google-api-python-client==1.12.8
 homoglyphs==2.0.4
 lxml==4.6.3
-Pillow==8.2.0
+Pillow==8.3.2
 python-memcached==1.59
-requests==2.25.1
+requests==2.26.0
 toml==0.10.2
 
 # Api dependencies
-django-cors-headers==3.7.0
+django-cors-headers==3.8.0
 django-filter==2.4.0
 django-oauth-toolkit==1.5.0
 django-rest-swagger==2.2.0
 djangorestframework-xml==2.0.0
 djangorestframework==3.12.4
-drf-extensions==0.7.0
+drf-extensions==0.7.1
 dry-rest-permissions==0.1.10
 oauth2client==4.1.3
 


### PR DESCRIPTION
Mise à jour triviale des dépendances Python

D'après le *changelog* de ces dépendances, on ne devrait pas avoir de surprise en mettant à jour ces dépendances.

Je ne mets pas à jour `black`, `Sphinx`, `elasticsearch`, `elasticsearch-dsl` et `google-api-python-client` car les changements sont importants et demandent des tests plus approfondis. Je ne mets pas à jour `GitPython` car les dernières versions ne nous apportent rien d'utile et sont même instables. Je ne mets pas à jour `django-munin` car la version 0.2.2 n'existe pas.

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que le site web fonctionne correctement