### PR TITLE
Mise à jour de Black

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
   PYTHON_VERSION: "3.7"
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "2.2.0"
-  BLACK_VERSION: "21.4b1"
+  BLACK_VERSION: "21.8b0" # needs to be also updated in requirements-dev.txt and .pre-commit-config.yaml
 
   # As GitHub Action does not allow environment variables
   # to be used in services definitions, these are only for

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     -   id: pyupgrade
         args: [--py36-plus]
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.8b0 # needs to be also updated in requirements-dev.txt and .github/workflows/ci.yml
     hooks:
       - id: black
         language_version: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,5 @@
 [tool.black]
 line-length = 120
-exclude = '''
-(
-  /(
-      node_modules
-    | \.venv
-    | build
-    | dist
-    | doc
-  )/
-)
-'''
+extend-exclude = """
+^/doc
+"""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-black==21.4b1  # penser à mettre à jour aussi .github/workflows/ci.yml
+black==21.8b0  # needs to be also updated in .github/workflows/ci.yml and .pre-commit-config.yaml
 colorlog==6.4.1
 django-debug-toolbar==3.2.2
 django-extensions==3.1.3


### PR DESCRIPTION
Mise à jour de Black

Je suis passé de `exclude` à `extend-exclude` dans la configuration pour que Black exclue par défaut les fichiers et dossiers listés dans le `.gitignore`.

**QA :** Je suppose que Github Actions devrait suffire