### PR TITLE
Supprime deux dépendances non utilisées

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ easy-thumbnails==2.8rc0
 factory-boy==3.2.0
 geoip2==4.2.0
 GitPython==3.1.14
-google-api-python-client==1.12.8
 homoglyphs==2.0.4
 lxml==4.6.3
 Pillow==8.3.2
@@ -32,7 +31,6 @@ djangorestframework-xml==2.0.0
 djangorestframework==3.12.4
 drf-extensions==0.7.1
 dry-rest-permissions==0.1.10
-oauth2client==4.1.3
 
 # Dependencies for slug generation, please be extra careful with those
 django-uuslug==1.2.0

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -257,6 +257,5 @@ ZDS_APP = {
     "visual_changes": [],
     "display_search_bar": True,
     "zmd": {"server": "http://127.0.0.1:27272", "disable_pings": False},
-    "stats_ga_viewid": "ga:86962671",
     "very_top_banner": {},
 }


### PR DESCRIPTION
Supprime deux dépendances non utilisées depuis le passage de Google Analytics à Matomo

**QA :**
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que le site web fonctionne correctement