### PR TITLE
Retire des références aux versions des dépendances dans la doc

### DIFF
--- a/doc/source/install/extra-install-es.rst
+++ b/doc/source/install/extra-install-es.rst
@@ -44,13 +44,13 @@ Passez ensuite à la version 8 de java à l'aide de la commande ``alternatives -
 Installer Elasticsearch
 +++++++++++++++++++++++
 
-La procédure d'installation, si vous souhaitez utiliser Elasticsearch sans l'installer via le gestionnaire de paquets de votre distribution, est d'entrer les commandes suivantes dans votre *shell* préféré:
+La procédure d'installation, si vous souhaitez utiliser Elasticsearch sans l'installer via le gestionnaire de paquets de votre distribution, est d'entrer les commandes suivantes dans votre *shell* préféré. Remplacez ``X.Y.Z`` par la version spécifiée dans ``requirements.txt`` !
 
 .. sourcecode:: bash
 
-    wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.zip
-    unzip elasticsearch-5.5.2.zip
-    cd elasticsearch-5.5.2/
+    wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-X.Y.Z.zip
+    unzip elasticsearch-X.Y.Z.zip
+    cd elasticsearch-X.Y.Z/
 
 Pour démarrer Elasticsearch, utilisez
 
@@ -93,9 +93,14 @@ Sous Windows
 
 Elasticsearch requiert **la version 8** de Java, que vous pouvez trouver `sur la page officielle de java <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_. Prenez la version correspondante à votre système d'exploitation.
 
-Téléchargez ensuite Elasticsearch à l'adresse suivante : `https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.zip <https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.zip>`_, puis extrayez le dossier ``elasticsearch-5.5.2`` du zip à l'aide de votre outil préféré.
+Pour télécharger Elasticsearch :
 
-Pour démarer Elasticsearch, ouvrez un *shell* (ou un *powershell*) et rendez-vous dans le dossier ``elasticsearch-5.5.2``.
+* rendez-vous à l'adresse suivante : `https://www.elastic.co/fr/downloads/past-releases#elasticsearch <https://www.elastic.co/fr/downloads/past-releases#elasticsearch>`_ ;
+* choisissez la version spécifiée dans le fichier `requirements.txt` (désignée ci-après par ``X.Y.Z``);
+* téléchargez la version Windows ;
+* extrayez le dossier ``elasticsearch-X.Y.Z`` du zip à l'aide de votre outil préféré.
+
+Pour démarer Elasticsearch, ouvrez un *shell* (ou un *powershell*) et rendez-vous dans le dossier ``elasticsearch-X.Y.Z``.
 Exécutez ensuite la commande suivante :
 
 .. sourcecode:: bash
@@ -123,7 +128,7 @@ Vous devriez observer une réponse du même genre que celle-ci :
       "cluster_name" : "elasticsearch",
       "cluster_uuid" : "649S5bMUQOyRzYmQFVPA1A",
       "version" : {
-        "number" : "5.5.2",
+        "number" : "X.Y.Z",
         "build_hash" : "19c13d0",
         "build_date" : "2017-07-18T20:44:24.823Z",
         "build_snapshot" : false,

--- a/doc/source/install/extra-install-frontend.rst
+++ b/doc/source/install/extra-install-frontend.rst
@@ -8,7 +8,7 @@ Vous voulez nous aider au développement du frontend ? Installez Node.js et Yarn
 Installation de Node.js et Yarn
 ===============================
 
-Le frontend de Zeste de Savoir repose sur la version actuelle de Node.js supportée à long terme, la version 8. Vous pouvez installer Node.js 8 via `votre gestionnaire de paquet <https://nodejs.org/en/download/package-manager/>`_ (``apt``, ``yum``, …) ou en téléchargeant une `archive <https://nodejs.org/en/download/>`_.
+Le frontend de Zeste de Savoir repose sur la version de Node JS spécifiée dans ``.nvmrc``. Vous pouvez installer la version adéquate de Node.js via `votre gestionnaire de paquet <https://nodejs.org/en/download/package-manager/>`_ (``apt``, ``yum``, …) ou en téléchargeant une `archive <https://nodejs.org/en/download/>`_.
 
 Dans le cas où vous avez besoin de faire cohabiter sur votre système différentes versions de Node.js pour des projets différents, à l’instar de virtualenv ou rvm, il existe `nvm <https://github.com/creationix/nvm>`_ (Node Version Manager) qui permet d’installer plusieurs version de Node.js et de basculer d’une version à l’autre facilement.
 
@@ -17,14 +17,14 @@ Le gestionnaire de paquet ``npm`` (Node.js Package Manager) est fourni avec Node
 Vérifier que les bonnes versions sont installées
 ------------------------------------------------
 
-Pour vérifier que Node.js et yarn sont installés (et que vous avez les bonnes versions) :
+Pour vérifier que Node.js et yarn sont installés et que vous avez les bonnes versions (``X.Y.Z`` désigne la version spécifiée dans ``.nvmrc``) :
 
 .. sourcecode:: bash
 
     $ node -v
-    v8.x.x
+    vX.Y.Z
     $ yarn -v
-    0.27.x
+    X.Y.Z
 
 Si ``yarn`` n’est pas installé ou pas à jour, utilisez ``npm i -g yarn``.
 

--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -95,7 +95,7 @@ Composant ``node``
 
 Installe ``nvm`` et l'utilise pour installer ``node``, puis ``yarn``.
 Ajoute ensuite un ``.nvmrc`` dans le dossier et ajoute ``node use`` au script d'activation du *virtualenv* (pour qu'il soit automatiquement utilisé au chargement).
-La version de node installée est controlée par la variable d'environement ``ZDS_NODE_VERSION`` (dont la valeur est par défaut ``10.8.0``).
+La version de node installée est controlée par la variable d'environement ``ZDS_NODE_VERSION`` (dont la valeur est par défaut celle spécifiée dans ``.nvmrc``).
 
 Si vous ne souhaitez pas utiliser ce composant, il vous faut tout de même installer les outils du front-end manuellement. Pour cela, rendez-vous sur `la documentation dédiée au frontend <frontend-install.html>`_.
 
@@ -154,7 +154,7 @@ Composant ``elastic-local``
 
 Installe une version **locale** d'Elasticsearch dans un dossier ``.local`` situé dans le dossier de ZdS.
 La commande ``elasticsearch`` est ensuite ajoutée dans le *virtualenv*, de telle sorte à ce que ce soit cette version locale qui soit utilisée.
-La version d'Elasticsearch installée est controlée par la variable d'environement ``ZDS_ELASTIC_VERSION`` (dont la valeur est par défaut ``5.5.2``).
+La version d'Elasticsearch installée est controlée par la variable d'environement ``ZDS_ELASTIC_VERSION`` (voir ``scripts/define_variable.sh`` pour la valeur par défaut).
 
 Notez que vous pouvez choisir d'installer Elasticsearch manuellement, `comme décrit ici <./extra-install-es.html#sous-linux>`_.
 

--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -81,21 +81,21 @@ La liste des packages vous est donnée ci-dessous (pour Debian), si vous utilise
 Composant ``virtualenv``
 ========================
 
-Installe le *virtualenv* qui est un environement python cloisonné prévu pour ne pas interférer avec d'autres installation de python (`plus d'infos ici <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_).
+Installe le *virtualenv* qui est un environnement python cloisonné prévu pour ne pas interférer avec d'autres installation de python (`plus d'infos ici <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_).
 Ce que fait ce composant est tout simplement:
 
 .. sourcecode:: bash
 
     python3 -m venv $ZDS_VENV
 
-Le nom du *virtualenv* est donc controlé par la variable d'environement ``ZDS_VENV`` (dont la valeur est par défaut ``zdsenv``).
+Le nom du *virtualenv* est donc controlé par la variable d'environnement ``ZDS_VENV`` (dont la valeur est par défaut ``zdsenv``).
 
 Composant ``node``
 ==================
 
 Installe ``nvm`` et l'utilise pour installer ``node``, puis ``yarn``.
 Ajoute ensuite un ``.nvmrc`` dans le dossier et ajoute ``node use`` au script d'activation du *virtualenv* (pour qu'il soit automatiquement utilisé au chargement).
-La version de node installée est controlée par la variable d'environement ``ZDS_NODE_VERSION`` (dont la valeur est par défaut celle spécifiée dans ``.nvmrc``).
+La version de node installée est controlée par la variable d'environnement ``ZDS_NODE_VERSION`` (dont la valeur est par défaut celle spécifiée dans ``.nvmrc``).
 
 Si vous ne souhaitez pas utiliser ce composant, il vous faut tout de même installer les outils du front-end manuellement. Pour cela, rendez-vous sur `la documentation dédiée au frontend <frontend-install.html>`_.
 
@@ -154,7 +154,7 @@ Composant ``elastic-local``
 
 Installe une version **locale** d'Elasticsearch dans un dossier ``.local`` situé dans le dossier de ZdS.
 La commande ``elasticsearch`` est ensuite ajoutée dans le *virtualenv*, de telle sorte à ce que ce soit cette version locale qui soit utilisée.
-La version d'Elasticsearch installée est controlée par la variable d'environement ``ZDS_ELASTIC_VERSION`` (voir ``scripts/define_variable.sh`` pour la valeur par défaut).
+La version d'Elasticsearch installée est controlée par la variable d'environnement ``ZDS_ELASTIC_VERSION`` (voir ``scripts/define_variable.sh`` pour la valeur par défaut).
 
 Notez que vous pouvez choisir d'installer Elasticsearch manuellement, `comme décrit ici <./extra-install-es.html#sous-linux>`_.
 
@@ -171,7 +171,7 @@ Indépendament, le composant composant ``latex-template`` installe (ou met à jo
 Ce composant peut donc être utilisé même si vous avez installé TeX Live par d'autres moyens.
 
 Ces deux composants reposent sur des scripts situés dans `le dépot du template LaTeX <https://github.com/zestedesavoir/latex-template>`_.
-Le dépot installé est controlé par la variable d'environement ``ZDS_LATEX_REPO`` (dont la valeur est l'url actuelle du dépôt sur Github).
+Le dépot installé est controlé par la variable d'environnement ``ZDS_LATEX_REPO`` (dont la valeur est l'url actuelle du dépôt sur Github).
 
 .. note::
 


### PR DESCRIPTION
La documentation présente des références à des versions des dépendances. Je les retire pour renvoyer vers les sources de référence (.nvmrc, requirements.txt, etc.).

Numéro du ticket concerné (optionnel) : fix #6164

Je me suis basé sur les pages de doc mentionnées dans #5861, mais par rapport à cette PR, je n'ai pas modifié `packages.json` ni le script d'installation Windows.

### Contrôle qualité

* Générer la doc.
* Regarder qu'elle rend correctement.
* Vérifier que le propos est toujours cohérent.
* Vérifier qu'il n'y a pas d'erreur majeure ou de références à des versions qui traînerait de manière trop visible.