### PR TITLE
[Django 3.2] Remplace python-memcached par PyMemcacheCache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ google-api-python-client==1.12.8
 homoglyphs==2.0.4
 lxml==4.6.3
 Pillow==8.3.2
-python-memcached==1.59
+pymemcache==3.5.0
 requests==2.26.0
 toml==0.10.2
 

--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -52,7 +52,7 @@ EMAIL_PORT = 25
 
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
         "LOCATION": "127.0.0.1:11211",
     }
 }


### PR DESCRIPTION
Remplace python-memcached par PyMemcacheCache

**À fusionner lors du passage à Django 3.2**

> **Changed in Django 3.2:** Le moteur PyMemcacheCache a été ajouté.

> **Obsolète depuis la version 3.2:** Le moteur MemcachedCache est obsolète car python-memcached présente quelques problèmes et ne semble actuellement plus maintenu. Utilisez plutôt PyMemcacheCache ou PyLibMCCache.

**QA :** Vérifier le bon fonctionnement du cache sur la bêta