### PR TITLE
Cache les boutons éditer et citer pour les messages des MPs avec une seule personne

### DIFF
--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -58,13 +58,15 @@
 
     <div>
         {% for message in posts %}
-            {% captureas edit_link %}
-                {% url "private-posts-edit" topic.pk topic.slug message.pk %}
-            {% endcaptureas %}
+            {% if not topic.one_participant_remaining %}
+                {% captureas edit_link %}
+                    {% url "private-posts-edit" topic.pk topic.slug message.pk %}
+                {% endcaptureas %}
 
-            {% captureas cite_link %}
-                {% url "private-posts-new" topic.pk topic.slug %}?cite={{ message.pk }}
-            {% endcaptureas %}
+                {% captureas cite_link %}
+                    {% url "private-posts-new" topic.pk topic.slug %}?cite={{ message.pk }}
+                {% endcaptureas %}
+            {% endif %}
 
             {% captureas unread_link %}
                 {% url "private-post-unread" %}?message={{ message.pk }}


### PR DESCRIPTION
Fix #6104

Cache les boutons Éditer et Citer des messages d'un MP avec une seule personne (conversation avec un bot ou si tous les correspondant ont quitter le MP). En plus ce qui est rapporté dans l'issue, cliquer sur le bouton Citer n'avait en effet aucune action, mais provoquait en plus une erreur JavaScript ! J'ai aussi caché le bouton Éditer, car dans ce cas, l'édition du message est juste un textarea désactivé, sans aucune explication sur pourquoi on ne peut pas éditer le message (j'ai du fouiller dans le code pour voir que c'est désactivé si on est seul dans le MP).

## QA

- Dans un MP où est on tout seul (le plus simple est que user2 envoie un MP à user1, user1 quitte le MP, puis consulter le MP avec user2): il n'y a pas de bouton Citer et Éditer pour le message
- Dans un MP à plusieurs, les boutons sont bien présents.
