### PR TITLE
Grise les boutons de comparaisons de versions si elles sont identiques

### DIFF
--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -498,27 +498,54 @@
         {# END ONLINE VERSION #}
 
         {% if content.sha_public %}
-            <li>
-                <a href="{% url "content:diff" content.pk content.slug_repository %}?from={{ content.sha_public }}&amp;to={% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}" class="ico-after history blue">
-                    {% trans "Comparer avec la version en ligne" %}
-                </a>
-            </li>
+            {# interpreted as:  (version and (content.sha_public != version)) or ((not version) and (content.sha_public != content.sha_draft)) #}
+            {% if version and content.sha_public != version or not version and content.sha_public != content.sha_draft %}
+                <li>
+                    <a href="{% url "content:diff" content.pk content.slug_repository %}?from={{ content.sha_public }}&amp;to={% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}" class="ico-after history blue">
+                        {% trans "Comparer avec la version en ligne" %}
+                    </a>
+                </li>
+            {% else %}
+                <li class="inactive">
+                    <span class="ico-after history disabled">
+                        {% trans "Comparer avec la version en ligne (identique)" %}
+                    </a>
+                </li>
+            {% endif %}
         {% endif %}
 
         {% if content.sha_beta %}
-            <li>
-                <a href="{% url "content:diff" content.pk content.slug_repository %}?from={{ content.sha_beta }}&amp;to={% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}" class="ico-after history blue">
-                    {% trans "Comparer avec la bêta" %}
-                </a>
-            </li>
+            {# interpreted as:  (version and (content.sha_beta != version)) or ((not version) and (content.sha_beta != content.sha_draft)) #}
+            {% if version and content.sha_beta != version or not version and content.sha_beta != content.sha_draft %}
+                <li>
+                    <a href="{% url "content:diff" content.pk content.slug_repository %}?from={{ content.sha_beta }}&amp;to={% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}" class="ico-after history blue">
+                        {% trans "Comparer avec la bêta" %}
+                    </a>
+                </li>
+            {% else %}
+                <li class="inactive">
+                    <span class="ico-after history disabled">
+                        {% trans "Comparer avec la bêta (identique)" %}
+                    </a>
+                </li>
+            {% endif %}
         {% endif %}
 
         {% if content.in_validation %}
-            <li>
-                <a href="{% url "content:diff" content.pk content.slug_repository %}?from={{ validation.version }}&amp;to={% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}" class="ico-after history blue">
-                    {% trans "Comparer avec la version en validation" %}
-                </a>
-            </li>
+            {# interpreted as:  (version and (validation.version != version)) or ((not version) and (validation.version != content.sha_draft)) #}
+            {% if version and validation.version != version or not version and validation.version != content.sha_draft %}
+                <li>
+                    <a href="{% url "content:diff" content.pk content.slug_repository %}?from={{ validation.version }}&amp;to={% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}" class="ico-after history blue">
+                        {% trans "Comparer avec la version en validation" %}
+                    </a>
+                </li>
+            {% else %}
+                <li class="inactive">
+                    <span class="ico-after history disabled">
+                        {% trans "Comparer avec la version en validation (identique)" %}
+                    </a>
+                </li>
+            {% endif %}
         {% endif %}
 
         {# HISTORY #}

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -221,7 +221,7 @@ class SingleContentFormViewMixin(SingleContentViewMixin, ModalFormView):
 
 class SingleContentDetailViewMixin(SingleContentViewMixin, DetailView):
     """
-    This enhanced DetailView ensure,
+    This enhanced DetailView ensures,
 
     - by rewriting `get()`, that:
         * `self.object` contains the result of `get_object()` (as it must be if `get()` is not rewritten)


### PR DESCRIPTION
Fix #6105

Grise les boutons de comparaisons des contenus sur les versions à comparer sont identiques.

### Contrôle qualité

Le plus simple est de se créer, en tant qu'admin pour pouvoir tout faire depuis un unique compte, un article avec de nombreuses versions (créez une section, ajoutez un mot à chaque fois par exemple), et utiliser une version différente du contenu pour la mise en ligne, la validation et la bêta. En détails, voici comment j'ai fait ma QA:
1. Créer l'article, mettre tout de suite une licence et créer toutes les nombreuses versions.
2. Aller regarder l'historique des versions et activer la bêta pour une version. On arrive sur la page du contenu en bêta, on ne doit pas pouvoir comparer avec la version en bêta
3. Sélectionner une autre version du contenu: on peut comparer avec la version en bêta
4. Mettre cette version en validation. On arrive sur la page du contenu en validation, on ne peut pas comparer avec la version du contenu en validation, mais on peut comparer avec la version en bêta.
5. Valider la version en validation. On ne peut pas comparer avec la version en ligne ou en validation.
6. Faire encore des changements et renvoyer en validation, pour voir qu'on peut comparer la version en validation avec la version en ligne.

Bref, faites-vous un historique avec différentes versions, consultez les différentes versions et vérifiez que l'état des boutons pour comparer est correct.

Exemple de mon tableau d'historique une fois que j'ai fini de tester (oui, j'ai oublié d'ajouter la licence tout de suite au début...) :
![image](https://user-images.githubusercontent.com/5911232/135712063-3aea6271-d225-4590-9ba0-9460ff682f0b.png)
