### PR TITLE
Utilise le KaTeX de zmd pour ZdS

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -175,7 +175,7 @@ function spriteImages() {
 
 // Prepares files for zmarkdown
 function prepareZmd() {
-  return gulp.src(['node_modules/katex/dist/{katex.min.css,fonts/*}'])
+  return gulp.src(['zmd/node_modules/katex/dist/{katex.min.css,fonts/*}'])
     .pipe(gulp.dest('dist/css/'))
 }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "gulp-terser-js": "5.1.2",
     "gulp.spritesmith": "6.12.1",
     "jquery": "3.6.0",
-    "katex": "0.11.1",
     "moment": "2.29.1",
     "normalize.css": "8.0.1",
     "postcss": "8.3.0"

--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -434,6 +434,19 @@ if  ! $(_in "-back" $@) && ( $(_in "+back" $@) || $(_in "+base" $@) || $(_in "+f
 fi
 
 
+# zmd (zmd has to be installed before the build the front)
+if  ! $(_in "-zmd" $@) && ( $(_in "+zmd" $@) || $(_in "+base" $@) || $(_in "+full" $@) ); then
+    print_info "* [+zmd] install zmarkdown dependencies" --bold
+
+    make zmd-install; exVal=$?
+
+    if [[ $exVal != 0 ]]; then
+        print_error "!! Cannot install zmd (use \`-zmd\` to skip)"
+        exit 1
+    fi
+fi
+
+
 # install front
 if  ! $(_in "-front" $@) && ( $(_in "+front" $@) || $(_in "+base" $@) || $(_in "+full" $@) ); then
     print_info "* [+front] install front dependencies & build front" --bold
@@ -453,19 +466,6 @@ if  ! $(_in "-front" $@) && ( $(_in "+front" $@) || $(_in "+base" $@) || $(_in "
 
     if [[ $exVal != 0 ]]; then
         print_error "!! Cannot build-front (use \`-front\` to skip)"
-        exit 1
-    fi
-fi
-
-
-# zmd
-if  ! $(_in "-zmd" $@) && ( $(_in "+zmd" $@) || $(_in "+base" $@) || $(_in "+full" $@) ); then
-    print_info "* [+zmd] install zmarkdown dependencies" --bold
-
-    make zmd-install; exVal=$?
-
-    if [[ $exVal != 0 ]]; then
-        print_error "!! Cannot install zmd (use \`-zmd\` to skip)"
         exit 1
     fi
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -983,7 +983,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.19.0, commander@^2.20.0, commander@^2.8.1:
+commander@^2.20.0, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3648,13 +3648,6 @@ just-debounce@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.1.0.tgz#2f81a3ad4121a76bc7cb45dbf704c0d76a8e5ddf"
   integrity sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==
-
-katex@0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.11.1.tgz#df30ca40c565c9df01a466a00d53e079e84ffaa2"
-  integrity sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==
-  dependencies:
-    commander "^2.19.0"
 
 keyv@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Pour être sûr d'avoir vraiment les mêmes versions dans les deux modules.

Fix #6140

### Contrôle qualité

1. `make update`
2. Videz bien votre cache navigateur
3. Créez un commentaire / post / contenu / MP qui contienne des maths, par exemple:
    ```
    Un peu de maths: $\sum_ia_i$

    $$a \cdot x^2 + b \cdot x + c = 0 \quad \Longrightarrow \quad x = \frac {-b \pm \sqrt{b^2 - 4ac}}{2a}$$
    ``` 
    Les maths doivent correctement s'afficher.

Il faut peut-être aussi vérifier que les maths sont bien rendues dans les epubs.

@Situphen J'ai vérifié dans les scripts ansible, on installe bien zmd avant de builder le front.

Par contre, en faisant la PR, j'ai été surpris que `make build-front` ne râle pas, alors que les fichiers CSS de KaTeX étaient manquants...
