### PR TITLE
Ajoute des tests et refactorise RemoveSuggestion

### DIFF
--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -11,7 +11,7 @@ from zds.utils.forms import CommonLayoutEditor, CommonLayoutVersionEditor
 from zds.utils.models import SubCategory, Licence
 from zds.tutorialv2.models import TYPE_CHOICES
 from zds.utils.models import HelpWriting
-from zds.tutorialv2.models.database import PublishableContent, ContentContributionRole
+from zds.tutorialv2.models.database import PublishableContent, ContentContributionRole, ContentSuggestion
 from django.utils.translation import gettext_lazy as _
 from zds.member.models import Profile
 from zds.tutorialv2.utils import slugify_raise_on_invalid, InvalidSlugError
@@ -1363,10 +1363,18 @@ class SearchSuggestionForm(forms.Form):
 
 class RemoveSuggestionForm(forms.Form):
 
-    pk_suggestion = forms.CharField(
+    pk_suggestion = forms.IntegerField(
         label=_("Suggestion"),
         required=True,
+        error_messages={"does_not_exist": _("La suggestion sélectionnée n'existe pas.")},
     )
+
+    def clean_pk_suggestion(self):
+        pk_suggestion = self.cleaned_data.get("pk_suggestion")
+        suggestion = ContentSuggestion.objects.filter(id=pk_suggestion).first()
+        if suggestion is None:
+            self.add_error("pk_suggestion", self.fields["pk_suggestion"].error_messages["does_not_exist"])
+        return pk_suggestion
 
 
 class ToggleHelpForm(forms.Form):

--- a/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
+++ b/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
@@ -49,7 +49,6 @@ class RemoveSuggestionPermissionTests(TutorialTestMixin, TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_authenticated_author(self):
-        # TODO: this behavior is actually wrong, it should be only authorized for staff.
         self.client.force_login(self.author)
         self.content.type = "TUTORIAL"
         self.content.save()

--- a/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
+++ b/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
@@ -20,7 +20,6 @@ class RemoveSuggestionPermissionTests(TutorialTestMixin, TestCase):
         self.author = ProfileFactory().user
         self.staff = StaffProfileFactory().user
         self.outsider = ProfileFactory().user
-        self.other = ProfileFactory().user
 
         # Create contents and suggestion
         self.content = PublishableContentFactory(author_list=[self.author])

--- a/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
+++ b/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
@@ -3,8 +3,8 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.utils.html import escape
 
-from zds.member.factories import ProfileFactory, StaffProfileFactory
-from zds.tutorialv2.factories import PublishableContentFactory
+from zds.member.tests.factories import ProfileFactory, StaffProfileFactory
+from zds.tutorialv2.tests.factories import PublishableContentFactory
 from zds.tutorialv2.forms import RemoveSuggestionForm
 from zds.tutorialv2.models.database import ContentSuggestion
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents

--- a/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
+++ b/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
@@ -98,7 +98,6 @@ class RemoveSuggestionWorkflowTests(TutorialTestMixin, TestCase):
         self.form_url = reverse("content:remove-suggestion", kwargs={"pk": self.content.pk})
         self.success_message_fragment = _("Vous avez enlevé")
         self.error_messages = RemoveSuggestionForm.declared_fields["pk_suggestion"].error_messages
-        print(self.error_messages)
         # Log in with an authorized user to perform the tests
         self.client.force_login(self.staff)
 

--- a/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
+++ b/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
@@ -1,0 +1,120 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from django.utils.html import escape
+
+from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.tutorialv2.factories import PublishableContentFactory
+from zds.tutorialv2.models.database import ContentSuggestion
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+
+
+@override_for_contents()
+class RemoveSuggestionPermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+        self.other = ProfileFactory().user
+
+        # Create contents and suggestion
+        self.content = PublishableContentFactory(author_list=[self.author])
+        self.suggested_content = PublishableContentFactory()
+        self.suggestion = ContentSuggestion(publication=self.content, suggestion=self.suggested_content)
+        self.suggestion.save()
+
+        # Get information to be reused in tests
+        self.form_url = reverse("content:remove-suggestion", kwargs={"pk": self.content.pk})
+        self.login_url = reverse("member-login") + "?next=" + self.form_url
+        self.content_url = reverse("content:view", kwargs={"pk": self.content.pk, "slug": self.content.slug})
+        self.form_data = {"pk_suggestion": self.suggestion.pk}
+
+    def test_not_authenticated(self):
+        self.client.logout()
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_outsider(self):
+        self.client.force_login(self.outsider)
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+    def test_authenticated_author(self):
+        # TODO: this behavior is actually wrong, it should be only authorized for staff.
+        self.client.force_login(self.author)
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff_tutorial(self):
+        self.client.force_login(self.staff)
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff_article(self):
+        self.client.force_login(self.staff)
+        self.content.type = "ARTICLE"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff_opinion(self):
+        self.client.force_login(self.staff)
+        self.content.type = "OPINION"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+
+class RemoveSuggestionWorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create users
+        self.staff = StaffProfileFactory().user
+        self.author = ProfileFactory().user
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author])
+        self.suggested_content_1 = PublishableContentFactory()
+        self.suggested_content_2 = PublishableContentFactory()
+        self.suggestion_1 = ContentSuggestion(publication=self.content, suggestion=self.suggested_content_1)
+        self.suggestion_1.save()
+        self.suggestion_2 = ContentSuggestion(publication=self.content, suggestion=self.suggested_content_2)
+        self.suggestion_2.save()
+
+        # Get information to be reused in tests
+        self.form_url = reverse("content:remove-suggestion", kwargs={"pk": self.content.pk})
+        self.success_message_fragment = _("Vous avez enlevé")
+        self.error_message_fragment = _("Les suggestions sélectionnées n'existent pas.")
+
+        # Log in with an authorized user to perform the tests
+        self.client.force_login(self.staff)
+
+    def test_existing(self):
+        response = self.client.post(self.form_url, {"pk_suggestion": self.suggestion_1.pk}, follow=True)
+        # Check that we display correct message
+        self.assertContains(response, escape(self.success_message_fragment))
+        # Check update of database
+        with self.assertRaises(ContentSuggestion.DoesNotExist):
+            ContentSuggestion.objects.get(pk=self.suggestion_1.pk)
+        ContentSuggestion.objects.get(pk=self.suggestion_2.pk)  # succeeds
+
+    def test_empty(self):
+        response = self.client.post(self.form_url, {"pk_suggestion": ""}, follow=True)
+        self.assertContains(response, escape(self.error_message_fragment))
+
+    def test_invalid(self):
+        # TODO: There is a 404, but an error message would be more appropriate
+        response = self.client.post(self.form_url, {"pk_suggestion": "420"})  # pk must not exist
+        self.assertEqual(response.status_code, 404)

--- a/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
+++ b/zds/tutorialv2/tests/tests_views/tests_removesuggestion.py
@@ -8,7 +8,6 @@ from zds.tutorialv2.factories import PublishableContentFactory
 from zds.tutorialv2.forms import RemoveSuggestionForm
 from zds.tutorialv2.models.database import ContentSuggestion
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
-from zds.tutorialv2.views.editorialization import RemoveSuggestion
 
 
 @override_for_contents()

--- a/zds/tutorialv2/views/editorialization.py
+++ b/zds/tutorialv2/views/editorialization.py
@@ -1,51 +1,55 @@
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
+from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 
-from zds.member.decorator import LoggedWithReadWriteHability, PermissionRequiredMixin
+from zds.member.decorator import LoggedWithReadWriteHability, can_write_and_read_now, PermissionRequiredMixin
 from zds.tutorialv2.forms import RemoveSuggestionForm, EditContentTagsForm
 from zds.tutorialv2.mixins import SingleContentFormViewMixin
 from zds.tutorialv2.models.database import ContentSuggestion, PublishableContent
 
 
-class RemoveSuggestion(LoggedWithReadWriteHability, SingleContentFormViewMixin):
-
+class RemoveSuggestion(PermissionRequiredMixin, SingleContentFormViewMixin):
     form_class = RemoveSuggestionForm
+    modal_form = True
     only_draft_version = True
-    authorized_for_staff = True
+    permissions = ["tutorialv2.change_publishablecontent"]
+
+    @method_decorator(login_required)
+    @method_decorator(can_write_and_read_now)
+    def dispatch(self, *args, **kwargs):
+        if self.get_object().is_opinion:
+            raise PermissionDenied
+        return super().dispatch(*args, **kwargs)
 
     def form_valid(self, form):
-        _type = _("cet article")
-        if self.object.is_tutorial:
-            _type = _("ce tutoriel")
-        elif self.object.is_opinion:
-            raise PermissionDenied
-
-        content_suggestion = get_object_or_404(ContentSuggestion, pk=form.cleaned_data["pk_suggestion"])
-        content_suggestion.delete()
-
-        messages.success(
-            self.request,
-            _('Vous avez enlevé "{}" de la liste des suggestions de {}.').format(
-                content_suggestion.suggestion.title, _type
-            ),
-        )
-
-        if self.object.public_version:
-            self.success_url = self.object.get_absolute_url_online()
-        else:
-            self.success_url = self.object.get_absolute_url()
-
+        suggestion = ContentSuggestion.objects.get(pk=form.cleaned_data["pk_suggestion"])
+        suggestion.delete()
+        messages.success(self.request, self.get_success_message(suggestion))
         return super().form_valid(form)
 
     def form_invalid(self, form):
-        messages.error(self.request, str(_("Les suggestions sélectionnées n'existent pas.")))
+        form.previous_page_url = self.get_success_url()
+        return super().form_invalid(form)
+
+    def get_success_message(self, content_suggestion):
+        return _('Vous avez enlevé "{}" de la liste des suggestions de {}.').format(
+            content_suggestion.suggestion.title,
+            self.describe_type(),
+        )
+
+    def get_success_url(self):
         if self.object.public_version:
-            self.success_url = self.object.get_absolute_url_online()
+            return self.object.get_absolute_url_online()
         else:
-            self.success_url = self.object.get_absolute_url()
-        return super().form_valid(form)
+            return self.object.get_absolute_url()
+
+    def describe_type(self):
+        if self.object.is_tutorial:
+            return _("ce tutoriel")
+        return _("cet article")
 
 
 class AddSuggestion(LoggedWithReadWriteHability, PermissionRequiredMixin, SingleContentFormViewMixin):


### PR DESCRIPTION
Dans le cadre de la PR #5940, j'ai été embêté, parce que je me suis rendu compte que certains modules n'étaient pas testés du tout.

Cette PR :

  * rajoute des tests pour la vue `RemoveSuggestion` ;
  * refactorise `RemoveSuggestion` pour être un peu plus propre, notamment sur le workflow du formulaire ;
  * corrige un bug qui permettait à des auteurs motivés de faire des modifs alors que c'est normalement destiné au staff ;
  * fait des améliorations sur la robustesse et la testabilité de la vue (gestion d'erreurs notamment).

### Contrôle qualité

S'assurer de bien avoir Elastic Search d'installé (nécessaire pour ajouter des suggestions facilement).

- se connecter avec un compte staff
- créer des suggestions sur un contenu (ça j'y ai pas touché encore)
- les supprimer et voir que ça marche bien

Pour ce qui est du bug de passer outre l'autorisation staff, il suffit d'envoyer une requête en tant qu'auteur avec le bon formulaire (avec l'inspecteur prendre le formulaire staff, l'injecter sur une page en tant qu'auteur, en prenant soin de changer le token csrf et envoyer). Il faut donc tester que ce n'est plus possible.

Pour les courageux, il est aussi possible de s'amuser à envoyer des pk de suggestion vides, non existants ou non entiers en éditant le formulaire dans l'inspecteur.