### PR TITLE
Petite amélioration de la documentation

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -60,7 +60,7 @@ Par défaut, le serveur renvoie les réponses au format ``JSON`` mais il gère a
 
     $ curl -H "Accept: application/xml" https://zestedesavoir.com/api/membres/
 
-Les `formats de sortie (en) <http://www.django-rest-framework.org/api-guide/renderers/>`_ sont renseignés dans le fichier ``settings.py`` sous l'attribut ``DEFAULT_RENDERER_CLASSES`` du dictionnaire ``REST_FRAMEWORK``. Pour Django Rest Framework, tous les formats de sorties sont des ``renderer``.
+Les `formats de sortie (en) <https://www.django-rest-framework.org/api-guide/renderers/>`_ sont renseignés dans le fichier ``settings.py`` sous l'attribut ``DEFAULT_RENDERER_CLASSES`` du dictionnaire ``REST_FRAMEWORK``. Pour Django Rest Framework, tous les formats de sorties sont des ``renderer``.
 
 .. sourcecode:: python
 
@@ -78,7 +78,7 @@ Plusieurs formats d'entrées sont supportés par le serveur, à savoir le ``JSON
 
     $ curl -H "Content-Type: application/xml" https://zestedesavoir.com/api/membres/
 
-Les `formats d'entrée (en) <http://www.django-rest-framework.org/api-guide/parsers/>`_ sont renseignés dans le fichier ``settings.py`` sous l'attribut ``DEFAULT_PARSER_CLASSES`` du dictionnaire ``REST_FRAMEWORK``. Pour Django Rest Framework, tous les formats d'entrée sont des ``parser``.
+Les `formats d'entrée (en) <https://www.django-rest-framework.org/api-guide/parsers/>`_ sont renseignés dans le fichier ``settings.py`` sous l'attribut ``DEFAULT_PARSER_CLASSES`` du dictionnaire ``REST_FRAMEWORK``. Pour Django Rest Framework, tous les formats d'entrée sont des ``parser``.
 
 .. sourcecode:: python
 
@@ -94,9 +94,9 @@ Les `formats d'entrée (en) <http://www.django-rest-framework.org/api-guide/pars
 Cache
 -----
 
-Un cache spécifique à l'API est mis en place pour mettre en cache toutes les méthodes ``GET``. Le système n'est pas spécifique à Django Rest Framework mais est disponible via une librairie tierce qui a été développée spécialement pour fonctionner avec DRF, `DRF-Extensions (en) <http://chibisov.github.io/drf-extensions/docs/>`_.
+Un cache spécifique à l'API est mis en place pour mettre en cache toutes les méthodes ``GET``. Le système n'est pas spécifique à Django Rest Framework mais est disponible via une librairie tierce qui a été développée spécialement pour fonctionner avec DRF, `DRF-Extensions (en) <https://chibisov.github.io/drf-extensions/docs/>`_.
 
-Pour placer un cache, il suffit d'annoter la méthode ``GET`` voulue avec l'annotation ``@cache_response()`` (comme le mentionne la `documentation à ce sujet (en) <http://chibisov.github.io/drf-extensions/docs/#caching>`_
+Pour placer un cache, il suffit d'annoter la méthode ``GET`` voulue avec l'annotation ``@cache_response()`` (comme le mentionne la `documentation à ce sujet (en) <https://chibisov.github.io/drf-extensions/docs/#caching>`_
 ). Par exemple, la méthode ``GET`` pour récupérer la liste paginée des membres ressemblerait au code ci-dessous.
 
 .. sourcecode:: python
@@ -111,14 +111,14 @@ Pour placer un cache, il suffit d'annoter la méthode ``GET`` voulue avec l'anno
 
 Dans le contexte de Zeste de Savoir, ce n'est pas suffisant. Comme la plupart des routes ``GET`` peuvent prendre des paramètres, il faut permettre au cache de distinguer une URL X avec des paramètres et une URL Y avec d'autres paramètres. Ceci se fait en spécifiant une clé au cache de la méthode. Par exemple, pour la pagination, si aucune clé n'est renseignée, le cache renverra toujours le même résultat peu importe la page souhaitée.
 
-Pour enrichir la clé d'un cache, DRF-Extensions propose les ``KeyConstructor``. Toutes les informations et les possibilités à ce sujet sont disponibles dans la `documentation de cette librairie (en) <http://chibisov.github.io/drf-extensions/docs/#key-constructor>`_.
+Pour enrichir la clé d'un cache, DRF-Extensions propose les ``KeyConstructor``. Toutes les informations et les possibilités à ce sujet sont disponibles dans la `documentation de cette librairie (en) <https://chibisov.github.io/drf-extensions/docs/#key-constructors>`_.
 
 ETag
 ----
 
 Un ETag est un identifiant unique assigné par le serveur à chaque version d'une ressource accessible via une URL. Si la ressource accessible via cette URL change, un nouvel ETag sera assigné. Lorsque le client utilise cet en-tête, cela permet d'alléger le serveur : il suffit au serveur de comparer l'ETag de la ressource et celui fourni par le client pour décider si une requête en base de données est nécessaire.
 
-Le calcul de l'ETag n'est pas natif à Django Rest Framework mais est accessible via la `bibliothèque DRF-Extensions (en) <http://chibisov.github.io/drf-extensions/docs/#conditional-requests>`_. Le calcul est ajouté sur toutes les méthodes ``GET`` et ``PUT``. Il est inutile de calculer des ETags pour des requêtes ``POST`` et ``DELETE`` puisque ces deux méthodes ont pour objectif de créer et supprimer des ressources.
+Le calcul de l'ETag n'est pas natif à Django Rest Framework mais est accessible via la `bibliothèque DRF-Extensions (en) <https://chibisov.github.io/drf-extensions/docs/#conditional-requests>`_. Le calcul est ajouté sur toutes les méthodes ``GET`` et ``PUT``. Il est inutile de calculer des ETags pour des requêtes ``POST`` et ``DELETE`` puisque ces deux méthodes ont pour objectif de créer et supprimer des ressources.
 
 Pour placer un ETag, il suffit d'annoter la méthode voulue avec l'annotation ``@etag()``. Par exemple, la méthode ``GET`` pour récupérer la liste paginée des membres ressemblerait au code ci-dessous.
 
@@ -134,7 +134,7 @@ Pour placer un ETag, il suffit d'annoter la méthode voulue avec l'annotation ``
 
 Dans le contexte de Zeste de Savoir, ce n'est pas suffisant. Comme la plupart des routes ``GET`` et ``PUT`` peuvent prendre des paramètres, il faut permettre au cache de distinguer une URL X avec des paramètres et une URL Y avec d'autres paramètres. Ceci se fait en spécifiant une clé à l'ETag de la méthode. Par exemple, pour la pagination, si aucune clé n'est renseignée, l'ETag ne sera jamais recalculé peu importe la page souhaitée.
 
-Pour enrichir la clé de l'ETag, DRF-Extensions propose les ``KeyConstructor``. Toutes les informations et les possibilités à ce sujet sont disponibles dans la `documentation de cette librairie (en) <http://chibisov.github.io/drf-extensions/docs/#key-constructor>`_.
+Pour enrichir la clé de l'ETag, DRF-Extensions propose les ``KeyConstructor``. Toutes les informations et les possibilités à ce sujet sont disponibles dans la `documentation de cette librairie (en) <https://chibisov.github.io/drf-extensions/docs/#key-constructors>`_.
 
 **Note :** L'ETag et le cache peuvent fonctionner ensemble. Une méthode peut être annotée avec ``@etag()`` et ``@cache_response()``.
 
@@ -164,7 +164,7 @@ Le `throttling` permet d'imposer des limites au nombre de requêtes possibles po
         }
     }
 
-Il existe d'autres configurations possibles. Pour en prendre conscience, rendez-vous dans la `documentation du throttling (en) <http://www.django-rest-framework.org/api-guide/throttling/>`_.
+Il existe d'autres configurations possibles. Pour en prendre conscience, rendez-vous dans la `documentation du throttling (en) <https://www.django-rest-framework.org/api-guide/throttling/>`_.
 
 Pagination
 ----------
@@ -181,7 +181,7 @@ La pagination peut être configurée directement dans les vues de l'API mais aus
         'MAX_PAGINATE_BY': 100,             # Maximum limit allowed when using `?page_size=xxx`.
     }
 
-Toutes les informations complémentaires à ce sujet sont disponibles dans la `documentation de la pagination (en) <http://www.django-rest-framework.org/api-guide/pagination/>`_.
+Toutes les informations complémentaires à ce sujet sont disponibles dans la `documentation de la pagination (en) <https://www.django-rest-framework.org/api-guide/pagination/>`_.
 
 Son utilisation est simple, il suffit de renseigner la page avec le paramètre ``page`` et, optionnellement, ``page_size`` pour renseigner la taille de la page. Par exemple, récupérer la page 2 d'une page de taille 3 ressemblera à la requête suivante.
 
@@ -219,11 +219,11 @@ Authentification
 Bibliothèque tierce choisie
 ---------------------------
 
-Django Rest Framework supporte plusieurs systèmes d'authentification (comme en témoigne la `documentation sur l'authentification (en) <http://www.django-rest-framework.org/api-guide/authentication/>`_). Sur Zeste de Savoir, il a été décidé d'utiliser OAuth2 (dont la spécification du protocole est disponible via `ce lien (en) <http://tools.ietf.org/html/rfc6749>`_) pour tenter d'avoir le système le plus sécurisé possible.
+Django Rest Framework supporte plusieurs systèmes d'authentification (comme en témoigne la `documentation sur l'authentification (en) <https://www.django-rest-framework.org/api-guide/authentication/>`_). Sur Zeste de Savoir, il a été décidé d'utiliser OAuth2 (dont la spécification du protocole est disponible via `ce lien (en) <https://datatracker.ietf.org/doc/html/rfc6749>`_) pour tenter d'avoir le système le plus sécurisé possible.
 
-L'authentification n'est pas directement dans Django Rest Framework, il ne fait que supporter des librairies tierces qui s'en occupent. La librairie choisie est `Django OAuth Toolkit <https://django-oauth-toolkit.readthedocs.org/en/0.7.0/>`_ pour sa forte compatibilité avec Django Rest Framework, sa maintenance et sa compatibilité Python 3 et Django 1.7 (ou plus).
+L'authentification n'est pas directement dans Django Rest Framework, il ne fait que supporter des librairies tierces qui s'en occupent. La librairie choisie est `Django OAuth Toolkit <https://django-oauth-toolkit.readthedocs.io/en/stable/>`_ pour sa forte compatibilité avec Django Rest Framework et sa maintenance.
 
-Toute sa configuration est détaillée dans la `documentation de cette bibliothèque <https://django-oauth-toolkit.readthedocs.org/en/0.7.0/rest-framework/getting_started.html>`_.
+Toute sa configuration est détaillée dans la `documentation de cette bibliothèque <https://django-oauth-toolkit.readthedocs.io/en/stable/rest-framework/getting_started.html>`_.
 
 Utilisation
 -----------
@@ -312,12 +312,12 @@ A la suite de cela, de nouveaux tokens seront renvoyés et devront être sauvega
 Documentation (utilisation)
 ============================
 
-Django REST Swagger est une bibliothèque qui génère automatiquement la documentation d'une API Django basée sur la bibliothèque Django REST framework.
+Yet another Swagger generator (``drf-yasg``) est une bibliothèque qui génère automatiquement la documentation d'une API Django basée sur la bibliothèque Django REST framework.
 
-Cette documentation est accessible par l'url ``http://zestedesavoir.com/api/`` et, via cette page, il est possible de :
+Cette documentation est accessible par l'url ``https://zestedesavoir.com/api/`` et, via cette page, il est possible de :
 
 - Lister toutes les APIs pour toutes les ressources.
 - Connaitre les paramètres, les codes d'erreur et un exemple de réponse.
 - Exécuter toutes les routes disponibles dans l'API.
 
-Pour maintenir cette documentation, rendez-vous sur `sa documentation (en) <http://django-rest-swagger.readthedocs.org/en/latest/>`_ qui explique sur quoi se base la bibliothèque pour générer la documentation et comment y rajouter de l'information.
+Pour maintenir cette documentation, rendez-vous sur `sa documentation (en) <https://drf-yasg.readthedocs.io/en/stable/>`_ qui explique sur quoi se base la bibliothèque pour générer la documentation et comment y rajouter de l'information.

--- a/doc/source/back-end-code/arborescence-back.rst
+++ b/doc/source/back-end-code/arborescence-back.rst
@@ -78,7 +78,7 @@ Fichiers principaux
 
 Django étant basé sur une architecture de type Modèle-Vue-Template, on retrouve les modèles dans le fichier ``models.py`` et les contrôles associés à celles-ci dans ``views.py``. Ces dernières peuvent employer des classes formulaires qui sont définis dans ``forms.py``. Les URLs associées au module et permetant d'accéder aux vues sont définies dans ``urls.py``. On retrouve finalement des vues spécifiques associées aux fils RSS et Atom dans ``feeds.py``.
 
-On retrouve également des validateurs dans le fichier ``commons.py`` (voir à ce sujet `la documentation de Django <https://docs.djangoproject.com/fr/1.8/ref/validators/>`__).
+On retrouve également des validateurs dans le fichier ``commons.py`` (voir à ce sujet `la documentation de Django <https://docs.djangoproject.com/fr/2.2/ref/validators/>`__).
 
 Tests unitaires
 ---------------

--- a/doc/source/back-end-code/utils.rst
+++ b/doc/source/back-end-code/utils.rst
@@ -46,7 +46,7 @@ La doc de Django explique le principe des *context_processors* comme suit :
 | Les processeurs de contexte personnalisés peuvent se trouver n’importe où dans le code. Tout ce que Django demande, c’est que le réglage ``TEMPLATE_CONTEXT_PROCESSORS`` contienne le chemin vers le processeur personnalisé.
 |
 
-(pour plus de détails, `voir la documenation de Django à ce sujet <https://docs.djangoproject.com/fr/1.8/ref/templates/api/#subclassing-context-requestcontext>`__)
+(pour plus de détails, `voir la documentation de Django à ce sujet <https://docs.djangoproject.com/fr/2.2/ref/templates/api/#subclassing-context-requestcontext>`__)
 
 .. automodule:: zds.utils.context_processor
     :members:

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -18,7 +18,7 @@ Contribuer à Zeste De Savoir
 1. Créez une branche pour contenir votre travail.
 2. Faites vos modifications.
 3. Ajoutez un test pour votre modification. Seules les modifications de documentation et les réusinages n'ont pas besoin de nouveaux tests.
-4. Assurez-vous que vos tests passent en utilisant la commande ``python manage.py test`` (`voir la documentation <https://docs.djangoproject.com/fr/1.10/topics/testing/overview/#running-tests>`_). Lancer la commande sur tous les tests du site risque de prendre un certain temps et n'est pas nécessaire : les tests seront de toute manière lancés de manière automatisée sur votre *pull request*.
+4. Assurez-vous que vos tests passent en utilisant la commande ``python manage.py test`` (`voir la documentation <https://docs.djangoproject.com/fr/2.2/topics/testing/overview/#running-tests>`_). Lancer la commande sur tous les tests du site risque de prendre un certain temps et n'est pas nécessaire : les tests seront de toute manière lancés de manière automatisée sur votre *pull request*.
 5. Si vous avez fait des modifications du _frontend_, jouez les tests associés : ``yarn test``.
 6. Si vous modifiez les modèles (les fichiers ``models.py``), n'oubliez pas de créer les fichiers de migration : ``python manage.py makemigrations``.
 7. Poussez votre travail et faites une *pull request*.
@@ -27,9 +27,9 @@ Contribuer à Zeste De Savoir
 Quelques bonnes pratiques
 -------------------------
 
-* Respectez `les conventions de code de Django <https://docs.djangoproject.com/en/2.1/internals/contributing/writing-code/coding-style/>`_, ce qui inclut la `PEP 8 de Python <http://legacy.python.org/dev/peps/pep-0008/>`_.
+* Respectez `les conventions de code de Django <https://docs.djangoproject.com/fr/2.2/internals/contributing/writing-code/coding-style/>`_, ce qui inclut la `PEP 8 de Python <http://legacy.python.org/dev/peps/pep-0008/>`_.
 * Le code et les commentaires sont en anglais.
-* Le *workflow* Git utilisé est le `Git flow <http://nvie.com/posts/a-successful-git-branching-model/>`_, qui est `détaillé ici <./workflow.html>`_. En résumé :
+* Le *workflow* Git utilisé est le `Git flow <https://nvie.com/posts/a-successful-git-branching-model/>`_, qui est `détaillé ici <./workflow.html>`_. En résumé :
     * Les arrivées fonctionnalités et corrections de gros bugs hors release se font via des PR.
     * Ces PR sont unitaires. Aucune PR qui corrige plusieurs problèmes ou apporte plusieurs fonctionnalité ne sera accepté ; la règle est : une fonctionnalité ou une correction = une PR.
     * Ces PR sont mergées dans la branche ``dev`` (appelée ``develop`` dans le git flow standard), après une QA légère.

--- a/doc/source/front-end.rst
+++ b/doc/source/front-end.rst
@@ -6,11 +6,11 @@ Le terme *front-end* désigne la partie du code associée à l'affichage des don
 
 Il s'agit donc de la partie du code définissant le design et l'affichage, mais aussi de l'ergonomie, la réactivité et l'expérience utilisateur. Sa mise en place est basée sur trois langages :
 
-+ Le HTML, aidé du `langage de gabarit de Django <https://docs.djangoproject.com/fr/2.1/topics/templates/>`__ ;
-+ `SASS (en) <http://sass-lang.com/>`__ pour les feuilles de style ;
++ Le HTML, aidé du `langage de gabarit de Django <https://docs.djangoproject.com/fr/2.2/ref/templates/language/>`__ ;
++ `SASS (en) <https://sass-lang.com/>`__ pour les feuilles de style ;
 + JavaScript pour les interactions.
 
-`Node.js (en) <https://nodejs.org/>`__, `yarn (en) <https://yarnpkg.com/en/>`__ (gestionnaire de paquet pour Node.js) et `Gulp (en) <http://gulpjs.com/>`__ sont utilisés pour générer le code final minifié et cohérent. Le développement du *front-end* requiert donc des outils spécifiques dont l'installation `est expliquée ici <install/extra-install-frontend.html>`__.
+`Node.js (fr) <https://nodejs.org/fr/>`__, `yarn (en) <https://yarnpkg.com/>`__ (gestionnaire de paquet pour Node.js) et `Gulp (en) <https://gulpjs.com/>`__ sont utilisés pour générer le code final minifié et cohérent. Le développement du *front-end* requiert donc des outils spécifiques dont l'installation `est expliquée ici <install/extra-install-frontend.html>`__.
 
 **Navigateurs supportés** : Les dernières versions de Mozilla Firefox, Google Chrome, Safari et Microsoft Edge.
 

--- a/doc/source/front-end/arborescence-des-fichiers.rst
+++ b/doc/source/front-end/arborescence-des-fichiers.rst
@@ -4,7 +4,7 @@ Arborescence des dossiers
 
 Nous utilisons deux dossiers présents à la racine :
 
-- ``templates/`` pour les fichiers HTML, qui sont agrémentés du `langage de gabarit de Django <https://docs.djangoproject.com/fr/1.8/topics/templates/>`_ ;
+- ``templates/`` pour les fichiers HTML, qui sont agrémentés du `langage de gabarit de Django <https://docs.djangoproject.com/fr/2.2/topics/templates/>`_ ;
 - ``assets/`` pour les images, les smileys ainsi que les fichiers SCSS et JS.
 
 Lors de la compilation, un dossier ``dist/`` contenant les fichiers optimisés venant de ``assets/`` est créé.

--- a/doc/source/front-end/structure-du-site.rst
+++ b/doc/source/front-end/structure-du-site.rst
@@ -25,7 +25,7 @@ Il se peut aussi que les modules aient leur propre gabarit de base, auquel cas c
 
 .. seealso::
    Pour en savoir plus, n'hésitez pas à la partie de la documentation de Django sur
-   `l'héritage des gabarits <https://docs.djangoproject.com/fr/1.8/topics/templates/#template-inheritance>`_ !
+   `l'héritage des gabarits <https://docs.djangoproject.com/fr/2.2/ref/templates/language/#template-inheritance>`_ !
 
 
 L'en-tête

--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -3,7 +3,7 @@ Elements de templates personnalisés
 ===================================
 
 Le dossier ``zds/utils/templatetags/`` contient un ensemble de tags et filtres personnalisés pouvant être utilisés dans les gabarits (*templates*),
-`voir à ce sujet la documentation de Django <https://docs.djangoproject.com/fr/1.8/howto/custom-template-tags/>`_.
+`voir à ce sujet la documentation de Django <https://docs.djangoproject.com/fr/2.2/howto/custom-template-tags/>`_.
 
 La majorité de ces modules proposent aussi des fonctions proposant les même fonctionnalités depuis le reste du code
 Python.
@@ -198,7 +198,7 @@ génération des fichiers PDF et EPUB des tutos :
 Le module ``htmldiff``
 ======================
 
-Ce module définit le tag ``htmldiff`` qui affiche la différence entre deux chaînes de caractères, en utilisant `difflib (en) <https://docs.python.org/2/library/difflib.html>`__. Le code généré est un tableau HTML à l'intérieur d'une div. Il est employé pour afficher le *diff* des tutoriels et des articles.
+Ce module définit le tag ``htmldiff`` qui affiche la différence entre deux chaînes de caractères, en utilisant `difflib (en) <https://docs.python.org/3/library/difflib.html>`__. Le code généré est un tableau HTML à l'intérieur d'une div. Il est employé pour afficher le *diff* des tutoriels et des articles.
 
 .. sourcecode:: html+django
 
@@ -344,7 +344,7 @@ Le module ``profiles``
 ``user``
 --------
 
-Pour un objet de type ``Profile`` (`voir son implémentation <../back-end-code/member.html#zds.member.models.Profile>`__), ce filtre récupère son objet ``User`` correspondant (`voir les informations sur cet objet dans la documentation de Django <https://docs.djangoproject.com/fr/1.8/topics/auth/default/#user-objects>`__).
+Pour un objet de type ``Profile`` (`voir son implémentation <../back-end-code/member.html#zds.member.models.Profile>`__), ce filtre récupère son objet ``User`` correspondant (`voir les informations sur cet objet dans la documentation de Django <https://docs.djangoproject.com/fr/2.2/topics/auth/default/#user-objects>`__).
 
 Par exemple, le code suivant affichera le nom de l'utilisateur :
 

--- a/doc/source/guides/backend-tests.rst
+++ b/doc/source/guides/backend-tests.rst
@@ -78,6 +78,6 @@ Il suffit alors de remonter la sortie de la console et chercher des lignes de la
 
 Il ne vous reste alors plus qu'à corriger votre code ou mettre à jour les tests concernés. :-)
 
-Pour en savoir plus sur les tests avec Django, consultez la `documentation officielle <https://docs.djangoproject.com/en/dev/topics/testing/overview/>`_.
+Pour en savoir plus sur les tests avec Django, consultez la `documentation officielle <https://docs.djangoproject.com/fr/2.2/topics/testing/overview/>`_.
 
 Pour en savoir plus sur l'écriture de tests *backend* pour Zeste de Savoir, consultez le `guide correspondant <./write-backend-tests.html>`_.

--- a/doc/source/guides/write-backend-tests.rst
+++ b/doc/source/guides/write-backend-tests.rst
@@ -17,9 +17,6 @@ La présence de tests adéquats est vérifiée lors de l'assurance qualité des 
 
 Les contributions destinées purement à l'amélioration des tests sont les bienvenues. En effet, l'historique du projet fait que certaines parties du projet sont peu, mal, ou pas testées automatiquement.
 
-Quoi qu'il en soit, l'équipe est disponible sur le canal ``#dev-de-zds`` de `notre serveur Discord <https://discord.gg/ue5MTKq>`_ ou `le forum Dev Zone <https://zestedesavoir.com/forums/communaute/dev-zone/>`_ pour vous aider si vous avez des doutes, questions ou difficultés.
-
-
 Identifier ce qu'il faut tester
 ===============================
 

--- a/doc/source/guides/write-backend-tests.rst
+++ b/doc/source/guides/write-backend-tests.rst
@@ -81,8 +81,8 @@ Connaître les outils pratiques
 
 Quelques lectures en lien avec Django :
 
-* `l'aperçu global des tests avec Django <https://docs.djangoproject.com/en/2.2/topics/testing/overview/>`_ ;
-* `la documentation sur les outils de test fournis par Django <https://docs.djangoproject.com/en/2.2/topics/testing/tools/>`_.
+* `l'aperçu global des tests avec Django <https://docs.djangoproject.com/fr/2.2/topics/testing/overview/>`_ ;
+* `la documentation sur les outils de test fournis par Django <https://docs.djangoproject.com/fr/2.2/topics/testing/tools/>`_.
 
 Une tâche qui revient très souvent lors des tests est la création d'utilisateurs, sujets de forum, messages, tutoriels, articles, etc.
 Il existe des outils de développement pour faciliter leur création appelés *Factory* et qu'on retrouve dans les fichiers `factories.py` de chaque module. L'usage est simple, il suffit d'appeler le constructeur pour recevoir un objet du type souhaité :

--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -81,7 +81,7 @@ La liste des packages vous est donnée ci-dessous (pour Debian), si vous utilise
 Composant ``virtualenv``
 ========================
 
-Installe le *virtualenv* qui est un environnement python cloisonné prévu pour ne pas interférer avec d'autres installation de python (`plus d'infos ici <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_).
+Installe le *virtualenv* qui est un environnement python cloisonné prévu pour ne pas interférer avec d'autres installation de python (`plus d'infos ici <https://python-guide-fr.readthedocs.io/fr/latest/dev/virtualenvs.html#virtualenv>`_).
 Ce que fait ce composant est tout simplement:
 
 .. sourcecode:: bash

--- a/doc/source/utils/selenium.rst
+++ b/doc/source/utils/selenium.rst
@@ -32,9 +32,9 @@ Pour Mac OS ou Windows, il suffit de lire les instructions à l'adresse suivante
 Écriture des tests
 ~~~~~~~~~~~~~~~~~~
 
-Il est donc possible d'écrire des tests pour Django directement en utilisant la document de Selenium ici : <http://selenium-python.readthedocs.io/> et le `StaticLiveServerTestCase` de Django (<https://docs.djangoproject.com/fr/2.1/ref/contrib/staticfiles/#django.contrib.staticfiles.testing.StaticLiveServerTestCase>).
+Il est donc possible d'écrire des tests pour Django directement en utilisant la documentation de Selenium ici : <https://selenium-python.readthedocs.io/> et le `StaticLiveServerTestCase` de Django (<https://docs.djangoproject.com/fr/2.2/ref/contrib/staticfiles/#django.contrib.staticfiles.testing.StaticLiveServerTestCase>).
 
-Il est aussi possible d'utiliser l'extension Firefox (<https://addons.mozilla.org/en-US/firefox/addon/selenium-ide/>) et d'exporter le test généré, cependant, il est nécessaire de le réécrire pour prendre en compte Django et Python 3. De plus, il est nécessaire d'ajouter un tag à la classe afin de pouvoir lancer les tests Selenium séparément.
+Il est aussi possible d'utiliser l'extension Firefox (<https://addons.mozilla.org/fr/firefox/addon/selenium-ide/>) et d'exporter le test généré, cependant, il est nécessaire de le réécrire pour prendre en compte Django et Python 3. De plus, il est nécessaire d'ajouter un tag à la classe afin de pouvoir lancer les tests Selenium séparément.
 
 Voici le contenu d'un test :
 


### PR DESCRIPTION
- Met à jour quelques liens, notamment ceux de Django pour éviter que les lecteurs tombent sur une version ancienne avec un avertissement comme quoi la version est dépréciée
- Supprime un paragraphe redondant, car l'encart pour nous contacter est disponible tout en bas de la page et est inclus automatiquement donc est plus simple à maintenir sur le long terme

Le petit bémol est que la documentation de Django en 2.2 a des soucis de traductions sur certaines pages, donc elles sont en anglais quand c'est le cas. J'ai ouvert [un ticket](https://github.com/django/djangoproject.com/issues/1115) pour voir s'ils peuvent corriger ce soucis ou pas.