### PR TITLE
Ajoute des tests et refactorise AddSuggestion

### DIFF
--- a/zds/tutorialv2/tests/tests_views/tests_addsuggestion.py
+++ b/zds/tutorialv2/tests/tests_views/tests_addsuggestion.py
@@ -1,0 +1,151 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from django.utils.html import escape
+
+from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.tutorialv2.factories import PublishableContentFactory, PublishedContentFactory
+from zds.tutorialv2.models.database import ContentSuggestion
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+
+
+@override_for_contents()
+class AddSuggestionPermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+
+        # Create contents and suggestion
+        self.content = PublishableContentFactory(author_list=[self.author])
+        self.suggestable_content = PublishedContentFactory()
+
+        # Get information to be reused in tests
+        self.form_url = reverse("content:add-suggestion", kwargs={"pk": self.content.pk})
+        self.login_url = reverse("member-login") + "?next=" + self.form_url
+        self.content_url = reverse("content:view", kwargs={"pk": self.content.pk, "slug": self.content.slug})
+        self.form_data = {"options": self.suggestable_content.pk}
+
+    def test_not_authenticated(self):
+        self.client.logout()
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_outsider(self):
+        self.client.force_login(self.outsider)
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+    def test_authenticated_author(self):
+        self.client.force_login(self.author)
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+    def test_authenticated_staff_tutorial(self):
+        self.client.force_login(self.staff)
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff_article(self):
+        self.client.force_login(self.staff)
+        self.content.type = "ARTICLE"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff_opinion(self):
+        self.client.force_login(self.staff)
+        self.content.type = "OPINION"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+
+class AddSuggestionWorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create users
+        self.staff = StaffProfileFactory().user
+        self.author = ProfileFactory().user
+
+        # Createcontents
+        self.content = PublishableContentFactory(author_list=[self.author])
+        self.suggestable_content_1 = PublishedContentFactory()
+        self.suggestable_content_2 = PublishedContentFactory()
+        self.unpublished_content = PublishableContentFactory()
+
+        self.not_picked_opinion = PublishedContentFactory()
+        self.not_picked_opinion.type = "OPINION"
+        self.not_picked_opinion.save()
+
+        # Get information to be reused in tests
+        self.form_url = reverse("content:add-suggestion", kwargs={"pk": self.content.pk})
+        self.success_message_fragment = _("a été ajouté dans les suggestions")
+        self.error_message_fragment_unpublished = _("un contenu qui n'a pas été publié")
+        self.error_message_fragment_already_suggested = _("fait déjà partie des suggestions de")
+        self.error_message_fragment_self = _("en tant que suggestion pour lui même")
+        self.error_messge_fragment_not_picked = _("un billet qui n'a pas été mis en avant")
+
+        # Log in with an authorized user to perform the tests
+        self.client.force_login(self.staff)
+
+    def test_published_simple(self):
+        response = self.client.post(self.form_url, {"options": self.suggestable_content_1.pk}, follow=True)
+        self.assertContains(response, escape(self.success_message_fragment))
+        suggestion = ContentSuggestion.objects.get(publication=self.content, suggestion=self.suggestable_content_1)
+        self.assertEqual(list(ContentSuggestion.objects.all()), [suggestion])
+
+    def test_published_multiple(self):
+        response = self.client.post(
+            self.form_url, {"options": [self.suggestable_content_1.pk, self.suggestable_content_2.pk]}, follow=True
+        )
+        self.assertContains(response, escape(self.success_message_fragment))
+        suggestion_1 = ContentSuggestion.objects.get(publication=self.content, suggestion=self.suggestable_content_1)
+        suggestion_2 = ContentSuggestion.objects.get(publication=self.content, suggestion=self.suggestable_content_2)
+        self.assertEqual(list(ContentSuggestion.objects.all()), [suggestion_1, suggestion_2])
+
+    def test_already_suggested(self):
+        suggestion = ContentSuggestion(publication=self.content, suggestion=self.suggestable_content_1)
+        suggestion.save()
+        response = self.client.post(self.form_url, {"options": self.suggestable_content_1.pk}, follow=True)
+        self.assertContains(response, escape(self.error_message_fragment_already_suggested))
+        self.assertEqual(list(ContentSuggestion.objects.all()), [suggestion])
+
+    def test_self(self):
+        response = self.client.post(self.form_url, {"options": self.content.pk}, follow=True)
+        self.assertContains(response, escape(self.error_message_fragment_self))
+        self.assertQuerysetEqual(ContentSuggestion.objects.all(), [])
+
+    def test_not_picked_opinion(self):
+        response = self.client.post(self.form_url, {"options": self.not_picked_opinion.pk}, follow=True)
+        self.assertContains(response, escape(self.error_messge_fragment_not_picked))
+        self.assertQuerysetEqual(ContentSuggestion.objects.all(), [])
+
+    def test_unpublished(self):
+        response = self.client.post(self.form_url, {"options": self.unpublished_content.pk}, follow=True)
+        self.assertContains(response, escape(self.error_message_fragment_unpublished))
+        self.assertQuerysetEqual(ContentSuggestion.objects.all(), [])
+
+    def test_invalid(self):
+        response = self.client.post(self.form_url, {"options": "420"}, follow=True)  # pk must not exist
+        self.assertEqual(response.status_code, 404)
+
+    def test_not_integer(self):
+        with self.assertRaises(ValueError):
+            self.client.post(self.form_url, {"options": "abcd"}, follow=True)
+
+    def test_empty(self):
+        with self.assertRaises(ValueError):
+            self.client.post(self.form_url, {"options": ""}, follow=True)

--- a/zds/tutorialv2/views/editorialization.py
+++ b/zds/tutorialv2/views/editorialization.py
@@ -3,7 +3,7 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.translation import gettext_lazy as _
 
-from zds.member.decorator import LoggedWithReadWriteHability
+from zds.member.decorator import LoggedWithReadWriteHability, PermissionRequiredMixin
 from zds.tutorialv2.forms import RemoveSuggestionForm, EditContentTagsForm
 from zds.tutorialv2.mixins import SingleContentFormViewMixin
 from zds.tutorialv2.models.database import ContentSuggestion, PublishableContent
@@ -48,9 +48,10 @@ class RemoveSuggestion(LoggedWithReadWriteHability, SingleContentFormViewMixin):
         return super().form_valid(form)
 
 
-class AddSuggestion(LoggedWithReadWriteHability, SingleContentFormViewMixin):
+class AddSuggestion(LoggedWithReadWriteHability, PermissionRequiredMixin, SingleContentFormViewMixin):
     only_draft_version = True
     authorized_for_staff = True
+    permissions = ["tutorialv2.change_publishablecontent"]
 
     def post(self, request, *args, **kwargs):
         publication = get_object_or_404(PublishableContent, pk=kwargs["pk"])


### PR DESCRIPTION
Dans la suite de #6188, cette PR :

* rajoute des tests pour la vue AddSuggestion ;
* corrige un bug (déjà hotfixé) qui permettait à des auteurs motivés de faire des modifs alors que c'est normalement destiné au staff.

### Contrôle qualité

S'assurer de bien avoir Elastic Search d'installé (nécessaire pour ajouter des suggestions facilement).

- se connecter avec un compte staff
- créer des suggestions sur un contenu :
   * normalement (une ou plusieurs suggestions) et constater que ça fonctionne bien
   * envoyer des choses invalides (par exemple en bidouillant le formulaire) : vide, pas un id existant, un id qui n'est pas un nombre et observer ce qu'il se passe (il peut y avoir des 404 et des erreurs internes, je n'ai pas changé les comportements bruts de décoffrage actuels) ;
   *envoyer des suggestions interdites tels que des billets non-validés, des contenus non-publiés, des suggestions en double, suggérer le contenu lui-même et observer les erreurs associées.

Pour ce qui est du bug de passer outre l'autorisation staff, il suffit d'envoyer une requête en tant qu'auteur avec le bon formulaire (avec l'inspecteur prendre le formulaire staff, l'injecter sur une page en tant qu'auteur, en prenant soin de changer le token csrf et envoyer). Il faut donc tester que ce n'est plus possible.
