### PR TITLE
Ajoute des tests à AddContributor

### DIFF
--- a/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
+++ b/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
@@ -1,0 +1,192 @@
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from django.utils.html import escape
+
+
+from zds.member.factories import ProfileFactory, StaffProfileFactory
+from zds.tutorialv2.factories import PublishableContentFactory
+from zds.tutorialv2.forms import ContributionForm
+from zds.tutorialv2.models.database import ContentContribution, ContentContributionRole
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+
+
+def create_contribution(role, contributor, content):
+    contribution = ContentContribution(contribution_role=role, user=contributor, content=content)
+    contribution.save()
+    return contribution
+
+
+def create_role(title):
+    role = ContentContributionRole(title=title)
+    role.save()
+    return role
+
+
+@override_for_contents()
+class AddContributorPermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+        self.contributor = ProfileFactory().user
+        settings.ZDS_APP["member"]["bot_account"] = ProfileFactory().user.username
+
+        # Create content
+        self.content = PublishableContentFactory(author_list=[self.author])
+        self.role = create_role("Contributeur espiègle")
+
+        # Get information to be reused in tests
+        self.form_url = reverse("content:add-contributor", kwargs={"pk": self.content.pk})
+        self.login_url = reverse("member-login") + "?next=" + self.form_url
+        self.content_url = reverse("content:view", kwargs={"pk": self.content.pk, "slug": self.content.slug})
+        self.form_data = {"username": self.contributor, "contribution_role": self.role.pk}
+
+    def test_not_authenticated(self):
+        self.client.logout()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_outsider(self):
+        self.client.force_login(self.outsider)
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+    def test_authenticated_author(self):
+        self.client.force_login(self.author)
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff_tutorial(self):
+        self.client.force_login(self.staff)
+        self.content.type = "TUTORIAL"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff_article(self):
+        self.client.force_login(self.staff)
+        self.content.type = "ARTICLE"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff_opinion(self):
+        self.client.force_login(self.staff)
+        self.content.type = "OPINION"
+        self.content.save()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+
+class AddContributorWorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create entities for the test
+        self.author = ProfileFactory().user
+        self.contributor = ProfileFactory().user
+        self.role = create_role("Validateur")
+        self.content = PublishableContentFactory(author_list=[self.author])
+        settings.ZDS_APP["member"]["bot_account"] = ProfileFactory().user.username
+
+        # Get information to be reused in tests
+        self.form_url = reverse("content:add-contributor", kwargs={"pk": self.content.pk})
+        self.error_message_author_contributor = _("Un auteur ne peut pas être désigné comme contributeur")
+        self.error_message_empty_user = _("Veuillez renseigner l'utilisateur")
+        self.comment = "What an mischievious person!"
+
+        # Log in with an authorized user to perform the tests
+        self.client.force_login(self.author)
+
+    def test_correct(self):
+        form_data = {
+            "username": self.contributor,
+            "contribution_role": self.role.pk,
+            "comment": self.comment,
+        }
+        self.client.post(self.form_url, form_data, follow=True)
+        contribution = ContentContribution.objects.filter(
+            content=self.content.pk,
+            user=self.contributor,
+            contribution_role=self.role,
+            comment=self.comment,
+        ).first()
+        self.assertEqual(list(ContentContribution.objects.all()), [contribution])
+
+    def test_empty_user(self):
+        form_data = {
+            "username": "",
+            "contribution_role": self.role.pk,
+        }
+        response = self.client.post(self.form_url, form_data, follow=True)
+        self.assertContains(response, escape(ContributionForm.declared_fields["username"].error_messages["required"]))
+        self.assertEqual(list(ContentContribution.objects.all()), [])
+
+    def test_no_user(self):
+        form_data = {
+            "contribution_role": self.role.pk,
+        }
+        response = self.client.post(self.form_url, form_data, follow=True)
+        self.assertContains(response, escape(ContributionForm.declared_fields["username"].error_messages["required"]))
+        self.assertEqual(list(ContentContribution.objects.all()), [])
+
+    def test_invalid_user(self):
+        form_data = {
+            "username": "this pseudo does not exist",
+            "contribution_role": self.role.pk,
+        }
+        response = self.client.post(self.form_url, form_data, follow=True)
+        self.assertContains(response, escape(self.error_message_empty_user))
+        self.assertEqual(list(ContentContribution.objects.all()), [])
+
+    def test_author_contributor(self):
+        form_data = {
+            "username": self.author,
+            "contribution_role": self.role.pk,
+        }
+        response = self.client.post(self.form_url, form_data, follow=True)
+        self.assertContains(response, escape(self.error_message_author_contributor))
+        self.assertEqual(list(ContentContribution.objects.all()), [])
+
+    def test_empty_role(self):
+        form_data = {
+            "username": self.contributor,
+            "contribution_role": "",
+        }
+        response = self.client.post(self.form_url, form_data, follow=True)
+        self.assertContains(
+            response, escape(ContributionForm.declared_fields["contribution_role"].error_messages["required"])
+        )
+        self.assertEqual(list(ContentContribution.objects.all()), [])
+
+    def test_no_role(self):
+        form_data = {
+            "username": self.contributor,
+        }
+        response = self.client.post(self.form_url, form_data, follow=True)
+        self.assertContains(
+            response, escape(ContributionForm.declared_fields["contribution_role"].error_messages["required"])
+        )
+        self.assertEqual(list(ContentContribution.objects.all()), [])
+
+    def test_invalid_role(self):
+        form_data = {
+            "username": self.contributor,
+            "contribution_role": 3150,  # must be an invalid pk, integer or not
+        }
+        response = self.client.post(self.form_url, form_data, follow=True)
+        self.assertContains(
+            response, escape(ContributionForm.declared_fields["contribution_role"].error_messages["invalid_choice"])
+        )
+        self.assertEqual(list(ContentContribution.objects.all()), [])


### PR DESCRIPTION
Dans la lignée de #6193. Cette PR rajoute des tests pour la vue `AddContributor`.

Je n'ai pas changé du tout le comportement de la vue en elle-même, donc les tests unitaires devraient suffire. La vue n'était pas testée avant, et ça m'a fait remarquer quelques excentricités qui pourront être refactorisée un jour. ^^

### Contrôle qualité

Le passage des tests unitaires devrait suffire, parce que je n'ai pas du tout touché au code de la vue.

Une revue de code est la bienvenue (mais bon, c'est du code de test, pas le niveau maximal d'intérêt :D ).