### PR TITLE
Retire le champ de recherche (inactif) sur les profils

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -119,14 +119,6 @@
                         {% endfor %}
 
                         <div class="aside">
-                            <form action="{% url 'search:query' %}" id="search-member-form" class="search" method="get">
-                                {% csrf_token %}
-                                <label for="id_q" class="control-label">{% trans 'Recherche' %}</label>
-                                <input id="id_q" maxlength="150" name="q" required="required" type="search" placeholder="dans l'activité du membre (prochainement)" readonly>
-                                <input type="hidden" name="models" value="content">
-                                <button class="btn ico-after ico-search" type="submit" title="{% trans 'Rechercher' %}"><span>{% trans 'Rechercher' %}</span></button>
-                            </form>
-
                             <aside class="under-search">
                                 <ul class="presence-statistics-in-banner" aria-hidden="true">
                                     {{ presence_statistics }}


### PR DESCRIPTION
Fix #6191.

Le champ de recheche n'a pas été rendu fonctionnel depuis des mois ou des années. On pourra le remettre quand on aura quelque chose à proposer. ^^ 

### Contrôle qualité

* vérifier que ça ne casse pas le design sur écran normal
* pareil sur mobile
