### PR TITLE
Importe l'information 'ready_to_publish' depuis les archives

### DIFF
--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -1634,7 +1634,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # ensure the content
         self.assertEqual(versioned.get_introduction(), some_text)
-        self.assertEqual(versioned.get_introduction(), some_text)
+        self.assertEqual(versioned.get_conclusion(), some_text)
         self.assertEqual(len(versioned.children), 1)
 
         new_chapter = versioned.children[-1]

--- a/zds/tutorialv2/views/archives.py
+++ b/zds/tutorialv2/views/archives.py
@@ -198,6 +198,8 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
                         raise BadArchiveError(_(f"Le fichier « {child.conclusion} » n'est pas encodé en UTF-8"))
 
                 copy_to.repo_add_container(child.title, introduction, conclusion, do_commit=False, slug=child.slug)
+                copy_to.children[-1].ready_to_publish = child.ready_to_publish
+                copy_to.repo_update(copy_to.title, introduction, conclusion, do_commit=False)
                 UpdateContentWithArchive.update_from_new_version_in_zip(copy_to.children[-1], child, zip_file)
 
             elif isinstance(child, Extract):
@@ -381,6 +383,7 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
                 if new_version.conclusion:
                     conclusion = str(zfile.read(new_version.conclusion), "utf-8")
 
+                versioned.ready_to_publish = new_version.ready_to_publish
                 versioned.repo_update_top_container(
                     new_version.title, new_version.slug, introduction, conclusion, do_commit=False
                 )


### PR DESCRIPTION
L'import d'archives ne prenait pas en compte l'information 'ready_to_publish', c'est chose faite. Désormais exporter un contenu et le réimporter identiquement est idempotent à ce niveau-là. Ça permet aussi de changer les 'ready_to_publish' ailleurs et réimporter sur le site, comme le font certains auteurs.

Fix #6184.

**Remarque :** Ce n'est pas la meilleure correction possible. L'idéal serait de refactoriser l'import des archives entièrement, mais c'est pas le même boulot de développement ni de QA. La qualité du code et des interfaces peut être pas mal améliorée sous certains aspects.

### Contrôle qualité

Pour la correction du bug :

  * Créer un contenu, avec des parties sans sous parties, et des parties avec chapitre. Le but est d'avoir à la fois des conteneurs avec et sans enfants pour bien cadrer le code en testant.
  * Changer des status 'prêt à valider' dans différents endroits.
  * Exporter l'archive, constater que les statuts 'prêts à valider' sont bien ce qu'il faut.
  * Changer les statuts de manière aléatoire sur la publication
  * Importer l'archive et constater que les status de 'prêt à valider'  sont mis à jour avec ceux de l'archive.

Non régression : vérifier que les autres parties de l'archive sont importées correctement (par exemple modifier l'intro, les titres, etc.).