### PR TITLE
Améliore les messages d'erreur pour l'importation d'image

### DIFF
--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -333,7 +333,8 @@ class NewImage(ImageFromGalleryContextViewMixin, ImageCreateMixin, LoggedWithRea
             self.perform_create(
                 form.cleaned_data.get("title"), self.request.FILES.get("physical"), form.cleaned_data.get("legend")
             )
-        except NotAnImage:
+        except NotAnImage as e:
+            messages.error(self.request, _(f"Le fichier « {e} » n'est pas une image valide."))
             form.add_error("physical", _("Image invalide"))
             return super().form_invalid(form)
         self.success_url = reverse("gallery-image-edit", kwargs={"pk_gallery": self.gallery.pk, "pk": self.image.pk})
@@ -387,7 +388,12 @@ class EditImage(ImageFromGalleryContextViewMixin, ImageUpdateOrDeleteMixin, Logg
         data["title"] = form.cleaned_data.get("title")
         data["legend"] = form.cleaned_data.get("legend")
 
-        self.perform_update(data)
+        try:
+            self.perform_update(data)
+        except NotAnImage as e:
+            messages.error(self.request, _(f"Le fichier « {e} » n'est pas une image valide."))
+            form.add_error("physical", _("Image invalide"))
+            return super().form_invalid(form)
 
         self.success_url = reverse("gallery-image-edit", kwargs={"pk_gallery": self.gallery.pk, "pk": self.image.pk})
 


### PR DESCRIPTION
Améliore les messages d'erreur pour l'importation d'image

[Sujet du forum où le bug a été reporté](https://zestedesavoir.com/forums/sujet/15851/bug-dimport-dimages-svg/)

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`

- Ajout d'image
  - Aller dans une galerie
  - Cliquer sur "Ajouter une image"
  - Sélectionner une image invalide (par exemple un PDF)
  - Envoyer le formulaire
  - Vérifier que le bandeau orange « Le fichier « Bidule » n'est une image valide. » s'affiche
- Mise à jour d'image
  - Aller dans une galerie
  - Aller sur une image
  - Sélectionner une image invalide (par exemple un PDF)
  - Envoyer le formulaire (bouton « Mettre à jour »)
  - Vérifier que le bandeau orange « Le fichier « Bidule » n'est une image valide. » s'affiche
  - Vérifier que le message « Image invalide » s'affiche bien en dessous du bouton de sélection de l'image