### PR TITLE
Précise que changer une image ne la changera pas là où elle est déjà utilisée

### DIFF
--- a/doc/source/back-end/gallery.rst
+++ b/doc/source/back-end/gallery.rst
@@ -24,7 +24,7 @@ Il est ensuite possible d'uploader des images via le menu de gauche :
 
       Liens permettant d'uploader des images
 
-Via celui-ci, on peut importer des archives contenant des images (au format ZIP) ou des images seules. Dans ce dernier cas, le formulaire d'*upload* est le suivant :
+Via celui-ci, on peut importer des archives (au format ZIP) contenant des images ou des images seules. Dans ce dernier cas, le formulaire d'*upload* est le suivant :
 
    .. figure:: ../images/gallery/nouvelle-image.png
       :align: center
@@ -33,6 +33,9 @@ Via celui-ci, on peut importer des archives contenant des images (au format ZIP)
 
 Comme on peut le voir, chaque image doit posséder au minimum un titre et peut posséder une légende, qui sera employée par la suite. Il est donc conseillé de remplir également ce second champ, bien que ce ne soit pas obligatoire. Quant à l'image elle-même, sa taille ne peut pas excéder 1024 Kio.
 
+.. attention::
+    Le titre de l'image n'entre pas en compte dans le nommage de l'image une fois cette dernière téléchargée. Afin de réduire le risque de rencontrer des conflits de noms de fichiers, ces derniers sont hashés.
+
 Une fois l'image uploadée, il est possible d'y effectuer différentes actions sur la page qui lui est spécifique :
 
    .. figure:: ../images/gallery/gestion-image.png
@@ -40,13 +43,10 @@ Une fois l'image uploadée, il est possible d'y effectuer différentes actions s
 
       Gestion d'une image
 
-Autrement dit,
+Autrement dit :
 
-+ En modifier le titre, la légende ou encore l'image en elle-même. À noter que le titre et la légende peuvent être modifiés **sans qu'il ne soit nécessaire** d'uploader une nouvelle image.
++ En modifier le titre, la légende ou encore l'image en elle-même. À noter que le titre et la légende peuvent être modifiés **sans qu'il ne soit nécessaire** d'uploader une nouvelle image. Si une nouvelle version de l'image est uploadée, l'ancienne version de l'image n'est pas supprimée du serveur et reste accessible depuis son URL ; un nouvel identifiant (et donc une nouvelle URL) sera attribué à la nouvelle version de l'image. Cela signifie notamment que mettre à jour une image ne changera pas l'image là où elle a déjà été utilisée (tutoriel, article, message, ...). Ce comportement permet d'éviter que les images utilisées dans des contenus validés soient changées sans repasser par une validation.
 + Obtenir le code à insérer dans un champ de texte acceptant le Markdown pour l'image en elle-même, sa miniature ou encore la miniature accompagnée du lien vers l'image en taille réelle.
-
-.. attention::
-    Le titre de l'image n'entre pas en compte dans le nommage de l'image une fois cette dernière téléchargée. Afin de réduire le risque de rencontrer des conflits de noms de fichiers, ces derniers sont hashés.
 
 Les utilisateurs et leurs droits
 --------------------------------

--- a/zds/gallery/forms.py
+++ b/zds/gallery/forms.py
@@ -159,6 +159,9 @@ class UpdateImageForm(ImageForm):
         super().__init__(*args, **kwargs)
 
         self.fields["physical"].required = False
+        self.fields["physical"].label = _(
+            "Changer l'image (attention : cela ne changera pas l'image là où vous l'avez déjà utilisée ; un nouvel identifiant sera attribué à la nouvelle image)"
+        )
 
         self.helper = FormHelper()
         self.helper.form_class = "clearfix"


### PR DESCRIPTION
Précise à la fois dans la documentation et dans le formulaire pour mettre à jour une image dans une galerie, que ce changement n'affectera pas les utilisations précédentes de l'image.

### Contrôle qualité


  - Relire la documentation (`make generate-doc`)
  - Aller sur la page pour éditer une image, s'assurer que le label du champ pour uploader une image est bien changé.
