### PR TITLE
Corrige le lien de progdupeupl

### DIFF
--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -99,7 +99,7 @@ ZDS_APP = {
                 "code": "GPL v3",
                 "url_license": "http://www.gnu.org/licenses/gpl-3.0.html",
                 "provider_name": "Progdupeupl",
-                "provider_url": "http://pdp.microjoe.org",
+                "provider_url": "https://github.com/progdupeupl/pdp_website",
             },
             "licence_info_title": "http://zestedesavoir.com/tutoriels/281/le-droit-dauteur-creative-commons-et-les-lic"
             "ences-sur-zeste-de-savoir/",


### PR DESCRIPTION
Rapporté sur le [forum](https://zestedesavoir.com/forums/sujet/15862/lien-mort-dans-les-cgu/).

### Contrôle qualité

S'assurer que sur les pages des CGU et *À propos*, le lien vers progdupeupl mène vers le dépôt GitHub des sources du site progdupeupl.
