### PR TITLE
Ajout d’un passage sur nvm et bashrc

### DIFF
--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -39,13 +39,13 @@ Stoppez le serveur à l'aide de ctrl+c. Pour sortir de votre environnement, tape
 
 Vous pouvez également `indiquer à Git de ne pas effectuer de commit s'il y a des erreurs de formatage dans le code <../utils/git-pre-hook.html>`__.
 
-Si vous utilisez un shell autre que bash, et que vous avez l’erreur suivante quand vous activez zdsenv :
+Si vous utilisez un shell autre que bash, et que vous avez l’erreur suivante quand vous activez ``zdsenv`` :
 
 .. sourcecode:: bash
 
-    …/ZesteDeSavoir/zds-site/zdsenv/bin/activate:67: command not found: nvm
+    …/zds-site/zdsenv/bin/activate:67: command not found: nvm
 
-Alors c’est très probablement dû au script d’installation de nvm qui ne gère que bash. Pour corriger ce problème, ouvrez votre fichier bashrc et copiez les lignes concernant nvm dans le fichier de configuration de votre shell. Ces fichiers se trouvent dans votre répertoire utilisateur, par exemple :
+Alors c’est très probablement dû au script d’installation de nvm qui ne gère que Bash. Pour corriger ce problème, ouvrez votre fichier ``.bashrc`` et copiez les lignes concernant nvm dans le fichier de configuration de votre shell. Ces fichiers se trouvent dans votre répertoire utilisateur, par exemple :
 
 .. sourcecode:: bash
 

--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -35,10 +35,22 @@ Une fois que c'est fait, vous pouvez directement lancer votre instance à l'aide
     make zmd-start # démarrer zmarkdown
     make run-back # démarer le serveur django
 
-
 Stoppez le serveur à l'aide de ctrl+c. Pour sortir de votre environnement, tapez ``deactivate``.
 
 Vous pouvez également `indiquer à Git de ne pas effectuer de commit s'il y a des erreurs de formatage dans le code <../utils/git-pre-hook.html>`__.
+
+Si vous utilisez un shell autre que bash, et que vous avez l’erreur suivante quand vous activez zdsenv :
+
+.. sourcecode:: bash
+
+    …/ZesteDeSavoir/zds-site/zdsenv/bin/activate:67: command not found: nvm
+
+Alors c’est très probablement dû au script d’installation de nvm qui ne gère que bash. Pour corriger ce problème, ouvrez votre fichier bashrc et copiez les lignes concernant nvm dans le fichier de configuration de votre shell. Ces fichiers se trouvent dans votre répertoire utilisateur, par exemple :
+
+.. sourcecode:: bash
+
+    ~/.bashrc
+    ~/.zshrc
 
 Plus d'informations
 -------------------


### PR DESCRIPTION
Conseils pour gérer le cas où l’utilisateur utilise un autre shell que bash, alors que le script nvm ne configure que bash.

Numéro du ticket concerné : Fixes #6211

### Contrôle qualité

Juste relire le passage :)
