### PR TITLE
Mise à jour triviale des dépendances Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
   PYTHON_VERSION: "3.7"
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "2.2.0"
-  BLACK_VERSION: "21.10b0" # needs to be also updated in requirements-dev.txt and .pre-commit-config.yaml
+  BLACK_VERSION: "21.12b0" # needs to be also updated in requirements-dev.txt and .pre-commit-config.yaml
 
   # As GitHub Action does not allow environment variables
   # to be used in services definitions, these are only for

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     -   id: pyupgrade
         args: [--py36-plus]
   - repo: https://github.com/psf/black
-    rev: 21.10b0 # needs to be also updated in requirements-dev.txt and .github/workflows/ci.yml
+    rev: 21.12b0 # needs to be also updated in requirements-dev.txt and .github/workflows/ci.yml
     hooks:
       - id: black
         language_version: python3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 
-black==21.10b0  # needs to be also updated in .github/workflows/ci.yml and .pre-commit-config.yaml
+black==21.12b0  # needs to be also updated in .github/workflows/ci.yml and .pre-commit-config.yaml
 colorlog==6.6.0
-django-debug-toolbar==3.2.2
+django-debug-toolbar==3.2.4
 django-extensions==3.1.5
-Faker==9.8.1
-pre-commit==2.15.0
+Faker==10.0.0
+pre-commit==2.16.0
 PyYAML==6.0
 selenium==3.141.0
-Sphinx==4.3.0
+Sphinx==4.3.2
 sphinx_rtd_theme==1.0.0

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
 gunicorn==20.1.0
-mysqlclient==2.0.3
-sentry-sdk==1.4.3
-ujson==4.2.0
+mysqlclient==2.1.0
+sentry-sdk==1.5.1
+ujson==5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,24 +10,24 @@ django-crispy-forms==1.13.0
 django-model-utils==4.2.0
 django-munin==0.2.1
 django-recaptcha==2.0.6
-Django==2.2.24
+Django==2.2.25
 easy-thumbnails==2.8.0
 factory-boy==3.2.1
-geoip2==4.4.0
+geoip2==4.5.0
 GitPython==3.1.24
 homoglyphs==2.0.4
-lxml==4.6.4
+lxml==4.7.1
 Pillow==8.4.0
 python-memcached==1.59
 requests==2.26.0
 toml==0.10.2
 
 # Api dependencies
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
 django-filter==21.1
 django-oauth-toolkit==1.5.0
 djangorestframework-xml==2.0.0
-djangorestframework==3.12.4
+djangorestframework==3.13.1
 drf-extensions==0.7.1
 dry-rest-permissions==0.1.10
 drf_yasg==1.20.0


### PR DESCRIPTION
- Mise à jour a priori triviales pour tous les paquets
- Je n'ai pas mis à jour `coverage` et `coveralls` car ce n'est pas trivial (nouvelle version majeure pour les deux et [changement de l'héritage des configurations](https://github.com/TheKevJames/coveralls-python/blob/master/CHANGELOG.md#300-2021-01-12) pour `coveralls`)
- Je n'ai pas mis à jour `selenium` car ce n'est pas trivial (nouvelle version majeure, potentielle mise à jour de Java 11 OpenJDK)
- Comme d'habitude, je n'ai pas mis à jour `django-munin`, ` elasticsearch` et ` elasticsearch-dsl`

**Note** Certaines dépendances enlèvent le support de Python 3.6 étant donné que cette version n'est plus supportée depuis le 23 décembre.

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que le site web fonctionne globalement correctement
- `make generate-doc`
- Vérifier que la documentation fonctionne globalement correctement
