### PR TITLE
Corrige l'initialisation du menu mobile sur tablette

### DIFF
--- a/assets/js/mobile-menu.js
+++ b/assets/js/mobile-menu.js
@@ -46,7 +46,7 @@
    * Manage mobile sidebar on resize
    */
   $(window).on('resize', function() {
-    if (parseInt($('html').css('width')) < 960 && !disableMobileMenu) {
+    if (parseInt($('html').css('width')) < 1024 && !disableMobileMenu) {
       $('.page-container').css('width', $('html').css('width'))
 
       if (!$('#mobile-menu').hasClass('initialized')) {


### PR DESCRIPTION
Petite PR pour faire en sorte que le menu mobile soit initialisé sur les écrans entre 960 et 1024px.
Sur ces écrans le bouton "burger" s'affiche mais le menu ne s'ouvre pas.

C'est le cas lorsque j'affiche ZDS sur un demi écran 21/9.

⚠️ Le bug ne se produit pas lorsqu'on redimensionne d'une résolution supérieure 960 jusqu'à une résolution entre 960 et 1024 car dans ce cas le menu est déjà initialisé.

### Contrôle qualité

- Se rendre sur une page de ZDS affichant le menu
- Redimensionner sa fenêtre pour atteindre une largeur entre 960 et 1024px
- Recharger la page
- Le bouton "burger" fonctionne et ouvre le menu principal
