### PR TITLE
Redirection vers la version publique (si elle existe) d’un contenu inaccessible (#5858)

### DIFF
--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -144,7 +144,11 @@ class SingleContentPostMixin(SingleContentViewMixin):
     versioned = True
 
     def get_object(self, queryset=None):
-        self.object = super().get_object()
+        try:
+            self.object = super().get_object()
+        except RedirectToPublicVersion:
+            # This is a POST mixin, thus there is no public content redirection here.
+            raise PermissionDenied
 
         if self.versioned and "version" in self.request.POST["version"]:
             self.object.load_version_or_404(sha=self.request.POST["version"])

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -4709,7 +4709,8 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         content = PublishedContentFactory(author_list=[self.user_author])
         self.client.force_login(self.user_guest)
         resp = self.client.get(reverse("content:view", args=[content.pk, content.slug]))
-        self.assertEqual(403, resp.status_code)
+        self.assertEqual(301, resp.status_code)
+        self.assertEqual(reverse("tutorial:view", args=[content.pk, content.slug]), resp.url)
 
     def test_republish_with_different_slug(self):
         """Ensure that a new PublishedContent object is created and well filled"""

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -1168,7 +1168,8 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         content = PublishedContentFactory(author_list=[self.user_author])
         self.client.force_login(self.user_guest)
         resp = self.client.get(reverse("content:view", args=[content.pk, content.slug]))
-        self.assertEqual(403, resp.status_code)
+        self.assertEqual(301, resp.status_code)
+        self.assertEqual(reverse("tutorial:view", args=[content.pk, content.slug]), resp.url)
 
     def test_republish_with_different_slug(self):
         """Ensure that a new PublishedContent object is created and well filled"""


### PR DESCRIPTION
Fait en sorte que si un utilisateur n’a pas accès à un contenu en brouillon/bêta (URL en `/contenu`) on le renvoie vers la version publique (URL en `/article`, `/tutoriel` ou `/billet`) si elle existe. Dans le cas contraire, on conserve le comportement actuel avec une erreur de type « accès interdit ».

Cette PR est en POC parce que la solution que j’ai mise en place m’a l’air étrange et va tripoter un fichier `mixins.py`, donc je préfère avoir une solution à peu près propre conceptuellement avant de m’attaquer aux tests. D’ailleurs je ne sais pas où sont faits lesdits tests, je ne vois pas de `tests_mixins.py`.

Numéro du ticket concerné : #5858 

_(Tests en attente, cf supra)_

_(Pas d’action particulière de MEP)_

### Contrôle qualité

- [ ] Vérifier que l’URL privée d’un tuto, d’un article et d’un billet publiés renvoie biens vers l’URL publique quand on est pas connecté.
- [ ] Idem quand on est connecté avec un compte utilisateur normal.
- [ ] Vérifier qu’on est pas redirigé dans ces mêmes cas avec un compte auteur des contenus.
- [ ] Idem avec un compte admin.
- [ ] Vérifier qu’on a bien une erreur d’accès sur l’URL privée d’un tuto, d’un article et d’un billet non publiés quand on est pas connectés.
- [ ] Idem avec un compte utilisateur normal.
- [ ] Vérifier qu’on est pas redirigé dans ces mêmes cas avec un compte auteur des contenus.
- [ ] Idem avec un compte admin.
- [ ] Et tout pareil avec une URL qui contient un SHA explicite (URLs de bêta).

Je me rends compte en l’écrivant qu’elle va être pénible à tester, cette MR…

