### PR TITLE
Corrige les marges des listes sur mobile (#6232)

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -200,6 +200,11 @@
                 margin-right: $length-10;
             }
 
+            ul,
+            ol {
+                margin-right: $length-10;
+            }
+
             figure {
                 p,
                 blockquote {


### PR DESCRIPTION
Numéro du ticket concerné : #6232 

### Contrôle qualité

- Rebuildez le front et lancez le site.
- Connectez vous avec un compte pas en LS.
- Créez un message (de forum ou de commentaire) qui contient un paragraphe normal, une liste à puce et une liste numérotée dont les lignes sont assez longues pour passer à la ligne sur mobile.
- Vérifiez que les listes à puce n’ont plus le texte qui se colle à droite au niveau des retours à la ligne (le plus simple, c’est de jouer avec la largeur du navigateur)
- Vérifier que sur les largeurs « desktop » rien n’est cassé.
