### PR TITLE
Affichage des membres en LS (reprise de la PR #5837)

### DIFF
--- a/templates/forum/category/forum.html
+++ b/templates/forum/category/forum.html
@@ -66,7 +66,7 @@
 
 
 {% block new_btn %}
-  {% if user.can_write_now %}
+  {% if user.profile.can_write_now %}
       <a href="{% url 'topic-new' %}?forum={{ forum.pk }}" class="new-btn ico-after more blue">
           {% trans "Nouveau sujet" %}
       </a>

--- a/templates/forum/category/forum.html
+++ b/templates/forum/category/forum.html
@@ -66,9 +66,11 @@
 
 
 {% block new_btn %}
-    <a href="{% url 'topic-new' %}?forum={{ forum.pk }}" class="new-btn ico-after more blue">
-        {% trans "Nouveau sujet" %}
-    </a>
+  {% if user.can_write_now %}
+      <a href="{% url 'topic-new' %}?forum={{ forum.pk }}" class="new-btn ico-after more blue">
+          {% trans "Nouveau sujet" %}
+      </a>
+  {% endif %}
 {% endblock %}
 
 

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -161,19 +161,19 @@
 {% endblock %}
 
 
-
 {% block new_btn %}
-    <a href="{% url 'topic-new' %}?forum={{ topic.forum.pk }}" class="new-btn ico-after more blue">
-        {% trans "Nouveau sujet" %}
-    </a>
+  {% if user.can_write_now %}
+      <a href="{% url 'topic-new' %}?forum={{ topic.forum.pk }}" class="new-btn ico-after more blue">
+          {% trans "Nouveau sujet" %}
+      </a>
 
-    {% if topic.author.pk == user.pk and topic.first_post.is_visible or is_staff %}
-        <a href="{% url 'topic-edit' %}?topic={{ topic.pk }}" class="new-btn ico-after edit blue">
-            {% trans "Éditer le sujet" %}
-        </a>
-    {% endif %}
+      {% if topic.author.pk == user.pk and topic.first_post.is_visible or is_staff %}
+          <a href="{% url 'topic-edit' %}?topic={{ topic.pk }}" class="new-btn ico-after edit blue">
+              {% trans "Éditer le sujet" %}
+          </a>
+      {% endif %}
+  {% endif %}
 {% endblock %}
-
 
 
 {% block sidebar_actions %}

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -162,7 +162,7 @@
 
 
 {% block new_btn %}
-  {% if user.can_write_now %}
+  {% if user.profile.can_write_now %}
       <a href="{% url 'topic-new' %}?forum={{ topic.forum.pk }}" class="new-btn ico-after more blue">
           {% trans "Nouveau sujet" %}
       </a>

--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -23,6 +23,10 @@
             <a href="{% url "register-member" %}" class="alert-box-btn">{% trans "Créer un compte" %}</a>
         </p>
     </div>
+{% elif not user.can_write_now %}
+<div class="alert-box ico-after ico-alert light">
+    {% trans "Vous êtes en lecture seule. Vous ne pouvez pas poster de messages." %}
+</div>
 {% elif topic.antispam or is_antispam %}
     <div class="alert-box ico-after ico-alert light">
         {% trans "Vous venez de poster. Merci de patienter au moins 15 minutes entre deux messages consécutifs afin de limiter le flood." %}

--- a/templates/misc/message_form.html
+++ b/templates/misc/message_form.html
@@ -23,10 +23,10 @@
             <a href="{% url "register-member" %}" class="alert-box-btn">{% trans "Créer un compte" %}</a>
         </p>
     </div>
-{% elif not user.can_write_now %}
-<div class="alert-box ico-after ico-alert light">
-    {% trans "Vous êtes en lecture seule. Vous ne pouvez pas poster de messages." %}
-</div>
+{% elif not user.profile.can_write_now %}
+    <div class="alert-box ico-after ico-alert light">
+        {% trans "Vous êtes en lecture seule. Vous ne pouvez pas poster de messages." %}
+    </div>
 {% elif topic.antispam or is_antispam %}
     <div class="alert-box ico-after ico-alert light">
         {% trans "Vous venez de poster. Merci de patienter au moins 15 minutes entre deux messages consécutifs afin de limiter le flood." %}

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -776,6 +776,45 @@ class ForumMemberTests(TestCase):
         template_response = self.client.get(topic.get_absolute_url() + "?page=2")
         self.assertNotIn(expected, template_response.content.decode("utf-8"))
 
+    def test_frontend_topic_message_when_profile_readonly(self):
+        readonly_profile = ProfileFactory(can_write=False)
+        self.client.force_login(readonly_profile.user)
+
+        topic = TopicFactory(forum=self.forum11, author=readonly_profile.user)
+        PostFactory(topic=topic, author=readonly_profile.user, position=1)
+        PostFactory(topic=topic, author=self.user, position=2)
+
+        template_response = self.client.get(topic.get_absolute_url())
+        decoded_content = template_response.content.decode("utf-8")
+        self.assertNotIn("Nouveau sujet", decoded_content)
+        self.assertNotIn("Éditer le sujet", decoded_content)
+        self.assertIn("Vous êtes en lecture seule. Vous ne pouvez pas poster de messages.", decoded_content)
+
+    def test_frontend_topic_no_message_when_profile_can_write(self):
+        self.client.force_login(self.user2)
+
+        topic = TopicFactory(forum=self.forum11, author=self.user2)
+        PostFactory(topic=topic, author=self.user2, position=1)
+        PostFactory(topic=topic, author=self.user, position=2)
+
+        template_response = self.client.get(topic.get_absolute_url())
+        decoded_content = template_response.content.decode("utf-8")
+        self.assertIn("Nouveau sujet", decoded_content)
+        self.assertIn("Éditer le sujet", decoded_content)
+        self.assertNotIn("Vous êtes en lecture seule. Vous ne pouvez pas poster de messages.", decoded_content)
+
+    def test_frontend_no_create_topic_when_profile_readonly(self):
+        readonly_profile = ProfileFactory(can_write=False)
+        self.client.force_login(readonly_profile.user)
+
+        template_response = self.client.get(self.forum22.get_absolute_url())
+        self.assertNotIn("Nouveau sujet", template_response.content.decode("utf-8"))
+
+    def test_frontend_can_create_topic_when_profile_can_write(self):
+        self.client.force_login(self.user)
+        template_response = self.client.get(self.forum22.get_absolute_url())
+        self.assertIn("Nouveau sujet", template_response.content.decode("utf-8"))
+
 
 class ForumGuestTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
Affiche un message d’avertissement à la place du formulaire si le membre est en LS. Supprime aussi les liens d’édition et de création de sujets. 

Numéro du ticket concerné : #5684 

### Contrôle qualité

- Avec un compte normal (droits d’écriture), vérifier que :
    - Le lien « Nouveau sujet » est présent sur les pages de forum et de sujet
    - Le lien « Éditer le sujet » est présent sur les sujets créés par l’utilisateur
    - Le formulaire de rédaction est bien présent
- Avec un compte en lecture seule, vérifier que :
    - Le lien « Nouveau sujet » est absent des pages de forum et de sujets
    - Le lien « Éditer le sujet » est absent des sujets créés par l’utilisateur
    - Le formulaire de rédaction est remplacé par un avertissement qui indique que l’utilisateur est en LS.