### PR TITLE
Vérifie qu'il ne manque pas de migrations dans la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,9 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements-ci.txt
 
+      - name: Check no migration is missing
+        run: python manage.py makemigrations --check --dry-run
+
       - name: Build and start zmarkdown
         run: |
           make zmd-install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements-ci.txt
 
-      - name: Check no migration is missing
+      - name: Check that no migration is missing
         run: python manage.py makemigrations --check --dry-run
 
       - name: Build and start zmarkdown


### PR DESCRIPTION
Pour faire suite à la suggestion de @Situphen dans la PR https://github.com/zestedesavoir/zds-site/pull/6231, cette PR ajoute une étape dans la CI qui vérifie qu'il ne manque pas de migration de la base de données, et échoue le cas échéant.

**Cette PR ne passera pas la CI**, puisqu'il manque actuellement une migration dans le code, corrigé dans la PR de Situphen.

J'ai testé les changements en pushant une fois avec puis sans la migration manquante, ça se comporte bien comme on le souhaite.

En terme de QA, juste faire une petite revue de code (et me faire confiance quand je dis que ça fonctionne ! :D ).
