### PR TITLE
Ajoute Ubuntu 20.04 LTS dans la liste des versions Ubuntu testées du script d'installation

### DIFF
--- a/scripts/dependencies/ubuntu.txt
+++ b/scripts/dependencies/ubuntu.txt
@@ -1,5 +1,5 @@
 #title=Ubuntu
-#desc=Utilisation de apt-get / Testé sur : Ubuntu 16.04 LTS, 18.04 LTS, 19.04 & Linux Mint 19
+#desc=Utilisation de apt-get / Testé sur : 18.04 LTS, 19.04, 20.04 LTS & Linux Mint 19
 #updatecmd=apt-get -y update
 #installcmd=apt-get -y install
 git


### PR DESCRIPTION
Je développe sous Ubuntu 20.04 et j'ai eu l'occasion de réinstaller et autres, et ça marche bien.

J'ajoute donc une mention dans le script d'installation, similairement à #6239.

### Contrôle qualité

Dans l'absolu, il faut tenter l'installation sur une installation fraîche d'Ubuntu 20.04 LTS, en VM par exemple et suivre le tutoriel d'installation et vérifier que ça fonctionne.