### PR TITLE
Remplace notre implémentation de LoginRequiredMixin par celle de Django

### DIFF
--- a/zds/member/decorator.py
+++ b/zds/member/decorator.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin
 
 from django.core.exceptions import PermissionDenied
 from django.utils.decorators import method_decorator
@@ -43,19 +43,6 @@ class PermissionRequiredMixin:
 
     def dispatch(self, *args, **kwargs):
         self.check_permissions()
-        return super().dispatch(*args, **kwargs)
-
-
-class LoginRequiredMixin:
-    """
-    Represent the basic code that a Generic Class Based View has to use when
-    the required action needs the user to be logged in.
-    If the user is not logged in, the user is redirected to the connection form and the former action
-    is not executed.
-    """
-
-    @method_decorator(login_required)
-    def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 
 

--- a/zds/member/views.py
+++ b/zds/member/views.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User, Group
 from django.template.context_processors import csrf
 from django.core.exceptions import PermissionDenied
@@ -40,7 +41,7 @@ from zds.member.commons import (
     DeleteBanSanction,
     TokenGenerator,
 )
-from zds.member.decorator import can_write_and_read_now, LoginRequiredMixin, PermissionRequiredMixin
+from zds.member.decorator import can_write_and_read_now, PermissionRequiredMixin
 from zds.member.forms import (
     LoginForm,
     MiniProfileForm,

--- a/zds/tutorialv2/views/alerts.py
+++ b/zds/tutorialv2/views/alerts.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
@@ -10,7 +11,6 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 
-from zds.member.decorator import LoginRequiredMixin
 from zds.tutorialv2.models import TYPE_CHOICES_DICT
 from zds.tutorialv2.models.database import PublishableContent
 from zds.utils.models import Alert

--- a/zds/tutorialv2/views/archives.py
+++ b/zds/tutorialv2/views/archives.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from PIL import Image as ImagePIL
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
@@ -16,7 +17,7 @@ from easy_thumbnails.files import get_thumbnailer
 
 from zds import json_handler
 from zds.gallery.models import Image, Gallery
-from zds.member.decorator import LoginRequiredMixin, LoggedWithReadWriteHability
+from zds.member.decorator import LoggedWithReadWriteHability
 from zds.tutorialv2.forms import ImportContentForm, ImportNewContentForm
 from zds.tutorialv2.mixins import SingleContentDownloadViewMixin, SingleContentFormViewMixin
 from zds.tutorialv2.models.database import PublishableContent

--- a/zds/tutorialv2/views/comments.py
+++ b/zds/tutorialv2/views/comments.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.http import Http404, StreamingHttpResponse, HttpResponse
@@ -13,7 +14,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 
 from zds import json_handler
-from zds.member.decorator import LoggedWithReadWriteHability, LoginRequiredMixin, PermissionRequiredMixin
+from zds.member.decorator import LoggedWithReadWriteHability, PermissionRequiredMixin
 from zds.member.views import get_client_ip
 from zds.notification.models import ContentReactionAnswerSubscription
 from zds.tutorialv2.forms import NoteForm, NoteEditForm

--- a/zds/tutorialv2/views/containers_extracts.py
+++ b/zds/tutorialv2/views/containers_extracts.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime
 
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.http import JsonResponse, Http404
 from django.shortcuts import redirect
@@ -9,7 +10,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DeleteView, FormView
 
-from zds.member.decorator import LoggedWithReadWriteHability, LoginRequiredMixin
+from zds.member.decorator import LoggedWithReadWriteHability
 from zds.tutorialv2.forms import ContainerForm, WarnTypoForm, ExtractForm, MoveElementForm
 from zds.tutorialv2.mixins import (
     SingleContentFormViewMixin,

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.shortcuts import redirect, get_object_or_404
@@ -13,8 +14,8 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import DeleteView
 
 from zds.gallery.mixins import ImageCreateMixin, NotAnImage
-from zds.gallery.models import Gallery, Image
-from zds.member.decorator import LoggedWithReadWriteHability, LoginRequiredMixin
+from zds.gallery.models import Gallery
+from zds.member.decorator import LoggedWithReadWriteHability
 from zds.member.models import Profile
 from zds.tutorialv2.forms import (
     ContentForm,

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 from django.db.models import Q
@@ -13,7 +14,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView, FormView
 
-from zds.member.decorator import LoginRequiredMixin, PermissionRequiredMixin, LoggedWithReadWriteHability
+from zds.member.decorator import PermissionRequiredMixin, LoggedWithReadWriteHability
 from zds.mp.models import mark_read
 from zds.tutorialv2.forms import (
     AskValidationForm,

--- a/zds/tutorialv2/views/validations_opinions.py
+++ b/zds/tutorialv2/views/validations_opinions.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.db.models import F
@@ -14,7 +15,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, ListView
 
 from zds.gallery.models import Gallery
-from zds.member.decorator import LoggedWithReadWriteHability, LoginRequiredMixin, PermissionRequiredMixin
+from zds.member.decorator import LoggedWithReadWriteHability, PermissionRequiredMixin
 from zds.tutorialv2.forms import (
     PublicationForm,
     RevokeValidationForm,


### PR DESCRIPTION
Un des items de #6246.

Une partie de notre code utilisait déjà l'implémentation de Django, donc ça ne fait qu'éliminer de vieilles miettes.

### Contrôle qualité

En tant que visiteur non logué, vérifier qu'on est bien redirigé vers le login quand on utilise une page qui nécessite le login pour y accéder.