### PR TITLE
Place toujours LoginRequiredMixin le plus à gauche de la chaîne d'héritage

### DIFF
--- a/zds/tutorialv2/views/alerts.py
+++ b/zds/tutorialv2/views/alerts.py
@@ -16,7 +16,7 @@ from zds.tutorialv2.models.database import PublishableContent
 from zds.utils.models import Alert
 
 
-class SendContentAlert(FormView, LoginRequiredMixin):
+class SendContentAlert(LoginRequiredMixin, FormView):
     http_method_names = ["post"]
 
     @method_decorator(transaction.atomic)
@@ -48,7 +48,7 @@ class SendContentAlert(FormView, LoginRequiredMixin):
         return redirect(content.get_absolute_url_online())
 
 
-class SolveContentAlert(FormView, LoginRequiredMixin):
+class SolveContentAlert(LoginRequiredMixin, FormView):
     @method_decorator(transaction.atomic)
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)

--- a/zds/tutorialv2/views/comments.py
+++ b/zds/tutorialv2/views/comments.py
@@ -234,7 +234,7 @@ class UpdateNoteView(SendNoteFormView):
         return super().form_valid(form)
 
 
-class HideReaction(FormView, LoginRequiredMixin):
+class HideReaction(LoginRequiredMixin, FormView):
     http_method_names = ["post"]
 
     @method_decorator(transaction.atomic)
@@ -281,7 +281,7 @@ class ShowReaction(FormView, LoggedWithReadWriteHability, PermissionRequiredMixi
             raise Http404("Aucune réaction trouvée.")
 
 
-class SendNoteAlert(FormView, LoginRequiredMixin):
+class SendNoteAlert(LoginRequiredMixin, FormView):
     http_method_names = ["post"]
 
     @method_decorator(transaction.atomic)
@@ -312,7 +312,7 @@ class SendNoteAlert(FormView, LoginRequiredMixin):
         return redirect(reaction.get_absolute_url())
 
 
-class SolveNoteAlert(FormView, LoginRequiredMixin):
+class SolveNoteAlert(LoginRequiredMixin, FormView):
     @method_decorator(transaction.atomic)
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)


### PR DESCRIPTION
Comme recommandé par la documentation : https://docs.djangoproject.com/fr/3.2/topics/auth/default/#django.contrib.auth.mixins.LoginRequiredMixin


### Contrôle qualité

La CI devrait suffire, sinon tester d'accéder aux vues modifiées en étant connecté ou sans être connecté.
