### PR TITLE
Mise à jour de coverage et coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ env:
   NODE_VERSION: "12"
   PYTHON_VERSION: "3.7"
   MARIADB_VERSION: "10.4.10"
-  COVERALLS_VERSION: "2.2.0"
+  COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt
   BLACK_VERSION: "21.12b0" # needs to be also updated in requirements-dev.txt and .pre-commit-config.yaml
 
   # As GitHub Action does not allow environment variables
@@ -241,7 +241,7 @@ jobs:
         run: |
           echo $COVERALLS_FLAG_NAME
           python -m pip install coveralls==${{ env.COVERALLS_VERSION }}
-          coveralls
+          coveralls --service=github # See https://github.com/TheKevJames/coveralls-python/issues/252
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
           COVERALLS_PARALLEL: true
@@ -262,7 +262,7 @@ jobs:
       - name: Upload coverage data
         run: |
           python -m pip install coveralls==${{ env.COVERALLS_VERSION }}
-          coveralls --finish
+          coveralls --finish --service=github # See https://github.com/TheKevJames/coveralls-python/issues/252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 -r requirements-dev.txt
 -r requirements-prod.txt
 
-coverage==5.5
+coverage==6.3.2 # check if Coveralls needs to be also updated in .github/workflows/ci.yml


### PR DESCRIPTION
Mise à jour de coverage et coveralls

Il a été nécessaire d'ajouter `--service=github` pour que `coveralls` fonctionne correctement car sans cela il y a des erreurs 422 qui pointent le bout de leur nez. C'est un soucis chez `coveralls` dont la cause est pour l'instant inconnue. https://github.com/TheKevJames/coveralls-python/issues/252 

**QA :** Github Actions