### PR TITLE
(Export PDF) Enlève les conteneurs non validés

### DIFF
--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -414,7 +414,7 @@ class ZMarkdownRebberLatexPublicator(Publicator):
         replaced_media_url = settings.MEDIA_URL
         if replaced_media_url.startswith("/"):
             replaced_media_url = replaced_media_url[1:]
-        exported = export_content(public_versionned_source, with_text=True)
+        exported = export_content(public_versionned_source, with_text=True, ready_to_publish_only=True)
         # no title to avoid zmd to put it on the final latex
         del exported["title"]
         content, metadata, messages = render_markdown(

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -31,7 +31,7 @@ from zds.tutorialv2.utils import (
 from zds.tutorialv2.publication_utils import publish_content, unpublish_content
 from zds.tutorialv2.models.database import PublishableContent, PublishedContent, ContentReaction, ContentRead
 from django.core.management import call_command
-from zds.tutorialv2.publication_utils import Publicator, PublicatorRegistry
+from zds.tutorialv2.publication_utils import Publicator, PublicatorRegistry, ZMarkdownRebberLatexPublicator
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 from zds import json_handler
 from zds.utils.tests.factories import LicenceFactory
@@ -263,6 +263,13 @@ class UtilsTests(TutorialTestMixin, TestCase):
         """
         Test exported contents contain only ready_to_publish==True parts.
         """
+
+        # We need to produce at least the .tex file, so use the real PDF publicator:
+        previous_pdf_publicator = PublicatorRegistry.get("pdf")
+        previous_build_pdf_when_published = self.overridden_zds_app["content"]["build_pdf_when_published"]
+        PublicatorRegistry.registry["pdf"] = ZMarkdownRebberLatexPublicator(".pdf")
+        self.overridden_zds_app["content"]["build_pdf_when_published"] = True
+
         #  Medium-size tutorial
         midsize_tuto = PublishableContentFactory(type="TUTORIAL")
 
@@ -299,12 +306,30 @@ class UtilsTests(TutorialTestMixin, TestCase):
             self.assertIsNone(child.introduction)
             self.assertIsNone(child.conclusion)
 
+        # Test Markdown content:
         self.assertTrue(published.has_md())
         with Path(published.get_extra_contents_directory(), published.content_public_slug + ".md").open("r") as md:
             content = md.read()
             self.assertIn(chapter1.title, content)
             self.assertIn(chapter2.title, content)
             self.assertNotIn(chapter3.title, content)
+
+        # TODO: factorize getting texfile path with what is done in zds.tutorialv2.publication_utils.publish():
+        tmp_path = os.path.join(
+            settings.ZDS_APP["content"]["repo_public_path"], published.content_public_slug + "__building"
+        )
+        build_extra_contents_path = os.path.join(tmp_path, settings.ZDS_APP["content"]["extra_contents_dirname"])
+        base_name = os.path.join(build_extra_contents_path, published.content_public_slug)
+        tex_file = base_name + ".tex"
+        # PDF generation may fail, only test the tex content:
+        with open(tex_file) as tex:
+            content = tex.read()
+            self.assertIn(chapter1.title, content)
+            self.assertIn(chapter2.title, content)
+            self.assertNotIn(chapter3.title, content)
+
+        PublicatorRegistry.registry["pdf"] = previous_pdf_publicator
+        self.overridden_zds_app["content"]["build_pdf_when_published"] = previous_build_pdf_when_published
 
     def test_tagged_tree_extract(self):
         midsize = PublishableContentFactory(author_list=[self.user_author])

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -264,9 +264,10 @@ class UtilsTests(TutorialTestMixin, TestCase):
         Test exported contents contain only ready_to_publish==True parts.
         """
 
-        # We need to produce at least the .tex file, so use the real PDF publicator:
+        # We save the current settings for the PDF publicator:
         previous_pdf_publicator = PublicatorRegistry.get("pdf")
         previous_build_pdf_when_published = self.overridden_zds_app["content"]["build_pdf_when_published"]
+        # We need to produce at least the LaTeX file, so we use the real PDF publicator:
         PublicatorRegistry.registry["pdf"] = ZMarkdownRebberLatexPublicator(".pdf")
         self.overridden_zds_app["content"]["build_pdf_when_published"] = True
 
@@ -314,20 +315,21 @@ class UtilsTests(TutorialTestMixin, TestCase):
             self.assertIn(chapter2.title, content)
             self.assertNotIn(chapter3.title, content)
 
-        # TODO: factorize getting texfile path with what is done in zds.tutorialv2.publication_utils.publish():
+        # TODO: factorize getting the LaTeX file path with what is done in zds.tutorialv2.publication_utils.publish_content()
         tmp_path = os.path.join(
             settings.ZDS_APP["content"]["repo_public_path"], published.content_public_slug + "__building"
         )
         build_extra_contents_path = os.path.join(tmp_path, settings.ZDS_APP["content"]["extra_contents_dirname"])
         base_name = os.path.join(build_extra_contents_path, published.content_public_slug)
         tex_file = base_name + ".tex"
-        # PDF generation may fail, only test the tex content:
+        # PDF generation may fail, we only test the LaTeX content:
         with open(tex_file) as tex:
             content = tex.read()
             self.assertIn(chapter1.title, content)
             self.assertIn(chapter2.title, content)
             self.assertNotIn(chapter3.title, content)
 
+        # We set back the previous settings:
         PublicatorRegistry.registry["pdf"] = previous_pdf_publicator
         self.overridden_zds_app["content"]["build_pdf_when_published"] = previous_build_pdf_when_published
 

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -696,11 +696,13 @@ def export_extract(extract, with_text):
     return dct
 
 
-def export_container(container, with_text=False):
+def export_container(container, with_text=False, ready_to_publish_only=False):
     """Export a container to a dictionary
 
     :param container: the container
     :type container: zds.tutorialv2.models.models_versioned.Container
+    :param ready_to_publish_only: if True, returns only ready-to-publish containers
+    :type ready_to_publish_only: boolean
     :return: dictionary containing the information
     :rtype: dict
     """
@@ -727,7 +729,9 @@ def export_container(container, with_text=False):
     dct["ready_to_publish"] = container.ready_to_publish
     if container.has_sub_containers():
         for child in container.children:
-            dct["children"].append(export_container(child, with_text))
+            if ready_to_publish_only and not child.ready_to_publish:
+                continue
+            dct["children"].append(export_container(child, with_text, ready_to_publish_only))
     elif container.has_extracts():
         for child in container.children:
             dct["children"].append(export_extract(child, with_text))
@@ -735,14 +739,16 @@ def export_container(container, with_text=False):
     return dct
 
 
-def export_content(content, with_text=False):
+def export_content(content, with_text=False, ready_to_publish_only=False):
     """Export a content to dictionary in order to store them in a JSON file
 
     :param content: content to be exported
+    :param ready_to_publish_only: if True, returns only ready-to-publish containers
+    :type ready_to_publish_only: boolean
     :return: dictionary containing the information
     :rtype: dict
     """
-    dct = export_container(content, with_text)
+    dct = export_container(content, with_text, ready_to_publish_only)
 
     # append metadata :
     dct["version"] = 2.1


### PR DESCRIPTION
Les conteneurs avec `ready_to_publish` à `False` ne sont plus inclus dans l'export LaTeX et PDF des contenus publiés.

Corrige un des soucis de #6265 

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Télécharger l'archive du contenu [Un zeste de Python](https://zestedesavoir.com/tutoriels/2514/un-zeste-de-python/)
- Créer un nouveau tutoriel à partir de cette archive et le valider
- Dans un nouvel onglet de votre terminal, lancer `source zdsenv/bin/activate` puis `python manage.py publication_watchdog`
- Ouvrir l'export LaTeX et/ou PDF généré
- Vérifier que les conteneurs non validés n'apparaissent pas dedans (par exemple, « Plusieurs tâches en même temps »)