### PR TITLE
Remplace la vue de logout par la LogoutView de Django

### DIFF
--- a/zds/member/urls.py
+++ b/zds/member/urls.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.views import LogoutView
 from django.urls import re_path, path
 
 from zds.member.views import MemberList
@@ -16,7 +17,7 @@ from zds.member.views.moderation import (
     member_from_ip,
     modify_profile,
 )
-from zds.member.views.login import login_view, logout_view
+from zds.member.views.login import login_view
 from zds.member.views.hats import (
     HatsSettings,
     RequestedHatsList,
@@ -103,7 +104,7 @@ urlpatterns = [
     re_path(r"^casquettes/retirer/(?P<user_pk>\d+)/(?P<hat_pk>\d+)/$", remove_hat, name="remove-hat"),
     # membership
     re_path(r"^connexion/$", login_view, name="member-login"),
-    re_path(r"^deconnexion/$", logout_view, name="member-logout"),
+    re_path(r"^deconnexion/$", LogoutView.as_view(), name="member-logout"),
     re_path(r"^inscription/$", RegisterView.as_view(), name="register-member"),
     re_path(r"^reinitialisation/$", forgot_password, name="member-forgot-password"),
     re_path(r"^validation/$", SendValidationEmailView.as_view(), name="send-validation-email"),

--- a/zds/member/views/login.py
+++ b/zds/member/views/login.py
@@ -1,12 +1,10 @@
 from django.contrib import messages
-from django.contrib.auth import authenticate, login, logout
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth import authenticate, login
 from django.contrib.auth.models import User
 from django.template.context_processors import csrf
 from django.urls import reverse, resolve, Resolver404, NoReverseMatch
 from django.shortcuts import redirect, render, get_object_or_404
 from django.utils.translation import gettext_lazy as _
-from django.views.decorators.http import require_POST
 
 from zds.member.forms import LoginForm
 from zds.member.models import Profile
@@ -101,14 +99,3 @@ def login_view(request):
     csrf_tk["error"] = error
     csrf_tk["form"] = form
     return render(request, "member/login.html", {"form": form, "csrf_tk": csrf_tk})
-
-
-@login_required
-@require_POST
-def logout_view(request):
-    """Log user out."""
-
-    logout(request)
-    request.session.clear()
-    response = redirect(reverse("homepage"))
-    return response

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -7,6 +7,8 @@ from .base_dir import BASE_DIR
 
 zds_config = config.get("zds", {})
 
+LOGOUT_REDIRECT_URL = "homepage"
+
 GEOIP_PATH = str(BASE_DIR / "geodata")
 GEOIP_CITY = "GeoLite2-City.mmdb"
 


### PR DESCRIPTION
Un des items de #6246.

On utilise une vue fournie par Django plutôt qu'une vue custom. La vue en question permet de stocker la page de redirection comme config, ce que j'ai choisi de faire, afin d'éviter d'avoir un paramètre qui traîne dans le `urls.py` ou de faire une classe-fille pour juste une ligne.

### Contrôle qualité

Se connecter, se déconnecter et constater :

 * qu'on est bien redirigé vers la page d'accueil ;
 * que les cookies de session sont bien nettoyés.