### PR TITLE
Passe à zmarkdown 11

### DIFF
--- a/assets/js/spoiler.js
+++ b/assets/js/spoiler.js
@@ -7,7 +7,7 @@
 (function($) {
   'use strict'
 
-  function buildSpoilers($elem) {
+  function buildOldSpoilers($elem) {
     $elem.each(function() {
       const $this = $(this)
       if (!$this.hasClass('spoiler-build')) {
@@ -31,13 +31,27 @@
     })
   }
 
+  function buildNewSpoilers() {
+    for (const spoiler of document.querySelectorAll('details.custom-block-spoiler')) {
+      if (spoiler.querySelector('summary') === null) {
+        const summary = document.createElement('summary')
+        summary.classList.add('custom-block-heading')
+        summary.textContent = 'Afficher/Masquer le contenu masqué'
+        const body = spoiler.querySelector('.custom-block-body')
+        spoiler.insertBefore(summary, body)
+      }
+    }
+  }
+
   $(document).ready(function() {
     const $content = $('#content')
     $('div.spoiler').addClass('custom-block-spoiler') /* for compatibility */
-    buildSpoilers($content.find('.custom-block-spoiler'))
+    buildOldSpoilers($content.find('div.custom-block-spoiler'))
+    buildNewSpoilers()
     $content.on('DOMNodeInserted', function(e) {
-      const $spoilers = $(e.target).find('.custom-block-spoiler')
-      return buildSpoilers($spoilers)
+      const $spoilers = $(e.target).find('div.custom-block-spoiler')
+      buildOldSpoilers($spoilers)
+      return buildNewSpoilers()
     })
   })
 })(jQuery)

--- a/assets/js/spoiler.js
+++ b/assets/js/spoiler.js
@@ -33,12 +33,16 @@
 
   function buildNewSpoilers() {
     for (const spoiler of document.querySelectorAll('details.custom-block-spoiler')) {
-      if (spoiler.querySelector('summary') === null) {
-        const summary = document.createElement('summary')
+      let summary = spoiler.querySelector('summary')
+      if (summary === null) {
+        summary = document.createElement('summary')
         summary.classList.add('custom-block-heading')
         summary.textContent = 'Afficher/Masquer le contenu masqué'
         const body = spoiler.querySelector('.custom-block-body')
         spoiler.insertBefore(summary, body)
+      }
+      if (!summary.classList.contains('ico-after')) {
+        summary.classList.add('ico-after', 'view', 'light')
       }
     }
   }

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -241,6 +241,23 @@ h6 {
     }
 }
 
+/* CSS specific for new spoilers using <details> and <summary> */
+.custom-block-spoiler summary.custom-block-heading {
+    cursor: pointer;
+
+    &.ico-after {
+        padding-left: $length-32;
+
+        &:after {
+            margin: $length-8 0 0 $length-10;
+        }
+    }
+
+    &:hover {
+        background-color: $grey-800;
+    }
+}
+
 .js .spoiler, div.custom-block-spoiler {
     display: none;
 }

--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -241,7 +241,7 @@ h6 {
     }
 }
 
-.js .spoiler, .custom-block-spoiler {
+.js .spoiler, div.custom-block-spoiler {
     display: none;
 }
 

--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,9 +9,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "10.1.3"
+    "zmarkdown": "11.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   }
 }


### PR DESCRIPTION
Passe à zmarkdown 11 ([changelog](https://github.com/zestedesavoir/zmarkdown/releases/tag/zmarkdown@11.0.0))

Fixes #6275 

Je propose de vérifier les modifications concernant le LaTeX (notes de bas de page et tableaux) directement sur la bêta.

**Cette branche est sur la bêta**

**QA :**

- À partir de `upstream/dev` (donc avec zmarkdown 10.1.3), créer un message avec un bloc spoiler
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Créer un message avec : 
  - Un bloc spoiler sans titre
  - Un bloc spoiler avec titre
  - Un bloc de code d'une seule ligne
  - Un bloc de code de plusieurs lignes
  - Des pings de pseudos avec des tirets et des accents

Ce que j'ai testé : 

````
```py
oneliner = lambda x: x**2
```

```py
def twoliner(x):
    return x**2
```

Bonsoir, comment allez-vous ?[^note]

[^note]: Super Note de bas de page !

[[secret|Attention, ceci contient des mots de passe très secrets !]]
| - **Platine**
| - Or
| - *Argent*
| - ~~Bronze~~

[[secret]]
| - **Platine**
| - Or
| - *Argent*
| - ~~Bronze~~

@Bidule @Super-Bidule @Bidule-Hypé @Bidule-Ultra-Trop-Éclairé-de-la-vie @**Bidule**
````