### PR TITLE
Ajoute une précision à la documentation : `--just-print` pour voir les sous-commandes d'une commande make

### DIFF
--- a/doc/source/install/install-linux.rst
+++ b/doc/source/install/install-linux.rst
@@ -9,7 +9,7 @@ Pour installer une version locale de ZdS sur GNU/Linux, veuillez suivre les inst
 
     - Si une commande ne passe pas, essayez de savoir pourquoi avant de continuer.
     - Il est impératif que la locale ``fr_FR.UTF-8`` soit installée sur votre distribution.
-    - Si vous voulez savoir ce qui se cache derrière une commande ``make``, ouvrez le fichier nommé ``Makefile`` présent à la racine du projet.
+    - Si vous voulez savoir ce qui se cache derrière une commande ``make``, ajoutez ``--just-print`` à la commande ou ouvrez le fichier nommé ``Makefile`` présent à la racine du projet.
     - L'installation automatique des packages a été testée sour Ubuntu, Debian, Fedora et Archlinux. Si vous utilisez une autre distribution, essayez d'installer la liste de packages `située ici <#composant-packages>`_.
     - Si une erreur s'est glissée dans la doc, ou si la doc a glissé vers l'obscolescence, ouvrez `un ticket sur notre repo github <https://github.com/zestedesavoir/zds-site/issues/new>`_
     - Si malgré tout vous ne parvenez pas à installer ZdS, n'hésitez pas à ouvrir `un sujet sur le forum <https://zestedesavoir.com/forums/sujet/nouveau/?forum=2>`_


### PR DESCRIPTION
Doc : https://www.gnu.org/software/make/manual/make.html#index-_002d_002djust_002dprint
> When make is given the flag ‘-n’ or ‘--just-print’ it only echoes most recipes, without executing them. See Summary of Options. In this case even the recipe lines starting with ‘@’ are printed. This flag is useful for finding out which recipes make thinks are necessary without actually doing them.

Bonjour, j'ai commencé à lire votre documentation et j'ai constaté ce changement qui pourrait compléter la phrase 👍🏻 

### Contrôle qualité

Lire le changement et valider la formulation de la phrase pour que ça corresponde au style de la doc.
