### PR TITLE
Refactorise les urls des Mise en une

### DIFF
--- a/templates/featured/base.html
+++ b/templates/featured/base.html
@@ -15,20 +15,20 @@
 
 
 {% block breadcrumb_base %}
-    <li><a href="{% url 'featured-resource-list' %}">{% trans "Mise en avant du site" %}</a></li>
+    <li><a href="{% url "featured:resource-list" %}">{% trans "Mise en avant du site" %}</a></li>
 {% endblock %}
 
 
 
 {% block sidebar %}
     <aside class="sidebar accordeon mobile-menu-bloc" data-title="{% trans 'Action sur les unes' %}">
-        <a href="{% url 'featured-message-create' %}" class="new-btn ico-after more blue">
+        <a href="{% url "featured:message-create" %}" class="new-btn ico-after more blue">
             {% trans "Éditer le message d’accueil" %}
         </a>
-        <a href="{% url 'featured-resource-create' %}" class="new-btn ico-after more blue">
+        <a href="{% url "featured:resource-create" %}" class="new-btn ico-after more blue">
             {% trans "Nouvelle une" %}
         </a>
-        <a href="{% url 'featured-resource-requests' %}" class="new-btn ico-after star blue">
+        <a href="{% url "featured:resource-requests" %}" class="new-btn ico-after star blue">
             {% trans "Liste des requêtes pour les unes" %}
         </a>
 

--- a/templates/featured/index.html
+++ b/templates/featured/index.html
@@ -43,7 +43,7 @@
                         <input name="items" type="checkbox" value="{{ featured_resource.pk }}" form="form-delete-featured">
                     </div>
                     <div class="topic-description">
-                        <a href="{% url 'featured-resource-update' featured_resource.pk %}" class="topic-title-link navigable-link">
+                        <a href="{% url "featured:resource-update" featured_resource.pk %}" class="topic-title-link navigable-link">
                             <img src="{{ featured_resource.image_url|remove_url_scheme }}"
                                  data-caption="{{ featured_resource.title }}"
                                  alt="{{ featured_resource.title }}"
@@ -72,7 +72,7 @@
         {% include "misc/paginator.html" with position="bottom" %}
 
         <!-- Confirmation modal for deleting featured -->
-        <form id="form-delete-featured" name="form" method="post" action="{% url "featured-resource-list-delete" %}" class="modal modal-flex">
+        <form id="form-delete-featured" name="form" method="post" action="{% url "featured:resource-list-delete" %}" class="modal modal-flex">
             {% csrf_token %}
             <p>{% trans "Attention, vous vous apprêtez à supprimer toutes les unes sélectionnées." %}</p>
             <button type="submit" name="delete_multi" class="btn btn-submit">{% trans "Confirmer" %}</button>

--- a/templates/featured/list_requests.html
+++ b/templates/featured/list_requests.html
@@ -61,17 +61,17 @@
                     <td>{{ featured_request.num_vote }}</td>
                     <td>
                         {%  if featured_request.rejected %}
-                            <button type="button" class="btn btn-grey ico-after cross unpick-action" data-url="{% url 'featured-resource-request-update' featured_request.pk %}"
+                            <button type="button" class="btn btn-grey ico-after cross unpick-action" data-url="{% url "featured:resource-request-update" featured_request.pk %}"
                                     data-operation="CONSIDER">{% trans "Ne plus ignorer" %}</button>
                         {% else %}
-                            <button type="button" class="btn btn-grey ico-after hide unpick-action" data-url="{% url 'featured-resource-request-update' featured_request.pk %}"
+                            <button type="button" class="btn btn-grey ico-after hide unpick-action" data-url="{% url "featured:resource-request-update" featured_request.pk %}"
                                     data-operation="REJECT">{% trans "Ignorer" %}</button>
                         {% endif %}
 
-                        <button type="button" class="btn btn-grey ico-after hide unpick-action" data-url="{% url 'featured-resource-request-update' featured_request.pk %}"
+                        <button type="button" class="btn btn-grey ico-after hide unpick-action" data-url="{% url "featured:resource-request-update" featured_request.pk %}"
                                 data-operation="REJECT_FOR_GOOD">{% trans "Ignorer définitivement" %}</button>
 
-                        <a href="{% url "featured-resource-create" %}?content_type={% if featured_request.type == 'TOPIC' %}topic{% else %}published_content{% endif %}&amp;content_id={{ featured_request.content_object.pk }}">
+                        <a href="{% url "featured:resource-create" %}?content_type={% if featured_request.type == 'TOPIC' %}topic{% else %}published_content{% endif %}&amp;content_id={{ featured_request.content_object.pk }}">
                             <button type="button" class="btn btn-grey ico-after star">{% trans "Nouvelle une" %}</button>
                         </a>
                     </td>
@@ -95,28 +95,28 @@
         <h3>{% trans "Filtres" %}</h3>
         <ul>
             <li>
-                <a href="{% url "featured-resource-requests" %}?type=topic" class="ico-after view {% if request.GET.type == "topic" %}selected{% endif %}">
+                <a href="{% url "featured:resource-requests" %}?type=topic" class="ico-after view {% if request.GET.type == "topic" %}selected{% endif %}">
                     {% trans "Sujets proposés" %}
                 </a>
             </li>
             <li>
-                <a href="{% url "featured-resource-requests" %}?type=content" class="ico-after view {% if request.GET.type == "content" %}selected{% endif %}">
+                <a href="{% url "featured:resource-requests" %}?type=content" class="ico-after view {% if request.GET.type == "content" %}selected{% endif %}">
                     {% trans "Contenus proposés" %}
                 </a>
             </li>
             <li>
-                <a href="{% url "featured-resource-requests" %}?type=ignored" class="ico-after view {% if request.GET.type == "ignored" %}selected{% endif %}">
+                <a href="{% url "featured:resource-requests" %}?type=ignored" class="ico-after view {% if request.GET.type == "ignored" %}selected{% endif %}">
                     {% trans "Requêtes ignorées" %}
                 </a>
             </li>
             <li>
-                <a href="{% url "featured-resource-requests" %}?type=accepted" class="ico-after view {% if request.GET.type == "accepted" %}selected{% endif %}">
+                <a href="{% url "featured:resource-requests" %}?type=accepted" class="ico-after view {% if request.GET.type == "accepted" %}selected{% endif %}">
                     {% trans "Requêtes acceptées" %}
                 </a>
             </li>
             {% if request.GET.type %}
                 <li>
-                    <a href="{% url "featured-resource-requests" %}" class="ico-after cross red">
+                    <a href="{% url "featured:resource-requests" %}" class="ico-after cross red">
                         {% trans "Annuler le filtre" %}
                     </a>
                 </li>

--- a/templates/featured/resource/update.html
+++ b/templates/featured/resource/update.html
@@ -38,7 +38,7 @@
                 <a href="#delete-featured-resource" class="open-modal ico-after cross blue">
                     {% trans "Supprimer la une" %}
                 </a>
-                <form action="{% url "featured-resource-delete" featured_resource.pk %}" method="post" id="delete-featured-resource" class="modal modal-flex">
+                <form action="{% url "featured:resource-delete" featured_resource.pk %}" method="post" id="delete-featured-resource" class="modal modal-flex">
                     <p>
                         {% trans "Attention, vous vous apprêtez à supprimer définitivement cette une." %}
                     </p>

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -381,7 +381,7 @@
                 </li>
                 {% if perms.featured.change_featuredresource %}
                     <li>
-                        <a href="{% url "featured-resource-create" %}?content_type=topic&amp;content_id={{ topic.pk }}" class="ico-after star blue">
+                        <a href="{% url "featured:resource-create" %}?content_type=topic&amp;content_id={{ topic.pk }}" class="ico-after star blue">
                             {% trans "Ajouter en une" %}
                         </a>
                     </li>

--- a/templates/header.html
+++ b/templates/header.html
@@ -434,7 +434,7 @@
 
                         {% if perms.featured.change_featuredresource %}
                             <li class="staff-only">
-                                <a href="{% url 'featured-resource-list' %}">{% trans 'Gestion des mises en avant' %}</a>
+                                <a href="{% url "featured:resource-list" %}">{% trans 'Gestion des mises en avant' %}</a>
                             </li>
                         {% endif %}
                         <li>

--- a/templates/home.html
+++ b/templates/home.html
@@ -97,7 +97,7 @@
                 <span>{% trans "À la une" %}</span>
 
                 {% if perms.featured.change_featuredresource %}
-                    <a href="{% url "featured-resource-list" %}" class="btn btn-grey">{% trans "Gérer les unes" %}</a>
+                    <a href="{% url "featured:resource-list" %}" class="btn btn-grey">{% trans "Gérer les unes" %}</a>
                 {% endif %}
             </h1>
 

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -337,7 +337,7 @@
                     </li>
                     {% if perms.featured.change_featuredresource %}
                         <li>
-                            <a href="{% url "featured-resource-create" %}?content_type=published_content&amp;content_id={{ content.pk }}"
+                            <a href="{% url "featured:resource-create" %}?content_type=published_content&amp;content_id={{ content.pk }}"
                                class="ico-after star blue">
                                 {% trans "Ajouter en une" %}
                             </a>

--- a/zds/featured/forms.py
+++ b/zds/featured/forms.py
@@ -56,7 +56,7 @@ class FeaturedResourceForm(forms.ModelForm):
         self.helper = FormHelper()
         self.helper.form_class = "content-wrapper"
         self.helper.form_method = "post"
-        self.helper.form_action = reverse("featured-resource-create")
+        self.helper.form_action = reverse("featured:resource-create")
 
         fields = [Field("request"), Field("title"), Field("type"), Field("authors"), Field("image_url"), Field("url")]
 
@@ -92,7 +92,7 @@ class FeaturedMessageForm(forms.ModelForm):
         self.helper = FormHelper()
         self.helper.form_class = "content-wrapper"
         self.helper.form_method = "post"
-        self.helper.form_action = reverse("featured-message-create")
+        self.helper.form_action = reverse("featured:message-create")
 
         self.helper.layout = Layout(
             Field("hook"),

--- a/zds/featured/tests/tests.py
+++ b/zds/featured/tests/tests.py
@@ -24,12 +24,12 @@ class FeaturedResourceListViewTest(TestCase):
         staff = StaffProfileFactory()
         self.client.force_login(staff.user)
 
-        response = self.client.get(reverse("featured-resource-list"))
+        response = self.client.get(reverse("featured:resource-list"))
 
         self.assertEqual(200, response.status_code)
 
     def test_failure_list_of_featured_with_unauthenticated_user(self):
-        response = self.client.get(reverse("featured-resource-list"))
+        response = self.client.get(reverse("featured:resource-list"))
 
         self.assertEqual(403, response.status_code)
 
@@ -37,7 +37,7 @@ class FeaturedResourceListViewTest(TestCase):
         profile = ProfileFactory()
         self.client.force_login(profile.user)
 
-        response = self.client.get(reverse("featured-resource-list"))
+        response = self.client.get(reverse("featured:resource-list"))
 
         self.assertEqual(403, response.status_code)
 
@@ -61,7 +61,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
             "pubdate": pubdate,
         }
 
-        response = self.client.post(reverse("featured-resource-create"), fields, follow=True)
+        response = self.client.post(reverse("featured:resource-create"), fields, follow=True)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, FeaturedResource.objects.all().count())
@@ -77,7 +77,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         # now with major_update
         fields["major_update"] = "on"
 
-        response = self.client.post(reverse("featured-resource-create"), fields, follow=True)
+        response = self.client.post(reverse("featured:resource-create"), fields, follow=True)
         self.assertEqual(200, response.status_code)
         self.assertEqual(2, FeaturedResource.objects.all().count())
 
@@ -85,7 +85,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         self.assertTrue((datetime.now() - featured.pubdate).total_seconds() < 10)
 
     def test_failure_create_featured_with_unauthenticated_user(self):
-        response = self.client.get(reverse("featured-resource-create"))
+        response = self.client.get(reverse("featured:resource-create"))
 
         self.assertEqual(403, response.status_code)
 
@@ -93,7 +93,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         profile = ProfileFactory()
         self.client.force_login(profile.user)
 
-        response = self.client.get(reverse("featured-resource-create"))
+        response = self.client.get(reverse("featured:resource-create"))
 
         self.assertEqual(403, response.status_code)
 
@@ -103,7 +103,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
 
         self.assertEqual(0, FeaturedResource.objects.all().count())
         response = self.client.post(
-            reverse("featured-resource-create"),
+            reverse("featured:resource-create"),
             {
                 "title": "title",
                 "type": "type",
@@ -118,7 +118,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         self.assertEqual(0, FeaturedResource.objects.all().count())
 
         response = self.client.post(
-            reverse("featured-resource-create"),
+            reverse("featured:resource-create"),
             {
                 "title": "title",
                 "type": "type",
@@ -144,7 +144,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         self.client.force_login(staff.user)
         response = self.client.get(
             "{}{}".format(
-                reverse("featured-resource-create"), f"?content_type=published_content&content_id={tutorial.pk}"
+                reverse("featured:resource-create"), f"?content_type=published_content&content_id={tutorial.pk}"
             )
         )
         initial_dict = response.context["form"].initial
@@ -162,7 +162,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         staff = StaffProfileFactory()
         self.client.force_login(staff.user)
         response = self.client.get(
-            "{}?content_type=topic&content_id={}".format(reverse("featured-resource-create"), topic.id)
+            "{}?content_type=topic&content_id={}".format(reverse("featured:resource-create"), topic.id)
         )
         initial_dict = response.context["form"].initial
         self.assertEqual(initial_dict["title"], topic.title)
@@ -175,7 +175,7 @@ class FeaturedResourceCreateViewTest(TutorialTestMixin, TestCase):
         self.client.force_login(staff.user)
 
         response = self.client.get(
-            "{}?content_type=published_content&content_id=42".format(reverse("featured-resource-create"))
+            "{}?content_type=published_content&content_id=42".format(reverse("featured:resource-create"))
         )
         self.assertContains(response, _("Le contenu est introuvable"))
 
@@ -201,7 +201,7 @@ class FeaturedResourceUpdateViewTest(TestCase):
             "pubdate": pubdate,
         }
 
-        response = self.client.post(reverse("featured-resource-update", args=[news.pk]), fields, follow=True)
+        response = self.client.post(reverse("featured:resource-update", args=[news.pk]), fields, follow=True)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, FeaturedResource.objects.all().count())
@@ -221,13 +221,13 @@ class FeaturedResourceUpdateViewTest(TestCase):
 
         fields["major_update"] = "on"
 
-        response = self.client.post(reverse("featured-resource-update", args=[news.pk]), fields, follow=True)
+        response = self.client.post(reverse("featured:resource-update", args=[news.pk]), fields, follow=True)
         self.assertEqual(200, response.status_code)
         featured = FeaturedResource.objects.first()
         self.assertTrue((datetime.now() - featured.pubdate).total_seconds() < 10)
 
     def test_failure_create_featured_with_unauthenticated_user(self):
-        response = self.client.get(reverse("featured-resource-update", args=[42]))
+        response = self.client.get(reverse("featured:resource-update", args=[42]))
 
         self.assertEqual(403, response.status_code)
 
@@ -235,7 +235,7 @@ class FeaturedResourceUpdateViewTest(TestCase):
         profile = ProfileFactory()
         self.client.force_login(profile.user)
 
-        response = self.client.get(reverse("featured-resource-update", args=[42]))
+        response = self.client.get(reverse("featured:resource-update", args=[42]))
 
         self.assertEqual(403, response.status_code)
 
@@ -247,14 +247,14 @@ class FeaturedResourceDeleteViewTest(TestCase):
 
         news = FeaturedResourceFactory()
         self.assertEqual(1, FeaturedResource.objects.all().count())
-        response = self.client.post(reverse("featured-resource-delete", args=[news.pk]), follow=True)
+        response = self.client.post(reverse("featured:resource-delete", args=[news.pk]), follow=True)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(0, FeaturedResource.objects.filter(pk=news.pk).count())
 
     def test_failure_delete_featured_with_unauthenticated_user(self):
         news = FeaturedResourceFactory()
-        response = self.client.get(reverse("featured-resource-delete", args=[news.pk]))
+        response = self.client.get(reverse("featured:resource-delete", args=[news.pk]))
 
         self.assertEqual(403, response.status_code)
 
@@ -263,7 +263,7 @@ class FeaturedResourceDeleteViewTest(TestCase):
         self.client.force_login(profile.user)
 
         news = FeaturedResourceFactory()
-        response = self.client.get(reverse("featured-resource-delete", args=[news.pk]))
+        response = self.client.get(reverse("featured:resource-delete", args=[news.pk]))
 
         self.assertEqual(403, response.status_code)
 
@@ -277,7 +277,7 @@ class FeaturedResourceListDeleteViewTest(TestCase):
         news2 = FeaturedResourceFactory()
         self.assertEqual(2, FeaturedResource.objects.all().count())
         response = self.client.post(
-            reverse("featured-resource-list-delete"), {"items": [news.pk, news2.pk]}, follow=True
+            reverse("featured:resource-list-delete"), {"items": [news.pk, news2.pk]}, follow=True
         )
 
         self.assertEqual(200, response.status_code)
@@ -285,7 +285,7 @@ class FeaturedResourceListDeleteViewTest(TestCase):
         self.assertEqual(0, FeaturedResource.objects.filter(pk=news2.pk).count())
 
     def test_failure_list_delete_featured_with_unauthenticated_user(self):
-        response = self.client.get(reverse("featured-resource-list-delete"))
+        response = self.client.get(reverse("featured:resource-list-delete"))
 
         self.assertEqual(403, response.status_code)
 
@@ -293,7 +293,7 @@ class FeaturedResourceListDeleteViewTest(TestCase):
         profile = ProfileFactory()
         self.client.force_login(profile.user)
 
-        response = self.client.get(reverse("featured-resource-list-delete"))
+        response = self.client.get(reverse("featured:resource-list-delete"))
 
         self.assertEqual(403, response.status_code)
 
@@ -304,7 +304,7 @@ class FeaturedMessageCreateUpdateViewTest(TestCase):
         self.client.force_login(staff.user)
 
         response = self.client.post(
-            reverse("featured-message-create"),
+            reverse("featured:message-create"),
             {
                 "message": "message",
                 "url": "http://test.com",
@@ -320,7 +320,7 @@ class FeaturedMessageCreateUpdateViewTest(TestCase):
         self.client.force_login(staff.user)
 
         response = self.client.post(
-            reverse("featured-message-create"),
+            reverse("featured:message-create"),
             {
                 "message": "message",
                 "url": "http://test.com",
@@ -332,7 +332,7 @@ class FeaturedMessageCreateUpdateViewTest(TestCase):
         self.assertEqual(1, FeaturedMessage.objects.count())
 
         response = self.client.post(
-            reverse("featured-message-create"),
+            reverse("featured:message-create"),
             {
                 "message": "message",
                 "url": "http://test.com",
@@ -350,12 +350,12 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
         staff = StaffProfileFactory()
         self.client.force_login(staff.user)
 
-        response = self.client.get(reverse("featured-resource-requests"))
+        response = self.client.get(reverse("featured:resource-requests"))
 
         self.assertEqual(200, response.status_code)
 
     def test_failure_list_with_unauthenticated_user(self):
-        response = self.client.get(reverse("featured-resource-requests"))
+        response = self.client.get(reverse("featured:resource-requests"))
 
         self.assertEqual(403, response.status_code)
 
@@ -363,7 +363,7 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
         profile = ProfileFactory()
         self.client.force_login(profile.user)
 
-        response = self.client.get(reverse("featured-resource-requests"))
+        response = self.client.get(reverse("featured:resource-requests"))
 
         self.assertEqual(403, response.status_code)
 
@@ -388,7 +388,7 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
         staff = StaffProfileFactory()
         self.client.force_login(staff.user)
 
-        response = self.client.get(reverse("featured-resource-requests"))
+        response = self.client.get(reverse("featured:resource-requests"))
         self.assertEqual(200, response.status_code)
 
         self.assertEqual(len(response.context["featured_request_list"]), 2)
@@ -396,7 +396,7 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
         self.assertTrue(any(r.content_object == tutorial for r in response.context["featured_request_list"]))
 
         # filter topic
-        response = self.client.get(reverse("featured-resource-requests") + "?type=topic")
+        response = self.client.get(reverse("featured:resource-requests") + "?type=topic")
         self.assertEqual(200, response.status_code)
 
         self.assertEqual(len(response.context["featured_request_list"]), 1)
@@ -404,7 +404,7 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
         self.assertFalse(any(r.content_object == tutorial for r in response.context["featured_request_list"]))
 
         # filter tuto
-        response = self.client.get(reverse("featured-resource-requests") + "?type=content")
+        response = self.client.get(reverse("featured:resource-requests") + "?type=content")
         self.assertEqual(200, response.status_code)
 
         self.assertEqual(len(response.context["featured_request_list"]), 1)
@@ -417,13 +417,13 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
         q.rejected = True
         q.save()
 
-        response = self.client.get(reverse("featured-resource-requests") + "?type=topic")
+        response = self.client.get(reverse("featured:resource-requests") + "?type=topic")
         self.assertEqual(200, response.status_code)
 
         self.assertEqual(len(response.context["featured_request_list"]), 0)
 
         # filter ignored
-        response = self.client.get(reverse("featured-resource-requests") + "?type=ignored")
+        response = self.client.get(reverse("featured:resource-requests") + "?type=ignored")
         self.assertEqual(200, response.status_code)
 
         self.assertEqual(len(response.context["featured_request_list"]), 1)
@@ -431,7 +431,7 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
 
         # put back vote count to 0 for tutorial
         FeaturedRequested.objects.toogle_request(tutorial, author)
-        response = self.client.get(reverse("featured-resource-requests") + "?type=content")
+        response = self.client.get(reverse("featured:resource-requests") + "?type=content")
         self.assertEqual(200, response.status_code)
 
         self.assertEqual(len(response.context["featured_request_list"]), 0)  # does not appear with no votes
@@ -440,7 +440,7 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
         other = ProfileFactory().user
         FeaturedRequested.objects.toogle_request(topic, other)
 
-        response = self.client.get(reverse("featured-resource-requests") + "?type=topic")
+        response = self.client.get(reverse("featured:resource-requests") + "?type=topic")
         self.assertEqual(200, response.status_code)
 
         self.assertEqual(len(response.context["featured_request_list"]), 1)  # it is back!
@@ -465,7 +465,7 @@ class FeaturedRequestUpdateViewTest(TestCase):
         self.assertFalse(q.rejected)
 
         response = self.client.post(
-            reverse("featured-resource-request-update", kwargs={"pk": q.pk}), {"operation": "REJECT"}, follow=False
+            reverse("featured:resource-request-update", kwargs={"pk": q.pk}), {"operation": "REJECT"}, follow=False
         )
         self.assertEqual(200, response.status_code)
 
@@ -474,7 +474,7 @@ class FeaturedRequestUpdateViewTest(TestCase):
         self.assertFalse(q.rejected_for_good)
 
         response = self.client.post(
-            reverse("featured-resource-request-update", kwargs={"pk": q.pk}), {"operation": "CONSIDER"}, follow=False
+            reverse("featured:resource-request-update", kwargs={"pk": q.pk}), {"operation": "CONSIDER"}, follow=False
         )
         self.assertEqual(200, response.status_code)
 
@@ -482,7 +482,7 @@ class FeaturedRequestUpdateViewTest(TestCase):
         self.assertFalse(q.rejected)
 
         response = self.client.post(
-            reverse("featured-resource-request-update", kwargs={"pk": q.pk}),
+            reverse("featured:resource-request-update", kwargs={"pk": q.pk}),
             {"operation": "REJECT_FOR_GOOD"},
             follow=False,
         )

--- a/zds/featured/urls.py
+++ b/zds/featured/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import path
 
 from zds.featured.views import (
     FeaturedResourceList,
@@ -11,13 +11,15 @@ from zds.featured.views import (
     FeaturedRequestedUpdate,
 )
 
+app_name = "featured"
+
 urlpatterns = [
-    re_path(r"^$", FeaturedResourceList.as_view(), name="featured-resource-list"),
-    re_path(r"^unes/creer/$", FeaturedResourceCreate.as_view(), name="featured-resource-create"),
-    re_path(r"^unes/editer/(?P<pk>\d+)/$", FeaturedResourceUpdate.as_view(), name="featured-resource-update"),
-    re_path(r"^unes/supprimer/(?P<pk>\d+)/$", FeaturedResourceDeleteDetail.as_view(), name="featured-resource-delete"),
-    re_path(r"^unes/supprimer/$", FeaturedResourceDeleteList.as_view(), name="featured-resource-list-delete"),
-    re_path(r"^message/modifier/$", FeaturedMessageCreateUpdate.as_view(), name="featured-message-create"),
-    re_path(r"^unes/requetes/$", FeaturedRequestedList.as_view(), name="featured-resource-requests"),
-    re_path(r"^unes/requete/(?P<pk>\d+)/$", FeaturedRequestedUpdate.as_view(), name="featured-resource-request-update"),
+    path("", FeaturedResourceList.as_view(), name="resource-list"),
+    path("unes/creer/", FeaturedResourceCreate.as_view(), name="resource-create"),
+    path("unes/modifier/<int:pk>/", FeaturedResourceUpdate.as_view(), name="resource-update"),
+    path("unes/supprimer/<int:pk>/", FeaturedResourceDeleteDetail.as_view(), name="resource-delete"),
+    path("unes/supprimer/", FeaturedResourceDeleteList.as_view(), name="resource-list-delete"),
+    path("message/modifier/", FeaturedMessageCreateUpdate.as_view(), name="message-create"),
+    path("unes/requetes/", FeaturedRequestedList.as_view(), name="resource-requests"),
+    path("unes/requete/<int:pk>/", FeaturedRequestedUpdate.as_view(), name="resource-request-update"),
 ]

--- a/zds/featured/views.py
+++ b/zds/featured/views.py
@@ -137,7 +137,7 @@ class FeaturedResourceCreate(FeaturedViewMixin, CreateView):
                 pass
 
         messages.success(self.request, _("La une a été créée."))
-        return redirect(reverse("featured-resource-list"))
+        return redirect(reverse("featured:resource-list"))
 
 
 class FeaturedResourceUpdate(FeaturedViewMixin, UpdateView):
@@ -181,12 +181,12 @@ class FeaturedResourceUpdate(FeaturedViewMixin, UpdateView):
             self.object.pubdate = form.cleaned_data.get("pubdate")
 
         messages.success(self.request, _("La une a été mise à jour."))
-        self.success_url = reverse("featured-resource-list")
+        self.success_url = reverse("featured:resource-list")
         return super().form_valid(form)
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
-        form.helper.form_action = reverse("featured-resource-update", args=[self.object.pk])
+        form.helper.form_action = reverse("featured:resource-update", args=[self.object.pk])
         return form
 
 
@@ -198,7 +198,7 @@ class FeaturedResourceDeleteDetail(FeaturedViewMixin, DeleteView):
     model = FeaturedResource
 
     def dispatch(self, request, *args, **kwargs):
-        self.success_url = reverse("featured-resource-list")
+        self.success_url = reverse("featured:resource-list")
         return super().dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
@@ -227,7 +227,7 @@ class FeaturedResourceDeleteList(FeaturedViewMixin, MultipleObjectMixin, Redirec
 
         messages.success(request, _("Les unes ont été supprimées avec succès."))
 
-        return redirect(reverse("featured-resource-list"))
+        return redirect(reverse("featured:resource-list"))
 
 
 class FeaturedRequestedList(FeaturedViewMixin, ZdSPagingListView):
@@ -328,4 +328,4 @@ class FeaturedMessageCreateUpdate(FeaturedViewMixin, FormView):
         featured_message.save()
 
         messages.success(self.request, _("Le message a été changé"))
-        return redirect(reverse("featured-resource-list"))
+        return redirect(reverse("featured:resource-list"))

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.sitemaps import GenericSitemap, Sitemap
@@ -8,8 +9,6 @@ from zds.forum.models import ForumCategory, Forum, Topic, Tag
 from zds.pages.views import home as home_view
 from zds.member.views.profile import MemberDetail
 from zds.tutorialv2.models.database import PublishedContent
-
-from django.conf import settings
 
 
 # SiteMap data
@@ -91,7 +90,7 @@ urlpatterns = [
     re_path(r"^galerie/", include(("zds.gallery.urls", ""))),
     re_path(r"^rechercher/", include(("zds.searchv2.urls", "zds.searchv2"), namespace="search")),
     re_path(r"^munin/", include(("zds.munin.urls", ""))),
-    re_path(r"^mise-en-avant/", include(("zds.featured.urls", ""))),
+    path("mise-en-avant/", include("zds.featured.urls")),
     re_path(r"^notifications/", include(("zds.notification.urls", ""))),
     path("", include(("social_django.urls", "social_django"), namespace="social")),
     re_path(r"^munin/", include(("munin.urls", "munin"))),


### PR DESCRIPTION
Un des points de #6246 (mais qui mériterait probablement son propre ticket).

C'est une petite refactor de URLs. J'ai commencé par ce module, parce qu'il est simple. C'est le genre de choses où on aimerait bien avoir des tests à la Selenium pour éviter de casser des choses par accidents, d'ailleurs. ^^ 

Au menu : 
  * utilisation de `path` (plus lisible et parfait niveau flexibilité pour notre usage) au lieu de `re_path`;
  * ça a pour conséquence d'utiliser les nouveaux motifs systématiquement au lieu de regex ;
  * ajout d'un namespace pour hiérarchiser les noms d'urls comme il faut ;
  * un petit changement de vocabulaire marginal éditer -> modifier.

### Contrôle qualité

Jouer un peu avec le module de mise en Une / messages de page d'accueil. Le but est vraiment d'exercer les différentes routes, pas de tester le module en lui-même. Par exemple, on peut :

* créer, supprimer des unes ou messages d'accueil ;
* faire des requêtes de une, les ignorer, supprimer, etc.

