### PR TITLE
N'affiche pas le bouton "Retour à la vue globale" sur les stats d'un contenu sans section

### DIFF
--- a/templates/tutorialv2/stats/index.html
+++ b/templates/tutorialv2/stats/index.html
@@ -55,7 +55,7 @@
         {% endif %}
 
         {% if cumulative_stats %}
-            {% if display == 'global' %}
+            {% if display == 'global' and cumulative_stats|length > 1 %}
                 {% if form.non_field_errors %}
                     <p class="content-wrapper alert-box warning">
                         {{ form.non_field_errors.as_text }}
@@ -70,21 +70,21 @@
                     <th>{% trans "Vues" %}</th>
                     <th>{% trans "Temps moyen sur la page" %}</th>
                     <th>{% trans "Visiteurs uniques" %}</th>
-                    {% if display == 'global' %}<th></th>{% endif %}
+                    {% if display == 'global' and cumulative_stats|length > 1 %}<th></th>{% endif %}
                 </thead>
                 <tbody>
                     {% for url, view in cumulative_stats.items %}
                         <tr>
                             <td class="level-{{url.level}}">
                                 <a href="{{ url.url }}">{{ url.name }}</a>
-                                {% if display != 'details' %}
+                                {% if display != 'details' and cumulative_stats|length > 1 %}
                                 - <a href="?urls={{ url.url }}{% if request.GET.start_date %}&start_date={{request.GET.start_date}}{% endif %}{% if request.GET.end_date %}&end_date={{request.GET.end_date}}{% endif %}" >{% trans "(détails)" %}</a>
                                 {% endif %}
                             </td>
                             <td>{{ view.nb_hits }}</td>
                             <td>{{ view.avg_time_on_page|seconds_to_duration }}</td>
                             <td>{{ view.nb_uniq_visitors }}</td>
-                            {% if display == 'global' %}
+                            {% if display == 'global' and cumulative_stats|length > 1 %}
                                 <td><input name="urls" id="id_urls_{{forloop.counter1}}" value="{{ url.url }}" type="checkbox"></td>
                             {% endif %}
                         </tr>
@@ -92,8 +92,10 @@
                 </tbody>
             </table>
             {% if display == 'global' %}
-                <input type="submit" class="btn">{% trans "Comparer" %}</input>
-                </form>
+                {% if cumulative_stats|length > 1 %}
+                    <button type="submit" class="btn">{% trans "Comparer" %}</button>
+                    </form>
+                {% endif %}
             {% elif not content.has_extracts %}
                 <a href="{% url "content:stats-content" content.pk content.slug %}" class="btn btn-submit">{% trans "Revenir à la vue globale" %}</a>
             {% endif %}

--- a/zds/tutorialv2/views/statistics.py
+++ b/zds/tutorialv2/views/statistics.py
@@ -147,10 +147,10 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
     def get_display_mode(self, urls):
         # TODO make display_mode an enum ?
         # Good idea, but not straightforward for the template integration
-        if len(urls) == 1:
-            return "details"
         if len(urls) == len(self.get_content_urls()):
             return "global"
+        if len(urls) == 1:
+            return "details"
         return "comparison"
 
     @staticmethod


### PR DESCRIPTION
J'ai remarqué que sur la page des statistiques d'un billet sans section, le bouton *Revenir à la vue globale* est affiché, alors qu'on est déjà sur la vue globale. Cette PR corrige ce problème et ajoute les tests correspondants. Au passage, j'ai corrigé le mauvais affichage tu texte du bouton *Comparer*.

### Contrôle qualité

Vérifier les tests ajoutés.

Pas évident à tester en local, donc je déploie cette PR sur la bêta de ce pas. S'assurer que les différentes vues possibles sur la page des statistiques sont correctes (vue globale, vue détaillée, comparaison de pages), avec par exemple les statistiques des contenus suivants :
- https://beta.zestedesavoir.com/tutoriels/3843/dates-durees-et-horloges-en-informatique/
- https://beta.zestedesavoir.com/billets/4152/somme-telescopique/

