### PR TITLE
Refactorise le module de MP

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -219,7 +219,7 @@
             <div class="notifs-links">
                 {# MESSAGERIE PRIVEE #}
                 <div>
-                    <a href="{% url "mp-list" %}" class="ico-link" title="{% trans 'Messagerie privée' %}">
+                    <a href="{% url "mp:list" %}" class="ico-link" title="{% trans 'Messagerie privée' %}">
                         {% if header_private_topic_notifications.total > 0 %}
                             <span class="notif-count">{{ header_private_topic_notifications.total }}</span>
                         {% endif %}
@@ -229,7 +229,7 @@
                     <div class="header-dropdown">
                         <span class="dropdown-title dropdown-pm">
                             <h1>{% trans "Messagerie privée" %}</h1>
-                            <a href="{% url "mp-new" %}" class="ico-after pm-new white" title="{% trans 'Envoyer un nouveau message privé' %}"></a>
+                            <a href="{% url "mp:create" %}" class="ico-after pm-new white" title="{% trans 'Envoyer un nouveau message privé' %}"></a>
                         </span>
 
                         <ul class="dropdown-list">
@@ -252,7 +252,7 @@
                                 </li>
                             {% endif %}
                         </ul>
-                        <a href="{% url "mp-list" %}" class="dropdown-link-all">
+                        <a href="{% url "mp:list" %}" class="dropdown-link-all">
                             {% trans "Toutes les conversations" %}
                         </a>
                     </div>

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -151,7 +151,7 @@
                                 </a>
                             {% endif %}
                             {% if usr != user and not profile.is_private and profile.can_read_now %}
-                                <a href="{% url 'mp-new' %}?username={{ usr.username }}" class="btn-ico btn ico-after cite light">
+                                <a href="{% url "mp:create" %}?username={{ usr.username }}" class="btn-ico btn ico-after cite light">
                                     {% trans "Envoyer un message" %}
                                 </a>
                             {% endif %}

--- a/templates/member/sidebar.html
+++ b/templates/member/sidebar.html
@@ -28,7 +28,7 @@
             <ul>
                 {% if usr != user and not profile.is_private and profile.can_read_now %}
                     <li>
-                        <a href="{% url 'mp-new' %}?username={{ usr.username }}" class="ico-after cite blue">
+                        <a href="{% url "mp:create" %}?username={{ usr.username }}" class="ico-after cite blue">
                             {% trans "Envoyer un message privé" %}
                         </a>
                     </li>

--- a/templates/mp/base.html
+++ b/templates/mp/base.html
@@ -16,14 +16,14 @@
 
 
 {% block breadcrumb_base %}
-    <li><a href="{% url "mp-list" %}">{% trans "Messagerie privée" %}</a></li>
+    <li><a href="{% url "mp:list" %}">{% trans "Messagerie privée" %}</a></li>
 {% endblock %}
 
 
 
 {% block sidebar %}
     <aside class="sidebar mobile-menu-hide">
-        <a href="{% url 'mp-new' %}" class="new-btn ico-after more blue">
+        <a href="{% url "mp:create" %}" class="new-btn ico-after more blue">
             {% trans "Nouvelle conversation" %}
         </a>
         {% block sidebar_actions %}{% endblock %}

--- a/templates/mp/index.html
+++ b/templates/mp/index.html
@@ -107,7 +107,7 @@
                     {% trans "Supprimer les conversations sélectionnées" %}
                 </a>
 
-                <form action="{% url "mp-list-delete" %}" method="post" id="delete-conversations" class="modal modal-flex">
+                <form action="{% url "mp:list-delete" %}" method="post" id="delete-conversations" class="modal modal-flex">
                     <p>
                         {% trans "Attention, vous vous apprêtez à supprimer toutes les conversations sélectionnées" %}.
                     </p>

--- a/templates/mp/post/edit.html
+++ b/templates/mp/post/edit.html
@@ -46,7 +46,7 @@
             <ul>
                 <li>
                     <a href="#add-participant" class="open-modal">{% trans "Ajouter un membre" %}</a>
-                    <form action="{% url "mp-edit-participant" topic.pk topic.slug %}" method="post" id="add-participant" class="modal modal-flex">
+                    <form action="{% url "mp:edit-participant" topic.pk topic.slug %}" method="post" id="add-participant" class="modal modal-flex">
                         <p>
                             {% trans "Vous allez rajouter un nouveau membre dans la conversation privée" %}.
                         </p>

--- a/templates/mp/post/new.html
+++ b/templates/mp/post/new.html
@@ -41,7 +41,7 @@
     {% endif %}
 
     {% captureas form_action %}
-        {% url "private-posts-new" topic.pk topic.slug %}
+        {% url "mp:answer" topic.pk topic.slug %}
     {% endcaptureas %}
 
     {% include "misc/message_form.html" with member=user text=form.text.value %}
@@ -55,11 +55,11 @@
     <div class="content-wrapper">
         {% for message in posts %}
             {% captureas edit_link %}
-                {% url "private-posts-edit" topic.pk topic.slug message.pk %}
+                {% url "mp:post-edit" message.pk %}
             {% endcaptureas %}
 
             {% captureas cite_link %}
-                {% url "private-posts-new" topic.pk topic.slug %}?cite={{ message.pk }}
+                {% url "mp:answer" topic.pk topic.slug %}?cite={{ message.pk }}
             {% endcaptureas %}
 
             {% include "misc/message.part.html" with can_hide=False is_mp=True %}

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -60,11 +60,11 @@
         {% for message in posts %}
             {% if not topic.one_participant_remaining %}
                 {% captureas edit_link %}
-                    {% url "private-posts-edit" topic.pk topic.slug message.pk %}
+                    {% url "mp:post-edit" message.pk %}
                 {% endcaptureas %}
 
                 {% captureas cite_link %}
-                    {% url "private-posts-new" topic.pk topic.slug %}?cite={{ message.pk }}
+                    {% url "mp:answer" topic.pk topic.slug %}?cite={{ message.pk }}
                 {% endcaptureas %}
             {% endif %}
 
@@ -73,7 +73,7 @@
             {% endcaptureas %}
 
             {% captureas unread_link %}
-                {% url "private-post-unread" %}?message={{ message.pk }}
+                {% url "mp:post-unread" message.pk %}
             {% endcaptureas %}
 
             {% if forloop.first and page_obj.number > 1 %}
@@ -98,7 +98,7 @@
 
 
     {% captureas form_action %}
-        {% url "private-posts-new" topic.pk topic.slug %}
+        {% url "mp:answer" topic.pk topic.slug %}
     {% endcaptureas %}
 
     {% include "misc/message_form.html" with member=user %}
@@ -115,7 +115,7 @@
                     <a href="#add-participant" class="open-modal ico-after more blue">
                         {% trans "Ajouter un membre" %}
                     </a>
-                    <form action="{% url "mp-edit-participant" topic.pk topic.slug %}" method="post" id="add-participant" class="modal modal-flex">
+                    <form action="{% url "mp:edit-participant" topic.pk topic.slug %}" method="post" id="add-participant" class="modal modal-flex">
                         <p>
                             {% trans "Vous allez rajouter un nouveau membre dans la conversation privée." %}
                         </p>
@@ -132,7 +132,7 @@
                 </li>
 
                 <li>
-                    <a href="{% url "mp-edit-topic" topic.pk topic.slug %}" class="ico-after edit blue">
+                    <a href="{% url "mp:edit" topic.pk topic.slug %}" class="ico-after edit blue">
                         {% trans "Éditer la conversation" %}
                     </a>
                 </li>
@@ -142,7 +142,7 @@
                 <a href="#leave-conversation" class="open-modal ico-after cross blue">
                     {% trans "Quitter la conversation" %}
                 </a>
-                <form action="{% url "mp-delete" topic.pk topic.slug %}" method="post" id="leave-conversation" class="modal modal-flex">
+                <form action="{% url "mp:leave" topic.pk topic.slug %}" method="post" id="leave-conversation" class="modal modal-flex">
                     <p>
                         {% trans "Attention, vous vous apprêtez à quitter définitivement cette conversation." %}
                     </p>

--- a/templates/mp/topic/index.html
+++ b/templates/mp/topic/index.html
@@ -73,7 +73,7 @@
             {% endcaptureas %}
 
             {% captureas unread_link %}
-                {% url "mp:post-unread" message.pk %}
+                {% url "mp:mark-post-unread" message.pk %}
             {% endcaptureas %}
 
             {% if forloop.first and page_obj.number > 1 %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -653,7 +653,7 @@
                     </li>
                 {% endif %}
                 <li>
-                    <a  href="{% url 'mp-new' %}?{% for username in content.authors.all %}&amp;username={{ username }}{% endfor %}"
+                    <a  href="{% url "mp:create" %}?{% for username in content.authors.all %}&amp;username={{ username }}{% endfor %}"
                         class="ico-after cite blue"
                     >
                         {% trans "Envoyer un MP" %}

--- a/zds/mp/commons.py
+++ b/zds/mp/commons.py
@@ -1,12 +1,6 @@
 from datetime import datetime
 
-from django.views.generic.detail import SingleObjectMixin
-from django.http import Http404
-from django.shortcuts import get_object_or_404
-
-from zds.mp.models import PrivateTopicRead, PrivatePost
 from zds.utils.templatetags.emarkdown import emarkdown
-from zds.mp import signals
 
 
 class LeavePrivateTopic:
@@ -37,42 +31,3 @@ class UpdatePrivatePost:
         instance.update = datetime.now()
         instance.save()
         return instance
-
-    @staticmethod
-    def perform_unread_private_post(post, user):
-        """
-        Mark the private post as unread. If it is in first position, the whole topic is marked as unread.
-        """
-        # mark the previous post as read
-        try:
-            previous_post = PrivatePost.objects.get(
-                privatetopic=post.privatetopic, position_in_topic=post.position_in_topic - 1
-            )
-            # update the record, if it exists
-            try:
-                topic = PrivateTopicRead.objects.get(privatetopic=post.privatetopic, user=user)
-                topic.privatepost = previous_post
-            # no existing record to update, create a new record
-            except PrivateTopicRead.DoesNotExist:
-                topic = PrivateTopicRead(privatepost=previous_post, privatetopic=post.privatetopic, user=user)
-            topic.save()
-        # no previous post to mark as read, remove the topic from read list instead
-        except PrivatePost.DoesNotExist:
-            try:
-                topic = PrivateTopicRead.objects.get(privatetopic=post.privatetopic, user=user)
-                topic.delete()
-            except PrivateTopicRead.DoesNotExist:  # record already removed, nothing to do
-                pass
-
-        signals.message_unread.send(sender=post.privatetopic.__class__, instance=post, user=user)
-
-
-class SinglePrivatePostObjectMixin(SingleObjectMixin):
-    object = None
-
-    def get_object(self, queryset=None):
-        try:
-            post_pk = int(self.request.GET.get("message"))
-        except (KeyError, ValueError, TypeError):
-            raise Http404
-        return get_object_or_404(PrivatePost, pk=post_pk)

--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -103,7 +103,7 @@ class PrivatePostForm(forms.Form):
     def __init__(self, topic, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.form_action = reverse("private-posts-new", args=[topic.pk, topic.slug()])
+        self.helper.form_action = reverse("mp:answer", args=[topic.pk, topic.slug()])
         self.helper.form_method = "post"
 
         self.helper.layout = Layout(

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -89,7 +89,7 @@ class PrivateTopic(models.Model):
         :return: PrivateTopic object URL
         :rtype: str
         """
-        return reverse("private-posts-list", args=[self.pk, self.slug()])
+        return reverse("mp:view", args=[self.pk, self.slug()])
 
     def slug(self):
         """

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -400,6 +400,13 @@ class PrivatePost(models.Model):
             is_same_private_topic = private_topic == self.privatetopic
         return is_same_private_topic and self.privatetopic.last_message == self
 
+    def get_previous(self):
+        """Return the previous post in the topic or 'None' if the post is the first one."""
+        return PrivatePost.objects.filter(
+            privatetopic=self.privatetopic,
+            position_in_topic=self.position_in_topic - 1,
+        ).first()
+
     def get_user_vote(self, user):
         """Get a user vote (like, dislike or neutral)"""
         if user.is_authenticated:

--- a/zds/mp/tests/tests_models.py
+++ b/zds/mp/tests/tests_models.py
@@ -35,7 +35,7 @@ class PrivateTopicTest(TestCase):
         self.post2 = PrivatePostFactory(privatetopic=self.topic1, author=self.user2, position_in_topic=2)
 
     def test_get_absolute_url(self):
-        url = reverse("private-posts-list", args=[self.topic1.pk, self.topic1.slug()])
+        url = reverse("mp:view", args=[self.topic1.pk, self.topic1.slug()])
 
         self.assertEqual(self.topic1.get_absolute_url(), url)
 

--- a/zds/mp/tests/tests_utils.py
+++ b/zds/mp/tests/tests_utils.py
@@ -43,7 +43,7 @@ class MpUtilTest(TestCase):
 
     def test_new_mp_email(self):
         response = self.client.post(
-            reverse("mp-new"),
+            reverse("mp:create"),
             {
                 "participants": self.user2.username
                 + ", "
@@ -78,7 +78,7 @@ class MpUtilTest(TestCase):
 
         # Create a MP
         self.client.post(
-            reverse("mp-new"),
+            reverse("mp:create"),
             {
                 "participants": self.user2.username
                 + ", "
@@ -101,7 +101,7 @@ class MpUtilTest(TestCase):
         # Add an answer
         topic1 = PrivateTopic.objects.get()
         self.client.post(
-            reverse("private-posts-new", args=[topic1.pk, topic1.slug]),
+            reverse("mp:answer", args=[topic1.pk, topic1.slug()]),
             {"text": "answer", "last_post": topic1.last_message.pk},
             follow=True,
         )

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -90,6 +90,25 @@ class IndexViewTest(TestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class OldViewTest(TestCase):
+    """Test the view redirecting former topic URLs to the new ones."""
+
+    def test_nominal(self):
+        """Test the redirection on a nominal case."""
+        user = ProfileFactory().user
+        topic = PrivateTopicFactory(author=user)
+        PrivatePostFactory(privatetopic=topic, author=user, position_in_topic=1)
+
+        url_args = {"pk": topic.pk, "topic_slug": topic.slug()}
+        url = reverse("mp:old-view", kwargs=url_args)
+
+        self.client.force_login(user)
+        response = self.client.get(url)
+
+        redirect_url = reverse("mp:view", kwargs=url_args)
+        self.assertRedirects(response, redirect_url, status_code=301)
+
+
 class TopicViewTest(TestCase):
     def setUp(self):
         self.profile1 = ProfileFactory()

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -895,30 +895,30 @@ class PrivatePostUnreadTest(TestCase):
     def test_denies_anonymous(self):
         """Test the case of an unauthenticated user trying to unread a private post."""
         self.client.logout()
-        response = self.client.get(reverse("mp:post-unread", kwargs={"pk": self.post2.pk}), follow=True)
+        response = self.client.get(reverse("mp:mark-post-unread", kwargs={"pk": self.post2.pk}), follow=True)
 
         self.assertRedirects(
             response,
-            reverse("member-login") + "?next=" + reverse("mp:post-unread", kwargs={"pk": self.post2.pk}),
+            reverse("member-login") + "?next=" + reverse("mp:mark-post-unread", kwargs={"pk": self.post2.pk}),
         )
 
     def test_failing_unread_post(self):
         """Test cases of invalid unread requests by an authenticated user."""
         self.client.force_login(self.author.user)
         # parameter doesn't (yet) exist
-        result = self.client.get(reverse("mp:post-unread", kwargs={"pk": 424242}), follow=False)
+        result = self.client.get(reverse("mp:mark-post-unread", kwargs={"pk": 424242}), follow=False)
         self.assertEqual(result.status_code, 404)
 
     def test_user_not_participating(self):
         """Test the case of a user not participating in a private topic attempting to unread a post."""
         self.client.force_login(self.outsider.user)
-        result = self.client.get(reverse("mp:post-unread", kwargs={"pk": self.post2.pk}), follow=False)
+        result = self.client.get(reverse("mp:mark-post-unread", kwargs={"pk": self.post2.pk}), follow=False)
         self.assertEqual(result.status_code, 403)
 
     @patch("zds.mp.signals.message_unread")
     def test_unread_first_post(self, message_unread):
         self.client.force_login(self.participant.user)
-        result = self.client.get(reverse("mp:post-unread", kwargs={"pk": self.post1.pk}), follow=True)
+        result = self.client.get(reverse("mp:mark-post-unread", kwargs={"pk": self.post1.pk}), follow=True)
         self.assertRedirects(result, reverse("mp:list"))
         with self.assertRaises(PrivateTopicRead.DoesNotExist):
             PrivateTopicRead.objects.get(privatetopic=self.post1.privatetopic, user=self.participant.user)
@@ -927,7 +927,7 @@ class PrivatePostUnreadTest(TestCase):
     @patch("zds.mp.signals.message_unread")
     def test_unread_normal_post(self, message_unread):
         self.client.force_login(self.participant.user)
-        self.client.get(reverse("mp:post-unread", kwargs={"pk": self.post2.pk}), follow=True)
+        self.client.get(reverse("mp:mark-post-unread", kwargs={"pk": self.post2.pk}), follow=True)
         topic_read = PrivateTopicRead.objects.get(privatetopic=self.post2.privatetopic, user=self.participant.user)
         self.assertEqual(topic_read.privatetopic, self.topic1)
         self.assertEqual(topic_read.user, self.participant.user)
@@ -937,8 +937,8 @@ class PrivatePostUnreadTest(TestCase):
     @patch("zds.mp.signals.message_unread")
     def test_multiple_unread1(self, message_unread):
         self.client.force_login(self.participant.user)
-        self.client.get(reverse("mp:post-unread", kwargs={"pk": self.post1.pk}), follow=True)
-        self.client.get(reverse("mp:post-unread", kwargs={"pk": self.post2.pk}), follow=True)
+        self.client.get(reverse("mp:mark-post-unread", kwargs={"pk": self.post1.pk}), follow=True)
+        self.client.get(reverse("mp:mark-post-unread", kwargs={"pk": self.post2.pk}), follow=True)
         topic_read = PrivateTopicRead.objects.get(privatetopic=self.post2.privatetopic, user=self.participant.user)
         self.assertEqual(topic_read.privatetopic, self.topic1)
         self.assertEqual(topic_read.user, self.participant.user)
@@ -949,7 +949,7 @@ class PrivatePostUnreadTest(TestCase):
     def test_multiple_unread2(self, message_unread):
         self.client.force_login(self.participant.user)
         for _ in range(2):
-            self.client.get(reverse("mp:post-unread", kwargs={"pk": self.post1.pk}), follow=True)
+            self.client.get(reverse("mp:mark-post-unread", kwargs={"pk": self.post1.pk}), follow=True)
         with self.assertRaises(PrivateTopicRead.DoesNotExist):
             PrivateTopicRead.objects.get(privatetopic=self.post1.privatetopic, user=self.participant.user)
         self.assertEqual(message_unread.send.call_count, 2)
@@ -958,6 +958,6 @@ class PrivatePostUnreadTest(TestCase):
         mark_read(self.topic1, self.author.user)
         topic_read_old = PrivateTopicRead.objects.filter(privatetopic=self.topic1, user=self.author.user)
         self.client.force_login(self.participant.user)
-        self.client.get(reverse("mp:post-unread", kwargs={"pk": self.post2.pk}), follow=True)
+        self.client.get(reverse("mp:mark-post-unread", kwargs={"pk": self.post2.pk}), follow=True)
         topic_read_new = PrivateTopicRead.objects.filter(privatetopic=self.topic1, user=self.author.user)
         self.assertQuerysetEqual(topic_read_old, [repr(t) for t in topic_read_new])

--- a/zds/mp/urls.py
+++ b/zds/mp/urls.py
@@ -38,5 +38,5 @@ urlpatterns = [
     ),
     # Routes related to a single message
     path("message/<int:pk>/modifier/", PrivatePostEdit.as_view(), name="post-edit"),
-    path("message/<int:pk>/marquer-non-lu/", PrivatePostUnread.as_view(), name="post-unread"),
+    path("message/<int:pk>/marquer-non-lu/", PrivatePostUnread.as_view(), name="mark-post-unread"),
 ]

--- a/zds/mp/urls.py
+++ b/zds/mp/urls.py
@@ -1,4 +1,5 @@
-from django.urls import re_path
+from django.urls import path
+from django.views.generic.base import RedirectView
 
 from zds.mp.views import (
     PrivateTopicList,
@@ -13,26 +14,29 @@ from zds.mp.views import (
     PrivateTopicEdit,
 )
 
+app_name = "mp"
 
 urlpatterns = [
-    # Topics.
-    re_path(r"^$", PrivateTopicList.as_view(), name="mp-list"),
-    re_path(r"^quitter/$", PrivateTopicLeaveList.as_view(), name="mp-list-delete"),
-    re_path(r"^creer/$", PrivateTopicNew.as_view(), name="mp-new"),
-    re_path(r"^(?P<pk>\d+)/(?P<topic_slug>.+)/quitter/$", PrivateTopicLeaveDetail.as_view(), name="mp-delete"),
-    re_path(r"^(?P<pk>\d+)/(?P<topic_slug>.+)/editer/topic/$", PrivateTopicEdit.as_view(), name="mp-edit-topic"),
-    re_path(
-        r"^(?P<pk>\d+)/(?P<topic_slug>.+)/editer/participants/$",
+    # Routes related to the set of topics
+    path("", PrivateTopicList.as_view(), name="list"),
+    path("quitter/", PrivateTopicLeaveList.as_view(), name="list-delete"),
+    path("creer/", PrivateTopicNew.as_view(), name="create"),
+    # Routes related to a single existing topic
+    path("<int:pk>/<slug:topic_slug>/", PrivatePostList.as_view(), name="view"),
+    path(
+        "<int:pk>/<slug:topic_slug>/messages/",
+        RedirectView.as_view(pattern_name="mp:view", permanent=True),
+        name="old-view",
+    ),
+    path("<int:pk>/<slug:topic_slug>/repondre/", PrivatePostAnswer.as_view(), name="answer"),
+    path("<int:pk>/<slug:topic_slug>/quitter/", PrivateTopicLeaveDetail.as_view(), name="leave"),
+    path("<int:pk>/<slug:topic_slug>/modifier/", PrivateTopicEdit.as_view(), name="edit"),
+    path(
+        "<int:pk>/<slug:topic_slug>/modifier/participants/",
         PrivateTopicAddParticipant.as_view(),
-        name="mp-edit-participant",
+        name="edit-participant",
     ),
-    # Posts.
-    re_path(r"^(?P<pk>\d+)/(?P<topic_slug>.+)/messages/$", PrivatePostList.as_view(), name="private-posts-list"),
-    re_path(r"^(?P<pk>\d+)/(?P<topic_slug>.+)/messages/creer/$", PrivatePostAnswer.as_view(), name="private-posts-new"),
-    re_path(
-        r"^(?P<topic_pk>\d+)/(?P<topic_slug>.+)/messages/(?P<pk>\d+)/editer/$",
-        PrivatePostEdit.as_view(),
-        name="private-posts-edit",
-    ),
-    re_path(r"^message/nonlu/$", PrivatePostUnread.as_view(), name="private-post-unread"),
+    # Routes related to a single message
+    path("message/<int:pk>/modifier/", PrivatePostEdit.as_view(), name="post-edit"),
+    path("message/<int:pk>/marquer-non-lu/", PrivatePostUnread.as_view(), name="post-unread"),
 ]

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -15,16 +15,16 @@ from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.list import MultipleObjectMixin
 from django.views.decorators.http import require_GET
 
-
 from zds.member.models import Profile
-from zds.mp.commons import LeavePrivateTopic, UpdatePrivatePost, SinglePrivatePostObjectMixin
+from zds.mp import signals
+from zds.mp.commons import LeavePrivateTopic, UpdatePrivatePost
 from zds.mp.decorator import is_participant
 from zds.utils.models import get_hat_from_request
 from zds.forum.utils import CreatePostView
 from zds.mp.utils import send_mp, send_message_mp
 from zds.utils.paginator import ZdSPagingListView
 from .forms import PrivateTopicForm, PrivatePostForm, PrivateTopicEditForm
-from .models import PrivateTopic, PrivatePost, mark_read, NotReachableError
+from .models import PrivateTopic, PrivateTopicRead, PrivatePost, mark_read, NotReachableError
 
 
 class PrivateTopicList(ZdSPagingListView):
@@ -158,7 +158,7 @@ class PrivateTopicLeaveDetail(LeavePrivateTopic, SingleObjectMixin, RedirectView
         topic = self.get_object()
         self.perform_destroy(topic)
         messages.success(request, _("Vous avez quitté la conversation avec succès."))
-        return redirect(reverse("mp-list"))
+        return redirect(reverse("mp:list"))
 
     def get_current_user(self):
         return self.request.user
@@ -196,7 +196,7 @@ class PrivateTopicAddParticipant(SingleObjectMixin, RedirectView):
         except NotReachableError:
             messages.warning(request, _("""Le membre n'a pas été ajouté à la conversation, car il est injoignable."""))
 
-        return redirect(reverse("private-posts-list", args=[topic.pk, topic.slug()]))
+        return redirect(reverse("mp:view", args=[topic.pk, topic.slug()]))
 
 
 class PrivateTopicLeaveList(LeavePrivateTopic, MultipleObjectMixin, RedirectView):
@@ -217,7 +217,7 @@ class PrivateTopicLeaveList(LeavePrivateTopic, MultipleObjectMixin, RedirectView
     def post(self, request, *args, **kwargs):
         for topic in self.get_queryset():
             self.perform_destroy(topic)
-        return redirect(reverse("mp-list"))
+        return redirect(reverse("mp:list"))
 
     def get_current_user(self):
         return self.request.user
@@ -302,7 +302,7 @@ class PrivatePostEdit(UpdateView, UpdatePrivatePost):
     Edits a post on a MP.
     """
 
-    current_post = None
+    post = None
     topic = None
     queryset = PrivatePost.objects.all()
     template_name = "mp/post/edit.html"
@@ -313,37 +313,34 @@ class PrivatePostEdit(UpdateView, UpdatePrivatePost):
         return super().dispatch(request, *args, **kwargs)
 
     def get_object(self, queryset=None):
-        # if post.position_in_topic >= 1:
-        self.topic = get_object_or_404(PrivateTopic, pk=(self.kwargs.get("topic_pk", None)))
-        self.current_post = super().get_object(queryset)
-        last = get_object_or_404(PrivatePost, pk=self.topic.last_message.pk)
+        self.post = super().get_object(queryset)
+        self.topic = self.post.privatetopic
+        last_post = get_object_or_404(PrivatePost, pk=self.topic.last_message.pk)
         # Only edit last private post
-        if not last.pk == self.current_post.pk:
+        if not last_post.pk == self.post.pk:
             raise PermissionDenied
-        # Making sure the user is allowed to do that. Author of the post must to be the user logged.
-        if self.current_post.author != self.request.user:
+        # Making sure the user is allowed to do that. Author of the post must be the logged user.
+        if self.post.author != self.request.user:
             raise PermissionDenied
-        return self.current_post
+        return self.post
 
     def get(self, request, *args, **kwargs):
-        self.current_post = self.get_object()
-        form = self.form_class(self.topic, initial={"text": self.current_post.text})
-        form.helper.form_action = reverse(
-            "private-posts-edit", args=[self.topic.pk, self.topic.slug(), self.current_post.pk]
-        )
+        self.post = self.get_object()
+        form = self.form_class(self.topic, initial={"text": self.post.text})
+        form.helper.form_action = reverse("mp:post-edit", args=[self.post.pk])
         return render(
             request,
             self.template_name,
             {
-                "post": self.current_post,
+                "post": self.post,
                 "topic": self.topic,
-                "text": self.current_post.text,
+                "text": self.post.text,
                 "form": form,
             },
         )
 
     def post(self, request, *args, **kwargs):
-        self.current_post = self.get_object()
+        self.post = self.get_object()
         form = self.get_form(self.form_class)
 
         if "preview" in request.POST:
@@ -357,7 +354,7 @@ class PrivatePostEdit(UpdateView, UpdatePrivatePost):
             request,
             self.template_name,
             {
-                "post": self.current_post,
+                "post": self.post,
                 "topic": self.topic,
                 "form": form,
             },
@@ -365,20 +362,17 @@ class PrivatePostEdit(UpdateView, UpdatePrivatePost):
 
     def get_form(self, form_class=PrivatePostForm):
         form = self.form_class(self.topic, self.request.POST)
-        form.helper.form_action = reverse(
-            "private-posts-edit", args=[self.topic.pk, self.topic.slug(), self.current_post.pk]
-        )
+        form.helper.form_action = reverse("mp:post-edit", args=[self.post.pk])
         return form
 
     def form_valid(self, form):
-        self.perform_update(
-            self.current_post, self.request.POST, hat=get_hat_from_request(self.request, self.current_post.author)
-        )
-
-        return redirect(self.current_post.get_absolute_url())
+        self.perform_update(self.post, self.request.POST, hat=get_hat_from_request(self.request, self.post.author))
+        return redirect(self.post.get_absolute_url())
 
 
-class PrivatePostUnread(UpdateView, UpdatePrivatePost, SinglePrivatePostObjectMixin):
+class PrivatePostUnread(UpdateView):
+    queryset = PrivatePost.objects.all()
+
     @method_decorator(require_GET)
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
@@ -391,4 +385,4 @@ class PrivatePostUnread(UpdateView, UpdatePrivatePost, SinglePrivatePostObjectMi
         ):
             raise PermissionDenied
         self.perform_unread_private_post(self.object, self.request.user)
-        return redirect(reverse("mp-list"))
+        return redirect(reverse("mp:list"))

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -819,7 +819,7 @@ class NotificationPrivateTopicTest(TestCase):
 
         self.assertEqual(1, len(Notification.objects.get_unread_notifications_of(self.user1)))
 
-        response = self.client.post(reverse("mp-delete", args=[topic.pk, topic.slug]), follow=True)
+        response = self.client.post(reverse("mp:leave", args=[topic.pk, topic.slug()]), follow=True)
         self.assertEqual(200, response.status_code)
         self.assertEqual(0, len(Notification.objects.get_unread_notifications_of(self.user1)))
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -1059,7 +1059,7 @@ class WarnTypoForm(forms.Form):
             usernames += "username=" + user.username
 
         msg = _('<p>Pas assez de place ? <a href="{}?title={}&{}">Envoyez un MP {}</a> !</a>').format(
-            reverse("mp-new"), pm_title, usernames, _("à l'auteur") if num_of_authors == 1 else _("aux auteurs")
+            reverse("mp:create"), pm_title, usernames, _("à l'auteur") if num_of_authors == 1 else _("aux auteurs")
         )
 
         version = content.sha_beta

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -214,7 +214,7 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
         for author in self.authors.all():
             get += "&" + urlencode({"username": author.username})
 
-        return reverse("mp-new") + get
+        return reverse("mp:create") + get
 
     def get_repo_path(self, relative=False):
         """Get the path to the tutorial repository

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -83,7 +83,7 @@ admin.autodiscover()
 urlpatterns = [
     re_path(r"^", include(("zds.tutorialv2.urls", ""))),
     re_path(r"^forums/", include(("zds.forum.urls", ""))),
-    re_path(r"^mp/", include(("zds.mp.urls", ""))),
+    path("mp/", include("zds.mp.urls")),
     re_path(r"^membres/", include(("zds.member.urls", ""))),
     re_path(r"^admin/", admin.site.urls),
     path("pages/", include("zds.pages.urls")),


### PR DESCRIPTION
Un des items de #6246.

* Refacto des URL :
  * utilise `path` au lieu de `re_path` et les nouveaux motifs en conséquence
  * ajoute un *namespace* `mp` pour ce module
  * change les noms de route pour des noms plus courts, plus simples et visant à être plus clairs
  * change la route pour éditer un message qui requérait l'id et le slug du topic pour agir seulement sur un message (ils ont leur propre id)
  * change la route pour marquer non lu qui avait été faite de manière un peu tordue (par moi, en l'occurrence :D)

* Autres refacto au passage :
  * bouge du code (`perform_unread`) pour marquer un message comme non lu à un meilleur endroit (c'était surprenant)
  * refactoriser `perform_unread` parce que c'est illisible

**Note importante** : je change les URL "applicatives" (les machins sur lesquels ont clique mais vers lesquels on ne lie jamais normalement), mais aussi l'URL pour voir un MP. **J'ai mis une redirection pour le lien vers un MP uniquement.**

### Contrôle qualité

Vérifier que les MP fonctionnent bien en exerçant toutes les URL.

Vérifier que marquer les MP non-lu fonctionne bien (en gras + notification).
