### PR TITLE
Met à jour Django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-crispy-forms==1.11.2
 django-model-utils==4.1.1
 django-munin==0.2.1
 django-recaptcha==2.0.6
-Django==2.2.27
+Django==2.2.28
 easy-thumbnails==2.8rc0
 factory-boy==3.2.0
 geoip2==4.2.0


### PR DESCRIPTION
Mise à jour qui inclut des correctifs de sécurité (cf l'[article concernant cette version](https://www.djangoproject.com/weblog/2022/apr/11/security-releases/)).

Contrairement à la PR #6289 , cette PR met à jour Django dans la version 30.1 de ZdS, qui contient encore la version 2 de Django.

### Contrôle qualité

S'assurer que le site fonctionne (j'ai du lancer `make new-db` après `make update`).
