### PR TITLE
Corrections dans la documentation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W  # treat warnings as errors to make the CI fails if there are any
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/doc/source/back-end-code/forum.rst
+++ b/doc/source/back-end-code/forum.rst
@@ -24,3 +24,9 @@ Vues (``views.py``)
 
 .. automodule:: zds.forum.views
     :members:
+
+Les utilitaires (``utils.py``)
+==============================
+
+.. automodule:: zds.forum.utils
+    :members:

--- a/doc/source/back-end-code/private-message.rst
+++ b/doc/source/back-end-code/private-message.rst
@@ -17,3 +17,15 @@ Vues (``views.py``)
 
 .. automodule:: zds.mp.views
     :members:
+
+Les utilitaires (``utils.py``)
+==============================
+
+Ce module ajoute des fonctions utiles permettant de gérer l'ajout et la réponse à des messages privés.
+
+Il est important d'utiliser ces méthodes pour réaliser ces actions sous peine d'oublier des actions.
+
+Ces méthodes permettent un lien direct avec le module "notifications".
+
+.. automodule:: zds.mp.utils
+    :members:

--- a/doc/source/back-end-code/utils.rst
+++ b/doc/source/back-end-code/utils.rst
@@ -12,24 +12,6 @@ Modèles (``models.py``)
 .. automodule:: zds.utils.models
     :members:
 
-Forums (``forums.py``)
-======================
-
-.. automodule:: zds.utils.forums
-    :members:
-
-Messages privés (``mps.py``)
-============================
-
-Ce module ajoute des fonctions utiles permettant de gérer l'ajout et la réponse à des messages privés.
-
-Il est important d'utiliser ces méthodes pour réaliser ces actions sous peine d'oublier des actions.
-
-Ces méthodes permettent un lien direct avec le module "notifications".
-
-.. automodule:: zds.utils.mps
-    :members:
-
 Tutoriels (``tutorials.py``)
 ============================
 

--- a/doc/source/front-end/charte-interface.rst
+++ b/doc/source/front-end/charte-interface.rst
@@ -56,7 +56,7 @@ une couleur pour quelque chose, vous devez piocher dedans.
    :align: center
 
 .. seealso::
-   Cette palette est également `disponible en version interactive <https://zestedesavoir.github.io/normes-graphiques/#couleurs>`_,
+   Cette palette est également `disponible en version interactive <https://zestedesavoir.github.io/normes-graphiques/#couleurs>`__,
    avec un outil pour déterminer la couleur la plus proche d'une couleur donnée
    dans la palette.
 
@@ -76,7 +76,8 @@ Ainsi, n'écrivez pas :
 
 Mais plutôt :
 
-.. sourcecode:: scss
+.. La coloration syntaxique ne comprend pas le dollar (cf https://github.com/pygments/pygments/issues/2130), donc pas de langage précisé
+.. sourcecode::
 
    .smoothie {
        color: $accent-400;
@@ -117,7 +118,7 @@ Concernant les **tailles** de texte, elles sont également normalisées. Vous po
    :align: center
 
 .. seealso::
-   Cette liste est également `disponible en version interactive <https://zestedesavoir.github.io/normes-graphiques/#polices>`_,
+   Cette liste est également `disponible en version interactive <https://zestedesavoir.github.io/normes-graphiques/#polices>`__,
    avec prévisualisation pour les trois familles de police utilisées.
 
 Longueurs
@@ -134,7 +135,7 @@ de la variable correspond à la longueur en pixels (ou en dixième de ``rem``).
    :align: center
 
 .. seealso::
-   Cette liste est également `disponible en version interactive <https://zestedesavoir.github.io/normes-graphiques/#longueurs>`_.
+   Cette liste est également `disponible en version interactive <https://zestedesavoir.github.io/normes-graphiques/#longueurs>`__.
 
 .. attention::
    Cette norme peut être ignorée s'il s'agit d'aligner des éléments au pixel près. Cela dit, un code
@@ -154,7 +155,7 @@ Si un élément doit recevoir une ombre, utilisez l'une des six ombres standardi
    :align: center
 
 .. seealso::
-   Cette liste est également `disponible en version interactive <https://zestedesavoir.github.io/normes-graphiques/#ombres>`_.
+   Cette liste est également `disponible en version interactive <https://zestedesavoir.github.io/normes-graphiques/#ombres>`__.
 
 Arrondis
 --------
@@ -167,7 +168,7 @@ circulaire, l'élément devra avoir des dimensions carrées).
    :align: center
 
 .. seealso::
-   Cette liste est également `disponible en version interactive <https://zestedesavoir.github.io/normes-graphiques/#arrondis>`_.
+   Cette liste est également `disponible en version interactive <https://zestedesavoir.github.io/normes-graphiques/#arrondis>`__.
 
 
 Recommandations pour un SCSS propre

--- a/doc/source/install/extra-install-latex.rst
+++ b/doc/source/install/extra-install-latex.rst
@@ -30,7 +30,7 @@ Installer une distribution LaTeX
 
 + Sous Windows, vous pouvez installer `MikTeX <https://miktex.org/download>`_ ou `TexLive <https://www.tug.org/texlive/>`_.
 + Sous macOS, vous pouvez installer `MacTex <https://www.tug.org/mactex/mactex-download.html>`_.
-+ Sous Linux, vous pouvez utiliser `TexLive <https://www.tug.org/texlive/>`_ (qui est probablement disponible dans votre gestionnaire de paquet). Notez que si vous êtes à l'aise, vous pouvez également installer une version allégée, `comme c'est fait ici <https://github.com/zestedesavoir/latex-template/blob/master/scripts/install_texlive.sh>`_ ou `dans le script d'installation automatisé <./install-linux.html##composant-tex-local-et-latex-template>`_.
++ Sous Linux, vous pouvez utiliser `TexLive <https://www.tug.org/texlive/>`_ (qui est probablement disponible dans votre gestionnaire de paquet). Notez que si vous êtes à l'aise, vous pouvez également installer une version allégée, `comme c'est fait ici <https://github.com/zestedesavoir/latex-template/blob/master/scripts/install_texlive.sh>`_ ou `dans le script d'installation automatisé <./install-linux.html#composant-tex-local-et-latex-template>`_.
 
 Si vous n'êtes pas famillier avec LaTeX, choisissez d'installer la version **complète**.
 La liste des packages nécessaire `est disponible ici <https://github.com/zestedesavoir/latex-template/blob/master/scripts/packages>`_, mais n'est peut être pas exhaustive.

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -453,9 +453,9 @@ class Comment(models.Model):
         """
         We override the save method for two tasks:
         1. we want to analyze the pings in the message to know if notifications
-           needs to be created;
+        needs to be created;
         2. if this comment is marked as potential spam, we need to open an alert
-           in case of update by its author.
+        in case of update by its author.
         """
         super().save(*args, **kwargs)
 


### PR DESCRIPTION
* Correction d'un lien dans la doc
* Génère la documentation en traitant les avertissements comme des erreurs, pour faire échouer la CI en cas d'avertissement
* Corrige les avertissements lors de la génération de la doc 

### Contrôle qualité

Générer la doc `make generate-doc` et vérifier que la doc est bien générée (ouvrir `doc/build/html/index.html`).

Note à celui qui fusionnera : pas la peine de squasher les commits, ils ont chacun leur propre rôle.
