### PR TITLE
Corrige la version de Django affichée sur la page "À propos"

### DIFF
--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -72,8 +72,8 @@
 
             <h4>{% trans "Site" %}</h4>
             <ul>
-                <li><a href="https://www.python.org/">Python 3</a></li>
-                <li><a href="https://www.djangoproject.com/">Django 2.2</a></li>
+                <li><a href="https://www.python.org/">Python {{ python_major_version }}</a></li>
+                <li><a href="https://www.djangoproject.com/">Django {{ django_major_version }}</a></li>
             </ul>
 
             <h4>HTTP(S) + WSGI</h4>

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -1,6 +1,8 @@
 import random
 from datetime import datetime
+import sys
 
+import django
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
@@ -66,6 +68,8 @@ def about(request):
             "default_repository_url": get_repository_url(
                 settings.ZDS_APP["github_projects"]["default_repository"], "base_url"
             ),
+            "django_major_version": django.VERSION[0],
+            "python_major_version": sys.version_info.major,
         },
     )
 


### PR DESCRIPTION
Récupère dynamiquement la version pour ne pas avoir à le faire pour les
prochaines mises à jour. Également pour la version de Python.

### Contrôle qualité

Vérifier les versions de Django et Python qui s'affichent sur la page "À propos".
