### PR TITLE
Refactorise les URL de la galerie

### DIFF
--- a/templates/gallery/base.html
+++ b/templates/gallery/base.html
@@ -10,14 +10,14 @@
 
 
 {% block breadcrumb_base %}
-    <li><a href="{% url "gallery-list" %}">{% trans "Galeries" %}</a></li>
+    <li><a href="{% url "gallery:list" %}">{% trans "Galeries" %}</a></li>
 {% endblock %}
 
 
 
 {% block sidebar %}
     <aside class="sidebar mobile-menu-hide">
-        <a href="{% url "gallery-new" %}" class="new-btn ico-after more blue">
+        <a href="{% url "gallery:create" %}" class="new-btn ico-after more blue">
             {% trans "Créer une galerie" %}
         </a>
 
@@ -31,19 +31,19 @@
                     <ul>
                         {% if permissions.write %}
                             <li>
-                                <a href="{% url "gallery-image-new" gallery.pk %}" class="ico-after more blue">
+                                <a href="{% url "gallery:image-add" gallery.pk %}" class="ico-after more blue">
                                     {% trans "Ajouter une image" %}
                                 </a>
                             </li>
                             {% if not content_linked %}
                                 <li>
-                                    <a href="{% url "gallery-edit" gallery.pk gallery.slug %}" class="ico-after edit blue">
+                                    <a href="{% url "gallery:edit" gallery.pk %}" class="ico-after edit blue">
                                         {% trans "Éditer la galerie" %}
                                     </a>
                                 </li>
                             {% endif %}
                             <li>
-                                <a href="{% url "gallery-image-import" gallery.pk %}" class="ico-after import blue">
+                                <a href="{% url "gallery:image-import" gallery.pk %}" class="ico-after import blue">
                                     {% trans "Importer une archive" %}
                                 </a>
                             </li>
@@ -52,7 +52,7 @@
                                     <a href="#delete-galleries" class="open-modal ico-after cross red">
                                         {% trans "Supprimer la galerie" %}
                                     </a>
-                                    <form action="{% url "galleries-delete" %}" method="post" id="delete-galleries" class="modal modal-flex">
+                                    <form action="{% url "gallery:delete" %}" method="post" id="delete-galleries" class="modal modal-flex">
                                         <input name="g_items" type="hidden" value="{{ gallery.pk }}" form="delete-galleries" />
                                         <p>{% trans "Êtes-vous certain de vouloir supprimer cette galerie ?" %}</p>
                                         {% csrf_token %}

--- a/templates/gallery/gallery/details.html
+++ b/templates/gallery/gallery/details.html
@@ -70,7 +70,7 @@
                                                 <td>
                                                     {# droits #}
                                                     {% if u.user != current_user %}
-                                                        <form action="{% url "gallery-members" gallery.pk %}" method="post">
+                                                        <form action="{% url "gallery:members" gallery.pk %}" method="post">
                                                             {% csrf_token %}
                                                             <input type="hidden" name="action" value="edit">
                                                             <input type="hidden" name="user" value="{{ u.user.username }}">
@@ -85,7 +85,7 @@
                                                 </td>
                                                 <td>
                                                     {# suppression #}
-                                                    <form action="{% url "gallery-members" gallery.pk %}" method="post">
+                                                    <form action="{% url "gallery:members" gallery.pk %}" method="post">
                                                         {% csrf_token %}
                                                         <input type="hidden" name="action" value="leave">
                                                         <input type="hidden" name="user" value="{{ u.user.username }}">
@@ -127,7 +127,7 @@
                 <!-- Delete images -->
                 <a class="btn btn-cancel open-modal" href="#form-delete-images">{% trans "Supprimer la sélection" %}</a>
                 <!-- Confirmation modal -->
-                <form id="form-delete-images" name="form" method="post" action="{% url "gallery-image-delete" gallery.pk %}" class="modal modal-flex">
+                <form id="form-delete-images" name="form" method="post" action="{% url "gallery:image-delete" gallery.pk %}" class="modal modal-flex">
                     <input type="hidden" name="gallery" value="{{ gallery.pk }}">
                     {% csrf_token %}
                     <p>{% trans "Attention, vous vous appretez à supprimer toutes les images sélectionnées." %}</p>
@@ -149,7 +149,7 @@
                         {% endif %}
                     </div>
                     <div class="topic-description has-image" title="{{ img.title }}">
-                        <a href="{% url "gallery-image-edit" gallery.pk img.pk %}" class="topic-title-link navigable-link">
+                        <a href="{% url "gallery:image-edit" gallery.pk img.pk %}" class="topic-title-link navigable-link">
                             <img src="{{ img.physical.gallery.url }}"
                                  data-caption="{{ img.title }}"
                                  alt="{{ img.title }}"
@@ -164,7 +164,7 @@
                 </div>
             {% endfor %}
 
-            <a href="{% url "gallery-image-new" gallery.pk %}" title="Ajouter une image" class="gallery-item add-image">+</a>
+            <a href="{% url "gallery:image-add" gallery.pk %}" title="Ajouter une image" class="gallery-item add-image">+</a>
         </div>
     {% else %}
         <p>
@@ -172,8 +172,8 @@
             <br>
 
             {% if permissions.write %}
-                {% url "gallery-image-new" gallery.pk as new_img_url %}
-                {% url "gallery-image-import" gallery.pk as import_archive %}
+                {% url "gallery:image-add" gallery.pk as new_img_url %}
+                {% url "gallery:image-import" gallery.pk as import_archive %}
                 {% blocktrans %}
                     Vous pouvez <a href="{{new_img_url}}">ajouter une image</a> à cette galerie dès à présent, ou <a href="{{ import_archive }}">importer une archive</a> !
                 {% endblocktrans %}

--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -80,7 +80,7 @@
     {% if galleries|length == 0 %}
         <p>
             {% trans "Vous n’avez pas encore de galerie" %}. <br>
-            <a href="{% url "gallery-new" %}">{% trans "Créer une galerie" %}</a>.
+            <a href="{% url "gallery:create" %}">{% trans "Créer une galerie" %}</a>.
         </p>
     {% endif %}
 
@@ -99,7 +99,7 @@
                         {% trans "Supprimer les galeries sélectionnées" %}
                     </a>
 
-                    <form action="{% url "galleries-delete" %}" method="post" id="delete-galleries" class="modal modal-flex">
+                    <form action="{% url "gallery:delete" %}" method="post" id="delete-galleries" class="modal modal-flex">
                         <p>
                             {% trans "Attention, vous vous apprêtez à supprimer toutes les galeries sélectionnées" %}.
                         </p>

--- a/templates/gallery/image/edit.html
+++ b/templates/gallery/image/edit.html
@@ -93,7 +93,7 @@
 
         {% if permissions.write %}
             {# Confirmation modal for deleting image #}
-            <form id="form-delete-image" name="form" method="post" action="{% url "gallery-image-delete" gallery.pk %}" class="modal modal-flex">
+            <form id="form-delete-image" name="form" method="post" action="{% url "gallery:image-delete" gallery.pk %}" class="modal modal-flex">
                 {% csrf_token %}
                 <input type="hidden" name="image" value="{{ image.pk }}">
                 <p>{% trans "Attention, vous vous apprêtez à supprimer cette image." %}</p>

--- a/templates/header.html
+++ b/templates/header.html
@@ -367,7 +367,7 @@
                             <a href="{% url "opinion:find-opinion" user.username %}">{% trans "Mes billets" %}</a>
                         </li>
                         <li>
-                            <a href="{% url "gallery-list" %}">{% trans "Galeries d’images" %}</a>
+                            <a href="{% url "gallery:list" %}">{% trans "Galeries d’images" %}</a>
                         </li>
                         <li>
                             <a href="{% url "update-member" %}">{% trans "Paramètres" %}</a>

--- a/templates/tutorialv2/create/container.html
+++ b/templates/tutorialv2/create/container.html
@@ -39,7 +39,7 @@
 
 {% block sidebar_actions %}
     <li>
-        <a href="{% url "gallery-image-new" gallery.pk %}" class="ico-after more blue">
+        <a href="{% url "gallery:image-add" gallery.pk %}" class="ico-after more blue">
             {% trans "Ajouter une image à la galerie" %}
         </a>
     </li>

--- a/templates/tutorialv2/create/extract.html
+++ b/templates/tutorialv2/create/extract.html
@@ -44,7 +44,7 @@
 
 {% block sidebar_actions %}
     <li>
-        <a href="{% url "gallery-image-new" gallery.pk %}" class="ico-after more blue">
+        <a href="{% url "gallery:image-add" gallery.pk %}" class="ico-after more blue">
             {% trans "Ajouter une image à la galerie" %}
         </a>
     </li>

--- a/templates/tutorialv2/edit/container.html
+++ b/templates/tutorialv2/edit/container.html
@@ -40,7 +40,7 @@
 
 {% block sidebar_actions %}
     <li>
-        <a href="{% url "gallery-image-new" gallery.pk %}" class="ico-after more blue">
+        <a href="{% url "gallery:image-add" gallery.pk %}" class="ico-after more blue">
             {% trans "Ajouter une image à la galerie" %}
         </a>
     </li>

--- a/templates/tutorialv2/edit/content.html
+++ b/templates/tutorialv2/edit/content.html
@@ -38,7 +38,7 @@
 
 {% block sidebar_actions %}
     <li>
-        <a href="{% url "gallery-image-new" gallery.pk %}" class="ico-after more blue">
+        <a href="{% url "gallery:image-add" gallery.pk %}" class="ico-after more blue">
             {% trans "Ajouter une image à la galerie" %}
         </a>
     </li>

--- a/templates/tutorialv2/edit/extract.html
+++ b/templates/tutorialv2/edit/extract.html
@@ -46,7 +46,7 @@
 
 {% block sidebar_actions %}
     <li>
-        <a href="{% url "gallery-image-new" gallery.pk %}" class="ico-after more blue">
+        <a href="{% url "gallery:image-add" gallery.pk %}" class="ico-after more blue">
             {% trans "Ajouter une image à la galerie" %}
         </a>
     </li>

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -622,7 +622,7 @@
     {# GALERY #}
     {% if can_edit %}
         <li>
-            <a href="{% url "gallery-details" gallery.pk gallery.slug %}" class="ico-after offline blue">
+            <a href="{% url "gallery:details" gallery.pk gallery.slug %}" class="ico-after offline blue">
                 {% trans "Aller à la galerie liée" %}
             </a>
         </li>

--- a/zds/gallery/forms.py
+++ b/zds/gallery/forms.py
@@ -22,7 +22,7 @@ class GalleryForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_class = "clearfix"
-        self.helper.form_action = reverse("gallery-new")
+        self.helper.form_action = reverse("gallery:create")
         self.helper.form_method = "post"
 
         self.helper.layout = Layout(
@@ -94,7 +94,7 @@ class UserGalleryForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_class = "modal modal-flex"
         self.helper.form_id = "add-user-modal"
-        self.helper.form_action = reverse("gallery-members", kwargs={"pk": gallery.pk})
+        self.helper.form_action = reverse("gallery:members", kwargs={"pk": gallery.pk})
         self.helper.form_method = "post"
 
         self.helper.layout = Layout(

--- a/zds/gallery/models.py
+++ b/zds/gallery/models.py
@@ -210,7 +210,7 @@ class Gallery(models.Model):
         :return: Gallery object URL
         :rtype: str
         """
-        return reverse("gallery-details", args=[self.pk, self.slug])
+        return reverse("gallery:details", args=[self.pk, self.slug])
 
     def get_gallery_path(self):
         """Get the filesystem path to this gallery root.

--- a/zds/gallery/tests/tests_models.py
+++ b/zds/gallery/tests/tests_models.py
@@ -82,7 +82,7 @@ class GalleryTest(TestCase):
         self.gallery.delete()
 
     def test_get_absolute_url(self):
-        absolute_url = reverse("gallery-details", args=[self.gallery.pk, self.gallery.slug])
+        absolute_url = reverse("gallery:details", args=[self.gallery.pk, self.gallery.slug])
         self.assertEqual(absolute_url, self.gallery.get_absolute_url())
 
     def test_get_linked_users(self):

--- a/zds/gallery/urls.py
+++ b/zds/gallery/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import path
 
 from zds.gallery.views import (
     NewGallery,
@@ -13,19 +13,20 @@ from zds.gallery.views import (
     EditGalleryMembers,
 )
 
+app_name = "gallery"
 
 urlpatterns = [
     # Index
-    re_path(r"^$", ListGallery.as_view(), name="gallery-list"),
-    # Gallery operation
-    re_path(r"^nouveau/$", NewGallery.as_view(), name="gallery-new"),
-    re_path(r"^(?P<pk>\d+)/(?P<slug>.+)/$", GalleryDetails.as_view(), name="gallery-details"),
-    re_path(r"^editer/(?P<pk>\d+)/(?P<slug>.+)/$", EditGallery.as_view(), name="gallery-edit"),
-    re_path(r"^membres/(?P<pk>\d+)/$", EditGalleryMembers.as_view(), name="gallery-members"),
-    re_path(r"^supprimer/$", DeleteGalleries.as_view(), name="galleries-delete"),
+    path("", ListGallery.as_view(), name="list"),
+    # Gallery operations
+    path("creer/", NewGallery.as_view(), name="create"),
+    path("<int:pk>/<slug:slug>/", GalleryDetails.as_view(), name="details"),
+    path("modifier/<int:pk>/", EditGallery.as_view(), name="edit"),
+    path("membres/<int:pk>/", EditGalleryMembers.as_view(), name="members"),
+    path("supprimer/", DeleteGalleries.as_view(), name="delete"),
     # Image operations
-    re_path(r"^image/ajouter/(?P<pk_gallery>\d+)/$", NewImage.as_view(), name="gallery-image-new"),
-    re_path(r"^image/supprimer/(?P<pk_gallery>\d+)/$", DeleteImages.as_view(), name="gallery-image-delete"),
-    re_path(r"^image/editer/(?P<pk_gallery>\d+)/(?P<pk>\d+)/$", EditImage.as_view(), name="gallery-image-edit"),
-    re_path(r"^image/importer/(?P<pk_gallery>\d+)/$", ImportImages.as_view(), name="gallery-image-import"),
+    path("<int:pk_gallery>/image/ajouter/", NewImage.as_view(), name="image-add"),
+    path("<int:pk_gallery>/image/supprimer/", DeleteImages.as_view(), name="image-delete"),
+    path("<int:pk_gallery>/image/<int:pk>/modifier/", EditImage.as_view(), name="image-edit"),
+    path("<int:pk_gallery>/image/importer/", ImportImages.as_view(), name="image-import"),
 ]

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -118,7 +118,7 @@ class EditGallery(LoggedWithReadWriteHability, GalleryUpdateOrDeleteMixin, FormV
 
     def dispatch(self, *args, **kwargs):
         try:
-            self.get_gallery(pk=self.kwargs.get("pk"), slug=self.kwargs.get("slug"))
+            self.get_gallery(pk=self.kwargs.get("pk"))
         except Gallery.DoesNotExist:
             raise Http404()
 
@@ -206,7 +206,7 @@ class DeleteGalleries(LoggedWithReadWriteHability, GalleryUpdateOrDeleteMixin, V
 
             self.perform_delete()
 
-        success_url = reverse("gallery-list")
+        success_url = reverse("gallery:list")
         return HttpResponseRedirect(success_url)
 
 
@@ -218,7 +218,7 @@ class EditGalleryMembers(LoggedWithReadWriteHability, GalleryUpdateOrDeleteMixin
 
     def dispatch(self, *args, **kwargs):
         try:
-            self.get_gallery(pk=self.kwargs.get("pk"), slug=self.kwargs.get("slug"))
+            self.get_gallery(pk=self.kwargs.get("pk"))
         except Gallery.DoesNotExist:
             raise Http404()
 
@@ -288,7 +288,7 @@ class EditGalleryMembers(LoggedWithReadWriteHability, GalleryUpdateOrDeleteMixin
         if not has_deleted and not modify_self:
             self.success_url = self.gallery.get_absolute_url()
         else:
-            self.success_url = reverse("gallery-list")
+            self.success_url = reverse("gallery:list")
 
         return super().form_valid(form)
 
@@ -300,7 +300,7 @@ class ImageFromGalleryViewMixin(GalleryMixin, View):
 
     def dispatch(self, request, *args, **kwargs):
         try:
-            self.get_gallery(pk=self.kwargs.get("pk_gallery"), slug=self.kwargs.get("slug"))
+            self.get_gallery(pk=self.kwargs.get("pk_gallery"))
         except Gallery.DoesNotExist:
             raise Http404()
 
@@ -337,7 +337,7 @@ class NewImage(ImageFromGalleryContextViewMixin, ImageCreateMixin, LoggedWithRea
             messages.error(self.request, _(f"Le fichier « {e} » n'est pas une image valide."))
             form.add_error("physical", _("Image invalide"))
             return super().form_invalid(form)
-        self.success_url = reverse("gallery-image-edit", kwargs={"pk_gallery": self.gallery.pk, "pk": self.image.pk})
+        self.success_url = reverse("gallery:image-edit", kwargs={"pk_gallery": self.gallery.pk, "pk": self.image.pk})
 
         return super().form_valid(form)
 
@@ -395,7 +395,7 @@ class EditImage(ImageFromGalleryContextViewMixin, ImageUpdateOrDeleteMixin, Logg
             form.add_error("physical", _("Image invalide"))
             return super().form_invalid(form)
 
-        self.success_url = reverse("gallery-image-edit", kwargs={"pk_gallery": self.gallery.pk, "pk": self.image.pk})
+        self.success_url = reverse("gallery:image-edit", kwargs={"pk_gallery": self.gallery.pk, "pk": self.image.pk})
 
         return super().form_valid(form)
 

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -301,7 +301,7 @@ class ProfileForm(MiniProfileForm):
                 _(
                     """
                 <p>
-                    <a href="{% url 'gallery-list' %}">Choisir un avatar dans une galerie</a><br/>
+                    <a href="{% url "gallery:list" %}">Choisir un avatar dans une galerie</a><br/>
                     Naviguez vers l'image voulue et cliquez sur le bouton "<em>Choisir comme avatar</em>".<br/>
                     Créez une galerie et importez votre avatar si ce n'est pas déjà fait !
                 </p>

--- a/zds/member/tests/views/tests_login.py
+++ b/zds/member/tests/views/tests_login.py
@@ -51,11 +51,11 @@ class MemberTests(TestCase):
         # login a user. Good password and next parameter then
         # redirection to the "next" page.
         result = self.client.post(
-            reverse("member-login") + "?next=" + reverse("gallery-list"),
+            reverse("member-login") + "?next=" + reverse("gallery:list"),
             {"username": user.user.username, "password": "hostel77", "remember": "remember"},
             follow=False,
         )
-        self.assertRedirects(result, reverse("gallery-list"))
+        self.assertRedirects(result, reverse("gallery:list"))
 
         # check the user is redirected to the home page if
         # the "next" parameter points to a non-existing page.
@@ -69,8 +69,8 @@ class MemberTests(TestCase):
         # check if the login form will redirect if there is
         # a next parameter.
         self.client.logout()
-        result = self.client.get(reverse("member-login") + "?next=" + reverse("gallery-list"))
-        self.assertContains(result, reverse("member-login") + "?next=" + reverse("gallery-list"), count=1)
+        result = self.client.get(reverse("member-login") + "?next=" + reverse("gallery:list"))
+        self.assertContains(result, reverse("member-login") + "?next=" + reverse("gallery:list"), count=1)
 
     def test_nonascii(self):
         user = NonAsciiProfileFactory()

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -3514,14 +3514,14 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.client.force_login(self.user_author)
 
         # try to delete gallery
-        result = self.client.post(reverse("galleries-delete"), {"delete": "", "gallery": gallery.pk}, follow=True)
+        result = self.client.post(reverse("gallery:delete"), {"delete": "", "gallery": gallery.pk}, follow=True)
 
         self.assertEqual(result.status_code, 403)
         self.assertEqual(1, Gallery.objects.filter(pk=self.tuto.gallery.pk).count())  # gallery not deleted
 
         # try to add to gallery
         result = self.client.post(
-            reverse("gallery-members", kwargs={"pk": gallery.pk}),
+            reverse("gallery:members", kwargs={"pk": gallery.pk}),
             {"action": "add", "user": self.user_staff.username, "mode": "R"},
             follow=True,
         )
@@ -3531,7 +3531,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         # try to leave gallery
         result = self.client.post(
-            reverse("gallery-members", kwargs={"pk": gallery.pk}),
+            reverse("gallery:members", kwargs={"pk": gallery.pk}),
             {
                 "action": "leave",
                 "user": self.user_author.username,

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -88,7 +88,7 @@ urlpatterns = [
     re_path(r"^membres/", include(("zds.member.urls", ""))),
     re_path(r"^admin/", admin.site.urls),
     re_path(r"^pages/", include(("zds.pages.urls", ""))),
-    re_path(r"^galerie/", include(("zds.gallery.urls", ""))),
+    path("galerie/", include("zds.gallery.urls")),
     re_path(r"^rechercher/", include(("zds.searchv2.urls", "zds.searchv2"), namespace="search")),
     re_path(r"^munin/", include(("zds.munin.urls", ""))),
     re_path(r"^mise-en-avant/", include(("zds.featured.urls", ""))),


### PR DESCRIPTION
Lié à #6246.

Au menu de cette refacto des URL de la galerie :

* utilise un namespace,
* utilise path au lieu de re_path,
* renomme "new" en "create",
* retire le slug pour les URLs de formulaire, il est conservé pour la vue "details".

### Contrôle qualité

Vérifier que la galerie continue de fonctionner nominalement (juste exercer toutes les routes).

Vérifier que les liens ailleurs sont toujours bons (notamment côté tuto).