### PR TITLE
Refactorise les URL du forum

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -127,7 +127,7 @@
 
     {# RSS links #}
     {% with request.GET|yesno:'?,'|add:request.GET.urlencode as rss_params %}
-    <link rel="alternate" type="application/rss+xml" title="Forum" href="{% url "post-feed-rss" %}{{ rss_params | safe }}">
+    <link rel="alternate" type="application/rss+xml" title="Forum" href="{% url "forum:post-feed-rss" %}{{ rss_params | safe }}">
     <link rel="alternate" type="application/rss+xml" title="Nouveaux tutoriels (RSS)" href="{% url "tutorial:feed-rss" %}{{ rss_params | safe }}">
     <link rel="alternate" type="application/atom+xml" title="Nouveaux tutoriels (ATOM)" href="{% url "tutorial:feed-atom" %}{{ rss_params | safe }}">
     <link rel="alternate" type="application/rss+xml" title="Nouveaux articles (RSS)" href="{% url "article:feed-rss" %}{{ rss_params | safe }}">

--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -29,7 +29,7 @@
 
 {% block breadcrumb_base %}
     <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
-        <a href="{% url "cats-forums-list" %}" itemprop="url">
+        <a href="{% url "forum:cats-forums-list" %}" itemprop="url">
             <span itemprop="title">{% trans "Forums" %}</span>
         </a>
     </li>
@@ -87,7 +87,7 @@
                         <ul>
                             {% for topic in topics %}
                                 <li>
-                                    <form action="{% url 'topic-edit' %}" method="post">
+                                    <form action="{% url "forum:topic-edit" %}" method="post">
                                         <input type="hidden" name="topic" value="{{ topic.pk }}">
                                         <input type="hidden" name="page" value="{% if page %} {{ page }} {% else %} 1 {% endif %}">
                                         <input type="hidden" name="follow" value="1">

--- a/templates/forum/category/forum.html
+++ b/templates/forum/category/forum.html
@@ -67,7 +67,7 @@
 
 {% block new_btn %}
   {% if user.profile.can_write_now %}
-      <a href="{% url 'topic-new' %}?forum={{ forum.pk }}" class="new-btn ico-after more blue">
+      <a href="{% url "forum:topic-new" %}?forum={{ forum.pk }}" class="new-btn ico-after more blue">
           {% trans "Nouveau sujet" %}
       </a>
   {% endif %}
@@ -107,7 +107,7 @@
 {% block sidebar_actions %}
     <li>
         {% with forum_is_followed=forum|is_followed_for_new_topic %}
-            {% url 'forum-topics-list' forum.category.slug forum.slug as link_follow %}
+            {% url "forum:topics-list" forum.category.slug forum.slug as link_follow %}
             {% if forum_is_followed %}
                 {% trans "Suivre ce forum" as data_onclick %}
                 {% trans "Ne plus suivre ce forum" as button_text %}
@@ -121,7 +121,7 @@
 
     <li>
         {% with forum_is_email_followed=forum|is_email_followed_for_new_topic %}
-            {% url 'forum-topics-list' forum.category.slug forum.slug as link_follow %}
+            {% url "forum:topics-list" forum.category.slug forum.slug as link_follow %}
             {% if forum_is_email_followed %}
                 {% trans "Être notifié par courriel" as data_onclick %}
                 {% trans "Ne plus être notifié par courriel" as button_text %}
@@ -140,21 +140,21 @@
         <h3>{% trans "Filtres" %}</h3>
         <ul>
             <li>
-                <a href="{% url "forum-topics-list" forum.category.slug forum.slug %}?filter=solve"
+                <a href="{% url "forum:topics-list" forum.category.slug forum.slug %}?filter=solve"
                    class="ico-after tick green {% if request.GET.filter == "solve" %}selected{% endif %}"
                 >
                     {% trans "Sujets résolus" %}
                 </a>
             </li>
             <li>
-                <a href="{% url "forum-topics-list" forum.category.slug forum.slug %}?filter=unsolve"
+                <a href="{% url "forum:topics-list" forum.category.slug forum.slug %}?filter=unsolve"
                    class="ico-after tick blue {% if request.GET.filter == "unsolve" %}selected{% endif %}"
                 >
                     {% trans "Sujets non résolus" %}
                 </a>
             </li>
             <li>
-                <a href="{% url "forum-topics-list" forum.category.slug forum.slug %}?filter=noanswer"
+                <a href="{% url "forum:topics-list" forum.category.slug forum.slug %}?filter=noanswer"
                    class="ico-after view {% if request.GET.filter == "noanswer" %}selected{% endif %}"
                 >
                     {% trans "Sujets sans réponse" %}
@@ -162,7 +162,7 @@
             </li>
             {% if request.GET.filter %}
                 <li>
-                    <a href="{% url "forum-topics-list" forum.category.slug forum.slug %}"
+                    <a href="{% url "forum:topics-list" forum.category.slug forum.slug %}"
                        class="ico-after cross blue"
                     >
                         {% trans "Annuler le filtre" %}

--- a/templates/forum/find/post.html
+++ b/templates/forum/find/post.html
@@ -22,7 +22,7 @@
     {% with profile=usr|profile %}
         <li><a href="{{ profile.get_absolute_url }}">{{ usr.username }}</a></li>
     {% endwith %}
-    <li><a href="{% url 'post-find' usr.pk %}">{% trans "Messages postés" %}</a></li>
+    <li><a href="{% url "forum:post-find" usr.pk %}">{% trans "Messages postés" %}</a></li>
     <li>{% trans "Recherche" %}</li>
 {% endblock %}
 

--- a/templates/forum/find/topic_by_tag.html
+++ b/templates/forum/find/topic_by_tag.html
@@ -41,7 +41,7 @@
 {% block sidebar_actions %}
     <li>
         {% with tag_is_followed=tag|is_followed_for_new_topic %}
-            {% url 'topic-tag-find' tag.slug as link_follow %}
+            {% url "forum:topic-tag-find" tag.slug as link_follow %}
             {% if tag_is_followed %}
                 {% trans "Suivre ce tag" as data_onclick %}
                 {% trans "Ne plus suivre ce tag" as button_text %}
@@ -54,7 +54,7 @@
     </li>
     <li>
         {% with tag_is_email_followed=tag|is_email_followed_for_new_topic %}
-            {% url 'topic-tag-find' tag.slug as link_follow %}
+            {% url "forum:topic-tag-find" tag.slug as link_follow %}
             {% if tag_is_email_followed %}
                 {% trans "Être notifié par courriel" as data_onclick %}
                 {% trans "Ne plus être notifié par courriel" as button_text %}
@@ -73,21 +73,21 @@
         <h3>{% trans "Filtres" %}</h3>
         <ul>
             <li>
-                <a href="{% url 'topic-tag-find' tag.slug %}?filter=solve"
+                <a href="{% url "forum:topic-tag-find" tag.slug %}?filter=solve"
                    class="ico-after tick green {% if request.GET.filter == "solve" %}selected{% endif %}"
                 >
                     {% trans "Sujets résolus" %}
                 </a>
             </li>
             <li>
-                <a href="{% url 'topic-tag-find' tag.slug %}?filter=unsolve"
+                <a href="{% url "forum:topic-tag-find" tag.slug %}?filter=unsolve"
                    class="ico-after tick blue {% if request.GET.filter == "unsolve" %}selected{% endif %}"
                 >
                     {% trans "Sujets non résolus" %}
                 </a>
             </li>
             <li>
-                <a href="{% url 'topic-tag-find' tag.slug %}?filter=noanswer"
+                <a href="{% url "forum:topic-tag-find" tag.slug %}?filter=noanswer"
                    class="ico-after view {% if request.GET.filter == "noanswer" %}selected{% endif %}"
                 >
                     {% trans "Sujets sans réponse" %}
@@ -95,7 +95,7 @@
             </li>
             {% if request.GET.filter %}
                 <li>
-                    <a href="{% url 'topic-tag-find' tag.slug %}"
+                    <a href="{% url "forum:topic-tag-find" tag.slug %}"
                        class="ico-after cross blue"
                     >
                         {% trans "Annuler le filtre" %}

--- a/templates/forum/includes/feed.part.html
+++ b/templates/forum/includes/feed.part.html
@@ -2,9 +2,9 @@
 <div class="mobile-menu-bloc mobile-all-links" data-title="Flux">
     <h3>{% trans "Flux" %}</h3>
     <ul>
-        <li><a href="{% url "post-feed-rss" %}{{param}}{{value}}" class="ico-after rss blue">{% trans "Nouveaux messages (RSS)" %}</a></li>
-        <li><a href="{% url "post-feed-atom" %}{{param}}{{value}}" class="ico-after rss blue">{% trans "Nouveaux messages (ATOM)" %}</a></li>
-        <li><a href="{% url "topic-feed-rss" %}{{param}}{{value}}" class="ico-after rss blue">{% trans "Nouveaux sujets (RSS)" %}</a></li>
-        <li><a href="{% url "topic-feed-atom" %}{{param}}{{value}}" class="ico-after rss blue">{% trans "Nouveaux sujets (ATOM)" %}</a></li>
+        <li><a href="{% url "forum:post-feed-rss" %}{{param}}{{value}}" class="ico-after rss blue">{% trans "Nouveaux messages (RSS)" %}</a></li>
+        <li><a href="{% url "forum:post-feed-atom" %}{{param}}{{value}}" class="ico-after rss blue">{% trans "Nouveaux messages (ATOM)" %}</a></li>
+        <li><a href="{% url "forum:topic-feed-rss" %}{{param}}{{value}}" class="ico-after rss blue">{% trans "Nouveaux sujets (RSS)" %}</a></li>
+        <li><a href="{% url "forum:topic-feed-atom" %}{{param}}{{value}}" class="ico-after rss blue">{% trans "Nouveaux sujets (ATOM)" %}</a></li>
     </ul>
 </div>

--- a/templates/forum/includes/topic_item.part.html
+++ b/templates/forum/includes/topic_item.part.html
@@ -50,7 +50,7 @@
             {% for tag in topic.tags.all|slice:":3" %}
                 {% if tag.slug %}
                     <li>
-                        <a href="{% url 'topic-tag-find' tag.slug %}" title="Tag {{ tag.title }}">
+                        <a href="{% url "forum:topic-tag-find" tag.slug %}" title="Tag {{ tag.title }}">
                             {{ tag.title }}
                         </a>
                     </li>

--- a/templates/forum/includes/topic_row.part.html
+++ b/templates/forum/includes/topic_row.part.html
@@ -32,7 +32,7 @@
                     {% for tag in topic.tags.all %}
                         {% if tag.slug %}
                             <li>
-                                <a href="{% url 'topic-tag-find' tag.slug %}" class="topic-tag" title="Tag {{ tag.title }}">
+                                <a href="{% url "forum:topic-tag-find" tag.slug %}" class="topic-tag" title="Tag {{ tag.title }}">
                                     {{ tag.title }}
                                 </a>
                             </li>

--- a/templates/forum/includes/topic_solve_form.part.html
+++ b/templates/forum/includes/topic_solve_form.part.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<form action="{% url 'topic-edit' %}" method="post">
+<form action="{% url "forum:topic-edit" %}" method="post">
     <input type="hidden" name="topic" value="{{ topic.pk }}">
     <input type="hidden" name="nb" value="{{ nb }}">
     <input type="hidden" name="page" value="{{ nb }}">

--- a/templates/forum/last_topics.html
+++ b/templates/forum/last_topics.html
@@ -26,7 +26,7 @@
 
 
 {% block new_btn %}
-    <a href="{% url 'cats-forums-list' %}" class="new-btn ico-after view blue">
+    <a href="{% url "forum:cats-forums-list" %}" class="new-btn ico-after view blue">
         {% trans "Tous les forums" %}
     </a>
 {% endblock %}
@@ -38,14 +38,14 @@
         <h3>{% trans "Ordre de tri" %}</h3>
         <ul>
             <li>
-                <a href="{% url 'last-subjects' %}?order=creation"
+                <a href="{% url "forum:last-subjects" %}?order=creation"
                    class="ico-after move {% if request.GET.order == 'creation' %}selected{% endif %}"
                 >
                     {% trans "Date de création" %}
                 </a>
             </li>
             <li>
-                <a href="{% url 'last-subjects' %}?order=last_post"
+                <a href="{% url "forum:last-subjects" %}?order=last_post"
                    class="ico-after history {% if request.GET.order == 'last_post' %}selected{% endif %}"
                 >
                     {% trans "Date de la dernière réponse" %}

--- a/templates/forum/post/new.html
+++ b/templates/forum/post/new.html
@@ -47,7 +47,7 @@
     <div class="content-wrapper">
         {% for message in posts %}
             {% captureas edit_link %}
-                {% url 'post-edit' %}?message={{ message.pk }}
+                {% url "forum:post-edit" %}?message={{ message.pk }}
             {% endcaptureas %}
 
             {% captureas hide_link %}{{ edit_link }}{% endcaptureas %}
@@ -55,11 +55,11 @@
             {% captureas alert_link %}{{ edit_link }}{% endcaptureas %}
 
             {% captureas cite_link %}
-                {% url 'post-new' %}?sujet={{ topic.pk }}&amp;cite={{ message.pk }}
+                {% url "forum:post-new" %}?sujet={{ topic.pk }}&amp;cite={{ message.pk }}
             {% endcaptureas %}
 
             {% captureas helpful_link %}
-                {% url 'post-useful' %}?message={{ message.pk }}
+                {% url "forum:post-useful" %}?message={{ message.pk }}
             {% endcaptureas %}
 
             {% captureas karma_link %}
@@ -67,7 +67,7 @@
             {% endcaptureas %}
 
             {% captureas alerts_solve_link %}
-                {% url "forum-solve-alert" %}
+                {% url "forum:solve-alert" %}
             {% endcaptureas %}
 
             {% include "misc/message.part.html" with perms_change=perms.forum.change_topic %}

--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -58,7 +58,7 @@
             {% for tag in topic.tags.all %}
                 {% if tag.slug %}
                 <li>
-                    <a href="{% url 'topic-tag-find' tag.slug %}" rel="tag">
+                    <a href="{% url "forum:topic-tag-find" tag.slug %}" rel="tag">
                         {{ tag.title }}
                     </a>
                 </li>
@@ -87,26 +87,26 @@
     {% for message in posts %}
         {% captureas edit_link %}
             {% if message.pk == topic.first_post.pk %}
-                {% url 'topic-edit' %}?topic={{ topic.pk }}
+                {% url "forum:topic-edit" %}?topic={{ topic.pk }}
             {% else %}
-                {% url 'post-edit' %}?message={{ message.pk }}
+                {% url "forum:post-edit" %}?message={{ message.pk }}
             {% endif %}
         {% endcaptureas %}
 
         {% captureas post_action_link %}
-            {% url 'post-edit' %}?message={{ message.pk }}
+            {% url "forum:post-edit" %}?message={{ message.pk }}
         {% endcaptureas %}
 
         {% captureas hide_link %}{{ post_action_link }}{% endcaptureas %}
         {% captureas show_link %}{{ post_action_link }}{% endcaptureas %}
-        {% captureas alert_link %}{% url 'post-create-alert' %}?message={{ message.pk }}{% endcaptureas %}
+        {% captureas alert_link %}{% url "forum:post-create-alert" %}?message={{ message.pk }}{% endcaptureas %}
 
         {% captureas cite_link %}
-            {% url 'post-new' %}?sujet={{ topic.pk }}&amp;cite={{ message.pk }}
+            {% url "forum:post-new" %}?sujet={{ topic.pk }}&amp;cite={{ message.pk }}
         {% endcaptureas %}
 
         {% captureas helpful_link %}
-            {% url 'post-useful' %}?message={{ message.pk }}
+            {% url "forum:post-useful" %}?message={{ message.pk }}
         {% endcaptureas %}
 
         {% captureas karma_link %}
@@ -114,11 +114,11 @@
         {% endcaptureas %}
 
         {% captureas alerts_solve_link %}
-            {% url "forum-solve-alert" %}
+            {% url "forum:solve-alert" %}
         {% endcaptureas %}
 
         {% captureas unread_link %}
-            {% url 'post-unread' %}?message={{ message.pk }}
+            {% url "forum:post-unread" %}?message={{ message.pk }}
         {% endcaptureas %}
 
         {% if forloop.first and page_obj.number > 1 %}
@@ -146,7 +146,7 @@
 
     {# Anwser form #}
     {% captureas form_action %}
-        {% url 'post-new' %}?sujet={{ topic.pk }}
+        {% url "forum:post-new" %}?sujet={{ topic.pk }}
     {% endcaptureas %}
 
     {% include "misc/message_form.html" with member=user %}
@@ -163,12 +163,12 @@
 
 {% block new_btn %}
   {% if user.profile.can_write_now %}
-      <a href="{% url 'topic-new' %}?forum={{ topic.forum.pk }}" class="new-btn ico-after more blue">
+      <a href="{% url "forum:topic-new" %}?forum={{ topic.forum.pk }}" class="new-btn ico-after more blue">
           {% trans "Nouveau sujet" %}
       </a>
 
       {% if topic.author.pk == user.pk and topic.first_post.is_visible or is_staff %}
-          <a href="{% url 'topic-edit' %}?topic={{ topic.pk }}" class="new-btn ico-after edit blue">
+          <a href="{% url "forum:topic-edit" %}?topic={{ topic.pk }}" class="new-btn ico-after edit blue">
               {% trans "Éditer le sujet" %}
           </a>
       {% endif %}
@@ -184,7 +184,7 @@
     {% endif %}
 
     <li>
-        {% url 'topic-edit' as link_follow_without_parameter %}
+        {% url "forum:topic-edit" as link_follow_without_parameter %}
 
         {% with topic_is_followed=topic|is_followed %}
         {% with topic_id=topic.pk|stringformat:"s" %}
@@ -203,7 +203,7 @@
     </li>
 
     <li>
-        {% url 'topic-edit' as link_follow_without_parameter %}
+        {% url "forum:topic-edit" as link_follow_without_parameter %}
 
         {% with topic_is_email_followed=topic|is_email_followed %}
         {% with topic_id=topic.pk|stringformat:"s" %}
@@ -222,7 +222,7 @@
     </li>
 
     <li>
-        {% url 'topic-edit' as link_request_without_parameter %}
+        {% url "forum:topic-edit" as link_request_without_parameter %}
 
         {% with topic_id=topic.pk|stringformat:"s" %}
         {% with link_request=link_request_without_parameter|add:'?topic='|add:topic_id %}
@@ -266,7 +266,7 @@
                 {% else %}
                     <li>
                         <a href="#create-issue" class="open-modal ico-after github blue">{% trans 'Créer un ticket' %}</a>
-                        <form action="{% url 'manage-issue' topic.pk %}" method="post" id="create-issue" class="modal modal-flex">
+                        <form action="{% url "forum:manage-issue" topic.pk %}" method="post" id="create-issue" class="modal modal-flex">
                             {% if has_token %}
                                 {% csrf_token %}
                                 <select name="repository">
@@ -296,7 +296,7 @@
 
                     <li>
                         <a href="#link-issue" class="open-modal ico-after arrow-right blue">{% trans 'Associer un ticket' %}</a>
-                        <form action="{% url 'manage-issue' topic.pk %}" method="post" id="link-issue" class="modal modal-flex">
+                        <form action="{% url "forum:manage-issue" topic.pk %}" method="post" id="link-issue" class="modal modal-flex">
                             {% csrf_token %}
                             <p>
                                 {% trans "Quel est le dépôt et le numéro du ticket GitHub que vous souhaitez associer ?" %}
@@ -332,7 +332,7 @@
                             {% trans "Fermer le sujet" %}
                         {% endif %}
                     </a>
-                    <form action="{% url 'topic-edit' %}" method="post" id="lock-open-topic-{{ topic.pk }}" class="modal modal-flex">
+                    <form action="{% url "forum:topic-edit" %}" method="post" id="lock-open-topic-{{ topic.pk }}" class="modal modal-flex">
                         <input type="hidden" name="topic" value="{{ topic.pk }}">
                         <input type="hidden" name="nb" value="{{ nb }}">
                         <input type="hidden" name="page" value="{{ nb }}">
@@ -358,7 +358,7 @@
                 </li>
 
                 <li>
-                    <form action="{% url 'topic-edit' %}" method="post">
+                    <form action="{% url "forum:topic-edit" %}" method="post">
                         <input type="hidden" name="topic" value="{{ topic.pk }}">
                         <input type="hidden" name="nb" value="{{ nb }}">
                         <input type="hidden" name="page" value="{{ nb }}">

--- a/templates/header.html
+++ b/templates/header.html
@@ -151,13 +151,13 @@
                 {% endcache %}
             </li>
             <li>
-                <a href="{% url "cats-forums-list" %}" class="mobile-menu-link has-dropdown {% block menu_forum %}{% endblock %}">
+                <a href="{% url "forum:cats-forums-list" %}" class="mobile-menu-link has-dropdown {% block menu_forum %}{% endblock %}">
                     {% trans "Forum" %}
                     <span class="arrow"></span>
                 </a>
                 {% cache 1800 menu_forum user|groups %}
                     <div class="header-dropdown header-menu-dropdown">
-                        <a href="{% url "cats-forums-list" %}" class="dropdown-link-all">
+                        <a href="{% url "forum:cats-forums-list" %}" class="dropdown-link-all">
                             {% trans "Tous les forums" %}
                         </a>
 
@@ -167,7 +167,7 @@
                                     <li>
                                         <ul>
                                             <li class="dropdown-title">
-                                                <a href="{% url "cat-forums-list" slug %}">
+                                                <a href="{% url "forum:cat-forums-list" slug %}">
                                                     {{ title }}
                                                 </a>
                                             </li>

--- a/templates/home.html
+++ b/templates/home.html
@@ -24,7 +24,7 @@
 
 {% block content_out %}
     {% url 'opinion:list' as url_opinions %}
-    {% url 'cats-forums-list' as url_forums %}
+    {% url "forum:cats-forums-list" as url_forums %}
     {% url 'publication:list' as url_publications %}
 
     {% url 'pages-association' as url_association %}
@@ -169,7 +169,7 @@
             <section itemscope itemtype="http://schema.org/ItemList">
                 <h2 class="home-heading ico-after ico-forum" itemprop="name">
                     <span>{% trans "Derniers sujets" %}</span>
-                    <a href="{% url 'last-subjects' %}" class="btn btn-grey">{% trans "En voir plus" %}</a>
+                    <a href="{% url "forum:last-subjects" %}" class="btn btn-grey">{% trans "En voir plus" %}</a>
                 </h2>
 
                 <meta itemprop="itemListOrder" content="Descending">

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -466,7 +466,7 @@
                                             </div>
 
                                             {% if topics_count > 0 %}
-                                                <a href="{% url 'topic-find' usr.pk %}" class="tail">
+                                                <a href="{% url "topic-find" usr.pk %}" class="tail">
                                                     <p>
                                                         {% blocktrans count topics_count=topics_count %}
                                                             <span class="bold">{{ topics_count }}</span> sujet créé
@@ -478,7 +478,7 @@
                                             {% endif %}
 
                                             {% if followed_topics_count > 0 and profile.user == user %}
-                                                <a href="{% url 'followed-topic-find' %}" class="tail">
+                                                <a href="{% url "forum:followed-topic-find" %}" class="tail">
                                                     <p>
 
                                                         {% blocktrans count followed_topics_count=followed_topics_count %}
@@ -491,7 +491,7 @@
                                             {% endif %}
 
                                             {% if messages_count > 0 %}
-                                                <a href="{% url 'post-find' usr.pk %}" class="tail">
+                                                <a href="{% url "forum:post-find" usr.pk %}" class="tail">
                                                     <p>
                                                         {% blocktrans count messages_count=messages_count %}
                                                             <span class="bold">{{ messages_count }}</span> message posté
@@ -553,7 +553,7 @@
                     <section>
                         <h2 itemprop="name">
                             <span>{% trans 'Derniers sujets créés' %}</span>
-                            <a href="{% url 'topic-find' usr.pk %}" class="btn btn-grey">{% trans 'Voir tout' %}</a>
+                            <a href="{% url "forum:topic-find" usr.pk %}" class="btn btn-grey">{% trans 'Voir tout' %}</a>
                         </h2>
 
                         {% if topics %}

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -466,7 +466,7 @@
                                             </div>
 
                                             {% if topics_count > 0 %}
-                                                <a href="{% url "topic-find" usr.pk %}" class="tail">
+                                                <a href="{% url "forum:topic-find" usr.pk %}" class="tail">
                                                     <p>
                                                         {% blocktrans count topics_count=topics_count %}
                                                             <span class="bold">{{ topics_count }}</span> sujet créé

--- a/zds/featured/tests/tests.py
+++ b/zds/featured/tests/tests.py
@@ -505,7 +505,7 @@ class FeaturedRequestToggleTest(TutorialTestMixin, TestCase):
         topic = TopicFactory(forum=forum, author=author.user)
 
         response = self.client.post(
-            reverse("topic-edit") + f"?topic={topic.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic.pk}",
             {"request_featured": 1},
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
@@ -521,7 +521,7 @@ class FeaturedRequestToggleTest(TutorialTestMixin, TestCase):
         topic.save()
 
         response = self.client.post(
-            reverse("topic-edit") + f"?topic={topic.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic.pk}",
             {"request_featured": 1},
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -154,7 +154,7 @@ class MoveTopicForm(forms.Form):
     def __init__(self, topic, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.form_action = reverse("topic-edit")
+        self.helper.form_action = reverse("forum:topic-edit")
         self.helper.form_class = "modal modal-flex"
         self.helper.form_id = "move-topic"
         self.helper.form_method = "post"

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -54,7 +54,7 @@ class ForumCategory(models.Model):
         return self.title
 
     def get_absolute_url(self):
-        return reverse("cat-forums-list", kwargs={"slug": self.slug})
+        return reverse("forum:cat-forums-list", kwargs={"slug": self.slug})
 
     def get_forums(self, user, with_count=False):
         """get all forums that user can access
@@ -101,7 +101,7 @@ class Forum(models.Model):
         return self.title
 
     def get_absolute_url(self):
-        return reverse("forum-topics-list", kwargs={"cat_slug": self.category.slug, "forum_slug": self.slug})
+        return reverse("forum:topics-list", kwargs={"cat_slug": self.category.slug, "forum_slug": self.slug})
 
     def get_topic_count(self):
         """Retrieve or aggregate the number of threads in this forum. If this number already exists, it must be stored \
@@ -246,7 +246,7 @@ class Topic(AbstractESDjangoIndexable):
         return text
 
     def get_absolute_url(self):
-        return reverse("topic-posts-list", args=[self.pk, self.slug()])
+        return reverse("forum:topic-posts-list", args=[self.pk, self.slug()])
 
     def slug(self):
         return old_slugify(self.title)

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -37,40 +37,42 @@ class ForumMemberTests(TestCase):
 
     def feed_rss_display(self):
         """Test each rss feed feed"""
-        response = self.client.get(reverse("post-feed-rss"), follow=False)
+        response = self.client.get(reverse("forum:post-feed-rss"), follow=False)
         self.assertEqual(response.status_code, 200)
 
         for forum in Forum.objects.all():
-            response = self.client.get(reverse("post-feed-rss") + f"?forum={forum.pk}", follow=False)
+            response = self.client.get(reverse("forum:post-feed-rss") + f"?forum={forum.pk}", follow=False)
             self.assertEqual(response.status_code, 200)
 
         for tag in Tag.objects.all():
-            response = self.client.get(reverse("post-feed-rss") + f"?tag={tag.pk}", follow=False)
+            response = self.client.get(reverse("forum:post-feed-rss") + f"?tag={tag.pk}", follow=False)
             self.assertEqual(response.status_code, 200)
 
         for forum in Forum.objects.all():
             for tag in Tag.objects.all():
-                response = self.client.get(reverse("post-feed-rss") + f"?tag={tag.pk}&forum={forum.pk}", follow=False)
+                response = self.client.get(
+                    reverse("forum:post-feed-rss") + f"?tag={tag.pk}&forum={forum.pk}", follow=False
+                )
                 self.assertEqual(response.status_code, 200)
 
     def test_display(self):
         """Test forum display (full: root, category, forum) Topic display test
         is in creation topic test."""
         # Forum root
-        response = self.client.get(reverse("cats-forums-list"))
+        response = self.client.get(reverse("forum:cats-forums-list"))
         self.assertContains(response, "Liste des forums")
         # ForumCategory
-        response = self.client.get(reverse("cat-forums-list", args=[self.category1.slug]))
+        response = self.client.get(reverse("forum:cat-forums-list", args=[self.category1.slug]))
         self.assertContains(response, self.category1.title)
         # Forum
-        response = self.client.get(reverse("forum-topics-list", args=[self.category1.slug, self.forum11.slug]))
+        response = self.client.get(reverse("forum:topics-list", args=[self.category1.slug, self.forum11.slug]))
         self.assertContains(response, self.category1.title)
         self.assertContains(response, self.forum11.title)
 
     def test_create_topic(self):
         """To test all aspects of topic's creation by member."""
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum12.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum12.pk}",
             {
                 "title": "Un autre sujet",
                 "subtitle": "Encore ces lombards en plein ete",
@@ -118,7 +120,7 @@ class ForumMemberTests(TestCase):
 
         # With a weird pk
         result = self.client.post(
-            reverse("topic-new") + "?forum=" + "abc",
+            reverse("forum:topic-new") + "?forum=" + "abc",
             {
                 "title": "Un autre sujet",
                 "subtitle": "Encore ces lombards en plein ete",
@@ -130,7 +132,7 @@ class ForumMemberTests(TestCase):
 
         # With a missing pk
         result = self.client.post(
-            reverse("topic-new") + "?forum=",
+            reverse("forum:topic-new") + "?forum=",
             {
                 "title": "Un autre sujet",
                 "subtitle": "Encore ces lombards en plein ete",
@@ -142,7 +144,7 @@ class ForumMemberTests(TestCase):
 
         # With a missing parameter
         result = self.client.post(
-            reverse("topic-new"),
+            reverse("forum:topic-new"),
             {
                 "title": "Un autre sujet",
                 "subtitle": "Encore ces lombards en plein ete",
@@ -169,7 +171,7 @@ class ForumMemberTests(TestCase):
 
         # check if we send an empty text
         result = self.client.post(
-            reverse("post-new") + f"?sujet={topic1.pk}",
+            reverse("forum:post-new") + f"?sujet={topic1.pk}",
             {"last_post": topic1.last_message.pk, "text": ""},
             follow=False,
         )
@@ -182,7 +184,7 @@ class ForumMemberTests(TestCase):
         # now check a valid post containing utf8mb4 characters
         post_content = "Une famille 👩‍👩‍👦 mangeant un gratin d'🍆🍆 ne blesse pas les innocents 🐙🐙🐙."
         result = self.client.post(
-            reverse("post-new") + f"?sujet={topic1.pk}",
+            reverse("forum:post-new") + f"?sujet={topic1.pk}",
             {"last_post": topic1.last_message.pk, "text": post_content},
             follow=False,
         )
@@ -210,7 +212,7 @@ class ForumMemberTests(TestCase):
 
         # test antispam return 403
         result = self.client.post(
-            reverse("post-new") + f"?sujet={topic1.pk}",
+            reverse("forum:post-new") + f"?sujet={topic1.pk}",
             {"last_post": topic1.last_message.pk, "text": "Testons l'antispam"},
             follow=False,
         )
@@ -231,7 +233,7 @@ class ForumMemberTests(TestCase):
 
         # missing parameter
         result = self.client.post(
-            reverse("post-new"),
+            reverse("forum:post-new"),
             {
                 "last_post": topic1.last_message.pk,
                 "text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter ",
@@ -243,7 +245,7 @@ class ForumMemberTests(TestCase):
 
         # weird parameter
         result = self.client.post(
-            reverse("post-new") + "?sujet=" + "abc",
+            reverse("forum:post-new") + "?sujet=" + "abc",
             {
                 "last_post": topic1.last_message.pk,
                 "text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter ",
@@ -255,7 +257,7 @@ class ForumMemberTests(TestCase):
 
         # non-existing (yet) parameter
         result = self.client.post(
-            reverse("post-new") + "?sujet=" + "424242",
+            reverse("forum:post-new") + "?sujet=" + "424242",
             {
                 "last_post": topic1.last_message.pk,
                 "text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter ",
@@ -278,7 +280,7 @@ class ForumMemberTests(TestCase):
         expected_subtitle = "Encore ces lombards en plein été"
         expected_text = "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter "
         result = self.client.post(
-            reverse("topic-edit") + f"?topic={topic1.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic1.pk}",
             {"title": expected_title, "subtitle": expected_subtitle, "text": expected_text, "tags": ""},
             follow=False,
         )
@@ -306,7 +308,7 @@ class ForumMemberTests(TestCase):
 
         # check if topic is valid (no topic)
         result = self.client.post(
-            reverse("topic-edit") + f"?topic={topic2.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic2.pk}",
             {"title": "", "subtitle": expected_subtitle, "text": expected_text, "tags": ""},
             follow=False,
         )
@@ -314,7 +316,7 @@ class ForumMemberTests(TestCase):
 
         # check if topic is valid (tags only)
         result = self.client.post(
-            reverse("topic-edit") + f"?topic={topic2.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic2.pk}",
             {"title": "", "subtitle": expected_subtitle, "text": expected_text, "tags": "foo, bar"},
             follow=False,
         )
@@ -322,7 +324,7 @@ class ForumMemberTests(TestCase):
 
         # check if topic is valid (spaces only)
         result = self.client.post(
-            reverse("topic-edit") + f"?topic={topic2.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic2.pk}",
             {"title": "  ", "subtitle": expected_subtitle, "text": expected_text, "tags": ""},
             follow=False,
         )
@@ -330,7 +332,7 @@ class ForumMemberTests(TestCase):
 
         # check if topic is valid (valid title)
         result = self.client.post(
-            reverse("topic-edit") + f"?topic={topic2.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic2.pk}",
             {"title": expected_title, "subtitle": expected_subtitle, "text": expected_text, "tags": ""},
             follow=False,
         )
@@ -344,7 +346,7 @@ class ForumMemberTests(TestCase):
         post3 = PostFactory(topic=topic1, author=self.user, position=3)
 
         result = self.client.post(
-            reverse("post-edit") + f"?message={post2.pk}",
+            reverse("forum:post-edit") + f"?message={post2.pk}",
             {"text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter "},
             follow=False,
         )
@@ -373,7 +375,7 @@ class ForumMemberTests(TestCase):
 
         # if the post pk is altered
         result = self.client.post(
-            reverse("post-edit") + "?message=abcd",
+            reverse("forum:post-edit") + "?message=abcd",
             {"text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter "},
             follow=False,
         )
@@ -387,13 +389,15 @@ class ForumMemberTests(TestCase):
         post2 = PostFactory(topic=topic1, author=self.user, position=2)
         post3 = PostFactory(topic=topic1, author=self.user, position=3)
 
-        result = self.client.post(reverse("post-edit") + f"?message={post2.pk}", {"text": "  "}, follow=True)
+        result = self.client.post(reverse("forum:post-edit") + f"?message={post2.pk}", {"text": "  "}, follow=True)
 
         self.assertEqual(result.status_code, 200)
-        self.assertEqual(result.request["PATH_INFO"], "/forums/message/editer/")
+        self.assertEqual(result.request["PATH_INFO"], "/forums/message/modifier/")
         self.assertEqual(result.request["QUERY_STRING"], f"message={post2.pk}")
 
-        result = self.client.post(reverse("post-edit") + f"?message={post3.pk}", {"text": " contenu "}, follow=True)
+        result = self.client.post(
+            reverse("forum:post-edit") + f"?message={post3.pk}", {"text": " contenu "}, follow=True
+        )
 
         self.assertEqual(result.status_code, 200)
         self.assertNotEqual(result.request["PATH_INFO"], "/forums/message/editer/")
@@ -406,12 +410,12 @@ class ForumMemberTests(TestCase):
         post2 = PostFactory(topic=topic1, author=user1, position=2)
         PostFactory(topic=topic1, author=user1, position=3)
 
-        result = self.client.get(reverse("post-new") + f"?sujet={topic1.pk}&cite={post2.pk}", follow=True)
+        result = self.client.get(reverse("forum:post-new") + f"?sujet={topic1.pk}&cite={post2.pk}", follow=True)
 
         self.assertEqual(result.status_code, 200)
 
         # if the quote pk is altered
-        result = self.client.get(reverse("post-new") + f"?sujet={topic1.pk}&cite=abcd", follow=True)
+        result = self.client.get(reverse("forum:post-new") + f"?sujet={topic1.pk}&cite=abcd", follow=True)
 
         self.assertEqual(result.status_code, 404)
 
@@ -424,7 +428,7 @@ class ForumMemberTests(TestCase):
         PostFactory(topic=topic1, author=user1, position=3)
 
         result = self.client.post(
-            reverse("post-create-alert") + f"?message={post2.pk}",
+            reverse("forum:post-create-alert") + f"?message={post2.pk}",
             {"signal_text": "Troll", "signal_message": "confirmer"},
             follow=False,
         )
@@ -435,7 +439,7 @@ class ForumMemberTests(TestCase):
         self.assertEqual(Alert.objects.get(author=self.user, solved=False).text, "Troll")
 
         result = self.client.post(
-            reverse("post-create-alert") + f"?message={post1.pk}",
+            reverse("forum:post-create-alert") + f"?message={post1.pk}",
             {"signal_text": "Bad title", "signal_message": "confirmer"},
             follow=False,
         )
@@ -449,7 +453,7 @@ class ForumMemberTests(TestCase):
         alert = Alert.objects.get(comment=post2.pk)
         # try as a normal user
         result = self.client.post(
-            reverse("forum-solve-alert"),
+            reverse("forum:solve-alert"),
             {
                 "alert_pk": alert.pk,
             },
@@ -462,7 +466,7 @@ class ForumMemberTests(TestCase):
         # try again as staff
         resolve_reason = "Everything is OK kid"
         result = self.client.post(
-            reverse("forum-solve-alert"), {"alert_pk": alert.pk, "text": resolve_reason}, follow=False
+            reverse("forum:solve-alert"), {"alert_pk": alert.pk, "text": resolve_reason}, follow=False
         )
         self.assertEqual(result.status_code, 302)
         alert = Alert.objects.get(pk=alert.pk)
@@ -476,7 +480,7 @@ class ForumMemberTests(TestCase):
             "delete_message": "",
             "text_hidden": "Bad guy!",
         }
-        response = self.client.post(reverse("post-edit") + f"?message={post1.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:post-edit") + f"?message={post1.pk}", data, follow=False)
         self.assertEqual(302, response.status_code)
         # alerts automatically solved
         self.assertEqual(Alert.objects.filter(author=self.user, solved=False).count(), 0)
@@ -491,7 +495,7 @@ class ForumMemberTests(TestCase):
         PostFactory(topic=topic1, author=user1, position=3)
 
         result = self.client.post(
-            reverse("post-create-alert") + f"?message={post2.pk}",
+            reverse("forum:post-create-alert") + f"?message={post2.pk}",
             {"signal_text": "Troll", "signal_message": "confirmer"},
             follow=False,
         )
@@ -502,7 +506,7 @@ class ForumMemberTests(TestCase):
         self.client.force_login(staff1)
         # try again as staff
         result = self.client.post(
-            reverse("forum-solve-alert"),
+            reverse("forum:solve-alert"),
             {
                 "alert_pk": alert.pk,
             },
@@ -519,7 +523,7 @@ class ForumMemberTests(TestCase):
         post2 = PostFactory(topic=topic1, author=user1, position=2)
         post3 = PostFactory(topic=topic1, author=user1, position=3)
 
-        result = self.client.post(reverse("post-useful") + f"?message={post2.pk}", follow=False)
+        result = self.client.post(reverse("forum:post-useful") + f"?message={post2.pk}", follow=False)
 
         self.assertEqual(result.status_code, 302)
 
@@ -528,7 +532,7 @@ class ForumMemberTests(TestCase):
         self.assertEqual(Post.objects.get(pk=post3.pk).is_useful, False)
 
         # useful the first post
-        result = self.client.post(reverse("post-useful") + f"?message={post1.pk}", follow=False)
+        result = self.client.post(reverse("forum:post-useful") + f"?message={post1.pk}", follow=False)
         self.assertEqual(result.status_code, 302)
 
         self.assertEqual(Post.objects.get(pk=post1.pk).is_useful, True)
@@ -540,7 +544,7 @@ class ForumMemberTests(TestCase):
         post4 = PostFactory(topic=topic1, author=user1, position=1)
         post5 = PostFactory(topic=topic1, author=self.user, position=2)
 
-        result = self.client.post(reverse("post-useful") + f"?message={post5.pk}", follow=False)
+        result = self.client.post(reverse("forum:post-useful") + f"?message={post5.pk}", follow=False)
 
         self.assertEqual(result.status_code, 302)
 
@@ -550,7 +554,7 @@ class ForumMemberTests(TestCase):
         # useful if you are staff
         staff = StaffProfileFactory().user
         self.client.force_login(staff)
-        result = self.client.post(reverse("post-useful") + f"?message={post4.pk}", follow=False)
+        result = self.client.post(reverse("forum:post-useful") + f"?message={post4.pk}", follow=False)
         self.assertNotEqual(result.status_code, 403)
         self.assertEqual(Post.objects.get(pk=post4.pk).is_useful, True)
         self.assertEqual(Post.objects.get(pk=post5.pk).is_useful, True)
@@ -559,17 +563,17 @@ class ForumMemberTests(TestCase):
         """To test some failing cases when a member mark a post is useful."""
 
         # missing parameter
-        result = self.client.post(reverse("post-useful"), follow=False)
+        result = self.client.post(reverse("forum:post-useful"), follow=False)
 
         self.assertEqual(result.status_code, 404)
 
         # weird parameter
-        result = self.client.post(reverse("post-useful") + "?message=" + "abc", follow=False)
+        result = self.client.post(reverse("forum:post-useful") + "?message=" + "abc", follow=False)
 
         self.assertEqual(result.status_code, 404)
 
         # not existing (yet) pk parameter
-        result = self.client.post(reverse("post-useful") + "?message=" + "424242", follow=False)
+        result = self.client.post(reverse("forum:post-useful") + "?message=" + "424242", follow=False)
 
         self.assertEqual(result.status_code, 404)
 
@@ -583,7 +587,7 @@ class ForumMemberTests(TestCase):
 
         # not staff member can't move topic
         result = self.client.post(
-            reverse("topic-edit"), {"move": "", "forum": self.forum12, "topic": topic1.pk}, follow=False
+            reverse("forum:topic-edit"), {"move": "", "forum": self.forum12, "topic": topic1.pk}, follow=False
         )
 
         self.assertEqual(result.status_code, 403)
@@ -593,7 +597,7 @@ class ForumMemberTests(TestCase):
         self.client.force_login(staff1)
 
         result = self.client.post(
-            reverse("topic-edit"), {"move": "", "forum": self.forum12.pk, "topic": topic1.pk}, follow=False
+            reverse("forum:topic-edit"), {"move": "", "forum": self.forum12.pk, "topic": topic1.pk}, follow=False
         )
 
         self.assertEqual(result.status_code, 302)
@@ -615,7 +619,7 @@ class ForumMemberTests(TestCase):
 
         # missing parameter
         result = self.client.post(
-            reverse("topic-edit"),
+            reverse("forum:topic-edit"),
             {
                 "move": "",
                 "forum": self.forum12.pk,
@@ -627,14 +631,14 @@ class ForumMemberTests(TestCase):
 
         # weird parameter
         result = self.client.post(
-            reverse("topic-edit"), {"move": "", "forum": self.forum12.pk, "topic": "abc"}, follow=False
+            reverse("forum:topic-edit"), {"move": "", "forum": self.forum12.pk, "topic": "abc"}, follow=False
         )
 
         self.assertEqual(result.status_code, 404)
 
         # non-existing (yet) parameter
         result = self.client.post(
-            reverse("topic-edit"), {"move": "", "forum": self.forum12.pk, "topic": "424242"}, follow=False
+            reverse("forum:topic-edit"), {"move": "", "forum": self.forum12.pk, "topic": "424242"}, follow=False
         )
 
         self.assertEqual(result.status_code, 404)
@@ -646,7 +650,7 @@ class ForumMemberTests(TestCase):
         PostFactory(topic=topic1, author=self.user2, position=1)
 
         result = self.client.post(
-            reverse("post-new") + f"?sujet={topic1.pk}",
+            reverse("forum:post-new") + f"?sujet={topic1.pk}",
             {"last_post": topic1.last_message.pk, "text": " "},
             follow=False,
         )
@@ -665,7 +669,7 @@ class ForumMemberTests(TestCase):
         self.assertNotEqual(tag_c_sharp.title, tag_c.title)
         # post a topic with a tag
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum12.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum12.pk}",
             {
                 "title": "Un autre sujet",
                 "subtitle": "Encore ces lombards en plein ete",
@@ -712,13 +716,13 @@ class ForumMemberTests(TestCase):
         init_topic_count = Topic.objects.all().count()
 
         # Empty fields
-        response = self.client.post(reverse("topic-new") + f"?forum={self.forum12.pk}", {}, follow=False)
+        response = self.client.post(reverse("forum:topic-new") + f"?forum={self.forum12.pk}", {}, follow=False)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Topic.objects.all().count(), init_topic_count)
 
         # Blank data
         response = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum12.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum12.pk}",
             {
                 "title": " ",
                 "text": " ",
@@ -737,24 +741,26 @@ class ForumMemberTests(TestCase):
         PostFactory(topic=topic1, author=self.user, position=3)
 
         # simple member can read public topic
-        result = self.client.get(reverse("topic-posts-list", args=[topic1.pk, old_slugify(topic1.title)]), follow=True)
+        result = self.client.get(
+            reverse("forum:topic-posts-list", args=[topic1.pk, old_slugify(topic1.title)]), follow=True
+        )
         self.assertEqual(result.status_code, 200)
 
     def test_failing_unread_post(self):
         """Test failing cases when a member try to mark as unread a post."""
 
         # parameter is missing
-        result = self.client.get(reverse("post-unread"), follow=False)
+        result = self.client.get(reverse("forum:post-unread"), follow=False)
 
         self.assertEqual(result.status_code, 404)
 
         # parameter is weird
-        result = self.client.get(reverse("post-unread") + "?message=" + "abc", follow=False)
+        result = self.client.get(reverse("forum:post-unread") + "?message=" + "abc", follow=False)
 
         self.assertEqual(result.status_code, 404)
 
         # pk doesn't (yet) exist
-        result = self.client.get(reverse("post-unread") + "?message=" + "424242", follow=False)
+        result = self.client.get(reverse("forum:post-unread") + "?message=" + "424242", follow=False)
 
         self.assertEqual(result.status_code, 404)
 
@@ -833,40 +839,42 @@ class ForumGuestTests(TestCase):
 
     def feed_rss_display(self):
         """Test each rss feed feed"""
-        response = self.client.get(reverse("post-feed-rss"), follow=False)
+        response = self.client.get(reverse("forum:post-feed-rss"), follow=False)
         self.assertEqual(response.status_code, 200)
 
         for forum in Forum.objects.all():
-            response = self.client.get(reverse("post-feed-rss") + f"?forum={forum.pk}", follow=False)
+            response = self.client.get(reverse("forum:post-feed-rss") + f"?forum={forum.pk}", follow=False)
             self.assertEqual(response.status_code, 200)
 
         for tag in Tag.objects.all():
-            response = self.client.get(reverse("post-feed-rss") + f"?tag={tag.pk}", follow=False)
+            response = self.client.get(reverse("forum:post-feed-rss") + f"?tag={tag.pk}", follow=False)
             self.assertEqual(response.status_code, 200)
 
         for forum in Forum.objects.all():
             for tag in Tag.objects.all():
-                response = self.client.get(reverse("post-feed-rss") + f"?tag={tag.pk}&forum={forum.pk}", follow=False)
+                response = self.client.get(
+                    reverse("forum:post-feed-rss") + f"?tag={tag.pk}&forum={forum.pk}", follow=False
+                )
                 self.assertEqual(response.status_code, 200)
 
     def test_display(self):
         """Test forum display (full: root, category, forum) Topic display test
         is in creation topic test."""
         # Forum root
-        response = self.client.get(reverse("cats-forums-list"))
+        response = self.client.get(reverse("forum:cats-forums-list"))
         self.assertContains(response, "Liste des forums")
         # ForumCategory
-        response = self.client.get(reverse("cat-forums-list", args=[self.category1.slug]))
+        response = self.client.get(reverse("forum:cat-forums-list", args=[self.category1.slug]))
         self.assertContains(response, self.category1.title)
         # Forum
-        response = self.client.get(reverse("forum-topics-list", args=[self.category1.slug, self.forum11.slug]))
+        response = self.client.get(reverse("forum:topics-list", args=[self.category1.slug, self.forum11.slug]))
         self.assertContains(response, self.category1.title)
         self.assertContains(response, self.forum11.title)
 
     def test_create_topic(self):
         """To test all aspects of topic's creation by guest."""
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum12.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum12.pk}",
             {
                 "title": "Un autre sujet",
                 "subtitle": "Encore ces lombards en plein ete",
@@ -890,7 +898,7 @@ class ForumGuestTests(TestCase):
         PostFactory(topic=topic1, author=user1, position=3)
 
         result = self.client.post(
-            reverse("post-new") + f"?sujet={topic1.pk}",
+            reverse("forum:post-new") + f"?sujet={topic1.pk}",
             {
                 "last_post": topic1.last_message.pk,
                 "text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter ",
@@ -916,7 +924,7 @@ class ForumGuestTests(TestCase):
         PostFactory(topic=topic3, author=self.user, position=1)
 
         result = self.client.post(
-            reverse("post-edit") + f"?message={post1.pk}",
+            reverse("forum:post-edit") + f"?message={post1.pk}",
             {
                 "title": "Un autre sujet",
                 "subtitle": "Encore ces lombards en plein été",
@@ -942,7 +950,7 @@ class ForumGuestTests(TestCase):
         PostFactory(topic=topic1, author=self.user, position=3)
 
         result = self.client.post(
-            reverse("post-edit") + f"?message={post2.pk}",
+            reverse("forum:post-edit") + f"?message={post2.pk}",
             {"text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter "},
             follow=False,
         )
@@ -961,7 +969,7 @@ class ForumGuestTests(TestCase):
         post2 = PostFactory(topic=topic1, author=user1, position=2)
         PostFactory(topic=topic1, author=user1, position=3)
 
-        result = self.client.get(reverse("post-new") + f"?sujet={topic1.pk}&cite={post2.pk}", follow=False)
+        result = self.client.get(reverse("forum:post-new") + f"?sujet={topic1.pk}&cite={post2.pk}", follow=False)
 
         self.assertEqual(result.status_code, 302)
 
@@ -974,7 +982,7 @@ class ForumGuestTests(TestCase):
         PostFactory(topic=topic1, author=user1, position=3)
 
         result = self.client.post(
-            reverse("post-edit") + f"?message={post2.pk}",
+            reverse("forum:post-edit") + f"?message={post2.pk}",
             {"signal_text": "Troll", "signal_message": "confirmer"},
             follow=False,
         )
@@ -991,7 +999,7 @@ class ForumGuestTests(TestCase):
         post2 = PostFactory(topic=topic1, author=user1, position=2)
         post3 = PostFactory(topic=topic1, author=user1, position=3)
 
-        result = self.client.get(reverse("post-useful") + f"?message={post2.pk}", follow=False)
+        result = self.client.get(reverse("forum:post-useful") + f"?message={post2.pk}", follow=False)
 
         self.assertEqual(result.status_code, 405)
 
@@ -1009,7 +1017,7 @@ class ForumGuestTests(TestCase):
 
         # not staff guest can't move topic
         result = self.client.post(
-            reverse("topic-edit"), {"move": "", "forum": self.forum12, "topic": topic1.pk}, follow=False
+            reverse("forum:topic-edit"), {"move": "", "forum": self.forum12, "topic": topic1.pk}, follow=False
         )
 
         self.assertEqual(result.status_code, 302)
@@ -1024,7 +1032,9 @@ class ForumGuestTests(TestCase):
         PostFactory(topic=topic1, author=self.user, position=3)
 
         # guest can read public topic
-        result = self.client.get(reverse("topic-posts-list", args=[topic1.pk, old_slugify(topic1.title)]), follow=True)
+        result = self.client.get(
+            reverse("forum:topic-posts-list", args=[topic1.pk, old_slugify(topic1.title)]), follow=True
+        )
         self.assertEqual(result.status_code, 200)
 
     def test_filter_topic(self):

--- a/zds/forum/tests/tests_feeds.py
+++ b/zds/forum/tests/tests_feeds.py
@@ -151,10 +151,10 @@ class LastTopicsFeedTest(TestCase):
         buggy_topic.title = "Strange char: \u0007"
         buggy_topic.save()
 
-        request = self.client.get(reverse("topic-feed-rss"))
+        request = self.client.get(reverse("forum:topic-feed-rss"))
         self.assertEqual(request.status_code, 200)
 
-        request = self.client.get(reverse("topic-feed-atom"))
+        request = self.client.get(reverse("forum:topic-feed-atom"))
         self.assertEqual(request.status_code, 200)
 
 
@@ -316,8 +316,8 @@ class LastPostsFeedTest(TestCase):
         post.update_content("Strange char: \u0007")
         post.save()
 
-        request = self.client.get(reverse("post-feed-rss"))
+        request = self.client.get(reverse("forum:post-feed-rss"))
         self.assertEqual(request.status_code, 200)
 
-        request = self.client.get(reverse("post-feed-atom"))
+        request = self.client.get(reverse("forum:post-feed-atom"))
         self.assertEqual(request.status_code, 200)

--- a/zds/forum/tests/tests_feeds.py
+++ b/zds/forum/tests/tests_feeds.py
@@ -47,7 +47,7 @@ class LastTopicsFeedTest(TestCase):
         """Get object should return the given parameteres in an object"""
 
         factory = RequestFactory()
-        request = factory.get(reverse("topic-feed-rss") + "?forum=fofo&tag=tatag")
+        request = factory.get(reverse("forum:topic-feed-rss") + "?forum=fofo&tag=tatag")
         obj = self.topicfeed.get_object(request=request)
         self.assertEqual(obj["forum"], "fofo")
         self.assertEqual(obj["tag"], "tatag")
@@ -211,7 +211,7 @@ class LastPostsFeedTest(TestCase):
         """Get object should return the given parameteres in an object"""
 
         factory = RequestFactory()
-        request = factory.get(reverse("post-feed-rss") + "?forum=fofo&tag=tatag")
+        request = factory.get(reverse("forum:post-feed-rss") + "?forum=fofo&tag=tatag")
         obj = self.postfeed.get_object(request=request)
         self.assertEqual(obj["forum"], "fofo")
         self.assertEqual(obj["tag"], "tatag")

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -19,7 +19,7 @@ class LastTopicsViewTests(TestCase):
         self.client.force_login(profile.user)
         _, forum = create_category_and_forum()
         create_topic_in_forum(forum, profile)
-        response = self.client.get(reverse("last-subjects"))
+        response = self.client.get(reverse("forum:last-subjects"))
         self.assertEqual(200, response.status_code)
         self.assertTrue(Topic.objects.last() in response.context["topics"])
 
@@ -27,7 +27,7 @@ class LastTopicsViewTests(TestCase):
         profile = ProfileFactory()
         _, forum = create_category_and_forum()
         create_topic_in_forum(forum, profile)
-        response = self.client.get(reverse("last-subjects"))
+        response = self.client.get(reverse("forum:last-subjects"))
         self.assertEqual(200, response.status_code)
         self.assertTrue(Topic.objects.last() in response.context["topics"])
 
@@ -39,14 +39,14 @@ class LastTopicsViewTests(TestCase):
         # Tests with a user who cannot read the last topic.
         profile = ProfileFactory()
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("last-subjects"))
+        response = self.client.get(reverse("forum:last-subjects"))
         self.assertEqual(200, response.status_code)
         self.assertTrue(Topic.objects.last() not in response.context["topics"])
         # Adds to the user the right to read the last topic, and test again.
         profile.user.groups.add(group)
         profile.user.save()
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("last-subjects"))
+        response = self.client.get(reverse("forum:last-subjects"))
         self.assertEqual(200, response.status_code)
         self.assertTrue(Topic.objects.last() in response.context["topics"])
 
@@ -56,7 +56,7 @@ class CategoriesForumsListViewTests(TestCase):
         profile = ProfileFactory()
         category, forum = create_category_and_forum()
 
-        response = self.client.get(reverse("cats-forums-list"))
+        response = self.client.get(reverse("forum:cats-forums-list"))
 
         self.assertEqual(200, response.status_code)
         current_category = response.context["categories"].get(pk=category.pk)
@@ -69,7 +69,7 @@ class CategoriesForumsListViewTests(TestCase):
         profile = ProfileFactory()
         category, forum = create_category_and_forum(group)
 
-        response = self.client.get(reverse("cats-forums-list"))
+        response = self.client.get(reverse("forum:cats-forums-list"))
 
         self.assertEqual(200, response.status_code)
         current_category = response.context["categories"].get(pk=category.pk)
@@ -80,7 +80,7 @@ class CategoriesForumsListViewTests(TestCase):
         profile.user.save()
         self.client.force_login(profile.user)
 
-        response = self.client.get(reverse("cats-forums-list"))
+        response = self.client.get(reverse("forum:cats-forums-list"))
 
         self.assertEqual(200, response.status_code)
         current_category = response.context["categories"].get(pk=category.pk)
@@ -98,7 +98,7 @@ class CategoriesForumsListViewTests(TestCase):
 
         self.client.force_login(staff.user)
         data = {"lock": "true", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertTrue(Topic.objects.get(pk=topic.pk).is_locked)
@@ -111,7 +111,7 @@ class CategoryForumsDetailViewTest(TestCase):
         profile = ProfileFactory()
         category, forum = create_category_and_forum()
 
-        response = self.client.get(reverse("cat-forums-list", args=[category.slug]))
+        response = self.client.get(reverse("forum:cat-forums-list", args=[category.slug]))
 
         self.assertEqual(200, response.status_code)
         current_category = response.context["category"]
@@ -125,7 +125,7 @@ class CategoryForumsDetailViewTest(TestCase):
         profile = ProfileFactory()
         category, forum = create_category_and_forum(group)
 
-        response = self.client.get(reverse("cat-forums-list", args=[category.slug]))
+        response = self.client.get(reverse("forum:cat-forums-list", args=[category.slug]))
 
         self.assertEqual(200, response.status_code)
         current_category = response.context["category"]
@@ -136,7 +136,7 @@ class CategoryForumsDetailViewTest(TestCase):
         profile.user.save()
         self.client.force_login(profile.user)
 
-        response = self.client.get(reverse("cat-forums-list", args=[category.slug]))
+        response = self.client.get(reverse("forum:cat-forums-list", args=[category.slug]))
 
         self.assertEqual(200, response.status_code)
         current_category = response.context["category"]
@@ -147,7 +147,7 @@ class CategoryForumsDetailViewTest(TestCase):
 
 class ForumTopicsListViewTest(TestCase):
     def test_failure_list_all_topics_of_a_wrong_forum(self):
-        response = self.client.get(reverse("forum-topics-list", args=["x", "x"]))
+        response = self.client.get(reverse("forum:topics-list", args=["x", "x"]))
 
         self.assertEqual(404, response.status_code)
 
@@ -155,7 +155,7 @@ class ForumTopicsListViewTest(TestCase):
         group = Group.objects.create(name="DummyGroup_1")
         category, forum = create_category_and_forum(group)
 
-        response = self.client.get(reverse("forum-topics-list", args=[category.slug, forum.slug]))
+        response = self.client.get(reverse("forum:topics-list", args=[category.slug, forum.slug]))
 
         self.assertEqual(403, response.status_code)
 
@@ -164,7 +164,7 @@ class ForumTopicsListViewTest(TestCase):
         category, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        response = self.client.get(reverse("forum-topics-list", args=[category.slug, forum.slug]))
+        response = self.client.get(reverse("forum:topics-list", args=[category.slug, forum.slug]))
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(forum, response.context["forum"])
@@ -178,7 +178,7 @@ class ForumTopicsListViewTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
         topic_sticky = create_topic_in_forum(forum, profile, is_sticky=True)
 
-        response = self.client.get(reverse("forum-topics-list", args=[category.slug, forum.slug]))
+        response = self.client.get(reverse("forum:topics-list", args=[category.slug, forum.slug]))
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(forum, response.context["forum"])
@@ -193,7 +193,7 @@ class ForumTopicsListViewTest(TestCase):
         create_topic_in_forum(forum, profile)
         topic_solved = create_topic_in_forum(forum, profile, is_solved=True)
 
-        response = self.client.get(reverse("forum-topics-list", args=[category.slug, forum.slug]) + "?filter=solve")
+        response = self.client.get(reverse("forum:topics-list", args=[category.slug, forum.slug]) + "?filter=solve")
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(forum, response.context["forum"])
@@ -206,7 +206,7 @@ class ForumTopicsListViewTest(TestCase):
         topic_unsolved = create_topic_in_forum(forum, profile)
         create_topic_in_forum(forum, profile, is_solved=True)
 
-        response = self.client.get(reverse("forum-topics-list", args=[category.slug, forum.slug]) + "?filter=unsolve")
+        response = self.client.get(reverse("forum:topics-list", args=[category.slug, forum.slug]) + "?filter=unsolve")
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(forum, response.context["forum"])
@@ -219,7 +219,7 @@ class ForumTopicsListViewTest(TestCase):
         create_topic_in_forum(forum, profile)
         create_topic_in_forum(forum, profile, is_solved=True)
 
-        response = self.client.get(reverse("forum-topics-list", args=[category.slug, forum.slug]) + "?filter=noanswer")
+        response = self.client.get(reverse("forum:topics-list", args=[category.slug, forum.slug]) + "?filter=noanswer")
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(forum, response.context["forum"])
@@ -233,7 +233,7 @@ class TopicPostsListViewTest(TestCase):
         category, forum = create_category_and_forum(group)
         topic = create_topic_in_forum(forum, profile)
 
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
 
         self.assertEqual(403, response.status_code)
 
@@ -242,7 +242,7 @@ class TopicPostsListViewTest(TestCase):
         category, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, "x"]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, "x"]))
 
         self.assertEqual(302, response.status_code)
 
@@ -251,7 +251,7 @@ class TopicPostsListViewTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(topic, response.context["topic"])
@@ -266,7 +266,7 @@ class TopicPostsListViewTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, response.context["subscriber_count"])
@@ -276,7 +276,7 @@ class TopicNewTest(TestCase):
     def test_failure_create_topic_with_a_post_with_client_unauthenticated(self):
         _, forum = create_category_and_forum()
 
-        response = self.client.post(reverse("topic-new") + f"?forum={forum.pk}")
+        response = self.client.post(reverse("forum:topic-new") + f"?forum={forum.pk}")
 
         self.assertEqual(302, response.status_code)
 
@@ -288,7 +288,7 @@ class TopicNewTest(TestCase):
         _, forum = create_category_and_forum()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("topic-new") + f"?forum={forum.pk}")
+        response = self.client.post(reverse("forum:topic-new") + f"?forum={forum.pk}")
 
         self.assertEqual(403, response.status_code)
 
@@ -298,7 +298,7 @@ class TopicNewTest(TestCase):
         _, forum = create_category_and_forum(group)
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("topic-new") + f"?forum={forum.pk}")
+        response = self.client.post(reverse("forum:topic-new") + f"?forum={forum.pk}")
 
         self.assertEqual(403, response.status_code)
 
@@ -306,7 +306,7 @@ class TopicNewTest(TestCase):
         profile = ProfileFactory()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("topic-new") + "?forum=x")
+        response = self.client.post(reverse("forum:topic-new") + "?forum=x")
 
         self.assertEqual(404, response.status_code)
 
@@ -315,7 +315,7 @@ class TopicNewTest(TestCase):
         _, forum = create_category_and_forum()
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("topic-new") + f"?forum={forum.pk}")
+        response = self.client.get(reverse("forum:topic-new") + f"?forum={forum.pk}")
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(forum, response.context["forum"])
@@ -328,11 +328,11 @@ class TopicNewTest(TestCase):
         _, forum = create_category_and_forum()
         self.client.force_login(profile.user)
         data = {"title": "Title of the topic", "subtitle": "Subtitle of the topic", "text": "A new post!", "tags": ""}
-        self.client.post(reverse("topic-new") + f"?forum={forum.pk}", data, follow=False)
+        self.client.post(reverse("forum:topic-new") + f"?forum={forum.pk}", data, follow=False)
         self.client.logout()
         self.client.force_login(profile2.user)
         data = {"title": "Title of the topic", "subtitle": "Subtitle of the topic", "text": "A new post!", "tags": ""}
-        self.client.post(reverse("topic-new") + f"?forum={forum.pk}", data, follow=False)
+        self.client.post(reverse("forum:topic-new") + f"?forum={forum.pk}", data, follow=False)
         self.client.logout()
         self.client.force_login(profile.user)
         topic = Topic.objects.last()
@@ -355,7 +355,7 @@ class TopicNewTest(TestCase):
         self.client.force_login(profile.user)
         data = {"preview": "", "text": "A new post!"}
         response = self.client.post(
-            reverse("topic-new") + f"?forum={forum.pk}",
+            reverse("forum:topic-new") + f"?forum={forum.pk}",
             data,
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
             follow=False,
@@ -374,7 +374,7 @@ class TopicNewTest(TestCase):
             "subtitle": "Subtitle of the topic",
             "text": "A new post!",
         }
-        response = self.client.post(reverse("topic-new") + f"?forum={forum.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-new") + f"?forum={forum.pk}", data, follow=False)
 
         self.assertEqual(200, response.status_code)
 
@@ -384,7 +384,7 @@ class TopicNewTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"title": "Title of the topic", "subtitle": "Subtitle of the topic", "text": "A new post!", "tags": ""}
-        response = self.client.post(reverse("topic-new") + f"?forum={forum.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-new") + f"?forum={forum.pk}", data, follow=False)
 
         self.assertEqual(302, response.status_code)
 
@@ -403,7 +403,7 @@ class TopicNewTest(TestCase):
             "tags": "",
             "with_hat": hat.pk,
         }
-        response = self.client.post(reverse("topic-new") + f"?forum={forum.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-new") + f"?forum={forum.pk}", data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertEqual(Post.objects.latest("pubdate").hat, hat)
@@ -411,7 +411,7 @@ class TopicNewTest(TestCase):
 
 class TopicEditTest(TestCase):
     def test_failure_edit_topic_with_client_unauthenticated(self):
-        response = self.client.post(reverse("topic-edit"))
+        response = self.client.post(reverse("forum:topic-edit"))
 
         self.assertEqual(302, response.status_code)
 
@@ -422,7 +422,7 @@ class TopicEditTest(TestCase):
         profile.save()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("topic-edit"))
+        response = self.client.post(reverse("forum:topic-edit"))
 
         self.assertEqual(403, response.status_code)
 
@@ -431,7 +431,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         response = self.client.post(
-            reverse("topic-edit"),
+            reverse("forum:topic-edit"),
             {
                 "topic": "abc",
             },
@@ -445,7 +445,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         response = self.client.post(
-            reverse("topic-edit"),
+            reverse("forum:topic-edit"),
             {
                 "topic": 99999,
             },
@@ -461,7 +461,9 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, HTTP_X_REQUESTED_WITH="XMLHttpRequest", follow=False)
+        response = self.client.post(
+            reverse("forum:topic-edit"), data, HTTP_X_REQUESTED_WITH="XMLHttpRequest", follow=False
+        )
 
         self.assertEqual(200, response.status_code)
 
@@ -472,7 +474,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(302, response.status_code)
 
@@ -483,12 +485,12 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"follow": "1"}
-        response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertIsNotNone(TopicAnswerSubscription.objects.get_existing(profile.user, topic, is_active=False))
 
-        response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertIsNotNone(TopicAnswerSubscription.objects.get_existing(profile.user, topic, is_active=True))
@@ -504,12 +506,12 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"follow": "1"}
-        response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertIsNotNone(TopicAnswerSubscription.objects.get_existing(profile.user, topic, is_active=False))
 
-        response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertIsNotNone(TopicAnswerSubscription.objects.get_existing(profile.user, topic, is_active=True))
@@ -521,14 +523,14 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"email": "1"}
-        response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertIsNotNone(
             TopicAnswerSubscription.objects.get_existing(profile.user, topic, is_active=True, by_email=True)
         )
 
-        response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertIsNotNone(
@@ -544,7 +546,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"solved": "", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(403, response.status_code)
 
@@ -555,7 +557,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"solved": "", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(302, response.status_code)
         topic = Topic.objects.get(pk=topic.pk)
@@ -571,7 +573,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(staff.user)
         data = {"solved": "", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(302, response.status_code)
         topic = Topic.objects.get(pk=topic.pk)
@@ -587,7 +589,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"lock": "true", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(403, response.status_code)
 
@@ -600,13 +602,13 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(staff.user)
         data = {"lock": "true", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertTrue(Topic.objects.get(pk=topic.pk).is_locked)
 
         data = {"lock": "false", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertFalse(Topic.objects.get(pk=topic.pk).is_locked)
@@ -620,7 +622,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"sticky": "true", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(403, response.status_code)
 
@@ -633,13 +635,13 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(staff.user)
         data = {"sticky": "true", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertTrue(Topic.objects.get(pk=topic.pk).is_sticky)
 
         data = {"sticky": "false", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertFalse(Topic.objects.get(pk=topic.pk).is_sticky)
@@ -654,7 +656,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"move": "", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(topic_moved.send.call_count, 0)
         self.assertEqual(403, response.status_code)
@@ -669,7 +671,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(staff.user)
         data = {"move": "", "forum": "abc", "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(topic_moved.send.call_count, 0)
         self.assertEqual(404, response.status_code)
@@ -684,7 +686,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(staff.user)
         data = {"move": "", "forum": 99999, "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(topic_moved.send.call_count, 0)
         self.assertEqual(404, response.status_code)
@@ -701,7 +703,7 @@ class TopicEditTest(TestCase):
 
         self.client.force_login(staff.user)
         data = {"move": "", "forum": another_forum.pk, "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(topic_moved.send.call_count, 1)
         self.assertEqual(302, response.status_code)
@@ -713,11 +715,11 @@ class TopicEditTest(TestCase):
 
         another_profile = ProfileFactory()
         self.client.force_login(another_profile.user)
-        response = self.client.get(reverse("topic-edit") + f"?topic={topic.pk}", follow=False)
+        response = self.client.get(reverse("forum:topic-edit") + f"?topic={topic.pk}", follow=False)
         self.assertEqual(403, response.status_code)
 
         data = {"text": "New text for the post"}
-        response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit") + f"?topic={topic.pk}", data, follow=False)
         self.assertEqual(403, response.status_code)
 
     def test_success_edit_topic_staff_in_get_method(self):
@@ -728,7 +730,7 @@ class TopicEditTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(staff.user)
-        response = self.client.get(reverse("topic-edit") + f"?topic={topic.pk}", follow=False)
+        response = self.client.get(reverse("forum:topic-edit") + f"?topic={topic.pk}", follow=False)
 
         self.assertEqual(200, response.status_code)
 
@@ -738,7 +740,7 @@ class TopicEditTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("topic-edit") + f"?topic={topic.pk}", follow=False)
+        response = self.client.get(reverse("forum:topic-edit") + f"?topic={topic.pk}", follow=False)
 
         self.assertEqual(200, response.status_code)
 
@@ -754,7 +756,7 @@ class TopicEditTest(TestCase):
             "subtitle": "New subtitle",
             "text": "A new post!",
         }
-        response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(topic, response.context["topic"])
@@ -773,7 +775,7 @@ class TopicEditTest(TestCase):
             "text": "A new post!",
         }
         response = self.client.post(
-            reverse("topic-edit") + f"?topic={topic.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic.pk}",
             data,
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
             follow=False,
@@ -792,7 +794,7 @@ class TopicEditTest(TestCase):
             "subtitle": "New subtitle",
             "text": "A new post!",
         }
-        response = self.client.post(reverse("topic-edit") + f"?topic={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit") + f"?topic={topic.pk}", data, follow=False)
 
         self.assertEqual(302, response.status_code)
         topic = Topic.objects.get(pk=topic.pk)
@@ -804,7 +806,7 @@ class TopicEditTest(TestCase):
 
 class FindTopicTest(TestCase):
     def test_failure_find_topics_of_a_member_not_found(self):
-        response = self.client.get(reverse("topic-find", args=[9999]), follow=False)
+        response = self.client.get(reverse("forum:topic-find", args=[9999]), follow=False)
 
         self.assertEqual(404, response.status_code)
 
@@ -813,7 +815,7 @@ class FindTopicTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        response = self.client.get(reverse("topic-find", args=[profile.user.pk]), follow=False)
+        response = self.client.get(reverse("forum:topic-find", args=[profile.user.pk]), follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context["topics"]))
@@ -839,7 +841,7 @@ class FindTopicTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("topic-find", args=[profile.user.pk]), follow=False)
+        response = self.client.get(reverse("forum:topic-find", args=[profile.user.pk]), follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context["topics"]))
@@ -848,16 +850,16 @@ class FindTopicTest(TestCase):
 
 class FindFollowedTopicTest(TestCase):
     def test_public_cant_access_followed_topics(self):
-        response = self.client.get(reverse("followed-topic-find"), follow=False)
+        response = self.client.get(reverse("forum:followed-topic-find"), follow=False)
         self.assertEqual(302, response.status_code)
-        self.assertRedirects(response, reverse("member-login") + "?next=" + reverse("followed-topic-find"))
+        self.assertRedirects(response, reverse("member-login") + "?next=" + reverse("forum:followed-topic-find"))
 
     def test_success_find_followed_topics_of_a_member(self):
         profile = ProfileFactory()
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("followed-topic-find"), follow=False)
+        response = self.client.get(reverse("forum:followed-topic-find"), follow=False)
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context["topics"]))
         self.assertEqual(topic, response.context["topics"][0])
@@ -865,7 +867,7 @@ class FindFollowedTopicTest(TestCase):
 
 class FindTopicByTagTest(TestCase):
     def test_failure_find_topics_of_a_tag_not_found(self):
-        response = self.client.get(reverse("topic-tag-find", args=["x"]), follow=False)
+        response = self.client.get(reverse("forum:topic-tag-find", args=["x"]), follow=False)
 
         self.assertEqual(404, response.status_code)
 
@@ -877,7 +879,7 @@ class FindTopicByTagTest(TestCase):
         topic.add_tags([tag.title])
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("topic-tag-find", args=[tag.slug]), follow=False)
+        response = self.client.get(reverse("forum:topic-tag-find", args=[tag.slug]), follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context["topics"]))
@@ -906,7 +908,7 @@ class FindTopicByTagTest(TestCase):
         topic.add_tags([tag.title])
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("topic-tag-find", args=[tag.slug]), follow=False)
+        response = self.client.get(reverse("forum:topic-tag-find", args=[tag.slug]), follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context["topics"]))
@@ -921,7 +923,7 @@ class FindTopicByTagTest(TestCase):
         tag = TagFactory()
         topic_solved.add_tags([tag.title])
 
-        response = self.client.get(reverse("topic-tag-find", args=[tag.slug]) + "?filter=solve")
+        response = self.client.get(reverse("forum:topic-tag-find", args=[tag.slug]) + "?filter=solve")
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context["topics"]))
@@ -936,7 +938,7 @@ class FindTopicByTagTest(TestCase):
         tag = TagFactory()
         topic_unsolved.add_tags([tag.title])
 
-        response = self.client.get(reverse("topic-tag-find", args=[tag.slug]) + "?filter=unsolve")
+        response = self.client.get(reverse("forum:topic-tag-find", args=[tag.slug]) + "?filter=unsolve")
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context["topics"]))
@@ -952,7 +954,7 @@ class FindTopicByTagTest(TestCase):
         topic.add_tags([tag.title])
         another_topic.add_tags([tag.title])
 
-        response = self.client.get(reverse("topic-tag-find", args=[tag.slug]) + "?filter=noanswer")
+        response = self.client.get(reverse("forum:topic-tag-find", args=[tag.slug]) + "?filter=noanswer")
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(2, len(response.context["topics"]))
@@ -966,17 +968,17 @@ class FindTopicByTagTest(TestCase):
         tag = TagFactory()
         topic_solved.add_tags([tag.title])
 
-        response = self.client.get(reverse("old-topic-tag-find", args=[tag.pk, tag.slug]))
+        response = self.client.get(reverse("forum:old-topic-tag-find", args=[tag.pk, tag.slug]))
         self.assertEqual(301, response.status_code)
 
-        response = self.client.get(reverse("old-topic-tag-find", args=[tag.pk, tag.slug]), follow=True)
+        response = self.client.get(reverse("forum:old-topic-tag-find", args=[tag.pk, tag.slug]), follow=True)
         self.assertEqual(1, len(response.context["topics"]))
         self.assertEqual(tag, response.context["tag"])
 
 
 class PostNewTest(TestCase):
     def test_failure_new_post_with_client_unauthenticated(self):
-        response = self.client.post(reverse("post-new"))
+        response = self.client.post(reverse("forum:post-new"))
 
         self.assertEqual(302, response.status_code)
 
@@ -987,7 +989,7 @@ class PostNewTest(TestCase):
         profile.save()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-new"))
+        response = self.client.post(reverse("forum:post-new"))
 
         self.assertEqual(403, response.status_code)
 
@@ -995,7 +997,7 @@ class PostNewTest(TestCase):
         profile = ProfileFactory()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-new") + "?sujet=abc", follow=False)
+        response = self.client.post(reverse("forum:post-new") + "?sujet=abc", follow=False)
 
         self.assertEqual(404, response.status_code)
 
@@ -1003,7 +1005,7 @@ class PostNewTest(TestCase):
         profile = ProfileFactory()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-new") + "?sujet=99999", follow=False)
+        response = self.client.post(reverse("forum:post-new") + "?sujet=99999", follow=False)
 
         self.assertEqual(404, response.status_code)
 
@@ -1014,7 +1016,7 @@ class PostNewTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-new") + f"?sujet={topic.pk}")
+        response = self.client.get(reverse("forum:post-new") + f"?sujet={topic.pk}")
 
         self.assertEqual(403, response.status_code)
 
@@ -1024,7 +1026,7 @@ class PostNewTest(TestCase):
         topic = create_topic_in_forum(forum, profile, is_locked=True)
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-new") + f"?sujet={topic.pk}")
+        response = self.client.get(reverse("forum:post-new") + f"?sujet={topic.pk}")
 
         self.assertEqual(403, response.status_code)
 
@@ -1036,7 +1038,7 @@ class PostNewTest(TestCase):
         topic.last_message.save()
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-new") + f"?sujet={topic.pk}")
+        response = self.client.get(reverse("forum:post-new") + f"?sujet={topic.pk}")
 
         self.assertEqual(403, response.status_code)
 
@@ -1047,7 +1049,7 @@ class PostNewTest(TestCase):
 
         profile = ProfileFactory()
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-new") + f"?sujet={topic.pk}", follow=False)
+        response = self.client.get(reverse("forum:post-new") + f"?sujet={topic.pk}", follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(topic, response.context["topic"])
@@ -1063,7 +1065,7 @@ class PostNewTest(TestCase):
         profile = ProfileFactory()
         self.client.force_login(profile.user)
         response = self.client.get(
-            reverse("post-new") + f"?sujet={topic.pk}&cite={topic.last_message.pk}",
+            reverse("forum:post-new") + f"?sujet={topic.pk}&cite={topic.last_message.pk}",
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
             follow=False,
         )
@@ -1078,7 +1080,7 @@ class PostNewTest(TestCase):
         profile = ProfileFactory()
         self.client.force_login(profile.user)
         data = {"preview": "", "text": "A new post!", "last_post": topic.last_message.pk}
-        response = self.client.post(reverse("post-new") + f"?sujet={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:post-new") + f"?sujet={topic.pk}", data, follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(topic, response.context["topic"])
@@ -1095,7 +1097,7 @@ class PostNewTest(TestCase):
         self.client.force_login(profile.user)
         data = {"preview": "", "text": "A new post!", "last_post": topic.last_message.pk}
         response = self.client.post(
-            reverse("post-new") + f"?sujet={topic.pk}",
+            reverse("forum:post-new") + f"?sujet={topic.pk}",
             data,
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
             follow=False,
@@ -1111,7 +1113,7 @@ class PostNewTest(TestCase):
         profile = ProfileFactory()
         self.client.force_login(profile.user)
         data = {"text": "A new post!", "last_post": topic.last_message.pk}
-        response = self.client.post(reverse("post-new") + f"?sujet={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:post-new") + f"?sujet={topic.pk}", data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertEqual(2, Post.objects.filter(topic__pk=topic.pk).count())
@@ -1137,7 +1139,7 @@ class PostNewTest(TestCase):
             "last_post": topic.last_message.pk,
             "with_hat": "abc",
         }
-        response = self.client.post(reverse("post-new") + f"?sujet={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:post-new") + f"?sujet={topic.pk}", data, follow=False)
         self.assertEqual(302, response.status_code)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(2, Post.objects.filter(topic__pk=topic.pk).count())
@@ -1150,7 +1152,7 @@ class PostNewTest(TestCase):
             "last_post": topic.last_message.pk,
             "with_hat": 1587,
         }
-        response = self.client.post(reverse("post-new") + f"?sujet={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:post-new") + f"?sujet={topic.pk}", data, follow=False)
         self.assertEqual(302, response.status_code)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(2, Post.objects.filter(topic__pk=topic.pk).count())
@@ -1163,7 +1165,7 @@ class PostNewTest(TestCase):
             "last_post": topic.last_message.pk,
             "with_hat": other_hat.pk,
         }
-        response = self.client.post(reverse("post-new") + f"?sujet={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:post-new") + f"?sujet={topic.pk}", data, follow=False)
         self.assertEqual(302, response.status_code)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(2, Post.objects.filter(topic__pk=topic.pk).count())
@@ -1176,7 +1178,7 @@ class PostNewTest(TestCase):
             "last_post": topic.last_message.pk,
             "with_hat": hat.pk,
         }
-        response = self.client.post(reverse("post-new") + f"?sujet={topic.pk}", data, follow=False)
+        response = self.client.post(reverse("forum:post-new") + f"?sujet={topic.pk}", data, follow=False)
         self.assertEqual(302, response.status_code)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(2, Post.objects.filter(topic__pk=topic.pk).count())
@@ -1185,7 +1187,7 @@ class PostNewTest(TestCase):
 
 class PostEditTest(TestCase):
     def test_failure_edit_post_with_client_unauthenticated(self):
-        response = self.client.post(reverse("post-edit"))
+        response = self.client.post(reverse("forum:post-edit"))
 
         self.assertEqual(302, response.status_code)
 
@@ -1196,7 +1198,7 @@ class PostEditTest(TestCase):
         profile.save()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-edit"))
+        response = self.client.post(reverse("forum:post-edit"))
 
         self.assertEqual(403, response.status_code)
 
@@ -1204,7 +1206,7 @@ class PostEditTest(TestCase):
         profile = ProfileFactory()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-edit") + "?message=abc", follow=False)
+        response = self.client.post(reverse("forum:post-edit") + "?message=abc", follow=False)
 
         self.assertEqual(404, response.status_code)
 
@@ -1212,7 +1214,7 @@ class PostEditTest(TestCase):
         profile = ProfileFactory()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-edit") + "?message=99999", follow=False)
+        response = self.client.post(reverse("forum:post-edit") + "?message=99999", follow=False)
 
         self.assertEqual(404, response.status_code)
 
@@ -1223,7 +1225,7 @@ class PostEditTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-edit") + f"?message={topic.last_message.pk}")
+        response = self.client.get(reverse("forum:post-edit") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(403, response.status_code)
 
@@ -1234,7 +1236,7 @@ class PostEditTest(TestCase):
 
         profile = ProfileFactory()
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-edit") + f"?message={topic.last_message.pk}")
+        response = self.client.get(reverse("forum:post-edit") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(403, response.status_code)
 
@@ -1244,7 +1246,7 @@ class PostEditTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-edit") + f"?message={topic.last_message.pk}", follow=False)
+        response = self.client.get(reverse("forum:post-edit") + f"?message={topic.last_message.pk}", follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(topic, response.context["topic"])
@@ -1259,7 +1261,9 @@ class PostEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"preview": "", "text": "A new post!"}
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
 
         self.assertEqual(200, response.status_code)
 
@@ -1274,7 +1278,7 @@ class PostEditTest(TestCase):
             "text": "A new post!",
         }
         response = self.client.post(
-            reverse("post-edit") + f"?message={topic.last_message.pk}",
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}",
             data,
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
             follow=False,
@@ -1289,7 +1293,9 @@ class PostEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"text": "A new post!"}
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
 
         self.assertEqual(302, response.status_code)
         post = Post.objects.get(pk=topic.last_message.pk)
@@ -1304,7 +1310,9 @@ class PostEditTest(TestCase):
         profile = ProfileFactory()
         self.client.force_login(profile.user)
         data = {"delete_message": ""}
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
 
         self.assertEqual(403, response.status_code)
 
@@ -1316,7 +1324,9 @@ class PostEditTest(TestCase):
         self.client.force_login(profile.user)
         # WARNING : if author is not staff he can't send a delete message.
         data = {"delete_message": ""}
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
 
         self.assertEqual(302, response.status_code)
         post = Post.objects.get(pk=topic.last_message.pk)
@@ -1334,7 +1344,9 @@ class PostEditTest(TestCase):
         self.client.force_login(staff.user)
         text_hidden_expected = "Bad guy!"
         data = {"delete_message": "", "text_hidden": text_hidden_expected}
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
 
         self.assertEqual(302, response.status_code)
         post = Post.objects.get(pk=topic.last_message.pk)
@@ -1349,14 +1361,14 @@ class PostEditTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-useful") + f"?message={topic.last_message.pk}", follow=False)
+        response = self.client.post(reverse("forum:post-useful") + f"?message={topic.last_message.pk}", follow=False)
         self.assertEqual(302, response.status_code)
 
         response = self.client.get(topic.get_absolute_url(), follow=False)
         self.assertNotContains(response, "green hidden")
 
         response = self.client.post(
-            reverse("post-edit") + f"?message={topic.last_message.pk}", {"delete_message": ""}, follow=False
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", {"delete_message": ""}, follow=False
         )
         self.assertEqual(302, response.status_code)
 
@@ -1371,7 +1383,9 @@ class PostEditTest(TestCase):
         profile = ProfileFactory()
         self.client.force_login(profile.user)
         data = {"show_message": ""}
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
 
         self.assertEqual(403, response.status_code)
 
@@ -1382,7 +1396,9 @@ class PostEditTest(TestCase):
 
         self.client.force_login(profile.user)
         data = {"show_message": ""}
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
 
         self.assertEqual(403, response.status_code)
 
@@ -1400,7 +1416,9 @@ class PostEditTest(TestCase):
         data = {
             "show_message": "",
         }
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
 
         self.assertEqual(302, response.status_code)
         post = Post.objects.get(pk=topic.last_message.pk)
@@ -1417,7 +1435,7 @@ class PostEditTest(TestCase):
         text_expected = "Bad guy!"
         data = {"signal_message": "", "signal_text": text_expected}
         response = self.client.post(
-            reverse("post-create-alert") + f"?message={topic.last_message.pk}", data, follow=False
+            reverse("forum:post-create-alert") + f"?message={topic.last_message.pk}", data, follow=False
         )
 
         self.assertEqual(302, response.status_code)
@@ -1435,13 +1453,15 @@ class PostEditTest(TestCase):
         self.client.force_login(profile.user)
         data = {"delete_message": ""}
 
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
         self.assertEqual(302, response.status_code)
 
-        response = self.client.get(reverse("post-edit") + f"?message={topic.last_message.pk}")
+        response = self.client.get(reverse("forum:post-edit") + f"?message={topic.last_message.pk}")
         self.assertEqual(403, response.status_code)
 
-        response = self.client.get(reverse("topic-edit") + f"?topic={topic.pk}", follow=False)
+        response = self.client.get(reverse("forum:topic-edit") + f"?topic={topic.pk}", follow=False)
         self.assertEqual(403, response.status_code)
 
     def test_hat_edit(self):
@@ -1461,13 +1481,13 @@ class PostEditTest(TestCase):
             "last_post": topic.last_message.pk,
             "with_hat": hat.pk,
         }
-        self.client.post(reverse("post-new") + f"?sujet={topic.pk}", data, follow=False)
+        self.client.post(reverse("forum:post-new") + f"?sujet={topic.pk}", data, follow=False)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(topic.last_message.hat, hat)  # Hat was used
 
         # test that it's possible to remove the hat
         data = {"text": "A new post!"}
-        self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        self.client.post(reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(topic.last_message.hat, None)  # Hat was removed
 
@@ -1476,7 +1496,7 @@ class PostEditTest(TestCase):
             "text": "A new post!",
             "with_hat": other_hat.pk,
         }
-        self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        self.client.post(reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(topic.last_message.hat, None)  # Hat wasn't used
 
@@ -1486,7 +1506,7 @@ class PostEditTest(TestCase):
             "text": "A new post!",
             "with_hat": other_hat.pk,
         }
-        self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        self.client.post(reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
         topic = Topic.objects.get(pk=topic.pk)  # refresh
         self.assertEqual(topic.last_message.hat, other_hat)  # Now, it works
 
@@ -1501,7 +1521,9 @@ class PostEditTest(TestCase):
         # Edit post
         self.client.force_login(profile.user)
         data = {"text": "A new post!"}
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
         self.assertEqual(302, response.status_code)
 
         # Check that an archive was created
@@ -1516,12 +1538,12 @@ class PostEditTest(TestCase):
 
 class PostUsefulTest(TestCase):
     def test_failure_post_useful_require_method_post(self):
-        response = self.client.get(reverse("post-useful"), follow=False)
+        response = self.client.get(reverse("forum:post-useful"), follow=False)
 
         self.assertEqual(405, response.status_code)
 
     def test_failure_post_useful_with_client_unauthenticated(self):
-        response = self.client.post(reverse("post-useful"), follow=False)
+        response = self.client.post(reverse("forum:post-useful"), follow=False)
 
         self.assertEqual(302, response.status_code)
 
@@ -1532,7 +1554,7 @@ class PostUsefulTest(TestCase):
         profile.save()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-useful"))
+        response = self.client.post(reverse("forum:post-useful"))
 
         self.assertEqual(403, response.status_code)
 
@@ -1540,7 +1562,7 @@ class PostUsefulTest(TestCase):
         profile = ProfileFactory()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-useful") + "?message=abc", follow=False)
+        response = self.client.post(reverse("forum:post-useful") + "?message=abc", follow=False)
 
         self.assertEqual(404, response.status_code)
 
@@ -1548,7 +1570,7 @@ class PostUsefulTest(TestCase):
         profile = ProfileFactory()
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-useful") + "?message=99999", follow=False)
+        response = self.client.post(reverse("forum:post-useful") + "?message=99999", follow=False)
 
         self.assertEqual(404, response.status_code)
 
@@ -1560,7 +1582,7 @@ class PostUsefulTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-useful") + f"?message={topic.last_message.pk}")
+        response = self.client.post(reverse("forum:post-useful") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(403, response.status_code)
 
@@ -1570,7 +1592,7 @@ class PostUsefulTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-useful") + f"?message={topic.last_message.pk}")
+        response = self.client.post(reverse("forum:post-useful") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(302, response.status_code)
 
@@ -1581,7 +1603,7 @@ class PostUsefulTest(TestCase):
 
         profile = ProfileFactory()
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-useful") + f"?message={topic.last_message.pk}")
+        response = self.client.post(reverse("forum:post-useful") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(403, response.status_code)
 
@@ -1594,7 +1616,7 @@ class PostUsefulTest(TestCase):
 
         self.client.force_login(profile.user)
         response = self.client.post(
-            reverse("post-useful") + f"?message={post.pk}", HTTP_X_REQUESTED_WITH="XMLHttpRequest", follow=False
+            reverse("forum:post-useful") + f"?message={post.pk}", HTTP_X_REQUESTED_WITH="XMLHttpRequest", follow=False
         )
 
         self.assertEqual(200, response.status_code)
@@ -1608,7 +1630,7 @@ class PostUsefulTest(TestCase):
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
         self.client.force_login(profile.user)
-        response = self.client.post(reverse("post-useful") + f"?message={post.pk}", follow=False)
+        response = self.client.post(reverse("forum:post-useful") + f"?message={post.pk}", follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertTrue(Post.objects.get(pk=post.pk).is_useful)
@@ -1620,7 +1642,7 @@ class PostUsefulTest(TestCase):
 
         staff = StaffProfileFactory()
         self.client.force_login(staff.user)
-        response = self.client.post(reverse("post-useful") + f"?message={topic.last_message.pk}", follow=False)
+        response = self.client.post(reverse("forum:post-useful") + f"?message={topic.last_message.pk}", follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertTrue(Post.objects.get(pk=topic.last_message.pk).is_useful)
@@ -1645,7 +1667,7 @@ class PostUsefulTest(TestCase):
         # Logged-out users should not see any “useful message” button
 
         self.client.logout()
-        response = self.client.get(reverse("topic-posts-list", args=[user_topic.pk, user_topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[user_topic.pk, user_topic.slug()]))
         self.assertNotContains(response, mark_button_under_message)
         self.assertNotContains(response, mark_button_in_menu)
 
@@ -1654,11 +1676,11 @@ class PostUsefulTest(TestCase):
 
         self.client.force_login(user.user)
 
-        response = self.client.get(reverse("topic-posts-list", args=[user_topic.pk, user_topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[user_topic.pk, user_topic.slug()]))
         self.assertContains(response, mark_button_under_message)
         self.assertNotContains(response, mark_button_in_menu)
 
-        response = self.client.get(reverse("topic-posts-list", args=[staff_topic.pk, staff_topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[staff_topic.pk, staff_topic.slug()]))
         self.assertNotContains(response, mark_button_under_message)
         self.assertNotContains(response, mark_button_in_menu)
 
@@ -1667,11 +1689,11 @@ class PostUsefulTest(TestCase):
 
         self.client.force_login(staff.user)
 
-        response = self.client.get(reverse("topic-posts-list", args=[user_topic.pk, user_topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[user_topic.pk, user_topic.slug()]))
         self.assertNotContains(response, mark_button_under_message)
         self.assertContains(response, mark_button_in_menu)
 
-        response = self.client.get(reverse("topic-posts-list", args=[staff_topic.pk, staff_topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[staff_topic.pk, staff_topic.slug()]))
         self.assertContains(response, mark_button_under_message)
         self.assertNotContains(response, mark_button_in_menu)
 
@@ -1685,12 +1707,12 @@ class MessageActionTest(TestCase):
         PostFactory(topic=topic, author=another_profile.user, position=2)
 
         # unauthenticated, no 'Alert' button
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertNotContains(response, "Signaler")
 
         # authenticated, two 'Alert' buttons because we have two messages
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         alerts = [word for word in str(response.content).split() if word == "alert"]
         self.assertEqual(len(alerts), 2)
 
@@ -1699,16 +1721,18 @@ class MessageActionTest(TestCase):
         self.client.force_login(staff.user)
         text_hidden_expected = "Bad guy!"
         data = {"delete_message": "", "text_hidden": text_hidden_expected}
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
         self.assertEqual(302, response.status_code)
 
         # staff can alert all messages
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertContains(response, '<a href="#signal-message-', count=2)
 
         # authenticated, user can alert the hidden message too
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertContains(response, '<a href="#signal-message-', count=2)
 
     def test_hide(self):
@@ -1719,17 +1743,17 @@ class MessageActionTest(TestCase):
         PostFactory(topic=topic, author=another_profile.user, position=2)
 
         # two posts are displayed
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         posts = [word for word in response.content.decode().split() if word == "m'appelle"]
         self.assertEqual(len(posts), 2)
 
         # unauthenticated, no 'Hide' button
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertNotContains(response, "Masquer")
 
         # authenticated, only one 'Hide' buttons because our user only posted one of them
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         hide_buttons = [word for word in response.content.decode().split() if word == "hide"]
         self.assertEqual(len(hide_buttons), 1)
 
@@ -1738,13 +1762,15 @@ class MessageActionTest(TestCase):
         self.client.force_login(staff.user)
         text_hidden_expected = "Bad guy!"
         data = {"delete_message": "", "text_hidden": text_hidden_expected}
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
         self.assertEqual(302, response.status_code)
 
         # unauthenticated
         # only one post is displayed, visitor can see hide reason and cannot show or re-enable
         self.client.logout()
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         posts = [word for word in response.content.decode().split() if word == "m'appelle"]
         self.assertEqual(len(posts), 1)
         self.assertNotContains(response, '<details class="message-text message-hidden-container">')
@@ -1753,14 +1779,14 @@ class MessageActionTest(TestCase):
 
         # user cannot show or re-enable their message
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertNotContains(response, '<details class="message-text message-hidden-container">')
         self.assertNotContains(response, "Démasquer")
         self.assertContains(response, "Bad guy!")
 
         # staff can show or re-enable
         self.client.force_login(staff.user)
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertContains(response, '<details class="message-text message-hidden-container">')
         self.assertContains(response, "Démasquer")
         self.assertContains(response, "Bad guy!")
@@ -1768,12 +1794,14 @@ class MessageActionTest(TestCase):
         data = {
             "show_message": "",
         }
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
         self.assertEqual(302, response.status_code)
 
         # two posts are displayed again
         self.client.logout()
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         posts = [word for word in response.content.decode().split() if word == "m'appelle"]
         self.assertEqual(len(posts), 2)
 
@@ -1781,13 +1809,13 @@ class MessageActionTest(TestCase):
 class PostUnreadTest(TestCase):
     @patch("zds.forum.signals.post_unread")
     def test_failure_post_unread_require_method_get(self, post_unread):
-        response = self.client.post(reverse("post-unread"), follow=False)
+        response = self.client.post(reverse("forum:post-unread"), follow=False)
         self.assertEqual(post_unread.send.call_count, 0)
         self.assertEqual(405, response.status_code)
 
     @patch("zds.forum.signals.post_unread")
     def test_failure_post_unread_with_client_unauthenticated(self, post_unread):
-        response = self.client.get(reverse("post-unread"), follow=False)
+        response = self.client.get(reverse("forum:post-unread"), follow=False)
         self.assertEqual(post_unread.send.call_count, 0)
         self.assertEqual(302, response.status_code)
 
@@ -1799,7 +1827,7 @@ class PostUnreadTest(TestCase):
         profile.save()
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-unread"))
+        response = self.client.get(reverse("forum:post-unread"))
 
         self.assertEqual(post_unread.send.call_count, 0)
         self.assertEqual(403, response.status_code)
@@ -1809,7 +1837,7 @@ class PostUnreadTest(TestCase):
         profile = ProfileFactory()
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-unread") + "?message=abc", follow=False)
+        response = self.client.get(reverse("forum:post-unread") + "?message=abc", follow=False)
 
         self.assertEqual(post_unread.send.call_count, 0)
         self.assertEqual(404, response.status_code)
@@ -1819,7 +1847,7 @@ class PostUnreadTest(TestCase):
         profile = ProfileFactory()
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-unread") + "?message=99999", follow=False)
+        response = self.client.get(reverse("forum:post-unread") + "?message=99999", follow=False)
 
         self.assertEqual(post_unread.send.call_count, 0)
         self.assertEqual(404, response.status_code)
@@ -1833,7 +1861,7 @@ class PostUnreadTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-unread") + f"?message={topic.last_message.pk}")
+        response = self.client.get(reverse("forum:post-unread") + f"?message={topic.last_message.pk}")
 
         self.assertEqual(post_unread.send.call_count, 0)
         self.assertEqual(403, response.status_code)
@@ -1847,7 +1875,7 @@ class PostUnreadTest(TestCase):
         post = PostFactory(topic=topic, author=another_profile.user, position=2)
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-unread") + f"?message={post.pk}", follow=False)
+        response = self.client.get(reverse("forum:post-unread") + f"?message={post.pk}", follow=False)
 
         self.assertEqual(post_unread.send.call_count, 1)
         self.assertEqual(302, response.status_code)
@@ -1855,7 +1883,7 @@ class PostUnreadTest(TestCase):
 
 class FindPostTest(TestCase):
     def test_failure_find_topics_of_a_member_not_found(self):
-        response = self.client.get(reverse("post-find", args=[9999]), follow=False)
+        response = self.client.get(reverse("forum:post-find", args=[9999]), follow=False)
 
         self.assertEqual(404, response.status_code)
 
@@ -1864,7 +1892,7 @@ class FindPostTest(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        response = self.client.get(reverse("post-find", args=[profile.user.pk]), follow=False)
+        response = self.client.get(reverse("forum:post-find", args=[profile.user.pk]), follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context["posts"]))
@@ -1890,7 +1918,7 @@ class FindPostTest(TestCase):
         topic = create_topic_in_forum(forum, profile)
 
         self.client.force_login(profile.user)
-        response = self.client.get(reverse("post-find", args=[profile.user.pk]), follow=False)
+        response = self.client.get(reverse("forum:post-find", args=[profile.user.pk]), follow=False)
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.context["posts"]))

--- a/zds/forum/urls.py
+++ b/zds/forum/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import path
 
 from zds.forum import feeds
 from zds.forum.views import (
@@ -22,39 +22,41 @@ from zds.forum.views import (
     FindFollowedTopic,
 )
 
+app_name = "forum"
+
 urlpatterns = [
     # Feeds
-    re_path(r"^flux/messages/rss/$", feeds.LastPostsFeedRSS(), name="post-feed-rss"),
-    re_path(r"^flux/messages/atom/$", feeds.LastPostsFeedATOM(), name="post-feed-atom"),
-    re_path(r"^flux/sujets/rss/$", feeds.LastTopicsFeedRSS(), name="topic-feed-rss"),
-    re_path(r"^flux/sujets/atom/$", feeds.LastTopicsFeedATOM(), name="topic-feed-atom"),
+    path("flux/messages/rss/", feeds.LastPostsFeedRSS(), name="post-feed-rss"),
+    path("flux/messages/atom/", feeds.LastPostsFeedATOM(), name="post-feed-atom"),
+    path("flux/sujets/rss/", feeds.LastTopicsFeedRSS(), name="topic-feed-rss"),
+    path("flux/sujets/atom/", feeds.LastTopicsFeedATOM(), name="topic-feed-atom"),
     # Developers warning: if you update something here, check and update help_text
     # on ForumCategory slug field
     # Moderation
-    re_path(r"^resolution_alerte/$", solve_alert, name="forum-solve-alert"),
+    path("resolution_alerte/", solve_alert, name="solve-alert"),
     # Viewing a thread
-    re_path(r"^sujet/nouveau/$", TopicNew.as_view(), name="topic-new"),
-    re_path(r"^sujet/editer/$", TopicEdit.as_view(), name="topic-edit"),
-    re_path(r"^sujet/github/(?P<pk>\d+)/$", ManageGitHubIssue.as_view(), name="manage-issue"),
-    re_path(r"^sujet/(?P<topic_pk>\d+)/(?P<topic_slug>.+)/$", TopicPostsListView.as_view(), name="topic-posts-list"),
-    re_path(r"^sujets/membre/(?P<user_pk>\d+)/$", FindTopic.as_view(), name="topic-find"),
-    re_path(r"^sujets/suivis/$", FindFollowedTopic.as_view(), name="followed-topic-find"),
+    path("sujet/nouveau/", TopicNew.as_view(), name="topic-new"),
+    path("sujet/modifier/", TopicEdit.as_view(), name="topic-edit"),
+    path("sujet/github/<int:pk>/", ManageGitHubIssue.as_view(), name="manage-issue"),
+    path("sujet/<int:topic_pk>/<slug:topic_slug>/", TopicPostsListView.as_view(), name="topic-posts-list"),
+    path("sujets/membre/<int:user_pk>/", FindTopic.as_view(), name="topic-find"),
+    path("sujets/suivis/", FindFollowedTopic.as_view(), name="followed-topic-find"),
     # The first is kept for URL backward-compatibility.
-    re_path(r"^sujets/tag/(?P<tag_pk>\d+)/(?P<tag_slug>.+)/$", FindTopicByTag.as_view(), name="old-topic-tag-find"),
-    re_path(r"^sujets/tag/(?P<tag_slug>.+)/$", FindTopicByTag.as_view(), name="topic-tag-find"),
+    path("sujets/tag/<int:tag_pk>/<slug:tag_slug>/", FindTopicByTag.as_view(), name="old-topic-tag-find"),
+    path("sujets/tag/<slug:tag_slug>/", FindTopicByTag.as_view(), name="topic-tag-find"),
     # Message-related
-    re_path(r"^message/nouveau/$", PostNew.as_view(), name="post-new"),
-    re_path(r"^message/editer/$", PostEdit.as_view(), name="post-edit"),
-    re_path(r"^message/utile/$", PostUseful.as_view(), name="post-useful"),
-    re_path(r"^message/signaler/$", PostSignal.as_view(), name="post-create-alert"),
-    re_path(r"^message/nonlu/$", PostUnread.as_view(), name="post-unread"),
-    re_path(r"^messages/(?P<user_pk>\d+)/$", FindPost.as_view(), name="post-find"),
-    # Last subjects.
-    re_path(r"^derniers-sujets/$", LastTopicsListView.as_view(), name="last-subjects"),
-    # Categories and forums list.
-    re_path(r"^$", CategoriesForumsListView.as_view(), name="cats-forums-list"),
+    path("message/nouveau/", PostNew.as_view(), name="post-new"),
+    path("message/modifier/", PostEdit.as_view(), name="post-edit"),
+    path("message/utile/", PostUseful.as_view(), name="post-useful"),
+    path("message/signaler/", PostSignal.as_view(), name="post-create-alert"),
+    path("message/nonlu/", PostUnread.as_view(), name="post-unread"),
+    path("messages/<int:user_pk>/", FindPost.as_view(), name="post-find"),
+    # Last subjects
+    path("derniers-sujets/", LastTopicsListView.as_view(), name="last-subjects"),
+    # Categories and forums list
+    path("", CategoriesForumsListView.as_view(), name="cats-forums-list"),
     # Forum details
-    re_path(r"^(?P<cat_slug>.+)/(?P<forum_slug>.+)/$", ForumTopicsListView.as_view(), name="forum-topics-list"),
+    path("<slug:cat_slug>/<slug:forum_slug>/", ForumTopicsListView.as_view(), name="topics-list"),
     # Forums belonging to one category
-    re_path(r"^(?P<slug>.+)/$", ForumCategoryForumsDetailView.as_view(), name="cat-forums-list"),
+    path("<slug:slug>/", ForumCategoryForumsDetailView.as_view(), name="cat-forums-list"),
 ]

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -189,7 +189,7 @@ class TopicPostsListView(ZdSPagingListView, FeatureableMixin, SingleObjectMixin)
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         form = PostForm(self.object, self.request.user)
-        form.helper.form_action = reverse("post-new") + "?sujet=" + str(self.object.pk)
+        form.helper.form_action = reverse("forum:post-new") + "?sujet=" + str(self.object.pk)
 
         posts = self.build_list_with_previous_item(context["object_list"])
         context.update(
@@ -311,7 +311,7 @@ class TopicEdit(UpdateView, SingleObjectMixin, TopicEditMixin, FeatureableMixin)
     def dispatch(self, request, *args, **kwargs):
         self.object = self.get_object()
         if not self.object.forum.can_read(request.user):
-            return redirect(reverse("cats-forums-list"))
+            return redirect(reverse("forum:cats-forums-list"))
         if (
             ("text" in request.POST or request.method == "GET")
             and self.object.author != request.user
@@ -413,12 +413,12 @@ class TopicEdit(UpdateView, SingleObjectMixin, TopicEditMixin, FeatureableMixin)
 
     def create_form(self, form_class, **kwargs):
         form = form_class(initial=kwargs)
-        form.helper.form_action = reverse("topic-edit") + f"?topic={self.object.pk}"
+        form.helper.form_action = reverse("forum:topic-edit") + f"?topic={self.object.pk}"
         return form
 
     def get_form(self, form_class=TopicForm):
         form = form_class(self.request.POST)
-        form.helper.form_action = reverse("topic-edit") + f"?topic={self.object.pk}"
+        form.helper.form_action = reverse("forum:topic-edit") + f"?topic={self.object.pk}"
         return form
 
     def form_valid(self, form):
@@ -500,7 +500,7 @@ class FindTopicByTag(FilterMixin, ForumEditMixin, ZdSPagingListView, SingleObjec
 
     def get(self, request, *args, **kwargs):
         if self.kwargs.get("tag_pk"):
-            return redirect("topic-tag-find", tag_slug=self.kwargs.get("tag_slug"), permanent=True)
+            return redirect("forum:topic-tag-find", tag_slug=self.kwargs.get("tag_slug"), permanent=True)
         self.object = self.get_object()
         return super().get(request, *args, **kwargs)
 
@@ -579,12 +579,12 @@ class PostNew(CreatePostView):
 
     def create_forum(self, form_class, **kwargs):
         form = form_class(self.object, self.request.user, initial=kwargs)
-        form.helper.form_action = reverse("post-new") + "?sujet=" + str(self.object.pk)
+        form.helper.form_action = reverse("forum:post-new") + "?sujet=" + str(self.object.pk)
         return form
 
     def get_form(self, form_class=PostForm):
         form = self.form_class(self.object, self.request.user, self.request.POST)
-        form.helper.form_action = reverse("post-new") + "?sujet=" + str(self.object.pk)
+        form.helper.form_action = reverse("forum:post-new") + "?sujet=" + str(self.object.pk)
         return form
 
     def form_valid(self, form):
@@ -673,12 +673,12 @@ class PostEdit(UpdateView, SinglePostObjectMixin, PostEditMixin):
 
     def create_form(self, form_class, **kwargs):
         form = form_class(self.object.topic, self.request.user, initial=kwargs)
-        form.helper.form_action = reverse("post-edit") + "?message=" + str(self.object.pk)
+        form.helper.form_action = reverse("forum:post-edit") + "?message=" + str(self.object.pk)
         return form
 
     def get_form(self, form_class=PostForm):
         form = self.form_class(self.object.topic, self.request.user, self.request.POST)
-        form.helper.form_action = reverse("post-edit") + "?message=" + str(self.object.pk)
+        form.helper.form_action = reverse("forum:post-edit") + "?message=" + str(self.object.pk)
         return form
 
     def form_valid(self, form):
@@ -746,7 +746,7 @@ class PostUnread(UpdateView, SinglePostObjectMixin, PostEditMixin):
         self.perform_unread_message(self.object, self.request.user)
 
         return redirect(
-            reverse("forum-topics-list", args=[self.object.topic.forum.category.slug, self.object.topic.forum.slug])
+            reverse("forum:topics-list", args=[self.object.topic.forum.category.slug, self.object.topic.forum.slug])
         )
 
 

--- a/zds/member/views/profile.py
+++ b/zds/member/views/profile.py
@@ -106,7 +106,7 @@ class MemberDetail(DetailView):
         if count_post > 0:
             summary.append(
                 (
-                    reverse_lazy("post-find", args=(profile.user.pk,)),
+                    reverse_lazy("forum:post-find", args=(profile.user.pk,)),
                     count_post,
                     __("message{}").format(pluralize_fr(count_post)),
                 )
@@ -116,7 +116,7 @@ class MemberDetail(DetailView):
         if count_topic > 0:
             summary.append(
                 (
-                    reverse_lazy("topic-find", args=(profile.user.pk,)),
+                    reverse_lazy("forum:topic-find", args=(profile.user.pk,)),
                     count_topic,
                     __("sujet{} créé{}").format(pluralize_fr(count_topic), pluralize_fr(count_topic)),
                 )
@@ -126,7 +126,7 @@ class MemberDetail(DetailView):
         if count_followed_topic > 0 and is_user_profile:
             summary.append(
                 (
-                    reverse_lazy("followed-topic-find"),
+                    reverse_lazy("forum:followed-topic-find"),
                     count_followed_topic,
                     __("sujet{} suivi{}").format(
                         pluralize_fr(count_followed_topic), pluralize_fr(count_followed_topic)

--- a/zds/member/views/register.py
+++ b/zds/member/views/register.py
@@ -265,7 +265,7 @@ def activate_account(request):
             "site_name": settings.ZDS_APP["site"]["literal_name"],
             "library_url": settings.ZDS_APP["site"]["url"] + reverse("publication:list"),
             "opinions_url": settings.ZDS_APP["site"]["url"] + reverse("opinion:list"),
-            "forums_url": settings.ZDS_APP["site"]["url"] + reverse("cats-forums-list"),
+            "forums_url": settings.ZDS_APP["site"]["url"] + reverse("forum:cats-forums-list"),
         },
     )
 

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -60,7 +60,7 @@ class NotificationForumTest(TestCase):
         When we create a topic, the author follows it.
         """
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum12.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum12.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -103,7 +103,7 @@ class NotificationForumTest(TestCase):
         )
         self.assertIsNotNone(notification)
 
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertEqual(response.status_code, 200)
 
         # Checks that the notification is reading now.
@@ -124,7 +124,7 @@ class NotificationForumTest(TestCase):
         PostFactory(topic=topic1, author=self.user2, position=1)
 
         result = self.client.post(
-            reverse("post-new") + f"?sujet={topic1.pk}",
+            reverse("forum:post-new") + f"?sujet={topic1.pk}",
             {
                 "last_post": topic1.last_message.pk,
                 "text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter ",
@@ -157,7 +157,7 @@ class NotificationForumTest(TestCase):
         PostFactory(topic=topic1, author=self.user2, position=1)
 
         result = self.client.post(
-            reverse("post-new") + f"?sujet={topic1.pk}",
+            reverse("forum:post-new") + f"?sujet={topic1.pk}",
             {
                 "last_post": topic1.last_message.pk,
                 "text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter ",
@@ -173,7 +173,9 @@ class NotificationForumTest(TestCase):
         self.client.logout()
         self.client.force_login(self.user2)
 
-        result = self.client.get(reverse("topic-posts-list", args=[topic1.pk, old_slugify(topic1.title)]), follow=True)
+        result = self.client.get(
+            reverse("forum:topic-posts-list", args=[topic1.pk, old_slugify(topic1.title)]), follow=True
+        )
         self.assertEqual(result.status_code, 200)
 
         notification = Notification.objects.get(subscription__user=self.user2)
@@ -198,7 +200,7 @@ class NotificationForumTest(TestCase):
 
         self.client.force_login(StaffProfileFactory().user)
         data = {"move": "", "forum": forum_not_read.pk, "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(302, response.status_code)
         self.assertIsNotNone(TopicAnswerSubscription.objects.get_existing(self.user1, topic, is_active=False))
@@ -215,7 +217,7 @@ class NotificationForumTest(TestCase):
         PostFactory(topic=topic1, author=self.user1, position=2)
         post = PostFactory(topic=topic1, author=self.user2, position=3)
 
-        result = self.client.get(reverse("post-unread") + f"?message={post.pk}", follow=False)
+        result = self.client.get(reverse("forum:post-unread") + f"?message={post.pk}", follow=False)
 
         self.assertEqual(result.status_code, 302)
 
@@ -238,7 +240,9 @@ class NotificationForumTest(TestCase):
         # hide last post
         data = {"delete_message": ""}
         self.client.force_login(StaffProfileFactory().user)
-        response = self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        response = self.client.post(
+            reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False
+        )
         self.assertEqual(302, response.status_code)
 
         notifications = Notification.objects.filter(object_id=topic.last_message.pk, is_read=True).all()
@@ -326,7 +330,7 @@ class NotificationForumTest(TestCase):
         notifications = Notification.objects.filter(object_id=topic.pk, is_read=False).all()
         self.assertEqual(1, len(notifications))
 
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertEqual(response.status_code, 200)
 
         notifications = Notification.objects.filter(object_id=topic.pk, is_read=False).all()
@@ -344,7 +348,7 @@ class NotificationForumTest(TestCase):
         staff = StaffProfileFactory()
         self.client.force_login(staff.user)
         data = {"move": "", "forum": self.forum12.pk, "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
         self.assertEqual(302, response.status_code)
 
         topic = Topic.objects.get(pk=topic.pk)
@@ -353,7 +357,7 @@ class NotificationForumTest(TestCase):
 
         self.client.logout()
         self.client.force_login(self.user1)
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertEqual(200, response.status_code)
 
         self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=True).all()))
@@ -386,7 +390,7 @@ class NotificationForumTest(TestCase):
         staff = StaffProfileFactory()
         self.client.force_login(staff.user)
         data = {"move": "", "forum": self.forum12.pk, "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
         self.assertEqual(302, response.status_code)
 
         topic = Topic.objects.get(pk=topic.pk)
@@ -395,7 +399,7 @@ class NotificationForumTest(TestCase):
 
         self.client.logout()
         self.client.force_login(self.user1)
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertEqual(200, response.status_code)
 
         self.assertEqual(1, len(Notification.objects.filter(object_id=topic.pk, is_read=True, is_dead=False).all()))
@@ -456,7 +460,7 @@ class NotificationForumTest(TestCase):
         notifications = Notification.objects.filter(object_id=topic.pk, is_read=False).all()
         self.assertEqual(1, len(notifications))
 
-        response = self.client.get(reverse("topic-posts-list", args=[topic.pk, topic.slug()]))
+        response = self.client.get(reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]))
         self.assertEqual(response.status_code, 200)
 
         notifications = Notification.objects.filter(object_id=topic.pk, is_read=False).all()
@@ -472,7 +476,7 @@ class NotificationForumTest(TestCase):
         PostFactory(topic=topic, author=self.user1, position=1)
 
         self.client.post(
-            reverse("topic-edit") + f"?topic={topic.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic.pk}",
             {
                 "title": "Un autre sujet",
                 "subtitle": "Encore ces lombards en plein ete",
@@ -499,7 +503,7 @@ class NotificationForumTest(TestCase):
         self.assertEqual(1, len(notifications))
 
         self.client.post(
-            reverse("topic-edit") + f"?topic={topic.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic.pk}",
             {
                 "title": "Un autre sujet",
                 "subtitle": "Encore ces lombards en plein été",

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -51,7 +51,7 @@ class ForumNotification(TestCase):
     def test_ping_unknown(self):
         self.client.force_login(self.user2)
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum11.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum11.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -68,7 +68,7 @@ class ForumNotification(TestCase):
     def test_no_auto_ping(self):
         self.client.force_login(self.user2)
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum11.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum11.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -87,7 +87,7 @@ class ForumNotification(TestCase):
         pinged_users = [ProfileFactory(), ProfileFactory(), ProfileFactory(), ProfileFactory()]
         self.client.force_login(self.user2)
         self.client.post(
-            reverse("topic-new") + f"?forum={self.forum11.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum11.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -104,7 +104,7 @@ class ForumNotification(TestCase):
         self.assertFalse(PingSubscription.objects.get_existing(pinged_users[2].user, post, True))
         self.assertFalse(PingSubscription.objects.get_existing(pinged_users[3].user, post, True))
         self.client.post(
-            reverse("topic-edit") + f"?topic={topic.pk}",
+            reverse("forum:topic-edit") + f"?topic={topic.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -123,7 +123,7 @@ class ForumNotification(TestCase):
         """
         self.client.force_login(self.user2)
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum11.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum11.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -140,7 +140,7 @@ class ForumNotification(TestCase):
         user3 = ProfileFactory().user
         post = Topic.objects.last().last_message
         result = self.client.post(
-            reverse("post-edit") + f"?message={post.pk}",
+            reverse("forum:post-edit") + f"?message={post.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -153,7 +153,7 @@ class ForumNotification(TestCase):
         self.assertEqual(1, PingSubscription.objects.count(), "No added subscription.")
         self.assertEqual(1, Notification.objects.count())
         result = self.client.post(
-            reverse("post-edit") + f"?message={post.pk}",
+            reverse("forum:post-edit") + f"?message={post.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -174,7 +174,7 @@ class ForumNotification(TestCase):
         """
         self.client.force_login(self.user2)
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum11.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum11.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -190,7 +190,7 @@ class ForumNotification(TestCase):
         self.assertEqual(1, Notification.objects.count())
         post = Topic.objects.last().last_message
         result = self.client.post(
-            reverse("post-edit") + f"?message={post.pk}",
+            reverse("forum:post-edit") + f"?message={post.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -209,7 +209,7 @@ class ForumNotification(TestCase):
         NewTopicSubscription.objects.get_or_create_active(self.user1, self.forum11)
         self.client.force_login(self.user2)
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum11.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum11.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -228,7 +228,7 @@ class ForumNotification(TestCase):
         self.client.logout()
         self.client.force_login(self.staff)
         data = {"move": "", "forum": self.forum12.pk, "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
         self.assertEqual(302, response.status_code)
         subscription = NewTopicSubscription.objects.get_existing(self.user1, self.forum11, True)
         self.assertIsNotNone(subscription, "There must still be an active subscription")
@@ -241,7 +241,7 @@ class ForumNotification(TestCase):
     def test_no_ping_on_private_forum(self):
         self.client.force_login(self.staff)
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum12.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum12.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -259,7 +259,7 @@ class ForumNotification(TestCase):
     def test_no_dead_ping_notif_on_moving_to_private_forum(self):
         self.client.force_login(self.user2)
         result = self.client.post(
-            reverse("topic-new") + f"?forum={self.forum11.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum11.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -278,7 +278,7 @@ class ForumNotification(TestCase):
         self.client.logout()
         self.client.force_login(self.staff)
         data = {"move": "", "forum": self.forum12.pk, "topic": topic.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
         self.assertEqual(302, response.status_code)
         subscription = PingSubscription.objects.get_existing(self.user1, topic.last_message, True)
         self.assertIsNotNone(subscription, "There must still be an active subscription")
@@ -292,7 +292,7 @@ class ForumNotification(TestCase):
         NewTopicSubscription.objects.get_or_create_active(self.to_be_changed_staff, self.forum12)
         self.client.force_login(self.staff)
         self.client.post(
-            reverse("topic-new") + f"?forum={self.forum12.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum12.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -318,7 +318,7 @@ class ForumNotification(TestCase):
         NewTopicSubscription.objects.get_or_create_active(self.to_be_changed_staff, self.forum12)
         self.client.force_login(self.staff)
         self.client.post(
-            reverse("topic-new") + f"?forum={self.forum12.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum12.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -343,7 +343,7 @@ class ForumNotification(TestCase):
     def test_no_more_topic_answer_notif_on_losing_all_groups(self):
         self.client.force_login(self.to_be_changed_staff)
         self.client.post(
-            reverse("topic-new") + f"?forum={self.forum12.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum12.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -356,7 +356,7 @@ class ForumNotification(TestCase):
 
         self.client.force_login(self.staff)
         self.client.post(
-            reverse("post-new") + f"?sujet={topic.pk}",
+            reverse("forum:post-new") + f"?sujet={topic.pk}",
             {
                 "last_post": topic.last_message.pk,
                 "text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter ",
@@ -384,7 +384,7 @@ class ForumNotification(TestCase):
     def test_no_more_topic_answer_notif_on_losing_one_group(self):
         self.client.force_login(self.to_be_changed_staff)
         self.client.post(
-            reverse("topic-new") + f"?forum={self.forum12.pk}",
+            reverse("forum:topic-new") + f"?forum={self.forum12.pk}",
             {
                 "title": "Super sujet",
                 "subtitle": "Pour tester les notifs",
@@ -397,7 +397,7 @@ class ForumNotification(TestCase):
 
         self.client.force_login(self.staff)
         self.client.post(
-            reverse("post-new") + f"?sujet={topic.pk}",
+            reverse("forum:post-new") + f"?sujet={topic.pk}",
             {
                 "last_post": topic.last_message.pk,
                 "text": "C'est tout simplement l'histoire de la ville de Paris que je voudrais vous conter ",

--- a/zds/pages/tests.py
+++ b/zds/pages/tests.py
@@ -206,7 +206,7 @@ class CommentEditsHistoryTests(TestCase):
 
         self.client.force_login(self.user)
         data = {"text": "A new post!"}
-        self.client.post(reverse("post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
+        self.client.post(reverse("forum:post-edit") + f"?message={topic.last_message.pk}", data, follow=False)
         self.post = topic.last_message
         self.edit = CommentEdit.objects.latest("date")
 

--- a/zds/searchv2/tests/tests_views.py
+++ b/zds/searchv2/tests/tests_views.py
@@ -621,7 +621,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.client.force_login(self.staff)
 
         data = {"move": "", "forum": hidden_forum.pk, "topic": topic_1.pk}
-        response = self.client.post(reverse("topic-edit"), data, follow=False)
+        response = self.client.post(reverse("forum:topic-edit"), data, follow=False)
 
         self.assertEqual(302, response.status_code)
 

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -82,7 +82,7 @@ admin.autodiscover()
 
 urlpatterns = [
     re_path(r"^", include(("zds.tutorialv2.urls", ""))),
-    re_path(r"^forums/", include(("zds.forum.urls", ""))),
+    path("forums/", include("zds.forum.urls")),
     path("mp/", include("zds.mp.urls")),
     re_path(r"^membres/", include(("zds.member.urls", ""))),
     re_path(r"^admin/", admin.site.urls),

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -772,7 +772,7 @@ class Tag(models.Model):
         return self.title
 
     def get_absolute_url(self):
-        return reverse("topic-tag-find", kwargs={"tag_slug": self.slug})
+        return reverse("forum:topic-tag-find", kwargs={"tag_slug": self.slug})
 
     def save(self, *args, **kwargs):
         self.title = self.title.strip()

--- a/zds/utils/tests/tests_comments.py
+++ b/zds/utils/tests/tests_comments.py
@@ -49,8 +49,8 @@ class PotentialSpamTests(TutorialTestMixin, TestCase):
         comment = topic.last_message
 
         self.common_test_mark_as_potential_spam(
-            url_comments_list=reverse("topic-posts-list", args=[topic.pk, topic.slug()]),
-            url_comment_edit=reverse("post-edit") + f"?message={comment.pk}",
+            url_comments_list=reverse("forum:topic-posts-list", args=[topic.pk, topic.slug()]),
+            url_comment_edit=reverse("forum:post-edit") + f"?message={comment.pk}",
             comment=comment,
             author=author,
             staff=staff,


### PR DESCRIPTION
Lié à #6246.

Au menu de cette refacto des URL du forum :

* utilise un namespace,
* utilise path au lieu de re_path,
* remplacer "editer" par "modifier",

### Contrôle qualité

Vérifier que les forums continuent de fonctionner nominalement (juste exercer toutes les routes).