### PR TITLE
Refactorise les URL munin

### DIFF
--- a/zds/munin/urls.py
+++ b/zds/munin/urls.py
@@ -1,13 +1,13 @@
-from django.urls import re_path
+from django.urls import path
 
 from zds.munin.views import total_topics, total_posts, total_mps, total_tutorials, total_articles, total_opinions
 
 
 urlpatterns = [
-    re_path(r"^total_topics/$", total_topics, name="total_topics"),
-    re_path(r"^total_posts/$", total_posts, name="total_posts"),
-    re_path(r"^total_mps/$", total_mps, name="total_mp"),
-    re_path(r"^total_tutorials/$", total_tutorials, name="total_tutorial"),
-    re_path(r"^total_articles/$", total_articles, name="total_articles"),
-    re_path(r"^total_opinions/$", total_opinions, name="total_opinions"),
+    path("total_topics/", total_topics, name="total_topics"),
+    path("total_posts/", total_posts, name="total_posts"),
+    path("total_mps/", total_mps, name="total_mp"),
+    path("total_tutorials/", total_tutorials, name="total_tutorial"),
+    path("total_articles/", total_articles, name="total_articles"),
+    path("total_opinions/", total_opinions, name="total_opinions"),
 ]

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -90,7 +90,7 @@ urlpatterns = [
     re_path(r"^pages/", include(("zds.pages.urls", ""))),
     re_path(r"^galerie/", include(("zds.gallery.urls", ""))),
     re_path(r"^rechercher/", include(("zds.searchv2.urls", "zds.searchv2"), namespace="search")),
-    re_path(r"^munin/", include(("zds.munin.urls", ""))),
+    path("munin/", include(("zds.munin.urls", ""))),
     re_path(r"^mise-en-avant/", include(("zds.featured.urls", ""))),
     re_path(r"^notifications/", include(("zds.notification.urls", ""))),
     path("", include(("social_django.urls", "social_django"), namespace="social")),


### PR DESCRIPTION
Lié à #6246.

Au menu de cette refacto des URL munin : path au lieu de re_path.

### Contrôle qualité

Je ne sais pas trop comment vérifier... J'ai pas du tout touché à la forme du motif, donc ça devrait passer, mais l'optimisme, c'est pas de la QA.