### PR TITLE
Refactorise les URL de notifications

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -260,7 +260,7 @@
 
                 {# NOTIFICATIONS #}
                 <div>
-                    <a href="{% url 'notification-list' %}" class="ico-link" title="{% trans 'Notifications' %}">
+                    <a href="{% url "notification:list" %}" class="ico-link" title="{% trans 'Notifications' %}">
                         {% if header_general_notifications.total > 0 %}
                             <span class="notif-count">{{ header_general_notifications.total }}</span>
                         {% endif %}
@@ -290,7 +290,7 @@
                                 </li>
                             {% endif %}
                         </ul>
-                        <a href="{% url 'notification-list' %}" class="dropdown-link-all">
+                        <a href="{% url "notification:list" %}" class="dropdown-link-all">
                             {% trans "Toutes les notifications" %}
                         </a>
                     </div>

--- a/templates/notification/followed.html
+++ b/templates/notification/followed.html
@@ -64,7 +64,7 @@
             <ul>
                 <li>
                     <a href="#mark-notifications-as-read" class="open-modal ico-after tick green">{% trans 'Tout marquer comme lu' %}</a>
-                    <form action="{% url 'mark-notifications-as-read' %}" method="post" id="mark-notifications-as-read" class="modal modal-flex">
+                    <form action="{% url "notification:mark-as-read" %}" method="post" id="mark-notifications-as-read" class="modal modal-flex">
                         {% csrf_token %}
                         <p>
                             {% trans 'Voulez-vous vraiment marquer toutes vos notifications comme lues ?' %}

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -949,7 +949,7 @@ class NotificationTest(TestCase):
 
         self.assertFalse(topic.is_read)
 
-        result = self.client.post(reverse("mark-notifications-as-read"), follow=False)
+        result = self.client.post(reverse("notification:mark-as-read"), follow=False)
         self.assertEqual(result.status_code, 302)
 
         notifications = Notification.objects.get_unread_notifications_of(self.user1)

--- a/zds/notification/urls.py
+++ b/zds/notification/urls.py
@@ -1,8 +1,10 @@
-from django.urls import re_path
+from django.urls import path
 
 from zds.notification.views import NotificationList, mark_notifications_as_read
 
+app_name = "notification"
+
 urlpatterns = [
-    re_path(r"^$", NotificationList.as_view(), name="notification-list"),
-    re_path(r"^marquer-comme-lues/$", mark_notifications_as_read, name="mark-notifications-as-read"),
+    path("", NotificationList.as_view(), name="list"),
+    path("marquer-comme-lues/", mark_notifications_as_read, name="mark-as-read"),
 ]

--- a/zds/notification/views.py
+++ b/zds/notification/views.py
@@ -64,4 +64,4 @@ def mark_notifications_as_read(request):
 
     messages.success(request, _("Vos notifications ont bien été marquées comme lues."))
 
-    return redirect(reverse("notification-list"))
+    return redirect(reverse("notification:list"))

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -92,7 +92,7 @@ urlpatterns = [
     re_path(r"^rechercher/", include(("zds.searchv2.urls", "zds.searchv2"), namespace="search")),
     re_path(r"^munin/", include(("zds.munin.urls", ""))),
     re_path(r"^mise-en-avant/", include(("zds.featured.urls", ""))),
-    re_path(r"^notifications/", include(("zds.notification.urls", ""))),
+    path("notifications/", include("zds.notification.urls")),
     path("", include(("social_django.urls", "social_django"), namespace="social")),
     re_path(r"^munin/", include(("munin.urls", "munin"))),
     re_path(r"^$", home_view, name="homepage"),


### PR DESCRIPTION
Lié à #6246.

Au menu de cette refacto des URL de notification : 
* path au lieu de re_path,
* un namespace,
* des petits changement de noms possibles grâce au namespace.

### Contrôle qualité

Effacer toutes les notifs et afficher la liste de toutes les notifications.