### PR TITLE
Refactorise les URL de 'pages'

### DIFF
--- a/zds/pages/urls.py
+++ b/zds/pages/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import path
 
 from zds.pages.views import (
     about,
@@ -16,16 +16,16 @@ from zds.pages.views import (
 
 urlpatterns = [
     # single pages
-    re_path(r"^apropos/$", about, name="pages-about"),
-    re_path(r"^association/$", association, name="pages-association"),
-    re_path(r"^contact/$", ContactView.as_view(), name="pages-contact"),
-    re_path(r"^cgu/$", eula, name="pages-eula"),
-    re_path(r"^alertes/$", alerts, name="pages-alerts"),
-    re_path(r"^cookies/$", cookies, name="pages-cookies"),
-    re_path(r"^historique-editions/(?P<comment_pk>\d+)/$", CommentEditsHistory.as_view(), name="comment-edits-history"),
-    re_path(r"^contenu-original/(?P<pk>\d+)/$", EditDetail.as_view(), name="edit-detail"),
-    re_path(r"^restaurer-edition/(?P<edit_pk>\d+)/$", restore_edit, name="restore-edit"),
-    re_path(r"^supprimer-contenu-edition/(?P<edit_pk>\d+)/$", delete_edit_content, name="delete-edit-content"),
+    path("apropos/", about, name="pages-about"),
+    path("association/", association, name="pages-association"),
+    path("contact/", ContactView.as_view(), name="pages-contact"),
+    path("cgu/", eula, name="pages-eula"),
+    path("alertes/", alerts, name="pages-alerts"),
+    path("cookies/", cookies, name="pages-cookies"),
+    path("historique-editions/<int:comment_pk>/", CommentEditsHistory.as_view(), name="comment-edits-history"),
+    path("contenu-original/<int:pk>/", EditDetail.as_view(), name="edit-detail"),
+    path("restaurer-edition/<int:edit_pk>/", restore_edit, name="restore-edit"),
+    path("supprimer-contenu-edition/<int:edit_pk>/", delete_edit_content, name="delete-edit-content"),
     # index
-    re_path(r"^$", index, name="pages-index"),
+    path("", index, name="pages-index"),
 ]

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -87,7 +87,7 @@ urlpatterns = [
     re_path(r"^mp/", include(("zds.mp.urls", ""))),
     re_path(r"^membres/", include(("zds.member.urls", ""))),
     re_path(r"^admin/", admin.site.urls),
-    re_path(r"^pages/", include(("zds.pages.urls", ""))),
+    path("pages/", include("zds.pages.urls")),
     re_path(r"^galerie/", include(("zds.gallery.urls", ""))),
     re_path(r"^rechercher/", include(("zds.searchv2.urls", "zds.searchv2"), namespace="search")),
     re_path(r"^munin/", include(("zds.munin.urls", ""))),


### PR DESCRIPTION
Lié à #6246.

Au menu de cette refacto des URL de 'pages' : path au lieu de re_path et c'est tout. J'ai rien changé d'autre, parce qu'on a des URL un peu généralistes qui se sont retrouvée là et je préfère ne pas y toucher.

### Contrôle qualité

Se promener sur les pages genre "à propos" et compagnie. Exercer les routes pour l'historique d'édition de messages.