### PR TITLE
Refactorise les URL de recherche

### DIFF
--- a/zds/searchv2/urls.py
+++ b/zds/searchv2/urls.py
@@ -1,9 +1,11 @@
-from django.urls import re_path
+from django.urls import path
 from zds.searchv2.views import SearchView, opensearch, SimilarTopicsView, SuggestionContentView
 
+app_name = "search"
+
 urlpatterns = [
-    re_path(r"^$", SearchView.as_view(), name="query"),
-    re_path(r"^sujets-similaires/$", SimilarTopicsView.as_view(), name="similar"),
-    re_path(r"^suggestion-contenu/$", SuggestionContentView.as_view(), name="suggestion"),
-    re_path(r"^opensearch\.xml$", opensearch, name="opensearch"),
+    path("", SearchView.as_view(), name="query"),
+    path("sujets-similaires/", SimilarTopicsView.as_view(), name="similar"),
+    path("suggestion-contenu/", SuggestionContentView.as_view(), name="suggestion"),
+    path("opensearch.xml", opensearch, name="opensearch"),
 ]

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -89,7 +89,7 @@ urlpatterns = [
     re_path(r"^admin/", admin.site.urls),
     re_path(r"^pages/", include(("zds.pages.urls", ""))),
     re_path(r"^galerie/", include(("zds.gallery.urls", ""))),
-    re_path(r"^rechercher/", include(("zds.searchv2.urls", "zds.searchv2"), namespace="search")),
+    path("rechercher/", include("zds.searchv2.urls")),
     re_path(r"^munin/", include(("zds.munin.urls", ""))),
     re_path(r"^mise-en-avant/", include(("zds.featured.urls", ""))),
     re_path(r"^notifications/", include(("zds.notification.urls", ""))),


### PR DESCRIPTION
Lié à #6246.

Au menu de cette refacto des URL de recherche : 

* path au lieu de re_path 
* déplacement du namespace sous forme de "app_name" (c'est équivalent pour notre usage et plus local)

### Contrôle qualité

Exercer les différentes routes de recherche du fichier urls.py.