### PR TITLE
Refactorise les URL des contenus

### DIFF
--- a/zds/tutorialv2/urls/__init__.py
+++ b/zds/tutorialv2/urls/__init__.py
@@ -1,18 +1,16 @@
-from django.urls import include, re_path
+from django.urls import include, path
 
 urlpatterns = [
-    re_path(r"^contenus/", include(("zds.tutorialv2.urls.urls_contents", "zds.tutorialv2.urls"), namespace="content")),
-    re_path(
-        r"^validations/",
+    path("contenus/", include(("zds.tutorialv2.urls.urls_contents", "zds.tutorialv2.urls"), namespace="content")),
+    path(
+        "validations/",
         include(("zds.tutorialv2.urls.urls_validations", "zds.tutorialv2.urls"), namespace="validation"),
     ),
-    re_path(
-        r"^tutoriels/", include(("zds.tutorialv2.urls.urls_tutorials", "zds.tutorialv2.urls"), namespace="tutorial")
-    ),
-    re_path(r"^billets/", include(("zds.tutorialv2.urls.urls_opinions", "zds.tutorialv2.urls"), namespace="opinion")),
-    re_path(r"^articles/", include(("zds.tutorialv2.urls.urls_articles", "zds.tutorialv2.urls"), namespace="article")),
-    re_path(
-        r"^bibliotheque/",
+    path("tutoriels/", include(("zds.tutorialv2.urls.urls_tutorials", "zds.tutorialv2.urls"), namespace="tutorial")),
+    path("billets/", include(("zds.tutorialv2.urls.urls_opinions", "zds.tutorialv2.urls"), namespace="opinion")),
+    path("articles/", include(("zds.tutorialv2.urls.urls_articles", "zds.tutorialv2.urls"), namespace="article")),
+    path(
+        "bibliotheque/",
         include(("zds.tutorialv2.urls.urls_publications", "zds.tutorialv2.urls"), namespace="publication"),
     ),
 ]

--- a/zds/tutorialv2/urls/urls_articles.py
+++ b/zds/tutorialv2/urls/urls_articles.py
@@ -9,35 +9,27 @@ from zds.tutorialv2.feeds import LastArticlesFeedRSS, LastArticlesFeedATOM
 
 urlpatterns = [
     # Flux
-    re_path(r"^flux/rss/$", LastArticlesFeedRSS(), name="feed-rss"),
-    re_path(r"^flux/atom/$", LastArticlesFeedATOM(), name="feed-atom"),
+    path("flux/rss/", LastArticlesFeedRSS(), name="feed-rss"),
+    path("flux/atom/", LastArticlesFeedATOM(), name="feed-atom"),
     # View
-    re_path(r"^(?P<pk>\d+)/(?P<slug>.+)/$", DisplayOnlineArticle.as_view(), name="view"),
+    path("<int:pk>/<slug:slug>/", DisplayOnlineArticle.as_view(), name="view"),
     # Downloads
-    re_path(
-        r"^md/(?P<pk>\d+)/(?P<slug>.+)\.md$", DownloadOnlineArticle.as_view(requested_file="md"), name="download-md"
-    ),
-    re_path(
-        r"^html/(?P<pk>\d+)/(?P<slug>.+)\.html$",
+    path("md/<int:pk>/<slug:slug>.md", DownloadOnlineArticle.as_view(requested_file="md"), name="download-md"),
+    path(
+        "html/<int:pk>/<slug:slug>.html",
         DownloadOnlineArticle.as_view(requested_file="html"),
         name="download-html",
     ),
-    re_path(
-        r"^pdf/(?P<pk>\d+)/(?P<slug>.+)\.pdf$", DownloadOnlineArticle.as_view(requested_file="pdf"), name="download-pdf"
-    ),
-    re_path(
-        r"^tex/(?P<pk>\d+)/(?P<slug>.+)\.tex$", DownloadOnlineArticle.as_view(requested_file="tex"), name="download-tex"
-    ),
-    re_path(
-        r"^epub/(?P<pk>\d+)/(?P<slug>.+)\.epub$",
+    path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineArticle.as_view(requested_file="pdf"), name="download-pdf"),
+    path("tex/<int:pk>/<slug:slug>.tex", DownloadOnlineArticle.as_view(requested_file="tex"), name="download-tex"),
+    path(
+        "epub/<int:pk>/<slug:slug>.epub",
         DownloadOnlineArticle.as_view(requested_file="epub"),
         name="download-epub",
     ),
-    re_path(
-        r"^zip/(?P<pk>\d+)/(?P<slug>.+)\.zip$", DownloadOnlineArticle.as_view(requested_file="zip"), name="download-zip"
-    ),
+    path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineArticle.as_view(requested_file="zip"), name="download-zip"),
     # Listing
-    re_path(r"^$", RedirectView.as_view(pattern_name="publication:list", permanent=True)),
+    path("", RedirectView.as_view(pattern_name="publication:list", permanent=True)),
     re_path(r"tags/*", TagsListView.as_view(displayed_types=["ARTICLE"]), name="tags"),
     path(
         "voir/<str:username>/",

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -43,10 +43,8 @@ from zds.tutorialv2.views.comments import (
 
 urlpatterns = [
     # Flux
-    re_path(r"^flux/rss/$", RedirectView.as_view(pattern_name="publication:feed-rss", permanent=True), name="feed-rss"),
-    re_path(
-        r"^flux/atom/$", RedirectView.as_view(pattern_name="publication:feed-atom", permanent=True), name="feed-atom"
-    ),
+    path("flux/rss/", RedirectView.as_view(pattern_name="publication:feed-rss", permanent=True), name="feed-rss"),
+    path("flux/atom/", RedirectView.as_view(pattern_name="publication:feed-atom", permanent=True), name="feed-atom"),
     path("voir/<str:username>/", ContentOfAuthor.as_view(type="ALL", context_object_name="contents"), name="find-all"),
     path(
         "contributions/<str:username>/",
@@ -57,139 +55,133 @@ urlpatterns = [
     path("tutoriels/<int:pk>/", RedirectOldContentOfAuthor.as_view(type="TUTORIAL")),
     path("articles/<int:pk>/", RedirectOldContentOfAuthor.as_view(type="ARTICLE")),
     path("tribunes/<int:pk>/", RedirectOldContentOfAuthor.as_view(type="OPINION")),
-    re_path(r"^aides/$", ContentsWithHelps.as_view(), name="helps"),
-    re_path(r"^aides/(?P<pk>\d+)/change/$", ChangeHelp.as_view(), name="helps-change"),
-    re_path(
-        r"^(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/(?P<container_slug>.+)/$",
+    path("aides/", ContentsWithHelps.as_view(), name="helps"),
+    path("aides/<int:pk>/change/", ChangeHelp.as_view(), name="helps-change"),
+    path(
+        "<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/",
         DisplayContainer.as_view(public_is_prioritary=False),
         name="view-container",
     ),
-    re_path(
-        r"^(?P<pk>\d+)/(?P<slug>.+)/(?P<container_slug>.+)/$",
+    path(
+        "<int:pk>/<slug:slug>/<slug:container_slug>/",
         DisplayContainer.as_view(public_is_prioritary=False),
         name="view-container",
     ),
-    re_path(r"^(?P<pk>\d+)/(?P<slug>.+)/$", DisplayContent.as_view(public_is_prioritary=False), name="view"),
-    re_path(r"^telecharger/(?P<pk>\d+)/(?P<slug>.+)/$", DownloadContent.as_view(), name="download-zip"),
+    path("<int:pk>/<slug:slug>/", DisplayContent.as_view(public_is_prioritary=False), name="view"),
+    path("telecharger/<int:pk>/<slug:slug>/", DownloadContent.as_view(), name="download-zip"),
     # beta:
-    re_path(
-        r"^beta/(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/(?P<container_slug>.+)/$",
+    path(
+        "beta/<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/",
         DisplayBetaContainer.as_view(public_is_prioritary=False),
         name="beta-view-container",
     ),
-    re_path(
-        r"^beta/(?P<pk>\d+)/(?P<slug>.+)/(?P<container_slug>.+)/$",
+    path(
+        "beta/<int:pk>/<slug:slug>/<slug:container_slug>/",
         DisplayBetaContainer.as_view(public_is_prioritary=False),
         name="beta-view-container",
     ),
-    re_path(r"^beta/(?P<pk>\d+)/(?P<slug>.+)/$", DisplayBetaContent.as_view(), name="beta-view"),
+    path("beta/<int:pk>/<slug:slug>/", DisplayBetaContent.as_view(), name="beta-view"),
     # reactions:
-    re_path(r"^reactions/ajouter/$", SendNoteFormView.as_view(redirection_is_needed=False), name="add-reaction"),
-    re_path(r"^reactions/editer/$", UpdateNoteView.as_view(redirection_is_needed=False), name="update-reaction"),
-    re_path(r"^reactions/cacher/(?P<pk>\d+)/$", HideReaction.as_view(), name="hide-reaction"),
-    re_path(r"^reactions/afficher/(?P<pk>\d+)/$", ShowReaction.as_view(), name="show-reaction"),
-    re_path(r"^reactions/alerter/(?P<pk>\d+)/$", SendNoteAlert.as_view(), name="alert-reaction"),
-    re_path(r"^reactions/resoudre/$", SolveNoteAlert.as_view(), name="resolve-reaction"),
+    path("reactions/ajouter/", SendNoteFormView.as_view(redirection_is_needed=False), name="add-reaction"),
+    path("reactions/editer/", UpdateNoteView.as_view(redirection_is_needed=False), name="update-reaction"),
+    path("reactions/cacher/<int:pk>/", HideReaction.as_view(), name="hide-reaction"),
+    path("reactions/afficher/<int:pk>/", ShowReaction.as_view(), name="show-reaction"),
+    path("reactions/alerter/<int:pk>/", SendNoteAlert.as_view(), name="alert-reaction"),
+    path("reactions/resoudre/", SolveNoteAlert.as_view(), name="resolve-reaction"),
     # follow:
-    re_path(r"^suivre/(?P<pk>\d+)/reactions/$", FollowContentReaction.as_view(), name="follow-reactions"),
-    re_path(r"^suivre/membres/(?P<pk>\d+)/$", FollowNewContent.as_view(), name="follow"),
+    path("suivre/<int:pk>/reactions/", FollowContentReaction.as_view(), name="follow-reactions"),
+    path("suivre/membres/<int:pk>/", FollowNewContent.as_view(), name="follow"),
     # request
-    re_path(r"^requete/(?P<pk>\d+)/$", RequestFeaturedContent.as_view(), name="request-featured"),
+    path("requete/<int:pk>/", RequestFeaturedContent.as_view(), name="request-featured"),
     # content alerts:
-    re_path(r"^alerter/(?P<pk>\d+)/$", SendContentAlert.as_view(), name="alert-content"),
-    re_path(r"^resoudre/(?P<pk>\d+)/$", SolveContentAlert.as_view(), name="resolve-content"),
+    path("alerter/<int:pk>/", SendContentAlert.as_view(), name="alert-content"),
+    path("resoudre/<int:pk>/", SolveContentAlert.as_view(), name="resolve-content"),
     # typo:
-    re_path(r"^reactions/typo/$", WarnTypo.as_view(), name="warn-typo"),
+    path("reactions/typo/", WarnTypo.as_view(), name="warn-typo"),
     # create:
     path("nouveau-contenu/<str:created_content_type>/", CreateContent.as_view(), name="create-content"),
-    re_path(
-        r"^nouveau-conteneur/(?P<pk>\d+)/(?P<slug>.+)/(?P<container_slug>.+)/$",
+    path(
+        "nouveau-conteneur/<int:pk>/<slug:slug>/<slug:container_slug>/",
         CreateContainer.as_view(),
         name="create-container",
     ),
-    re_path(r"^nouveau-conteneur/(?P<pk>\d+)/(?P<slug>.+)/$", CreateContainer.as_view(), name="create-container"),
-    re_path(
-        r"^nouvelle-section/(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/(?P<container_slug>.+)/$",
+    path("nouveau-conteneur/<int:pk>/<slug:slug>/", CreateContainer.as_view(), name="create-container"),
+    path(
+        "nouvelle-section/<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/",
         CreateExtract.as_view(),
         name="create-extract",
     ),
-    re_path(
-        r"^nouvelle-section/(?P<pk>\d+)/(?P<slug>.+)/(?P<container_slug>.+)/$",
+    path(
+        "nouvelle-section/<int:pk>/<slug:slug>/<slug:container_slug>/",
         CreateExtract.as_view(),
         name="create-extract",
     ),
-    re_path(r"^nouvelle-section/(?P<pk>\d+)/(?P<slug>.+)/$", CreateExtract.as_view(), name="create-extract"),
+    path("nouvelle-section/<int:pk>/<slug:slug>/", CreateExtract.as_view(), name="create-extract"),
     # edit:
-    re_path(
-        r"^editer-conteneur/(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/" r"(?P<container_slug>.+)/$",
+    path(
+        "editer-conteneur/<int:pk>/<slug:slug>/<slug:parent_container_slug>/" r"<slug:container_slug>/",
         EditContainer.as_view(),
         name="edit-container",
     ),
-    re_path(
-        r"^editer-conteneur/(?P<pk>\d+)/(?P<slug>.+)/(?P<container_slug>.+)/$",
+    path(
+        "editer-conteneur/<int:pk>/<slug:slug>/<slug:container_slug>/",
         EditContainer.as_view(),
         name="edit-container",
     ),
-    re_path(
-        r"^editer-section/(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/"
-        r"(?P<container_slug>.+)/(?P<extract_slug>.+)/$",
+    path(
+        "editer-section/<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/<slug:extract_slug>/",
         EditExtract.as_view(),
         name="edit-extract",
     ),
-    re_path(
-        r"^editer-section/(?P<pk>\d+)/(?P<slug>.+)/(?P<container_slug>.+)/(?P<extract_slug>.+)/$",
+    path(
+        "editer-section/<int:pk>/<slug:slug>/<slug:container_slug>/<slug:extract_slug>/",
         EditExtract.as_view(),
         name="edit-extract",
     ),
-    re_path(
-        r"^editer-section/(?P<pk>\d+)/(?P<slug>.+)/(?P<extract_slug>.+)/$", EditExtract.as_view(), name="edit-extract"
-    ),
-    re_path(r"^editer/(?P<pk>\d+)/(?P<slug>.+)/$", EditContent.as_view(), name="edit"),
-    re_path(r"^deplacer/$", MoveChild.as_view(), name="move-element"),
-    re_path(r"^historique/(?P<pk>\d+)/(?P<slug>.+)/$", DisplayHistory.as_view(), name="history"),
-    re_path(r"^comparaison/(?P<pk>\d+)/(?P<slug>.+)/$", DisplayDiff.as_view(), name="diff"),
-    re_path(r"^ajouter-contributeur/(?P<pk>\d+)/$", AddContributorToContent.as_view(), name="add-contributor"),
-    re_path(r"^enlever-contributeur/(?P<pk>\d+)/$", RemoveContributorFromContent.as_view(), name="remove-contributor"),
-    re_path(r"^ajouter-auteur/(?P<pk>\d+)/$", AddAuthorToContent.as_view(), name="add-author"),
-    re_path(r"^enlever-auteur/(?P<pk>\d+)/$", RemoveAuthorFromContent.as_view(), name="remove-author"),
+    path("editer-section/<int:pk>/<slug:slug>/<slug:extract_slug>/", EditExtract.as_view(), name="edit-extract"),
+    path("editer/<int:pk>/<slug:slug>/", EditContent.as_view(), name="edit"),
+    path("deplacer/", MoveChild.as_view(), name="move-element"),
+    path("historique/<int:pk>/<slug:slug>/", DisplayHistory.as_view(), name="history"),
+    path("comparaison/<int:pk>/<slug:slug>/", DisplayDiff.as_view(), name="diff"),
+    path("ajouter-contributeur/<int:pk>/", AddContributorToContent.as_view(), name="add-contributor"),
+    path("enlever-contributeur/<int:pk>/", RemoveContributorFromContent.as_view(), name="remove-contributor"),
+    path("ajouter-auteur/<int:pk>/", AddAuthorToContent.as_view(), name="add-author"),
+    path("enlever-auteur/<int:pk>/", RemoveAuthorFromContent.as_view(), name="remove-author"),
     # Modify the license
-    re_path(r"^modifier-licence/(?P<pk>\d+)/$", EditContentLicense.as_view(), name="edit-license"),
+    path("modifier-licence/<int:pk>/", EditContentLicense.as_view(), name="edit-license"),
     # Modify the tags
-    re_path(r"^modifier-tags/(?P<pk>\d+)/$", EditContentTags.as_view(), name="edit-tags"),
+    path("modifier-tags/<int:pk>/", EditContentTags.as_view(), name="edit-tags"),
     # beta:
-    re_path(r"^activer-beta/(?P<pk>\d+)/(?P<slug>.+)/$", ManageBetaContent.as_view(action="set"), name="set-beta"),
-    re_path(
-        r"^desactiver-beta/(?P<pk>\d+)/(?P<slug>.+)/$",
+    path("activer-beta/<int:pk>/<slug:slug>/", ManageBetaContent.as_view(action="set"), name="set-beta"),
+    path(
+        "desactiver-beta/<int:pk>/<slug:slug>/",
         ManageBetaContent.as_view(action="inactive"),
         name="inactive-beta",
     ),
-    re_path(r"^stats/(?P<pk>\d+)/(?P<slug>.+)/$", ContentStatisticsView.as_view(), name="stats-content"),
-    re_path(r"^ajouter-suggestion/(?P<pk>\d+)/$", AddSuggestion.as_view(), name="add-suggestion"),
-    re_path(r"^enlever-suggestion/(?P<pk>\d+)/$", RemoveSuggestion.as_view(), name="remove-suggestion"),
+    path("stats/<int:pk>/<slug:slug>/", ContentStatisticsView.as_view(), name="stats-content"),
+    path("ajouter-suggestion/<int:pk>/", AddSuggestion.as_view(), name="add-suggestion"),
+    path("enlever-suggestion/<int:pk>/", RemoveSuggestion.as_view(), name="remove-suggestion"),
     # jsfiddle support:
-    re_path(r"activer-js/", ActivateJSFiddleInContent.as_view(), name="activate-jsfiddle"),
+    path("activer-js/", ActivateJSFiddleInContent.as_view(), name="activate-jsfiddle"),
     # delete:
-    re_path(
-        r"^supprimer/(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/(?P<container_slug>.+)/"
-        r"(?P<object_slug>.+)/$",
+    path(
+        "supprimer/<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/<slug:object_slug>/",
         DeleteContainerOrExtract.as_view(),
         name="delete",
     ),
-    re_path(
-        r"^supprimer/(?P<pk>\d+)/(?P<slug>.+)/(?P<container_slug>.+)/(?P<object_slug>.+)/$",
+    path(
+        "supprimer/<int:pk>/<slug:slug>/<slug:container_slug>/<slug:object_slug>/",
         DeleteContainerOrExtract.as_view(),
         name="delete",
     ),
-    re_path(
-        r"^supprimer/(?P<pk>\d+)/(?P<slug>.+)/(?P<object_slug>.+)/$", DeleteContainerOrExtract.as_view(), name="delete"
-    ),
-    re_path(r"^supprimer/(?P<pk>\d+)/(?P<slug>.+)/$", DeleteContent.as_view(), name="delete"),
+    path("supprimer/<int:pk>/<slug:slug>/<slug:object_slug>/", DeleteContainerOrExtract.as_view(), name="delete"),
+    path("supprimer/<int:pk>/<slug:slug>/", DeleteContent.as_view(), name="delete"),
     # markdown import
-    re_path(r"^importer/archive/nouveau/$", CreateContentFromArchive.as_view(), name="import-new"),
-    re_path(r"^importer/(?P<pk>\d+)/(?P<slug>.+)/$", UpdateContentWithArchive.as_view(), name="import"),
+    path("importer/archive/nouveau/", CreateContentFromArchive.as_view(), name="import-new"),
+    path("importer/<int:pk>/<slug:slug>/", UpdateContentWithArchive.as_view(), name="import"),
     # tags
-    re_path(r"^tags/$", TagsListView.as_view(), name="tags"),
-    re_path(r"^$", RedirectView.as_view(pattern_name="publication:list", permanent=True), name="list"),
+    path("tags/", TagsListView.as_view(), name="tags"),
+    path("", RedirectView.as_view(pattern_name="publication:list", permanent=True), name="list"),
     # Journal of events
-    re_path(r"^evenements/(?P<pk>\d+)/$", EventsList.as_view(), name="events"),
+    path("evenements/<int:pk>/", EventsList.as_view(), name="events"),
 ]

--- a/zds/tutorialv2/urls/urls_opinions.py
+++ b/zds/tutorialv2/urls/urls_opinions.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path, path
 
 from zds.tutorialv2.feeds import LastOpinionsFeedRSS, LastOpinionsFeedATOM
 from zds.tutorialv2.views.lists import ListOpinions, ContentOfAuthor
@@ -7,35 +7,27 @@ from zds.tutorialv2.views.display import DisplayOnlineOpinion
 
 urlpatterns = [
     # Flux
-    re_path(r"^flux/rss/$", LastOpinionsFeedRSS(), name="feed-rss"),
-    re_path(r"^flux/atom/$", LastOpinionsFeedATOM(), name="feed-atom"),
+    path("flux/rss/", LastOpinionsFeedRSS(), name="feed-rss"),
+    path("flux/atom/", LastOpinionsFeedATOM(), name="feed-atom"),
     # View
-    re_path(r"^(?P<pk>\d+)/(?P<slug>.+)/$", DisplayOnlineOpinion.as_view(), name="view"),
+    path("<int:pk>/<slug:slug>/", DisplayOnlineOpinion.as_view(), name="view"),
     # downloads:
-    re_path(
-        r"^md/(?P<pk>\d+)/(?P<slug>.+)\.md$", DownloadOnlineOpinion.as_view(requested_file="md"), name="download-md"
-    ),
-    re_path(
-        r"^html/(?P<pk>\d+)/(?P<slug>.+)\.html$",
+    path("md/<int:pk>/<slug:slug>.md", DownloadOnlineOpinion.as_view(requested_file="md"), name="download-md"),
+    path(
+        "html/<int:pk>/<slug:slug>.html",
         DownloadOnlineOpinion.as_view(requested_file="html"),
         name="download-html",
     ),
-    re_path(
-        r"^pdf/(?P<pk>\d+)/(?P<slug>.+)\.pdf$", DownloadOnlineOpinion.as_view(requested_file="pdf"), name="download-pdf"
-    ),
-    re_path(
-        r"^epub/(?P<pk>\d+)/(?P<slug>.+)\.epub$",
+    path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineOpinion.as_view(requested_file="pdf"), name="download-pdf"),
+    path(
+        "epub/<int:pk>/<slug:slug>.epub",
         DownloadOnlineOpinion.as_view(requested_file="epub"),
         name="download-epub",
     ),
-    re_path(
-        r"^zip/(?P<pk>\d+)/(?P<slug>.+)\.zip$", DownloadOnlineOpinion.as_view(requested_file="zip"), name="download-zip"
-    ),
-    re_path(
-        r"^tex/(?P<pk>\d+)/(?P<slug>.+)\.tex$", DownloadOnlineOpinion.as_view(requested_file="tex"), name="download-tex"
-    ),
+    path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineOpinion.as_view(requested_file="zip"), name="download-zip"),
+    path("tex/<int:pk>/<slug:slug>.tex", DownloadOnlineOpinion.as_view(requested_file="tex"), name="download-tex"),
     # Listing
-    re_path(r"^$", ListOpinions.as_view(), name="list"),
+    path("", ListOpinions.as_view(), name="list"),
     path(
         "voir/<str:username>/",
         ContentOfAuthor.as_view(type="OPINION", context_object_name="opinions", sort="creation"),

--- a/zds/tutorialv2/urls/urls_publications.py
+++ b/zds/tutorialv2/urls/urls_publications.py
@@ -1,13 +1,13 @@
-from django.urls import re_path
+from django.urls import path
 
 from zds.tutorialv2.views.lists import ViewPublications
 from zds.tutorialv2.feeds import LastContentFeedRSS, LastContentFeedATOM
 
 urlpatterns = [
     # Flux
-    re_path(r"^flux/rss/$", LastContentFeedRSS(), name="feed-rss"),
-    re_path(r"^flux/atom/$", LastContentFeedATOM(), name="feed-atom"),
-    re_path(r"^(?P<slug_category>.+)/(?P<slug>.+)/$", ViewPublications.as_view(), name="subcategory"),
-    re_path(r"^(?P<slug>.+)/$", ViewPublications.as_view(), name="category"),
-    re_path(r"^$", ViewPublications.as_view(), name="list"),
+    path("flux/rss/", LastContentFeedRSS(), name="feed-rss"),
+    path("flux/atom/", LastContentFeedATOM(), name="feed-atom"),
+    path("<slug:slug_category>/<slug:slug>/", ViewPublications.as_view(), name="subcategory"),
+    path("<slug:slug>/", ViewPublications.as_view(), name="category"),
+    path("", ViewPublications.as_view(), name="list"),
 ]

--- a/zds/tutorialv2/urls/urls_tutorials.py
+++ b/zds/tutorialv2/urls/urls_tutorials.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 from django.views.generic.base import RedirectView
 from zds.tutorialv2.views.contributors import ContentOfContributors
 
@@ -11,57 +11,33 @@ from zds.tutorialv2.feeds import LastTutorialsFeedRSS, LastTutorialsFeedATOM
 
 urlpatterns = [
     # flux
-    re_path(r"^flux/rss/$", LastTutorialsFeedRSS(), name="feed-rss"),
-    re_path(r"^flux/atom/$", LastTutorialsFeedATOM(), name="feed-atom"),
+    path("flux/rss/", LastTutorialsFeedRSS(), name="feed-rss"),
+    path("flux/atom/", LastTutorialsFeedATOM(), name="feed-atom"),
     # view
-    re_path(
-        r"^(?P<pk>\d+)/(?P<slug>.+)/(?P<p2>\d+)/(?P<parent_container_slug>.+)/(?P<p3>\d+)/(?P<container_slug>.+)/$",
+    path(
+        "<int:pk>/<slug:slug>/<int:p2>/<slug:parent_container_slug>/<int:p3>/<slug:container_slug>/",
         RedirectContentSEO.as_view(),
         name="redirect_old_tuto",
     ),
-    re_path(
-        r"^(?P<pk>\d+)/(?P<slug>.+)/(?P<parent_container_slug>.+)/(?P<container_slug>.+)/$",
+    path(
+        "<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/",
         DisplayOnlineContainer.as_view(),
         name="view-container",
     ),
-    re_path(
-        r"^(?P<pk>\d+)/(?P<slug>.+)/(?P<container_slug>.+)/$", DisplayOnlineContainer.as_view(), name="view-container"
-    ),
-    re_path(r"^(?P<pk>\d+)/(?P<slug>.+)/$", DisplayOnlineTutorial.as_view(), name="view"),
+    path("<int:pk>/<slug:slug>/<slug:container_slug>/", DisplayOnlineContainer.as_view(), name="view-container"),
+    path("<int:pk>/<slug:slug>/", DisplayOnlineTutorial.as_view(), name="view"),
     # downloads:
-    re_path(
-        r"^md/(?P<pk>\d+)/(?P<slug>.+)\.md$", DownloadOnlineTutorial.as_view(requested_file="md"), name="download-md"
-    ),
-    re_path(
-        r"^html/(?P<pk>\d+)/(?P<slug>.+)\.html$",
-        DownloadOnlineTutorial.as_view(requested_file="html"),
-        name="download-html",
-    ),
-    re_path(
-        r"^pdf/(?P<pk>\d+)/(?P<slug>.+)\.pdf$",
-        DownloadOnlineTutorial.as_view(requested_file="pdf"),
-        name="download-pdf",
-    ),
-    re_path(
-        r"^epub/(?P<pk>\d+)/(?P<slug>.+)\.epub$",
-        DownloadOnlineTutorial.as_view(requested_file="epub"),
-        name="download-epub",
-    ),
-    re_path(
-        r"^zip/(?P<pk>\d+)/(?P<slug>.+)\.zip$",
-        DownloadOnlineTutorial.as_view(requested_file="zip"),
-        name="download-zip",
-    ),
-    re_path(
-        r"^tex/(?P<pk>\d+)/(?P<slug>.+)\.tex$",
-        DownloadOnlineTutorial.as_view(requested_file="tex"),
-        name="download-tex",
-    ),
+    path("md/<int:pk>/<slug:slug>.md", DownloadOnlineTutorial.as_view(requested_file="md"), name="download-md"),
+    path("html/<int:pk>/<slug:slug>.html", DownloadOnlineTutorial.as_view(requested_file="html"), name="download-html"),
+    path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineTutorial.as_view(requested_file="pdf"), name="download-pdf"),
+    path("epub/<int:pk>/<slug:slug>.epub", DownloadOnlineTutorial.as_view(requested_file="epub"), name="download-epub"),
+    path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineTutorial.as_view(requested_file="zip"), name="download-zip"),
+    path("tex/<int:pk>/<slug:slug>.tex", DownloadOnlineTutorial.as_view(requested_file="tex"), name="download-tex"),
     #  Old beta url compatibility
-    re_path(r"^beta/(?P<pk>\d+)/(?P<slug>.+)/$", RedirectOldBetaTuto.as_view(), name="old-beta-url"),
+    path("beta/<int:pk>/<slug:slug>/", RedirectOldBetaTuto.as_view(), name="old-beta-url"),
     # Listing
-    re_path(r"^$", RedirectView.as_view(pattern_name="publication:list", permanent=True)),
-    re_path(r"tags/$", TagsListView.as_view(displayed_types=["TUTORIAL"]), name="tags"),
+    path("", RedirectView.as_view(pattern_name="publication:list", permanent=True)),
+    path("tags/", TagsListView.as_view(displayed_types=["TUTORIAL"]), name="tags"),
     path(
         "voir/<str:username>/",
         ContentOfAuthor.as_view(type="TUTORIAL", context_object_name="tutorials"),

--- a/zds/tutorialv2/urls/urls_validations.py
+++ b/zds/tutorialv2/urls/urls_validations.py
@@ -1,5 +1,4 @@
-from django.urls import re_path
-
+from django.urls import path
 from zds.tutorialv2.views.validations_contents import (
     AskValidationForContent,
     ReserveValidation,
@@ -23,28 +22,28 @@ from zds.tutorialv2.views.validations_opinions import (
 )
 
 urlpatterns = [
-    re_path(r"^historique/(?P<pk>\d+)/(?P<slug>.+)/$", ValidationHistoryView.as_view(), name="history"),
+    path("historique/<int:pk>/<slug:slug>/", ValidationHistoryView.as_view(), name="history"),
     # VALIDATION BEFORE PUBLICATION
     # 1. ask validation
-    re_path(r"^proposer/(?P<pk>\d+)/(?P<slug>.+)/$", AskValidationForContent.as_view(), name="ask"),
+    path("proposer/<int:pk>/<slug:slug>/", AskValidationForContent.as_view(), name="ask"),
     # 2. take (or cancel) validation
-    re_path(r"^reserver/(?P<pk>\d+)/$", ReserveValidation.as_view(), name="reserve"),
-    re_path(r"^annuler/(?P<pk>\d+)/$", CancelValidation.as_view(), name="cancel"),
+    path("reserver/<int:pk>/", ReserveValidation.as_view(), name="reserve"),
+    path("annuler/<int:pk>/", CancelValidation.as_view(), name="cancel"),
     # 3. accept or reject validation
-    re_path(r"^refuser/(?P<pk>\d+)/$", RejectValidation.as_view(), name="reject"),
-    re_path(r"^accepter/(?P<pk>\d+)/$", AcceptValidation.as_view(), name="accept"),
+    path("refuser/<int:pk>/", RejectValidation.as_view(), name="reject"),
+    path("accepter/<int:pk>/", AcceptValidation.as_view(), name="accept"),
     # 4. cancel validation after publication
-    re_path(r"^revoquer/(?P<pk>\d+)/(?P<slug>.+)/$", RevokeValidation.as_view(), name="revoke"),
+    path("revoquer/<int:pk>/<slug:slug>/", RevokeValidation.as_view(), name="revoke"),
     # NO VALIDATION BEFORE PUBLICATION
-    re_path(r"^publier/(?P<pk>\d+)/(?P<slug>.+)/$", PublishOpinion.as_view(), name="publish-opinion"),
-    re_path(r"^depublier/(?P<pk>\d+)/(?P<slug>.+)/$", UnpublishOpinion.as_view(), name="unpublish-opinion"),
-    re_path(r"^choisir/(?P<pk>\d+)/(?P<slug>.+)/$", PickOpinion.as_view(), name="pick-opinion"),
-    re_path(r"^ignorer/(?P<pk>\d+)/(?P<slug>.+)/$", DoNotPickOpinion.as_view(), name="ignore-opinion"),
-    re_path(r"^operation/annuler/(?P<pk>\d+)/$", RevokePickOperation.as_view(), name="revoke-ignore-opinion"),
-    re_path(r"^retirer/(?P<pk>\d+)/(?P<slug>.+)/$", UnpickOpinion.as_view(), name="unpick-opinion"),
-    re_path(r"^promouvoir/(?P<pk>\d+)/(?P<slug>.+)/$", PromoteOpinionToArticle.as_view(), name="promote-opinion"),
-    re_path(r"^marquer-obsolete/(?P<pk>\d+)/$", MarkObsolete.as_view(), name="mark-obsolete"),
+    path("publier/<int:pk>/<slug:slug>/", PublishOpinion.as_view(), name="publish-opinion"),
+    path("depublier/<int:pk>/<slug:slug>/", UnpublishOpinion.as_view(), name="unpublish-opinion"),
+    path("choisir/<int:pk>/<slug:slug>/", PickOpinion.as_view(), name="pick-opinion"),
+    path("ignorer/<int:pk>/<slug:slug>/", DoNotPickOpinion.as_view(), name="ignore-opinion"),
+    path("operation/annuler/<int:pk>/", RevokePickOperation.as_view(), name="revoke-ignore-opinion"),
+    path("retirer/<int:pk>/<slug:slug>/", UnpickOpinion.as_view(), name="unpick-opinion"),
+    path("promouvoir/<int:pk>/<slug:slug>/", PromoteOpinionToArticle.as_view(), name="promote-opinion"),
+    path("marquer-obsolete/<int:pk>/", MarkObsolete.as_view(), name="mark-obsolete"),
     # VALIDATION VIEWS FOR STAFF
-    re_path(r"^billets/$", ValidationOpinionListView.as_view(), name="list-opinion"),
-    re_path(r"^$", ValidationListView.as_view(), name="list"),
+    path("billets/", ValidationOpinionListView.as_view(), name="list-opinion"),
+    path("", ValidationListView.as_view(), name="list"),
 ]


### PR DESCRIPTION
Lié à #6246.

Au menu de cette refacto des URL des contenus : path au lieu de re_path et c'est tout. Les URL sont plus nombreuses et critiques, j'ai préféré rester modéré dans la refacto.

### Contrôle qualité

Exercer les différentes routes de recherche des tutoriels (peut-être pas besoin d'être exhautif...).