### PR TITLE
N'affiche *que* les tutoriels en bêta lorsque le filtre est actif

### DIFF
--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -172,7 +172,7 @@ class Profile(models.Model):
         :return: Queryset of draft contents with this user as author.
         """
         return self.get_user_contents_queryset(_type).filter(
-            sha_draft__isnull=False, sha_beta__isnull=True, sha_validation__isnull=True, sha_public__isnull=True
+            sha_draft__isempty=False, sha_beta__isempty=True, sha_validation__isempty=True, sha_public__isempty=True
         )
 
     def get_user_validate_contents_queryset(self, _type=None):
@@ -180,14 +180,14 @@ class Profile(models.Model):
         :param _type: if provided, request a specific type of content
         :return: Queryset of contents in validation with this user as author.
         """
-        return self.get_user_contents_queryset(_type).filter(sha_validation__isnull=False)
+        return self.get_user_contents_queryset(_type).filter(sha_validation__isempty=False)
 
     def get_user_beta_contents_queryset(self, _type=None):
         """
         :param _type: if provided, request a specific type of content
         :return: Queryset of contents in beta with this user as author.
         """
-        return self.get_user_contents_queryset(_type).filter(sha_beta__isnull=False)
+        return self.get_user_contents_queryset(_type).filter(sha_beta__isempty=False)
 
     def get_content_count(self, _type=None):
         """


### PR DESCRIPTION
Avec MariaDB, les chaînes de caractères qui sont censées être nulles, peuvent être NULL ou une chaîne de caractères vide. Cet commit ajoute une expression de recherche (field lookup) qui permet de traiter facilement ces deux cas.

Cela amenait des contenus pas en bêta à s'afficher en bêta sur la liste des contenus d'un utilisateur. Par exemple https://beta.zestedesavoir.com/tutoriels/voir/SpaceFox/?filter=beta ne doit pas contenir *Introduction à l'astronomie*. Le problème semble être spécifique à MariaDB (tout du moins il ne se produit pas avec SQLite), mais je n'ai pas réussi à le reproduire, même avec MariaDB en local.

### Contrôle qualité

S'assurer que les contenus s'affichent correctement sur les listes de contenus d'un utilisateur, en jouant avec les différents filtres.

Les tests semblent suffisant pour couvrir ces cas (des tests m'ont permis de corriger un bug dans `IsEmpty`). Le patch est déployé sur la bêta.
