### PR TITLE
Vide le stockage local lors de l'envoi avec Ctrl+Entrée

### DIFF
--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -1002,7 +1002,10 @@
     window.editors[this.id].previous_value = ''
 
     function submit(cm) {
-      if (cm.getValue() !== '') formEditor.submit()
+      if (cm.getValue() !== '') {
+        localStorage.removeItem('smde_' + mdeUniqueKey)
+        formEditor.submit()
+      }
     }
 
     easyMDE.codemirror.addKeyMap({


### PR DESCRIPTION
Fix #6309.

Cette PR corrige un soucis en ajoutant le vidage du stockage local lors de l'envoi avec Ctrl+Entrée dans les formulaires de forum.

J'ai choisi une option qui est normalement compatible avec tous les navigateurs. J'envoie un événement "submit" et le dispatche à l'éditeur, ce qui simule la soumission du formulaire via le bouton. Voir [cette page MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event) pour des infos sur pourquoi ça fonctionne.

Il n'y a pas non plus besoin de vérifier que le formulaire n'est pas vide, parce que c'est comme si on cliquait sur le bouton, avec les mêmes vérifications.

### Contrôle qualité

Astuce pour gagner du temps : changer le paramètre anti-spam `spam_limit_seconds` dans `zds.py` à une valeur plus basse (quelques secondes par exemple).

* Non régression : envoyer un message sur le forum avec le bouton, constater qu'il est bien envoyé et sans erreur, et que la zone de texte est vide (et que le local storage aussi, par conséquent).
* Correction du bug : envoyer un message sur le forum avec Ctrl+Entrée, constater qu'il est bien envoyé et sans erreur, et que la zone de texte (et le local storage) sont vides.