### PR TITLE
Adapte le texte de la modale de sélection des tags d'un contenu

### DIFF
--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -322,7 +322,7 @@ class ContentForm(ContainerForm):
 
 class EditContentTagsForm(forms.Form):
     tags = forms.CharField(
-        label=_("Tags séparés par des virgules (exemple : python,django,web) :"),
+        label=_("Tags séparés par des virgules (exemple : python,api,web) :"),
         max_length=64,
         required=False,
         widget=forms.TextInput(


### PR DESCRIPTION
Adapte le texte à la largeur de la modale, pour éviter que les deux
points ne se retrouvent seuls sur une nouvelle ligne.

### Contrôle qualité
- Se connecter en `admin`
- Aller sur la page d'un contenu publié
- Cliquer sur *Modifier les tags* dans la colonne à gauche
- Le texte d'indication du champ pour modifier les tags tient sur une seule ligne.
