### PR TITLE
Notifier normalement les MP de sanction

### DIFF
--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -214,7 +214,6 @@ class MemberSanctionState:
             msg,
             send_by_mail=True,
             force_email=True,
-            direct=False,
             hat=get_hat_from_settings("moderation"),
         )
 

--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -213,7 +213,8 @@ class MemberSanctionState:
             "",
             msg,
             send_by_mail=True,
-            direct=True,
+            force_email=True,
+            direct=False,
             hat=get_hat_from_settings("moderation"),
         )
 

--- a/zds/member/views/register.py
+++ b/zds/member/views/register.py
@@ -283,7 +283,6 @@ def activate_account(request):
         msg,
         send_by_mail=False,
         leave=True,
-        direct=False,
         hat=get_hat_from_settings("moderation"),
     )
     token.delete()

--- a/zds/mp/api/serializers.py
+++ b/zds/mp/api/serializers.py
@@ -185,7 +185,7 @@ class PrivatePostActionSerializer(serializers.ModelSerializer, TextValidator, Up
         author = self.context.get("view").request.user
 
         # Send post in mp
-        send_message_mp(author, topic, self.validated_data.get("text"), send_by_mail=True, direct=False)
+        send_message_mp(author, topic, self.validated_data.get("text"), send_by_mail=True)
         return topic.last_message
 
     def update(self, instance, validated_data):

--- a/zds/mp/utils.py
+++ b/zds/mp/utils.py
@@ -22,7 +22,6 @@ def send_mp(
     send_by_mail=True,
     force_email=False,
     leave=True,
-    direct=False,
     hat=None,
     automatically_read=None,
 ):
@@ -36,7 +35,6 @@ def send_mp(
     :param text: content of the private message
     :param send_by_mail: if True, also notify by email
     :param force_email: if True, send email even if the user has not enabled email notifications
-    :param direct: send a mail directly without mp (ex : ban members who wont connect again)
     :param leave: if True, do not add the sender to the topic
     :param hat: hat with which to send the private message
     :param automatically_read: a user or a list of users that will automatically be marked as having read of the mp
@@ -46,7 +44,7 @@ def send_mp(
     n_topic = PrivateTopic.create(title=title, subtitle=subtitle, author=author, recipients=users)
     signals.topic_created.send(sender=PrivateTopic, topic=n_topic, by_email=send_by_mail)
 
-    topic = send_message_mp(author, n_topic, text, send_by_mail, force_email, direct, hat)
+    topic = send_message_mp(author, n_topic, text, send_by_mail, force_email, hat)
 
     if automatically_read:
         if not isinstance(automatically_read, list):
@@ -60,9 +58,7 @@ def send_mp(
     return topic
 
 
-def send_message_mp(
-    author, n_topic, text, send_by_mail=True, force_email=False, direct=False, hat=None, no_notification_for=None
-):
+def send_message_mp(author, n_topic, text, send_by_mail=True, force_email=False, hat=None, no_notification_for=None):
     """
     Send a post in an MP.
 
@@ -71,7 +67,6 @@ def send_message_mp(
     :param text: content of the message
     :param send_by_mail: if True, also notify by email
     :param force_email: if True, send email even if the user has not enabled email notifications
-    :param direct: send a mail directly without private message (ex : banned members who won't connect again)
     :param hat: hat attached to the message
     :param no_notification_for: list of participants who won't be notified of the message
     """
@@ -101,7 +96,6 @@ def send_message_mp(
         post=post,
         by_email=send_by_mail,
         force_email=force_email,
-        by_mp=not direct,
         no_notification_for=no_notification_for,
     )
     if no_notification_for:

--- a/zds/mp/utils.py
+++ b/zds/mp/utils.py
@@ -20,6 +20,7 @@ def send_mp(
     subtitle,
     text,
     send_by_mail=True,
+    force_email=False,
     leave=True,
     direct=False,
     hat=None,
@@ -33,7 +34,8 @@ def send_mp(
     :param title: title of the private topic
     :param subtitle: subtitle of the private topic
     :param text: content of the private message
-    :param send_by_mail:
+    :param send_by_mail: if True, also notify by email
+    :param force_email: if True, send email even if the user has not enabled email notifications
     :param direct: send a mail directly without mp (ex : ban members who wont connect again)
     :param leave: if True, do not add the sender to the topic
     :param hat: hat with which to send the private message
@@ -44,7 +46,7 @@ def send_mp(
     n_topic = PrivateTopic.create(title=title, subtitle=subtitle, author=author, recipients=users)
     signals.topic_created.send(sender=PrivateTopic, topic=n_topic, by_email=send_by_mail)
 
-    topic = send_message_mp(author, n_topic, text, send_by_mail, direct, hat)
+    topic = send_message_mp(author, n_topic, text, send_by_mail, force_email, direct, hat)
 
     if automatically_read:
         if not isinstance(automatically_read, list):
@@ -58,7 +60,9 @@ def send_mp(
     return topic
 
 
-def send_message_mp(author, n_topic, text, send_by_mail=True, direct=False, hat=None, no_notification_for=None):
+def send_message_mp(
+    author, n_topic, text, send_by_mail=True, force_email=False, direct=False, hat=None, no_notification_for=None
+):
     """
     Send a post in an MP.
 
@@ -66,6 +70,7 @@ def send_message_mp(author, n_topic, text, send_by_mail=True, direct=False, hat=
     :param n_topic: topic in which it will be sent
     :param text: content of the message
     :param send_by_mail: if True, also notify by email
+    :param force_email: if True, send email even if the user has not enabled email notifications
     :param direct: send a mail directly without private message (ex : banned members who won't connect again)
     :param hat: hat attached to the message
     :param no_notification_for: list of participants who won't be notified of the message
@@ -91,26 +96,14 @@ def send_message_mp(author, n_topic, text, send_by_mail=True, direct=False, hat=
     n_topic.last_message = post
     n_topic.save()
 
-    if not direct:
-        signals.message_added.send(
-            sender=post.__class__, post=post, by_email=send_by_mail, no_notification_for=no_notification_for
-        )
-
-    if send_by_mail and direct:
-        subject = "{} : {}".format(settings.ZDS_APP["site"]["literal_name"], n_topic.title)
-        from_email = "{} <{}>".format(
-            settings.ZDS_APP["site"]["literal_name"], settings.ZDS_APP["site"]["email_noreply"]
-        )
-        for recipient in n_topic.participants.values_list("email", flat=True):
-            message_html = render_to_string("email/direct.html", {"msg": emarkdown(text)})
-            message_txt = render_to_string("email/direct.txt", {"msg": text})
-
-            msg = EmailMultiAlternatives(subject, message_txt, from_email, [recipient])
-            msg.attach_alternative(message_html, "text/html")
-            try:
-                msg.send()
-            except Exception as e:
-                logger.exception("Message was not sent to %s due to %s", recipient, e)
+    signals.message_added.send(
+        sender=post.__class__,
+        post=post,
+        by_email=send_by_mail,
+        force_email=force_email,
+        by_mp=not direct,
+        no_notification_for=no_notification_for,
+    )
     if no_notification_for:
         if not isinstance(no_notification_for, list):
             no_notification_for = [no_notification_for]

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -425,13 +425,14 @@ def create_private_topic_event(sender, *, topic, by_email, **__):
 
 @receiver(mp_signals.message_added, sender=PrivatePost)
 @disable_for_loaddata
-def answer_private_topic_event(sender, *, post, by_email, no_notification_for=None, **__):
+def answer_private_topic_event(sender, *, post, by_email, force_email, by_mp, no_notification_for=None, **__):
     """
     Sends PrivateTopicAnswerSubscription to the subscribers to the topic and subscribe
     the author to the following answers to the topic.
 
     :param post: the new post.
     :param by_email: Send or not an email.
+    :param force_email: Send email even if the user has not enabled email notifications
     :param no_notification_for: user or group of user to ignore, really usefull when dealing with moderation message.
     """
 
@@ -439,10 +440,14 @@ def answer_private_topic_event(sender, *, post, by_email, no_notification_for=No
     for subscription in subscription_list:
         if subscription.user != post.author:
             is_new_mp = post.position_in_topic == 1
-            send_email = by_email and (
-                subscription.user.profile.email_for_answer or (is_new_mp and subscription.user.profile.email_for_new_mp)
+            send_email = force_email or (
+                by_email
+                and (
+                    subscription.user.profile.email_for_answer
+                    or (is_new_mp and subscription.user.profile.email_for_new_mp)
+                )
             )
-            subscription.send_notification(content=post, sender=post.author, send_email=send_email)
+            subscription.send_notification(content=post, sender=post.author, send_email=send_email, send_mp=by_mp)
 
 
 @receiver(pre_delete, sender=PrivateTopic)

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -425,7 +425,7 @@ def create_private_topic_event(sender, *, topic, by_email, **__):
 
 @receiver(mp_signals.message_added, sender=PrivatePost)
 @disable_for_loaddata
-def answer_private_topic_event(sender, *, post, by_email, force_email, by_mp, no_notification_for=None, **__):
+def answer_private_topic_event(sender, *, post, by_email, force_email, no_notification_for=None, **__):
     """
     Sends PrivateTopicAnswerSubscription to the subscribers to the topic and subscribe
     the author to the following answers to the topic.
@@ -447,7 +447,7 @@ def answer_private_topic_event(sender, *, post, by_email, force_email, by_mp, no
                     or (is_new_mp and subscription.user.profile.email_for_new_mp)
                 )
             )
-            subscription.send_notification(content=post, sender=post.author, send_email=send_email, send_mp=by_mp)
+            subscription.send_notification(content=post, sender=post.author, send_email=send_email)
 
 
 @receiver(pre_delete, sender=PrivateTopic)

--- a/zds/tutorialv2/views/contributors.py
+++ b/zds/tutorialv2/views/contributors.py
@@ -90,7 +90,6 @@ class AddContributorToContent(LoggedWithReadWriteHability, SingleContentFormView
                     },
                 ),
                 send_by_mail=True,
-                direct=False,
                 leave=True,
             )
             signals.contributors_management.send(

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -340,7 +340,6 @@ class ReserveValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
                         msg,
                         send_by_mail=True,
                         leave=False,
-                        direct=False,
                         hat=get_hat_from_settings("validation"),
                     )
                     validation.content.save()
@@ -441,7 +440,6 @@ class RejectValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
                 validation.content.title,
                 msg,
                 send_by_mail=True,
-                direct=False,
                 hat=get_hat_from_settings("validation"),
             )
             validation.content.save()
@@ -593,7 +591,6 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
                     validation.content.title,
                     msg,
                     send_by_mail=True,
-                    direct=False,
                     hat=get_hat_from_settings("validation"),
                 )
                 self.object.save()

--- a/zds/tutorialv2/views/validations_opinions.py
+++ b/zds/tutorialv2/views/validations_opinions.py
@@ -145,7 +145,6 @@ class UnpublishOpinion(LoginRequiredMixin, SingleOnlineContentFormViewMixin, Doe
                         versioned.title,
                         msg,
                         send_by_mail=True,
-                        direct=False,
                         hat=get_hat_from_settings("moderation"),
                     )
                     self.object.save()
@@ -241,7 +240,6 @@ class DoNotPickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormView
                             versioned.title,
                             msg,
                             send_by_mail=True,
-                            direct=False,
                             hat=get_hat_from_settings("moderation"),
                         )
                         self.object.save()
@@ -337,7 +335,6 @@ class PickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMixin
                 versioned.title,
                 msg,
                 send_by_mail=True,
-                direct=False,
                 hat=get_hat_from_settings("moderation"),
             )
             self.object.save()
@@ -411,7 +408,6 @@ class UnpickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMix
                 versioned.title,
                 msg,
                 send_by_mail=True,
-                direct=False,
                 hat=get_hat_from_settings("moderation"),
             )
             self.object.save()
@@ -551,7 +547,6 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
             versionned_article.title,
             msg,
             send_by_mail=True,
-            direct=False,
             hat=get_hat_from_settings("validation"),
         )
         article.save()

--- a/zds/utils/tests/tests_interventions.py
+++ b/zds/utils/tests/tests_interventions.py
@@ -44,7 +44,7 @@ class InterventionsTest(TestCase):
         )
         self.validation.save()
 
-        self.topic = send_mp(author=self.author.user, users=[], title="Title", text="Testing", subtitle="", leave=False)
+        self.topic = send_mp(author=self.author.user, users=[], title="Title", subtitle="", text="Testing", leave=False)
         self.topic.add_participant(self.user.user)
         send_message_mp(self.user.user, self.topic, "Testing")
 


### PR DESCRIPTION
Fix #5746.

Actuellement, quand un utilisateur est sanctionné, un email et un MP sont envoyés mais le MP n'est pas notifié convenablement (càd qu'il n'y a pas de bulle rouge à côté de l'icône de messagerie). Cette PR effectue quelques changements qui permettent de mieux gérer ce cas et de bien notifier l'utilisateur lorsqu'il est sanctionné.

### Contrôle qualité
* Se connecter en tant que staff
* Appliquer une sanction à user1 (par exemple, LS ou LS temporaire)
* Se déconnecter
* Se connecter en tant que user1
**Résultat attendu:** Une notification (bulle rouge) est présente à côté de l'icône de messagerie, notifiant l'utilisateur de sa sanction.
* Se déconnecter
* Se connecter en tant que staff
* Retirer la sanction à user1
* Se déconnecter
* Se connecter en tant que user1
**Résultat attendu:** Une notification (bulle rouge) est présente à côté de l'icône de messagerie, notifiant l'utilisateur de la levée de sa sanction.