### PR TITLE
Supprime les caractères non supportés par les flux RSS et ATOM

### DIFF
--- a/zds/forum/feeds.py
+++ b/zds/forum/feeds.py
@@ -1,10 +1,9 @@
 from django.contrib.syndication.views import Feed
-
-from django.utils.feedgenerator import Atom1Feed
 from django.conf import settings
 from django.utils.timezone import make_aware
 from pytz import AmbiguousTimeError, NonExistentTimeError
 
+from zds.utils.feeds import DropControlCharsRss201rev2Feed, DropControlCharsAtom1Feed
 from .models import Post, Topic
 
 
@@ -41,6 +40,7 @@ class LastPostsFeedRSS(Feed, ItemMixin):
     title = "Derniers messages sur {}".format(settings.ZDS_APP["site"]["literal_name"])
     link = "/forums/"
     description = "Les derniers messages parus sur le forum de {}.".format(settings.ZDS_APP["site"]["literal_name"])
+    feed_type = DropControlCharsRss201rev2Feed
 
     def get_object(self, request):
         return request_object(request)
@@ -65,7 +65,7 @@ class LastPostsFeedRSS(Feed, ItemMixin):
 
 
 class LastPostsFeedATOM(LastPostsFeedRSS):
-    feed_type = Atom1Feed
+    feed_type = DropControlCharsAtom1Feed
     subtitle = LastPostsFeedRSS.description
 
 
@@ -73,6 +73,7 @@ class LastTopicsFeedRSS(Feed, ItemMixin):
     title = "Derniers sujets sur {}".format(settings.ZDS_APP["site"]["literal_name"])
     link = "/forums/"
     description = "Les derniers sujets créés sur le forum de {}.".format(settings.ZDS_APP["site"]["literal_name"])
+    feed_type = DropControlCharsRss201rev2Feed
 
     def get_object(self, request):
         return request_object(request)
@@ -97,5 +98,5 @@ class LastTopicsFeedRSS(Feed, ItemMixin):
 
 
 class LastTopicsFeedATOM(LastTopicsFeedRSS):
-    feed_type = Atom1Feed
+    feed_type = DropControlCharsAtom1Feed
     subtitle = LastTopicsFeedRSS.description

--- a/zds/forum/feeds.py
+++ b/zds/forum/feeds.py
@@ -40,7 +40,7 @@ def request_object(request):
 class LastPostsFeedRSS(Feed, ItemMixin):
     title = "Derniers messages sur {}".format(settings.ZDS_APP["site"]["literal_name"])
     link = "/forums/"
-    description = "Les derniers messages " "parus sur le forum de {}.".format(settings.ZDS_APP["site"]["literal_name"])
+    description = "Les derniers messages parus sur le forum de {}.".format(settings.ZDS_APP["site"]["literal_name"])
 
     def get_object(self, request):
         return request_object(request)

--- a/zds/forum/tests/tests_feeds.py
+++ b/zds/forum/tests/tests_feeds.py
@@ -139,6 +139,24 @@ class LastTopicsFeedTest(TestCase):
         ret = self.topicfeed.item_link(item=topics[0])
         self.assertEqual(ret, ref)
 
+    def test_content_control_chars(self):
+        """
+        Test 'control characters' in content of the feed doesn't break it.
+
+        The '\u0007' character in the post content belongs to a character
+        family that is  not supported in RSS or Atom feeds and will break their
+        generation.
+        """
+        buggy_topic = TopicFactory(forum=self.forum2, author=self.user)
+        buggy_topic.title = "Strange char: \u0007"
+        buggy_topic.save()
+
+        request = self.client.get(reverse("topic-feed-rss"))
+        self.assertEqual(request.status_code, 200)
+
+        request = self.client.get(reverse("topic-feed-atom"))
+        self.assertEqual(request.status_code, 200)
+
 
 class LastPostsFeedTest(TestCase):
     def setUp(self):
@@ -284,3 +302,22 @@ class LastPostsFeedTest(TestCase):
         posts = self.postfeed.items(obj={"tag": self.tag2.pk})
         ret = self.postfeed.item_link(item=posts[0])
         self.assertEqual(ret, ref)
+
+    def test_content_control_chars(self):
+        """
+        Test 'control characters' in content of the feed doesn't break it.
+
+        The '\u0007' character in the post content belongs to a character
+        family that is  not supported in RSS or Atom feeds and will break their
+        generation.
+        """
+        buggy_topic = TopicFactory(forum=self.forum2, author=self.user)
+        post = PostFactory(topic=buggy_topic, author=self.user, position=1)
+        post.update_content("Strange char: \u0007")
+        post.save()
+
+        request = self.client.get(reverse("post-feed-rss"))
+        self.assertEqual(request.status_code, 200)
+
+        request = self.client.get(reverse("post-feed-atom"))
+        self.assertEqual(request.status_code, 200)

--- a/zds/forum/tests/tests_feeds.py
+++ b/zds/forum/tests/tests_feeds.py
@@ -8,7 +8,7 @@ from zds.forum.feeds import LastPostsFeedRSS, LastPostsFeedATOM, LastTopicsFeedR
 from zds.member.tests.factories import ProfileFactory
 
 
-class LastTopicsFeedRSSTest(TestCase):
+class LastTopicsFeedTest(TestCase):
     def setUp(self):
         # prepare a user and 2 Topic (with and without tags)
 
@@ -35,7 +35,7 @@ class LastTopicsFeedRSSTest(TestCase):
         self.assertEqual(self.topicfeed.link, "/forums/")
         reftitle = "Derniers sujets sur {}".format(settings.ZDS_APP["site"]["literal_name"])
         self.assertEqual(self.topicfeed.title, reftitle)
-        refdescription = "Les derniers sujets créés " "sur le forum de {}.".format(
+        refdescription = "Les derniers sujets créés sur le forum de {}.".format(
             settings.ZDS_APP["site"]["literal_name"]
         )
         self.assertEqual(self.topicfeed.description, refdescription)
@@ -76,7 +76,7 @@ class LastTopicsFeedRSSTest(TestCase):
     def test_items_bad_cases(self):
         """test that right items are sent back according to obj"""
 
-        # test empty values, return value shoulb be empty
+        # test empty values, return value should be empty
         obj = {"forum": -1, "tag": -1}
         topics = self.topicfeed.items(obj=obj)
         self.assertEqual(len(topics), 0)
@@ -140,7 +140,7 @@ class LastTopicsFeedRSSTest(TestCase):
         self.assertEqual(ret, ref)
 
 
-class LastPostFeedTest(TestCase):
+class LastPostsFeedTest(TestCase):
     def setUp(self):
         # prepare a user and 2 Topic (with and without tags)
 
@@ -160,7 +160,7 @@ class LastPostFeedTest(TestCase):
         self.topic2.tags.add(self.tag)
         self.topic2.save()
 
-        # create 2 posts un each forum
+        # create 2 posts in each forum
         PostFactory(topic=self.topic1, author=self.user, position=1)
         PostFactory(topic=self.topic1, author=self.user, position=2)
         PostFactory(topic=self.topic2, author=self.user, position=1)
@@ -181,7 +181,7 @@ class LastPostFeedTest(TestCase):
         self.assertEqual(self.postfeed.link, "/forums/")
         reftitle = "Derniers messages sur {}".format(settings.ZDS_APP["site"]["literal_name"])
         self.assertEqual(self.postfeed.title, reftitle)
-        refdescription = "Les derniers messages " "parus sur le forum de {}.".format(
+        refdescription = "Les derniers messages parus sur le forum de {}.".format(
             settings.ZDS_APP["site"]["literal_name"]
         )
         self.assertEqual(self.postfeed.description, refdescription)

--- a/zds/tutorialv2/feeds.py
+++ b/zds/tutorialv2/feeds.py
@@ -2,10 +2,10 @@ from django.conf import settings
 from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import make_aware
-from django.utils.feedgenerator import Atom1Feed
 from django.utils.translation import gettext_lazy as _
 from pytz import AmbiguousTimeError, NonExistentTimeError
 
+from zds.utils.feeds import DropControlCharsRss201rev2Feed, DropControlCharsAtom1Feed
 from zds.utils.models import Category, SubCategory, Tag
 from zds.utils.uuslug_wrapper import slugify
 from zds.tutorialv2.models.database import PublishedContent
@@ -21,6 +21,7 @@ class LastContentFeedRSS(Feed):
     link = ""
     content_type = None
     query_params = {}
+    feed_type = DropControlCharsRss201rev2Feed
 
     def get_object(self, request, *args, **kwargs):
         self.query_params = request.GET
@@ -80,7 +81,7 @@ class LastContentFeedRSS(Feed):
 
 
 class LastContentFeedATOM(LastContentFeedRSS):
-    feed_type = Atom1Feed
+    feed_type = DropControlCharsAtom1Feed
     subtitle = LastContentFeedRSS.description
 
 
@@ -96,7 +97,7 @@ class LastTutorialsFeedRSS(LastContentFeedRSS):
 
 
 class LastTutorialsFeedATOM(LastTutorialsFeedRSS):
-    feed_type = Atom1Feed
+    feed_type = DropControlCharsAtom1Feed
     subtitle = LastTutorialsFeedRSS.description
 
 
@@ -112,7 +113,7 @@ class LastArticlesFeedRSS(LastContentFeedRSS):
 
 
 class LastArticlesFeedATOM(LastArticlesFeedRSS):
-    feed_type = Atom1Feed
+    feed_type = DropControlCharsAtom1Feed
     subtitle = LastArticlesFeedRSS.description
 
 
@@ -128,5 +129,5 @@ class LastOpinionsFeedRSS(LastContentFeedRSS):
 
 
 class LastOpinionsFeedATOM(LastOpinionsFeedRSS):
-    feed_type = Atom1Feed
+    feed_type = DropControlCharsAtom1Feed
     subtitle = LastOpinionsFeedRSS.description

--- a/zds/tutorialv2/tests/tests_feeds.py
+++ b/zds/tutorialv2/tests/tests_feeds.py
@@ -2,11 +2,10 @@ from django.conf import settings
 from django.http import Http404
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.contrib.auth.models import Group
 
 from zds.gallery.tests.factories import UserGalleryFactory
-from zds.member.tests.factories import ProfileFactory, StaffProfileFactory, UserFactory
-from zds.forum.tests.factories import ForumFactory, ForumCategoryFactory, TagFactory
+from zds.member.tests.factories import ProfileFactory
+from zds.forum.tests.factories import TagFactory
 from zds.tutorialv2.models.database import PublishedContent
 from zds.tutorialv2.feeds import LastTutorialsFeedRSS, LastTutorialsFeedATOM, LastArticlesFeedRSS, LastArticlesFeedATOM
 from zds.tutorialv2.tests.factories import (
@@ -26,35 +25,17 @@ overridden_zds_app["content"]["repo_public_path"] = settings.BASE_DIR / "content
 
 @override_settings(MEDIA_ROOT=settings.BASE_DIR / "media-test")
 @override_settings(ZDS_APP=overridden_zds_app)
-class LastTutorialsFeedRSSTest(TutorialTestMixin, TestCase):
+class LastTutorialsFeedsTest(TutorialTestMixin, TestCase):
     def setUp(self):
         self.overridden_zds_app = overridden_zds_app
         # don't build PDF to speed up the tests
         overridden_zds_app["content"]["build_pdf_when_published"] = False
-
-        self.staff = StaffProfileFactory().user
-
-        settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
-        self.mas = ProfileFactory().user
-        overridden_zds_app["member"]["bot_account"] = self.mas.username
-
-        bot = Group(name=overridden_zds_app["member"]["bot_group"])
-        bot.save()
-        self.external = UserFactory(username=overridden_zds_app["member"]["external_account"], password="anything")
-
-        self.beta_forum = ForumFactory(
-            pk=overridden_zds_app["forum"]["beta_forum_id"],
-            category=ForumCategoryFactory(position=1),
-            position_in_category=1,
-        )  # ensure that the forum, for the beta versions, is created
 
         self.licence = LicenceFactory()
         self.subcategory = SubCategoryFactory()
         self.tag = TagFactory()
 
         self.user_author = ProfileFactory().user
-        self.user_staff = StaffProfileFactory().user
-        self.user_guest = ProfileFactory().user
 
         # create a tutorial
         self.tuto = PublishableContentFactory(type="TUTORIAL")
@@ -211,35 +192,17 @@ class LastTutorialsFeedRSSTest(TutorialTestMixin, TestCase):
 
 
 @override_settings(ZDS_APP=overridden_zds_app)
-class LastArticlesFeedRSSTest(TutorialTestMixin, TestCase):
+class LastArticlesFeedsTest(TutorialTestMixin, TestCase):
     def setUp(self):
         self.overridden_zds_app = overridden_zds_app
         # don't build PDF to speed up the tests
         overridden_zds_app["content"]["build_pdf_when_published"] = False
-
-        self.staff = StaffProfileFactory().user
-
-        settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
-        self.mas = ProfileFactory().user
-        overridden_zds_app["member"]["bot_account"] = self.mas.username
-
-        bot = Group(name=overridden_zds_app["member"]["bot_group"])
-        bot.save()
-        self.external = UserFactory(username=overridden_zds_app["member"]["external_account"], password="anything")
-
-        self.beta_forum = ForumFactory(
-            pk=overridden_zds_app["forum"]["beta_forum_id"],
-            category=ForumCategoryFactory(position=1),
-            position_in_category=1,
-        )  # ensure that the forum, for the beta versions, is created
 
         self.licence = LicenceFactory()
         self.subcategory = SubCategoryFactory()
         self.tag = TagFactory()
 
         self.user_author = ProfileFactory().user
-        self.user_staff = StaffProfileFactory().user
-        self.user_guest = ProfileFactory().user
 
         # create an article
         self.article = PublishableContentFactory(type="ARTICLE")

--- a/zds/tutorialv2/tests/tests_feeds.py
+++ b/zds/tutorialv2/tests/tests_feeds.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.http import Http404
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.urls import reverse
 
 from zds.gallery.tests.factories import UserGalleryFactory
 from zds.member.tests.factories import ProfileFactory
@@ -17,6 +18,7 @@ from zds.tutorialv2.feeds import (
 )
 from zds.tutorialv2.tests.factories import (
     PublishableContentFactory,
+    PublishedContentFactory,
     ContainerFactory,
     ExtractFactory,
 )
@@ -197,6 +199,27 @@ class LastTutorialsFeedsTest(TutorialTestMixin, TestCase):
         self.tutofeed.query_params = {"tag": "invalid"}
         self.assertRaises(Http404, self.tutofeed.items)
 
+    def test_content_control_chars(self):
+        """
+        Test 'control characters' in content of the feed doesn't break it.
+
+        The '\u0007' character in the post content belongs to a character
+        family that is  not supported in RSS or Atom feeds and will break their
+        generation.
+        """
+        buggy_tutorial = PublishedContentFactory(
+            author_list=[self.user_author], type="TUTORIAL", description="Strange char: \u0007"
+        )
+        buggy_tutorial.subcategory.add(self.subcategory)
+        buggy_tutorial.tags.add(self.tag)
+        buggy_tutorial.save()
+
+        request = self.client.get(reverse("tutorial:feed-rss"))
+        self.assertEqual(request.status_code, 200)
+
+        request = self.client.get(reverse("tutorial:feed-atom"))
+        self.assertEqual(request.status_code, 200)
+
 
 @override_settings(ZDS_APP=overridden_zds_app)
 class LastArticlesFeedsTest(TutorialTestMixin, TestCase):
@@ -362,6 +385,27 @@ class LastArticlesFeedsTest(TutorialTestMixin, TestCase):
         self.articlefeed.query_params = {"tag": "invalid"}
         self.assertRaises(Http404, self.articlefeed.items)
 
+    def test_content_control_chars(self):
+        """
+        Test 'control characters' in content of the feed doesn't break it.
+
+        The '\u0007' character in the post content belongs to a character
+        family that is  not supported in RSS or Atom feeds and will break their
+        generation.
+        """
+        buggy_article = PublishedContentFactory(
+            author_list=[self.user_author], type="ARTICLE", description="Strange char: \u0007"
+        )
+        buggy_article.subcategory.add(self.subcategory)
+        buggy_article.tags.add(self.tag)
+        buggy_article.save()
+
+        request = self.client.get(reverse("article:feed-rss"))
+        self.assertEqual(request.status_code, 200)
+
+        request = self.client.get(reverse("article:feed-atom"))
+        self.assertEqual(request.status_code, 200)
+
 
 @override_settings(ZDS_APP=overridden_zds_app)
 class LastOpinionsFeedsTest(TutorialTestMixin, TestCase):
@@ -503,3 +547,24 @@ class LastOpinionsFeedsTest(TutorialTestMixin, TestCase):
 
         self.opinionfeed.query_params = {"tag": "invalid"}
         self.assertRaises(Http404, self.opinionfeed.items)
+
+    def test_content_control_chars(self):
+        """
+        Test 'control characters' in content of the feed doesn't break it.
+
+        The '\u0007' character in the post content belongs to a character
+        family that is  not supported in RSS or Atom feeds and will break their
+        generation.
+        """
+        buggy_opinion = PublishedContentFactory(
+            author_list=[self.user_author], type="OPINION", description="Strange char: \u0007"
+        )
+        buggy_opinion.subcategory.add(self.subcategory)
+        buggy_opinion.tags.add(self.tag)
+        buggy_opinion.save()
+
+        request = self.client.get(reverse("opinion:feed-rss"))
+        self.assertEqual(request.status_code, 200)
+
+        request = self.client.get(reverse("opinion:feed-atom"))
+        self.assertEqual(request.status_code, 200)

--- a/zds/utils/feeds.py
+++ b/zds/utils/feeds.py
@@ -1,0 +1,34 @@
+import re
+
+from django.utils.feedgenerator import Atom1Feed, Rss201rev2Feed
+from django.utils.xmlutils import SimplerXMLGenerator
+
+
+class DropControlCharsXMLGenerator(SimplerXMLGenerator):
+    def characters(self, content):
+        # From django.utils.xmlutils.SimplerXMLGenerator.characters()
+        super().characters(re.sub(r"[\x00-\x08\x0B-\x0C\x0E-\x1F]", "", content))
+
+
+class DropControlCharsRss201rev2Feed(Rss201rev2Feed):
+    def write(self, outfile, encoding):
+        # From django.utils.feedgenerator.RssFeed.write()
+        handler = DropControlCharsXMLGenerator(outfile, encoding)
+        handler.startDocument()
+        handler.startElement("rss", self.rss_attributes())
+        handler.startElement("channel", self.root_attributes())
+        self.add_root_elements(handler)
+        self.write_items(handler)
+        self.endChannelElement(handler)
+        handler.endElement("rss")
+
+
+class DropControlCharsAtom1Feed(Atom1Feed):
+    def write(self, outfile, encoding):
+        # From django.utils.feedgenerator.Atom1Feed.write()
+        handler = DropControlCharsXMLGenerator(outfile, encoding)
+        handler.startDocument()
+        handler.startElement("feed", self.root_attributes())
+        self.add_root_elements(handler)
+        self.write_items(handler)
+        handler.endElement("feed")


### PR DESCRIPTION
La principale contribution de cette PR est de supprimer les "caractères de contrôles" qui [ne sont pas supportés](https://docs.djangoproject.com/fr/3.2/ref/contrib/syndication/#the-low-level-framework) dans les flux RSS et ATOM, mais qui peuvent être présents dans les contenus qui sont affichés dans les flux. J'en ai profité pour nettoyer un peu le code et ajouter les tests pour les flux des billets (il y avait des tests pour les flux des articles et des tutoriels, mais pas pour les billets).

### Contrôle qualité

J'ai ajouté les tests correspondant, donc la CI devrait suffire.

- Faire une revue de code
- Créer un article / tutoriel / billet / sujet de forum dont le titre ou la description contiennent des caractères qui posent problème. Ce peut être en copiant le morceau de code inline `]%B5G}%B5%D0&@"s0%DFRncrypted.txt` depuis le premier message de ce [sujet](https://beta.zestedesavoir.com/forums/sujet/8741/chiffrement-aes-avec-cryptopp/). Il faut le copier depuis ZdS et non depuis GitHub, car GitHub supprime/convertit les caractères qui posent problème
- Récupérer les flux RSS et ATOM contenant le contenu que vous venez de créer. La génération des flux doit fonctionner et ne pas déclencher d'erreur.

Je me suis inspiré de cette réponse sur [StackOverflow](https://stackoverflow.com/a/52908280) pour implémenter la correction, mais il y a peut-être plus élégant...

Note : vous pouvez visualiser les caractères bizarres et invisibles avec ce [site](https://www.soscisurvey.de/tools/view-chars.php) par exemple.

Note à celui qui mergera : ne squashez pas les commits.