### PR TITLE
Gère les utilisateurs inexistants dans RedirectOldContentOfAuthor

### DIFF
--- a/zds/tutorialv2/tests/tests_views/tests_redirect.py
+++ b/zds/tutorialv2/tests/tests_views/tests_redirect.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+
+from zds.member.tests.factories import ProfileFactory
+
+
+class RedirectOldContentOfAuthorTest(TestCase):
+    def test_redirect(self):
+        user = ProfileFactory().user
+
+        response = self.client.get(f"/contenus/tutoriels/{user.pk}", follow=True)
+        self.assertRedirects(response, f"/tutoriels/voir/{user}/", status_code=301)
+
+        response = self.client.get(f"/contenus/articles/{user.pk}", follow=True)
+        self.assertRedirects(response, f"/articles/voir/{user}/", status_code=301)
+
+        response = self.client.get(f"/contenus/tribunes/{user.pk}", follow=True)
+        self.assertRedirects(response, f"/billets/voir/{user}/", status_code=301)
+
+        response = self.client.get(f"/contenus/foo/{user.pk}", follow=True)
+        self.assertEqual(response.status_code, 404)

--- a/zds/tutorialv2/tests/tests_views/tests_redirect.py
+++ b/zds/tutorialv2/tests/tests_views/tests_redirect.py
@@ -19,5 +19,5 @@ class RedirectOldContentOfAuthorTest(TestCase):
 
         # The user with pk=3954 doesn't exist (the view in the redirection
         # triggers the 404, so we need to follow the response):
-        response = self.client.get("/contenus/tutoriels/3954", follow=True)
+        response = self.client.get(reverse("content:legacy-find-tutorial", args=[3954]), follow=True)
         self.assertEqual(response.status_code, 404)

--- a/zds/tutorialv2/tests/tests_views/tests_redirect.py
+++ b/zds/tutorialv2/tests/tests_views/tests_redirect.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.urls import reverse
 
 from zds.member.tests.factories import ProfileFactory
 
@@ -7,18 +8,16 @@ class RedirectOldContentOfAuthorTest(TestCase):
     def test_redirect(self):
         user = ProfileFactory().user
 
-        response = self.client.get(f"/contenus/tutoriels/{user.pk}", follow=True)
-        self.assertRedirects(response, f"/tutoriels/voir/{user}/", status_code=301)
+        response = self.client.get(reverse("content:legacy-find-tutorial", args=[user.pk]))
+        self.assertRedirects(response, reverse("tutorial:find-tutorial", args=[user]), status_code=301)
 
-        response = self.client.get(f"/contenus/articles/{user.pk}", follow=True)
-        self.assertRedirects(response, f"/articles/voir/{user}/", status_code=301)
+        response = self.client.get(reverse("content:legacy-find-article", args=[user.pk]))
+        self.assertRedirects(response, reverse("article:find-article", args=[user]), status_code=301)
 
-        response = self.client.get(f"/contenus/tribunes/{user.pk}", follow=True)
-        self.assertRedirects(response, f"/billets/voir/{user}/", status_code=301)
+        response = self.client.get(reverse("content:legacy-find-opinion", args=[user.pk]))
+        self.assertRedirects(response, reverse("opinion:find-opinion", args=[user]), status_code=301)
 
-        response = self.client.get(f"/contenus/foo/{user.pk}", follow=True)
-        self.assertEqual(response.status_code, 404)
-
-        # The user with pk=3954 doesn't exist:
+        # The user with pk=3954 doesn't exist (the view in the redirection
+        # triggers the 404, so we need to follow the response):
         response = self.client.get("/contenus/tutoriels/3954", follow=True)
         self.assertEqual(response.status_code, 404)

--- a/zds/tutorialv2/tests/tests_views/tests_redirect.py
+++ b/zds/tutorialv2/tests/tests_views/tests_redirect.py
@@ -18,3 +18,7 @@ class RedirectOldContentOfAuthorTest(TestCase):
 
         response = self.client.get(f"/contenus/foo/{user.pk}", follow=True)
         self.assertEqual(response.status_code, 404)
+
+        # The user with pk=3954 doesn't exist:
+        response = self.client.get("/contenus/tutoriels/3954", follow=True)
+        self.assertEqual(response.status_code, 404)

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -52,9 +52,9 @@ urlpatterns = [
         name="find-contribution-all",
     ),
     path("commentaires/<int:pk>/", ListContentReactions.as_view(), name="list-content-reactions"),
-    path("tutoriels/<int:pk>/", RedirectOldContentOfAuthor.as_view(type="TUTORIAL")),
-    path("articles/<int:pk>/", RedirectOldContentOfAuthor.as_view(type="ARTICLE")),
-    path("tribunes/<int:pk>/", RedirectOldContentOfAuthor.as_view(type="OPINION")),
+    path("tutoriels/<int:pk>/", RedirectOldContentOfAuthor.as_view(type="TUTORIAL"), name="legacy-find-tutorial"),
+    path("articles/<int:pk>/", RedirectOldContentOfAuthor.as_view(type="ARTICLE"), name="legacy-find-article"),
+    path("tribunes/<int:pk>/", RedirectOldContentOfAuthor.as_view(type="OPINION"), name="legacy-find-opinion"),
     path("aides/", ContentsWithHelps.as_view(), name="helps"),
     path("aides/<int:pk>/change/", ChangeHelp.as_view(), name="helps-change"),
     path(

--- a/zds/tutorialv2/views/redirect.py
+++ b/zds/tutorialv2/views/redirect.py
@@ -40,7 +40,8 @@ class RedirectOldBetaTuto(RedirectView):
 class RedirectOldContentOfAuthor(RedirectView):
     """
     allows to redirect the old lists of users' tutorials/articles/opinions (with
-    pks) to the new ones (with usernames and different root).
+    pks) to the new ones (with usernames and different root):
+    /contenus/tutoriels/user_pk/ => /tutoriels/voir/user_slug/
     """
 
     permanent = True

--- a/zds/tutorialv2/views/redirect.py
+++ b/zds/tutorialv2/views/redirect.py
@@ -40,8 +40,7 @@ class RedirectOldBetaTuto(RedirectView):
 class RedirectOldContentOfAuthor(RedirectView):
     """
     allows to redirect the old lists of users' tutorials/articles/opinions (with
-    pks) to the new ones (with usernames and different root):
-    /contenus/tutoriels/user_pk/ => /tutoriels/voir/user_slug/
+    pks) to the new ones (with usernames and different root).
     """
 
     permanent = True

--- a/zds/tutorialv2/views/redirect.py
+++ b/zds/tutorialv2/views/redirect.py
@@ -51,6 +51,9 @@ class RedirectOldContentOfAuthor(RedirectView):
         user = User.objects.filter(pk=int(kwargs["pk"])).first()
         route = None
 
+        if not user:
+            raise Http404("Cet utilisateur est inconnu dans le système")
+
         if self.type == "TUTORIAL":
             route = "tutorial:find-tutorial"
         elif self.type == "ARTICLE":


### PR DESCRIPTION
La vue `RedirectOldContentOfAuthor` permet de rediriger les anciennes URLs `/contenus/tutoriels/{user_pk}` vers une URL de la forme `/tutoriels/voir/{user_slug}`. Cependant si `user_pk` recevait l'id d'un utilisateur inexistant, une erreur 500 était levée. Cette PR corrige ce problème et ajoute les tests pour cette vue.

Problème rapporté par Sentry.

### Contrôle qualité

- Utiliser l'ancienne URL pour un utilisateur qui existe, par exemple : http://127.0.0.1:8000/contenus/tutoriels/10/ doit rediriger vers http://127.0.0.1:8000/tutoriels/voir/user1/
- Utiliser l'ancienne URL pour un utilisateur qui n'existe pas, par exemple : http://127.0.0.1:8000/contenus/tutoriels/128/. La page doit renvoyer une 404 et non pas une 500.
