### PR TITLE
Rajout de champ mot de passe aux pages de Désinscription et de changements d'email

### DIFF
--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -1,6 +1,6 @@
 {% extends "member/settings/base.html" %}
 {% load i18n %}
-
+{% load crispy_forms_tags %}
 
 {% block breadcrumb %}
     <li>{% trans "Désinscription" %}</li>
@@ -89,17 +89,5 @@
         <a href="#unregister" class="open-modal btn btn-cancel">{% trans "Me désinscrire" %}</a>
     </p>
 
-    <form
-        method="post"
-        action="{% url "member-unregister" %}"
-        id="unregister"
-        class="modal modal-flex"
-    >
-        <p>
-            {% trans "C’est votre dernière chance de rester parmi nous" %}...
-        </p>
-
-        {% csrf_token %}
-        <button type="submit" class="btn btn-submit">{% trans "Me désinscrire" %}</button>
-    </form>
+    {% crispy unregister_form %}
 {% endblock %}

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -22,7 +22,7 @@ from zds.member.validators import (
     validate_zds_password,
     validate_raw_zds_username,
 )
-from zds.utils.forms import IncludeEasyMDE
+from zds.utils.forms import IncludeEasyMDE, FieldPasswordMixin
 from zds.utils.misc import contains_utf8mb4
 from zds.utils.models import Licence, HatRequest, Hat
 from zds.utils import get_current_user
@@ -366,7 +366,7 @@ class GitHubTokenForm(forms.Form):
         )
 
 
-class ChangeUserForm(forms.Form):
+class ChangeUserForm(forms.Form, FieldPasswordMixin):
     """
     Update username and email
     """
@@ -393,6 +393,11 @@ class ChangeUserForm(forms.Form):
         widget=forms.CheckboxSelectMultiple,
     )
 
+    password = forms.CharField(
+        label=_("Mot de passe (confirmation)"),
+        widget=forms.PasswordInput,
+    )
+
     def __init__(self, user, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
@@ -402,6 +407,8 @@ class ChangeUserForm(forms.Form):
         self.previous_username = user.username
         self.fields["options"].initial = ""
 
+        self.user = user
+
         if user.profile and user.profile.show_email:
             self.fields["options"].initial += "show_email"
 
@@ -409,6 +416,7 @@ class ChangeUserForm(forms.Form):
             Field("username", value=user.username),
             Field("email", value=user.email),
             Field("options"),
+            Field("password"),
             ButtonHolder(
                 StrictButton(_("Enregistrer"), type="submit"),
             ),
@@ -417,6 +425,7 @@ class ChangeUserForm(forms.Form):
     def clean(self):
         validate_raw_zds_username(self.data)
         cleaned_data = super().clean()
+        cleaned_data = self.check_correct_password(cleaned_data)
         cleaned_data["previous_username"] = self.previous_username
         cleaned_data["previous_email"] = self.previous_email
         username = cleaned_data.get("username")
@@ -430,10 +439,53 @@ class ChangeUserForm(forms.Form):
         return cleaned_data
 
 
-# TODO: Updates the password --> requires a better name
-class ChangePasswordForm(forms.Form):
+class UnregisterForm(forms.Form, FieldPasswordMixin):
+    """
+    Unregister form
+    """
 
-    password_old = forms.CharField(
+    password = forms.CharField(
+        label=_("Mot de passe (confirmation)"),
+        widget=forms.PasswordInput,
+    )
+
+    def __init__(self, user, *args, **kwargs):
+        super(UnregisterForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_id = "unregister"
+        self.helper.form_class = "modal modal-flex"
+        self.helper.form_method = "post"
+        self.helper.form_action = reverse("member-unregister")
+
+        self.user = user
+
+        self.helper.layout = Layout(
+            Field("password"),
+            HTML(
+                _(
+                    """
+                <p>
+                    C’est votre dernière chance de rester parmi nous ...
+                </p>
+            """
+                )
+            ),
+            ButtonHolder(
+                StrictButton(_("Me désinscrire"), type="submit"),
+            ),
+        )
+
+    def clean(self):
+        cleaned_data = super(UnregisterForm, self).clean()
+        cleaned_data = self.check_correct_password(cleaned_data)
+
+        return cleaned_data
+
+
+# TODO: Updates the password --> requires a better name
+class ChangePasswordForm(forms.Form, FieldPasswordMixin):
+
+    password = forms.CharField(
         label=_("Mot de passe actuel"),
         widget=forms.PasswordInput,
     )
@@ -461,7 +513,7 @@ class ChangePasswordForm(forms.Form):
         self.user = user
 
         self.helper.layout = Layout(
-            Field("password_old"),
+            Field("password"),
             Field("password_new"),
             Field("password_confirm"),
             ButtonHolder(
@@ -471,18 +523,7 @@ class ChangePasswordForm(forms.Form):
 
     def clean(self):
         cleaned_data = super().clean()
-
-        password_old = cleaned_data.get("password_old")
-
-        # Check if the actual password is not empty
-        if password_old:
-            user_exist = authenticate(username=self.user.username, password=password_old)
-            # Check if the user exist with old informations.
-            if not user_exist and password_old != "":
-                self._errors["password_old"] = self.error_class([_("Mot de passe incorrect.")])
-                if "password_old" in cleaned_data:
-                    del cleaned_data["password_old"]
-
+        cleaned_data = self.check_correct_password(cleaned_data)
         return validate_passwords(cleaned_data, password_label="password_new", username=self.user.username)
 
 

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -22,7 +22,7 @@ from zds.member.validators import (
     validate_zds_password,
     validate_raw_zds_username,
 )
-from zds.utils.forms import IncludeEasyMDE, FieldPasswordMixin
+from zds.utils.forms import IncludeEasyMDE, PasswordRequiredForm
 from zds.utils.misc import contains_utf8mb4
 from zds.utils.models import Licence, HatRequest, Hat
 from zds.utils import get_current_user
@@ -366,7 +366,7 @@ class GitHubTokenForm(forms.Form):
         )
 
 
-class ChangeUserForm(forms.Form, FieldPasswordMixin):
+class ChangeUserForm(PasswordRequiredForm):
     """
     Update username and email
     """
@@ -391,11 +391,6 @@ class ChangeUserForm(forms.Form, FieldPasswordMixin):
         required=False,
         choices=(("show_email", _("Afficher mon adresse courriel publiquement")),),
         widget=forms.CheckboxSelectMultiple,
-    )
-
-    password = forms.CharField(
-        label=_("Mot de passe (confirmation)"),
-        widget=forms.PasswordInput,
     )
 
     def __init__(self, user, *args, **kwargs):
@@ -439,15 +434,10 @@ class ChangeUserForm(forms.Form, FieldPasswordMixin):
         return cleaned_data
 
 
-class UnregisterForm(forms.Form, FieldPasswordMixin):
+class UnregisterForm(PasswordRequiredForm):
     """
     Unregister form
     """
-
-    password = forms.CharField(
-        label=_("Mot de passe (confirmation)"),
-        widget=forms.PasswordInput,
-    )
 
     def __init__(self, user, *args, **kwargs):
         super(UnregisterForm, self).__init__(*args, **kwargs)
@@ -483,12 +473,7 @@ class UnregisterForm(forms.Form, FieldPasswordMixin):
 
 
 # TODO: Updates the password --> requires a better name
-class ChangePasswordForm(forms.Form, FieldPasswordMixin):
-
-    password = forms.CharField(
-        label=_("Mot de passe actuel"),
-        widget=forms.PasswordInput,
-    )
+class ChangePasswordForm(PasswordRequiredForm):
 
     password_new = forms.CharField(
         label=_("Nouveau mot de passe"),

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -420,7 +420,6 @@ class ChangeUserForm(PasswordRequiredForm):
     def clean(self):
         validate_raw_zds_username(self.data)
         cleaned_data = super().clean()
-        cleaned_data = self.check_correct_password(cleaned_data)
         cleaned_data["previous_username"] = self.previous_username
         cleaned_data["previous_email"] = self.previous_email
         username = cleaned_data.get("username")
@@ -440,7 +439,7 @@ class UnregisterForm(PasswordRequiredForm):
     """
 
     def __init__(self, user, *args, **kwargs):
-        super(UnregisterForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_id = "unregister"
         self.helper.form_class = "modal modal-flex"
@@ -464,12 +463,6 @@ class UnregisterForm(PasswordRequiredForm):
                 StrictButton(_("Me désinscrire"), type="submit"),
             ),
         )
-
-    def clean(self):
-        cleaned_data = super(UnregisterForm, self).clean()
-        cleaned_data = self.check_correct_password(cleaned_data)
-
-        return cleaned_data
 
 
 # TODO: Updates the password --> requires a better name
@@ -508,7 +501,6 @@ class ChangePasswordForm(PasswordRequiredForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        cleaned_data = self.check_correct_password(cleaned_data)
         return validate_passwords(cleaned_data, password_label="password_new", username=self.user.username)
 
 

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -10,6 +10,7 @@ from zds.member.forms import (
     NewPasswordForm,
     KarmaForm,
     UsernameAndEmailForm,
+    UnregisterForm,
 )
 from zds.member.models import BannedEmailProvider
 from zds.member.tests.factories import StaffProfileFactory
@@ -163,6 +164,21 @@ class RegisterFormTest(TestCase):
         self.assertFalse(form.is_valid())
 
 
+class UnregisterFormTest(TestCase):
+    """
+    Check the unregistering form.
+    """
+
+    def setUp(self):
+        self.user1 = ProfileFactory()
+
+    def test_password_is_required(self):
+        data = {}
+        form = UnregisterForm(data=data, user=self.user1.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("password", form.errors.keys())
+
+
 class MiniProfileFormTest(TestCase):
     """
     Check the miniprofile form.
@@ -235,22 +251,22 @@ class ChangeUserFormTest(TestCase):
         self.user2 = ProfileFactory()
 
     def test_valid_change_username_user_form(self):
-        data = {"username": "MyNewPseudo", "email": self.user1.user.email}
+        data = {"username": "MyNewPseudo", "email": self.user1.user.email, "password": "hostel77"}
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertTrue(form.is_valid())
 
     def test_valid_change_email_user_form(self):
-        data = {"username": self.user1.user.username, "email": "test@gmail.com"}
+        data = {"username": self.user1.user.username, "email": "test@gmail.com", "password": "hostel77"}
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertTrue(form.is_valid())
 
     def test_already_used_username_user_form(self):
-        data = {"username": self.user2.user.username, "email": self.user1.user.email}
+        data = {"username": self.user2.user.username, "email": self.user1.user.email, "password": "hostel77"}
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
     def test_already_used_email_user_form(self):
-        data = {"username": self.user1.user.username, "email": self.user2.user.email}
+        data = {"username": self.user1.user.username, "email": self.user2.user.email, "password": "hostel77"}
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
@@ -258,28 +274,28 @@ class ChangeUserFormTest(TestCase):
         moderator = StaffProfileFactory().user
         if not BannedEmailProvider.objects.filter(provider="yopmail.com").exists():
             BannedEmailProvider.objects.create(provider="yopmail.com", moderator=moderator)
-        data = {"username": self.user1.user.username, "email": "test@yopmail.com"}
+        data = {"username": self.user1.user.username, "email": "test@yopmail.com", "password": "hostel77"}
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
     def test_wrong_email_user_form(self):
-        data = {"username": self.user1.user.username, "email": "wrong@"}
+        data = {"username": self.user1.user.username, "email": "wrong@", "password": "hostel77"}
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
-        data = {"username": self.user1.user.username, "email": "@test.com"}
+        data = {"username": self.user1.user.username, "email": "@test.com", "password": "hostel77"}
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
-        data = {"username": self.user1.user.username, "email": "wrong@test"}
+        data = {"username": self.user1.user.username, "email": "wrong@test", "password": "hostel77"}
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
-        data = {"username": self.user1.user.username, "email": "wrong@.com"}
+        data = {"username": self.user1.user.username, "email": "wrong@.com", "password": "hostel77"}
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
-        data = {"username": self.user1.user.username, "email": "wrongtest.com"}
+        data = {"username": self.user1.user.username, "email": "wrongtest.com", "password": "hostel77"}
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
@@ -287,6 +303,7 @@ class ChangeUserFormTest(TestCase):
         ProfileFactory()
         data = {
             "username": "  ZeTester  ",
+            "password": "hostel77",
             "email": self.user1.user.email,
         }
         form = ChangeUserForm(data=data, user=self.user1.user)
@@ -296,6 +313,7 @@ class ChangeUserFormTest(TestCase):
         ProfileFactory()
         data = {
             "username": "Ze,Tester",
+            "password": "hostel77",
             "email": self.user1.user.email,
         }
         form = ChangeUserForm(data=data, user=self.user1.user)
@@ -305,10 +323,21 @@ class ChangeUserFormTest(TestCase):
         ProfileFactory()
         data = {
             "username": "Ze/Tester",
+            "password": "hostel77",
             "email": self.user1.user.email,
         }
         form = ChangeUserForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
+
+    def test_password_is_required(self):
+        ProfileFactory()
+        data = {
+            "username": "ZeTester",
+            "email": self.user1.user.email,
+        }
+        form = ChangeUserForm(data=data, user=self.user1.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("password", form.errors.keys())
 
 
 class ChangePasswordFormTest(TestCase):
@@ -323,7 +352,7 @@ class ChangePasswordFormTest(TestCase):
 
     def test_valid_change_password_form(self):
         data = {
-            "password_old": self.old_password,
+            "password": self.old_password,
             "password_new": self.new_password,
             "password_confirm": self.new_password,
         }
@@ -331,25 +360,25 @@ class ChangePasswordFormTest(TestCase):
         self.assertTrue(form.is_valid())
 
     def test_old_wrong_change_password_form(self):
-        data = {"password_old": "Wronnnng", "password_new": self.new_password, "password_confirm": self.new_password}
+        data = {"password": "Wronnnng", "password_new": self.new_password, "password_confirm": self.new_password}
         form = ChangePasswordForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
     def test_not_matching_change_password_form(self):
-        data = {"password_old": self.old_password, "password_new": self.new_password, "password_confirm": "Wronnnng"}
+        data = {"password": self.old_password, "password_new": self.new_password, "password_confirm": "Wronnnng"}
         form = ChangePasswordForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
     def test_too_short_change_password_form(self):
         too_short = "short"
-        data = {"password_old": self.old_password, "password_new": too_short, "password_confirm": too_short}
+        data = {"password": self.old_password, "password_new": too_short, "password_confirm": too_short}
         form = ChangePasswordForm(data=data, user=self.user1.user)
         self.assertFalse(form.is_valid())
 
     def test_match_username_change_password_form(self):
         self.user1.user.username = "LongName"
         data = {
-            "password_old": self.old_password,
+            "password": self.old_password,
             "password_new": self.user1.user.username,
             "password_confirm": self.user1.user.username,
         }

--- a/zds/member/tests/views/tests_emailproviders.py
+++ b/zds/member/tests/views/tests_emailproviders.py
@@ -29,7 +29,7 @@ class EmailProvidersTests(TestCase):
         # Edit the email with an unknown provider
         self.client.post(
             reverse("update-username-email-member"),
-            {"username": user.username, "email": "test@unknown-provider-edit.com"},
+            {"username": user.username, "email": "test@unknown-provider-edit.com", "password": "hostel77"},
             follow=False,
         )
         # A new provider object should have been created

--- a/zds/member/tests/views/tests_moderation.py
+++ b/zds/member/tests/views/tests_moderation.py
@@ -335,7 +335,7 @@ class TestsModeration(TestCase):
         tester = ProfileFactory()
         old_pseudo = tester.user.username
         self.client.force_login(tester.user)
-        data = {"username": "dummy", "email": tester.user.email}
+        data = {"username": "dummy", "email": tester.user.email, "password": "hostel77"}
         result = self.client.post(reverse("update-username-email-member"), data, follow=False)
 
         self.assertEqual(result.status_code, 302)

--- a/zds/member/tests/views/tests_register.py
+++ b/zds/member/tests/views/tests_register.py
@@ -87,13 +87,13 @@ class TestRegister(TutorialTestMixin, TestCase):
 
         # test not logged user can't unregister.
         self.client.logout()
-        result = self.client.post(reverse("member-unregister"), follow=False)
+        result = self.client.post(reverse("member-unregister"), {"password": "hostel77"}, follow=False)
         self.assertEqual(result.status_code, 302)
 
         # test logged user can unregister.
         user = ProfileFactory()
         self.client.force_login(user.user)
-        result = self.client.post(reverse("member-unregister"), follow=False)
+        result = self.client.post(reverse("member-unregister"), {"password": "hostel77"}, follow=False)
         self.assertEqual(result.status_code, 302)
         self.assertEqual(User.objects.filter(username=user.user.username).count(), 0)
 
@@ -190,7 +190,7 @@ class TestRegister(TutorialTestMixin, TestCase):
 
         # login and unregister:
         self.client.force_login(user.user)
-        result = self.client.post(reverse("member-unregister"), follow=False)
+        result = self.client.post(reverse("member-unregister"), {"password": "hostel77"}, follow=False)
         self.assertEqual(result.status_code, 302)
 
         # check that the bot have taken authorship of tutorial:

--- a/zds/member/views/register.py
+++ b/zds/member/views/register.py
@@ -24,7 +24,7 @@ from zds.member.commons import (
     ProfileCreate,
     TokenGenerator,
 )
-from zds.member.forms import RegisterForm, UsernameAndEmailForm, LoginForm
+from zds.member.forms import RegisterForm, UsernameAndEmailForm, LoginForm, UnregisterForm
 from zds.member.models import (
     Profile,
     TokenRegister,
@@ -158,7 +158,10 @@ def warning_unregister(request):
     Display a warning page showing what will happen when the user
     unregisters.
     """
-    return render(request, "member/settings/unregister.html", {"user": request.user})
+    unregister_form = UnregisterForm(request.user)
+    return render(
+        request, "member/settings/unregister.html", {"user": request.user, "unregister_form": unregister_form}
+    )
 
 
 @login_required
@@ -166,6 +169,16 @@ def warning_unregister(request):
 @transaction.atomic
 def unregister(request):
     """Allow members to unregister."""
+
+    unregister_form = UnregisterForm(request.user, data=request.POST)
+
+    if not unregister_form.is_valid():
+        for field, errors in unregister_form.errors.items():
+            for error in errors:
+                messages.error(request, error)
+        return render(
+            request, "member/settings/unregister.html", {"user": request.user, "unregister_form": unregister_form}
+        )
 
     anonymous = get_object_or_404(User, username=settings.ZDS_APP["member"]["anonymous_account"])
     external = get_object_or_404(User, username=settings.ZDS_APP["member"]["external_account"])

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -372,7 +372,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
         # unregister author and unpublish
         self.client.force_login(self.user_author)
-        result = self.client.post(reverse("member-unregister"), follow=False)
+        result = self.client.post(reverse("member-unregister"), {"password": "hostel77"}, follow=False)
         self.assertEqual(result.status_code, 302)
 
         self.client.force_login(self.user_staff)
@@ -598,7 +598,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
                 self.assertEqual(result.status_code, 302)
 
                 if unregister_author:
-                    result = self.client.post(reverse("member-unregister"), follow=False)
+                    result = self.client.post(reverse("member-unregister"), {"password": "hostel77"}, follow=False)
                     self.assertEqual(result.status_code, 302)
 
                 # login as staff

--- a/zds/tutorialv2/tests/tests_views/tests_events.py
+++ b/zds/tutorialv2/tests/tests_views/tests_events.py
@@ -93,7 +93,7 @@ class EventListTests(TutorialTestMixin, TestCase):
         # Unregister users
         for user in [self.author, self.coauthor, self.contributor]:
             self.client.force_login(user)
-            response = self.client.post(reverse("member-unregister"), follow=False)
+            response = self.client.post(reverse("member-unregister"), {"password": "hostel77"}, follow=False)
             self.assertEqual(response.status_code, 302)
 
         # Access the event list page

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -1384,7 +1384,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         registered_validation.save()
 
         self.client.force_login(self.user_author)
-        result = self.client.post(reverse("member-unregister"), follow=False)
+        result = self.client.post(reverse("member-unregister"), {"password": "hostel77"}, follow=False)
         self.assertEqual(result.status_code, 302)
 
         self.client.force_login(self.user_staff)

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -2,6 +2,7 @@ import logging
 
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.layout import Layout, ButtonHolder, Field, Div, HTML
+from django.contrib.auth import authenticate
 from django.utils.translation import gettext_lazy as _
 from django.template import defaultfilters
 from zds.utils.models import Tag
@@ -157,3 +158,17 @@ class FieldValidatorMixin:
     def check_text_length_limit(self, text, max_length, message_format):
         if len(text) > max_length:
             self._errors["text"] = [message_format().format(max_length)]
+
+
+class FieldPasswordMixin:
+    def check_correct_password(self, cleaned_data):
+        password = cleaned_data.get("password")
+
+        if password and self.user:
+            user_exist = authenticate(username=self.user.username, password=password)
+            # Check if the user exist.
+            if not user_exist and password != "":
+                self._errors["password"] = self.error_class([_("Mot de passe incorrect.")])
+                if "password" in cleaned_data:
+                    del cleaned_data["password"]
+        return cleaned_data

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -164,11 +164,12 @@ class FieldValidatorMixin:
 class PasswordRequiredForm(forms.Form):
 
     password = forms.CharField(
-        label=_("Mot de passe (confirmation)"),
+        label=_("Mot de passe actuel"),
         widget=forms.PasswordInput,
     )
 
-    def check_correct_password(self, cleaned_data):
+    def clean(self):
+        cleaned_data = super().clean()
         password = cleaned_data.get("password")
 
         if password and self.user:

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -3,6 +3,7 @@ import logging
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.layout import Layout, ButtonHolder, Field, Div, HTML
 from django.contrib.auth import authenticate
+from django import forms
 from django.utils.translation import gettext_lazy as _
 from django.template import defaultfilters
 from zds.utils.models import Tag
@@ -160,7 +161,13 @@ class FieldValidatorMixin:
             self._errors["text"] = [message_format().format(max_length)]
 
 
-class FieldPasswordMixin:
+class PasswordRequiredForm(forms.Form):
+
+    password = forms.CharField(
+        label=_("Mot de passe (confirmation)"),
+        widget=forms.PasswordInput,
+    )
+
     def check_correct_password(self, cleaned_data):
         password = cleaned_data.get("password")
 


### PR DESCRIPTION
Fix #5372.

Change la façon dont on gère les confirmations par mot de passe en ajoutant un FieldPasswordMixin. Et utilise ce mixin pour ajouter une confirmation aux pages de désincriptions et celle de changement d'email.

### Contrôle qualité
**Scénario 1:**
* Se connecter
* Se rendre sur la page de modification de nom d'utilisateur et d'email
* Essayer de modifier son nom d'utilisateur ou email sans remplir le champ de mot de passe
**Résultat attendu:** la soumission ne fonctionne pas, le mot de passe est un champ obligatoire

**Scénario 2:**
* Se connecter
* Se rendre sur la page de modification de nom d'utilisateur et d'email
* Essayer de modifier son nom d'utilisateur ou email en fournissant un mot de passe incorrect
**Résultat attendu:** la mise à jour échoue avec un message mentionnant que le mot de passe est incorrect

**Scénario 3:**
* Se connecter
* Se rendre sur la page de modification de nom d'utilisateur et d'email
* Essayer de modifier son nom d'utilisateur ou email en fournissant le bon mot de passe
**Résultat attendu:** La mise à jour fonctionne

Répéter ces trois scénarios pour les pages de déinscription et celle de changement de mot de passe.