### PR TITLE
Mise à jour triviale des dépendances Python

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 -r requirements-dev.txt
 -r requirements-prod.txt
 
-coverage==6.3.2 # check if Coveralls needs to be also updated in .github/workflows/ci.yml
+coverage==6.4.1 # check if Coveralls needs to be also updated in .github/workflows/ci.yml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,11 +2,11 @@
 
 black==22.3.0  # needs to be also updated in .github/workflows/ci.yml and .pre-commit-config.yaml
 colorlog==6.6.0
-django-debug-toolbar==3.2.4
+django-debug-toolbar==3.5.0
 django-extensions==3.1.5
-Faker==13.3.0
-pre-commit==2.17.0
+Faker==13.14.0
+pre-commit==2.19.0
 PyYAML==6.0
-selenium==4.1.0
-Sphinx==4.4.0
+selenium==4.3.0
+Sphinx==5.0.2
 sphinx_rtd_theme==1.0.0

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
 gunicorn==20.1.0
-mysqlclient==2.1.0
-sentry-sdk==1.5.6
-ujson==5.1.0
+mysqlclient==2.1.1
+sentry-sdk==1.6.0
+ujson==5.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ elasticsearch==5.5.3
 social-auth-app-django==5.0.0
 
 # Explicit dependencies (references in code)
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.1
 django-crispy-forms==1.14.0
 django-model-utils==4.2.0
 django-munin==0.2.1
@@ -12,18 +12,18 @@ django-recaptcha==3.0.0
 Django==3.2.13
 easy-thumbnails==2.8.1
 factory-boy==3.2.1
-geoip2==4.5.0
+geoip2==4.6.0
 GitPython==3.1.27
 homoglyphs==2.0.4
-lxml==4.8.0
-Pillow==9.0.1
-pymemcache==3.5.1
-requests==2.27.1
+lxml==4.9.0
+Pillow==9.1.1
+pymemcache==3.5.2
+requests==2.28.0
 toml==0.10.2
 
 # Api dependencies
-django-cors-headers==3.11.0
-django-filter==21.1
+django-cors-headers==3.13.0
+django-filter==22.1
 django-oauth-toolkit==1.7.0
 djangorestframework-xml==2.0.0
 djangorestframework==3.13.1
@@ -33,4 +33,4 @@ drf_yasg==1.20.0
 
 # Dependencies for slug generation, please be extra careful with those
 django-uuslug==2.0.0
-python-slugify==6.1.1
+python-slugify==6.1.2

--- a/zds/member/tests/tests_front.py
+++ b/zds/member/tests/tests_front.py
@@ -2,6 +2,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test import tag
 from django.urls import reverse
 from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options
 
 
@@ -22,11 +23,11 @@ class MemberFrontTests(StaticLiveServerTestCase):
 
     def test_zestedesavoir_is_present(self):
         self.selenium.get(self.live_server_url + "/")
-        self.assertEqual("Zeste de Savoir", self.selenium.find_element_by_css_selector("p.copyright").text[:15])
+        self.assertEqual("Zeste de Savoir", self.selenium.find_element(By.CSS_SELECTOR, "p.copyright").text[:15])
         self.assertEqual("Zeste de Savoir", self.selenium.title)
 
     def test_trigger_remember(self):
         self.selenium.get(self.live_server_url + reverse("member-login"))
-        is_checked = self.selenium.find_element_by_id("id_remember").is_selected()
-        self.selenium.find_element_by_id("id_remember").click()
-        self.assertNotEqual(is_checked, self.selenium.find_element_by_id("id_remember").is_selected())
+        is_checked = self.selenium.find_element(By.ID, "id_remember").is_selected()
+        self.selenium.find_element(By.ID, "id_remember").click()
+        self.assertNotEqual(is_checked, self.selenium.find_element(By.ID, "id_remember").is_selected())

--- a/zds/tutorialv2/tests/__init__.py
+++ b/zds/tutorialv2/tests/__init__.py
@@ -5,6 +5,7 @@ import shutil
 
 from django.urls import reverse
 from django.test.utils import override_settings
+from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 
 from zds.tutorialv2.models.database import Validation
@@ -43,26 +44,26 @@ class TutorialTestMixin:
 
 
 class TutorialFrontMixin:
+    def find_element(self, element):
+        return self.selenium.find_element(By.CSS_SELECTOR, element)
+
     def login(self, profile):
         """
         TODO: This is definitely way too slow. Fasten this.
         """
-        selenium = self.selenium
-        find_element = selenium.find_element_by_css_selector
+        self.selenium.get(self.live_server_url + reverse("member-login"))
 
-        selenium.get(self.live_server_url + reverse("member-login"))
-
-        username = find_element(".content-container input#id_username")
-        password = find_element(".content-container input#id_password")
+        username = self.find_element(".content-container input#id_username")
+        password = self.find_element(".content-container input#id_password")
         username.send_keys(profile.user.username)
         password.send_keys("hostel77")
 
-        find_element(".content-container button[type=submit]").click()
+        self.find_element(".content-container button[type=submit]").click()
 
         # Wait until the user is logged in (this raises if the element
         # is not found).
 
-        find_element(".header-container .logbox #my-account .username")
+        self.find_element(".header-container .logbox #my-account .username")
 
     def login_author(self):
         self.login(self.user_author.profile)
@@ -71,30 +72,26 @@ class TutorialFrontMixin:
         self.login(self.user_staff.profile)
 
     def logout(self):
-        find_element = self.selenium.find_element_by_css_selector
-        find_element("#my-account").click()
-        find_element('form[action="/membres/deconnexion/"] button').click()
+        self.find_element("#my-account").click()
+        self.find_element('form[action="/membres/deconnexion/"] button').click()
 
     def ask_validation(self):
-        find_element = self.selenium.find_element_by_css_selector
         self.selenium.get(self.live_server_url + self.content.get_absolute_url())
-        find_element('a[href="#ask-validation"]').click()
-        find_element("#ask-validation textarea").send_keys("Coucou.")
-        find_element('#ask-validation button[type="submit"]').click()
+        self.find_element('a[href="#ask-validation"]').click()
+        self.find_element("#ask-validation textarea").send_keys("Coucou.")
+        self.find_element('#ask-validation button[type="submit"]').click()
 
     def take_reservation(self):
-        find_element = self.selenium.find_element_by_css_selector
         self.selenium.get(self.live_server_url + self.content.get_absolute_url())
         validation = Validation.objects.filter(content=self.content).first()
-        find_element(f'form[action="/validations/reserver/{validation.pk}/"] button').click()
+        self.find_element(f'form[action="/validations/reserver/{validation.pk}/"] button').click()
 
     def validate(self):
-        find_element = self.selenium.find_element_by_css_selector
         self.selenium.get(self.live_server_url + self.content.get_absolute_url())
         validation = Validation.objects.filter(content=self.content).first()
-        find_element('a[href="#valid-publish"]').click()
-        find_element("form#valid-publish textarea").send_keys("Coucou.")
-        find_element(f'form[action="/validations/accepter/{validation.pk}/"] button').click()
+        self.find_element('a[href="#valid-publish"]').click()
+        self.find_element("form#valid-publish textarea").send_keys("Coucou.")
+        self.find_element(f'form[action="/validations/accepter/{validation.pk}/"] button').click()
 
     def wait_element_attribute_change(self, locator, attribute, initial_value, time):
         return WebDriverWait(self.selenium, time).until(AttributeHasChanged(locator, attribute, initial_value))

--- a/zds/tutorialv2/tests/tests_front.py
+++ b/zds/tutorialv2/tests/tests_front.py
@@ -76,7 +76,6 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
     def test_partial_publication(self):
         self.login_author()
         self.selenium.get(self.live_server_url + self.ignored_part.get_absolute_url())
-        find_element = self.selenium.find_element_by_css_selector
         button = WebDriverWait(self.selenium, 20).until(
             expected_conditions.element_to_be_clickable((By.CSS_SELECTOR, ".readiness"))
         )
@@ -88,7 +87,7 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
         self.assertFalse(self.ignored_part.ready_to_publish, "part should be marked as not ready to publish")
         self.selenium.get(self.live_server_url + self.content.get_absolute_url())
         self.selenium.get(self.live_server_url + self.ignored_part.get_absolute_url())
-        button = find_element(".readiness")
+        button = self.find_element(".readiness")
         self.assertNotEqual(
             readiness, button.get_attribute("data-is-ready"), "part should be marked as not ready to publish"
         )
@@ -102,7 +101,7 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
         self.selenium.get(self.live_server_url + url)
         self.assertRaises(
             WebDriverException,
-            find_element,
+            self.find_element,
             'a[href="{}"]'.format(
                 reverse(
                     "tutorial:view-container",
@@ -113,7 +112,6 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
 
     def test_collaborative_article_edition_and_editor_persistence(self):
         selenium = self.selenium
-        find_element = selenium.find_element_by_css_selector
 
         author = ProfileFactory()
 
@@ -129,7 +127,7 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
         selenium.execute_script('localStorage.setItem("editor_choice", "new")')  # we want the new editor
         selenium.get(self.live_server_url + article_edit_url)
 
-        intro = find_element("div#div_id_introduction div.CodeMirror")
+        intro = self.find_element("div#div_id_introduction div.CodeMirror")
         # ActionChains: Support for CodeMirror https://stackoverflow.com/a/48969245/2226755
         action_chains = ActionChains(selenium)
         scrollDriverTo(selenium, 0, 312)
@@ -137,18 +135,17 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
         action_chains.send_keys("intro").perform()
 
         output = "div#div_id_introduction div.CodeMirror div.CodeMirror-code"
-        self.assertEqual("intro", find_element(output).text)
+        self.assertEqual("intro", self.find_element(output).text)
 
         article.sha_draft = versioned_article.repo_update("article", "new intro", "", update_slug=False)
         article.save()
 
         selenium.refresh()
 
-        self.assertEqual("new intro", find_element(".md-editor#id_introduction").get_attribute("value"))
+        self.assertEqual("new intro", self.find_element(".md-editor#id_introduction").get_attribute("value"))
 
     def test_the_editor_forgets_its_content_on_form_submission(self):
         selenium = self.selenium
-        find_element = selenium.find_element_by_css_selector
 
         author = ProfileFactory()
 
@@ -162,20 +159,20 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
             ec.element_to_be_clickable((By.CSS_SELECTOR, "input[type=checkbox][name=subcategory]"))
         ).click()
 
-        find_element("#id_title").send_keys("Oulipo")
+        self.find_element("#id_title").send_keys("Oulipo")
 
-        intro = find_element("div#div_id_introduction div.CodeMirror")
+        intro = self.find_element("div#div_id_introduction div.CodeMirror")
         action_chains = ActionChains(selenium)
         action_chains.click(intro).perform()
         action_chains.send_keys("Le cadavre exquis boira le vin nouveau.").perform()
 
-        find_element(".content-container button[type=submit]").click()
+        self.find_element(".content-container button[type=submit]").click()
 
         self.assertTrue(WebDriverWait(selenium, 10).until(ec.title_contains("Oulipo")))
 
         selenium.get(new_article_url)
 
-        self.assertEqual("", find_element(".md-editor#id_introduction").get_attribute("value"))
+        self.assertEqual("", self.find_element(".md-editor#id_introduction").get_attribute("value"))
 
 
 def scrollDriverTo(driver, x, y):


### PR DESCRIPTION
Mise à jour triviale des dépendances Python

Je n'ai pas mis à jour `django-oauth-toolkit` car la nouvelle version contient des *breaking change* conséquents.

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que le site fonctionne correctement dans sa globalité
- `make generate-doc` puis ouvrir `doc/build/html/index.html` dans un navigateur
- S'assurer que la documentation n'est pas cassée