### PR TITLE
Améliore le sommaire de la barre latérale

### DIFF
--- a/assets/scss/layout/_sidebar.scss
+++ b/assets/scss/layout/_sidebar.scss
@@ -86,11 +86,16 @@
     h4 {
         padding-top: $length-20;
         font-size: $font-size-8;
-
+        padding-top: $length-16;
+        padding-bottom: $length-16;
+        border-bottom: $length-1 solid $grey-100;
         a {
             text-decoration: none;
             color: $grey-800;
         }
+         &:hover, &:focus {
+             background: $color-sidebar-hover;
+         }
     }
 
     &.accordeon h4 {
@@ -452,10 +457,10 @@
 
     &.summary {
         h4 {
-            padding-bottom: $length-6;
+            padding-bottom: $length-16;
             padding-right: $length-16;
 
-            border-bottom: $length-1 solid $grey-000;
+            border-bottom: $length-1 solid $grey-100;
 
             overflow: hidden;
             text-overflow: ellipsis;


### PR DESCRIPTION
Ajoute une couleur bleue au survol de l'élément, recentre le texte ajoute une bordure entre les éléments.

Fix #6176 

### Contrôle qualité

Vérifier sur la barre latérale d'un contenu : 
 -  la présence de bordure entre les titres
 - le texte est aligné verticalement
 - l'élément se bleute au survol
 - 
![image](https://user-images.githubusercontent.com/8135797/175824497-abe15fcb-0f22-405a-9e36-059c928960f1.png)

