### PR TITLE
Stop le décalage de l'astuce

### DIFF
--- a/assets/js/markdown-help.js
+++ b/assets/js/markdown-help.js
@@ -36,7 +36,7 @@
         class: 'markdown-help',
         html: '<strong>Astuce :</strong> ' + tips[Math.floor(Math.random() * tips.length)] + ' <a href="' + linkToMarkdownHelp + "\">Envie d'en savoir plus ?</a><a href='#close-alert-box' class='close-alert-box ico-after cross'>Masquer</a>"
       })
-      $(this).after($help)
+      $(this).parent().after($help)
     })
   }
 


### PR DESCRIPTION
Fix #6247 

### Contrôle qualité

- Ouvrir une page avec le nouvel éditeur
- Recharger la page jusqu'à avoir une aide d'une ligne
- Mettre l'éditeur en Apreçu sur le côté
- Vérifier que l'astuce n'est pas décalé.
