### PR TITLE
Importer une nouvelle version d'un contenu ne mélange plus les introductions et conclusions

### DIFF
--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -577,7 +577,9 @@ class Container:
         if do_commit:
             return self.top_container().commit_changes(commit_message)
 
-    def repo_add_container(self, title, introduction, conclusion, commit_message="", do_commit=True, slug=None):
+    def repo_add_container(
+        self, title, introduction, conclusion, commit_message="", do_commit=True, slug=None, ready_to_publish=None
+    ):
         """
         :param title: title of the new container
         :param introduction: text of its introduction
@@ -610,6 +612,8 @@ class Container:
         if not commit_message:
             commit_message = _("Création du conteneur « {} »").format(title)
 
+        if ready_to_publish is not None:
+            subcontainer.ready_to_publish = ready_to_publish
         return subcontainer.repo_update(
             title, introduction, conclusion, commit_message=commit_message, do_commit=do_commit
         )

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -1803,6 +1803,9 @@ class ContentTests(TutorialTestMixin, TestCase):
         content.sha_draft = sha
         content.save()
 
+        original_intro = versioned.get_introduction()
+        original_conclu = versioned.get_conclusion()
+
         # Download archive of initial state for content
         result = self.client.get(reverse("content:download-zip", args=[content.pk, content.slug]), follow=False)
         self.assertEqual(result.status_code, 200)
@@ -1814,7 +1817,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         # Failure to import this information defaults also to True, this is to make sure.
         versioned.children[0].children[0].ready_to_publish = True
         versioned.children[1].ready_to_publish = True
-        sha = versioned.repo_update_top_container(content.title, content.slug, "introduction", "conclusion")
+        sha = versioned.repo_update_top_container(content.title, content.slug, original_intro, original_conclu)
         content.sha_draft = sha
         content.save()
 
@@ -1832,6 +1835,9 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertTrue(versioned.children[0].children[1].ready_to_publish)
         self.assertFalse(versioned.children[0].children[0].ready_to_publish)
         self.assertFalse(versioned.children[1].ready_to_publish)
+
+        self.assertEqual(original_intro, versioned.get_introduction())
+        self.assertEqual(original_conclu, versioned.get_conclusion())
 
     def test_display_history(self):
         """Test DisplayHistory view"""

--- a/zds/tutorialv2/views/archives.py
+++ b/zds/tutorialv2/views/archives.py
@@ -198,9 +198,14 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
                     except UnicodeDecodeError:
                         raise BadArchiveError(_(f"Le fichier « {child.conclusion} » n'est pas encodé en UTF-8"))
 
-                copy_to.repo_add_container(child.title, introduction, conclusion, do_commit=False, slug=child.slug)
-                copy_to.children[-1].ready_to_publish = child.ready_to_publish
-                copy_to.repo_update(copy_to.title, introduction, conclusion, do_commit=False)
+                copy_to.repo_add_container(
+                    child.title,
+                    introduction,
+                    conclusion,
+                    do_commit=False,
+                    slug=child.slug,
+                    ready_to_publish=child.ready_to_publish,
+                )
                 UpdateContentWithArchive.update_from_new_version_in_zip(copy_to.children[-1], child, zip_file)
 
             elif isinstance(child, Extract):


### PR DESCRIPTION
Depuis la fusion de #6203, lors de l'importation d'un contenu, l'introduction et la conclusion d'un conteneur étaient remplacés par ceux du dernier enfant de celui-ci. Cette PR corrige ce soucis et ajoute un test pour éviter une régression plus tard.

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Télécharger [l'archive du tutoriel « Un zeste de Python »](https://zestedesavoir.com/tutoriels/zip/2514/un-zeste-de-python.zip)
- Utiliser la fonction « Importer un nouveau contenu » avec l'archive pour créer le tutoriel
- Utiliser la fonction « Importer une nouvelle version » avec la même archive
- Vérifier que l'introduction et la conclusion n'a pas été modifiée
- Vérifier que les sections `not_ready_to_publish` sont bien grisées comme il se doit