### PR TITLE
N'envoie pas de MP lors de la dépublication de contenu sans auteur inscrit

### DIFF
--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -30,6 +30,16 @@ def is_reachable(user):
     return settings.ZDS_APP["member"]["bot_group"] not in user_group_names
 
 
+def filter_reachable(users):
+    """
+    Returns a list with only reachable users.
+
+    :param user: a list of users
+    :return: list of reachable users.
+    """
+    return [u for u in users if is_reachable(u)]
+
+
 class PrivateTopic(models.Model):
     """
     Private topic, containing private posts.

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import patch
 
 from django.conf import settings
+from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django.urls import reverse
 from django.test import TestCase
@@ -31,9 +32,16 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
     def setUp(self):
 
         self.overridden_zds_app["member"]["bot_account"] = ProfileFactory().user.username
+        self.bot_group = Group()
+        self.bot_group.name = settings.ZDS_APP["member"]["bot_group"]
+        self.bot_group.save()
         self.licence = LicenceFactory()
         self.anonymous = UserFactory(username=settings.ZDS_APP["member"]["anonymous_account"], password="anything")
+        self.anonymous.groups.add(self.bot_group)
+        self.anonymous.save()
         self.external = UserFactory(username=settings.ZDS_APP["member"]["external_account"], password="anything")
+        self.external.groups.add(self.bot_group)
+        self.external.save()
 
         self.user_author = ProfileFactory().user
         self.user_staff = StaffProfileFactory().user

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -62,7 +62,11 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         bot = Group(name=overridden_zds_app["member"]["bot_group"])
         bot.save()
         self.external = UserFactory(username=overridden_zds_app["member"]["external_account"], password="anything")
+        self.external.groups.add(bot)
+        self.external.save()
         self.anonymous = UserFactory(username=settings.ZDS_APP["member"]["anonymous_account"], password="anything")
+        self.anonymous.groups.add(bot)
+        self.anonymous.save()
 
         self.beta_forum = ForumFactory(
             pk=overridden_zds_app["forum"]["beta_forum_id"],

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -62,6 +62,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         bot = Group(name=overridden_zds_app["member"]["bot_group"])
         bot.save()
         self.external = UserFactory(username=overridden_zds_app["member"]["external_account"], password="anything")
+        self.anonymous = UserFactory(username=settings.ZDS_APP["member"]["anonymous_account"], password="anything")
 
         self.beta_forum = ForumFactory(
             pk=overridden_zds_app["forum"]["beta_forum_id"],
@@ -1354,6 +1355,35 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
             },
             follow=False,
         )
+        public_count = PublishedContent.objects.count()
+        result = self.client.post(
+            reverse("validation:revoke", kwargs={"pk": article.pk, "slug": article.public_version.content_public_slug}),
+            {"text": "This content was bad", "version": article.public_version.sha_public},
+            follow=False,
+        )
+        self.assertEqual(302, result.status_code)
+        self.assertEqual(public_count - 1, PublishedContent.objects.count())
+        self.assertEqual("PENDING", Validation.objects.get(pk=registered_validation.pk).status)
+
+    def test_unpublish_unregistered_author(self):
+        article = PublishedContentFactory(type="ARTICLE", author_list=[self.user_author], licence=self.licence)
+        registered_validation = Validation(
+            content=article,
+            version=article.sha_draft,
+            status="ACCEPT",
+            comment_authors="bla",
+            comment_validator="bla",
+            date_reserve=datetime.datetime.now(),
+            date_proposition=datetime.datetime.now(),
+            date_validation=datetime.datetime.now(),
+        )
+        registered_validation.save()
+
+        self.client.force_login(self.user_author)
+        result = self.client.post(reverse("member-unregister"), follow=False)
+        self.assertEqual(result.status_code, 302)
+
+        self.client.force_login(self.user_staff)
         public_count = PublishedContent.objects.count()
         result = self.client.post(
             reverse("validation:revoke", kwargs={"pk": article.pk, "slug": article.public_version.content_public_slug}),

--- a/zds/tutorialv2/views/validations_opinions.py
+++ b/zds/tutorialv2/views/validations_opinions.py
@@ -16,6 +16,8 @@ from django.views.generic import FormView, ListView
 
 from zds.gallery.models import Gallery
 from zds.member.decorator import LoggedWithReadWriteHability
+from zds.mp.models import filter_reachable
+from zds.mp.utils import send_mp, send_message_mp
 from zds.tutorialv2 import signals
 from zds.tutorialv2.forms import (
     PublicationForm,
@@ -31,7 +33,6 @@ from zds.tutorialv2.publication_utils import publish_content, FailureDuringPubli
 from zds.tutorialv2.utils import clone_repo
 from zds.tutorialv2.views.validations_contents import logger
 from zds.utils.models import get_hat_from_settings
-from zds.mp.utils import send_mp, send_message_mp
 
 
 class PublishOpinion(LoggedWithReadWriteHability, DoesNotRequireValidationFormViewMixin):
@@ -134,19 +135,20 @@ class UnpublishOpinion(LoginRequiredMixin, SingleOnlineContentFormViewMixin, Doe
                     hat=get_hat_from_settings("moderation"),
                     no_notification_for=[self.request.user],
                 )
-            elif versioned.authors.first().username != settings.ZDS_APP["member"]["external_account"]:
-                # Send a message only if the author is still registered:
-                self.object.validation_private_message = send_mp(
-                    bot,
-                    versioned.authors.all(),
-                    self.object.validation_message_title,
-                    versioned.title,
-                    msg,
-                    send_by_mail=True,
-                    direct=False,
-                    hat=get_hat_from_settings("moderation"),
-                )
-                self.object.save()
+            else:
+                recipients = filter_reachable(versioned.authors.all())
+                if len(recipients) > 0:
+                    self.object.validation_private_message = send_mp(
+                        bot,
+                        recipients,
+                        self.object.validation_message_title,
+                        versioned.title,
+                        msg,
+                        send_by_mail=True,
+                        direct=False,
+                        hat=get_hat_from_settings("moderation"),
+                    )
+                    self.object.save()
 
         signals.opinions_management.send(
             sender=self.__class__, performer=self.request.user, content=self.object, action="unpublish"
@@ -229,19 +231,20 @@ class DoNotPickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormView
                         hat=get_hat_from_settings("moderation"),
                         no_notification_for=[self.request.user],
                     )
-                elif versioned.authors.first().username != settings.ZDS_APP["member"]["external_account"]:
-                    # Send a message only if the author is still registered:
-                    self.object.validation_private_message = send_mp(
-                        bot,
-                        versioned.authors.all(),
-                        self.object.validation_message_title,
-                        versioned.title,
-                        msg,
-                        send_by_mail=True,
-                        direct=False,
-                        hat=get_hat_from_settings("moderation"),
-                    )
-                    self.object.save()
+                else:
+                    recipients = filter_reachable(versioned.authors.all())
+                    if len(recipients) > 0:
+                        self.object.validation_private_message = send_mp(
+                            bot,
+                            recipients,
+                            self.object.validation_message_title,
+                            versioned.title,
+                            msg,
+                            send_by_mail=True,
+                            direct=False,
+                            hat=get_hat_from_settings("moderation"),
+                        )
+                        self.object.save()
         except ValueError:
             logger.exception("Could not %s the opinion %s", form.cleaned_data["operation"], str(self.object))
             return HttpResponse(json.dumps({"result": "FAIL", "reason": str(_("Mauvaise opération"))}), status=400)


### PR DESCRIPTION
Fix #6353

### Contrôle qualité

Le scénario qui pose problème :
1. Avec un utilisateur A, créer et publier un billet
2. En tant qu'utilisateur A, se désinscrire (*Paramètres* > *Désinscription*)
3. Se connecter en tant qu'`admin` et *modérer* ce billet (dans la section *Administration* de la colonne à gauche du billet)
4. On revient sur la liste des billets et tout fonctionne comme attendu

Vérifier que le comportement normal fonctionne toujours :
1. Avec un utilisateur A, créer et publier un billet
2. Se connecter en tant qu'`admin` et *modérer* ce billet (dans la section *Administration* de la colonne à gauche du billet)
3. On revient sur la liste des billets et tout fonctionne comme attendu
4. Se connecter avec l'utilisateur A, il a bien reçu un MP le notifiant de la modération et la dépublication du billet

Vérifier que ça fonctionne toujours lorsqu'il y a plusieurs auteurs :
1. Avec un utilisateur A, créer un billet, y ajouter l'utilisateur B comme auteur, publier le billet
2. En tant qu'utilisateur A, se désinscrire (*Paramètres* > *Désinscription*)
3. Se connecter en tant qu'`admin` et *modérer* ce billet (dans la section *Administration* de la colonne à gauche du billet)
4. On revient sur la liste des billets et tout fonctionne comme attendu
4. Se connecter avec l'utilisateur B, il a bien reçu un MP le notifiant de la modération et la dépublication du billet

Refaire les scénarios :
- en *dépubliant* le billet
- avec un tutoriel et en *dépubliant*
- avec un article et en *dépubliant*