### PR TITLE
Ajoute une numérotation visuelle aux titres

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -6,6 +6,7 @@ body:before {
   h2, h3, h4, h5 {
     &:before {
       margin-inline-end: .4ex;
+      opacity: .88;
     }
   }
 

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -1,17 +1,20 @@
 body:before {
-  counter-reset: part;
-  counter-reset: chapter;
-  counter-reset: section;
-  counter-reset: subsection;
+  counter-reset: part chapter section subsection;
 }
 
 .article-content {
+  h2, h3, h4, h5 {
+    &:before {
+      margin-inline-end: .4ex;
+    }
+  }
+
   h2 {
     counter-increment: part;
     counter-set: chapter;
 
     &:before {
-      content: counter(part) ". ";
+      content: counter(part) ".";
     }
   }
 
@@ -20,7 +23,7 @@ body:before {
     counter-set: section;
 
     &:before {
-      content: counter(part) "." counter(chapter) ". ";
+      content: counter(part) "." counter(chapter) ".";
     }
   }
 
@@ -37,7 +40,7 @@ body:before {
     counter-increment: subsection;
 
     &:before {
-      content: counter(part) "." counter(chapter) "." counter(section) "." counter(subsection) ". ";
+      content: counter(part) "." counter(chapter) "." counter(section) "." counter(subsection) ".";
     }
   }
 }

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -1,3 +1,40 @@
+body:before {
+    counter-reset: part;
+    counter-reset: chapter;
+    counter-reset: section;
+    counter-reset: subsection;
+}
+.article-content h2 {
+    counter-increment: part;
+    counter-set: chapter;
+
+    &:before {
+        content: counter(part) ". ";
+    }
+}
+.article-content h3 {
+    counter-increment: chapter;
+    counter-set: section;
+
+    &:before {
+        content: counter(part) "." counter(chapter) ". ";
+    }
+}
+.article-content h4 {
+    counter-increment: section;
+    counter-set: subsection;
+
+    &:before {
+        content: counter(part) "." counter(chapter) "." counter(section);
+    }
+}
+.article-content h5 {
+    counter-increment: subsection;
+
+    &:before {
+        content: counter(part) "." counter(chapter) "." counter(section) "." counter(subsection) ". ";
+    }
+}
 .small-content-wrapper {
     width: 90%;
     max-width: $length-512;

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -1,265 +1,272 @@
 body:before {
-    counter-reset: part;
-    counter-reset: chapter;
-    counter-reset: section;
-    counter-reset: subsection;
+  counter-reset: part;
+  counter-reset: chapter;
+  counter-reset: section;
+  counter-reset: subsection;
 }
-.article-content h2 {
+
+.article-content {
+  h2 {
     counter-increment: part;
     counter-set: chapter;
 
     &:before {
-        content: counter(part) ". ";
+      content: counter(part) ". ";
     }
-}
-.article-content h3 {
+  }
+
+  h3 {
     counter-increment: chapter;
     counter-set: section;
 
     &:before {
-        content: counter(part) "." counter(chapter) ". ";
+      content: counter(part) "." counter(chapter) ". ";
     }
-}
-.article-content h4 {
+  }
+
+  h4 {
     counter-increment: section;
     counter-set: subsection;
 
     &:before {
-        content: counter(part) "." counter(chapter) "." counter(section);
+      content: counter(part) "." counter(chapter) "." counter(section);
     }
-}
-.article-content h5 {
+  }
+
+  h5 {
     counter-increment: subsection;
 
     &:before {
-        content: counter(part) "." counter(chapter) "." counter(section) "." counter(subsection) ". ";
+      content: counter(part) "." counter(chapter) "." counter(section) "." counter(subsection) ". ";
     }
+  }
 }
+
 .small-content-wrapper {
-    width: 90%;
-    max-width: $length-512;
-    margin: $length-20 auto;
+  width: 90%;
+  max-width: $length-512;
+  margin: $length-20 auto;
 }
 
 .main .content-container {
-    .content-wrapper {
-        &.article-content,
-        &.members {
-            padding-left: 2%;
-            padding-right: 2%;
-        }
+  .content-wrapper {
+    &.article-content,
+    &.members {
+      padding-left: 2%;
+      padding-right: 2%;
+    }
+  }
+
+  section > h2 {
+    display: flex;
+
+    span {
+      flex: 2;
     }
 
-    section > h2 {
-        display: flex;
+    .btn {
+      float: none;
+    }
+  }
 
-        span {
-            flex: 2;
+  .article-content {
+    .extract-wrapper {
+      h3, h4, h5, h6 {
+        &:first-child {
+          margin-top: $length-14;
         }
-
-        .btn {
-            float: none;
-        }
+      }
     }
 
-    .article-content {
-        .extract-wrapper {
-            h3, h4, h5, h6 {
-                &:first-child {
-                    margin-top: $length-14;
-                }
-            }
-        }
+    p,
+    > a,
+    p a,
+    th,
+    td,
+    ul:not(.pagination),
+    ol:not(.summary-part) {
+      font-family: $font-serif;
+      font-size: $font-size-10;
+    }
+  }
 
-        p,
-        > a,
-        p a,
-        th,
-        td,
-        ul:not(.pagination),
-        ol:not(.summary-part) {
-            font-family: $font-serif;
-            font-size: $font-size-10;
+  .content-wrapper.comment-author,
+  .comment-author {
+    margin-bottom: $length-20;
+    padding: $length-8 $length-16;
+
+    background: $grey-100;
+
+    color: $grey-800;
+
+    blockquote {
+      margin: $length-10 0;
+      padding: $length-6 0 $length-6 $length-16;
+
+      border-left: $length-6 solid $grey-200;
+    }
+  }
+
+  .article-content .summary-part {
+    font-size: $font-size-7;
+    color: $accent-800;
+
+    h3,
+    h4 {
+      width: 90%;
+      font-weight: normal;
+
+      a {
+        text-decoration: none;
+
+        &:not(.btn) {
+          &:hover,
+          &:focus {
+            text-decoration: underline;
+          }
         }
+      }
     }
 
-    .content-wrapper.comment-author,
-    .comment-author {
-        margin-bottom: $length-20;
-        padding: $length-8 $length-16;
+    h3 {
+      margin: 0 0 $length-6;
+      font-size: $length-20;
 
-        background: $grey-100;
-
-        color: $grey-800;
-
-        blockquote {
-            margin: $length-10 0;
-            padding: $length-6 0 $length-6 $length-16;
-
-            border-left: $length-6 solid$grey-200;
-        }
-    }
-
-    .article-content .summary-part {
-        font-size: $font-size-7;
+      a {
         color: $accent-800;
-
-        h3,
-        h4 {
-            width: 90%;
-            font-weight: normal;
-
-            a {
-                text-decoration: none;
-
-                &:not(.btn) {
-                    &:hover,
-                    &:focus {
-                        text-decoration: underline;
-                    }
-                }
-            }
-        }
-
-        h3 {
-            margin: 0 0 $length-6;
-            font-size: $length-20;
-
-            a {
-                color: $accent-800;
-            }
-        }
-
-        .summary-part {
-            margin-bottom: $length-16;
-            padding-left: 0;
-
-            list-style: none;
-
-            h4 {
-                font-size: $font-size-10;
-                margin: $length-2 0;
-            }
-        }
+      }
     }
 
-    .article-content,
-    .message-content {
-        margin-bottom: $length-20;
-        color: $black;
+    .summary-part {
+      margin-bottom: $length-16;
+      padding-left: 0;
 
-        @import "base/content";
+      list-style: none;
+
+      h4 {
+        font-size: $font-size-10;
+        margin: $length-2 0;
+      }
     }
+  }
 
-    .message-content {
-        h3, h4, h5, h6 {
-            &:first-child {
-                margin-top: $length-14;
-            }
-        }
+  .article-content,
+  .message-content {
+    margin-bottom: $length-20;
+    color: $black;
+
+    @import "base/content";
+  }
+
+  .message-content {
+    h3, h4, h5, h6 {
+      &:first-child {
+        margin-top: $length-14;
+      }
     }
+  }
 
-    .comments-title {
-        margin: $length-48 0 $length-20;
-        border-bottom: $length-1 solid $color-secondary;
+  .comments-title {
+    margin: $length-48 0 $length-20;
+    border-bottom: $length-1 solid $color-secondary;
 
-        color: $color-primary;
+    color: $color-primary;
 
-        font-size: $font-size-6;
-        font-weight: normal;
-    }
+    font-size: $font-size-6;
+    font-weight: normal;
+  }
 
-    p.is-dimmed {
-        color: $grey-500;
-    }
+  p.is-dimmed {
+    color: $grey-500;
+  }
 }
 
 @include wide {
-    .full-content-wrapper .tutorial-list article {
-        width: 29.3%;
-    }
+  .full-content-wrapper .tutorial-list article {
+    width: 29.3%;
+  }
 }
 
 @include desktop {
-    .content-wrapper,
-    .full-content-wrapper {
-        margin: 0 0 0 4%;
+  .content-wrapper,
+  .full-content-wrapper {
+    margin: 0 0 0 4%;
 
-        &.without-margin {
-            margin: 0;
-        }
-
-        .content-wrapper {
-            max-width: none;
-            margin: 0;
-        }
+    &.without-margin {
+      margin: 0;
     }
+
+    .content-wrapper {
+      max-width: none;
+      margin: 0;
+    }
+  }
 }
 
 @include until-desktop {
-    .main .content-container {
-        .taglist,
-        .pubdate {
-            margin-left: $length-10;
-            margin-right: $length-10;
-        }
-
-        .article-content {
-            p,
-            ol,
-            ul:not(.pagination) {
-                font-size: $font-size-10;
-            }
-        }
-
-        .content-wrapper,
-        .full-content-wrapper {
-            h1:not(.ico-after),
-            h2:not(.ico-after),
-            h3,
-            .subtitle {
-                padding-left: $length-10;
-                padding-right: $length-10;
-            }
-
-            .illu img {
-                display: none;
-            }
-
-            h4,
-            h5,
-            h6,
-            .members,
-            p,
-            figure,
-            blockquote {
-                margin-left: $length-10;
-                margin-right: $length-10;
-            }
-
-            ul,
-            ol {
-                margin-right: $length-10;
-            }
-
-            figure {
-                p,
-                blockquote {
-                    margin-left: 0;
-                    margin-right: 0;
-                }
-            }
-
-            .license {
-                margin-right: $length-6;
-            }
-        }
+  .main .content-container {
+    .taglist,
+    .pubdate {
+      margin-left: $length-10;
+      margin-right: $length-10;
     }
+
+    .article-content {
+      p,
+      ol,
+      ul:not(.pagination) {
+        font-size: $font-size-10;
+      }
+    }
+
+    .content-wrapper,
+    .full-content-wrapper {
+      h1:not(.ico-after),
+      h2:not(.ico-after),
+      h3,
+      .subtitle {
+        padding-left: $length-10;
+        padding-right: $length-10;
+      }
+
+      .illu img {
+        display: none;
+      }
+
+      h4,
+      h5,
+      h6,
+      .members,
+      p,
+      figure,
+      blockquote {
+        margin-left: $length-10;
+        margin-right: $length-10;
+      }
+
+      ul,
+      ol {
+        margin-right: $length-10;
+      }
+
+      figure {
+        p,
+        blockquote {
+          margin-left: 0;
+          margin-right: 0;
+        }
+      }
+
+      .license {
+        margin-right: $length-6;
+      }
+    }
+  }
 }
 
 @include mobile {
-    .main .content-container .article-content .btn {
-        float: none;
-        text-align: center;
-    }
+  .main .content-container .article-content .btn {
+    float: none;
+    text-align: center;
+  }
 }


### PR DESCRIPTION

Fix #6228 

La PR ajoute une numérotation visuelle sur le site web comme sur le PDF : 
![hierarchy](https://user-images.githubusercontent.com/1523653/180873129-43613d7b-cb39-4157-8d17-47d1e6d68563.png)

Pour l'instant le seul cas aux limites ce sont les h3/h4 dans les introductions de tuto/parties et de ce fait dans les billets rédigés dans l'intro

### Contrôle qualité

Builder le front et refresh le cache

Aller dans un big tuto, visiter un de ses chapitres 
Aller dans un mini tuto
Aller dans un article
Aller dans un billet

A chaque fois lorsqu'on met des titres, on a des numérotations.
<!-- Merci ! -->
