### PR TITLE
Empêche les notifications lorsqu'un nouveau topic est créé dans un forum auquel l'utilisateur n'a pas accès

### DIFF
--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -329,7 +329,7 @@ def new_topic_event(sender, *, instance, created=True, **__):
 
         subscriptions = NewTopicSubscription.objects.get_subscriptions(topic.forum)
         for subscription in subscriptions:
-            if subscription.user != topic.author:
+            if subscription.user != topic.author and topic.forum.can_read(subscription.user):
                 subscription.send_notification(content=topic, sender=topic.author)
 
 

--- a/zds/notification/tests/tests_basics.py
+++ b/zds/notification/tests/tests_basics.py
@@ -425,6 +425,25 @@ class NotificationForumTest(TestCase):
         notifications = Notification.objects.filter(object_id=topic2.pk, is_read=False).all()
         self.assertEqual(0, len(notifications))
 
+    def test_no_notification_on_new_topic_in_hidden_forum(self):
+        """
+        When a user subscribes to a forum that gets hidden and a topic is created in that forum, no notification is sent
+        """
+        # Subscribe.
+        user1 = ProfileFactory().user
+        user2 = ProfileFactory().user
+
+        group = Group.objects.create(name="Restricted")
+        user2.groups.add(group)
+        user2.save()
+        category, forum = create_category_and_forum(group)
+
+        NewTopicSubscription.objects.toggle_follow(forum, user1)
+        topic1 = TopicFactory(forum=forum, author=user2)
+
+        notifications = Notification.objects.filter(object_id=topic1.pk, is_read=False).all()
+        self.assertEqual(0, len(notifications))
+
     def test_no_notification_on_a_tag_subscribed_in_hidden_forum(self):
         """
         When a user subscribes to a tag and a topic is created using that tag in a hidden forum, no notification is sent


### PR DESCRIPTION
Fix #6218

### Contrôle qualité

**Scénario 1:**
* Se connecter avec user
* S'abonner à un forum
* Se déconnecter
* Se connecter à l'interface admin et rendre ce forum uniquement accessible au staff (cela peut se faire directement via la db également via un insert dans `forum_forum_groups `)
* Se connecter avec staff
* Créer un topic dans la zone staff dans ce forum
* Se déconnecter
* Se connecter avec user
**Résultat attendu:** Aucune notification n'a été générée car le topic a été créé dans un forum auquel user n'a pas accès

**Test de non-régression:**
* Se connecter avec user
* S'abonner à un forum quelconque
* Se déconnecter
* Se connecter avec staff
* Créer un topic dans ce forum
* Se déconnecter
* Se connecter avec user
**Résultat attendu:** Une notification a bien été créée concernant ce topic, car il a été créé dans un forum auquel user a accès
