### PR TITLE
Corrige une erreur lors de l'affichage de l'API

### DIFF
--- a/templates/drf-yasg/swagger-ui.html
+++ b/templates/drf-yasg/swagger-ui.html
@@ -42,6 +42,5 @@
     <script src="{% static 'drf-yasg/swagger-ui-dist/swagger-ui-standalone-preset.js' %}"></script>
     <script src="{% static 'drf-yasg/insQ.min.js' %}"></script>
     <script src="{% static 'drf-yasg/immutable.min.js' %}"></script>
-    <script src="{% static 'drf-yasg/url-polyfill.min.js' %}"></script>
     <script src="{% static 'drf-yasg/swagger-ui-init.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Suite au commit [ef302ef928980614efd7de96f94b252b8606109f](https://github.com/axnsan12/drf-yasg/commit/ef302ef928980614efd7de96f94b252b8606109f) de drf-yasg, inclus dans la version 1.20.1.

Sans cette PR, la page qui décrit l'API n'est pas accessible à cause d'une erreur 500 (uniquement sur la bêta).

### Contrôle qualité

Aller sur la page qui décrit l'API dans une version locale (lancée avec `make run-back-fast` par exemple) puis sur le serveur de bêta (cette PR sera déployée dessus dans quelques instants).
