### PR TITLE
Retire l'export HTML

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -12,12 +12,10 @@ Sitemap: https://zestedesavoir.com/sitemap-tutos.xml
 User-agent: *
 Disallow: /api/
 Disallow: /articles/epub/
-Disallow: /articles/html/
 Disallow: /articles/md/
 Disallow: /articles/tex/
 Disallow: /articles/zip/
 Disallow: /billets/epub/
-Disallow: /billets/html/
 Disallow: /billets/md/
 Disallow: /billets/tex/
 Disallow: /billets/zip/
@@ -27,7 +25,6 @@ Disallow: /oldarticles/
 Disallow: /oldtutoriels/
 Disallow: /rechercher/
 Disallow: /tutoriels/epub/
-Disallow: /tutoriels/html/
 Disallow: /tutoriels/md/
 Disallow: /tutoriels/tex/
 Disallow: /tutoriels/zip/

--- a/templates/tutorialv2/includes/list_of_exports.html
+++ b/templates/tutorialv2/includes/list_of_exports.html
@@ -16,18 +16,6 @@
                 </li>
             {% endif %}
         {% endif %}
-        {% if public_object.has_html %}
-            <li>
-                <a href="{{ public_object.get_absolute_url_html }}" class="ico-after download blue">
-                    {% trans "HTML" %}
-                    {% with size=public_object.get_size_html %}
-                        {% if size %}
-                            ({{ size|filesizeformat }})
-                        {% endif %}
-                    {% endwith %}
-                </a>
-            </li>
-        {% endif %}
         {% if public_object.has_pdf %}
             <li>
                 <a href="{{ public_object.get_absolute_url_pdf }}" class="ico-after download blue">

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -44,7 +44,7 @@ from zds.tutorialv2.models.help_requests import HelpWriting
 from zds.utils.templatetags.emarkdown import render_markdown_stats
 from zds.utils.uuslug_wrapper import uuslug
 
-ALLOWED_TYPES = ["pdf", "md", "html", "epub", "zip", "tex"]
+ALLOWED_TYPES = ["pdf", "md", "epub", "zip", "tex"]
 logger = logging.getLogger(__name__)
 
 

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -790,14 +790,6 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
         """
         return self.has_type("md")
 
-    def has_html(self):
-        """Check if the html version of the content is available
-
-        :return: ``True`` if available, ``False`` otherwise
-        :rtype: bool
-        """
-        return self.has_type("html")
-
     def has_pdf(self):
         """Check if the pdf version of the content is available
 

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -22,7 +22,7 @@ from zds.tutorialv2.publish_container import publish_use_manifest
 from zds.tutorialv2.signals import content_unpublished
 from zds.tutorialv2.utils import export_content
 from zds.forum.utils import send_post, lock_topic
-from zds.utils.templatetags.emarkdown import render_markdown, MD_PARSING_ERROR
+from zds.utils.templatetags.emarkdown import render_markdown
 from zds.utils.templatetags.smileys_def import SMILEYS_BASE_PATH, LICENSES_BASE_PATH
 
 logger = logging.getLogger(__name__)
@@ -329,29 +329,6 @@ class ZipPublicator(Publicator):
             # no need to move zip file because it is already dumped to the public directory
         except (OSError, ValueError) as e:
             raise FailureDuringPublication("Zip could not be created", e)
-
-
-class ZmarkdownHtmlPublicator(Publicator):
-    def publish(self, md_file_path, base_name, **kwargs):
-        md_flat_content = _read_flat_markdown(md_file_path)
-        published_content_entity = self.get_published_content_entity(md_file_path)
-        html_flat_content, *_ = render_markdown(md_flat_content, disable_ping=True, disable_js=True)
-        html_file_path = path.splitext(md_file_path)[0] + ".html"
-        if str(MD_PARSING_ERROR) in html_flat_content:
-            logging.getLogger(self.__class__.__name__).error("HTML could not be rendered")
-            return
-
-        with open(html_file_path, mode="w", encoding="utf-8") as final_file:
-            final_file.write(html_flat_content)
-        shutil.move(
-            html_file_path,
-            str(
-                Path(
-                    published_content_entity.get_extra_contents_directory(),
-                    published_content_entity.content_public_slug + ".html",
-                )
-            ),
-        )
 
 
 @PublicatorRegistry.register("pdf")

--- a/zds/tutorialv2/urls/urls_articles.py
+++ b/zds/tutorialv2/urls/urls_articles.py
@@ -15,18 +15,9 @@ urlpatterns = [
     path("<int:pk>/<slug:slug>/", DisplayOnlineArticle.as_view(), name="view"),
     # Downloads
     path("md/<int:pk>/<slug:slug>.md", DownloadOnlineArticle.as_view(requested_file="md"), name="download-md"),
-    path(
-        "html/<int:pk>/<slug:slug>.html",
-        DownloadOnlineArticle.as_view(requested_file="html"),
-        name="download-html",
-    ),
     path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineArticle.as_view(requested_file="pdf"), name="download-pdf"),
     path("tex/<int:pk>/<slug:slug>.tex", DownloadOnlineArticle.as_view(requested_file="tex"), name="download-tex"),
-    path(
-        "epub/<int:pk>/<slug:slug>.epub",
-        DownloadOnlineArticle.as_view(requested_file="epub"),
-        name="download-epub",
-    ),
+    path("epub/<int:pk>/<slug:slug>.epub", DownloadOnlineArticle.as_view(requested_file="epub"), name="download-epub"),
     path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineArticle.as_view(requested_file="zip"), name="download-zip"),
     # Listing
     path("", RedirectView.as_view(pattern_name="publication:list", permanent=True)),

--- a/zds/tutorialv2/urls/urls_opinions.py
+++ b/zds/tutorialv2/urls/urls_opinions.py
@@ -1,4 +1,4 @@
-from django.urls import path, path
+from django.urls import path
 
 from zds.tutorialv2.feeds import LastOpinionsFeedRSS, LastOpinionsFeedATOM
 from zds.tutorialv2.views.lists import ListOpinions, ContentOfAuthor

--- a/zds/tutorialv2/urls/urls_opinions.py
+++ b/zds/tutorialv2/urls/urls_opinions.py
@@ -13,17 +13,8 @@ urlpatterns = [
     path("<int:pk>/<slug:slug>/", DisplayOnlineOpinion.as_view(), name="view"),
     # downloads:
     path("md/<int:pk>/<slug:slug>.md", DownloadOnlineOpinion.as_view(requested_file="md"), name="download-md"),
-    path(
-        "html/<int:pk>/<slug:slug>.html",
-        DownloadOnlineOpinion.as_view(requested_file="html"),
-        name="download-html",
-    ),
     path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineOpinion.as_view(requested_file="pdf"), name="download-pdf"),
-    path(
-        "epub/<int:pk>/<slug:slug>.epub",
-        DownloadOnlineOpinion.as_view(requested_file="epub"),
-        name="download-epub",
-    ),
+    path("epub/<int:pk>/<slug:slug>.epub", DownloadOnlineOpinion.as_view(requested_file="epub"), name="download-epub"),
     path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineOpinion.as_view(requested_file="zip"), name="download-zip"),
     path("tex/<int:pk>/<slug:slug>.tex", DownloadOnlineOpinion.as_view(requested_file="tex"), name="download-tex"),
     # Listing

--- a/zds/tutorialv2/urls/urls_tutorials.py
+++ b/zds/tutorialv2/urls/urls_tutorials.py
@@ -28,7 +28,6 @@ urlpatterns = [
     path("<int:pk>/<slug:slug>/", DisplayOnlineTutorial.as_view(), name="view"),
     # downloads:
     path("md/<int:pk>/<slug:slug>.md", DownloadOnlineTutorial.as_view(requested_file="md"), name="download-md"),
-    path("html/<int:pk>/<slug:slug>.html", DownloadOnlineTutorial.as_view(requested_file="html"), name="download-html"),
     path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineTutorial.as_view(requested_file="pdf"), name="download-pdf"),
     path("epub/<int:pk>/<slug:slug>.epub", DownloadOnlineTutorial.as_view(requested_file="epub"), name="download-epub"),
     path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineTutorial.as_view(requested_file="zip"), name="download-zip"),


### PR DESCRIPTION
Fix #5806.

Reprise de #5997. 

J'ai pris en compte le fait de supprimer les lignes obsolètes du `robots.txt`.

### Contrôle qualité

* Ajouter un tutoriel, article et billet au site de test
* Vérifier l'absence du lien vers le fichier HTML

Et les tests automatisés doivent passer aussi, évidemment.

