### PR TITLE
Vérifie la présence des comptes essentiels au démarrage de l'application

### DIFF
--- a/fixtures/bots.yaml
+++ b/fixtures/bots.yaml
@@ -1,0 +1,20 @@
+-   model: auth.user
+    pk: 5
+    fields:
+        first_name: anonymous
+        last_name: User
+        username: anonymous
+        password: pbkdf2_sha256$12000$DWHNLpO3jXIv$MrnMZblGu1Q+xemP4XK2keLtbyfkRXxczPTLhSJ0AAM=
+        is_superuser: False
+        groups:
+            - 2
+-   model: auth.user
+    pk: 6
+    fields:
+        first_name: external
+        last_name: User
+        username: external
+        password: pbkdf2_sha256$12000$DWHNLpO3jXIv$MrnMZblGu1Q+xemP4XK2keLtbyfkRXxczPTLhSJ0AAM=
+        is_superuser: False
+        groups:
+            - 2

--- a/fixtures/bots.yaml
+++ b/fixtures/bots.yaml
@@ -18,3 +18,13 @@
         is_superuser: False
         groups:
             - 2
+-   model: auth.user
+    pk: 9
+    fields:
+        first_name: Clem
+        last_name: Sanspépins
+        username: bot
+        password: pbkdf2_sha256$150000$bzWpLKZ2InfO$pmA3IQng4g+79tJ4p99GHKfEkGoztRnzDqa7Ny6jNu8=
+        is_superuser: False
+        groups:
+            - 2

--- a/fixtures/users.yaml
+++ b/fixtures/users.yaml
@@ -207,26 +207,6 @@
         password: pbkdf2_sha256$12000$FssznaRHkjFK$8GvNM2oqOIHRNNr4G+8s+cbk6LIYXaxGOsI1Hh6cswI=
         is_superuser: False
 -   model: auth.user
-    pk: 5
-    fields:
-        first_name: Anonymous
-        last_name: User
-        username: anonymous
-        password: pbkdf2_sha256$12000$DWHNLpO3jXIv$MrnMZblGu1Q+xemP4XK2keLtbyfkRXxczPTLhSJ0AAM=
-        is_superuser: False
-        groups:
-            - - bot
--   model: auth.user
-    pk: 6
-    fields:
-        first_name: External
-        last_name: User
-        username: external
-        password: pbkdf2_sha256$12000$DWHNLpO3jXIv$MrnMZblGu1Q+xemP4XK2keLtbyfkRXxczPTLhSJ0AAM=
-        is_superuser: False
-        groups:
-            - - bot
--   model: auth.user
     pk: 7
     fields:
         first_name: decalage

--- a/fixtures/users.yaml
+++ b/fixtures/users.yaml
@@ -224,16 +224,6 @@
         is_superuser: False
         groups:
             - - devs
--   model: auth.user
-    pk: 9
-    fields:
-        first_name: Clem
-        last_name: Sanspépins
-        username: bot
-        password: pbkdf2_sha256$150000$bzWpLKZ2InfO$pmA3IQng4g+79tJ4p99GHKfEkGoztRnzDqa7Ny6jNu8=
-        is_superuser: False
-        groups:
-            - - bot
 
 -   model: member.Profile
     pk: 1

--- a/zds/member/commons.py
+++ b/zds/member/commons.py
@@ -10,6 +10,7 @@ from django.template.defaultfilters import pluralize
 from django.utils.translation import gettext_lazy as _
 
 from zds.member.models import Profile, TokenRegister, Ban
+from zds.member.utils import get_bot_account
 from zds.utils.models import get_hat_from_settings
 from zds.mp.utils import send_mp
 
@@ -205,7 +206,7 @@ class MemberSanctionState:
         :return: nothing
         :rtype: None
         """
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
         send_mp(
             bot,
             [ban.user],

--- a/zds/member/migrations/0011_bannedemailprovider_newemailprovider.py
+++ b/zds/member/migrations/0011_bannedemailprovider_newemailprovider.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 
 from zds.member.models import BannedEmailProvider
+from zds.member.utils import get_bot_account
 
 
 def forwards_func(apps, schema_editor):
@@ -818,7 +819,7 @@ def forwards_func(apps, schema_editor):
     ]
 
     try:
-        bot = User.objects.get(username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
         bans = [BannedEmailProvider(provider=p, moderator=bot) for p in providers]
         BannedEmailProvider.objects.bulk_create(bans)
     except User.DoesNotExist:

--- a/zds/member/utils.py
+++ b/zds/member/utils.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.contrib.auth.models import User
 from social_django.middleware import SocialAuthExceptionMiddleware
 from django.contrib import messages
 from django.utils.translation import gettext_lazy as _
@@ -23,3 +25,27 @@ class ZDSCustomizeSocialAuthExceptionMiddleware(SocialAuthExceptionMiddleware):
 
     def get_redirect_uri(self, *_, **__):
         return reverse("member-login")
+
+
+def get_bot_account() -> User:
+    """
+    Get the bot account.
+    Used for example to send automated private messages.
+    """
+    return User.objects.get(username=settings.ZDS_APP["member"]["bot_account"])
+
+
+def get_external_account() -> User:
+    """
+    Get the external account.
+    Used for example to mark publications by authors not registered on the site.
+    """
+    return User.objects.get(username=settings.ZDS_APP["member"]["external_account"])
+
+
+def get_anonymous_account() -> User:
+    """
+    Get the anonymous account.
+    Used for example as a replacement for unregistered users.
+    """
+    return User.objects.get(username=settings.ZDS_APP["member"]["anonymous_account"])

--- a/zds/member/views/admin.py
+++ b/zds/member/views/admin.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext_lazy as _
 
 from zds.member.forms import PromoteMemberForm
 from zds.member.models import Profile
+from zds.member.utils import get_bot_account
 from zds.utils.models import get_hat_from_settings
 from zds.mp.utils import send_mp
 
@@ -62,7 +63,7 @@ def settings_promote(request, user_pk):
         user.save()
 
         usergroups = user.groups.all()
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
         msg = _(
             "Bonjour {0},\n\n" "Un administrateur vient de modifier les groupes " "auxquels vous appartenez.  \n"
         ).format(user.username)

--- a/zds/member/views/profile.py
+++ b/zds/member/views/profile.py
@@ -31,6 +31,7 @@ from zds.member.models import (
     Ban,
     NewEmailProvider,
 )
+from zds.member.utils import get_bot_account
 from zds.notification.models import TopicAnswerSubscription, NewPublicationSubscription
 from zds.tutorialv2.models import CONTENT_TYPES
 from zds.tutorialv2.models.database import PublishedContent, ContentContribution, ContentReaction
@@ -417,7 +418,7 @@ class UpdateUsernameEmailMember(UpdateMember):
         previous_email = form.cleaned_data.get("previous_email")
         if new_username and new_username != previous_username:
             # Add a karma message for the staff
-            bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+            bot = get_bot_account()
             KarmaNote(
                 user=profile.user,
                 moderator=bot,

--- a/zds/member/views/register.py
+++ b/zds/member/views/register.py
@@ -33,6 +33,7 @@ from zds.member.models import (
     BannedEmailProvider,
     NewEmailProvider,
 )
+from zds.member.utils import get_bot_account, get_anonymous_account, get_external_account
 from zds.member.views import get_client_ip
 from zds.mp.models import PrivatePost, PrivateTopic
 from zds.tutorialv2.models.database import PickListOperation
@@ -180,8 +181,8 @@ def unregister(request):
             request, "member/settings/unregister.html", {"user": request.user, "unregister_form": unregister_form}
         )
 
-    anonymous = get_object_or_404(User, username=settings.ZDS_APP["member"]["anonymous_account"])
-    external = get_object_or_404(User, username=settings.ZDS_APP["member"]["external_account"])
+    anonymous = get_anonymous_account()
+    external = get_external_account()
     current = request.user
     # Nota : as of v21 all about content paternity is held by a proper receiver in zds.tutorialv2.models.database
     PickListOperation.objects.filter(staff_user=current).update(staff_user=anonymous)
@@ -276,7 +277,7 @@ def activate_account(request):
     usr.save()
 
     # Send welcome message
-    bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+    bot = get_bot_account()
     msg = render_to_string(
         "member/messages/account_activated.md",
         {

--- a/zds/tutorialv2/management/commands/migrate_to_zep25.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep25.py
@@ -5,6 +5,8 @@ from django.shortcuts import get_object_or_404
 from django.utils.text import slugify
 
 from django.conf import settings
+
+from zds.member.utils import get_bot_account, get_anonymous_account, get_external_account
 from zds.tutorialv2.models.database import PublishableContent
 from zds.utils.models import Category, SubCategory, CategorySubCategory, Tag
 from zds.mp.utils import send_mp
@@ -137,11 +139,11 @@ class Command(BaseCommand):
 
         :return: None
         """
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
         bots = [
-            get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"]),
-            get_object_or_404(User, username=settings.ZDS_APP["member"]["anonymous_account"]),
-            get_object_or_404(User, username=settings.ZDS_APP["member"]["external_account"]),
+            get_bot_account(),
+            get_anonymous_account(),
+            get_external_account(),
         ]
         users = []
         contents = PublishableContent.objects.all()

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -24,6 +24,7 @@ from gitdb.exc import BadName
 from zds import json_handler
 from zds.forum.models import Topic
 from zds.gallery.models import Image, Gallery, UserGallery, GALLERY_WRITE
+from zds.member.utils import get_external_account
 from zds.mp.models import PrivateTopic
 from zds.searchv2.models import (
     AbstractESDjangoIndexable,
@@ -1518,7 +1519,7 @@ def transfer_paternity_receiver(sender, instance, **kwargs):
     """
     transfer paternity to external user on user deletion
     """
-    external = sender.objects.get(username=settings.ZDS_APP["member"]["external_account"])
+    external = get_external_account()
     PublishableContent.objects.transfer_paternity(instance, external, UserGallery)
     PublishedContent.objects.transfer_paternity(instance, external)
 

--- a/zds/tutorialv2/views/authors.py
+++ b/zds/tutorialv2/views/authors.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext_lazy as _
 
 from zds.gallery.models import UserGallery, GALLERY_WRITE
 from zds.member.decorator import LoggedWithReadWriteHability
+from zds.member.utils import get_bot_account
 from zds.tutorialv2 import signals
 
 from zds.tutorialv2.forms import AuthorForm, RemoveAuthorForm
@@ -37,7 +38,7 @@ class AddAuthorToContent(LoggedWithReadWriteHability, SingleContentFormViewMixin
         elif self.object.is_opinion:
             _type = _("du billet")
 
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
         all_authors_pk = [author.pk for author in self.object.authors.all()]
         for user in form.cleaned_data["users"]:
             if user.pk not in all_authors_pk:
@@ -121,7 +122,7 @@ class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormView
         elif self.object.is_opinion:
             _type = (_("ce billet"), _("du billet"))
 
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
         for user in users:
             if RemoveAuthorFromContent.remove_author(self.object, user):
                 if user.pk == self.request.user.pk:

--- a/zds/tutorialv2/views/beta.py
+++ b/zds/tutorialv2/views/beta.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext_lazy as _
 
 from zds.forum.models import Topic, Forum, mark_read
 from zds.member.decorator import LoggedWithReadWriteHability
+from zds.member.utils import get_bot_account
 from zds.notification.models import TopicAnswerSubscription
 from zds.tutorialv2 import signals
 from zds.tutorialv2.forms import BetaForm
@@ -127,7 +128,7 @@ class ManageBetaContent(LoggedWithReadWriteHability, SingleContentFormViewMixin)
                     all_tags = self._get_all_tags()
                     topic = self._create_beta_topic(msg, beta_version, _type, all_tags)
 
-                    bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+                    bot = get_bot_account()
                     msg_pm = render_to_string(
                         "tutorialv2/messages/beta_activate_pm.md",
                         {

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -17,6 +17,7 @@ from zds.gallery.mixins import ImageCreateMixin, NotAnImage
 from zds.gallery.models import Gallery
 from zds.member.decorator import LoggedWithReadWriteHability
 from zds.member.models import Profile
+from zds.member.utils import get_bot_account
 from zds.tutorialv2.forms import (
     ContentForm,
     JsFiddleActivationForm,
@@ -400,7 +401,7 @@ class DeleteContent(LoginRequiredMixin, SingleContentViewMixin, DeleteView):
                     messages.error(self.request, _("Merci de fournir une raison à la suppression."))
                     return redirect(self.object.get_absolute_url())
                 else:
-                    bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+                    bot = get_bot_account()
                     msg = render_to_string(
                         "tutorialv2/messages/validation_cancel_on_delete.md",
                         {

--- a/zds/tutorialv2/views/contributors.py
+++ b/zds/tutorialv2/views/contributors.py
@@ -12,6 +12,7 @@ from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 
 from zds.member.decorator import LoggedWithReadWriteHability
+from zds.member.utils import get_bot_account
 from zds.notification.models import NewPublicationSubscription
 from zds.tutorialv2 import signals
 from zds.tutorialv2.forms import ContributionForm, RemoveContributionForm
@@ -47,7 +48,7 @@ class AddContributorToContent(LoggedWithReadWriteHability, SingleContentFormView
         elif self.object.is_opinion:
             raise PermissionDenied
 
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
         all_authors_pk = [author.pk for author in self.object.authors.all()]
         user = form.cleaned_data["user"]
         if user.pk in all_authors_pk:

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView, FormView
 
 from zds.member.decorator import LoggedWithReadWriteHability
+from zds.member.utils import get_bot_account
 from zds.mp.models import mark_read, filter_reachable
 from zds.tutorialv2 import signals
 from zds.tutorialv2.forms import (
@@ -157,7 +158,7 @@ class AskValidationForContent(LoggedWithReadWriteHability, SingleContentFormView
 
         # warn the former validator that an update has been made, if any
         if old_validator:
-            bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+            bot = get_bot_account()
             msg = render_to_string(
                 "tutorialv2/messages/validation_change.md",
                 {
@@ -249,7 +250,7 @@ class CancelValidation(LoginRequiredMixin, ModalFormView):
 
         # warn the former validator that the whole thing has been cancelled
         if validation.validator:
-            bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+            bot = get_bot_account()
             msg = render_to_string(
                 "tutorialv2/messages/validation_cancel.md",
                 {
@@ -431,7 +432,7 @@ class RejectValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
             },
         )
 
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
         if not validation.content.validation_private_message:
             validation.content.validation_private_message = send_mp(
                 bot,
@@ -582,7 +583,7 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
                 },
             )
 
-            bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+            bot = get_bot_account()
             if not validation.content.validation_private_message:
                 validation.content.validation_private_message = send_mp(
                     bot,

--- a/zds/tutorialv2/views/validations_opinions.py
+++ b/zds/tutorialv2/views/validations_opinions.py
@@ -16,6 +16,7 @@ from django.views.generic import FormView, ListView
 
 from zds.gallery.models import Gallery
 from zds.member.decorator import LoggedWithReadWriteHability
+from zds.member.utils import get_bot_account
 from zds.mp.models import filter_reachable
 from zds.mp.utils import send_mp, send_message_mp
 from zds.tutorialv2 import signals
@@ -126,7 +127,7 @@ class UnpublishOpinion(LoginRequiredMixin, SingleOnlineContentFormViewMixin, Doe
                 },
             )
 
-            bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+            bot = get_bot_account()
             if self.object.validation_private_message:
                 send_message_mp(
                     bot,
@@ -221,7 +222,7 @@ class DoNotPickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormView
                     },
                 )
 
-                bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+                bot = get_bot_account()
                 if self.object.validation_private_message:
                     send_message_mp(
                         bot,
@@ -326,7 +327,7 @@ class PickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMixin
             },
         )
 
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
         if not self.object.validation_private_message:
             self.object.validation_private_message = send_mp(
                 bot,
@@ -399,7 +400,7 @@ class UnpickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMix
             },
         )
 
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
         if not self.object.validation_private_message:
             self.object.validation_private_message = send_mp(
                 bot,
@@ -538,7 +539,7 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
             },
         )
 
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
 
         article.validation_private_message = send_mp(
             bot,

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -74,4 +74,7 @@ def check_essential_accounts():
         try:
             User.objects.get(username=username)
         except User.DoesNotExist:
-            raise Exception(f"User {username!r} does not exist. You must create it to run the server.")
+            raise Exception(
+                f"User {username!r} does not exist. You must create it to run the server. "
+                f"On a development instance, load the fixtures to solve this issue."
+            )

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -1,6 +1,8 @@
 import hashlib
 import re
 
+from django.contrib.auth import get_user_model
+
 THUMB_MAX_WIDTH = 80
 THUMB_MAX_HEIGHT = 80
 
@@ -54,3 +56,22 @@ def contains_utf8mb4(s):
         s = str(s, "utf-8")
     re_pattern = re.compile("[^\u0000-\uD7FF\uE000-\uFFFF]", re.UNICODE)
     return s != re_pattern.sub("\uFFFD", s)
+
+
+def check_essential_accounts():
+    """
+    Verify that essential accounts are present in the database.
+    Raise an exception if it not the case.
+    """
+
+    from django.conf import settings
+
+    User = get_user_model()
+    essential_accounts = ("bot_account", "anonymous_account", "external_account")
+
+    for account in essential_accounts:
+        username = settings.ZDS_APP["member"][account]
+        try:
+            User.objects.get(username=username)
+        except User.DoesNotExist:
+            raise Exception(f"User {username!r} does not exist. You must create it to run the server.")

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext_lazy as _
 from django.dispatch import receiver
 from django.template.loader import render_to_string
 
+from zds.member.utils import get_bot_account
 from zds.utils import signals
 from zds.mp.models import PrivateTopic
 from zds.tutorialv2.models import TYPE_CHOICES, TYPE_CHOICES_DICT
@@ -246,7 +247,7 @@ class HatRequest(models.Model):
             raise Exception("This request is already solved.")
 
         if moderator is None:
-            moderator = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+            moderator = get_bot_account()
 
         if is_granted:
             if self.get_hat() is None and hat_name:
@@ -267,7 +268,7 @@ class HatRequest(models.Model):
         if self.is_granted is None:
             raise Exception("The request must have been solved to use this method.")
 
-        solved_by_bot = self.moderator == get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        solved_by_bot = self.moderator == get_bot_account()
 
         message = render_to_string(
             "member/messages/hat_request_decision.md",
@@ -513,7 +514,7 @@ class Comment(models.Model):
         # the post was edited. If an open alert already exists for this reason, we update the
         # date of this alert to avoid lots of them stacking up.
         if self.old_text != self.text and self.is_potential_spam and self.editor == self.author:
-            bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+            bot = get_bot_account()
             alert_text = _("Ce message, soupçonné d'être un spam, a été modifié.")
 
             try:
@@ -702,7 +703,7 @@ class Alert(models.Model):
         """
         self.resolve_reason = resolve_reason or None
         if msg_title and msg_content:
-            bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+            bot = get_bot_account()
             privatetopic = send_mp(
                 bot,
                 [self.author],

--- a/zds/utils/tests/test_misc.py
+++ b/zds/utils/tests/test_misc.py
@@ -1,8 +1,9 @@
 import datetime
+from django.conf import settings
 from django.test import TestCase
-from zds.member.tests.factories import ProfileFactory, StaffProfileFactory
+from zds.member.tests.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.tutorialv2.tests.factories import PublishedContentFactory
-from zds.utils.misc import contains_utf8mb4
+from zds.utils.misc import contains_utf8mb4, check_essential_accounts
 from zds.utils.models import Alert
 from zds.utils.context_processor import get_header_notifications
 
@@ -31,3 +32,15 @@ class Misc(TestCase):
         filter_result = get_header_notifications(staff.user)["alerts"]
         self.assertEqual(1, filter_result["total"])
         self.assertEqual(alert.text, filter_result["list"][0]["text"])
+
+
+class CheckEssentialAccountsTest(TestCase):
+    def test_with_accounts(self):
+        UserFactory(username=settings.ZDS_APP["member"]["bot_account"])
+        UserFactory(username=settings.ZDS_APP["member"]["anonymous_account"])
+        UserFactory(username=settings.ZDS_APP["member"]["external_account"])
+        check_essential_accounts()
+
+    def test_without_accounts(self):
+        with self.assertRaises(Exception):
+            check_essential_accounts()

--- a/zds/utils/tests/tests_comments.py
+++ b/zds/utils/tests/tests_comments.py
@@ -8,6 +8,7 @@ from rest_framework.test import APIClient
 
 from zds.forum.tests.factories import PostFactory, create_category_and_forum, create_topic_in_forum
 from zds.member.tests.factories import ProfileFactory, StaffProfileFactory
+from zds.member.utils import get_bot_account
 from zds.tutorialv2.tests.factories import PublishedContentFactory
 from zds.tutorialv2.models import CONTENT_TYPES
 from zds.tutorialv2.models.database import PublishableContent
@@ -85,7 +86,7 @@ class PotentialSpamTests(TutorialTestMixin, TestCase):
         )
 
     def common_test_mark_as_potential_spam(self, url_comments_list, url_comment_edit, comment, author, staff):
-        bot = get_object_or_404(User, username=settings.ZDS_APP["member"]["bot_account"])
+        bot = get_bot_account()
 
         potential_spam_class_not_there_if_not_staff = "potential-spam"
         potential_spam_classes_if_hidden = 'class="message-potential-spam alert ico-after hidden"'

--- a/zds/wsgi.py
+++ b/zds/wsgi.py
@@ -1,6 +1,8 @@
 import os
 from django.core.wsgi import get_wsgi_application
 
+from zds.utils.misc import check_essential_accounts
+
 """
 WSGI config for zds project.
 
@@ -13,3 +15,5 @@ https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "zds.settings.prod")
 
 application = get_wsgi_application()
+
+check_essential_accounts()


### PR DESCRIPTION
Fix #4872.

Reprise de #4873.

- Ajoute une vérification de la présence des comptes essentiels (bot + auteur externe + anonyme) au démarrage de l'application
- Simplifie la récupération des comptes bots dans tout le code
- Déplace les bots dans un fichier de fixtures dédié.

### Contrôle qualité

Vérifier le déclenchement de l'erreur :
- Supprimer la base de donnée (locale)
- Appliquer les migrations (sans les fixtures)
- Vérifier qu'on a une exception qui correspond à l'absence d'un compte

Ensuite, vérifier l'absence de l'erreur :
- générer les fixtures (ça importe les comptes essentiels)
- vérifier que ça démarre comme il faut