### PR TITLE
Les votes dans les MPs ne devraient pas être anonymes

### DIFF
--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -444,11 +444,7 @@ class PrivatePost(models.Model):
     def get_votes(self):
         """Get the non-anonymous votes"""
         if not hasattr(self, "votes"):
-            self.votes = (
-                PrivatePostVote.objects.filter(private_post=self, id__gt=settings.VOTES_ID_LIMIT)
-                .select_related("user")
-                .all()
-            )
+            self.votes = PrivatePostVote.objects.filter(private_post=self).select_related("user").all()
 
         return self.votes
 


### PR DESCRIPTION
Fix #6372 (partiellement)

L'issue 6372 reportait deux problèmes indépendants concernant les votes dans les MPs. J'ai décidé de les régler avec deux PR indépendantes. L'autre est dans #6375.

### Contrôle qualité
* Se connecter avec user1
* Envoyer un MP à user2
* Se connecter avec user2
* Ouvrir le MP envoyé par user1 et liker le premier message
* **Avec user1:** Rafraichir la page du MP, survoler le like sur le premier post
**Comportement actuel:** Le like est anonyme
**Nouveau comportement:** On voit que le like vient de user2
