### PR TITLE
Règle un problème d'affichage des votes dans les MPs

### DIFF
--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -24,7 +24,7 @@ from zds.forum.utils import CreatePostView
 from zds.mp.utils import send_mp, send_message_mp
 from zds.utils.paginator import ZdSPagingListView
 from .forms import PrivateTopicForm, PrivatePostForm, PrivateTopicEditForm
-from .models import PrivateTopic, PrivateTopicRead, PrivatePost, mark_read, NotReachableError
+from .models import PrivateTopic, PrivateTopicRead, PrivatePost, mark_read, NotReachableError, PrivatePostVote
 
 
 class PrivateTopicList(ZdSPagingListView):
@@ -254,6 +254,10 @@ class PrivatePostList(ZdSPagingListView, SingleObjectMixin):
             context["user_can_modify"] = [self.object.last_message.pk]
         else:
             context["user_can_modify"] = []
+
+        votes = PrivatePostVote.objects.filter(user_id=self.request.user.pk, private_post__in=context["posts"]).all()
+        context["user_like"] = [vote.private_post_id for vote in votes if vote.positive]
+        context["user_dislike"] = [vote.private_post_id for vote in votes if not vote.positive]
 
         return context
 


### PR DESCRIPTION
Fix #6372 (partiellement)

L'issue 6372 reportait deux problèmes indépendants concernant les votes dans les MPs. J'ai décidé de les régler avec deux PR indépendantes. L'autre est dans #6374.

### Contrôle qualité
* Se connecter avec user1
* Envoyer un MP à user2
* Se connecter avec user2
* Ouvrir le MP envoyé par user1 et liker le premier message
* Rafraichir la page du MP
**Comportement actuel:** Le pouce en l'air est vert "clair" (avec une opacité de 0.5)
**Nouveau comportement:** Le pouce en l'air est vert foncté (avec un opacité de 1)
