### PR TITLE
Corrige la route pour dissocier un ticket GitHub d'un sujet du forum

### DIFF
--- a/templates/forum/topic/index.html
+++ b/templates/forum/topic/index.html
@@ -255,7 +255,7 @@
                         <li>
                             <a href="#unlink-issue" class="open-modal ico-after cross red">{% trans 'Dissocier le ticket' %}</a>
                         </li>
-                        <form action="{% url 'manage-issue' topic.pk %}" method="post" id="unlink-issue" class="modal modal-flex">
+                        <form action="{% url "forum:manage-issue" topic.pk %}" method="post" id="unlink-issue" class="modal modal-flex">
                             {% csrf_token %}
                             <p>
                                 {% trans 'Voulez-vous vraiment dissocier ce sujet de son ticket GitHub ?' %}


### PR DESCRIPTION
Cette PR corrige la route pour dissocier un ticket GitHub d'un sujet du forum (probablement un oubli lors de la refactorisation des URLs) et ajoute un test pour s'assurer que ce genre de problème ne passe plus sous nos radars.

Problème rapporté par Sentry.


### QA

Le plus simple est sans doute de faire une revue de code et de constater que le changement principal est correct et ne peut pas introduire de bug, sinon il est possible que je déploie cette PR sur la bêta. Si #6377 est fusionné lors de la QA, il est aussi possible modifier les champs *Ticket GitHub* (avec n'importe quelle valeur) et *Nom du dépôt GitHub* (par une des valeurs des dépôts définies dans la [configuration](https://github.com/zestedesavoir/zds-site/blob/dev/zds/settings/abstract_base/zds.py#L125-L126)) et en tant qu'utilisateur `dev`, aller sur la page du sujet et constater qu'elle s'affiche correctement.