### PR TITLE
Passe à la version 22.04 d'Ubuntu pour GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   # Lint the Python back-end with flake8.
   lint-back:
     name: Lint back-end
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
   # Build the documentation and upload it as an artifact.
   build-doc:
     name: Build Sphinx documentation
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -83,7 +83,7 @@ jobs:
   # Build the website front-end and upload built assets as an artifact.
   build-front:
     name: Lint and build front-end
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -130,7 +130,7 @@ jobs:
   test:
     name: Install and test zds-site
     needs: build-front
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -251,7 +251,7 @@ jobs:
   coverage:
     name: Push coverage to Coveralls
     needs: test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Set up Python ${{ env.PYTHON_VERSION }}
@@ -271,7 +271,7 @@ jobs:
   push_doc:
     name: Push documentation to GitHub Pages
     needs: ["build-doc", "test"]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: "github.ref == 'refs/heads/dev'"
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ env:
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt
   BLACK_VERSION: "22.6.0" # needs to be also updated in requirements-dev.txt and .pre-commit-config.yaml
+  GECKODRIVER_VERSION: "0.31.0"
 
   # As GitHub Action does not allow environment variables
   # to be used in services definitions, these are only for
@@ -176,6 +177,15 @@ jobs:
           mysql database: "ci_db_name"
           mysql root password: "ci_root_password"
 
+      - name: Install Firefox
+        run: sudo apt-get update && sudo apt-get install firefox
+
+      - name: Install Geckodriver
+        run: |
+          wget https://github.com/mozilla/geckodriver/releases/download/v${{ env.GECKODRIVER_VERSION }}/geckodriver-v${{ env.GECKODRIVER_VERSION }}-linux64.tar.gz
+          mkdir geckodriver
+          tar -xzf geckodriver-v${{ env.GECKODRIVER_VERSION }}-linux64.tar.gz -C geckodriver
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -233,7 +243,7 @@ jobs:
 
       - name: Run tests for ${{ matrix.module }}
         run: |
-          export PATH="$PATH:$GECKOWEBDRIVER"
+          export PATH="$PATH:$PWD/geckodriver"
           coverage run --source='.' manage.py test -v=2 --keepdb --settings zds.settings.ci_test ${{ matrix.module }}
 
       - name: Analyze coverage


### PR DESCRIPTION
L'image `ubuntu-18.04` qu'on utilise actuellement pour la CI est dépréciée depuis le 8 août (cf
https://github.com/actions/runner-images/issues/6002). Cette PR passe la version d'Ubuntu à 22.04 (qui est aussi une LTS).

Malheureusement, la version 22.04 de l'image n'inclut plus geckodriver ni Firefox (cf
[le README de la version 22.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md) vs [le README de la version 18.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu1804-Readme.md)), il faut donc les installer manuellement.

### QA

- Revue de code
- S'assurer que la CI passe avec tous les tests, y compris front avec Selenium.