### PR TITLE
Mise à jour triviale des dépendances Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
   PYTHON_VERSION: "3.7"
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt
-  BLACK_VERSION: "22.6.0" # needs to be also updated in requirements-dev.txt and .pre-commit-config.yaml
+  BLACK_VERSION: "22.8.0" # needs to be also updated in requirements-dev.txt and .pre-commit-config.yaml
   GECKODRIVER_VERSION: "0.31.0"
 
   # As GitHub Action does not allow environment variables

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.37.3
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/psf/black
-    rev: 22.6.0 # needs to be also updated in requirements-dev.txt and .github/workflows/ci.yml
+    rev: 22.8.0 # needs to be also updated in requirements-dev.txt and .github/workflows/ci.yml
     hooks:
       - id: black
         language_version: python3

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 -r requirements-dev.txt
 -r requirements-prod.txt
 
-coverage==6.4.2 # check if Coveralls needs to be also updated in .github/workflows/ci.yml
+coverage==6.4.4 # check if Coveralls needs to be also updated in .github/workflows/ci.yml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 
-black==22.6.0  # needs to be also updated in .github/workflows/ci.yml and .pre-commit-config.yaml
-colorlog==6.6.0
-django-debug-toolbar==3.5.0
+black==22.8.0  # needs to be also updated in .github/workflows/ci.yml and .pre-commit-config.yaml
+colorlog==6.7.0
+django-debug-toolbar==3.6.0
 django-extensions==3.2.0
-Faker==13.15.0
+Faker==14.2.0
 pre-commit==2.20.0
 PyYAML==6.0
-selenium==4.3.0
-Sphinx==5.0.2
+selenium==4.4.3
+Sphinx==5.1.1
 sphinx_rtd_theme==1.0.0

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -2,5 +2,5 @@
 
 gunicorn==20.1.0
 mysqlclient==2.1.1
-sentry-sdk==1.7.2
+sentry-sdk==1.9.8
 ujson==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ django-crispy-forms==1.14.0
 django-model-utils==4.2.0
 django-munin==0.2.1
 django-recaptcha==3.0.0
-Django==3.2.14
-easy-thumbnails==2.8.1
+Django==3.2.15
+easy-thumbnails[svg]==2.8.3
 factory-boy==3.2.1
 geoip2==4.6.0
 GitPython==3.1.27
@@ -29,7 +29,7 @@ djangorestframework-xml==2.0.0
 djangorestframework==3.13.1
 drf-extensions==0.7.1
 dry-rest-permissions==0.1.10
-drf_yasg==1.21.0
+drf_yasg==1.21.3
 
 # Dependencies for slug generation, please be extra careful with those
 django-uuslug==2.0.0


### PR DESCRIPTION
Mise à jour triviale des dépendances Python

Je n'ai pas mis à jour `django-oauth-toolkit` car la nouvelle version contient des *breaking change* conséquents.

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier que le site fonctionne correctement dans sa globalité
- `make generate-doc` puis ouvrir `doc/build/html/index.html` dans un navigateur
- S'assurer que la documentation n'est pas cassée