### PR TITLE
Corrige l'affichage des longs pseudos sur le profil sur mobile

### DIFF
--- a/assets/scss/pages/_flexpage.scss
+++ b/assets/scss/pages/_flexpage.scss
@@ -222,6 +222,8 @@ $content-width: 1145px;
             color: white;
             font-size: $font-size-6;
 
+            overflow: hidden;
+
             .line {
                 display: block;
                 line-height: 1.5;

--- a/assets/scss/pages/_flexpage.scss
+++ b/assets/scss/pages/_flexpage.scss
@@ -251,14 +251,8 @@ $content-width: 1145px;
                 font-size: $font-size-3;
                 line-height: 1;
 
-                @include mobile {
-                    display: flex;
-                    align-items: baseline;
-
-                    :first-child {
-                        flex: 12;
-                    }
-                }
+                overflow: hidden;
+                text-overflow: ellipsis;
             }
 
             h2 {


### PR DESCRIPTION
Fix #5989.

Ça règle les soucis courants. Je n'ai pas géré les cas encore plus extrêmes qui cassent aussi le design sur ordinateur, ça me paraît trop rare pour être traité avant que le cas ne se présente effectivement.

### Contrôle qualité

* Créer un compte avec long pseudo ; j'ai choisi "TrèèèèèèèèèèèèèèsLoooongPseudo".
* Mettez-lui une sanction et/ou un signalement (important pour voir le comportement des blocs associés).
* Regarder que la page  est affichée normalement sur une largeur ordinateur.
* Utilisez vos outils développeurs pour réduire la taille jusqu'à des tailles ridicules et constater que le pseudo ne déborde pas (d'autres choses peuvent déborder notamment pour le staff, c'est un autre sujet).

* Vérifier également que les autres flexpages (la bibliothèque en particulier) fonctionnent bien aussi.