### PR TITLE
Corrige le style du pied-de-page pour qu'il ne dépasse plus

### DIFF
--- a/assets/scss/layout/_footer.scss
+++ b/assets/scss/layout/_footer.scss
@@ -13,9 +13,9 @@
     }
 
     .copyright, .links {
-        flex-shrink: 1;
-        flex-grow: 1;
-        min-width: 0;
+        flex-shrink: 0;
+        flex-grow: 5;
+        flex-basis: 0;
     }
 
     .copyright {
@@ -63,7 +63,7 @@
         }
 
         &.social {
-            flex-grow: 0;
+            flex-grow: 1;
             flex-shrink: 0;
             flex-basis: auto;
             text-align: center;

--- a/assets/scss/layout/_footer.scss
+++ b/assets/scss/layout/_footer.scss
@@ -15,7 +15,6 @@
     .copyright, .links {
         flex-shrink: 1;
         flex-grow: 1;
-        flex-basis: 0;
         min-width: 0;
     }
 


### PR DESCRIPTION
Fix #6146.

Le pied de page se réduit désormais correctement sans causer une bande blanche sur la droite pour certaines t'ailles d'écran.

### Contrôle qualité

Réduire une page progressivement et voir que le pied de page est toujours bien affiché.

**Note**: Cela marche parfaitement sur certaines pages (forum par exemple), mais pas sur d'autres (bibliothèque, page d'accueil) où il reste une bande blanche bien que le pied de page soit bien en ordre. C'est un souci indépendant lié aux colonnes de vignettes, qui est *hors du périmètre de cette PR.*