### PR TITLE
Corrige la taille des images de profil par défaut

### DIFF
--- a/templates/forum/base.html
+++ b/templates/forum/base.html
@@ -4,8 +4,6 @@
 {% load date %}
 {% load profile %}
 {% load i18n %}
-{% load remove_url_scheme %}
-
 
 
 {% block head_extra %}
@@ -142,7 +140,7 @@
                                         {% with answer=topic.get_last_answer %}
                                             {% if answer %}
                                                 {% with profile=answer.author|profile %}
-                                                    <img src="{{ profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar">
+                                                    <img src="{% avatar_url profile %}" alt="" class="avatar">
                                                 {% endwith %}
                                                 <span class="topic-last-answer">
                                                     {% trans "Dernière réponse" %}

--- a/templates/header.html
+++ b/templates/header.html
@@ -3,7 +3,6 @@
 {% load i18n %}
 {% load interventions %}
 {% load profile %}
-{% load remove_url_scheme %}
 {% load set %}
 {% load topbar %}
 {% load captureas %}
@@ -237,7 +236,7 @@
                                 <li>
                                     <a href="{{ notification.url }}">
                                         <header>
-                                            <img src="{{ notification.author.profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar">
+                                            <img src="{% avatar_url notification.author.profile %}" alt="" class="avatar">
                                             <span class="username">{{ notification.author.username }}</span>
                                             <span class="date">{{ notification.pubdate|format_date:True|capfirst }}</span>
                                         </header>
@@ -275,7 +274,7 @@
                                 <li>
                                     <a href="{{ first_unread.url }}">
                                       <header>
-                                          <img src="{{ first_unread.author.profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar">
+                                          <img src="{% avatar_url first_unread.author.profile %}" alt="" class="avatar">
                                           <span class="username">{{ first_unread.author.username }}</span>
                                           <span class="date">{{ first_unread.pubdate|format_date:True|capfirst }}</span>
                                       </header>
@@ -345,7 +344,7 @@
                            data-active="open-my-account"
                        {% endif %}
                     >
-                        <img src="{{ profile.get_avatar_url|remove_url_scheme }}" alt="Mon compte" class="avatar">
+                        <img src="{% avatar_url profile %}" alt="Mon compte" class="avatar">
                         <span class="username label">{{ user.username }}</span>
                     </a>
                 {% endwith %}

--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -10,7 +10,6 @@
 {% load messages %}
 {% load pluralize_fr %}
 {% load profile %}
-{% load remove_url_scheme %}
 
 
 
@@ -79,7 +78,7 @@
                 <div class="flexpage-title-tool">
                     <div class="avatar">
                         <figure>
-                            <img src="{{ profile.get_avatar_url|remove_url_scheme }}" alt="{% trans "Avatar" %}" />
+                            <img src="{% avatar_url profile size=200 %}" alt="{% trans "Avatar" %}" />
                         </figure>
                     </div>
 

--- a/templates/misc/member_item.part.html
+++ b/templates/misc/member_item.part.html
@@ -1,6 +1,5 @@
 {% load profile %}
 {% load i18n %}
-{% load remove_url_scheme %}
 
 {% with profile=member|profile %}
     {% spaceless %}
@@ -14,7 +13,7 @@
            {% endif %}>
 
             {% if avatar %}
-                <img src="{{ profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar" itemprop="image" aria-hidden="true" />
+                <img src="{% avatar_url profile %}" alt="" class="avatar" itemprop="image" aria-hidden="true" />
             {% endif %}
 
             <span itemprop="name">{{ profile.user.username }}</span>

--- a/templates/misc/message_user.html
+++ b/templates/misc/message_user.html
@@ -1,12 +1,11 @@
 {% load profile %}
 {% load i18n %}
-{% load remove_url_scheme %}
 
 
 <div class="user">
     {% with profile=member|profile %}
         <a href="{{ member.get_absolute_url }}" class="avatar-link">
-            <img src="{{ profile.get_avatar_url|remove_url_scheme }}" alt="" class="avatar">
+            <img src="{% avatar_url profile %}" alt="" class="avatar">
         </a>
 
         {% include 'misc/badge.part.html' %}

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -111,7 +111,7 @@ class Profile(models.Model):
         self._cached_city = (self.last_ip_address, geo_location)
         return geo_location
 
-    def get_avatar_url(self):
+    def get_avatar_url(self, size=80):
         """Get the avatar URL for this profile.
         If the user has defined a custom URL, use it.
         If not, use Gravatar.
@@ -124,8 +124,8 @@ class Profile(models.Model):
             else:
                 return self.avatar_url
         else:
-            return "https://secure.gravatar.com/avatar/{}?d=identicon".format(
-                md5(self.user.email.lower().encode("utf-8")).hexdigest()
+            return "https://secure.gravatar.com/avatar/{}?d=identicon&s={}".format(
+                md5(self.user.email.lower().encode("utf-8")).hexdigest(), size
             )
 
     def get_post_count(self):

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -31,12 +31,8 @@ class MemberModelsTest(TutorialTestMixin, TestCase):
 
     def test_get_avatar_url(self):
         # if no url was specified -> gravatar !
-        self.assertEqual(
-            self.user1.get_avatar_url(),
-            "https://secure.gravatar.com/avatar/{}?d=identicon".format(
-                md5(self.user1.user.email.lower().encode()).hexdigest()
-            ),
-        )
+        self.assertIn("gravatar.com", self.user1.get_avatar_url())
+
         # if an url is specified -> take it !
         user2 = ProfileFactory()
         testurl = "http://test.com/avatar.jpg"

--- a/zds/utils/templatetags/profile.py
+++ b/zds/utils/templatetags/profile.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from django.core.cache import cache
 
 from zds.member.models import Profile
-
+from zds.utils.templatetags.remove_url_scheme import remove_url_scheme
 
 register = template.Library()
 
@@ -68,3 +68,9 @@ def state(current_user):
     except Profile.DoesNotExist:
         user_state = None
     return user_state
+
+
+@register.simple_tag
+def avatar_url(profile, size=80):
+    url = profile.get_avatar_url(size)
+    return remove_url_scheme(url)

--- a/zds/utils/templatetags/profile.py
+++ b/zds/utils/templatetags/profile.py
@@ -71,6 +71,12 @@ def state(current_user):
 
 
 @register.simple_tag
-def avatar_url(profile, size=80):
-    url = profile.get_avatar_url(size)
-    return remove_url_scheme(url)
+def avatar_url(profile: Profile, size=80) -> str:
+    """
+    Return the URL of the avatar of a profile.
+    If the profile is None, return an empty string.
+    """
+    if profile is not None:
+        url = profile.get_avatar_url(size)
+        return remove_url_scheme(url)
+    return ""


### PR DESCRIPTION
Reprise de #5467.

Les avatars par défaut sont trop petit sur la page de profil, cette PR les remet à une bonne taille.

J'ai opté pour une option à base de *templatag*, que j'ai généralisée à tous les endroits que j'ai pu trouver où on affiche les avatar. Un argument par défaut permet de rester léger sur la syntaxe dans les templates.

J'ai aussi modifié un test en conséquence en le rendant moins spécifique volontairement. Je ne crois pas qu'on ai besoin de reproduire le code fonctionnel dans le test pour vérifir que l'adresse exacte est bien la bonne.

### Contrôle qualité

Se promener sur le profil et voir que les avatars par défaut sont à la bonne taille.

Se promener partout où on rencontre des avatars (pages de tutos pour les auteurs, commentaire, notifications, MP, forums, etc.) et voir que rien n'est cassé.