### PR TITLE
Fix mp security by Aabu

### DIFF
--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -625,6 +625,7 @@ class LeaveViewTest(TestCase):
     def setUp(self):
         self.profile1 = ProfileFactory()
         self.profile2 = ProfileFactory()
+        self.profile3 = ProfileFactory()
 
         self.anonymous_account = UserFactory(username=settings.ZDS_APP["member"]["anonymous_account"])
         self.bot_group = Group()
@@ -649,6 +650,14 @@ class LeaveViewTest(TestCase):
         self.assertRedirects(
             response, reverse("member-login") + "?next=" + reverse("mp:leave", args=[1, "private-topic"])
         )
+
+    def test_denies_leave_topic_as_random_member(self):
+        self.client.force_login(self.profile3.user)
+
+        response = self.client.post(reverse("mp:leave", args=[self.topic1.pk, self.topic1.slug()]), follow=True)
+
+        self.assertEqual(403, response.status_code)
+        self.assertEqual(1, PrivateTopic.objects.filter(pk=self.topic1.pk).count())
 
     def test_fail_leave_topic_no_exist(self):
 

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -156,6 +156,8 @@ class PrivateTopicLeaveDetail(LeavePrivateTopic, SingleObjectMixin, RedirectView
 
     def post(self, request, *args, **kwargs):
         topic = self.get_object()
+        if not topic.is_participant(self.get_current_user()):
+            raise PermissionDenied
         self.perform_destroy(topic)
         messages.success(request, _("Vous avez quitté la conversation avec succès."))
         return redirect(reverse("mp:list"))


### PR DESCRIPTION
Security breach : voici le rapport 

> 
Sous ces conditions :
>
> - il faut être connecté ;
> - il faut connaître l'ID d'un MP et son slug ;
> - il faut que la personne soit seule dans le MP cible ;
>
alors, il est possible de faire quitter le MP à la personne alors qu'on n'est pas cette personne.
>
J'ai pu le faire en rejouant la requête envoyée lors qu'on quitte le MP, ce qui a eu pour effet de faire quitter l'autre personne. On n'est pas obligé d'être un ancien participant, on peut reprendre n'importe quelle requête qui quitte un MP et changer la cible.

La faille a été fix sur beta et dev avec le code joint.