### PR TITLE
Corrige le domaine pour les placeholders des Unes

### DIFF
--- a/fixtures/featured.yaml
+++ b/fixtures/featured.yaml
@@ -4,7 +4,7 @@
         title: Première une
         type: sujet
         authors: Machin
-        image_url: https://placehold.it/228/00618a/FFFFFF&text=One
+        image_url: https://via.placeholder.com/228/00618a/FFFFFF&text=One
         url: https://zestedesavoir.com
         pubdate: 2013-12-21 13:20:30
 -   model: featured.FeaturedResource
@@ -13,7 +13,7 @@
         title: Seconde une
         type: tutoriel
         authors: Bidule
-        image_url: https://placehold.it/228/00618a/FFFFFF&text=Two
+        image_url: https://via.placeholder.com/228/00618a/FFFFFF&text=Two
         url: https://zestedesavoir.com
         pubdate: 2013-12-21 13:20:30
 -   model: featured.FeaturedResource
@@ -21,7 +21,7 @@
     fields:
         title: Troisième une
         type: article
-        image_url: https://placehold.it/228/00618a/FFFFFF&text=Three
+        image_url: https://via.placeholder.com/228/00618a/FFFFFF&text=Three
         url: https://zestedesavoir.com
         pubdate: 2013-12-21 13:20:30
 -   model: featured.FeaturedResource
@@ -30,7 +30,7 @@
         title: Quatrième une
         type: projet
         authors: Truc
-        image_url: https://placehold.it/228/00618a/FFFFFF&text=Four
+        image_url: https://via.placeholder.com/228/00618a/FFFFFF&text=Four
         url: https://zestedesavoir.com
         pubdate: 2013-12-21 13:20:30
 -   model: featured.FeaturedResource
@@ -39,6 +39,6 @@
         title: Cinquième une
         type: tutoriel
         authors: L'idiot du village
-        image_url: https://placehold.it/228/00618a/FFFFFF&text=Five
+        image_url: https://via.placeholder.com/228/00618a/FFFFFF&text=Five
         url: https://zestedesavoir.com
         pubdate: 2013-12-21 13:20:30


### PR DESCRIPTION
Le nom de domaine pour les placeholders a changé il y a quelque temps, donc on ne pouvait plus charger les images utilisées en Une sur l'environnement de dév. C'est désormais corrigé.

### Contrôle qualité

Charger les unes depuis les fixures et constater qu'elles sont bien affichées : Five, Four, Three, Two, One.