### PR TITLE
Passage à zmarkdown 11.3.0

### DIFF
--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import requests
 from django.core.exceptions import ObjectDoesNotExist
+from django.template.defaultfilters import date
 from django.template.loader import render_to_string
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
@@ -414,6 +415,7 @@ class ZMarkdownRebberLatexPublicator(Publicator):
             images_download_dir=str(base_directory / "images"),
             local_url_to_local_path=["/", replacement_image_url],
             heading_shift=-1,
+            date=date(published_content_entity.last_publication_date, "l d F Y"),
         )
         if content == "" and messages:
             raise FailureDuringPublication(f"Markdown was not parsed due to {messages}")

--- a/zmd/package-lock.json
+++ b/zmd/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "zmarkdown": "11.0.2"
+        "zmarkdown": "11.3.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -464,64 +464,49 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.74.0.tgz",
+      "integrity": "sha512-JK6IRGgdtZjswGfaGIHNWIThffhOHzVIIaGmglui+VFIzOsOqePjoxaDV0MEvzafxXZD7eWqGE5RGuZ0n6HFVg==",
+      "dependencies": {
+        "@sentry/core": "7.74.0",
+        "@sentry/types": "7.74.0",
+        "@sentry/utils": "7.74.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sentry/core": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
-      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.74.0.tgz",
+      "integrity": "sha512-83NRuqn7nDZkSVBN5yJQqcpXDG4yMYiB7TkYUKrGTzBpRy6KUOrkCdybuKk0oraTIGiGSe5WEwCFySiNgR9FzA==",
       "dependencies": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.74.0",
+        "@sentry/utils": "7.74.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/hub": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
-      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
-      "dependencies": {
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
-      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
-      "dependencies": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz",
-      "integrity": "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==",
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.74.0.tgz",
+      "integrity": "sha512-uBmW2/z0cz/WFIG74ZF7lSipO0XNzMf9yrdqnZXnGDYsUZE4I4QiqDN0hNi6fkTgf9MYRC8uFem2OkAvyPJ74Q==",
       "dependencies": {
-        "@sentry/core": "5.30.0",
-        "@sentry/hub": "5.30.0",
-        "@sentry/tracing": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "cookie": "^0.4.1",
+        "@sentry-internal/tracing": "7.74.0",
+        "@sentry/core": "7.74.0",
+        "@sentry/types": "7.74.0",
+        "@sentry/utils": "7.74.0",
+        "cookie": "^0.5.0",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/node/node_modules/agent-base": {
@@ -533,6 +518,14 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@sentry/node/node_modules/https-proxy-agent": {
@@ -547,39 +540,24 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@sentry/tracing": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.30.0.tgz",
-      "integrity": "sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==",
-      "dependencies": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@sentry/types": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
-      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.74.0.tgz",
+      "integrity": "sha512-rI5eIRbUycWjn6s6o3yAjjWtIvYSxZDdnKv5je2EZINfLKcMPj1dkl6wQd2F4y7gLfD/N6Y0wZYIXC3DUdJQQg==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
-      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.74.0.tgz",
+      "integrity": "sha512-k3np8nuTPtx5KDODPtULfFln4UXdE56MZCcF19Jv6Ljxf+YN/Ady1+0Oi3e0XoSvFpWNyWnglauT7M65qCE6kg==",
       "dependencies": {
-        "@sentry/types": "5.30.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.74.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@tokenizer/token": {
@@ -2282,7 +2260,7 @@
     "node_modules/lodash.trimend": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
-      "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
+      "integrity": "sha512-lsD+k73XztDsMBKPKvzHXRKFNMohTjoTKIIo4ADLn5dA65LZ1BqlAvSXhR2rPEC3BgAUQnzMnorqDtqn2z4IHA=="
     },
     "node_modules/log-driver": {
       "version": "1.2.7",
@@ -3180,9 +3158,9 @@
       }
     },
     "node_modules/rebber": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/rebber/-/rebber-5.3.0.tgz",
-      "integrity": "sha512-vLdJGRTgf+e/ADc9k0hWIgKd6P4HESNQ33MgISTit+d20y8YeORcSHJ0oovlpUelmw63BUcIwzeG83sWScZakA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/rebber/-/rebber-5.4.0.tgz",
+      "integrity": "sha512-tRBDkBgITaJqLmr9dMnm20bGE87TSItSU92pJYSOazoRVGpMz14yrKe2NC6xnLa/bYfaDHMqi98MjceqL+4HAw==",
       "dependencies": {
         "clone": "^2.1.2",
         "collapse-white-space": "^1.0.6",
@@ -3193,9 +3171,9 @@
       }
     },
     "node_modules/rebber-plugins": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/rebber-plugins/-/rebber-plugins-4.3.6.tgz",
-      "integrity": "sha512-aVSNmN/VlqeE9pAP/DqCrMBDI4kOzPRz1LrdGHFX4JivX47SpetfHZXiXTBm8g+Ol7puxD+AnjZhIpBt6mOOLg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/rebber-plugins/-/rebber-plugins-4.3.7.tgz",
+      "integrity": "sha512-pSLSoEFgXAcOtbL0a/pT2QHr8GlEoVB9EARGEmEDkxhb76gc7OfxgQU3IXP4pCcDpA9UHQreyirlNDXQKdRvPw==",
       "dependencies": {
         "has": "^1.0.3",
         "xtend": "^4.0.2"
@@ -3451,6 +3429,14 @@
       "resolved": "https://registry.npmjs.org/remark-escape-escaped/-/remark-escape-escaped-0.0.34.tgz",
       "integrity": "sha512-OIwASe42Y3X5XVJIGqweBlzaICuK2luAmj8nxl5od7ZDQX37z+QTdVCw1uvsrrnoEuzYTg/HjvgRjVRNFmJtgA=="
     },
+    "node_modules/remark-fix-guillemets": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/remark-fix-guillemets/-/remark-fix-guillemets-1.1.2.tgz",
+      "integrity": "sha512-SFJtChHJQDLUFqEkB39VqR3O53Pn43vTI8m9NIx7Q87oizTai7tff0xFkjAkTUoQZhg1M+0rgWkOY9zab+9tSA==",
+      "dependencies": {
+        "unist-util-visit": "^2.0.3"
+      }
+    },
     "node_modules/remark-footnotes": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-2.0.0.tgz",
@@ -3461,9 +3447,9 @@
       }
     },
     "node_modules/remark-grid-tables": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/remark-grid-tables/-/remark-grid-tables-2.1.2.tgz",
-      "integrity": "sha512-KBbhPlVh3ct01cJDgjcWLChBNUzlsYpNCif/rqYVVagP4L3gIJF7Vw7jTmoRzXtAOU7tS0Gw92p3zXEMomxnxw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/remark-grid-tables/-/remark-grid-tables-2.2.0.tgz",
+      "integrity": "sha512-BgC8TjQUNr6PcMA11MWSEq5zDkji6un3kI592Cbcmy8pUYdhvScH0opxImqYNF372fUGCRN7NAZle5BRYeQjLw==",
       "dependencies": {
         "grapheme-splitter": "^1.0.4",
         "lodash.trimend": "^4.5.1",
@@ -4501,12 +4487,12 @@
       }
     },
     "node_modules/zmarkdown": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-11.0.2.tgz",
-      "integrity": "sha512-hCxLA4miB9zoAAoFaH4688QZ4TR/+BqaaPWN6bZcZ5J2vLpzmIcPMocAlIFm2o3TyRImNWsX5L2k5Mg7J/dHdg==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-11.3.0.tgz",
+      "integrity": "sha512-Q76+dHS7d1aSue2GUnhOI2JBTx6CgvMfbNANqlH/GoRtNewgNnZ+i9RF2DY/MFibkw9cSKdyWK2p0ciJ47Ymgg==",
       "dependencies": {
         "@pm2/io": "^4.3.5",
-        "@sentry/node": "^5.24.2",
+        "@sentry/node": "^7.19.0",
         "body-parser": "^1.19.0",
         "clone": "^2.1.2",
         "cors": "^2.8.5",
@@ -4516,8 +4502,8 @@
         "katex": "0.11.1",
         "md-attr-parser": "^1.3.0",
         "pm2": "^4.4.1",
-        "rebber": "^5.3.0",
-        "rebber-plugins": "^4.3.2",
+        "rebber": "^5.4.0",
+        "rebber-plugins": "^4.3.7",
         "rehype-autolink-headings": "^4.0.0",
         "rehype-footnotes-title": "^2.0.0",
         "rehype-highlight": "^4.0.0",
@@ -4530,14 +4516,15 @@
         "rehype-stringify": "^8.0.0",
         "remark-abbr": "^1.4.1",
         "remark-align": "^1.2.14",
-        "remark-captions": "^2.2.2",
+        "remark-captions": "^2.2.3",
         "remark-comments": "^1.2.9",
         "remark-custom-blocks": "^2.6.0",
         "remark-disable-tokenizers": "^1.1.0",
         "remark-emoticons": "^2.3.1",
         "remark-escape-escaped": "^0.0.34",
+        "remark-fix-guillemets": "^1.1.2",
         "remark-footnotes": "^2.0.0",
-        "remark-grid-tables": "^2.1.2",
+        "remark-grid-tables": "^2.2.0",
         "remark-heading-shift": "^1.1.1",
         "remark-heading-trailing-spaces": "^0.0.31",
         "remark-iframes": "^4.0.5",
@@ -4560,7 +4547,7 @@
         "typographic-em-dashes": "^1.0.2",
         "typographic-en-dashes": "^1.0.1",
         "typographic-exclamation-mark": "^1.0.16",
-        "typographic-guillemets": "^1.0.16",
+        "typographic-guillemets": "^1.1.0",
         "typographic-percent": "^1.0.16",
         "typographic-permille": "^1.0.16",
         "typographic-question-mark": "^1.0.16",
@@ -4914,52 +4901,40 @@
         }
       }
     },
+    "@sentry-internal/tracing": {
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.74.0.tgz",
+      "integrity": "sha512-JK6IRGgdtZjswGfaGIHNWIThffhOHzVIIaGmglui+VFIzOsOqePjoxaDV0MEvzafxXZD7eWqGE5RGuZ0n6HFVg==",
+      "requires": {
+        "@sentry/core": "7.74.0",
+        "@sentry/types": "7.74.0",
+        "@sentry/utils": "7.74.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      }
+    },
     "@sentry/core": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
-      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.74.0.tgz",
+      "integrity": "sha512-83NRuqn7nDZkSVBN5yJQqcpXDG4yMYiB7TkYUKrGTzBpRy6KUOrkCdybuKk0oraTIGiGSe5WEwCFySiNgR9FzA==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/hub": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
-      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
-      "requires": {
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/minimal": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
-      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
-      "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.74.0",
+        "@sentry/utils": "7.74.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz",
-      "integrity": "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==",
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.74.0.tgz",
+      "integrity": "sha512-uBmW2/z0cz/WFIG74ZF7lSipO0XNzMf9yrdqnZXnGDYsUZE4I4QiqDN0hNi6fkTgf9MYRC8uFem2OkAvyPJ74Q==",
       "requires": {
-        "@sentry/core": "5.30.0",
-        "@sentry/hub": "5.30.0",
-        "@sentry/tracing": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "cookie": "^0.4.1",
+        "@sentry-internal/tracing": "7.74.0",
+        "@sentry/core": "7.74.0",
+        "@sentry/types": "7.74.0",
+        "@sentry/utils": "7.74.0",
+        "cookie": "^0.5.0",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "dependencies": {
         "agent-base": {
@@ -4969,6 +4944,11 @@
           "requires": {
             "debug": "4"
           }
+        },
+        "cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
         },
         "https-proxy-agent": {
           "version": "5.0.1",
@@ -4981,30 +4961,18 @@
         }
       }
     },
-    "@sentry/tracing": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.30.0.tgz",
-      "integrity": "sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==",
-      "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
-      }
-    },
     "@sentry/types": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
-      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.74.0.tgz",
+      "integrity": "sha512-rI5eIRbUycWjn6s6o3yAjjWtIvYSxZDdnKv5je2EZINfLKcMPj1dkl6wQd2F4y7gLfD/N6Y0wZYIXC3DUdJQQg=="
     },
     "@sentry/utils": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
-      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.74.0.tgz",
+      "integrity": "sha512-k3np8nuTPtx5KDODPtULfFln4UXdE56MZCcF19Jv6Ljxf+YN/Ady1+0Oi3e0XoSvFpWNyWnglauT7M65qCE6kg==",
       "requires": {
-        "@sentry/types": "5.30.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.74.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       }
     },
     "@tokenizer/token": {
@@ -6276,7 +6244,7 @@
     "lodash.trimend": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
-      "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
+      "integrity": "sha512-lsD+k73XztDsMBKPKvzHXRKFNMohTjoTKIIo4ADLn5dA65LZ1BqlAvSXhR2rPEC3BgAUQnzMnorqDtqn2z4IHA=="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -6957,9 +6925,9 @@
       }
     },
     "rebber": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/rebber/-/rebber-5.3.0.tgz",
-      "integrity": "sha512-vLdJGRTgf+e/ADc9k0hWIgKd6P4HESNQ33MgISTit+d20y8YeORcSHJ0oovlpUelmw63BUcIwzeG83sWScZakA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/rebber/-/rebber-5.4.0.tgz",
+      "integrity": "sha512-tRBDkBgITaJqLmr9dMnm20bGE87TSItSU92pJYSOazoRVGpMz14yrKe2NC6xnLa/bYfaDHMqi98MjceqL+4HAw==",
       "requires": {
         "clone": "^2.1.2",
         "collapse-white-space": "^1.0.6",
@@ -6970,9 +6938,9 @@
       }
     },
     "rebber-plugins": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/rebber-plugins/-/rebber-plugins-4.3.6.tgz",
-      "integrity": "sha512-aVSNmN/VlqeE9pAP/DqCrMBDI4kOzPRz1LrdGHFX4JivX47SpetfHZXiXTBm8g+Ol7puxD+AnjZhIpBt6mOOLg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/rebber-plugins/-/rebber-plugins-4.3.7.tgz",
+      "integrity": "sha512-pSLSoEFgXAcOtbL0a/pT2QHr8GlEoVB9EARGEmEDkxhb76gc7OfxgQU3IXP4pCcDpA9UHQreyirlNDXQKdRvPw==",
       "requires": {
         "has": "^1.0.3",
         "xtend": "^4.0.2"
@@ -7188,15 +7156,23 @@
       "resolved": "https://registry.npmjs.org/remark-escape-escaped/-/remark-escape-escaped-0.0.34.tgz",
       "integrity": "sha512-OIwASe42Y3X5XVJIGqweBlzaICuK2luAmj8nxl5od7ZDQX37z+QTdVCw1uvsrrnoEuzYTg/HjvgRjVRNFmJtgA=="
     },
+    "remark-fix-guillemets": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/remark-fix-guillemets/-/remark-fix-guillemets-1.1.2.tgz",
+      "integrity": "sha512-SFJtChHJQDLUFqEkB39VqR3O53Pn43vTI8m9NIx7Q87oizTai7tff0xFkjAkTUoQZhg1M+0rgWkOY9zab+9tSA==",
+      "requires": {
+        "unist-util-visit": "^2.0.3"
+      }
+    },
     "remark-footnotes": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-2.0.0.tgz",
       "integrity": "sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ=="
     },
     "remark-grid-tables": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/remark-grid-tables/-/remark-grid-tables-2.1.2.tgz",
-      "integrity": "sha512-KBbhPlVh3ct01cJDgjcWLChBNUzlsYpNCif/rqYVVagP4L3gIJF7Vw7jTmoRzXtAOU7tS0Gw92p3zXEMomxnxw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/remark-grid-tables/-/remark-grid-tables-2.2.0.tgz",
+      "integrity": "sha512-BgC8TjQUNr6PcMA11MWSEq5zDkji6un3kI592Cbcmy8pUYdhvScH0opxImqYNF372fUGCRN7NAZle5BRYeQjLw==",
       "requires": {
         "grapheme-splitter": "^1.0.4",
         "lodash.trimend": "^4.5.1",
@@ -7996,12 +7972,12 @@
       }
     },
     "zmarkdown": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-11.0.2.tgz",
-      "integrity": "sha512-hCxLA4miB9zoAAoFaH4688QZ4TR/+BqaaPWN6bZcZ5J2vLpzmIcPMocAlIFm2o3TyRImNWsX5L2k5Mg7J/dHdg==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-11.3.0.tgz",
+      "integrity": "sha512-Q76+dHS7d1aSue2GUnhOI2JBTx6CgvMfbNANqlH/GoRtNewgNnZ+i9RF2DY/MFibkw9cSKdyWK2p0ciJ47Ymgg==",
       "requires": {
         "@pm2/io": "^4.3.5",
-        "@sentry/node": "^5.24.2",
+        "@sentry/node": "^7.19.0",
         "body-parser": "^1.19.0",
         "clone": "^2.1.2",
         "cors": "^2.8.5",
@@ -8011,8 +7987,8 @@
         "katex": "0.11.1",
         "md-attr-parser": "^1.3.0",
         "pm2": "^4.4.1",
-        "rebber": "^5.3.0",
-        "rebber-plugins": "^4.3.2",
+        "rebber": "^5.4.0",
+        "rebber-plugins": "^4.3.7",
         "rehype-autolink-headings": "^4.0.0",
         "rehype-footnotes-title": "^2.0.0",
         "rehype-highlight": "^4.0.0",
@@ -8025,14 +8001,15 @@
         "rehype-stringify": "^8.0.0",
         "remark-abbr": "^1.4.1",
         "remark-align": "^1.2.14",
-        "remark-captions": "^2.2.2",
+        "remark-captions": "^2.2.3",
         "remark-comments": "^1.2.9",
         "remark-custom-blocks": "^2.6.0",
         "remark-disable-tokenizers": "^1.1.0",
         "remark-emoticons": "^2.3.1",
         "remark-escape-escaped": "^0.0.34",
+        "remark-fix-guillemets": "^1.1.2",
         "remark-footnotes": "^2.0.0",
-        "remark-grid-tables": "^2.1.2",
+        "remark-grid-tables": "^2.2.0",
         "remark-heading-shift": "^1.1.1",
         "remark-heading-trailing-spaces": "^0.0.31",
         "remark-iframes": "^4.0.5",
@@ -8055,7 +8032,7 @@
         "typographic-em-dashes": "^1.0.2",
         "typographic-en-dashes": "^1.0.1",
         "typographic-exclamation-mark": "^1.0.16",
-        "typographic-guillemets": "^1.0.16",
+        "typographic-guillemets": "^1.1.0",
         "typographic-percent": "^1.0.16",
         "typographic-permille": "^1.0.16",
         "typographic-question-mark": "^1.0.16",

--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "11.0.2"
+    "zmarkdown": "11.3.0"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
Passage à zmarkdown 11.3.0

Ce qui est intéressant pour nous, c'est la correction d'un bug et le remplacement de la date d'exportation par la date de publication dans les PDF. Il y a l'option `enforce_shift` dont je n'ai pas vraiment compris le fonctionnement qui ne nous impacte pas actuellement mais nous impactera probablement dans la prochaine version majeure (car sa valeur par défaut va changer).

[Notes de version zmarkdown](https://github.com/zestedesavoir/zmarkdown/releases)

**QA :**

- Sur la branche `upstream/dev`
- Dans un premier terminal, lancer le site web (avec par exemple `source zdsenv/bin/activate && make zmd-start && make run-back`)
- Dans un deuxième terminal, lancer la génération des PDF (avec par exemple `source zdsenv/bin/activate && python manage.py publication_watchdog`)
- Sur ma branche
- Dans le premier terminal, arrêter zmarkdown (`make zmd-stop`) puis mettre à jour (`make update`) et relancer le site web (`make zmd-start && make run-back`)
- Dans le deuxième terminal, relancer la génération des PDF (`python manage.py publication_watchdog`)
- Se connecter avec le compte `admin`
- Aller sur un contenu publié à une date antérieure à aujourd'hui
- Ouvrir son PDF et vérifier que sa date est celle d'aujourd'hui
- Lancer la génération des exports
- Une fois l'export généré, ouvrir à nouveau le PDF et vérifier que la date correspond à la date de publication