### PR TITLE
Fix #6414

### DIFF
--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -155,6 +155,9 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
                     * char_count
                     / settings.ZDS_APP["content"]["characters_per_minute"]
                 )
+            else:
+                logger.warning("For unknown reason content with id %s has no char count", self.object.pk)
+                context["reading_time"] = 0
         except ZeroDivisionError as e:
             logger.warning("could not compute reading time: setting characters_per_minute is set to zero (error=%s)", e)
 

--- a/zds/utils/templatetags/humanize_duration.py
+++ b/zds/utils/templatetags/humanize_duration.py
@@ -1,8 +1,11 @@
+import logging
+import numbers
 from typing import Tuple, List, Iterator, Iterable
 
 from django import template
 from django.utils.translation import ngettext, gettext as _
 
+logger = logging.getLogger(__file__)
 register = template.Library()
 
 
@@ -14,6 +17,9 @@ def humanize_duration(duration_min: int) -> str:
 
     See the unit tests for examples of results.
     """
+    if not isinstance(duration_min, int):
+        logger.warning("Invalid duration %s", duration_min)
+        return humanize_duration(0)
     duration_min = max(duration_min, 0)  # to avoid surprises with modulo operations
     truncated_value = _truncate_duration(
         duration_min,

--- a/zds/utils/tests/tests_humanize_duration.py
+++ b/zds/utils/tests/tests_humanize_duration.py
@@ -17,6 +17,7 @@ class TemplateTagsTest(TestCase):
             {"input": 110, "expected": "1 heure et 45 minutes"},
             {"input": 125, "expected": "2 heures"},
             {"input": 155, "expected": "2 heures et 30 minutes"},
+            {"input": "", "expected": "moins d'une minute"},
             {"input": 24 * 60, "expected": "24 heures"},
             {"input": 48 * 60, "expected": "48 heures"},
         ]


### PR DESCRIPTION
- s'assure qu'on donne un duration_min au template
- s'assure que si on a pas un int on met "moins d'une minute"

# QA

- publier un tuto
- ouvrir le shell django et mettre charcount à 0 sur l'objet publicversion
- ouvrir la page d'accueil du tuto

ça peut être déployé sur la béta