### PR TITLE
Ne demande pas de mot de passe aux utilisateurs qui n'en ont pas

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -411,7 +411,7 @@ class ChangeUserForm(PasswordRequiredForm):
             Field("username", value=user.username),
             Field("email", value=user.email),
             Field("options"),
-            Field("password"),
+            self.insert_password_required_field(),
             ButtonHolder(
                 StrictButton(_("Enregistrer"), type="submit"),
             ),
@@ -449,7 +449,7 @@ class UnregisterForm(PasswordRequiredForm):
         self.user = user
 
         self.helper.layout = Layout(
-            Field("password"),
+            self.insert_password_required_field(),
             HTML(
                 _(
                     """
@@ -491,7 +491,7 @@ class ChangePasswordForm(PasswordRequiredForm):
         self.user = user
 
         self.helper.layout = Layout(
-            Field("password"),
+            self.insert_password_required_field(),
             Field("password_new"),
             Field("password_confirm"),
             ButtonHolder(

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -168,11 +168,17 @@ class PasswordRequiredForm(forms.Form):
         widget=forms.PasswordInput,
     )
 
+    def insert_password_required_field(self):
+        if self.user.has_usable_password():
+            return Field("password")
+        else:
+            del self.fields["password"]
+
     def clean(self):
         cleaned_data = super().clean()
         password = cleaned_data.get("password")
 
-        if password and self.user:
+        if password and self.user and self.user.has_usable_password():
             user_exist = authenticate(username=self.user.username, password=password)
             # Check if the user exist.
             if not user_exist and password != "":


### PR DESCRIPTION
Dans les formulaires sensibles, on continue d'exiger le mot de passe actuel pour les utilisateurs qui en ont un (ceux qui se sont inscrits de manière classique), mais on ne le demande pas aux utilisateurs qui n'en ont pas (ceux qui se connectent via leur réseau social).

Cette vérification est faite via la fonction `User.has_usable_password()` fournie par Django (et _pas_ avec le champ `User.password`).

Fixes #6419 

**QA :** Étant donné que la connexion avec les réseaux sociaux ne fonctionnent pas actuellement en local, il faudra vérifier le bon fonctionnement sur la bêta. Pour la même raison, il me parait difficile d'ajouter des tests de non régression là-dessus.

Sur les pages de désinscription, changement de pseudo et courriel ainsi que changement de mot de passe : 
- avec un compte inscrit **de manière classique**, vérifier que le mot de passe actuel **est** bien demandé ;
- avec un compte inscrit **via les réseaux sociaux**, vérifier que le mot de passe actuel **n'est pas** demandé ;
- avec un compte inscrit **via les réseaux sociaux**,
  - créer un mot de passe via la page changement de mot de passe,
  - puis se reconnecter (c'est déjà le comportement actuel),
  - puis vérifier que le mot de passe actuel **est** bien demandé.