### PR TITLE
Enlève la bande blanche sur les pages avec le nouvel éditeur

### DIFF
--- a/assets/scss/components/_editor-new.scss
+++ b/assets/scss/components/_editor-new.scss
@@ -58,6 +58,8 @@
                 cursor: pointer;
                 vertical-align: middle;
 
+                white-space: normal;
+
                 &.emoji {
                     zoom: 100%;
                     width: 48px;


### PR DESCRIPTION
Depuis la dernière mise à jour du nouvel éditeur, une bande blanche apparaît à droite sur les pages où le nouvel éditeur est utilisé. Cela est une conséquence de la PR https://github.com/Ionaru/easy-markdown-editor/pull/461 qui a ajouté `white-space: nowrap` sur les boutons de l'éditeur. Cette PR corrige ce soucis.

Lié au ticket #6421 

**QA :** Aller sur une page avec le nouvel éditeur et vérifier qu'il n'y a plus de bande blanche sur la droite 