### PR TITLE
Utilise la police monospace pour le nouvel éditeur peu importe sa localisation

### DIFF
--- a/assets/scss/components/_editor-new.scss
+++ b/assets/scss/components/_editor-new.scss
@@ -203,6 +203,10 @@
 
         .CodeMirror {
             width: 100%;
+
+            pre {
+                font-family: $font-monospace;
+            }
         }
 
         .editor-preview {


### PR DESCRIPTION
Actuellement, le nouvel éditeur utilise la police monospace seulement lorsqu'il est dans un `.message-content` ou `.article-content`, ce qui n'est pas tout le temps le cas. Cette PR impose l'utilisation de la police monospace tout le temps pour le nouvel éditeur.

Fixes #6421 

**QA :** Vérifier que l'éditeur utilise bien la police monospace sur les pages de contenus (réponse sur un sujet, commentaire d'un contenu) mais aussi sur les autres (édition d'un message, création d'un sujet, etc.)