### PR TITLE
Plus de déconnexion après modification du mot de passe

### DIFF
--- a/zds/member/views/profile.py
+++ b/zds/member/views/profile.py
@@ -2,6 +2,7 @@ from urllib.parse import unquote
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
@@ -385,6 +386,7 @@ class UpdatePasswordMember(UpdateMember):
 
     def update_profile(self, profile, form):
         profile.user.set_password(form.data["password_new"])
+        update_session_auth_hash(self.request, profile.user)
 
     def get_success_message(self):
         return _("Le mot de passe a correctement été mis à jour.")

--- a/zds/member/views/profile.py
+++ b/zds/member/views/profile.py
@@ -386,6 +386,7 @@ class UpdatePasswordMember(UpdateMember):
 
     def update_profile(self, profile, form):
         profile.user.set_password(form.data["password_new"])
+        # to avoid being disconnected after changing the password:
         update_session_auth_hash(self.request, profile.user)
 
     def get_success_message(self):


### PR DESCRIPTION
Actuellement, on est déconnecté lorsqu'on change son mot de passe, ce qui est assez perturbant. Cette PR corrige ce soucis en utilisant [la fonction de Django `update_session_auth_hash`]( https://docs.djangoproject.com/fr/3.2/topics/auth/default/#session-invalidation-on-password-change) prévue pour ça.

À noter pour le futur que Django propose [des vues prêtes à l'emploi pour le changement et la réinitialisation du mot de passe](https://docs.djangoproject.com/fr/3.2/topics/auth/default/#module-django.contrib.auth.views), si on souhaite éviter de gérer cela par nous même comme actuellement.

**QA :** Modifier son mot de passe et vérifier que l'on n'est pas déconnecté