### PR TITLE
(API) Supprime le support du format XML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ toml==0.10.2
 django-cors-headers==3.13.0
 django-filter==22.1
 django-oauth-toolkit==1.7.0
-djangorestframework-xml==2.0.0
 djangorestframework==3.13.1
 drf-extensions==0.7.1
 dry-rest-permissions==0.1.10

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -194,15 +194,11 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_PARSER_CLASSES": (
         "rest_framework.parsers.JSONParser",
-        # 'rest_framework.parsers.XMLParser',
-        "rest_framework_xml.parsers.XMLParser",
         "rest_framework.parsers.FormParser",
         "rest_framework.parsers.MultiPartParser",
     ),
     "DEFAULT_RENDERER_CLASSES": (
         "rest_framework.renderers.JSONRenderer",
-        # 'rest_framework.renderers.XMLRenderer',
-        "rest_framework_xml.renderers.XMLRenderer",
         "rest_framework.renderers.BrowsableAPIRenderer",
     ),
     "DEFAULT_THROTTLE_CLASSES": (


### PR DESCRIPTION
Supprime le support du format XML pour l'API

Lié au ticket #6417

**QA :** Github Actions devrait suffire ?