### PR TITLE
Répare la CI

### DIFF
--- a/zds/tutorialv2/tests/tests_front.py
+++ b/zds/tutorialv2/tests/tests_front.py
@@ -163,6 +163,7 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
 
         intro = self.find_element("div#div_id_introduction div.CodeMirror")
         action_chains = ActionChains(selenium)
+        scrollDriverTo(selenium, 0, 312)
         action_chains.click(intro).perform()
         action_chains.send_keys("Le cadavre exquis boira le vin nouveau.").perform()
 


### PR DESCRIPTION
La version de Firefox installée sur Github Actions est passée de 106 à 107 et maintenant on a un test Selenium qui échoue. La raison est qu'on essaie de cliquer sur un élément qui n'est pas visible à l'écran donc une erreur est retournée. Pour résoudre cela, on scrolle un peu vers le bas pour rendre l'élément visible.

**QA :** Github Actions