### PR TITLE
Amélioration de la connexion via les réseaux sociaux

### DIFF
--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -4,7 +4,7 @@ from django.core.validators import EmailValidator, ProhibitNullCharactersValidat
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
-from zds.utils.misc import contains_utf8mb4, replace_utf8mb4
+from zds.utils.misc import contains_utf8mb4, remove_utf8mb4
 from zds.member.models import BannedEmailProvider, Profile
 
 
@@ -74,7 +74,9 @@ def clean_username_social_auth(username):
     """
     Clean username of accounts created using social auth.
     """
-    return replace_utf8mb4(username).replace(",", "").replace("/", "")
+    # These three conditions are the same as the first three in the "validate_zds_username" function below.
+    # If you modify one of them here, make sure you do the same there!
+    return remove_utf8mb4(username).replace(",", "").replace("/", "")
 
 
 def validate_zds_username(value, check_username_available=True):
@@ -95,6 +97,9 @@ def validate_zds_username(value, check_username_available=True):
     msg = None
     user_count = User.objects.filter(username=value).count()
     skeleton_user_count = Profile.objects.filter(username_skeleton=Profile.find_username_skeleton(value)).count()
+
+    # These first three conditions are the same as those in the "clean_username_social_auth" function above.
+    # If you modify one of them here, make sure you do the same there!
     if "," in value:
         msg = _("Le nom d'utilisateur ne peut contenir de virgules")
     elif "/" in value:

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -4,7 +4,7 @@ from django.core.validators import EmailValidator, ProhibitNullCharactersValidat
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
-from zds.utils.misc import contains_utf8mb4
+from zds.utils.misc import contains_utf8mb4, replace_utf8mb4
 from zds.member.models import BannedEmailProvider, Profile
 
 
@@ -68,6 +68,13 @@ class ZdSEmailValidator(EmailValidator):
 
 
 validate_zds_email = ZdSEmailValidator()
+
+
+def clean_username_social_auth(username):
+    """
+    Clean username of accounts created using social auth.
+    """
+    return replace_utf8mb4(username).replace(",", "").replace("/", "")
 
 
 def validate_zds_username(value, check_username_available=True):

--- a/zds/settings/abstract_base/requirements.py
+++ b/zds/settings/abstract_base/requirements.py
@@ -10,6 +10,8 @@ THUMBNAIL_PRESERVE_EXTENSIONS = ("svg",)
 
 social_auth_config = config.get("social_auth", {})
 
+SOCIAL_AUTH_CLEAN_USERNAME_FUNCTION = "zds.member.validators.clean_username_social_auth"
+
 SOCIAL_AUTH_RAISE_EXCEPTIONS = False
 
 SOCIAL_AUTH_FACEBOOK_SCOPE = ["email"]

--- a/zds/settings/abstract_base/requirements.py
+++ b/zds/settings/abstract_base/requirements.py
@@ -15,6 +15,7 @@ SOCIAL_AUTH_CLEAN_USERNAME_FUNCTION = "zds.member.validators.clean_username_soci
 SOCIAL_AUTH_RAISE_EXCEPTIONS = False
 
 SOCIAL_AUTH_FACEBOOK_SCOPE = ["email"]
+SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {"fields": "name,email"}
 
 SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.social_details",

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -49,14 +49,21 @@ def convert_camel_to_underscore(camel_case):
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
 
 
-def contains_utf8mb4(s):
+def replace_utf8mb4(s):
     """
-    This string contains at least one character of more than 3 bytes
+    Replace characters of more than 3 bytes with the replacement character.
     """
     if not isinstance(s, str):
         s = str(s, "utf-8")
     re_pattern = re.compile("[^\u0000-\uD7FF\uE000-\uFFFF]", re.UNICODE)
-    return s != re_pattern.sub("\uFFFD", s)
+    return re_pattern.sub("\uFFFD", s)
+
+
+def contains_utf8mb4(s):
+    """
+    Check if this string contains at least one character of more than 3 bytes.
+    """
+    return s != replace_utf8mb4(s)
 
 
 def check_essential_accounts():

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -49,21 +49,21 @@ def convert_camel_to_underscore(camel_case):
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
 
 
-def replace_utf8mb4(s):
+def remove_utf8mb4(s):
     """
-    Replace characters of more than 3 bytes with the replacement character.
+    Remove characters of more than 3 bytes.
     """
     if not isinstance(s, str):
         s = str(s, "utf-8")
     re_pattern = re.compile("[^\u0000-\uD7FF\uE000-\uFFFF]", re.UNICODE)
-    return re_pattern.sub("\uFFFD", s)
+    return re_pattern.sub("", s)
 
 
 def contains_utf8mb4(s):
     """
     Check if this string contains at least one character of more than 3 bytes.
     """
-    return s != replace_utf8mb4(s)
+    return s != remove_utf8mb4(s)
 
 
 def check_essential_accounts():

--- a/zds/utils/tests/test_misc.py
+++ b/zds/utils/tests/test_misc.py
@@ -3,19 +3,19 @@ from django.conf import settings
 from django.test import TestCase
 from zds.member.tests.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.tutorialv2.tests.factories import PublishedContentFactory
-from zds.utils.misc import contains_utf8mb4, check_essential_accounts, replace_utf8mb4
+from zds.utils.misc import contains_utf8mb4, check_essential_accounts, remove_utf8mb4
 from zds.utils.models import Alert
 from zds.utils.context_processor import get_header_notifications
 
 
 class Misc(TestCase):
-    def test_replace_utf8mb4(self):
-        self.assertEqual("abc", replace_utf8mb4("abc"))
-        self.assertEqual("abc", replace_utf8mb4("abc"))
-        self.assertEqual("abc€", replace_utf8mb4("abc€"))
-        self.assertEqual("abc€", replace_utf8mb4("abc€"))
-        self.assertEqual("a�tbc€", replace_utf8mb4("a🐙tbc€"))
-        self.assertEqual("a�tbc€", replace_utf8mb4("a🐙tbc€"))
+    def test_remove_utf8mb4(self):
+        self.assertEqual("abc", remove_utf8mb4("abc"))
+        self.assertEqual("abc", remove_utf8mb4("abc"))
+        self.assertEqual("abc€", remove_utf8mb4("abc€"))
+        self.assertEqual("abc€", remove_utf8mb4("abc€"))
+        self.assertEqual("atbc€", remove_utf8mb4("a🐙tbc€"))
+        self.assertEqual("atbc€", remove_utf8mb4("a🐙tbc€"))
 
     def test_contains_utf8mb4(self):
         self.assertFalse(contains_utf8mb4("abc"))

--- a/zds/utils/tests/test_misc.py
+++ b/zds/utils/tests/test_misc.py
@@ -3,13 +3,21 @@ from django.conf import settings
 from django.test import TestCase
 from zds.member.tests.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.tutorialv2.tests.factories import PublishedContentFactory
-from zds.utils.misc import contains_utf8mb4, check_essential_accounts
+from zds.utils.misc import contains_utf8mb4, check_essential_accounts, replace_utf8mb4
 from zds.utils.models import Alert
 from zds.utils.context_processor import get_header_notifications
 
 
 class Misc(TestCase):
-    def test_utf8mb4(self):
+    def test_replace_utf8mb4(self):
+        self.assertEqual("abc", replace_utf8mb4("abc"))
+        self.assertEqual("abc", replace_utf8mb4("abc"))
+        self.assertEqual("abc€", replace_utf8mb4("abc€"))
+        self.assertEqual("abc€", replace_utf8mb4("abc€"))
+        self.assertEqual("a�tbc€", replace_utf8mb4("a🐙tbc€"))
+        self.assertEqual("a�tbc€", replace_utf8mb4("a🐙tbc€"))
+
+    def test_contains_utf8mb4(self):
         self.assertFalse(contains_utf8mb4("abc"))
         self.assertFalse(contains_utf8mb4("abc"))
         self.assertFalse(contains_utf8mb4("abc€"))


### PR DESCRIPTION
Amélioration de la connexion via les réseaux sociaux en deux points.

Fixes #6274

- (On n'enlève plus les lettres accentuées des pseudos)
  Lors de la première connexion depuis un réseau social et donc de la création du membre en base de données, une fonction de nettoyage des pseudos est appliquée par notre dépendance `social-auth-app-django`. Celle-ci consiste en l'application de deux expressions régulières ci-dessous et a notamment pour conséquence la suppression des lettres accentuées et des espaces.
  ```py
  NO_ASCII_REGEX = re.compile(r"[^\x00-\x7F]+")
  NO_SPECIAL_REGEX = re.compile(r"[^\w.@+_-]+", re.UNICODE)

  def clean_username(cls, value):
      """Clean username removing any unsupported character"""
      value = NO_ASCII_REGEX.sub("", value)
      value = NO_SPECIAL_REGEX.sub("", value)
  return value
  ```
  Heureusement, j'ai remarqué qu'il est possible de remplacer cette fonction par une autre fonction. Il faut alors définir la variable `SOCIAL_AUTH_CLEAN_USERNAME_FUNCTION` avec le chemin vers cette nouvelle fonction. La fonction de nettoyage des pseudos que je propose supprime les virgules et les barres obliques comme c'est le cas dans le module `member` (cf. [ce bout de code](https://github.com/zestedesavoir/zds-site/blob/a333b4c965acd6816624f8e901bb9da99881f3d6/zds/member/validators.py#L83-L86)), mais ne remplace pas les caractères utf8mb4.
  
  **J'ai besoin d'un avis sur ce changement.** Sur la fonctionnalité en elle-même, je pense que garder les lettres accentuées est une bonne chose mais je ne sais pas si garder les espaces est souhaitable, notamment car ça complique le ping dans les messages. Sur l'implémentation, est-ce que j'oublie quelque chose ? Normalement, on ne devrait pas avoir de soucis avec les comptes Google car les pseudos sont créés à partir de l'adresse de courriel, mais avec les comptes Facebook il doit être possible d'avoir des caractères assez exotiques.

- (On récupère l'adresse de courriel des comptes Facebook)
  Figurez-vous que demander le scope de suffit pas et qu'il faut explicitement demander à récupérer ce champ à l'aide de la variable `SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS`. Malheureusement, il me semble que ce n'est pas rétroactif donc seuls les nouveaux comptes en bénéficieront.

**QA :** Vérifier le bon fonctionnement de la connexion via les réseaux sociaux, notamment Facebook. (Cela se fera directement sur la bêta.)