### PR TITLE
Augmente légèrement la taille des équations entre les paragraphes (#5477)

### DIFF
--- a/assets/scss/base/_content.scss
+++ b/assets/scss/base/_content.scss
@@ -579,6 +579,10 @@ td {
     display: contents;  /* overrides katex.css that creates display:inline-block and generate bad box */
 }
 
+.math-display {
+    font-size: $font-size-9;
+}
+
 .inlineMathDouble .katex {
     max-width: 100%;
     overflow-x: auto;


### PR DESCRIPTION
<!-- Décrivez vos changements ici (optionnel pour les tous petits changements). -->
Dans le fichier `assets/scss/base/_content.scss` à la ligne 582, j'ai ajouté ce code :
```scss
.math-display {
    font-size: $font-size-9;
}
```
<!-- Remplacez XXXX par le numéro de ticket corrigé par vos changements : GitHub fermera le ticket mentionné automatiquement (voir https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue pour plus de détails). Supprimez la ligne s'il n'y a pas de ticket associé. --!>
Fix #5477 

<!-- Si votre PR modifie du code Python, mettez à jour ou créez les tests unitaires associés. Signalez vos éventuelles difficultés afin que des contributeurs expérimentés puissent vous aider. -->

<!-- Si votre pull request requiert des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->

### Contrôle qualité

<!-- Donnez des instructions pour nous aider à vérifier vos changements.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->
 Exécuter : 
```bash
make zmd-start
make run
```
Ensuite ajouter un article et mettre le contenu suivant : 
```
Lorem ipsum
$$\tag{hi} x+y^{2x}$$
Lorem ipsum
```
Puis, on peut vérifier en inspectant l'élément sur l'article que la taille de la police est 1.6em.
<!-- Merci ! -->
