### PR TITLE
Affiche les objectifs d'une publication dans son en-tête (et corrige un souci avec l'affichage des catégories)

### DIFF
--- a/templates/tutorialv2/includes/categories.part.html
+++ b/templates/tutorialv2/includes/categories.part.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+
+<p>
+    {% trans "Catégorie" %}{{ categories|pluralize }} :
+
+    {# Warning: whitespace in the lines below is crucial for rendering, despite ruining legibility. Change with care. #}
+    {% for category in categories %}{% if forloop.first %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %}
+        {% if content.is_opinion %}
+            <a href="{% url 'opinion:list' %}?category={{ category.slug }}">{{ category.title }}</a>
+        {% else %}
+            <a href="{% url 'publication:list' %}?subcategory={{ category.slug }}">{{ category.title }}</a>{% endif %}{% endfor %}
+</p>

--- a/templates/tutorialv2/includes/goals.part.html
+++ b/templates/tutorialv2/includes/goals.part.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+
+{% if goals %}
+    <p>
+        {% trans "Objectif" %}{{ goals|pluralize }}{%trans " :" %}
+        {% comment %}
+            Warning: whitespace in the loop below is crucial to ensure correct rendering.
+            That's why it is written as a one-liner. Take care when modifying it.
+        {% endcomment %}
+        {% for goal in goals %}{% if not forloop.first %}, {% endif %}<a href="{% url "content:view-goals" %}?objectif_{{ goal.id }}">{{ goal }}</a>{% endfor %}
+    </p>
+{% endif %}

--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -68,6 +68,8 @@
             {% endfor %}
         </p>
 
+        {% include "tutorialv2/includes/goals.part.html" with goals=publishablecontent.goals.all %}
+
         {% if online and not is_part_or_chapter %}
             <p>{% blocktrans with reading_time=reading_time|humanize_duration %}Temps de lecture estimé à {{ reading_time }}.{% endblocktrans %}</p>
         {% endif %}

--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -55,18 +55,7 @@
             {% endif %}
         {% endwith %}
 
-        <p>
-            {% trans "Catégorie" %}{{ content.subcategory.all|pluralize }} :
-
-            {% for category in content.subcategory.all %}
-                {% if forloop.first %}{% elif forloop.last %} {% trans "et" %}{% else %},{% endif %}
-                {% if content.is_opinion %}
-                    <a href="{% url 'opinion:list' %}?category={{ category.slug }}">{{ category.title }}</a>
-                {% else %}
-                    <a href="{% url 'publication:list' %}?subcategory={{ category.slug }}">{{ category.title }}</a>
-                {% endif %}
-            {% endfor %}
-        </p>
+        {% include "tutorialv2/includes/categories.part.html" with categories=content.subcategory.all %}
 
         {% include "tutorialv2/includes/goals.part.html" with goals=publishablecontent.goals.all %}
 


### PR DESCRIPTION
En lien avec la nouvelle classification par objectifs (voir le [projet associé)](https://github.com/orgs/zestedesavoir/projects/3/views/2).

Cette PR ajoute l'affichage des objectifs d'une publication dans son en-tête, juste en dessous des catégories. J'ai repris un affichage similaire aux catégories (et même un peu plus simple). Le but premier est juste de rendre les objectifs visibles, pas de faire un bel affichage. C'est une évolution qui peut être faite après. Je suis allé au plus simple, délibérément.

Au passage, j'ai corrigé un petit bug d'affichage dans la liste des catégories (des espaces en trop dans certains cas).

### Contrôle qualité

- Se connecter en tant que staff (admin par exemple fait l'affaire)
- Aller sur une publication
- Jouer avec les objectifs et regarder l'affichage dans l'en-tête avec 0, 1, 2 et 3 objectifs. Vérifier que c'est propre.
- Faire pareil avec les catégories, vu que j'ai ajusté ça aussi à la marge.