### PR TITLE
Lève des restrictions sur les billets

### DIFF
--- a/templates/gallery/base.html
+++ b/templates/gallery/base.html
@@ -64,17 +64,7 @@
                         {% if content_linked %}
                             <li>
                                 <a href="{{ content_linked.get_absolute_url }}" class="ico-after offline blue">
-                                    {% trans "Aller" %}
-                                    {% if content_linked.type == "ARTICLE" %}
-                                        {% trans "à l’article" %}
-                                    {% elif content_linked.type == "TUTORIAL" %}
-                                        {% trans "au tutoriel" %}
-                                    {% elif content_linked.type == "OPINION" %}
-                                        {% trans "au billet" %}
-                                    {% else %}
-                                        {% trans "au contenu" %}
-                                    {% endif %}
-                                    {% trans "lié à cette galerie" %}
+                                    {% trans "Aller à la publication liée à cette galerie" %}
                                 </a>
                             </li>
                         {% endif %}

--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -59,16 +59,7 @@
                 {% if gallery.linked_content in linked_contents %}
                     {% with content=linked_contents|get_item:gallery.linked_content %}
                         <p class="topic-last-answer">
-                            {% trans "Liée" %}
-                            {% if content.is_article %}
-                                {% trans "à l’article" %}
-                            {% elif content.is_tutorial %}
-                                {% trans "au tutoriel" %}
-                            {% elif content.is_opinion %}
-                                {% trans "au billet" %}
-                            {% else %}
-                                {% trans "au contenu" %}
-                            {% endif %}
+                            {% trans "Liée à la publication" %}
                             «&NonBreakingSpace;<a href="{{ content.get_absolute_url }}">{{ content.title }}</a>&NonBreakingSpace;».
                         </p>
                     {% endwith %}

--- a/templates/tutorialv2/includes/obsolescence_warning.part.html
+++ b/templates/tutorialv2/includes/obsolescence_warning.part.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+
+<div class="content-wrapper">
+    <div class="alert-box warning">
+        {% blocktrans %}
+            Cette publication est obsolète. Elle peut contenir des informations intéressantes, mais faites preuve de prudence.
+        {% endblocktrans %}
+    </div>
+</div>

--- a/templates/tutorialv2/includes/tags_authors.part.html
+++ b/templates/tutorialv2/includes/tags_authors.part.html
@@ -39,8 +39,8 @@
         {% with count_contributions=contributions|length %}
             {% if count_contributions > 0 %}
                 <p>
-                    {% trans "Ce contenu a bénéficié des apports de" %}
-                    <a href="#view-contributions" class="open-modal">{{ count_contributions }} {% trans "contributeur" %}{{ count_contributions|pluralize }}</a>
+                    {% trans "Cette publication a bénéficié des apports de" %}
+                    <a href="#view-contributions" class="open-modal">{{ count_contributions }} {% trans "contributeur" %}{{ count_contributions|pluralize }}</a>.
 
                     <div class="modal modal-flex" id="view-contributions" data-modal-close="Fermer">
                         <div class="members is-fullwidth">

--- a/templates/tutorialv2/includes/warn_typo.part.html
+++ b/templates/tutorialv2/includes/warn_typo.part.html
@@ -4,25 +4,16 @@
 {% if user.is_authenticated and user not in content.authors.all %}
     <div class="warn-typo">
         <a href="#warn-typo-modal" class="open-modal btn btn-grey ico-after edit blue">
-            {% trans "Signaler une faute dans" %}
             {% if not container %}
-                {% if content.is_article %}
-                    {% trans "cet article" %}
-                {% elif content.is_tutorial %}
-                    {% trans "ce tutoriel" %}
-                {% elif content.is_opinion %}
-                    {% trans "ce billet" %}
-                {% endif %}
+                {% trans "Signaler une faute dans cette publication" %}
+            {% elif container.is_chapter %}
+                {% trans "Signaler une faute dans ce chapitre" %}
             {% else %}
-                {% if container.is_chapter %}
-                    {% trans "ce chapitre" %}
-                {% else %}
-                    {% trans "cette partie" %}
-                {% endif %}
+                {% trans "Signaler une faute dans cette partie" %}
             {% endif %}
         </a>
 
-        {% crispy formWarnTypo %}
+        {% crispy form_warn_typo %}
     </div>
 
 {% endif %}

--- a/templates/tutorialv2/messages/add_contribution_pm.md
+++ b/templates/tutorialv2/messages/add_contribution_pm.md
@@ -1,9 +1,9 @@
 {% load i18n %}
 
-{% blocktrans with title=content.title|safe type=type|safe user=user|safe %}
+{% blocktrans with title=content.title|safe user=user|safe %}
 Bonjour {{ user }},
 
-Vous avez été ajouté à la liste des contributeurs {{type}} « {{ title }} », en tant que {{role}}.
+Vous avez été ajouté à la liste des contributeurs de la publication « {{ title }} », en tant que {{ role }}.
 
 Merci pour votre participation !
 {%  endblocktrans %}

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -66,9 +66,7 @@
 
 
 {% block content %}
-    {% if content.is_tutorial %}
-        {% include "tutorialv2/includes/chapter_pager.part.html" with position="top" online=True %}
-    {% endif %}
+    {% include "tutorialv2/includes/chapter_pager.part.html" with position="top" online=True %}
     {% if container.has_extracts %}
         {{ container.get_content_online|safe }}
     {% else %}
@@ -88,9 +86,8 @@
         {% endif %}
 
     {% endif %}
-    {% if content.is_tutorial %}
-        {% include "tutorialv2/includes/chapter_pager.part.html" with position="bottom" online=True %}
-    {% endif %}
+
+    {% include "tutorialv2/includes/chapter_pager.part.html" with position="bottom" online=True %}
 
     {% include "tutorialv2/includes/warn_typo.part.html" with content=content %}
 {% endblock %}

--- a/templates/tutorialv2/view/container_online.html
+++ b/templates/tutorialv2/view/container_online.html
@@ -59,13 +59,7 @@
     {% include 'tutorialv2/includes/tags_authors.part.html' with content=content online=True is_part_or_chapter=True %}
 
     {% if is_obsolete %}
-        <div class="content-wrapper">
-            <div class="alert-box warning">
-                {% blocktrans %}
-                    Ce contenu est obsolète. Il peut contenir des informations intéressantes mais soyez prudent avec celles-ci.
-                {% endblocktrans %}
-            </div>
-        </div>
+        {% include "tutorialv2/includes/obsolescence_warning.part.html" %}
     {% endif %}
 {% endblock %}
 

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -349,12 +349,12 @@
     {% endif %}
     {# END AUTHORS #}
     {# CONTRIBUTORS #}
-    {% if can_add_something and formAddReviewer %}
+    {% if can_add_something %}
         <li>
             <a href="#add-contributor" class="open-modal ico-after more blue">
                 {% trans "Ajouter un contributeur" %}
             </a>
-            {% crispy formAddReviewer %}
+            {% crispy form_add_contributor %}
         </li>
         <li>
             <a href="#manage-contributions" class="open-modal ico-after gear blue">

--- a/templates/tutorialv2/view/content_online.html
+++ b/templates/tutorialv2/view/content_online.html
@@ -93,13 +93,7 @@
     {% include 'tutorialv2/includes/tags_authors.part.html' with content=content online=True %}
 
     {% if is_obsolete %}
-        <div class="content-wrapper">
-            <div class="alert-box warning">
-                {% blocktrans %}
-                    Ce contenu est obsolète. Il peut contenir des informations intéressantes mais soyez prudent avec celles-ci.
-                {% endblocktrans %}
-            </div>
-        </div>
+        {% include "tutorialv2/includes/obsolescence_warning.part.html" %}
     {% endif %}
 {% endblock %}
 

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -192,15 +192,6 @@ class Profile(models.Model):
         """
         return self.get_user_contents_queryset(_type).filter(sha_beta__isnull=False)
 
-    def get_content_count(self, _type=None):
-        """
-        :param _type: if provided, request a specific type of content
-        :return: the count of contents with this user as author. Count all contents no only published one.
-        """
-        if self.is_private():
-            return 0
-        return self.get_user_contents_queryset(_type).count()
-
     def get_contents(self, _type=None):
         """
         :param _type: if provided, request a specific type of content

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -270,12 +270,6 @@ class Profile(models.Model):
         """
         return self.get_beta_contents(_type="TUTORIAL")
 
-    def get_article_count(self):
-        """
-        :return: the count of articles with this user as author. Count all articles, no only published one.
-        """
-        return self.get_content_count(_type="ARTICLE")
-
     def get_articles(self):
         """
         :return: All articles with this user as author.

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -238,12 +238,6 @@ class Profile(models.Model):
         """
         return self.get_user_beta_contents_queryset(_type).all()
 
-    def get_tuto_count(self):
-        """
-        :return: the count of tutorials with this user as author. Count all tutorials, no only published one.
-        """
-        return self.get_content_count(_type="TUTORIAL")
-
     def get_tutos(self):
         """
         :return: All tutorials with this user as author.

--- a/zds/member/models.py
+++ b/zds/member/models.py
@@ -314,12 +314,6 @@ class Profile(models.Model):
         """
         return self.get_beta_contents(_type="ARTICLE")
 
-    def get_opinion_count(self):
-        """
-        :return: the count of opinions with this user as author. Count all opinions, no only published one.
-        """
-        return self.get_content_count(_type="OPINION")
-
     def get_opinions(self):
         """
         :return: All opinions with this user as author.

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -62,17 +62,6 @@ class MemberModelsTest(TutorialTestMixin, TestCase):
         # Should be 1
         self.assertEqual(self.user1.get_topic_count(), 1)
 
-    def test_get_tuto_count(self):
-        # Start with 0
-        self.assertEqual(self.user1.get_tuto_count(), 0)
-        # Create Tuto !
-        minituto = PublishableContentFactory(type="TUTORIAL")
-        minituto.authors.add(self.user1.user)
-        minituto.gallery = GalleryFactory()
-        minituto.save()
-        # Should be 1
-        self.assertEqual(self.user1.get_tuto_count(), 1)
-
     def test_get_tutos(self):
         # Start with 0
         self.assertEqual(len(self.user1.get_tutos()), 0)
@@ -142,7 +131,7 @@ class MemberModelsTest(TutorialTestMixin, TestCase):
 
     def test_get_article_count(self):
         # Start with 0
-        self.assertEqual(self.user1.get_tuto_count(), 0)
+        self.assertEqual(self.user1.get_article_count(), 0)
         # Create article !
         minituto = PublishableContentFactory(type="ARTICLE")
         minituto.authors.add(self.user1.user)

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -129,17 +129,6 @@ class MemberModelsTest(TutorialTestMixin, TestCase):
         self.assertEqual(len(betatetutos), 1)
         self.assertEqual(betatetuto, betatetutos[0])
 
-    def test_get_article_count(self):
-        # Start with 0
-        self.assertEqual(self.user1.get_article_count(), 0)
-        # Create article !
-        minituto = PublishableContentFactory(type="ARTICLE")
-        minituto.authors.add(self.user1.user)
-        minituto.gallery = GalleryFactory()
-        minituto.save()
-        # Should be 1
-        self.assertEqual(self.user1.get_article_count(), 1)
-
     def test_get_articles(self):
         # Start with 0
         self.assertEqual(len(self.user1.get_articles()), 0)

--- a/zds/tutorialv2/models/__init__.py
+++ b/zds/tutorialv2/models/__init__.py
@@ -8,7 +8,6 @@ CONTENT_TYPES = (
     # verbose_name_plural   User-friendly pluralized type name
     # category_name         User-friendly category name which contains this content
     # requires_validation   Boolean; whether this content has to be validated before publication
-    # single_container      Boolean; True if the content is a single container
     # beta                  Boolean; True if the content can be in beta
     {
         "name": "TUTORIAL",
@@ -16,7 +15,6 @@ CONTENT_TYPES = (
         "verbose_name_plural": "tutoriels",
         "category_name": "tutoriel",
         "requires_validation": True,
-        "single_container": False,
         "beta": True,
     },
     {
@@ -25,7 +23,6 @@ CONTENT_TYPES = (
         "verbose_name_plural": "articles",
         "category_name": "article",
         "requires_validation": True,
-        "single_container": True,
         "beta": True,
     },
     {
@@ -34,7 +31,6 @@ CONTENT_TYPES = (
         "verbose_name_plural": "billets",
         "category_name": "tribune",
         "requires_validation": False,
-        "single_container": True,
         "beta": False,
     },
 )
@@ -48,9 +44,6 @@ PICK_OPERATIONS = (
 
 # a list of contents which have to be validated before publication
 CONTENT_TYPES_REQUIRING_VALIDATION = [content["name"] for content in CONTENT_TYPES if content["requires_validation"]]
-
-# a list of contents which have one big container containing at least one small container
-SINGLE_CONTAINER_CONTENT_TYPES = [content["name"] for content in CONTENT_TYPES if content["single_container"]]
 
 # a list of contents which can be in beta
 CONTENT_TYPES_BETA = [content["name"] for content in CONTENT_TYPES if content["beta"]]

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -1,6 +1,7 @@
 import contextlib
 import copy
 from pathlib import Path
+from typing import List
 
 from zds import json_handler
 from git import Repo
@@ -15,7 +16,7 @@ from django.utils.translation import gettext_lazy as _
 from django.template.loader import render_to_string
 
 from zds.tutorialv2.models.mixins import TemplatableContentModelMixin
-from zds.tutorialv2.models import SINGLE_CONTAINER_CONTENT_TYPES, CONTENT_TYPES_BETA, CONTENT_TYPES_REQUIRING_VALIDATION
+from zds.tutorialv2.models import CONTENT_TYPES_BETA, CONTENT_TYPES_REQUIRING_VALIDATION
 from zds.tutorialv2.utils import default_slug_pool, export_content, get_commit_author, InvalidOperationError
 from zds.tutorialv2.utils import get_blob
 from zds.utils.validators import InvalidSlugError, check_slug
@@ -238,8 +239,7 @@ class Container:
         """
         if not self.has_extracts():
             if self.get_tree_depth() < settings.ZDS_APP["content"]["max_tree_depth"] - 1:
-                if not self.top_container().type in SINGLE_CONTAINER_CONTENT_TYPES:
-                    return True
+                return True
         return False
 
     def can_add_extract(self):
@@ -1320,21 +1320,16 @@ class VersionedContent(Container, TemplatableContentModelMixin):
 
         return path
 
-    def get_list_of_chapters(self):
-        """
-        :return: a list of chapters (Container which contains Extracts) in the reading order
-        :rtype: list[Container]
-        """
+    def get_list_of_chapters(self) -> List[Container]:
         continuous_list = []
-        if self.type not in SINGLE_CONTAINER_CONTENT_TYPES:  # cannot be paginated
-            if len(self.children) != 0 and isinstance(self.children[0], Container):  # children must be Containers!
-                for child in self.children:
-                    if len(child.children) != 0:
-                        if isinstance(child.children[0], Extract):
-                            continuous_list.append(child)  # it contains Extract, this is a chapter, so paginated
-                        else:  # Container is a part
-                            for sub_child in child.children:
-                                continuous_list.append(sub_child)  # even if empty `sub_child.childreen`, it's chapter
+        if len(self.children) != 0 and isinstance(self.children[0], Container):  # children must be Containers!
+            for child in self.children:
+                if len(child.children) != 0:
+                    if isinstance(child.children[0], Extract):
+                        continuous_list.append(child)  # it contains Extract, this is a chapter, so paginated
+                    else:  # Container is a part
+                        for sub_child in child.children:
+                            continuous_list.append(sub_child)  # even if empty `sub_child.childreen`, it's chapter
         return continuous_list
 
     def get_json(self):

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -30,7 +30,6 @@ from zds.utils.models import Alert
 @override_for_contents()
 class PublishedContentTests(TutorialTestMixin, TestCase):
     def setUp(self):
-
         self.overridden_zds_app["member"]["bot_account"] = ProfileFactory().user.username
         self.bot_group = Group()
         self.bot_group.name = settings.ZDS_APP["member"]["bot_group"]
@@ -181,14 +180,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertContains(resp, "Version brouillon", msg_prefix="Author must access their draft directly")
         self.assertNotContains(resp, "{}?subcategory=".format(reverse("publication:list")))
         self.assertContains(resp, "{}?category=".format(reverse("opinion:list")))
-
-    def test_no_help_for_tribune(self):
-        self.client.force_login(self.user_author)
-
-    def test_help_for_article(self):
-        self.client.force_login(self.user_author)
-        resp = self.client.get(reverse("content:create-content", kwargs={"created_content_type": "ARTICLE"}))
-        self.assertEqual(200, resp.status_code)
 
     def test_opinion_publication_staff(self):
         """

--- a/zds/tutorialv2/tests/tests_routes.py
+++ b/zds/tutorialv2/tests/tests_routes.py
@@ -1,0 +1,96 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from zds.tutorialv2.models.database import PublishableContent
+from zds.tutorialv2.publication_utils import publish_content
+from zds.tutorialv2.tests import override_for_contents, TutorialTestMixin
+from zds.tutorialv2.tests.factories import PublishableContentFactory, ContainerFactory
+
+
+@override_for_contents()
+class BasicRouteTests(TestCase, TutorialTestMixin):
+    def setUp(self):
+        self.build_content(self.content_type)
+        self.mock_publication_process(self.content)
+
+    def build_content(self, type):
+        self.content = PublishableContentFactory()
+        self.content.type = type
+        self.content.save()
+        content_versioned = self.content.load_version()
+        self.container = ContainerFactory(parent=content_versioned, db_object=self.content)
+        self.subcontainer = ContainerFactory(parent=self.container, db_object=self.content)
+
+    def assert_can_be_reached(self, route, route_args):
+        url = reverse(route, kwargs=route_args)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def mock_publication_process(self, content: PublishableContent):
+        published = publish_content(content, content.load_version())
+        content.sha_public = content.sha_draft
+        content.public_version = published
+        content.save()
+
+
+class OpinionDisplayRoutesTests(BasicRouteTests):
+    content_type = "OPINION"
+
+    def test_view(self):
+        route = "opinion:view"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+        }
+        self.assert_can_be_reached(route, route_args)
+
+    def test_view_container_one_level_deep(self):
+        route = "opinion:view-container"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+            "container_slug": self.container.slug,
+        }
+        self.assert_can_be_reached(route, route_args)
+
+    def test_view_container_two_level_deep(self):
+        route = "opinion:view-container"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+            "parent_container_slug": self.container.slug,
+            "container_slug": self.subcontainer.slug,
+        }
+        self.assert_can_be_reached(route, route_args)
+
+
+@override_for_contents()
+class ArticlesDisplayRoutesTests(BasicRouteTests):
+    content_type = "ARTICLE"
+
+    def test_view(self):
+        route = "article:view"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+        }
+        self.assert_can_be_reached(route, route_args)
+
+    def test_view_container_one_level_deep(self):
+        route = "article:view-container"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+            "container_slug": self.container.slug,
+        }
+        self.assert_can_be_reached(route, route_args)
+
+    def test_view_container_two_level_deep(self):
+        route = "article:view-container"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+            "parent_container_slug": self.container.slug,
+            "container_slug": self.subcontainer.slug,
+        }
+        self.assert_can_be_reached(route, route_args)

--- a/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
+++ b/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
@@ -61,26 +61,14 @@ class AddContributorPermissionTests(TutorialTestMixin, TestCase):
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
-    def test_authenticated_staff_tutorial(self):
+    def test_authenticated_staff(self):
         self.client.force_login(self.staff)
-        self.content.type = "TUTORIAL"
-        self.content.save()
-        response = self.client.post(self.form_url, self.form_data)
-        self.assertRedirects(response, self.content_url)
-
-    def test_authenticated_staff_article(self):
-        self.client.force_login(self.staff)
-        self.content.type = "ARTICLE"
-        self.content.save()
-        response = self.client.post(self.form_url, self.form_data)
-        self.assertRedirects(response, self.content_url)
-
-    def test_authenticated_staff_opinion(self):
-        self.client.force_login(self.staff)
-        self.content.type = "OPINION"
-        self.content.save()
-        response = self.client.post(self.form_url, self.form_data)
-        self.assertEqual(response.status_code, 403)
+        types = ["TUTORIAL", "ARTICLE", "OPINION"]
+        for type in types:
+            self.content.type = type
+            self.content.save()
+            response = self.client.post(self.form_url, self.form_data)
+            self.assertRedirects(response, self.content_url)
 
 
 class AddContributorWorkflowTests(TutorialTestMixin, TestCase):

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -1626,6 +1626,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
 
     def test_obsolete(self):
         # check that this function is only available for staff
+        message = _("Cette publication est obsolète.")
         self.client.force_login(self.user_author)
         result = self.client.post(reverse("validation:mark-obsolete", kwargs={"pk": self.tuto.pk}), follow=False)
         self.assertEqual(result.status_code, 403)
@@ -1634,24 +1635,24 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         # check that when the content is not marked as obsolete, the alert is not shown
         result = self.client.get(self.tuto.get_absolute_url_online(), follow=False)
         self.assertEqual(result.status_code, 200)
-        self.assertNotContains(result, _("Ce contenu est obsolète."))
+        self.assertNotContains(result, message)
         # now, let's mark the tutoriel as obsolete
         result = self.client.post(reverse("validation:mark-obsolete", kwargs={"pk": self.tuto.pk}), follow=False)
         self.assertEqual(result.status_code, 302)
         # check that the alert is shown
         result = self.client.get(self.tuto.get_absolute_url_online(), follow=False)
         self.assertEqual(result.status_code, 200)
-        self.assertContains(result, _("Ce contenu est obsolète."))
+        self.assertContains(result, message)
         # and on a chapter
         result = self.client.get(self.chapter1.get_absolute_url_online(), follow=False)
         self.assertEqual(result.status_code, 200)
-        self.assertContains(result, _("Ce contenu est obsolète."))
+        self.assertContains(result, message)
         # finally, check that this alert can be hidden
         result = self.client.post(reverse("validation:mark-obsolete", kwargs={"pk": self.tuto.pk}), follow=False)
         self.assertEqual(result.status_code, 302)
         result = self.client.get(self.tuto.get_absolute_url_online(), follow=False)
         self.assertEqual(result.status_code, 200)
-        self.assertNotContains(result, _("Ce contenu est obsolète."))
+        self.assertNotContains(result, message)
 
     def test_list_publications(self):
         """Test the behavior of the publication list"""

--- a/zds/tutorialv2/tests/tests_views/tests_removecontributor.py
+++ b/zds/tutorialv2/tests/tests_views/tests_removecontributor.py
@@ -61,25 +61,20 @@ class RemoveContributorPermissionTests(TutorialTestMixin, TestCase):
         self.assertRedirects(response, self.content_url)
 
     def test_authenticated_staff_tutorial(self):
-        self.client.force_login(self.staff)
-        self.content.type = "TUTORIAL"
-        self.content.save()
-        response = self.client.post(self.form_url, self.form_data)
-        self.assertRedirects(response, self.content_url)
+        self.perform_test_authenticated_staff("TUTORIAL")
 
     def test_authenticated_staff_article(self):
+        self.perform_test_authenticated_staff("ARTICLE")
+
+    def test_authenticated_staff_opinion(self):
+        self.perform_test_authenticated_staff("OPINION")
+
+    def perform_test_authenticated_staff(self, type):
         self.client.force_login(self.staff)
-        self.content.type = "ARTICLE"
+        self.content.type = type
         self.content.save()
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
-
-    def test_authenticated_staff_opinion(self):
-        self.client.force_login(self.staff)
-        self.content.type = "OPINION"
-        self.content.save()
-        response = self.client.post(self.form_url, self.form_data)
-        self.assertEqual(response.status_code, 403)
 
 
 class RemoveContributorWorkflowTests(TutorialTestMixin, TestCase):

--- a/zds/tutorialv2/urls/urls_articles.py
+++ b/zds/tutorialv2/urls/urls_articles.py
@@ -4,22 +4,33 @@ from django.views.generic.base import RedirectView
 from zds.tutorialv2.views.contributors import ContentOfContributors
 from zds.tutorialv2.views.lists import TagsListView, ContentOfAuthor
 from zds.tutorialv2.views.download_online import DownloadOnlineArticle
-from zds.tutorialv2.views.display import DisplayOnlineArticle
+from zds.tutorialv2.views.display import DisplayOnlineArticle, DisplayOnlineContainer
 from zds.tutorialv2.feeds import LastArticlesFeedRSS, LastArticlesFeedATOM
 
-urlpatterns = [
-    # Flux
+feed_patterns = [
     path("flux/rss/", LastArticlesFeedRSS(), name="feed-rss"),
     path("flux/atom/", LastArticlesFeedATOM(), name="feed-atom"),
-    # View
+]
+
+display_patterns = [
     path("<int:pk>/<slug:slug>/", DisplayOnlineArticle.as_view(), name="view"),
-    # Downloads
+    path(
+        "<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/",
+        DisplayOnlineContainer.as_view(),
+        name="view-container",
+    ),
+    path("<int:pk>/<slug:slug>/<slug:container_slug>/", DisplayOnlineContainer.as_view(), name="view-container"),
+]
+
+download_patterns = [
     path("md/<int:pk>/<slug:slug>.md", DownloadOnlineArticle.as_view(requested_file="md"), name="download-md"),
     path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineArticle.as_view(requested_file="pdf"), name="download-pdf"),
     path("tex/<int:pk>/<slug:slug>.tex", DownloadOnlineArticle.as_view(requested_file="tex"), name="download-tex"),
     path("epub/<int:pk>/<slug:slug>.epub", DownloadOnlineArticle.as_view(requested_file="epub"), name="download-epub"),
     path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineArticle.as_view(requested_file="zip"), name="download-zip"),
-    # Listing
+]
+
+listing_patterns = [
     path("", RedirectView.as_view(pattern_name="publication:list", permanent=True)),
     re_path(r"tags/*", TagsListView.as_view(displayed_types=["ARTICLE"]), name="tags"),
     path(
@@ -33,3 +44,5 @@ urlpatterns = [
         name="find-contributions-article",
     ),
 ]
+
+urlpatterns = feed_patterns + display_patterns + download_patterns + listing_patterns

--- a/zds/tutorialv2/urls/urls_opinions.py
+++ b/zds/tutorialv2/urls/urls_opinions.py
@@ -3,21 +3,32 @@ from django.urls import path
 from zds.tutorialv2.feeds import LastOpinionsFeedRSS, LastOpinionsFeedATOM
 from zds.tutorialv2.views.lists import ListOpinions, ContentOfAuthor
 from zds.tutorialv2.views.download_online import DownloadOnlineOpinion
-from zds.tutorialv2.views.display import DisplayOnlineOpinion
+from zds.tutorialv2.views.display import DisplayOnlineOpinion, DisplayOnlineContainer
 
-urlpatterns = [
-    # Flux
+feed_patterns = [
     path("flux/rss/", LastOpinionsFeedRSS(), name="feed-rss"),
     path("flux/atom/", LastOpinionsFeedATOM(), name="feed-atom"),
-    # View
+]
+
+display_patterns = [
     path("<int:pk>/<slug:slug>/", DisplayOnlineOpinion.as_view(), name="view"),
-    # downloads:
+    path(
+        "<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/",
+        DisplayOnlineContainer.as_view(),
+        name="view-container",
+    ),
+    path("<int:pk>/<slug:slug>/<slug:container_slug>/", DisplayOnlineContainer.as_view(), name="view-container"),
+]
+
+download_patterns = [
     path("md/<int:pk>/<slug:slug>.md", DownloadOnlineOpinion.as_view(requested_file="md"), name="download-md"),
     path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineOpinion.as_view(requested_file="pdf"), name="download-pdf"),
     path("epub/<int:pk>/<slug:slug>.epub", DownloadOnlineOpinion.as_view(requested_file="epub"), name="download-epub"),
     path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineOpinion.as_view(requested_file="zip"), name="download-zip"),
     path("tex/<int:pk>/<slug:slug>.tex", DownloadOnlineOpinion.as_view(requested_file="tex"), name="download-tex"),
-    # Listing
+]
+
+listing_patterns = [
     path("", ListOpinions.as_view(), name="list"),
     path(
         "voir/<str:username>/",
@@ -25,3 +36,5 @@ urlpatterns = [
         name="find-opinion",
     ),
 ]
+
+urlpatterns = feed_patterns + display_patterns + download_patterns + listing_patterns

--- a/zds/tutorialv2/views/containers_extracts.py
+++ b/zds/tutorialv2/views/containers_extracts.py
@@ -88,7 +88,7 @@ class DisplayContainer(LoginRequiredMixin, SingleContentDetailViewMixin):
         context["containers_target"] = get_target_tagged_tree(container, self.versioned_object)
 
         if self.versioned_object.is_beta:
-            context["formWarnTypo"] = WarnTypoForm(
+            context["form_warn_typo"] = WarnTypoForm(
                 self.versioned_object, container, public=False, initial={"target": container.get_path(relative=True)}
             )
 

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -176,7 +176,7 @@ class DisplayContent(LoginRequiredMixin, SingleContentDetailViewMixin):
             )
 
         if self.versioned_object.is_beta:
-            context["formWarnTypo"] = WarnTypoForm(self.versioned_object, self.versioned_object, public=False)
+            context["form_warn_typo"] = WarnTypoForm(self.versioned_object, self.versioned_object, public=False)
 
         context["validation"] = validation
         context["formJs"] = form_js

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -203,11 +203,11 @@ class DisplayContent(LoginRequiredMixin, SingleContentDetailViewMixin):
 
         context["gallery"] = self.object.gallery
         context["public_content_object"] = self.public_content_object
+        context["form_add_contributor"] = ContributionForm(content=self.object)
+        context["contributions"] = ContentContribution.objects.filter(content=self.object).order_by(
+            "contribution_role__position"
+        )
         if self.object.type.lower() != "opinion":
-            context["formAddReviewer"] = ContributionForm(content=self.object)
-            context["contributions"] = ContentContribution.objects.filter(content=self.object).order_by(
-                "contribution_role__position"
-            )
             context["content_suggestions"] = ContentSuggestion.objects.filter(publication=self.object)
             excluded_for_search = [str(x.suggestion.pk) for x in context["content_suggestions"]]
             excluded_for_search.append(str(self.object.pk))

--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -213,7 +213,6 @@ class DisplayOnlineContainer(SingleOnlineContentDetailViewMixin):
     """Base class that can show any content in any state"""
 
     template_name = "tutorialv2/view/container_online.html"
-    current_content_type = "TUTORIAL"  # obviously, an article cannot have container !
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/zds/tutorialv2/views/display.py
+++ b/zds/tutorialv2/views/display.py
@@ -64,7 +64,7 @@ class DisplayOnlineContent(FeatureableMixin, SingleOnlineContentDetailViewMixin)
                 self.versioned_object, initial={"version": self.versioned_object.sha_public}
             )
 
-        context["formWarnTypo"] = WarnTypoForm(self.versioned_object, self.versioned_object)
+        context["form_warn_typo"] = WarnTypoForm(self.versioned_object, self.versioned_object)
 
         reactions = list(
             ContentReaction.objects.select_related("author")
@@ -222,7 +222,7 @@ class DisplayOnlineContainer(SingleOnlineContentDetailViewMixin):
         context["container"] = container
         context["pm_link"] = self.object.get_absolute_contact_url(_("À propos de"))
 
-        context["formWarnTypo"] = WarnTypoForm(
+        context["form_warn_typo"] = WarnTypoForm(
             self.versioned_object, container, initial={"target": container.get_path(relative=True)}
         )
 


### PR DESCRIPTION
Dans le cadre de l['organisation des contenus](https://github.com/orgs/zestedesavoir/projects/3/views/2), cette PR :

- supprime des fonctions inutilisées en rapport avec la distinction billet/tuto/article ;
- rend générique certains affichages en utilisant "publication" au lieu de "tutoriel", "article" ou "billet ;
- déverouille la structure des billets et articles pour permettre tout comme les tutoriels ;
- permet l'ajout/suppression de contributeurs sur les billets.

### Contrôle qualité

- Créer un profil avec différents tutos, articles, billets, en beta ou non, et voir qu les statistiques sont affichées correctement (pour tester d'éventuelles régressions sur les suppressions de fonctions inutilisées).
- Vérifier que les affichages rendus génériques fonctionnent bien (voir le diff pour ceux concernés).
- Jouer à crer un article et billet avec une structure de tutoriel et constater que la publication fonctionne.
- Tester l'ajout et suppression de contributeurs sur les billets.