### PR TITLE
Corrige un détail de CSS pour la neige

### DIFF
--- a/assets/js/snow.js
+++ b/assets/js/snow.js
@@ -15,7 +15,7 @@
 
     canvas.style.background = window
       .getComputedStyle(this._parent)
-      .getPropertyValue('background-color')
+      .getPropertyValue('background')
     this._parent.style.background = 'transparent'
 
     // Append the canvas...


### PR DESCRIPTION
L'entête du site web est bleue mais avec un très léger gradient qui fait que son centre est plus clair que ses côtés. Actuellement, le code JS qui gère la neige rend transparent l'entête et applique la bonne couleur de fond au canvas qui gère la neige, mais sans le gradient. Lors du chargement de la neige sur la page, il y a donc un changement de couleur très léger mais énervant. Cette PR corrige ce soucis en appliquant au canvas la bonne couleur de fond et le gradient de couleur.

**QA :**

- `source zdsenv/bin/activate && make update && make zmd-start && make run`
- Activer la neige
  ```diff
  diff --git a/zds/settings/dev.py b/zds/settings/dev.py
  index 1f2c2e223..972f3a7af 100644
  --- a/zds/settings/dev.py
  +++ b/zds/settings/dev.py
  @@ -82,3 +82,5 @@ ZDS_APP["very_top_banner"] = {
       "message": "Version locale",
       "slug": "version-locale",
   }
  +
  +ZDS_APP["visual_changes"] = ["snow"]
  ```
- Vérifier lors du chargement de la page que la couleur de l'entête ne varie pas