### PR TITLE
Ajoute une commande pour lister les paquets Python à mettre à jour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ test-back-selenium: ## Run backend Selenium tests
 clean-back: ## Remove Python bytecode files (*.pyc)
 	find . -name '*.pyc' -exec rm {} \;
 
+list-outdated-back: ## List outdated Python packages
+	@echo "Package                 Version   Latest    Type"
+	@echo "----------------------- --------- --------- -----"
+	@pip list --outdated | grep "`awk -F== '{ print $$1 }' requirements*.txt | tr -s '\n' '\n' | sort`"
+
 ##
 ## ~ Frontend
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build Status| |Coverage Status| |Requirements Status| |Dependency Status| |Licence GPL|
+|Build Status| |Coverage Status| |Dependency Status| |Licence GPL|
 
 .. image:: https://github.com/zestedesavoir/zds-site/blob/36c6bbc50fdecd936768ef5a566d98f5d757fcbf/assets/images/logo-background.png
 
@@ -48,8 +48,6 @@ Conseils pour débuter
    :target: https://github.com/zestedesavoir/zds-site/actions
 .. |Coverage Status| image:: https://coveralls.io/repos/github/zestedesavoir/zds-site/badge.svg?branch=dev
    :target: https://coveralls.io/github/zestedesavoir/zds-site?branch=dev
-.. |Requirements Status| image:: https://requires.io/github/zestedesavoir/zds-site/requirements.svg?branch=dev
-   :target: https://requires.io/github/zestedesavoir/zds-site/requirements/?branch=dev
 .. |Dependency Status| image:: https://david-dm.org/zestedesavoir/zds-site.svg
    :target: https://david-dm.org/zestedesavoir/zds-site
 .. |Licence GPL| image:: https://img.shields.io/badge/license-GPL-blue.svg

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,4 @@ pre-commit==2.20.0
 PyYAML==6.0
 selenium==4.4.3
 Sphinx==5.1.1
-sphinx_rtd_theme==1.0.0
+sphinx-rtd-theme==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ django-oauth-toolkit==1.7.0
 djangorestframework==3.13.1
 drf-extensions==0.7.1
 dry-rest-permissions==0.1.10
-drf_yasg==1.21.3
+drf-yasg==1.21.3
 
 # Dependencies for slug generation, please be extra careful with those
 django-uuslug==2.0.0


### PR DESCRIPTION
Le service Requires.io que l'on utilisait pour lister les paquets Python à mettre à jour ne fonctionne plus (cf. [ce billet de blog](http://shiningpanda.com/requires-io-clap-de-fin/)). Je n'ai pas vraiment trouvé de service en ligne pour le remplacer, par contre j'ai découvert l'existence de la commande `pip list --outdated` qui liste les paquets avec une nouvelle version de disponible. Avec quelques commandes utilitaires, il est possible de restreindre cette liste aux seuls paquets présents dans les fichiers `requirements*.txt`, ceux qui nous intéressent. Au lieu d'un service en ligne, nous avons donc une nouvelle commande dans le Makefile : `make list-outdated-back` !

Note : J'ai été obligé de renommer deux paquets dans les fichiers `requirements*.txt` pour qu'ils correspondent avec la sortie de `pip list`, mais c'est purement cosmétique.

**QA :** Vérifier le bon fonctionnement de `make list-outdated-back`