### PR TITLE
colorisation des forums privés en orange dans la liste des forums

### DIFF
--- a/assets/scss/components/_topic-list.scss
+++ b/assets/scss/components/_topic-list.scss
@@ -256,6 +256,9 @@
             display: block;
             font-weight: normal;
             margin-top: $length-2;
+            &.staff-only {
+                color: $color-staff-link;
+            }
         }
     }
     .topic-infos + .topic-description {

--- a/templates/forum/includes/forums.part.html
+++ b/templates/forum/includes/forums.part.html
@@ -6,37 +6,37 @@
 
 
 {% for forum in forums %}
-<div class="topic navigable-elem">
-    <div class="topic-description">
-        <a href="{{ forum.get_absolute_url }}" class="navigable-link">
-            <h4 class="topic-title{% if forum.has_group %} staff-only{% endif %}" itemprop="itemListElement">
-                {{ forum.title }}
-            </h4>
-        </a>
-        <span class="topic-subtitle">
+    <div class="topic navigable-elem">
+        <div class="topic-description">
+            <a href="{{ forum.get_absolute_url }}" class="navigable-link">
+                <h4 class="topic-title{% if forum.has_group %} staff-only{% endif %}" itemprop="itemListElement">
+                    {{ forum.title }}
+                </h4>
+            </a>
+            <span class="topic-subtitle">
                 {{ forum.subtitle }}
             </span>
-    </div>
-    <p class="topic-answers">
+        </div>
+        <p class="topic-answers">
             <span title="Nombre de sujets dans le forum">
                 {{ forum.get_topic_count }}
             </span>
-        <span title="Nombre de messages dans le forum">
+            <span title="Nombre de messages dans le forum">
                 {{ forum.get_post_count }}
             </span>
-    </p>
-    <p class="topic-last-answer">
-        {% with last_message=forum.get_last_message %}
-        {% if last_message %}
-        {% captureas last_message_url %}{% spaceless %}
-        {% if user.is_authenticated %}
-        {{ last_message.topic.resolve_last_read_post_absolute_url }}
-        {% else %}
-        {{ last_message.topic.resolve_first_post_absolute_url }}
-        {% endif %}
-        {% endspaceless %}{% endcaptureas %}
-        {# if you are not connected, you get the first message of topic as "first non read" #}
-        <a href="{{ last_message_url }}">
+        </p>
+        <p class="topic-last-answer">
+            {% with last_message=forum.get_last_message %}
+                {% if last_message %}
+                    {% captureas last_message_url %}{% spaceless %}
+                        {% if user.is_authenticated %}
+                            {{ last_message.topic.resolve_last_read_post_absolute_url }}
+                        {% else %}
+                            {{ last_message.topic.resolve_first_post_absolute_url }}
+                        {% endif %}
+                    {% endspaceless %}{% endcaptureas %}
+                    {# if you are not connected, you get the first message of topic as "first non read" #}
+                    <a href="{{ last_message_url }}">
                         <span class="forum-last-message">
                             <span class="forum-last-message-long">
                                 {{ last_message.pubdate|format_date|capfirst }}
@@ -45,12 +45,12 @@
                                 {{ last_message.pubdate|format_date:True|capfirst }}
                             </span>
                         </span>
-            <span class="forum-last-message-title">{{ last_message.topic.title }}</span>
-        </a>
-        {% else %}
-        <span class="topic-no-last-answer">{% trans "Aucun sujet" %}</span>
-        {% endif %}
-        {% endwith %}
-    </p>
-</div>
+                        <span class="forum-last-message-title">{{ last_message.topic.title }}</span>
+                    </a>
+                {% else %}
+                    <span class="topic-no-last-answer">{% trans "Aucun sujet" %}</span>
+                {% endif %}
+            {% endwith %}
+        </p>
+    </div>
 {% endfor %}

--- a/templates/forum/includes/forums.part.html
+++ b/templates/forum/includes/forums.part.html
@@ -6,37 +6,37 @@
 
 
 {% for forum in forums %}
-    <div class="topic navigable-elem">
-        <div class="topic-description">
-            <a href="{{ forum.get_absolute_url }}" class="navigable-link">
-                <h4 class="topic-title" itemprop="itemListElement">
-                    {{ forum.title }}
-                </h4>
-            </a>
-            <span class="topic-subtitle">
+<div class="topic navigable-elem">
+    <div class="topic-description">
+        <a href="{{ forum.get_absolute_url }}" class="navigable-link">
+            <h4 class="topic-title{% if forum.has_group %} staff-only{% endif %}" itemprop="itemListElement">
+                {{ forum.title }}
+            </h4>
+        </a>
+        <span class="topic-subtitle">
                 {{ forum.subtitle }}
             </span>
-        </div>
-        <p class="topic-answers">
+    </div>
+    <p class="topic-answers">
             <span title="Nombre de sujets dans le forum">
                 {{ forum.get_topic_count }}
             </span>
-            <span title="Nombre de messages dans le forum">
+        <span title="Nombre de messages dans le forum">
                 {{ forum.get_post_count }}
             </span>
-        </p>
-        <p class="topic-last-answer">
-            {% with last_message=forum.get_last_message %}
-                {% if last_message %}
-                    {% captureas last_message_url %}{% spaceless %}
-                        {% if user.is_authenticated %}
-                            {{ last_message.topic.resolve_last_read_post_absolute_url }}
-                        {% else %}
-                            {{ last_message.topic.resolve_first_post_absolute_url }}
-                        {% endif %}
-                    {% endspaceless %}{% endcaptureas %}
-                    {# if you are not connected, you get the first message of topic as "first non read" #}
-                    <a href="{{ last_message_url }}">
+    </p>
+    <p class="topic-last-answer">
+        {% with last_message=forum.get_last_message %}
+        {% if last_message %}
+        {% captureas last_message_url %}{% spaceless %}
+        {% if user.is_authenticated %}
+        {{ last_message.topic.resolve_last_read_post_absolute_url }}
+        {% else %}
+        {{ last_message.topic.resolve_first_post_absolute_url }}
+        {% endif %}
+        {% endspaceless %}{% endcaptureas %}
+        {# if you are not connected, you get the first message of topic as "first non read" #}
+        <a href="{{ last_message_url }}">
                         <span class="forum-last-message">
                             <span class="forum-last-message-long">
                                 {{ last_message.pubdate|format_date|capfirst }}
@@ -45,12 +45,12 @@
                                 {{ last_message.pubdate|format_date:True|capfirst }}
                             </span>
                         </span>
-                        <span class="forum-last-message-title">{{ last_message.topic.title }}</span>
-                    </a>
-                {% else %}
-                    <span class="topic-no-last-answer">{% trans "Aucun sujet" %}</span>
-                {% endif %}
-            {% endwith %}
-        </p>
-    </div>
+            <span class="forum-last-message-title">{{ last_message.topic.title }}</span>
+        </a>
+        {% else %}
+        <span class="topic-no-last-answer">{% trans "Aucun sujet" %}</span>
+        {% endif %}
+        {% endwith %}
+    </p>
+</div>
 {% endfor %}


### PR DESCRIPTION
Ajout d'une couleur differente pour les forums privé dans la rubrique forums pour respecter le code couleur dans la barre de navigation.

Fix #6351 

### Contrôle qualité

Sur le serveur de bêta:
-Se connecter en tant que staff
-Aller dans la rubrique Forum
-Vérifier que le forum staff-only est en orange
