### PR TITLE
Suppression du paramètre Django SITE_ID

### DIFF
--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -182,8 +182,6 @@ INSTALLED_APPS = (
     # 'django.contrib.admindocs',
 )
 
-SITE_ID = 1
-
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "zds.api.pagination.DefaultPagination",
     "DEFAULT_SCHEMA_CLASS": "rest_framework.schemas.coreapi.AutoSchema",


### PR DESCRIPTION
Ce paramètre est requis lorsqu'on utilise le module `django.contrib.sites`. Mais on n'utilise plus ce module depuis 2015 (supprimé avec le commit c732cc47685848843e1431659c98a99b1ced93bc).

Il est donc aussi possible de supprimer la table `django_site` de la base de données.

### Contrôle qualité

S'assurer que le site fonctionne (la CI devrait être suffisante).
