### PR TITLE
Utilise $GITHUB_OUTPUT au lieu de set-output dans la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Retrieve pip cache directory
         id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache pip packages
         uses: actions/cache@v2
@@ -97,7 +97,7 @@ jobs:
 
       - name: Retrieve yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Node modules
         uses: actions/cache@v2
@@ -201,8 +201,7 @@ jobs:
 
       - name: Retrieve pip cache directory
         id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache pip packages
         uses: actions/cache@v2


### PR DESCRIPTION
Utiliser set-output est maintenant déprécié par GitHub Actions, voir https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Contrôle qualité

S'assurer que la CI fonctionne, en particulier les commandes modifiées.
