### PR TITLE
Configure un lancement périodique de la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: ["push", "pull_request"]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "30 3 * * WED" # every Wednesday at 3:30 AM, only main branch
 
 env:
   NODE_VERSION: "16" # needs to be also updated in .nvmrc
@@ -24,6 +28,9 @@ jobs:
     name: Lint back-end
     runs-on: ubuntu-22.04
 
+    # do not execute scheduled jobs on forks:
+    if: ${{ github.event.name != 'schedule' || github.repository_owner == 'zestedesavoir' }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -43,6 +50,9 @@ jobs:
   build-doc:
     name: Build Sphinx documentation
     runs-on: ubuntu-22.04
+
+    # do not execute scheduled jobs on forks:
+    if: ${{ github.event.name != 'schedule' || github.repository_owner == 'zestedesavoir' }}
 
     steps:
       - name: Checkout
@@ -85,6 +95,9 @@ jobs:
   build-front:
     name: Lint and build front-end
     runs-on: ubuntu-22.04
+
+    # do not execute scheduled jobs on forks:
+    if: ${{ github.event.name != 'schedule' || github.repository_owner == 'zestedesavoir' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Pour tester régulièrement les régressions qui proviendraient de nos dépendances dont les versions ne sont pas fixées de façon strictes.

En tant qu'auteur du commit introduit `schedule`, je devrais être le seul à recevoir les notifications liées aux exécutions planifiées (voir
https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs).

L'exécution planifiée ne se fera que sur la branche principale du dépôt (comportement par défaut de `schedule`, voir
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) et les conditions rajoutées au script empêchent d'avoir des exécutions planifiées sur les forks (ce que je ne considère pas utile et un gaspillage de ressources).



### Contrôle qualité

- être d'accord avec l'idée
- jeter un oeil sur les changements au fichier `ci.yml`, je ne suis pas complétement sûr de moi
