### PR TITLE
Supprime les mentions d'une newsletter dans les CGU

### DIFF
--- a/templates/pages/eula.html
+++ b/templates/pages/eula.html
@@ -181,10 +181,7 @@
         Toutes les données à caractère personnel transmises par les utilisateurs et membres du site sont recueillies dans le plus strict respect de la législation. Elles ont pour finalité une meilleure utilisation de {{ app.site.dns }} et sont donc utilisées par l’éditeur du site à cette fin.
     </p>
     <p>
-        Lors de son inscription, il est requis de l’utilisateur de fournir des informations le concernant. En particulier, l’adresse électronique pourra être utilisée par le site pour l’administration et la communication d’informations touchant l’ensemble des membres du site (par exemple : une modification importante de la structure du site, l’ajout de fonctionnalités, une modification des présentes conditions, les dernières publications du site (newsletter), etc.).
-    </p>
-    <p>
-        Le membre a le choix s’abonner ou non à la newsletter.
+        Lors de son inscription, il est requis de l’utilisateur de fournir des informations le concernant. En particulier, l’adresse électronique pourra être utilisée par le site pour l’administration et la communication d’informations touchant l’ensemble des membres du site (par exemple : une modification importante de la structure du site, l’ajout de fonctionnalités, une modification des présentes conditions, etc.).
     </p>
     <p>
         Les données concernant les utilisateurs (membres ou non) du site peuvent être également utilisées à des fins statistiques destinées à mesurer la fréquentation du site.


### PR DESCRIPTION
Il n'y pas de newsletter de ZdS. En particulier, le membre n'a en pratique pas la possibilité de se désabonner de cette newsletter inexistante.


### Contrôle qualité

Relire les parties changées des CGU.
