### PR TITLE
Fixe la version d'une dépendance implicite pour corriger la CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.3
 social-auth-app-django==5.0.0
+social-auth-core==4.3.0
 
 # Explicit dependencies (references in code)
 beautifulsoup4==4.11.1


### PR DESCRIPTION
On utilise le paquet Python `social-auth-app-django` qui dépend du paquet `social-auth-core`. Ce dernier est passé il y a quelques jours à la version 4.4.0 et `social-auth-app-django` renvoie une exception depuis. Les mainteneurs sont au courant du problème et je suppose qu'ils vont le corriger dans les prochains jours, mais je propose de fixer la dépendance à sa version 4.3.0 en attendant pour débloquer la CI. 

**QA :** Github Actions