### PR TITLE
Correction des paramètres de l'action de la CI pour déployer la doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: doc/build/html
-          CLEAN: true
+          folder: doc/build/html
+          clean: true


### PR DESCRIPTION
Follow-up of 40f5701f9f8e1f5a61bcc18e4209e50dd6421782

Adapte les paramètres de l'action pour déployer la documentation. J'ai mis à jour l'action un peu rapidement, il me semblait que les paramètres n'avaient pas changé. Voir https://github.com/JamesIves/github-pages-deploy-action

### Contrôle qualité

Regarder la CI.
