### PR TITLE
Corrige (vraiment) le déploiement de la documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,10 @@ jobs:
       - name: Build documentation
         run: make generate-doc
 
-      - name: Upload documentation as an artifact
-        uses: actions/upload-artifact@v3
+      - name: Upload documentation as a page artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          name: doc
           path: doc/build/html
-          retention-days: 1
 
   # Build the website front-end and upload built assets as an artifact.
   build-front:
@@ -296,15 +294,16 @@ jobs:
     runs-on: ubuntu-22.04
     if: "github.ref == 'refs/heads/dev'"
 
-    steps:
-      - name: Download previously built documentation
-        uses: actions/download-artifact@v3
-        with:
-          name: doc
-          path: doc/build/html
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: doc/build/html
-          clean: true
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Depuis la version 4, l'action JamesIves/github-pages-deploy-action a besoin d'un dépôt Git pour fonctionner, ce qui n'est pas le cas avec notre fonctionnement où on récupère l'artefact de la documentation. On remplace donc cette action par l'action actions/deploy-pages qui permet de déployer un artefact prévu pour un déploiement sur GitHub Pages.

### Contrôle qualité

J'ai fait des essais d'abord sur mon fork, et ça fonctionne. Donc juste une relecture des changements.
