### PR TITLE
Corrige le chemin du logo de ZdS pour l'accueil de la documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 |Build Status| |Coverage Status| |Licence GPL|
 
-.. image:: https://github.com/zestedesavoir/zds-site/blob/36c6bbc50fdecd936768ef5a566d98f5d757fcbf/assets/images/logo-background.png
+.. image:: https://raw.githubusercontent.com/zestedesavoir/zds-site/36c6bbc50fdecd936768ef5a566d98f5d757fcbf/assets/images/logo-background.png
 
 Qu'est-ce que Zeste de Savoir ?
 ===============================


### PR DESCRIPTION
Le fichier `README.rst` à la racine du dépôt est utilisé à la fois que README à affiché lorsqu'on arrive sur le dépôt sur GitHub, mais aussi comme page d'accueil de la documentation de ZdS. Le logo affiché en haut de ce fichier était bien affiché sur GitHub, mais pas dans la documentation (GitHub doit faire une tambouille pour trouver la bonne URL d'image à utiliser). Cette PR corrige le chemin du logo pour qu'il soit bien affiché à la fois sur GitHub et sur la documentation.

### Contrôle qualité

- le logo est bien affiché sur le README : https://github.com/philippemilink/zds-site/tree/fix-zds-logo-doc
- le logo est bien affiché dans la documentation : `make generate-doc` et consulter la page d'accueil de la documentation générée.
