### PR TITLE
Enlève la dépendence social-auth-core de requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.3
 social-auth-app-django==5.0.0
-social-auth-core==4.3.0
 
 # Explicit dependencies (references in code)
 beautifulsoup4==4.11.1


### PR DESCRIPTION
This reverts commit 2f5f2f06cb86bb431e259307189a2d35b7beea39.

Le problème qui imposait de figer la version de social-auth-core (https://github.com/python-social-auth/social-core/issues/773)  a été corrigé dans la version 4.4.1 de social-auth-core.

### Contrôle qualité

S'assurer que la version 4.4.1 du paquet Python social-auth-core est installée et vérifier que les tests passent (la CI devrait donc être suffisante).
