### PR TITLE
Corrige une typo pour ne pas exécuter la CI programmée sur les forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     # do not execute scheduled jobs on forks:
-    if: ${{ github.event.name != 'schedule' || github.repository_owner == 'zestedesavoir' }}
+    if: ${{ github.event_name != 'schedule' || github.repository_owner == 'zestedesavoir' }}
 
     steps:
       - name: Checkout
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     # do not execute scheduled jobs on forks:
-    if: ${{ github.event.name != 'schedule' || github.repository_owner == 'zestedesavoir' }}
+    if: ${{ github.event_name != 'schedule' || github.repository_owner == 'zestedesavoir' }}
 
     steps:
       - name: Checkout
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     # do not execute scheduled jobs on forks:
-    if: ${{ github.event.name != 'schedule' || github.repository_owner == 'zestedesavoir' }}
+    if: ${{ github.event_name != 'schedule' || github.repository_owner == 'zestedesavoir' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Le nom de l'événement est stocké dans `github.event_name` et pas `github.event.name` (cf la [doc](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)).

### Contrôle qualité

Relire les changements. J'ai testé sur mon fork en programmant la CI quotidiennement uniquement si le dépôt est mon fork et ça se comporte comme attendu, donc ça devrait être correct.