### PR TITLE
Passe le tooltip des sujets suivis au premier plan

### DIFF
--- a/assets/scss/layout/_sidebar.scss
+++ b/assets/scss/layout/_sidebar.scss
@@ -357,6 +357,7 @@
                 position: absolute;
                 top: -$length-14;
                 left: 102%;
+                z-index: 3;
 
                 display: flex;
                 align-items: center;


### PR DESCRIPTION
Fix #6432

### Contrôle qualité

(v. les instructions dans l'issue pour un screenshot)

  - Se connecter et s'abonner à quelques sujets
  - Créer un sujet
  - Se connecter avec un autre utilisateur (ou attendre 15 minutes que votre utilisateur ait le droit de poster à nouveau)
  - Se rendre sur le nouveau sujet et sélectionner le nouvel éditeur de texte
  - Passer la souris sur la liste des sujets suivis dans la barre de gauche, en particulier sur celui directement à gauche du "header" de l'éditeur de texte

**Ancien comportement:**
Le tooltip qui s'affiche lors du survol est caché par l'éditeur de texte

**Nouveau comportement:**
Le toolip passe devant l'éditeur de texte
