### PR TITLE
Mise à jour triviale des dépendances Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ env:
   PYTHON_VERSION: "3.7"
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt
-  BLACK_VERSION: "22.8.0" # needs to be also updated in requirements-dev.txt and .pre-commit-config.yaml
-  GECKODRIVER_VERSION: "0.31.0"
+  BLACK_VERSION: "23.3.0" # needs to be also updated in requirements-dev.txt and .pre-commit-config.yaml
+  GECKODRIVER_VERSION: "0.33.0"
 
   # As GitHub Action does not allow environment variables
   # to be used in services definitions, these are only for

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
+    rev: v3.4.0
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/psf/black
-    rev: 22.8.0 # needs to be also updated in requirements-dev.txt and .github/workflows/ci.yml
+    rev: 23.3.0 # needs to be also updated in requirements-dev.txt and .github/workflows/ci.yml
     hooks:
       - id: black
         language_version: python3

--- a/manage.py
+++ b/manage.py
@@ -55,7 +55,6 @@ if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "zds.settings.dev")
 
     if len(sys.argv) > 1 and sys.argv[1] in ["migrate", "test"]:
-
         from django.db.backends.mysql.creation import BaseDatabaseCreation
 
         BaseDatabaseCreation.sql_table_creation_suffix = patch_create_suffix(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 
-black==22.8.0  # needs to be also updated in .github/workflows/ci.yml and .pre-commit-config.yaml
+black==23.3.0  # needs to be also updated in .github/workflows/ci.yml and .pre-commit-config.yaml
 colorlog==6.7.0
-django-debug-toolbar==3.6.0
-django-extensions==3.2.0
-Faker==14.2.0
-pre-commit==2.20.0
+django-debug-toolbar==3.8.1
+django-extensions==3.2.1
+Faker==18.9.0
+pre-commit==2.21.0
 PyYAML==6.0
-selenium==4.4.3
-Sphinx==5.1.1
-sphinx-rtd-theme==1.0.0
+selenium==4.9.1
+Sphinx==5.3.0
+sphinx-rtd-theme==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,37 +1,37 @@
 # Implicit dependencies (optional dependencies of dependencies)
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.3
-social-auth-app-django==5.0.0
+social-auth-app-django==5.2.0
 
 # Explicit dependencies (references in code)
-beautifulsoup4==4.11.1
+beautifulsoup4==4.12.2
 django-crispy-forms==1.14.0
-django-model-utils==4.2.0
+django-model-utils==4.3.1
 django-munin==0.2.1
 django-recaptcha==3.0.0
-Django==3.2.15
+Django==3.2.19
 easy-thumbnails[svg]==2.8.3
 factory-boy==3.2.1
-geoip2==4.6.0
-GitPython==3.1.27
+geoip2==4.7.0
+GitPython==3.1.31
 homoglyphs==2.0.4
-lxml==4.9.1
-Pillow==9.2.0
-pymemcache==3.5.2
-requests==2.28.1
+lxml==4.9.2
+Pillow==9.5.0
+pymemcache==4.0.0
+requests==2.31.0
 
 # Api dependencies
-django-cors-headers==3.13.0
-django-filter==22.1
+django-cors-headers==4.0.0
+django-filter==23.2
 django-oauth-toolkit==1.7.0
 djangorestframework==3.14.0
 drf-extensions==0.7.1
 dry-rest-permissions==0.1.10
-drf-yasg==1.21.4
+drf-yasg==1.21.5
 
 # Dependencies for slug generation, please be extra careful with those
 django-uuslug==2.0.0
-python-slugify==6.1.2
+python-slugify==8.0.1
 
 # tomllib was added to the standard library in Python 3.11
 # tomli is only needed for older Python versions

--- a/zds/featured/migrations/0001_initial.py
+++ b/zds/featured/migrations/0001_initial.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0002_auto_20150601_1144"),
     ]

--- a/zds/featured/migrations/0002_auto_20150622_0956.py
+++ b/zds/featured/migrations/0002_auto_20150622_0956.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("featured", "0001_initial"),
     ]

--- a/zds/featured/migrations/0003_remove_featuredresource_authors.py
+++ b/zds/featured/migrations/0003_remove_featuredresource_authors.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("featured", "0002_auto_20150622_0956"),
     ]

--- a/zds/featured/migrations/0004_auto_20150622_0957.py
+++ b/zds/featured/migrations/0004_auto_20150622_0957.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("featured", "0003_remove_featuredresource_authors"),
     ]

--- a/zds/featured/migrations/0005_auto_20160114_1604.py
+++ b/zds/featured/migrations/0005_auto_20160114_1604.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("featured", "0004_auto_20150622_0957"),
     ]

--- a/zds/featured/migrations/0006_python_3.py
+++ b/zds/featured/migrations/0006_python_3.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("featured", "0005_auto_20160114_1604"),
     ]

--- a/zds/featured/migrations/0007_featuredrequested.py
+++ b/zds/featured/migrations/0007_featuredrequested.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("contenttypes", "0002_remove_content_type_name"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/zds/featured/migrations/0008_mandatory_message.py
+++ b/zds/featured/migrations/0008_mandatory_message.py
@@ -14,7 +14,6 @@ def revert(*_):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("featured", "0007_featuredrequested"),
     ]

--- a/zds/featured/views.py
+++ b/zds/featured/views.py
@@ -169,7 +169,6 @@ class FeaturedResourceUpdate(FeaturedViewMixin, UpdateView):
         return initial
 
     def form_valid(self, form):
-
         self.object.title = form.cleaned_data.get("title")
         self.object.type = form.cleaned_data.get("type")
         self.object.authors = form.cleaned_data.get("authors")

--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -144,7 +144,6 @@ class PostForm(forms.Form, FieldValidatorMixin):
 
 
 class MoveTopicForm(forms.Form):
-
     forum = forms.ModelChoiceField(
         label=_("Forum"),
         queryset=Forum.objects.all(),

--- a/zds/forum/migrations/0001_initial.py
+++ b/zds/forum/migrations/0001_initial.py
@@ -4,7 +4,6 @@ import zds.forum.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0001_initial"),
         ("auth", "0001_initial"),

--- a/zds/forum/migrations/0002_auto_20150410_1505.py
+++ b/zds/forum/migrations/0002_auto_20150410_1505.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0001_initial"),
     ]

--- a/zds/forum/migrations/0003_auto_20150414_2324.py
+++ b/zds/forum/migrations/0003_auto_20150414_2324.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0002_auto_20150410_1505"),
     ]

--- a/zds/forum/migrations/0003_auto_20151110_1145.py
+++ b/zds/forum/migrations/0003_auto_20151110_1145.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0003_auto_20150414_2324"),
     ]

--- a/zds/forum/migrations/0004_topic_update_index_date.py
+++ b/zds/forum/migrations/0004_topic_update_index_date.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0003_auto_20151110_1145"),
     ]

--- a/zds/forum/migrations/0005_auto_20151119_2224.py
+++ b/zds/forum/migrations/0005_auto_20151119_2224.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0004_topic_update_index_date"),
     ]

--- a/zds/forum/migrations/0006_auto_20160720_2259.py
+++ b/zds/forum/migrations/0006_auto_20160720_2259.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0005_auto_20151119_2224"),
     ]

--- a/zds/forum/migrations/0007_auto_20160827_2035.py
+++ b/zds/forum/migrations/0007_auto_20160827_2035.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0006_auto_20160720_2259"),
     ]

--- a/zds/forum/migrations/0008_auto_20161101_1122.py
+++ b/zds/forum/migrations/0008_auto_20161101_1122.py
@@ -17,7 +17,6 @@ def force_unicity(*args, **kwargs):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0008_remove_forum_image"),
     ]

--- a/zds/forum/migrations/0008_remove_forum_image.py
+++ b/zds/forum/migrations/0008_remove_forum_image.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0007_auto_20160827_2035"),
     ]

--- a/zds/forum/migrations/0009_remove_topic_key.py
+++ b/zds/forum/migrations/0009_remove_topic_key.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0008_auto_20161101_1122"),
     ]

--- a/zds/forum/migrations/0010_auto_20161112_1823.py
+++ b/zds/forum/migrations/0010_auto_20161112_1823.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0009_remove_topic_key"),
     ]

--- a/zds/forum/migrations/0011_auto_20170130_1823.py
+++ b/zds/forum/migrations/0011_auto_20170130_1823.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0010_auto_20161112_1823"),
     ]

--- a/zds/forum/migrations/0012_auto_20170204_2239.py
+++ b/zds/forum/migrations/0012_auto_20170204_2239.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0011_auto_20170130_1823"),
     ]

--- a/zds/forum/migrations/0013_auto_20170327_1349.py
+++ b/zds/forum/migrations/0013_auto_20170327_1349.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0012_auto_20170204_2239"),
     ]

--- a/zds/forum/migrations/0014_topic_github_issue.py
+++ b/zds/forum/migrations/0014_topic_github_issue.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0013_auto_20170327_1349"),
     ]

--- a/zds/forum/migrations/0015_python_3.py
+++ b/zds/forum/migrations/0015_python_3.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0014_topic_github_issue"),
     ]

--- a/zds/forum/migrations/0016_topic_solved_by.py
+++ b/zds/forum/migrations/0016_topic_solved_by.py
@@ -14,7 +14,6 @@ def forward(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("forum", "0015_python_3"),

--- a/zds/forum/migrations/0017_auto_20190114_1301.py
+++ b/zds/forum/migrations/0017_auto_20190114_1301.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0016_topic_solved_by"),
     ]

--- a/zds/forum/migrations/0019_post_is_potential_spam.py
+++ b/zds/forum/migrations/0019_post_is_potential_spam.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0018_auto_20200315_1749"),
     ]

--- a/zds/forum/migrations/0020_rename_post_is_potential_spam_to_temp_name_for_migration.py
+++ b/zds/forum/migrations/0020_rename_post_is_potential_spam_to_temp_name_for_migration.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0019_post_is_potential_spam"),
     ]

--- a/zds/forum/migrations/0021_remove_post_is_potential_spam.py
+++ b/zds/forum/migrations/0021_remove_post_is_potential_spam.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0020_rename_post_is_potential_spam_to_temp_name_for_migration"),
         # We must remove the field AFTER data was copied from this field to the comments table.

--- a/zds/forum/migrations/0022_topic_github_repository_name.py
+++ b/zds/forum/migrations/0022_topic_github_repository_name.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0021_remove_post_is_potential_spam"),
     ]

--- a/zds/forum/migrations/0023_allow_blank_solved_by_topic_field.py
+++ b/zds/forum/migrations/0023_allow_blank_solved_by_topic_field.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("forum", "0022_topic_github_repository_name"),

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -18,7 +18,6 @@ from zds.utils.models import Alert, Tag
 
 class ForumMemberTests(TestCase):
     def setUp(self):
-
         settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
         self.category1 = ForumCategoryFactory(position=1)
@@ -383,7 +382,6 @@ class ForumMemberTests(TestCase):
         self.assertEqual(result.status_code, 404)
 
     def test_edit_post_with_blank(self):
-
         topic1 = TopicFactory(forum=self.forum11, author=self.user)
         PostFactory(topic=topic1, author=self.user, position=1)
         post2 = PostFactory(topic=topic1, author=self.user, position=2)
@@ -661,7 +659,6 @@ class ForumMemberTests(TestCase):
         self.assertEqual(Post.objects.filter(topic=topic1.pk).count(), 1)
 
     def test_add_tag(self):
-
         tag_c_sharp = TagFactory(title="C#")
 
         tag_c = TagFactory(title="C")
@@ -824,7 +821,6 @@ class ForumMemberTests(TestCase):
 
 class ForumGuestTests(TestCase):
     def setUp(self):
-
         settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
         self.category1 = ForumCategoryFactory(position=1)
@@ -1163,7 +1159,6 @@ def get_topics(forum_pk, is_sticky, filter=None):
 
 class ManagerTests(TestCase):
     def setUp(self):
-
         self.cat1 = ForumCategoryFactory()
         self.forum1 = ForumFactory(category=self.cat1)
         self.forum2 = ForumFactory(category=self.cat1)
@@ -1180,7 +1175,6 @@ class ManagerTests(TestCase):
         TopicFactory(forum=self.forum3, author=self.staff.user)
 
     def test_get_last_topics(self):
-
         topics = Topic.objects.get_last_topics()
         self.assertEqual(2, len(topics))
 

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -34,7 +34,6 @@ from zds.utils.paginator import ZdSPagingListView
 
 
 class CategoriesForumsListView(ListView):
-
     context_object_name = "categories"
     template_name = "forum/index.html"
     queryset = ForumCategory.objects.all()
@@ -47,7 +46,6 @@ class CategoriesForumsListView(ListView):
 
 
 class ForumCategoryForumsDetailView(DetailView):
-
     context_object_name = "category"
     template_name = "forum/category/index.html"
     queryset = ForumCategory.objects.all()
@@ -59,7 +57,6 @@ class ForumCategoryForumsDetailView(DetailView):
 
 
 class LastTopicsListView(ListView):
-
     context_object_name = "topics"
     template_name = "forum/last_topics.html"
 
@@ -84,7 +81,6 @@ class LastTopicsListView(ListView):
 
 
 class ForumTopicsListView(FilterMixin, ForumEditMixin, ZdSPagingListView, UpdateView, SingleObjectMixin):
-
     context_object_name = "topics"
     paginate_by = settings.ZDS_APP["forum"]["topics_per_page"]
     template_name = "forum/category/forum.html"
@@ -169,7 +165,6 @@ class ForumTopicsListView(FilterMixin, ForumEditMixin, ZdSPagingListView, Update
 
 
 class TopicPostsListView(ZdSPagingListView, FeatureableMixin, SingleObjectMixin):
-
     context_object_name = "posts"
     paginate_by = settings.ZDS_APP["forum"]["posts_per_page"]
     template_name = "forum/topic/index.html"
@@ -240,7 +235,6 @@ class TopicPostsListView(ZdSPagingListView, FeatureableMixin, SingleObjectMixin)
 
 
 class TopicNew(CreateView, SingleObjectMixin):
-
     template_name = "forum/topic/new.html"
     form_class = TopicForm
     object = None
@@ -299,7 +293,6 @@ class TopicNew(CreateView, SingleObjectMixin):
 
 
 class TopicEdit(UpdateView, SingleObjectMixin, TopicEditMixin, FeatureableMixin):
-
     template_name = "forum/topic/edit.html"
     form_class = TopicForm
     object = None
@@ -427,7 +420,6 @@ class TopicEdit(UpdateView, SingleObjectMixin, TopicEditMixin, FeatureableMixin)
 
 
 class FindTopic(ZdSPagingListView, SingleObjectMixin):
-
     context_object_name = "topics"
     template_name = "forum/find/topic.html"
     paginate_by = settings.ZDS_APP["forum"]["topics_per_page"]
@@ -490,7 +482,6 @@ class FindFollowedTopic(ZdSPagingListView, SingleObjectMixin):
 
 
 class FindTopicByTag(FilterMixin, ForumEditMixin, ZdSPagingListView, SingleObjectMixin):
-
     context_object_name = "topics"
     paginate_by = settings.ZDS_APP["forum"]["topics_per_page"]
     template_name = "forum/find/topic_by_tag.html"
@@ -553,7 +544,6 @@ class FindTopicByTag(FilterMixin, ForumEditMixin, ZdSPagingListView, SingleObjec
 
 
 class PostNew(CreatePostView):
-
     model_quote = Post
     template_name = "forum/post/new.html"
     form_class = PostForm
@@ -600,7 +590,6 @@ class PostNew(CreatePostView):
 
 
 class PostEdit(UpdateView, SinglePostObjectMixin, PostEditMixin):
-
     template_name = "forum/post/edit.html"
     form_class = PostForm
 
@@ -687,7 +676,6 @@ class PostEdit(UpdateView, SinglePostObjectMixin, PostEditMixin):
 
 
 class PostSignal(UpdateView, SinglePostObjectMixin, PostEditMixin):
-
     http_method_names = ["post"]
 
     @method_decorator(login_required)
@@ -751,7 +739,6 @@ class PostUnread(UpdateView, SinglePostObjectMixin, PostEditMixin):
 
 
 class FindPost(ZdSPagingListView, SingleObjectMixin):
-
     context_object_name = "posts"
     template_name = "forum/find/post.html"
     paginate_by = settings.ZDS_APP["forum"]["posts_per_page"]

--- a/zds/gallery/api/serializers.py
+++ b/zds/gallery/api/serializers.py
@@ -117,7 +117,6 @@ class CustomPermissionField(serializers.Field):
 
 
 class ParticipantSerializer(ZdSModelSerializer, GalleryUpdateOrDeleteMixin):
-
     permissions = CustomPermissionField(source="can_write", read_only=True)
     id = serializers.IntegerField(source="user.pk", required=False)
     can_write = serializers.BooleanField(write_only=True)
@@ -130,7 +129,6 @@ class ParticipantSerializer(ZdSModelSerializer, GalleryUpdateOrDeleteMixin):
         return {"read": True, "write": obj.can_write()}
 
     def create(self, validated_data):
-
         if "user" not in validated_data:
             raise exceptions.ValidationError(_("Le champ `id` est obligatoire pour l'ajout d'un participant"))
 

--- a/zds/gallery/api/tests.py
+++ b/zds/gallery/api/tests.py
@@ -35,7 +35,6 @@ class GalleryListAPITest(APITestCase):
         self.assertIsNone(response.data.get("previous"))
 
     def test_get_list_of_gallery(self):
-
         gallery = GalleryFactory()
         UserGalleryFactory(user=self.profile.user, gallery=gallery)
         response = self.client.get(reverse("api:gallery:list"))
@@ -210,7 +209,6 @@ class GalleryDetailAPITest(TutorialTestMixin, APITestCase):
         self.assertEqual(UserGallery.objects.filter(gallery=self.gallery).count(), 1)
 
     def test_delete_fail_linked_content(self):
-
         response = self.client.delete(reverse("api:gallery:detail", kwargs={"pk": self.gallery_tuto.pk}))
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/zds/gallery/api/views.py
+++ b/zds/gallery/api/views.py
@@ -25,7 +25,6 @@ class PagingGalleryListKeyConstructor(PagingListKeyConstructor):
 
 
 class GalleryListView(ListCreateAPIView):
-
     filter_backends = (filters.SearchFilter, filters.OrderingFilter)
     search_fields = ("title",)
     ordering_fields = ("title", "update", "pubdate")
@@ -105,7 +104,6 @@ class GalleryDetailKeyConstructor(DetailKeyConstructor):
 
 
 class GalleryDetailView(RetrieveUpdateDestroyAPIView, NoPatchView, GalleryUpdateOrDeleteMixin):
-
     queryset = Gallery.objects.annotated_gallery()
     list_key_func = GalleryDetailKeyConstructor()
 
@@ -208,7 +206,6 @@ class PagingImageListKeyConstructor(PagingListKeyConstructor):
 
 
 class ImageListView(ListCreateAPIView):
-
     filter_backends = (filters.SearchFilter, filters.OrderingFilter)
     search_fields = ("title",)
     ordering_fields = ("title", "update", "pubdate")
@@ -307,7 +304,6 @@ class ImageDetailKeyConstructor(DetailKeyConstructor):
 
 
 class ImageDetailView(RetrieveUpdateDestroyAPIView, NoPatchView, ImageUpdateOrDeleteMixin):
-
     queryset = Image.objects
     list_key_func = ImageDetailKeyConstructor()
 
@@ -413,7 +409,6 @@ class PagingParticipantListKeyConstructor(PagingListKeyConstructor):
 
 
 class ParticipantListView(ListCreateAPIView):
-
     filter_backends = (filters.OrderingFilter,)
     ordering_fields = ("id",)
     list_key_func = PagingParticipantListKeyConstructor()
@@ -496,7 +491,6 @@ class ParticipantDetailKeyConstructor(DetailKeyConstructor):
 
 
 class ParticipantDetailView(RetrieveUpdateDestroyAPIView, NoPatchView, GalleryUpdateOrDeleteMixin):
-
     list_key_func = ParticipantDetailKeyConstructor()
     lookup_field = "user__pk"
 

--- a/zds/gallery/migrations/0001_initial.py
+++ b/zds/gallery/migrations/0001_initial.py
@@ -5,7 +5,6 @@ import zds.gallery.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/zds/gallery/migrations/0002_auto_20150409_2122.py
+++ b/zds/gallery/migrations/0002_auto_20150409_2122.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("gallery", "0001_initial"),
     ]

--- a/zds/gallery/migrations/0003_auto_20150928_1249.py
+++ b/zds/gallery/migrations/0003_auto_20150928_1249.py
@@ -4,7 +4,6 @@ import easy_thumbnails.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("gallery", "0002_auto_20150409_2122"),
     ]

--- a/zds/gallery/migrations/0004_python_3.py
+++ b/zds/gallery/migrations/0004_python_3.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("gallery", "0003_auto_20150928_1249"),
     ]

--- a/zds/gallery/migrations/0005_auto_20180816_2256.py
+++ b/zds/gallery/migrations/0005_auto_20180816_2256.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("gallery", "0004_python_3"),
     ]

--- a/zds/gallery/migrations/0006_usergallery_is_default.py
+++ b/zds/gallery/migrations/0006_usergallery_is_default.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("gallery", "0005_auto_20180816_2256"),
     ]

--- a/zds/gallery/migrations/0007_auto_20191122_1154.py
+++ b/zds/gallery/migrations/0007_auto_20191122_1154.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("gallery", "0006_usergallery_is_default"),
     ]

--- a/zds/gallery/mixins.py
+++ b/zds/gallery/mixins.py
@@ -196,7 +196,6 @@ class GalleryUpdateOrDeleteMixin(GalleryMixin):
 
 
 class ImageMixin(GalleryMixin):
-
     image = None
 
     def get_image(self, pk):

--- a/zds/gallery/tests/tests_forms.py
+++ b/zds/gallery/tests/tests_forms.py
@@ -99,7 +99,6 @@ class ImageFormTest(TestCase):
         upload_file.close()
 
     def test_empty_pic_image_form(self):
-
         data = {
             "title": "Test Title",
             "legend": "Test Legend",

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -507,7 +507,6 @@ class EditImageViewTest(TestCase):
         self.client.force_login(self.profile3.user)
 
         with (settings.BASE_DIR / "fixtures" / "logo.png").open("rb") as fp:
-
             self.client.post(
                 reverse("gallery:image-edit", args=[self.gallery.pk, self.image.pk]),
                 {"title": "modify with no perms", "legend": "test legend", "physical": fp},

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -144,7 +144,6 @@ class EditGallery(LoggedWithReadWriteHability, GalleryUpdateOrDeleteMixin, FormV
         return context
 
     def form_valid(self, form):
-
         self.perform_update(
             {
                 "title": form.cleaned_data["title"],
@@ -157,7 +156,6 @@ class EditGallery(LoggedWithReadWriteHability, GalleryUpdateOrDeleteMixin, FormV
 
 
 class DeleteGalleries(LoggedWithReadWriteHability, GalleryUpdateOrDeleteMixin, View):
-
     http_method_names = ["post"]
 
     def post(self, request, *args, **kwargs):
@@ -408,7 +406,6 @@ class DeleteImages(ImageFromGalleryViewMixin, ImageUpdateOrDeleteMixin, LoggedWi
     must_write = True
 
     def delete(self, request, *args, **kwargs):
-
         if "delete_multi" in request.POST:
             list_items = request.POST.getlist("g_items")
             Image.objects.filter(pk__in=list_items, gallery=self.gallery).delete()

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -467,7 +467,6 @@ class UnregisterForm(PasswordRequiredForm):
 
 # TODO: Updates the password --> requires a better name
 class ChangePasswordForm(PasswordRequiredForm):
-
     password_new = forms.CharField(
         label=_("Nouveau mot de passe"),
         min_length=MIN_PASSWORD_LENGTH,

--- a/zds/member/migrations/0001_initial.py
+++ b/zds/member/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/zds/member/migrations/0002_auto_20150601_1144.py
+++ b/zds/member/migrations/0002_auto_20150601_1144.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0001_initial"),
     ]

--- a/zds/member/migrations/0003_auto_20151019_2333.py
+++ b/zds/member/migrations/0003_auto_20151019_2333.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0002_auto_20150601_1144"),
     ]

--- a/zds/member/migrations/0004_profile_allow_temp_visual_changes.py
+++ b/zds/member/migrations/0004_profile_allow_temp_visual_changes.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0003_auto_20151019_2333"),
     ]

--- a/zds/member/migrations/0005_profile_github_token.py
+++ b/zds/member/migrations/0005_profile_github_token.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0004_profile_allow_temp_visual_changes"),
     ]

--- a/zds/member/migrations/0006_auto_20161119_1650.py
+++ b/zds/member/migrations/0006_auto_20161119_1650.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0005_profile_github_token"),
     ]

--- a/zds/member/migrations/0007_auto_20161119_1836.py
+++ b/zds/member/migrations/0007_auto_20161119_1836.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0006_auto_20161119_1650"),
     ]

--- a/zds/member/migrations/0008_remove_profile_sdz_tutorial.py
+++ b/zds/member/migrations/0008_remove_profile_sdz_tutorial.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0007_auto_20161119_1836"),
     ]

--- a/zds/member/migrations/0009_profile_show_staff_badge.py
+++ b/zds/member/migrations/0009_profile_show_staff_badge.py
@@ -18,7 +18,6 @@ def forwards_func(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0008_remove_profile_sdz_tutorial"),
     ]

--- a/zds/member/migrations/0010_profile_show_markdown_help.py
+++ b/zds/member/migrations/0010_profile_show_markdown_help.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0009_profile_show_staff_badge"),
     ]

--- a/zds/member/migrations/0011_bannedemailprovider_newemailprovider.py
+++ b/zds/member/migrations/0011_bannedemailprovider_newemailprovider.py
@@ -827,7 +827,6 @@ def forwards_func(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("member", "0010_profile_show_markdown_help"),

--- a/zds/member/migrations/0012_profile_licence.py
+++ b/zds/member/migrations/0012_profile_licence.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0012_commentedit"),
         ("member", "0011_bannedemailprovider_newemailprovider"),

--- a/zds/member/migrations/0013_auto_20170807_1930.py
+++ b/zds/member/migrations/0013_auto_20170807_1930.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0012_profile_licence"),
     ]

--- a/zds/member/migrations/0014_profile_use_old_smileys.py
+++ b/zds/member/migrations/0014_profile_use_old_smileys.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0013_auto_20170807_1930"),
     ]

--- a/zds/member/migrations/0015_auto_20170905_2220.py
+++ b/zds/member/migrations/0015_auto_20170905_2220.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0014_auto_20170905_2220"),
         ("member", "0014_profile_use_old_smileys"),

--- a/zds/member/migrations/0016_python_3.py
+++ b/zds/member/migrations/0016_python_3.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0015_auto_20170905_2220"),
     ]

--- a/zds/member/migrations/0017_profile_email_for_new_mp.py
+++ b/zds/member/migrations/0017_profile_email_for_new_mp.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0016_python_3"),
     ]

--- a/zds/member/migrations/0018_auto_20190114_1301.py
+++ b/zds/member/migrations/0018_auto_20190114_1301.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0017_profile_email_for_new_mp"),
     ]

--- a/zds/member/migrations/0019_profile_username_skeleton.py
+++ b/zds/member/migrations/0019_profile_username_skeleton.py
@@ -20,7 +20,6 @@ def remove_skeleton(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0018_auto_20190114_1301"),
     ]

--- a/zds/member/migrations/0020_auto_20201018_0841.py
+++ b/zds/member/migrations/0020_auto_20201018_0841.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0019_profile_username_skeleton"),
     ]

--- a/zds/member/migrations/0021_remove_profile_use_old_smileys.py
+++ b/zds/member/migrations/0021_remove_profile_use_old_smileys.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0020_auto_20201018_0841"),
     ]

--- a/zds/member/migrations/0022_add_hide_forum_activity.py
+++ b/zds/member/migrations/0022_add_hide_forum_activity.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0021_remove_profile_use_old_smileys"),
     ]

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -213,7 +213,6 @@ class MiniProfileFormTest(TestCase):
         self.assertTrue(form.is_valid())
 
     def test_too_long_site_url_miniprofile_form(self):
-
         # url is one char too long
         data = {"biography": "", "site": stringof2001chars, "avatar_url": "", "sign": ""}
         form = MiniProfileForm(data=data)

--- a/zds/member/tests/tests_models.py
+++ b/zds/member/tests/tests_models.py
@@ -257,7 +257,6 @@ class MemberModelsTest(TutorialTestMixin, TestCase):
         self.assertEqual(self.user1.get_active_alerts_count(), 1)
 
     def test_can_read_now(self):
-
         profile = ProfileFactory()
         profile.is_active = True
         profile.can_read = True
@@ -284,7 +283,6 @@ class MemberModelsTest(TutorialTestMixin, TestCase):
         self.assertFalse(self.user1.can_read_now())
 
     def test_can_write_now(self):
-
         self.user1.user.is_active = True
         self.user1.user.can_write = True
         self.assertTrue(self.user1.can_write_now())

--- a/zds/member/tests/views/tests_moderation.py
+++ b/zds/member/tests/views/tests_moderation.py
@@ -301,7 +301,6 @@ class TestsModeration(TestCase):
         self.assertEqual(result.status_code, 302)
 
     def test_failed_bot_sanctions(self):
-
         staff = StaffProfileFactory()
         self.client.force_login(staff.user)
 

--- a/zds/member/tests/views/tests_profile.py
+++ b/zds/member/tests/views/tests_profile.py
@@ -105,7 +105,6 @@ class MemberTests(TutorialTestMixin, TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_profile_page_of_weird_member_username(self):
-
         # create some user with weird username
         user_1 = ProfileFactory()
         user_2 = ProfileFactory()
@@ -147,7 +146,6 @@ class MemberTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
     def test_success_preview_biography(self):
-
         member = ProfileFactory()
         self.client.force_login(member.user)
 

--- a/zds/member/views/password_recovery.py
+++ b/zds/member/views/password_recovery.py
@@ -20,7 +20,6 @@ def forgot_password(request):
     if request.method == "POST":
         form = UsernameAndEmailForm(request.POST)
         if form.is_valid():
-
             # Get data from form
             data = form.data
             username = data["username"]

--- a/zds/member/views/register.py
+++ b/zds/member/views/register.py
@@ -101,7 +101,6 @@ class SendValidationEmailView(FormView, TokenGenerator):
     usr = None
 
     def get_user(self, username, email):
-
         if username:
             self.usr = get_object_or_404(User, username=username)
 

--- a/zds/migrations/oauth2_provider/0001_initial.py
+++ b/zds/migrations/oauth2_provider/0001_initial.py
@@ -5,7 +5,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/zds/mp/migrations/0001_initial.py
+++ b/zds/mp/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/zds/mp/migrations/0002_auto_20150416_1750.py
+++ b/zds/mp/migrations/0002_auto_20150416_1750.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("mp", "0001_initial"),
     ]

--- a/zds/mp/migrations/0003_privatepost_hat.py
+++ b/zds/mp/migrations/0003_privatepost_hat.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0014_auto_20170905_2220"),
         ("mp", "0002_auto_20150416_1750"),

--- a/zds/mp/migrations/0004_python_3.py
+++ b/zds/mp/migrations/0004_python_3.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("mp", "0003_privatepost_hat"),
     ]

--- a/zds/mp/migrations/0005_auto_20190110_1310.py
+++ b/zds/mp/migrations/0005_auto_20190110_1310.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("mp", "0004_python_3"),
     ]

--- a/zds/mp/migrations/0006_auto_20190114_1301.py
+++ b/zds/mp/migrations/0006_auto_20190114_1301.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("mp", "0005_auto_20190110_1310"),
     ]

--- a/zds/mp/migrations/0007_add_votes_to_private_post.py
+++ b/zds/mp/migrations/0007_add_votes_to_private_post.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("mp", "0006_auto_20190114_1301"),

--- a/zds/mp/tests/tests_utils.py
+++ b/zds/mp/tests/tests_utils.py
@@ -75,7 +75,6 @@ class MpUtilTest(TestCase):
         PrivateTopic.objects.all().delete()
 
     def test_answer_mp_email(self):
-
         # Create a MP
         self.client.post(
             reverse("mp:create"),

--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -32,7 +32,6 @@ class IndexViewTest(TestCase):
         self.assertEqual(0, PrivateTopic.objects.filter(pk=topic.pk).count())
 
     def test_success_delete_topic_as_author(self):
-
         self.client.force_login(self.profile1.user)
 
         response = self.client.post(reverse("mp:list-delete"), {"items": [self.topic1.pk]})
@@ -44,7 +43,6 @@ class IndexViewTest(TestCase):
         self.assertNotIn(self.profile2.user, topic.participants.all())
 
     def test_success_delete_topic_as_participant(self):
-
         self.client.force_login(self.profile2.user)
 
         response = self.client.post(reverse("mp:list-delete"), {"items": [self.topic1.pk]})
@@ -121,7 +119,6 @@ class TopicViewTest(TestCase):
         self.post2 = PrivatePostFactory(privatetopic=self.topic1, author=self.profile2.user, position_in_topic=2)
 
     def test_fail_topic_no_exist(self):
-
         self.client.force_login(self.profile1.user)
 
         response = self.client.get(reverse("mp:view", args=[12, "private-topic"]))
@@ -230,14 +227,12 @@ class NewTopicViewTest(TestCase):
         self.client.force_login(self.profile1.user)
 
     def test_denies_anonymous(self):
-
         self.client.logout()
         response = self.client.get(reverse("mp:create"), follow=True)
 
         self.assertRedirects(response, reverse("member-login") + "?next=" + reverse("mp:create"))
 
     def test_success_get_with_and_without_username(self):
-
         response = self.client.get(reverse("mp:create"))
 
         self.assertEqual(200, response.status_code)
@@ -249,7 +244,6 @@ class NewTopicViewTest(TestCase):
         self.assertEqual(self.profile2.user.username, response2.context["form"].initial["participants"])
 
     def test_success_get_with_multi_username(self):
-
         profile3 = ProfileFactory()
 
         response = self.client.get(
@@ -263,7 +257,6 @@ class NewTopicViewTest(TestCase):
         self.assertTrue(profile3.user.username in response.context["form"].initial["participants"])
 
     def test_success_get_with_and_without_title(self):
-
         response = self.client.get(reverse("mp:create"))
 
         self.assertEqual(200, response.status_code)
@@ -275,14 +268,12 @@ class NewTopicViewTest(TestCase):
         self.assertEqual("Test titre", response2.context["form"].initial["title"])
 
     def test_fail_get_with_username_not_exist(self):
-
         response2 = self.client.get(reverse("mp:create") + "?username=wrongusername")
 
         self.assertEqual(200, response2.status_code)
         self.assertEqual(response2.context["form"].initial["participants"], "")
 
     def test_success_preview(self):
-
         self.assertEqual(0, PrivateTopic.objects.all().count())
         response = self.client.post(
             reverse("mp:create"),
@@ -299,7 +290,6 @@ class NewTopicViewTest(TestCase):
         self.assertEqual(0, PrivateTopic.objects.all().count())
 
     def test_fail_new_topic_user_no_exist(self):
-
         self.assertEqual(0, PrivateTopic.objects.all().count())
         response = self.client.post(
             reverse("mp:create"),
@@ -310,7 +300,6 @@ class NewTopicViewTest(TestCase):
         self.assertEqual(0, PrivateTopic.objects.all().count())
 
     def test_fail_new_topic_user_no_active(self):
-
         profile_inactive = ProfileFactory()
         profile_inactive.user.is_active = False
         profile_inactive.user.save()
@@ -330,7 +319,6 @@ class NewTopicViewTest(TestCase):
         self.assertEqual(0, PrivateTopic.objects.all().count())
 
     def test_success_new_topic(self):
-
         self.assertEqual(0, PrivateTopic.objects.all().count())
         response = self.client.post(
             reverse("mp:create"),
@@ -358,7 +346,6 @@ class NewTopicViewTest(TestCase):
         self.assertEqual(PrivatePost.objects.latest("pubdate").hat, self.hat)
 
     def test_fail_new_topic_user_add_only_himself(self):
-
         self.assertEqual(0, PrivateTopic.objects.all().count())
         response = self.client.post(
             reverse("mp:create"),
@@ -370,7 +357,6 @@ class NewTopicViewTest(TestCase):
         self.assertEqual(0, PrivateTopic.objects.all().count())
 
     def test_fail_new_topic_user_add_himself_and_others(self):
-
         self.assertEqual(0, PrivateTopic.objects.all().count())
 
         participants = self.profile2.user.username
@@ -404,7 +390,6 @@ class AnswerViewTest(TestCase):
         self.client.force_login(self.profile1.user)
 
     def test_denies_anonymous(self):
-
         self.client.logout()
         response = self.client.get(reverse("mp:answer", args=[1, "private-topic"]), follow=True)
 
@@ -413,19 +398,16 @@ class AnswerViewTest(TestCase):
         )
 
     def test_fail_answer_not_send_topic_pk(self):
-
         response = self.client.post(reverse("mp:answer", args=[999, "private-topic"]))
 
         self.assertEqual(404, response.status_code)
 
     def test_fail_answer_topic_no_exist(self):
-
         response = self.client.post(reverse("mp:answer", args=[156, "private-topic"]))
 
         self.assertEqual(404, response.status_code)
 
     def test_fail_cite_post_no_exist(self):
-
         response = self.client.get(reverse("mp:answer", args=[self.topic1.pk, self.topic1.slug()]) + "&cite=4864")
 
         self.assertEqual(404, response.status_code)
@@ -446,7 +428,6 @@ class AnswerViewTest(TestCase):
         self.assertEqual(404, response.status_code)
 
     def test_success_cite_post(self):
-
         response = self.client.get(
             reverse("mp:answer", args=[self.topic1.pk, self.topic1.slug()]) + f"?cite={self.post2.pk}"
         )
@@ -454,7 +435,6 @@ class AnswerViewTest(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_success_preview_answer(self):
-
         response = self.client.post(
             reverse("mp:answer", args=[self.topic1.pk, self.topic1.slug()]),
             {"text": "answer", "preview": "", "last_post": self.topic1.last_message.pk},
@@ -464,7 +444,6 @@ class AnswerViewTest(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_success_answer(self):
-
         response = self.client.post(
             reverse("mp:answer", args=[self.topic1.pk, self.topic1.slug()]),
             {"text": "Bonjour Luc", "last_post": self.topic1.last_message.pk},
@@ -490,7 +469,6 @@ class AnswerViewTest(TestCase):
         self.assertEqual(PrivatePost.objects.latest("pubdate").hat, self.hat)
 
     def test_fail_answer_with_no_right(self):
-
         self.client.logout()
         self.client.force_login(self.profile3.user)
 
@@ -546,7 +524,6 @@ class EditPostViewTest(TestCase):
         self.client.force_login(self.profile1.user)
 
     def test_denies_anonymous(self):
-
         self.client.logout()
         response = self.client.get(reverse("mp:post-edit", args=[1]), follow=True)
 
@@ -564,7 +541,6 @@ class EditPostViewTest(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_fail_edit_post_no_exist(self):
-
         response = self.client.get(reverse("mp:post-edit", args=[154]))
 
         self.assertEqual(404, response.status_code)
@@ -580,7 +556,6 @@ class EditPostViewTest(TestCase):
         self.assertEqual(403, response.status_code)
 
     def test_success_edit_post(self):
-
         self.client.logout()
         self.client.force_login(self.profile2.user)
 
@@ -643,7 +618,6 @@ class LeaveViewTest(TestCase):
         self.client.force_login(self.profile1.user)
 
     def test_denies_anonymous(self):
-
         self.client.logout()
         response = self.client.get(reverse("mp:leave", args=[1, "private-topic"]), follow=True)
 
@@ -660,13 +634,11 @@ class LeaveViewTest(TestCase):
         self.assertEqual(1, PrivateTopic.objects.filter(pk=self.topic1.pk).count())
 
     def test_fail_leave_topic_no_exist(self):
-
         response = self.client.post(reverse("mp:leave", args=[999, "private-topic"]))
 
         self.assertEqual(404, response.status_code)
 
     def test_success_leave_topic_as_author_no_participants(self):
-
         self.topic1.participants.clear()
         self.topic1.save()
 
@@ -676,7 +648,6 @@ class LeaveViewTest(TestCase):
         self.assertEqual(0, PrivateTopic.objects.filter(pk=self.topic1.pk).all().count())
 
     def test_success_leave_topic_as_author(self):
-
         response = self.client.post(reverse("mp:leave", args=[self.topic1.pk, self.topic1.slug()]), follow=True)
 
         self.assertEqual(200, response.status_code)
@@ -685,7 +656,6 @@ class LeaveViewTest(TestCase):
         self.assertEqual(self.profile2.user, PrivateTopic.objects.get(pk=self.topic1.pk).author)
 
     def test_success_leave_topic_as_participant(self):
-
         self.client.logout()
         self.client.force_login(self.profile2.user)
 
@@ -717,7 +687,6 @@ class AddParticipantViewTest(TestCase):
         self.client.force_login(self.profile1.user)
 
     def test_denies_anonymous(self):
-
         self.client.logout()
         response = self.client.get(reverse("mp:edit-participant", args=[1, "private-topic"]), follow=True)
 
@@ -726,7 +695,6 @@ class AddParticipantViewTest(TestCase):
         )
 
     def test_fail_add_participant_topic_no_exist(self):
-
         response = self.client.post(reverse("mp:edit-participant", args=[451, "private-topic"]), follow=True)
 
         self.assertEqual(404, response.status_code)
@@ -745,7 +713,6 @@ class AddParticipantViewTest(TestCase):
         self.assertFalse(self.anonymous_account in self.topic1.participants.all())
 
     def test_fail_add_participant_who_no_exist(self):
-
         response = self.client.post(
             reverse("mp:edit-participant", args=[self.topic1.pk, self.topic1.slug()]),
             {"username": "178548"},
@@ -770,7 +737,6 @@ class AddParticipantViewTest(TestCase):
         self.assertNotIn(profile3.user, PrivateTopic.objects.get(pk=self.topic1.pk).participants.all())
 
     def test_fail_add_participant_already_in(self):
-
         response = self.client.post(
             reverse("mp:edit-participant", args=[self.topic1.pk, self.topic1.slug()]),
             {"username": self.profile2.user.username},
@@ -781,7 +747,6 @@ class AddParticipantViewTest(TestCase):
         self.assertEqual(1, len(response.context["messages"]))
 
     def test_success_add_participant(self):
-
         profile3 = ProfileFactory()
 
         response = self.client.post(
@@ -806,7 +771,6 @@ class PrivateTopicEditTest(TestCase):
         self.post2 = PrivatePostFactory(privatetopic=self.topic1, author=self.profile2.user, position_in_topic=2)
 
     def test_denies_anonymous(self):
-
         self.client.logout()
         self.topic1.title = "super title"
         self.topic1.subtitle = "super subtitle"
@@ -852,7 +816,6 @@ class PrivateTopicEditTest(TestCase):
         self.assertEqual("subtest", topic.subtitle)
 
     def test_fail_user_is_not_author(self):
-
         self.topic1.title = "super title"
         self.topic1.subtitle = "super subtitle"
         self.topic1.save()
@@ -888,7 +851,6 @@ class PrivateTopicEditTest(TestCase):
         self.assertEqual(404, response.status_code)
 
     def test_fail_blank_title(self):
-
         self.topic1.title = "super title"
         self.topic1.subtitle = "super subtitle"
         self.topic1.save()

--- a/zds/notification/migrations/0001_initial.py
+++ b/zds/notification/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0005_auto_20151119_2224"),
     ]

--- a/zds/notification/migrations/0002_auto_20151219_2302.py
+++ b/zds/notification/migrations/0002_auto_20151219_2302.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("contenttypes", "0001_initial"),
         ("member", "0004_profile_allow_temp_visual_changes"),

--- a/zds/notification/migrations/0004_auto_20160110_1221.py
+++ b/zds/notification/migrations/0004_auto_20160110_1221.py
@@ -3,7 +3,6 @@ import zds.notification.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0003_auto_20160103_0001"),
     ]

--- a/zds/notification/migrations/0005_auto_20160111_1936.py
+++ b/zds/notification/migrations/0005_auto_20160111_1936.py
@@ -3,7 +3,6 @@ import zds.notification.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0004_auto_20160110_1221"),
     ]

--- a/zds/notification/migrations/0006_auto_20160115_1724.py
+++ b/zds/notification/migrations/0006_auto_20160115_1724.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0005_auto_20160111_1936"),
     ]

--- a/zds/notification/migrations/0007_auto_20160121_2343.py
+++ b/zds/notification/migrations/0007_auto_20160121_2343.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("notification", "0006_auto_20160115_1724"),

--- a/zds/notification/migrations/0008_auto_20160507_1504.py
+++ b/zds/notification/migrations/0008_auto_20160507_1504.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0007_auto_20160121_2343"),
     ]

--- a/zds/notification/migrations/0009_newtopicsubscription.py
+++ b/zds/notification/migrations/0009_newtopicsubscription.py
@@ -3,7 +3,6 @@ import zds.notification.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0008_auto_20160507_1504"),
     ]

--- a/zds/notification/migrations/0010_newpublicationsubscription.py
+++ b/zds/notification/migrations/0010_newpublicationsubscription.py
@@ -3,7 +3,6 @@ import zds.notification.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0009_newtopicsubscription"),
     ]

--- a/zds/notification/migrations/0011_notification_is_dead.py
+++ b/zds/notification/migrations/0011_notification_is_dead.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0010_newpublicationsubscription"),
     ]

--- a/zds/notification/migrations/0012_auto_20160703_2255.py
+++ b/zds/notification/migrations/0012_auto_20160703_2255.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0011_notification_is_dead"),
     ]

--- a/zds/notification/migrations/0013_clean_notifications.py
+++ b/zds/notification/migrations/0013_clean_notifications.py
@@ -10,7 +10,6 @@ def cleanup(apps, *_):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0012_auto_20160703_2255"),
     ]

--- a/zds/notification/migrations/0014_pingsubscription.py
+++ b/zds/notification/migrations/0014_pingsubscription.py
@@ -3,7 +3,6 @@ import zds.notification.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0013_clean_notifications"),
     ]

--- a/zds/notification/migrations/0015_python_3.py
+++ b/zds/notification/migrations/0015_python_3.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0014_pingsubscription"),
     ]

--- a/zds/notification/migrations/0016_auto_20190114_1301.py
+++ b/zds/notification/migrations/0016_auto_20190114_1301.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0015_python_3"),
     ]

--- a/zds/notification/migrations/0017_clean_notifications_new_topic_forums_groups.py
+++ b/zds/notification/migrations/0017_clean_notifications_new_topic_forums_groups.py
@@ -16,7 +16,6 @@ def cleanup(apps, *_):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notification", "0016_auto_20190114_1301"),
     ]

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -40,7 +40,6 @@ def remove_group_subscription_on_quitting_groups(*, sender, instance, action, pk
     if action not in ("pre_clear", "pre_remove"):  # only on updating
         return
     if action == "pre_clear":
-
         remove_group_subscription_on_quitting_groups(
             sender=sender,
             instance=instance,

--- a/zds/notification/tests/tests_tricky.py
+++ b/zds/notification/tests/tests_tricky.py
@@ -426,7 +426,6 @@ class ForumNotification(TestCase):
 @override_for_contents()
 class ContentNotification(TestCase, TutorialTestMixin):
     def setUp(self):
-
         # don't build PDF to speed up the tests
         self.user1 = ProfileFactory().user
         self.user2 = ProfileFactory().user

--- a/zds/pages/migrations/0001_initial.py
+++ b/zds/pages/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("auth", "0006_require_contenttypes_0002"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/zds/pages/migrations/0002_auto_20170831_1023.py
+++ b/zds/pages/migrations/0002_auto_20170831_1023.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("pages", "0001_initial"),

--- a/zds/pages/migrations/0003_python_3.py
+++ b/zds/pages/migrations/0003_python_3.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("pages", "0002_auto_20170831_1023"),
     ]

--- a/zds/searchv2/forms.py
+++ b/zds/searchv2/forms.py
@@ -34,7 +34,6 @@ class SearchForm(forms.Form):
     from_library = forms.CharField(widget=forms.HiddenInput, required=False)
 
     def __init__(self, *args, **kwargs):
-
         super().__init__(*args, **kwargs)
 
         self.helper = FormHelper()

--- a/zds/searchv2/management/commands/es_manager.py
+++ b/zds/searchv2/management/commands/es_manager.py
@@ -30,7 +30,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-
         if options["action"] == "setup":
             self.setup_es()
         elif options["action"] == "clear":
@@ -43,7 +42,6 @@ class Command(BaseCommand):
             raise CommandError("unknown action {}".format(options["action"]))
 
     def setup_es(self):
-
         self.index_manager.reset_es_index(self.models)
         self.index_manager.setup_custom_analyzer()
 
@@ -56,7 +54,6 @@ class Command(BaseCommand):
             self.index_manager.clear_indexing_of_model(model)
 
     def index_documents(self, force_reindexing=False):
-
         if force_reindexing:
             self.setup_es()  # remove all previous data
 

--- a/zds/searchv2/tests/tests_models.py
+++ b/zds/searchv2/tests/tests_models.py
@@ -16,7 +16,6 @@ from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 @override_for_contents(ES_ENABLED=True, ES_SEARCH_INDEX={"name": "zds_search_test", "shards": 5, "replicas": 0})
 class ESIndexManagerTests(TutorialTestMixin, TestCase):
     def setUp(self):
-
         settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
         self.mas = ProfileFactory().user
         settings.ZDS_APP["member"]["bot_account"] = self.mas.username

--- a/zds/searchv2/tests/tests_utils.py
+++ b/zds/searchv2/tests/tests_utils.py
@@ -18,7 +18,6 @@ from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 @override_for_contents(ES_ENABLED=True, ES_SEARCH_INDEX={"name": "zds_search_test", "shards": 5, "replicas": 0})
 class UtilsTests(TutorialTestMixin, TestCase):
     def setUp(self):
-
         settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
         self.mas = ProfileFactory().user
         settings.ZDS_APP["member"]["bot_account"] = self.mas.username

--- a/zds/searchv2/tests/tests_views.py
+++ b/zds/searchv2/tests/tests_views.py
@@ -29,7 +29,6 @@ from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 @override_for_contents(ES_ENABLED=True, ES_SEARCH_INDEX={"name": "zds_search_test", "shards": 1, "replicas": 0})
 class ViewsTests(TutorialTestMixin, TestCase):
     def setUp(self):
-
         settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
         self.mas = ProfileFactory().user
         settings.ZDS_APP["member"]["bot_account"] = self.mas.username
@@ -547,7 +546,6 @@ class ViewsTests(TutorialTestMixin, TestCase):
         # NOTE: score are NOT the same for all documents, no matter how hard it tries to, small differences exists
 
         for model in self.indexable:
-
             # set a huge number to overcome the small differences:
             settings.ZDS_APP["search"]["boosts"][model.get_es_document_type()]["global"] = 10.0
 
@@ -562,7 +560,6 @@ class ViewsTests(TutorialTestMixin, TestCase):
             settings.ZDS_APP["search"]["boosts"][model.get_es_document_type()]["global"] = 1.0
 
     def test_change_topic_impacts_posts(self):
-
         if not self.manager.connected_to_es:
             return
 
@@ -651,7 +648,6 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.assertEqual(response.hits.total, 0)  # ok
 
     def test_change_publishedcontents_impacts_chapter(self):
-
         if not self.manager.connected_to_es:
             return
 
@@ -740,7 +736,6 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.assertEqual(chapters[0].meta.id, published.content_public_slug + "__" + chapter2.slug)  # got new chapter
 
     def test_opensearch(self):
-
         result = self.client.get(reverse("search:opensearch"), follow=False)
 
         self.assertEqual(result.status_code, 200)

--- a/zds/searchv2/views.py
+++ b/zds/searchv2/views.py
@@ -173,7 +173,6 @@ class SearchView(ZdSPagingListView):
             return []
 
         if self.search_query:
-
             # Searches forums the user is allowed to visit
             self.authorized_forums = get_authorized_forums(self.request.user)
 

--- a/zds/settings/abstract_base/config.py
+++ b/zds/settings/abstract_base/config.py
@@ -25,7 +25,6 @@ django_setting = os.environ.get("DJANGO_SETTINGS_MODULE")
 key = "ensure_settings_module"
 
 if key in config and config[key] != django_setting:
-
     raise Exception(
         (
             "The DJANGO_SETTINGS_MODULE environment variable is different than "

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -48,7 +48,6 @@ class ReviewerTypeModelChoiceField(forms.ModelChoiceField):
 
 
 class ContributionForm(forms.Form):
-
     contribution_role = ReviewerTypeModelChoiceField(
         label=_("Role"),
         required=True,
@@ -102,7 +101,6 @@ class ContributionForm(forms.Form):
 
 
 class RemoveContributionForm(forms.Form):
-
     pk_contribution = forms.CharField(
         label=_("Contributeur"),
         required=True,
@@ -110,7 +108,6 @@ class RemoveContributionForm(forms.Form):
 
 
 class AuthorForm(forms.Form):
-
     username = forms.CharField(label=_("Auteurs à ajouter séparés d'une virgule."), required=True)
 
     def __init__(self, *args, **kwargs):
@@ -168,7 +165,6 @@ class RemoveAuthorForm(AuthorForm):
 
 
 class ContainerForm(FormWithTitle):
-
     introduction = forms.CharField(
         label=_("Introduction"),
         required=False,
@@ -230,7 +226,6 @@ class ContainerForm(FormWithTitle):
 
 
 class ContentForm(ContainerForm):
-
     description = forms.CharField(
         label=_("Description"),
         max_length=PublishableContent._meta.get_field("description").max_length,
@@ -416,7 +411,6 @@ class EditContentLicenseForm(forms.Form):
 
 
 class ExtractForm(FormWithTitle):
-
     text = forms.CharField(
         label=_("Texte"),
         required=False,
@@ -448,7 +442,6 @@ class ExtractForm(FormWithTitle):
 
 
 class ImportForm(forms.Form):
-
     file = forms.FileField(label=_("Sélectionnez le contenu à importer."), required=True)
     images = forms.FileField(label=_("Fichier zip contenant les images du contenu."), required=False)
 
@@ -487,7 +480,6 @@ class ImportForm(forms.Form):
 
 
 class ImportContentForm(forms.Form):
-
     archive = forms.FileField(label=_("Sélectionnez l'archive de votre contenu."), required=True)
     image_archive = forms.FileField(label=_("Sélectionnez l'archive des images."), required=False)
 
@@ -539,7 +531,6 @@ class ImportContentForm(forms.Form):
 
 
 class ImportNewContentForm(ImportContentForm):
-
     subcategory = forms.ModelMultipleChoiceField(
         label=_(
             "Sous catégories de votre contenu. Si aucune catégorie ne convient "
@@ -674,7 +665,6 @@ class NoteEditForm(NoteForm):
 
 
 class AskValidationForm(forms.Form):
-
     text = forms.CharField(
         label="",
         required=False,
@@ -752,7 +742,6 @@ class AskValidationForm(forms.Form):
 
 
 class AcceptValidationForm(forms.Form):
-
     validation = None
 
     text = forms.CharField(
@@ -799,7 +788,6 @@ class AcceptValidationForm(forms.Form):
 
 
 class CancelValidationForm(forms.Form):
-
     text = forms.CharField(
         label="",
         required=True,
@@ -849,7 +837,6 @@ class CancelValidationForm(forms.Form):
 
 
 class RejectValidationForm(forms.Form):
-
     text = forms.CharField(
         label="",
         required=True,
@@ -903,7 +890,6 @@ class RejectValidationForm(forms.Form):
 
 
 class RevokeValidationForm(forms.Form):
-
     version = forms.CharField(widget=forms.HiddenInput())
 
     text = forms.CharField(
@@ -949,7 +935,6 @@ class RevokeValidationForm(forms.Form):
 
 
 class JsFiddleActivationForm(forms.Form):
-
     js_support = forms.BooleanField(label="À cocher pour activer JSFiddle.", required=False, initial=True)
 
     def __init__(self, *args, **kwargs):
@@ -980,7 +965,6 @@ class JsFiddleActivationForm(forms.Form):
 
 
 class MoveElementForm(forms.Form):
-
     child_slug = forms.HiddenInput()
     container_slug = forms.HiddenInput()
     first_level_slug = forms.HiddenInput()
@@ -1006,7 +990,6 @@ class MoveElementForm(forms.Form):
 
 
 class WarnTypoForm(forms.Form):
-
     text = forms.CharField(
         label="",
         required=True,
@@ -1149,7 +1132,6 @@ class PublicationForm(forms.Form):
 
 
 class UnpublicationForm(forms.Form):
-
     version = forms.CharField(widget=forms.HiddenInput())
 
     text = forms.CharField(
@@ -1181,7 +1163,6 @@ class UnpublicationForm(forms.Form):
 
 
 class PickOpinionForm(forms.Form):
-
     version = forms.CharField(widget=forms.HiddenInput())
 
     def __init__(self, content, *args, **kwargs):
@@ -1245,7 +1226,6 @@ class DoNotPickOpinionForm(forms.Form):
 
 
 class UnpickOpinionForm(forms.Form):
-
     version = forms.CharField(widget=forms.HiddenInput())
 
     text = forms.CharField(
@@ -1274,7 +1254,6 @@ class UnpickOpinionForm(forms.Form):
 
 
 class PromoteOpinionToArticleForm(forms.Form):
-
     version = forms.CharField(widget=forms.HiddenInput())
 
     def __init__(self, content, *args, **kwargs):
@@ -1351,7 +1330,6 @@ class SearchSuggestionForm(forms.Form):
 
 
 class RemoveSuggestionForm(forms.Form):
-
     pk_suggestion = forms.IntegerField(
         label=_("Suggestion"),
         required=True,

--- a/zds/tutorialv2/management/commands/adjust_slugs.py
+++ b/zds/tutorialv2/management/commands/adjust_slugs.py
@@ -13,7 +13,6 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **options):
-
         for c in PublishableContent.objects.all():
             if "'" in c.title:
                 good_slug = slugify(c.title)

--- a/zds/tutorialv2/management/commands/migrate_to_zep25.py
+++ b/zds/tutorialv2/management/commands/migrate_to_zep25.py
@@ -14,7 +14,6 @@ from zds.mp.utils import send_mp
 
 @transaction.atomic
 class Command(BaseCommand):
-
     help = (
         "Change all content categories to tags (ZEP-25).\n\n\nOptions:\n\n  No options run all commands (except he"
         "lp) in this order : tags, categories, alert, prod\n\n  alert         Send a private message to all author"

--- a/zds/tutorialv2/migrations/0001_initial.py
+++ b/zds/tutorialv2/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("forum", "0002_auto_20150410_1505"),
         ("gallery", "0001_initial"),

--- a/zds/tutorialv2/migrations/0002_auto_20150417_0445.py
+++ b/zds/tutorialv2/migrations/0002_auto_20150417_0445.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0001_initial"),
     ]

--- a/zds/tutorialv2/migrations/0003_auto_20150423_1429.py
+++ b/zds/tutorialv2/migrations/0003_auto_20150423_1429.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0002_auto_20150417_0445"),
     ]

--- a/zds/tutorialv2/migrations/0004_publishablecontent_public_version.py
+++ b/zds/tutorialv2/migrations/0004_publishablecontent_public_version.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0003_auto_20150423_1429"),
     ]

--- a/zds/tutorialv2/migrations/0005_auto_20150510_2114.py
+++ b/zds/tutorialv2/migrations/0005_auto_20150510_2114.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0004_publishablecontent_public_version"),
     ]

--- a/zds/tutorialv2/migrations/0006_publishablecontent_must_reindex.py
+++ b/zds/tutorialv2/migrations/0006_publishablecontent_must_reindex.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0005_auto_20150510_2114"),
     ]

--- a/zds/tutorialv2/migrations/0007_auto_20150803_1059.py
+++ b/zds/tutorialv2/migrations/0007_auto_20150803_1059.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0006_publishablecontent_must_reindex"),
     ]

--- a/zds/tutorialv2/migrations/0008_publishedcontent_update_date.py
+++ b/zds/tutorialv2/migrations/0008_publishedcontent_update_date.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0007_auto_20150803_1059"),
     ]

--- a/zds/tutorialv2/migrations/0009_publishedcontent_authors.py
+++ b/zds/tutorialv2/migrations/0009_publishedcontent_authors.py
@@ -11,7 +11,6 @@ def put_authors(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("tutorialv2", "0008_publishedcontent_update_date"),

--- a/zds/tutorialv2/migrations/0010_publishedcontent_sizes.py
+++ b/zds/tutorialv2/migrations/0010_publishedcontent_sizes.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0009_publishedcontent_authors"),
     ]

--- a/zds/tutorialv2/migrations/0011_auto_20160106_2231.py
+++ b/zds/tutorialv2/migrations/0011_auto_20160106_2231.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0010_publishedcontent_sizes"),
     ]

--- a/zds/tutorialv2/migrations/0012_publishablecontent_tags.py
+++ b/zds/tutorialv2/migrations/0012_publishablecontent_tags.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0001_initial"),
         ("tutorialv2", "0011_auto_20160106_2231"),

--- a/zds/tutorialv2/migrations/0013_auto_20160320_0908.py
+++ b/zds/tutorialv2/migrations/0013_auto_20160320_0908.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0012_publishablecontent_tags"),
     ]

--- a/zds/tutorialv2/migrations/0014_auto_20160331_0415.py
+++ b/zds/tutorialv2/migrations/0014_auto_20160331_0415.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0013_auto_20160320_0908"),
     ]

--- a/zds/tutorialv2/migrations/0015_publishedcontent_nb_letter.py
+++ b/zds/tutorialv2/migrations/0015_publishedcontent_nb_letter.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0014_auto_20160331_0415"),
     ]

--- a/zds/tutorialv2/migrations/0016_auto_20170201_1940.py
+++ b/zds/tutorialv2/migrations/0016_auto_20170201_1940.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0015_publishedcontent_nb_letter"),
     ]

--- a/zds/tutorialv2/migrations/0017_auto_20170204_2239.py
+++ b/zds/tutorialv2/migrations/0017_auto_20170204_2239.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0016_auto_20170201_1940"),
     ]

--- a/zds/tutorialv2/migrations/0018_publishedcontent_is_obsolete.py
+++ b/zds/tutorialv2/migrations/0018_publishedcontent_is_obsolete.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0017_auto_20170204_2239"),
     ]

--- a/zds/tutorialv2/migrations/0019_auto_20170208_1347.py
+++ b/zds/tutorialv2/migrations/0019_auto_20170208_1347.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0018_publishedcontent_is_obsolete"),
     ]

--- a/zds/tutorialv2/migrations/0020_auto_20170401_1521.py
+++ b/zds/tutorialv2/migrations/0020_auto_20170401_1521.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0019_auto_20170208_1347"),
     ]

--- a/zds/tutorialv2/migrations/0021_picklistoperation.py
+++ b/zds/tutorialv2/migrations/0021_picklistoperation.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("tutorialv2", "0020_auto_20170401_1521"),

--- a/zds/tutorialv2/migrations/0022_python_3.py
+++ b/zds/tutorialv2/migrations/0022_python_3.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0021_picklistoperation"),
     ]

--- a/zds/tutorialv2/migrations/0023_auto_20190114_1301.py
+++ b/zds/tutorialv2/migrations/0023_auto_20190114_1301.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0022_python_3"),
     ]

--- a/zds/tutorialv2/migrations/0023_publishablecontent_validation_private_message.py
+++ b/zds/tutorialv2/migrations/0023_publishablecontent_validation_private_message.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("mp", "0004_python_3"),
         ("tutorialv2", "0027_auto_20190912_1936"),

--- a/zds/tutorialv2/migrations/0024_publicationevent.py
+++ b/zds/tutorialv2/migrations/0024_publicationevent.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0023_auto_20190114_1301"),
     ]

--- a/zds/tutorialv2/migrations/0025_auto_20190415_1302.py
+++ b/zds/tutorialv2/migrations/0025_auto_20190415_1302.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0024_publicationevent"),
     ]

--- a/zds/tutorialv2/migrations/0026_publicationevent_date.py
+++ b/zds/tutorialv2/migrations/0026_publicationevent_date.py
@@ -5,7 +5,6 @@ import django.utils.timezone
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0025_auto_20190415_1302"),
     ]

--- a/zds/tutorialv2/migrations/0027_auto_20190912_1936.py
+++ b/zds/tutorialv2/migrations/0027_auto_20190912_1936.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0026_publicationevent_date"),
     ]

--- a/zds/tutorialv2/migrations/0028_auto_20191024_1918.py
+++ b/zds/tutorialv2/migrations/0028_auto_20191024_1918.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("tutorialv2", "0023_publishablecontent_validation_private_message"),

--- a/zds/tutorialv2/migrations/0029_auto_20191123_1955.py
+++ b/zds/tutorialv2/migrations/0029_auto_20191123_1955.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0028_auto_20191024_1918"),
     ]

--- a/zds/tutorialv2/migrations/0030_contentsuggestion.py
+++ b/zds/tutorialv2/migrations/0030_contentsuggestion.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0029_auto_20191123_1955"),
     ]

--- a/zds/tutorialv2/migrations/0031_source_is_url.py
+++ b/zds/tutorialv2/migrations/0031_source_is_url.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0030_contentsuggestion"),
     ]

--- a/zds/tutorialv2/migrations/0032_event.py
+++ b/zds/tutorialv2/migrations/0032_event.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("tutorialv2", "0031_source_is_url"),

--- a/zds/tutorialv2/migrations/0033_move_helpwriting.py
+++ b/zds/tutorialv2/migrations/0033_move_helpwriting.py
@@ -6,7 +6,6 @@ import zds
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0032_event"),
         ("utils", "0025_move_helpwriting"),

--- a/zds/tutorialv2/migrations/0034_goals.py
+++ b/zds/tutorialv2/migrations/0034_goals.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0033_move_helpwriting"),
     ]

--- a/zds/tutorialv2/migrations/0035_alter_publishablecontent_goals.py
+++ b/zds/tutorialv2/migrations/0035_alter_publishablecontent_goals.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0034_goals"),
     ]

--- a/zds/tutorialv2/migrations/0036_alter_contentsuggestion_options.py
+++ b/zds/tutorialv2/migrations/0036_alter_contentsuggestion_options.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0035_alter_publishablecontent_goals"),
     ]

--- a/zds/tutorialv2/migrations/0037_labels.py
+++ b/zds/tutorialv2/migrations/0037_labels.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0036_alter_contentsuggestion_options"),
     ]

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -403,14 +403,12 @@ class SingleOnlineContentViewMixin(ContentTypeMixin):
         return obj
 
     def get_object(self):
-
         obj = self.public_content_object.content
         if obj is None:
             raise Http404("Le contenu de la publication n'est pas trouvé.")
         return obj
 
     def get_versioned_object(self):
-
         return self.public_content_object.load_public_version_or_404()
 
 
@@ -433,7 +431,6 @@ class SingleOnlineContentDetailViewMixin(SingleOnlineContentViewMixin, DetailVie
     """
 
     def get(self, request, *args, **kwargs):
-
         try:
             self.public_content_object = self.get_public_object()
         except MustRedirect as redirection_url:
@@ -450,7 +447,6 @@ class SingleOnlineContentDetailViewMixin(SingleOnlineContentViewMixin, DetailVie
         return self.render_to_response(context)
 
     def get_context_data(self, **kwargs):
-
         context = super().get_context_data(**kwargs)
 
         context["content"] = self.versioned_object

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -1016,7 +1016,6 @@ class PublishedContent(AbstractESDjangoIndexable, TemplatableContentModelMixin, 
 
                 # chapters are only indexed for middle and big tuto
                 if versioned.has_sub_containers():
-
                     # delete possible previous chapters
                     if content.es_already_indexed:
                         index_manager.delete_by_query(

--- a/zds/tutorialv2/publish_container.py
+++ b/zds/tutorialv2/publish_container.py
@@ -204,7 +204,6 @@ def publish_container(
         container.children = []
         container.children_dict = {}
         for child in filter(lambda c: c.ready_to_publish, children):
-
             altered_version = copy.copy(child)
             container.children.append(altered_version)
             container.children_dict[altered_version.slug] = altered_version

--- a/zds/tutorialv2/tests/__init__.py
+++ b/zds/tutorialv2/tests/__init__.py
@@ -28,7 +28,6 @@ class override_for_contents(override_settings):
 
 
 class TutorialTestMixin:
-
     overridden_zds_app = overridden_zds_app
 
     def clean_media_dir(self):

--- a/zds/tutorialv2/tests/tests_move.py
+++ b/zds/tutorialv2/tests/tests_move.py
@@ -22,7 +22,6 @@ from zds.utils.tests.factories import SubCategoryFactory, LicenceFactory
 @override_for_contents()
 class ContentMoveTests(TutorialTestMixin, TestCase):
     def setUp(self):
-
         self.staff = StaffProfileFactory().user
 
         settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -30,7 +30,6 @@ from zds.utils.models import Alert
 @override_for_contents()
 class PublishedContentTests(TutorialTestMixin, TestCase):
     def setUp(self):
-
         self.overridden_zds_app["member"]["bot_account"] = ProfileFactory().user.username
         self.bot_group = Group()
         self.bot_group.name = settings.ZDS_APP["member"]["bot_group"]

--- a/zds/tutorialv2/tests/tests_views/tests_addauthor.py
+++ b/zds/tutorialv2/tests/tests_views/tests_addauthor.py
@@ -34,7 +34,6 @@ class AddAuthorTest(TutorialTestMixin, TestCase):
 
     @patch("zds.tutorialv2.signals.authors_management")
     def test_nominal(self, authors_management):
-
         result = self.client.post(
             reverse("content:add-author", args=[self.tuto.pk]), {"username": self.user_guest.username}, follow=False
         )
@@ -49,7 +48,6 @@ class AddAuthorTest(TutorialTestMixin, TestCase):
 
     @patch("zds.tutorialv2.signals.authors_management")
     def test_not_existing_user(self, authors_management):
-
         result = self.client.post(
             reverse("content:add-author", args=[self.tuto.pk]), {"username": "unknown"}, follow=False
         )
@@ -60,7 +58,6 @@ class AddAuthorTest(TutorialTestMixin, TestCase):
 
     @patch("zds.tutorialv2.signals.authors_management")
     def test_bot(self, authors_management):
-
         result = self.client.post(
             reverse("content:add-author", args=[self.tuto.pk]), {"username": self.external.username}, follow=False
         )

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -55,7 +55,6 @@ from zds import json_handler
 @override_for_contents()
 class ContentTests(TutorialTestMixin, TestCase):
     def setUp(self):
-
         self.staff = StaffProfileFactory().user
 
         settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
@@ -2241,7 +2240,6 @@ class ContentTests(TutorialTestMixin, TestCase):
 
     @patch("zds.tutorialv2.signals.jsfiddle_management")
     def test_js_fiddle_activation(self, jsfiddle_management):
-
         self.client.force_login(self.staff)
         result = self.client.post(
             reverse("content:activate-jsfiddle"), {"pk": self.tuto.pk, "js_support": "on"}, follow=True
@@ -2267,7 +2265,6 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(jsfiddle_management.send.call_count, 2)
 
     def test_validate_unexisting(self):
-
         self.client.force_login(self.user_author)
         result = self.client.post(
             reverse("validation:ask", kwargs={"pk": self.tuto.pk, "slug": self.tuto.slug}),
@@ -3016,7 +3013,6 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.client.force_login(self.user_author)
 
         for extra in avail_extra:
-
             result = self.client.get(published.get_absolute_url_to_extra_content(extra))
             self.assertEqual(result.status_code, 200)
         # test for visitor:

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -488,7 +488,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 404)
 
     def test_add_note(self):
-
         message_to_post = "la ZEP-12"
 
         self.client.force_login(self.user_guest)
@@ -650,7 +649,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertTrue(reaction.is_visible)
 
     def test_alert_reaction(self):
-
         self.client.force_login(self.user_guest)
 
         self.client.post(
@@ -715,7 +713,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         )
 
     def test_warn_typo_without_accessible_author(self):
-
         self.client.force_login(self.user_guest)
         result = self.client.post(
             reverse("content:warn-typo") + f"?pk={self.tuto.pk}",

--- a/zds/tutorialv2/tests/tests_views/tests_stats.py
+++ b/zds/tutorialv2/tests/tests_views/tests_stats.py
@@ -288,7 +288,6 @@ class StatTests(TestCase, TutorialTestMixin):
 
     @mock.patch("requests.post")
     def test_query_string_parameter_duration(self, mock_post):
-
         # By default we only have the last 7 days
         default_duration = 7
         self.client.force_login(self.user_author)

--- a/zds/tutorialv2/utils.py
+++ b/zds/tutorialv2/utils.py
@@ -461,7 +461,6 @@ def fill_containers_from_json(json_sub, parent):
     from zds.tutorialv2.models.versioned import Container, Extract
 
     if "children" in json_sub:
-
         for child in json_sub["children"]:
             if not all_is_string_appart_from_given_keys(child, ("children", "ready_to_publish")):
                 raise BadManifestError(

--- a/zds/tutorialv2/views/archives.py
+++ b/zds/tutorialv2/views/archives.py
@@ -183,7 +183,6 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
 
         for child in copy_from.children:
             if isinstance(child, Container):
-
                 introduction = ""
                 conclusion = ""
 
@@ -237,7 +236,6 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
             os.makedirs(temp)
 
         for image_path in zip_file.namelist():
-
             image_basename = os.path.basename(image_path)
 
             if not image_basename.strip():  # don't deal with directory
@@ -347,7 +345,6 @@ class UpdateContentWithArchive(LoggedWithReadWriteHability, SingleContentFormVie
                 messages.error(self.request, e.message)
                 return super().form_invalid(form)
             else:
-
                 # Warn the user if the license has been changed
                 manifest = json_handler.loads(str(zfile.read("manifest.json"), "utf-8"))
                 if new_version.licence and "licence" in manifest and manifest["licence"] != new_version.licence.code:
@@ -443,7 +440,6 @@ class CreateContentFromArchive(LoggedWithReadWriteHability, FormView):
     object = None
 
     def form_valid(self, form):
-
         if self.request.FILES["archive"]:
             try:
                 zfile = zipfile.ZipFile(self.request.FILES["archive"], "r")
@@ -460,7 +456,6 @@ class CreateContentFromArchive(LoggedWithReadWriteHability, FormView):
                 messages.error(self.request, _(e.message + " n'est pas correctement renseigné."))
                 return super().form_invalid(form)
             else:
-
                 # Warn the user if the license has been changed
                 manifest = json_handler.loads(str(zfile.read("manifest.json"), "utf-8"))
                 if new_content.licence and "licence" in manifest and manifest["licence"] != new_content.licence.code:

--- a/zds/tutorialv2/views/authors.py
+++ b/zds/tutorialv2/views/authors.py
@@ -30,7 +30,6 @@ class AddAuthorToContent(LoggedWithReadWriteHability, SingleContentFormViewMixin
         return redirect(url, self.request.user)
 
     def form_valid(self, form):
-
         _type = _("de l'article")
 
         if self.object.is_tutorial:
@@ -83,7 +82,6 @@ class AddAuthorToContent(LoggedWithReadWriteHability, SingleContentFormViewMixin
 
 
 class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormViewMixin):
-
     form_class = RemoveAuthorForm
     only_draft_version = True
     must_be_author = True
@@ -112,7 +110,6 @@ class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormView
         return False
 
     def form_valid(self, form):
-
         current_user = False
         users = form.cleaned_data["users"]
 

--- a/zds/tutorialv2/views/comments.py
+++ b/zds/tutorialv2/views/comments.py
@@ -24,7 +24,6 @@ from zds.utils.models import CommentEdit, get_hat_from_request, Alert
 
 
 class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewMixin):
-
     denied_if_lock = True
     form_class = NoteForm
     check_as = True
@@ -82,7 +81,6 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
         return context
 
     def get(self, request, *args, **kwargs):
-
         # handle quoting case
         if "cite" in self.request.GET:
             try:
@@ -112,7 +110,6 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
             )
 
     def post(self, request, *args, **kwargs):
-
         if "preview" in request.POST and request.is_ajax():
             content = render(request, "misc/preview.part.html", {"text": request.POST["text"]})
             return StreamingHttpResponse(content)
@@ -120,7 +117,6 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
             return super().post(request, *args, **kwargs)
 
     def form_valid(self, form):
-
         if self.check_as and self.object.antispam(self.request.user):
             raise PermissionDenied
 

--- a/zds/tutorialv2/views/containers_extracts.py
+++ b/zds/tutorialv2/views/containers_extracts.py
@@ -314,7 +314,6 @@ class DeleteContainerOrExtract(LoggedWithReadWriteHability, SingleContentViewMix
 
 
 class MoveChild(LoginRequiredMixin, SingleContentPostMixin, FormView):
-
     model = PublishableContent
     form_class = MoveElementForm
     versioned = False

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -90,7 +90,6 @@ class CreateContent(LoggedWithReadWriteHability, FormWithPreview):
         return context
 
     def form_valid(self, form):
-
         # create the object:
         self.content = PublishableContent()
         self.content.title = form.cleaned_data["title"]

--- a/zds/tutorialv2/views/contributors.py
+++ b/zds/tutorialv2/views/contributors.py
@@ -40,7 +40,6 @@ class AddContributorToContent(LoggedWithReadWriteHability, SingleContentFormView
         return redirect(url, self.request.user)
 
     def form_valid(self, form):
-
         _type = _("à l'article")
 
         if self.object.is_tutorial:
@@ -107,7 +106,6 @@ class AddContributorToContent(LoggedWithReadWriteHability, SingleContentFormView
 
 
 class RemoveContributorFromContent(LoggedWithReadWriteHability, SingleContentFormViewMixin):
-
     form_class = RemoveContributionForm
     only_draft_version = True
     must_be_author = True

--- a/zds/tutorialv2/views/download_online.py
+++ b/zds/tutorialv2/views/download_online.py
@@ -24,7 +24,6 @@ class DownloadOnlineContent(SingleOnlineContentViewMixin, DownloadViewMixin):
         return public_version.content.public_version.get_absolute_url_to_extra_content(self.requested_file)
 
     def get(self, context, **response_kwargs):
-
         # fill the variables
         try:
             self.public_content_object = self.get_public_object()
@@ -69,15 +68,12 @@ class DownloadOnlineContent(SingleOnlineContentViewMixin, DownloadViewMixin):
 
 
 class DownloadOnlineArticle(DownloadOnlineContent):
-
     current_content_type = "ARTICLE"
 
 
 class DownloadOnlineTutorial(DownloadOnlineContent):
-
     current_content_type = "TUTORIAL"
 
 
 class DownloadOnlineOpinion(DownloadOnlineContent):
-
     current_content_type = "OPINION"

--- a/zds/tutorialv2/views/editorialization.py
+++ b/zds/tutorialv2/views/editorialization.py
@@ -15,7 +15,6 @@ from zds.utils import get_current_user
 
 
 class RemoveSuggestion(PermissionRequiredMixin, SingleContentFormViewMixin):
-
     form_class = RemoveSuggestionForm
     modal_form = True
     only_draft_version = True

--- a/zds/tutorialv2/views/lists.py
+++ b/zds/tutorialv2/views/lists.py
@@ -299,7 +299,6 @@ class ViewPublications(TemplateView):
 
 
 class TagsListView(ListView):
-
     model = Tag
     template_name = "tutorialv2/view/tags.html"
     context_object_name = "tags"
@@ -427,7 +426,6 @@ class ContentOfAuthor(ZdSPagingListView):
 
 
 class ListContentReactions(ZdSPagingListView):
-
     context_object_name = "content_reactions"
     template_name = "tutorialv2/comment/list.html"
     paginate_by = settings.ZDS_APP["forum"]["posts_per_page"]

--- a/zds/tutorialv2/views/misc.py
+++ b/zds/tutorialv2/views/misc.py
@@ -74,7 +74,6 @@ class FollowNewContent(LoggedWithReadWriteHability, FormView):
 
 
 class WarnTypo(SingleContentFormViewMixin):
-
     modal_form = True
     form_class = WarnTypoForm
     must_be_author = False
@@ -84,7 +83,6 @@ class WarnTypo(SingleContentFormViewMixin):
     object = None
 
     def get_form_kwargs(self):
-
         kwargs = super().get_form_kwargs()
 
         versioned = self.get_versioned_object()

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -56,7 +56,6 @@ class ValidationListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     subcategory = None
 
     def get_queryset(self):
-
         # TODO: many filter at the same time ?
         # TODO: paginate ?
 
@@ -131,7 +130,6 @@ class AskValidationForContent(LoggedWithReadWriteHability, SingleContentFormView
         return kwargs
 
     def form_valid(self, form):
-
         old_validation = Validation.objects.filter(
             content__pk=self.object.pk, status__in=["PENDING", "PENDING_V"]
         ).first()
@@ -215,7 +213,6 @@ class CancelValidation(LoginRequiredMixin, ModalFormView):
         return kwargs
 
     def form_valid(self, form):
-
         user = self.request.user
 
         validation = (
@@ -365,7 +362,6 @@ class ReserveValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
 
 
 class ValidationHistoryView(LoginRequiredMixin, PermissionRequiredMixin, RequiresValidationViewMixin):
-
     model = PublishableContent
     permission_required = "tutorialv2.change_validation"
     template_name = "tutorialv2/validation/history.html"
@@ -397,7 +393,6 @@ class RejectValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
         return kwargs
 
     def form_valid(self, form):
-
         user = self.request.user
 
         validation = Validation.objects.filter(pk=self.kwargs["pk"]).last()
@@ -478,7 +473,6 @@ class AcceptValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
         return kwargs
 
     def form_valid(self, form):
-
         user = self.request.user
         validation = Validation.objects.filter(pk=self.kwargs["pk"]).last()
 
@@ -543,7 +537,6 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
         return kwargs
 
     def form_valid(self, form):
-
         versioned = self.versioned_object
 
         if form.cleaned_data["version"] != self.object.sha_public:
@@ -613,7 +606,6 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
 
 
 class MarkObsolete(LoginRequiredMixin, PermissionRequiredMixin, FormView):
-
     permission_required = "tutorialv2.change_validation"
 
     def get(self, request, *args, **kwargs):

--- a/zds/utils/api/tests.py
+++ b/zds/utils/api/tests.py
@@ -153,7 +153,6 @@ class TagListAPITest(APITestCase):
         publish_content(content, content_draft)
 
     def tearDown(self):
-
         if os.path.isdir(settings.ZDS_APP["content"]["repo_private_path"]):
             shutil.rmtree(settings.ZDS_APP["content"]["repo_private_path"])
         if os.path.isdir(settings.ZDS_APP["content"]["repo_public_path"]):

--- a/zds/utils/forms.py
+++ b/zds/utils/forms.py
@@ -162,7 +162,6 @@ class FieldValidatorMixin:
 
 
 class PasswordRequiredForm(forms.Form):
-
     password = forms.CharField(
         label=_("Mot de passe actuel"),
         widget=forms.PasswordInput,

--- a/zds/utils/highlighter.py
+++ b/zds/utils/highlighter.py
@@ -6,7 +6,6 @@ MAX_WRAP_TEXT = 50
 
 class SearchHighlighter(Highlighter):
     def render_html(self, highlight_locations=None, start_offset=None, end_offset=None):
-
         if start_offset is not None:
             start_offset = max([0, start_offset - MAX_WRAP_TEXT])
         if end_offset is not None:

--- a/zds/utils/management/commands/clean_alerts_and_notifications.py
+++ b/zds/utils/management/commands/clean_alerts_and_notifications.py
@@ -11,7 +11,6 @@ from zds.utils.models import Alert
 
 @transaction.atomic
 class Command(BaseCommand):
-
     help = "Clean up useless notifications & alerts."
 
     def add_arguments(self, parser):

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -617,7 +617,6 @@ ZDSResource = collections.namedtuple("zdsresource", ["name", "description", "cal
 
 @transaction.atomic
 class Command(BaseCommand):
-
     zds_resource_config = [
         ZDSResource("member", "basic users", load_member, tuple()),
         ZDSResource("staff", "privileged users", load_staff, tuple()),

--- a/zds/utils/management/tests.py
+++ b/zds/utils/management/tests.py
@@ -21,7 +21,6 @@ from zds.utils.management.commands.load_fixtures import Command as FixtureComman
 @override_for_contents()
 class CommandsTestCase(TutorialTestMixin, TestCase):
     def test_load_fixtures(self):
-
         args = []
         opts = {"modules": FixtureCommand.zds_resource_config}
         call_command("load_fixtures", *args, **opts)

--- a/zds/utils/migrations/0001_initial.py
+++ b/zds/utils/migrations/0001_initial.py
@@ -5,7 +5,6 @@ import zds.utils.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/zds/utils/migrations/0002_comment_update_index_date.py
+++ b/zds/utils/migrations/0002_comment_update_index_date.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0001_initial"),
     ]

--- a/zds/utils/migrations/0003_auto_20150414_2256.py
+++ b/zds/utils/migrations/0003_auto_20150414_2256.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0002_comment_update_index_date"),
     ]

--- a/zds/utils/migrations/0004_auto_20151229_1904.py
+++ b/zds/utils/migrations/0004_auto_20151229_1904.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0003_auto_20150414_2256"),
     ]

--- a/zds/utils/migrations/0005_commentvote.py
+++ b/zds/utils/migrations/0005_commentvote.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("utils", "0004_auto_20151229_1904"),

--- a/zds/utils/migrations/0006_auto_20160509_1633.py
+++ b/zds/utils/migrations/0006_auto_20160509_1633.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0005_commentvote"),
     ]

--- a/zds/utils/migrations/0007_auto_20160511_2153.py
+++ b/zds/utils/migrations/0007_auto_20160511_2153.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0006_auto_20160509_1633"),
     ]

--- a/zds/utils/migrations/0008_auto_20161112_1757.py
+++ b/zds/utils/migrations/0008_auto_20161112_1757.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("mp", "0002_auto_20150416_1750"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/zds/utils/migrations/0009_auto_20161113_2328.py
+++ b/zds/utils/migrations/0009_auto_20161113_2328.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0008_auto_20161112_1757"),
     ]

--- a/zds/utils/migrations/0010_auto_20170203_2100.py
+++ b/zds/utils/migrations/0010_auto_20170203_2100.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0009_auto_20161113_2328"),
     ]

--- a/zds/utils/migrations/0011_auto_20170401_1521.py
+++ b/zds/utils/migrations/0011_auto_20170401_1521.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tutorialv2", "0020_auto_20170401_1521"),
         ("utils", "0010_auto_20170203_2100"),

--- a/zds/utils/migrations/0012_commentedit.py
+++ b/zds/utils/migrations/0012_commentedit.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("utils", "0011_auto_20170401_1521"),

--- a/zds/utils/migrations/0013_tags.py
+++ b/zds/utils/migrations/0013_tags.py
@@ -29,7 +29,6 @@ def force_unicity(*args, **kwargs):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0012_commentedit"),
     ]

--- a/zds/utils/migrations/0014_auto_20170905_2220.py
+++ b/zds/utils/migrations/0014_auto_20170905_2220.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("utils", "0013_tags"),

--- a/zds/utils/migrations/0015_hat_group.py
+++ b/zds/utils/migrations/0015_hat_group.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("auth", "0008_alter_user_username_max_length"),
         ("utils", "0014_auto_20170905_2220"),

--- a/zds/utils/migrations/0016_python_3.py
+++ b/zds/utils/migrations/0016_python_3.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0015_hat_group"),
     ]

--- a/zds/utils/migrations/0017_hat_is_staff.py
+++ b/zds/utils/migrations/0017_hat_is_staff.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0016_python_3"),
     ]

--- a/zds/utils/migrations/0018_auto_20171006_2126.py
+++ b/zds/utils/migrations/0018_auto_20171006_2126.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("utils", "0017_hat_is_staff"),

--- a/zds/utils/migrations/0019_auto_20180102_1659.py
+++ b/zds/utils/migrations/0019_auto_20180102_1659.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0018_auto_20171006_2126"),
     ]

--- a/zds/utils/migrations/0020_auto_20180501_1059.py
+++ b/zds/utils/migrations/0020_auto_20180501_1059.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0019_auto_20180102_1659"),
     ]

--- a/zds/utils/migrations/0021_auto_20180826_1616.py
+++ b/zds/utils/migrations/0021_auto_20180826_1616.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("member", "0017_profile_email_for_new_mp"),
         ("utils", "0022_auto_20190115_1249"),

--- a/zds/utils/migrations/0021_auto_20190114_1301.py
+++ b/zds/utils/migrations/0021_auto_20190114_1301.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0020_auto_20180501_1059"),
     ]

--- a/zds/utils/migrations/0022_auto_20190115_1249.py
+++ b/zds/utils/migrations/0022_auto_20190115_1249.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0021_auto_20190114_1301"),
     ]

--- a/zds/utils/migrations/0022_set_default_latest_by_for_alerts.py
+++ b/zds/utils/migrations/0022_set_default_latest_by_for_alerts.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0021_auto_20180826_1616"),
     ]

--- a/zds/utils/migrations/0023_move_potential_spam_to_comment_model.py
+++ b/zds/utils/migrations/0023_move_potential_spam_to_comment_model.py
@@ -37,7 +37,6 @@ def copy_potential_spam_to_forum_post(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0022_set_default_latest_by_for_alerts"),
         # We must first temporarily rename the old field to something else, because

--- a/zds/utils/migrations/0024_alter_hatrequest_is_granted.py
+++ b/zds/utils/migrations/0024_alter_hatrequest_is_granted.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("utils", "0023_move_potential_spam_to_comment_model"),
     ]

--- a/zds/utils/migrations/0025_move_helpwriting.py
+++ b/zds/utils/migrations/0025_move_helpwriting.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("utils", "0024_alter_hatrequest_is_granted")]
 
     database_operations = [migrations.AlterModelTable("HelpWriting", "tutorialv2_helpwriting")]

--- a/zds/utils/templatetags/elasticsearch.py
+++ b/zds/utils/templatetags/elasticsearch.py
@@ -64,7 +64,6 @@ class HighlightNode(template.Node):
 
 @register.tag
 def highlight(parser, token):
-
     part = token.split_contents()
 
     if len(part) != 3:

--- a/zds/utils/templatetags/htmldiff.py
+++ b/zds/utils/templatetags/htmldiff.py
@@ -10,7 +10,6 @@ register = template.Library()
 
 @register.simple_tag
 def htmldiff(string1, string2):
-
     try:
         txt1 = string1.decode("utf-8").splitlines()
     # string1 is an empty SafeText from template

--- a/zds/utils/tests/tests_append_query_params.py
+++ b/zds/utils/tests/tests_append_query_params.py
@@ -15,7 +15,6 @@ class EasyTagTest(TestCase):
         self.wrapped_function = easy_tag(self.simple_function)
 
     def test_valid_call(self):
-
         # Call tag without parser and three elements
         ret = self.wrapped_function(None, Token(TokenType.TEXT, "elem1 elem2 elem3"))
 
@@ -30,7 +29,6 @@ class EasyTagTest(TestCase):
         self.assertEqual(self.simple_function.__doc__, self.wrapped_function.__doc__)
 
     def test_invalid_call(self):
-
         wf = self.wrapped_function
         # Check raising TemplateSyntaxError if call with too few arguments
         self.assertRaises(TemplateSyntaxError, wf, None, Token(TokenType.TEXT, "elem1 elem2"))
@@ -47,7 +45,6 @@ class AppendGetNodeTest(TestCase):
         self.context = Context({"request": factory.get("/data/test"), "var1": 1, "var2": 2})
 
     def test_valid_call(self):
-
         # Test normal call
         agn = AppendGetNode("key1=var1,key2=var2")
         tr = agn.render(self.context)
@@ -64,7 +61,6 @@ class AppendGetNodeTest(TestCase):
         self.assertEqual(tr, "/data/test")
 
     def test_invalid_call(self):
-
         # Test invalid format
 
         # Space separators args :
@@ -77,7 +73,6 @@ class AppendGetNodeTest(TestCase):
         self.assertRaises(VariableDoesNotExist, agn.render, self.context)
 
     def test_valid_templatetag(self):
-
         # Test normal call
         tr = Template("{% load append_query_params %}" "{% append_query_params key1=var1,key2=var2 %}").render(
             self.context

--- a/zds/utils/tests/tests_captureas.py
+++ b/zds/utils/tests/tests_captureas.py
@@ -7,7 +7,6 @@ class CaptureasNodeTest(TestCase):
         self.context = Context()
 
     def test_valid_templatetag(self):
-
         # Test empty element
         self.assertFalse("var1" in self.context)
         tr = Template("{% load captureas %}" "{% captureas var1%}" "{% endcaptureas %}").render(self.context)

--- a/zds/utils/tests/tests_date.py
+++ b/zds/utils/tests/tests_date.py
@@ -8,7 +8,6 @@ class DateFormatterTest(TestCase):
     # todo: Add test with localization parameters
 
     def setUp(self):
-
         now = datetime.now()
         date_previous_in_day = now - timedelta(hours=1)
         date_previous_abs = datetime(2013, 9, 12, hour=11, minute=10, second=42, microsecond=10)
@@ -78,7 +77,6 @@ class DateFormatterTest(TestCase):
         self.assertEqual("None", tr)
 
     def test_humane_time(self):
-
         # Default behaviour
         tr = Template("{% load date %}" "{{ date_epoch | humane_time }}").render(self.context)
 

--- a/zds/utils/tests/tests_interventions.py
+++ b/zds/utils/tests/tests_interventions.py
@@ -59,7 +59,6 @@ class InterventionsTest(TestCase):
         self.context = Context(cont)
 
     def test_interventions_privatetopics(self):
-
         self.client.force_login(self.author.user)
         response = self.client.post(reverse("homepage"))
         self.assertEqual(200, response.status_code)
@@ -73,7 +72,6 @@ class InterventionsTest(TestCase):
         self.assertContains(response, '<span class="notif-count">1</span>', html=True)
 
     def test_interventions_privatetopics_author_leave(self):
-
         # profile1 (author) leave topic
         move = self.topic.participants.first()
         self.topic.author = move

--- a/zds/utils/tests/tests_messages.py
+++ b/zds/utils/tests/tests_messages.py
@@ -10,11 +10,9 @@ LEVEL_TAGS = utils.get_level_tags()
 
 
 class FunctionTests(SimpleTestCase):
-
     tags = [constants.DEBUG, constants.INFO, constants.SUCCESS, constants.WARNING, constants.ERROR]
 
     def test_messages(self):
-
         for tag in self.tags:
             txt = f"some message with {repr(tag)}"
 

--- a/zds/utils/tests/tests_models.py
+++ b/zds/utils/tests/tests_models.py
@@ -74,13 +74,11 @@ class TagsTests(TestCase):
         self.assertEqual(validator.errors, [])
 
     def test_validator_with_special_char_only(self):
-
         validator = TagValidator()
         self.assertFalse(validator.validate_raw_string("^"))
         self.assertEqual(len(validator.errors), 1)
 
     def test_validator_with_utf8mb4(self):
-
         raw_string = "🐙☢,bla"
         validator = TagValidator()
         self.assertFalse(validator.validate_raw_string(raw_string))

--- a/zds/utils/validators.py
+++ b/zds/utils/validators.py
@@ -55,7 +55,6 @@ class InvalidSlugError(ValueError):
     """
 
     def __init__(self, *args, **kwargs):
-
         self.source = ""
         self.had_source = False
 


### PR DESCRIPTION
Mise à jour triviale des dépendances Python à leur dernière version, à l'exception de : 

- `elasticsearch` et `elasticsearch-dsl` comme d'habitude,
- `django-crispy-forms` et `django-oauth-toolkit` car il y a des changements majeurs,
- `pre-commit` et `Sphinx` car leurs dernières versions ne supportent plus Python 3.7 (version utilisée en production et avec Github Actions)