### PR TITLE
Améliore l'interface d'administration pour les labels

### DIFF
--- a/zds/tutorialv2/admin.py
+++ b/zds/tutorialv2/admin.py
@@ -124,6 +124,7 @@ class GoalAdmin(admin.ModelAdmin):
 class LabelAdmin(admin.ModelAdmin):
     list_display = ["name", "description"]
     ordering = ["name"]
+    prepopulated_fields = {"slug": ("name",)}
 
 
 admin.site.register(PublishableContent, PublishableContentAdmin)

--- a/zds/tutorialv2/models/labels.py
+++ b/zds/tutorialv2/models/labels.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.urls import reverse
 
 
 class Label(models.Model):
@@ -21,3 +22,6 @@ class Label(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_absolute_url(self):
+        return reverse("content:view-labels", args=[self.slug])


### PR DESCRIPTION
* Ajoute l'auto-complétion du champ pour le slug à partir du nom du label
* Ajoute un lien pour accéder à la page listant les contenus ayant tel label

### Contrôle qualité

- Depuis l'interface d'admin, créer un nouveau label : le champ slug est automatiquement complété à partir de ce qui est saisi dans le nom du label.
- Depuis l'interface d'admin, aller sur la page pour visualiser/modifier un label : il y a en haut à droite un bouton pour aller sur la page sur le site qui liste tous les contenus ayant ce label.


