### PR TITLE
Renomme la page "À propos" en "Crédits techniques"

### DIFF
--- a/doc/source/front-end/arborescence-des-fichiers.rst
+++ b/doc/source/front-end/arborescence-des-fichiers.rst
@@ -123,7 +123,7 @@ Voici un extrait du dossier contenant les gabaris :
     │   ...
     │
     ├── pages/  # Dossier contenant les pages du site
-    │   ├── about.html
+    │   ├── technologies.html
     │   ├── contact.html
     │   ...
     │

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -59,7 +59,7 @@
         <ul class="links">
             <li><a href="{% url "api:docs" %}">{% trans "API" %}</a></li>
             <li><a href="{% url "pages-eula" %}">{% trans "CGU" %}</a></li>
-            <li><a href="{% url "pages-about" %}">{% trans "À propos" %}</a></li>
+            <li><a href="{% url "pages-about" %}">{% trans "Crédits techniques" %}</a></li>
             {% if app.site.association %}
                 <li><a href="{% url "pages-association" %}">{% trans "L’association" %}</a></li>
                 <li>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -59,7 +59,7 @@
         <ul class="links">
             <li><a href="{% url "api:docs" %}">{% trans "API" %}</a></li>
             <li><a href="{% url "pages-eula" %}">{% trans "CGU" %}</a></li>
-            <li><a href="{% url "pages-about" %}">{% trans "Crédits techniques" %}</a></li>
+            <li><a href="{% url "pages-technologies" %}">{% trans "Crédits techniques" %}</a></li>
             {% if app.site.association %}
                 <li><a href="{% url "pages-association" %}">{% trans "L’association" %}</a></li>
                 <li>

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -24,7 +24,7 @@
 {% block content %}
     <ul>
         <li><a href="{% url "pages-eula" %}"><abbr title="{% trans "Conditions générales d’utilisation" %}">{% trans "CGU" %}</abbr></a></li>
-        <li><a href="{% url "pages-about" %}">{% trans "À propos" %}</a></li>
+        <li><a href="{% url "pages-technologies" %}">{% trans "Crédits techniques" %}</a></li>
         {% if app.site.association %}
             <li><a href="{% url "pages-association" %}">{% trans "L’association" %}</a></li>
             <li><a href="{{ app.site.association.subscribe_link }}">{% trans "Adhérer à l'association" %}</a></li>

--- a/templates/pages/technologies.html
+++ b/templates/pages/technologies.html
@@ -110,7 +110,7 @@
 
             <h4>Javascript</h4>
             <ul>
-                <li><a href="https://jquery.com/">jQuery 2.x</a></li>
+                <li><a href="https://jquery.com/">jQuery</a></li>
             </ul>
         </div>
     </div>

--- a/templates/pages/technologies.html
+++ b/templates/pages/technologies.html
@@ -6,19 +6,19 @@
 
 
 {% block title %}
-    {% trans "À propos" %}
+    {% trans "Crédits techniques" %}
 {% endblock %}
 
 
 
 {% block breadcrumb %}
-    <li>{% trans "À propos" %}</li>
+    <li>{% trans "Crédits techniques" %}</li>
 {% endblock %}
 
 
 
 {% block headline %}
-    <h1>{% trans "À propos" %}</h1>
+    <h1>{% trans "Crédits techniques" %}</h1>
 {% endblock %}
 
 

--- a/zds/pages/tests.py
+++ b/zds/pages/tests.py
@@ -38,7 +38,7 @@ class PagesMemberTests(TestCase):
         """Test: check that about page is alive."""
 
         result = self.client.get(
-            reverse("pages-about"),
+            reverse("pages-technologies"),
         )
 
         self.assertEqual(result.status_code, 200)
@@ -98,7 +98,7 @@ class PagesStaffTests(TestCase):
         """Test: check that about page is alive."""
 
         result = self.client.get(
-            reverse("pages-about"),
+            reverse("pages-technologies"),
         )
 
         self.assertEqual(result.status_code, 200)
@@ -154,7 +154,7 @@ class PagesGuestTests(TestCase):
         """Test: check that about page is alive."""
 
         result = self.client.get(
-            reverse("pages-about"),
+            reverse("pages-technologies"),
         )
 
         self.assertEqual(result.status_code, 200)

--- a/zds/pages/urls.py
+++ b/zds/pages/urls.py
@@ -16,7 +16,7 @@ from zds.pages.views import (
 
 urlpatterns = [
     # single pages
-    path("apropos/", about, name="pages-about"),
+    path("apropos/", about, name="pages-technologies"),
     path("association/", association, name="pages-association"),
     path("contact/", ContactView.as_view(), name="pages-contact"),
     path("cgu/", eula, name="pages-eula"),

--- a/zds/pages/urls.py
+++ b/zds/pages/urls.py
@@ -16,7 +16,7 @@ from zds.pages.views import (
 
 urlpatterns = [
     # single pages
-    path("apropos/", about, name="pages-technologies"),
+    path("technologies/", about, name="pages-technologies"),
     path("association/", association, name="pages-association"),
     path("contact/", ContactView.as_view(), name="pages-contact"),
     path("cgu/", eula, name="pages-eula"),

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -63,7 +63,7 @@ def about(request):
     """Display many informations about the website."""
     return render(
         request,
-        "pages/about.html",
+        "pages/technologies.html",
         {
             "default_repository_url": get_repository_url(
                 settings.ZDS_APP["github_projects"]["default_repository"], "base_url"


### PR DESCRIPTION
Proposition de renommer « à propos » en « crédits techniques » pour éviter la confusion avec une page de présentation du site/asso

<!-- Décrivez vos changements ici (optionnel pour les tous petits changements). -->

<!-- Remplacez XXXX par le numéro de ticket corrigé par vos changements : GitHub fermera le ticket mentionné automatiquement (voir https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue pour plus de détails). Supprimez la ligne s'il n'y a pas de ticket associé. --!>
Fix #XXXX 

<!-- Si votre PR modifie du code Python, mettez à jour ou créez les tests unitaires associés. Signalez vos éventuelles difficultés afin que des contributeurs expérimentés puissent vous aider. -->

<!-- Si votre pull request requiert des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->

### Contrôle qualité

<!-- Donnez des instructions pour nous aider à vérifier vos changements.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

<!-- Merci ! -->
