### PR TITLE
Renomme et change le comportement du templatetag humane_time

### DIFF
--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -86,23 +86,24 @@ Ce filtre formate une date au format ``DateTime`` destiné à être affiché sur
 
 Ce filtre effectue la même chose que ``format_date`` mais à destination des ``tooltip``.
 
-``humane_time``
----------------
+``date_from_timestamp``
+-----------------------
 
-Formate une date au format *Nombre de seconde depuis Epoch* en un élément lisible. Ainsi :
+Convertit une date au format *Nombre de seconde depuis Epoch* en un objet
+accepté par les autres filtres de ce module. Ainsi :
 
 .. sourcecode:: html+django
 
     {% load date %}
-    {{ date_epoch|humane_time }}
+    {{ date_epoch|date_from_timestamp|format_date }}
 
 sera rendu :
 
 .. sourcecode:: text
 
-    jeudi 01 janvier 1970 à 00h00
+    jeudi 01 janvier 1970 à 00h02
 
- …si le contenu de ``date_epoch`` était de ``42``.
+ …si le contenu de ``date_epoch`` était de ``122``.
 
 ``from_elasticsearch_date``
 ---------------------------

--- a/templates/tutorialv2/view/history.html
+++ b/templates/tutorialv2/view/history.html
@@ -111,7 +111,7 @@
                         {% endif %}
                     </td>
                     <td>
-                        {{ commit.authored_date|humane_time }}
+                        {{ commit.authored_date|date_from_timestamp|format_date }}
                     </td>
                     <td>
                         <a href="{% url "content:view" content.pk content.slug %}?version={{ commit.hexsha }}" >
@@ -161,7 +161,7 @@
                                                 {% trans "mettre à jour" %}
                                             {% endif %}
                                         {% endcaptureas %}
-                                        {% blocktrans with action=action date_version=commit.authored_date|humane_time content_title=content.title %}
+                                        {% blocktrans with action=action date_version=commit.authored_date|date_from_timestamp|format_date content_title=content.title %}
                                             Êtes-vous certain de vouloir <strong>{{ action }}</strong> la bêta pour le contenu
                                             "<em>{{ content_title }}</em>" dans sa version de {{ date_version }} ?
                                         {% endblocktrans %}

--- a/zds/utils/templatetags/date.py
+++ b/zds/utils/templatetags/date.py
@@ -85,9 +85,10 @@ def tooltip_date(value):
 
 
 @register.filter
-def humane_time(timestamp):
-    """Render time (number of second from epoch) to an human readable string"""
-    return format_date(datetime.fromtimestamp(timestamp))
+def date_from_timestamp(timestamp):
+    """Convert a timestamp (number of second from epoch) to a datetime object,
+    another filter should then be used to format the datetime object."""
+    return datetime.fromtimestamp(timestamp)
 
 
 @register.filter

--- a/zds/utils/tests/tests_date.py
+++ b/zds/utils/tests/tests_date.py
@@ -76,8 +76,8 @@ class DateFormatterTest(TestCase):
         tr = Template("{% load date %}" "{{ NoneVal | tooltip_date }}").render(self.context)
         self.assertEqual("None", tr)
 
-    def test_humane_time(self):
+    def test_date_from_timestamp(self):
         # Default behaviour
-        tr = Template("{% load date %}" "{{ date_epoch | humane_time }}").render(self.context)
+        tr = Template("{% load date %}" "{{ date_epoch | date_from_timestamp | format_date }}").render(self.context)
 
         self.assertEqual(tr, "jeudi 01 janvier 1970 à 01h00")


### PR DESCRIPTION
Le templatetag `humane_time` faisait deux choses : il convertissait un timestamp en un objet `datetime` et appliquait directement dessus le templatetag `format_date`.

Plusieurs choses n'allaient pas : 
- le nom n'est pas assez explicit
- si on a un timestamp, on obligé d'appliquer le templatetag `format_date`, aucun autre, sans possibilité de préciser d'éventuelles options
- ce templatetag faisait deux choses, c'est-à-dire une de trop

J'ai transformé ce templatetag en `date_from_timestamp` : il ne fait que convertir un timestamp en objet `datetime`, ce qui nous donne ensuite toute liberté pour appliquer n'importe quel templatetag de temps ensuite.

(j'en ai besoin pour la PR pour la recherche)

### Contrôle qualité

- Générer et relire la documentation
- Se connecter en tant qu'un membre qui a publié un tutoriel, aller sur la page de l'historique du tutoriel : les dates des commits doivent être correctement affichées, et en cliquant sur *Activer* pour activer la bêta, la date dans le message de la modale doit aussi être bien affichée.
