### PR TITLE
Remplace des URLs hard-codées par des appels à `reverse()`

### DIFF
--- a/zds/forum/forms.py
+++ b/zds/forum/forms.py
@@ -27,9 +27,7 @@ class TopicForm(forms.Form, FieldValidatorMixin):
         label=_("Tag(s) séparés par une virgule (exemple: python,django,web)"),
         max_length=64,
         required=False,
-        widget=forms.TextInput(
-            attrs={"data-autocomplete": '{ "type": "multiple", "fieldname": "title", "url": "/api/tags/?search=%s" }'}
-        ),
+        widget=forms.TextInput(),
     )
 
     text = forms.CharField(
@@ -44,6 +42,15 @@ class TopicForm(forms.Form, FieldValidatorMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.fields["tags"].widget.attrs.update(
+            {
+                "data-autocomplete": '{ "type": "multiple", "fieldname": "title", "url": "'
+                + reverse("api:utils:tags-list")
+                + '?search=%s" }'
+            }
+        )
+
         self.helper = FormHelper()
         self.helper.form_class = "content-wrapper"
         self.helper.form_method = "post"
@@ -53,11 +60,11 @@ class TopicForm(forms.Form, FieldValidatorMixin):
             Field("subtitle", autocomplete="off"),
             Field("tags"),
             HTML(
-                """<div id="topic-suggest" style="display:none;"  url="/rechercher/sujets-similaires/">
+                """<div id="topic-suggest" style="display:none;"  url="{}">
   <label>{}</label>
   <div id="topic-result-container" data-neither="{}"></div>
 </div>""".format(
-                    _("Sujets similaires au vôtre :"), _("Aucun résultat")
+                    reverse("search:similar"), _("Sujets similaires au vôtre :"), _("Aucun résultat")
                 )
             ),
             CommonLayoutEditor(),

--- a/zds/mp/forms.py
+++ b/zds/mp/forms.py
@@ -16,9 +16,8 @@ class PrivateTopicForm(forms.Form, ParticipantsStringValidator, TitleValidator, 
         label=_("Participants"),
         widget=forms.TextInput(
             attrs={
-                "placeholder": _("Les participants doivent " "être séparés par une virgule."),
+                "placeholder": _("Les participants doivent être séparés par une virgule."),
                 "required": "required",
-                "data-autocomplete": '{ "type": "multiple", "url": "/api/membres/?search=%s" }',
             }
         ),
     )
@@ -40,6 +39,12 @@ class PrivateTopicForm(forms.Form, ParticipantsStringValidator, TitleValidator, 
 
     def __init__(self, username, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.fields["participants"].widget.attrs.update(
+            {
+                "data-autocomplete": '{ "type": "multiple", "url": "' + reverse("api:member:list") + '?search=%s" }',
+            }
+        )
         self.helper = FormHelper()
         self.helper.form_class = "content-wrapper"
         self.helper.form_method = "post"


### PR DESCRIPTION
### Contrôle qualité

Se connecter en tant qu'admin, puis :
- aller sur la page pour créer un sujet sur le forum : il y a une requête pour chercher des sujets similaires (qui ne retournera rien si vous n'avez le moteur de recherche installé) et il y a des suggestions de tags qui s'affichent
- aller sur la page pour créer un MP : le champ pour ajouter des participants suggère les pseudos des participants (commencez à saisir `use` par exemple)
- aller sur la page d'un contenu, afficher la modale pour modifier les tags : le lien vers la liste des tags fonctionne et la suggestion des tags déjà existants fonctionne aussi
- toujours sur la page d'un contenu, afficher la modale pour ajouter une suggestion : il y a une requête pour chercher les contenus avec un titre correspondant aux premiers caractères saisis (qui ne retournera rien si vous n'avez le moteur de recherche installé)

Dans tous les cas, vous pouvez vérifier dans la console que les vues correspondantes aux URLs remplacées par des appels à `reverse()` sont bien appelées.
