### PR TITLE
Mise à jour des versions supportées de Debian

### DIFF
--- a/doc/source/install/install-docker.rst
+++ b/doc/source/install/install-docker.rst
@@ -16,7 +16,7 @@ Lancez un shell interactif dans un conteneur basé sur Debian :
 
 .. sourcecode:: bash
 
-    docker run -it -p 8000:8000 debian:bullseye
+    docker run -it -p 8000:8000 debian:bookworm
 
 
 Une fois dans le conteneur, saisissez les commandes suivantes :

--- a/scripts/dependencies/debian.txt
+++ b/scripts/dependencies/debian.txt
@@ -1,5 +1,5 @@
 #title=Debian
-#desc=Utilisation de apt-get / Testé sur Debian Stretch (9), Buster (10), Bullseye (11)
+#desc=Utilisation de apt-get / Testé sur Debian Buster (10), Bullseye (11), Bookworm (12)
 #updatecmd=apt-get -y update
 #installcmd=apt-get -y install
 git


### PR DESCRIPTION
- ajoute Bookworm
- retire Stretch (les mises à jour de sécurité sont arrêtées depuis le 6 juillet 2020, cf https://www.debian.org/releases/stretch/)

---------

ZdS fonctionne bien sur Debian 12 (pour être honnête, j'ai seulement testé l'installation et que la page d'accueil s'affiche bien), on peut donc officiellement supporter cette version.

Pour tester qu'une installation à partir de zéro sur un système vierge fonctionne, j'ai suivi les instructions pour l'utilisation avec Docker : https://github.com/philippemilink/zds-site/blob/718bc1ad6f50d86cca975f4544bb1394d407de7d/doc/source/install/install-docker.rst

Pour ceux qui utilisent un autre système, n'hésitez pas à regarder si une mise à jour du même genre ne serait pas nécessaire !

