### PR TITLE
Mise à jour triviale des dépendances Python

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ django-extensions==3.2.3
 Faker==18.13.0
 pre-commit==2.21.0
 PyYAML==6.0.1
-selenium==4.11.2
+selenium==4.9.1
 Sphinx==5.3.0
 sphinx-rtd-theme==1.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,10 +3,10 @@
 black==23.3.0  # needs to be also updated in .pre-commit-config.yaml
 colorlog==6.7.0
 django-debug-toolbar==3.8.1
-django-extensions==3.2.1
-Faker==18.9.0
+django-extensions==3.2.3
+Faker==18.13.0
 pre-commit==2.21.0
-PyYAML==6.0
-selenium==4.9.1
+PyYAML==6.0.1
+selenium==4.11.2
 Sphinx==5.3.0
-sphinx-rtd-theme==1.2.1
+sphinx-rtd-theme==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Implicit dependencies (optional dependencies of dependencies)
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.3
-social-auth-app-django==5.2.0
+social-auth-app-django==5.3.0
 
 # Explicit dependencies (references in code)
 beautifulsoup4==4.12.2
@@ -9,25 +9,25 @@ django-crispy-forms==1.14.0
 django-model-utils==4.3.1
 django-munin==0.2.1
 django-recaptcha==3.0.0
-Django==3.2.19
+Django==3.2.21
 easy-thumbnails[svg]==2.8.3
-factory-boy==3.2.1
+factory-boy==3.3.0
 geoip2==4.7.0
-GitPython==3.1.31
+GitPython==3.1.37
 homoglyphs==2.0.4
-lxml==4.9.2
+lxml==4.9.3
 Pillow==9.5.0
 pymemcache==4.0.0
 requests==2.31.0
 
 # Api dependencies
-django-cors-headers==4.0.0
-django-filter==23.2
+django-cors-headers==4.1.0
+django-filter==23.3
 django-oauth-toolkit==1.7.0
 djangorestframework==3.14.0
 drf-extensions==0.7.1
 dry-rest-permissions==0.1.10
-drf-yasg==1.21.5
+drf-yasg==1.21.7
 
 # Dependencies for slug generation, please be extra careful with those
 django-uuslug==2.0.0


### PR DESCRIPTION
Mise à jour triviale des dépendances Python à leur dernière version, à l'exception de : 

- `elasticsearch` et `elasticsearch-dsl` comme d'habitude,
- `django-crispy-forms` et `django-oauth-toolkit` car il y a des changements majeurs,
- `black`, `django-cors-headers`, `Faker`, `Pillow`, `pre-commit`, `selenium` et `Sphinx` car leurs dernières versions ne supportent plus Python 3.7 (version utilisée en production et avec Github Actions)
- `selenium` car la mise à jour fait planter la CI pour une raison inconnue