### PR TITLE
Passage à Python 3.9 et mise à jour des dépendances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   NODE_VERSION: "16" # needs to be also updated in .nvmrc
-  PYTHON_VERSION: "3.7"
+  PYTHON_VERSION: "3.9"
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt
   GECKODRIVER_VERSION: "0.33.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.2  # version 3.4.0 doesn't work with Python 3.7
+    rev: v3.13.0
     hooks:
     -   id: pyupgrade
-        args: [--py37-plus]
-  - repo: https://github.com/psf/black
-    rev: 23.3.0 # needs to be also updated in requirements-dev.txt
+        args: [--py39-plus]
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1 # needs to be also updated in requirements-dev.txt
     hooks:
       - id: black
         language_version: python3

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ clean-back: ## Remove Python bytecode files (*.pyc)
 	find . -name '*.pyc' -exec rm {} \;
 
 list-outdated-back: ## List outdated Python packages
+	@echo 'Info: You need to check `easy-thumbnails` version manually!'
 	@echo "Package                 Version   Latest    Type"
 	@echo "----------------------- --------- --------- -----"
 	@pip list --outdated | grep "`awk -F== '{ print $$1 }' requirements*.txt | tr -s '\n' '\n' | sort`"

--- a/doc/source/install/install-macos.rst
+++ b/doc/source/install/install-macos.rst
@@ -83,7 +83,7 @@ Pour vérifier, exécutez la commande suivante :
 
   python --version
 
-Si vous obtenez une version inférieure à Python 3.7 (et notamment si vous voyez
+Si vous obtenez une version inférieure à Python 3.9 (et notamment si vous voyez
 ``Python 2.7``), il vous faudra installer une version récente de Python avec
 Homebrew. Sinon, vous pouvez utiliser la version intégrée avec macOS de Python,
 mais vous devrez installer ``pip``.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ django-extensions==3.2.3
 Faker==19.6.2
 pre-commit==3.4.0
 PyYAML==6.0.1
-selenium==4.13.0
+selenium==4.9.1
 Sphinx==7.2.6
 sphinx-rtd-theme==1.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 
-black==23.3.0  # needs to be also updated in .pre-commit-config.yaml
+black==23.9.1  # needs to be also updated in .pre-commit-config.yaml
 colorlog==6.7.0
 django-debug-toolbar==3.8.1
 django-extensions==3.2.3
-Faker==18.13.0
-pre-commit==2.21.0
+Faker==19.6.2
+pre-commit==3.4.0
 PyYAML==6.0.1
-selenium==4.9.1
-Sphinx==5.3.0
+selenium==4.13.0
+Sphinx==7.2.6
 sphinx-rtd-theme==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-model-utils==4.3.1
 django-munin==0.2.1
 django-recaptcha==3.0.0
 Django==3.2.21
-easy-thumbnails[svg]==2.8.3
+easy-thumbnails[svg]==2.8.5
 factory-boy==3.3.0
 geoip2==4.7.0
 GitPython==3.1.37

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,12 +16,12 @@ geoip2==4.7.0
 GitPython==3.1.37
 homoglyphs==2.0.4
 lxml==4.9.3
-Pillow==9.5.0
+Pillow==10.0.1
 pymemcache==4.0.0
 requests==2.31.0
 
 # Api dependencies
-django-cors-headers==4.1.0
+django-cors-headers==4.2.0
 django-filter==23.3
 django-oauth-toolkit==1.7.0
 djangorestframework==3.14.0

--- a/zds/utils/templatetags/humanize_duration.py
+++ b/zds/utils/templatetags/humanize_duration.py
@@ -1,6 +1,7 @@
 import logging
 import numbers
-from typing import Tuple, List, Iterator, Iterable
+from typing import Tuple, List
+from collections.abc import Iterator, Iterable
 
 from django import template
 from django.utils.translation import ngettext, gettext as _
@@ -42,7 +43,7 @@ def _truncate_duration(duration: int, bounds: Iterable[int], precisions: Iterabl
     return duration
 
 
-def _minutes_to_hours_and_minutes(duration_min: int) -> Tuple[int, int]:
+def _minutes_to_hours_and_minutes(duration_min: int) -> tuple[int, int]:
     """
     Convert a duration expressed in minutes to a duration expressed in hours and minutes.
     `duration_min` shall be positive to ensure a correct behavior.

--- a/zds/utils/templatetags/profile.py
+++ b/zds/utils/templatetags/profile.py
@@ -11,7 +11,7 @@ register = template.Library()
 
 
 @register.filter("profile")
-@lru_cache()
+@lru_cache
 def profile(current_user):
     # we currently expect to receive a User in most cases, but as we move
     # toward using Profiles instead, we have to handle them as well.


### PR DESCRIPTION
- Passage à Python 3.9 (Github Actions et la documentation)
- Mise à jour triviale des dépendances Python à leur dernière version, à l'exception de : 
  - `elasticsearch` et `elasticsearch-dsl` comme d'habitude,
  - `django-crispy-forms` et `django-oauth-toolkit` car il y a des changements majeurs,
  - `selenium` car la mise à jour fait planter la CI pour une raison inconnue

**QA :** Github Actions + vérifier que le site web fonctionne bien en local + vérifier que la documentation est bien générée en local (mise à jour de Sphinx)