### PR TITLE
Mise à jour du script d'installation

### DIFF
--- a/scripts/define_variable.sh
+++ b/scripts/define_variable.sh
@@ -4,10 +4,14 @@ if [[ $ZDS_VENV == "" ]]; then
     ZDS_VENV="zdsenv"
 fi
 
+if [[ $ZDS_VENV_VERSION == "" ]]; then
+    ZDS_VENV_VERSION="20.24.5"
+fi
+
 ZDS_NODE_VERSION=$(cat $ZDSSITE_DIR/.nvmrc)
 
 if [[ $ZDS_NVM_VERSION == "" ]]; then
-    ZDS_NVM_VERSION="0.33.11"
+    ZDS_NVM_VERSION="0.39.5"
 fi
 
 if [[ $ZDS_ELASTIC_VERSION == "" ]]; then
@@ -19,7 +23,7 @@ if [[ $ZDS_LATEX_REPO == "" ]]; then
 fi
 
 if [[ $ZDS_JDK_VERSION == "" ]]; then
-    ZDS_JDK_VERSION="11.0.14.1"
+    ZDS_JDK_VERSION="11.0.20.1"
     # shellcheck disable=SC2034
     ZDS_JDK_REV="1"
 fi

--- a/scripts/dependencies/arch.txt
+++ b/scripts/dependencies/arch.txt
@@ -1,5 +1,5 @@
 #title=Arch
-#desc=Utilisation de pacman / Testé sur Arch
+#desc=Utilisation de pacman / Non testé sur les versions récentes
 #updatecmd=pacman -Syu --noconfirm
 #installcmd=pacman -S --noconfirm
 git

--- a/scripts/dependencies/debian.txt
+++ b/scripts/dependencies/debian.txt
@@ -1,5 +1,5 @@
 #title=Debian
-#desc=Utilisation de apt-get / Testé sur Debian Buster (10), Bullseye (11), Bookworm (12)
+#desc=Utilisation de apt-get / Testé sur Debian Bullseye (11), Bookworm (12)
 #updatecmd=apt-get -y update
 #installcmd=apt-get -y install
 git

--- a/scripts/dependencies/fedora.txt
+++ b/scripts/dependencies/fedora.txt
@@ -1,5 +1,5 @@
 #title=Fedora
-#desc=Utilisation de dnf / Testé sur Fedora 29, 30
+#desc=Utilisation de dnf / Non testé sur les versions récentes
 #installcmd=dnf -y install
 git
 wget

--- a/scripts/dependencies/ubuntu.txt
+++ b/scripts/dependencies/ubuntu.txt
@@ -1,5 +1,5 @@
 #title=Ubuntu
-#desc=Utilisation de apt-get / Testé sur : 18.04 LTS, 19.04, 20.04 LTS & Linux Mint 19
+#desc=Utilisation de apt-get / Testé sur : 22.04 LTS
 #updatecmd=apt-get -y update
 #installcmd=apt-get -y install
 git

--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -147,8 +147,8 @@ if  ! $(_in "-virtualenv" $@) && ( $(_in "+virtualenv" $@) || $(_in "+base" $@) 
             fi
         fi
 
-        print_info "* [+virtualenv] installing \`virtualenv 16.2.0\` with pip"
-        pip3 install --user virtualenv==16.2.0
+        print_info "* [+virtualenv] installing \`virtualenv $ZDS_VENV_VERSION\` with pip"
+        pip3 install --user virtualenv==$ZDS_VENV_VERSION
 
         print_info "* [+virtualenv] creating virtualenv"
         err=$(python3 -m venv $ZDS_VENV 3>&1 1>&2 2>&3 | sudo tee /dev/stderr)


### PR DESCRIPTION
**Dans la suite du passage à Python 3.9 #6530**

Mise à jour du script d'installation : 

- dernières versions de `virtualenv`, `nvm` et `openjdk`
- suppressions des anciennes distributions testées (car elles ne sont plus supportées depuis longtemps et/ou leur version par défaut de Python est inférieure à Python 3.9)
- ajout de Ubuntu 22.04 LTS dans les distributions testées car il s'agit de la distribution que j'utilise sans soucis depuis plusieurs mois

**QA :** à partir d'un clone du dépôt `https://github.com/Situphen/zds-site`, se mettre sur la branche `install-update` et lancer `make install-linux`