### PR TITLE
Retire l'argument obsolète "providing_args" pour la création des signaux (préparation pour Django 4)

### DIFF
--- a/zds/forum/signals.py
+++ b/zds/forum/signals.py
@@ -1,7 +1,16 @@
 from django.dispatch import Signal
 
-topic_moved = Signal(providing_args=["topic"])
-topic_edited = Signal(providing_args=["topic"])
-topic_read = Signal(providing_args=["instance", "user"])
-post_read = Signal(providing_args=["instance", "user"])
-post_unread = Signal(providing_args=["post", "user"])
+# argument: topic
+topic_moved = Signal()
+
+# argument: topic
+topic_edited = Signal()
+
+# arguments: instance, user
+topic_read = Signal()
+
+# arguments: instance, user
+post_read = Signal()
+
+# arguments: post, user
+post_unread = Signal()

--- a/zds/notification/signals.py
+++ b/zds/notification/signals.py
@@ -1,4 +1,5 @@
 from django.dispatch import Signal
 
 # is sent when a content is read (topic, article or tutorial)
-content_read = Signal(providing_args=["instance", "user", "target"])
+# arguments: instance, user, target
+content_read = Signal()

--- a/zds/tutorialv2/signals.py
+++ b/zds/tutorialv2/signals.py
@@ -1,11 +1,14 @@
 from django.dispatch.dispatcher import Signal
 
 # Display management
-content_read = Signal(providing_args=["instance", "user", "target"])
+# arguments: instance, user, target
+content_read = Signal()
 
 # Publication events
-content_published = Signal(providing_args=["instance", "user", "by_email"])
-content_unpublished = Signal(providing_args=["instance", "target", "moderator"])
+# arguments: instance, user, by_email
+content_published = Signal()
+# arguments: instance, target, moderator
+content_unpublished = Signal()
 
 # Authors management
 # For the signal below, the arguments "performer", "content", "author" and "action" shall be provided.

--- a/zds/utils/signals.py
+++ b/zds/utils/signals.py
@@ -1,4 +1,7 @@
 from django.dispatch import Signal
 
-ping = Signal(providing_args=["instance", "user", "by_email"])
-unping = Signal(providing_args=["instance", "user"])
+# arguments: instance, user, by_email
+ping = Signal()
+
+# arguments: instance, user
+unping = Signal()


### PR DESCRIPTION
Cette PR concoure à la préparation du passage à Django 4.X.

Certains de nos signaux sont crées en fournissant l'argument `providing_args`. Cet argument est déjà obsolète dans la version 3.2 de Django et est supprimé dans la 4.0.

J'ai effectué la correction suggérée, à savoir mettre l'information associée à cet argument dans un commentaire pour documenter.

### Contrôle qualité

- CI
- lancer le site et vérifier rapidement que ça marche normalement.
