### PR TITLE
Retire les usages du templatetag obsolète {% ifnotequal %} (préparation pour Django 4)

### DIFF
--- a/templates/misc/pagination.part.html
+++ b/templates/misc/pagination.part.html
@@ -11,7 +11,7 @@
     {% endcaptureas %}
 
     <ul class="pagination pagination-{{ position }}">
-        {% ifnotequal nb 1 %}
+        {% if nb != 1 %}
             <li class="prev">
                 {% with prev=nb|add:-1 %}
                     <a href="{% append_query_params page=prev %}{{ full_anchor }}" class="ico-after arrow-left blue" rel="prev">
@@ -21,18 +21,18 @@
                     </a>
                 {% endwith %}
             </li>
-        {% endifnotequal %}
+        {% endif %}
 
 
         {% for page in pages %}
             {% if page %}
                 <li>
                     <a
-                        {% ifnotequal page nb %}
+                        {% if page != nb %}
                             href="{% append_query_params page=page %}{{ full_anchor }}"
                         {% else %}
                             class="current"
-                        {% endifnotequal %}
+                        {% endif %}
                         {% if page|add:-1 == nb %}
                             rel="next"
                         {% elif page|add:1 == nb %}

--- a/templates/misc/paginator.html
+++ b/templates/misc/paginator.html
@@ -24,11 +24,11 @@
             {% if page_nb %}
                 <li>
                     <a
-                        {% ifnotequal page_nb page_obj.number %}
+                        {% if page_nb != page_obj.number %}
                             href="{% append_query_params page=page_nb %}{{ full_anchor }}"
                         {% else %}
                             class="current"
-                        {% endifnotequal %}
+                        {% endif %}
                         {% if page_nb|add:-1 == page_obj.number %}
                             rel="next"
                         {% elif page_nb|add:1 == page_obj.number %}


### PR DESCRIPTION
Le template tag `{% ifnotequal %}` est obsolète dans notre version de Django et sera retiré dans Django 4.

J'ai fait la correction recommandée, à savoir utiliser `{% if %}`, qui remplit tous les cas d'usage que faisait cet ancien templatetag.

### Contrôle qualité

- CI
- lancer le site et vérifier que ça marche à droite à gauche
- vérifier spécifiquement les pages avec de la pagination, vu que ça touche ses parties-là.
