### PR TITLE
Remplace la méthode obsolète request.is_ajax (préparation pour Django 4)

### DIFF
--- a/zds/forum/utils.py
+++ b/zds/forum/utils.py
@@ -10,7 +10,7 @@ from django.views.generic.detail import SingleObjectMixin
 from django.utils.translation import gettext as _
 from zds.forum.models import Forum, Topic, Post
 from zds.member.views import get_client_ip
-from zds.utils.misc import contains_utf8mb4
+from zds.utils.misc import contains_utf8mb4, is_ajax
 from zds.utils.mixins import QuoteMixin
 from zds.utils.models import CommentVote, get_hat_from_request
 
@@ -141,7 +141,7 @@ class CreatePostView(CreateView, SingleObjectMixin, QuoteMixin):
         if "cite" in request.GET:
             text = self.build_quote(request.GET.get("cite"), request.user)
 
-            if request.is_ajax():
+            if is_ajax(request):
                 return HttpResponse(json.dumps({"text": text}), content_type="application/json")
 
         form = self.create_forum(self.form_class, **{"text": text})
@@ -172,11 +172,11 @@ class CreatePostView(CreateView, SingleObjectMixin, QuoteMixin):
     def post(self, request, *args, **kwargs):
         form = self.get_form(self.form_class)
         new_post = None
-        if not request.is_ajax():
+        if not is_ajax(request):
             new_post = self.object.last_message.pk != int(request.POST.get("last_post"))
 
         if "preview" in request.POST or new_post:
-            if request.is_ajax():
+            if is_ajax(request):
                 content = render(request, "misc/preview.part.html", {"text": request.POST.get("text")})
                 return StreamingHttpResponse(content)
             else:

--- a/zds/forum/views.py
+++ b/zds/forum/views.py
@@ -28,6 +28,7 @@ from zds.featured.mixins import FeatureableMixin
 from zds.utils import old_slugify
 from zds.utils.context_processor import get_repository_url
 from zds.forum.utils import create_topic, send_post, CreatePostView
+from zds.utils.misc import is_ajax
 from zds.utils.mixins import FilterMixin
 from zds.utils.models import Alert, Tag, CommentVote
 from zds.utils.paginator import ZdSPagingListView
@@ -108,7 +109,7 @@ class ForumTopicsListView(FilterMixin, ForumEditMixin, ZdSPagingListView, Update
             response["email"] = self.perform_follow_by_email(self.object, request.user)
 
         self.object.save()
-        if request.is_ajax():
+        if is_ajax(request):
             return HttpResponse(json.dumps(response), content_type="application/json")
         return redirect(f"{self.object.get_absolute_url()}?page={self.page}")
 
@@ -265,7 +266,7 @@ class TopicNew(CreateView, SingleObjectMixin):
         form = self.get_form(self.form_class)
 
         if "preview" in request.POST:
-            if request.is_ajax():
+            if is_ajax(request):
                 content = render(request, "misc/preview.part.html", {"text": request.POST["text"]})
                 return StreamingHttpResponse(content)
             else:
@@ -356,7 +357,7 @@ class TopicEdit(UpdateView, SingleObjectMixin, TopicEditMixin, FeatureableMixin)
             form = self.get_form(self.form_class)
 
             if "preview" in request.POST:
-                if request.is_ajax():
+                if is_ajax(request):
                     content = render(request, "misc/preview.part.html", {"text": request.POST["text"]})
                     return StreamingHttpResponse(content)
                 else:
@@ -391,7 +392,7 @@ class TopicEdit(UpdateView, SingleObjectMixin, TopicEditMixin, FeatureableMixin)
             response["requesting"], response["newCount"] = self.toogle_featured_request(request.user)
 
         self.object.save()
-        if request.is_ajax():
+        if is_ajax(request):
             return HttpResponse(json.dumps(response), content_type="application/json")
         return redirect(f"{self.object.get_absolute_url()}?page={self.page}")
 
@@ -511,7 +512,7 @@ class FindTopicByTag(FilterMixin, ForumEditMixin, ZdSPagingListView, SingleObjec
             response["email"] = self.perform_follow_by_email(self.object, request.user)
 
         self.object.save()
-        if request.is_ajax():
+        if is_ajax(request):
             return HttpResponse(json.dumps(response), content_type="application/json")
         return redirect(f"{self.object.get_absolute_url()}?page={self.page}")
 
@@ -635,7 +636,7 @@ class PostEdit(UpdateView, SinglePostObjectMixin, PostEditMixin):
             form = self.get_form(self.form_class)
 
             if "preview" in request.POST:
-                if request.is_ajax():
+                if is_ajax(request):
                     content = render(request, "misc/preview.part.html", {"text": request.POST.get("text")})
                     return StreamingHttpResponse(content)
                 else:
@@ -717,7 +718,7 @@ class PostUseful(UpdateView, SinglePostObjectMixin, PostEditMixin):
     def post(self, request, *args, **kwargs):
         self.perform_useful(self.object)
 
-        if request.is_ajax():
+        if is_ajax(request):
             return HttpResponse(json.dumps(self.object.is_useful), content_type="application/json")
 
         return redirect(self.object.get_absolute_url())

--- a/zds/member/views/hats.py
+++ b/zds/member/views/hats.py
@@ -15,6 +15,7 @@ from django.views.generic import DetailView, CreateView
 from zds.member.decorator import LoginRequiredMixin
 from zds.member.forms import HatRequestForm
 from zds.pages.models import GroupContact
+from zds.utils.misc import is_ajax
 from zds.utils.models import HatRequest, Hat, get_hat_to_add
 from zds.utils.paginator import ZdSPagingListView
 
@@ -74,7 +75,7 @@ class HatsSettings(LoginRequiredMixin, CreateView):
         return initial
 
     def post(self, request, *args, **kwargs):
-        if "preview" in request.POST and request.is_ajax():
+        if "preview" in request.POST and is_ajax(request):
             content = render(request, "misc/preview.part.html", {"text": request.POST.get("text")})
             return StreamingHttpResponse(content)
 

--- a/zds/member/views/profile.py
+++ b/zds/member/views/profile.py
@@ -36,6 +36,7 @@ from zds.member.utils import get_bot_account
 from zds.notification.models import TopicAnswerSubscription, NewPublicationSubscription
 from zds.tutorialv2.models import CONTENT_TYPES
 from zds.tutorialv2.models.database import PublishedContent, ContentContribution, ContentReaction
+from zds.utils.misc import is_ajax
 from zds.utils.templatetags.pluralize_fr import pluralize_fr
 
 
@@ -244,7 +245,7 @@ class UpdateMember(UpdateView):
     def post(self, request, *args, **kwargs):
         form = self.form_class(request.POST)
 
-        if "preview" in request.POST and request.is_ajax():
+        if "preview" in request.POST and is_ajax(request):
             content = render(request, "misc/preview.part.html", {"text": request.POST.get("text")})
             return StreamingHttpResponse(content)
 

--- a/zds/middlewares/matomomiddleware.py
+++ b/zds/middlewares/matomomiddleware.py
@@ -10,6 +10,7 @@ from threading import Thread
 from django.urls import reverse
 
 from zds.member.views import get_client_ip
+from zds.utils.misc import is_ajax
 
 matomo_token_auth = settings.ZDS_APP["site"]["matomo_token_auth"]
 matomo_api_url = "{}/matomo.php?token_auth={}".format(settings.ZDS_APP["site"]["matomo_url"], matomo_token_auth)
@@ -96,7 +97,7 @@ class MatomoMiddleware:
             self.queue.put(tracking_params)
 
     def process_response(self, request, response):
-        if response.status_code not in tracked_status_code or request.is_ajax():
+        if response.status_code not in tracked_status_code or is_ajax(request):
             return response
         # only on get
         if request.method in tracked_methods:

--- a/zds/mp/views.py
+++ b/zds/mp/views.py
@@ -30,6 +30,7 @@ from .models import (
     PrivatePostVote,
     is_reachable,
 )
+from zds.utils.misc import is_ajax
 
 
 class PrivateTopicList(LoginRequiredMixin, ZdSPagingListView):
@@ -64,7 +65,7 @@ class PrivateTopicNew(LoginRequiredMixin, CreateView):
         form = self.get_form(self.form_class)
 
         if "preview" in request.POST:
-            if request.is_ajax():
+            if is_ajax(request):
                 content = render(request, "misc/preview.part.html", {"text": request.POST["text"]})
                 return StreamingHttpResponse(content)
             else:
@@ -307,7 +308,7 @@ class PrivatePostEdit(LoginRequiredMixin, UpdateView, UpdatePrivatePost):
         form = self.get_form(self.form_class)
 
         if "preview" in request.POST:
-            if request.is_ajax():
+            if is_ajax(request):
                 content = render(request, "misc/preview.part.html", {"text": request.POST["text"]})
                 return StreamingHttpResponse(content)
         elif form.is_valid():

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -12,6 +12,7 @@ from zds.forum.models import Topic
 from zds.tutorialv2.models.database import PublishableContent, PublishedContent, ContentRead
 from zds.tutorialv2.utils import mark_read
 from zds.tutorialv2.models.help_requests import HelpWriting
+from zds.utils.misc import is_ajax
 
 
 class SingleContentViewMixin:
@@ -186,7 +187,7 @@ class FormWithPreview(FormView):
 
         if "preview" in request.POST:
             self.form_invalid(form)
-            if request.is_ajax():
+            if is_ajax(self.request):
                 content = render_to_string("misc/preview.part.html", {"text": request.POST.get("text")})
                 return StreamingHttpResponse(content)
 

--- a/zds/tutorialv2/views/comments.py
+++ b/zds/tutorialv2/views/comments.py
@@ -20,6 +20,7 @@ from zds.notification.models import ContentReactionAnswerSubscription
 from zds.tutorialv2.forms import NoteForm, NoteEditForm
 from zds.tutorialv2.mixins import SingleOnlineContentFormViewMixin, MustRedirect, SingleOnlineContentViewMixin
 from zds.tutorialv2.models.database import ContentReaction
+from zds.utils.misc import is_ajax
 from zds.utils.models import CommentEdit, get_hat_from_request, Alert
 
 
@@ -97,7 +98,7 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
                 text = "\n".join("> " + line for line in reaction.text.split("\n"))
                 text += f"\nSource: [{reaction.author.username}]({reaction.get_absolute_url()})"
 
-                if self.request.is_ajax():
+                if is_ajax(self.request):
                     return StreamingHttpResponse(json_handler.dumps({"text": text}, ensure_ascii=False))
                 else:
                     self.quoted_reaction_text = text
@@ -110,7 +111,7 @@ class SendNoteFormView(LoggedWithReadWriteHability, SingleOnlineContentFormViewM
             )
 
     def post(self, request, *args, **kwargs):
-        if "preview" in request.POST and request.is_ajax():
+        if "preview" in request.POST and is_ajax(request):
             content = render(request, "misc/preview.part.html", {"text": request.POST["text"]})
             return StreamingHttpResponse(content)
         else:
@@ -362,6 +363,6 @@ class FollowContentReaction(LoggedWithReadWriteHability, SingleOnlineContentView
             response["follow"] = ContentReactionAnswerSubscription.objects.toggle_follow(
                 self.get_object(), self.request.user, True
             ).is_active
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             return HttpResponse(json_handler.dumps(response), content_type="application/json")
         return redirect(self.get_object().get_absolute_url())

--- a/zds/tutorialv2/views/containers_extracts.py
+++ b/zds/tutorialv2/views/containers_extracts.py
@@ -27,6 +27,7 @@ from zds.tutorialv2.utils import (
     try_adopt_new_child,
     TooDeepContainerError,
 )
+from zds.utils.misc import is_ajax
 
 logger = logging.getLogger(__name__)
 
@@ -277,7 +278,7 @@ class EditExtract(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
         self.object.update(sha_draft=sha, update_date=datetime.now())
 
         self.success_url = extract.get_absolute_url()
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             return JsonResponse(
                 {"result": "ok", "last_hash": extract.compute_hash(), "new_url": extract.get_edit_url()}
             )

--- a/zds/tutorialv2/views/help.py
+++ b/zds/tutorialv2/views/help.py
@@ -12,6 +12,7 @@ from zds.tutorialv2.mixins import SingleContentFormViewMixin
 
 from zds.tutorialv2.models.database import PublishableContent
 from zds.tutorialv2.models.help_requests import HelpWriting
+from zds.utils.misc import is_ajax
 from zds.utils.paginator import ZdSPagingListView
 
 
@@ -84,12 +85,12 @@ class ChangeHelp(LoggedWithReadWriteHability, SingleContentFormViewMixin):
             self.object.helps.remove(data["help_wanted"])
         self.object.save()
         signals.help_management.send(sender=self.__class__, performer=self.request.user, content=self.object)
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             return JsonResponse({"state": data["activated"]})
         self.success_url = self.object.get_absolute_url()
         return super().form_valid(form)
 
     def form_invalid(self, form):
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             return JsonResponse({"errors": form.errors}, status=400)
         return super().form_invalid(form)

--- a/zds/tutorialv2/views/misc.py
+++ b/zds/tutorialv2/views/misc.py
@@ -17,6 +17,7 @@ from zds.tutorialv2.forms import WarnTypoForm
 from zds.tutorialv2.mixins import SingleOnlineContentViewMixin, SingleContentFormViewMixin
 from zds.tutorialv2.utils import search_container_or_404
 from zds.mp.utils import send_mp
+from zds.utils.misc import is_ajax
 
 
 class RequestFeaturedContent(LoggedWithReadWriteHability, FeatureableMixin, SingleOnlineContentViewMixin, FormView):
@@ -32,7 +33,7 @@ class RequestFeaturedContent(LoggedWithReadWriteHability, FeatureableMixin, Sing
 
         response = dict()
         response["requesting"], response["newCount"] = self.toogle_featured_request(request.user)
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             return HttpResponse(json_handler.dumps(response), content_type="application/json")
         return redirect(self.public_content_object.get_absolute_url_online())
 
@@ -68,7 +69,7 @@ class FollowNewContent(LoggedWithReadWriteHability, FormView):
             elif "email" in request.POST:
                 response["email"] = self.perform_follow_by_email(user_to_follow, request.user)
 
-        if request.is_ajax():
+        if is_ajax(self.request):
             return HttpResponse(json_handler.dumps(response), content_type="application/json")
         return redirect(request.META.get("HTTP_REFERER"))
 

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -61,7 +61,7 @@ def contains_utf8mb4(s):
 def check_essential_accounts():
     """
     Verify that essential accounts are present in the database.
-    Raise an exception if it not the case.
+    Raise an exception if it is not the case.
     """
 
     from django.conf import settings

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -2,6 +2,7 @@ import hashlib
 import re
 
 from django.contrib.auth import get_user_model
+from django.http import HttpRequest
 
 THUMB_MAX_WIDTH = 80
 THUMB_MAX_HEIGHT = 80
@@ -78,3 +79,22 @@ def check_essential_accounts():
                 f"User {username!r} does not exist. You must create it to run the server. "
                 f"On a development instance, load the fixtures to solve this issue."
             )
+
+
+def is_ajax(request: HttpRequest):
+    """
+    Check whether the request was sent asynchronously.
+
+    The function returns True for :
+
+    * requests sent using jQuery.ajax() since it sets the header `X-Requested-With`
+      to `XMLHttpRequest` by default ;
+    * requests sent using the tools provided by `ajax.js`, which reproduce the behavior
+      described above to ease the progressive removal of jQuery from the codebase.
+
+    The function returns False for requests without the appropriate header.
+    These requests will not be recognized as AJAX.
+
+    The function replaces `request.is_ajax()`, which is removed starting from Django 4.0.
+    """
+    return request.META.get("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest"


### PR DESCRIPTION
Cette PR fait partie de modifications nécessaires pour passer à Django 4.

On utilise régulièrement `request.is_ajax()` pour savoir si la requête provient du frontend de manière asynchrone, etc. Django a décidé que la méthode de détection était trop spécifique à JQuery et a décidé de supprimer la méthode dans Django 4. Une correction simple est de créer sa propre fonction qui reprend la même logique, ce que j'ai fait. C'est aussi une des solutions recommandées.

J'ai corrigé une coquille dans un truc qui n'a rien à voir au passage. **Ne pas squasher au merge**, ça sera mieux pour ne pas tout mélanger.

### Contrôle qualité

- CI
- lancer le site et utiliser les pages qui font des requêtes asynchrones (la preview des messages, les champs avec autocomplétion, etc. ; on peut regarder le code si on veut exercer manuellement tous les chemins d'exécution)
