### PR TITLE
Mise à jour majeure de django-oauth-toolkit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ requests==2.31.0
 # Api dependencies
 django-cors-headers==4.3.1
 django-filter==23.5
-django-oauth-toolkit==1.7.0
+django-oauth-toolkit==2.3.0
 djangorestframework==3.14.0
 drf-extensions==0.7.1
 dry-rest-permissions==0.1.10

--- a/zds/api/utils.py
+++ b/zds/api/utils.py
@@ -1,0 +1,26 @@
+from oauth2_provider.models import Application, AccessToken
+
+CLEARTEXT_SECRET = "abcdefghijklmnopqrstuvwxyz1234567890"
+
+
+def authenticate_oauth2_client(client, user, password):
+    oauth2_client = Application.objects.create(
+        user=user,
+        client_type=Application.CLIENT_CONFIDENTIAL,
+        authorization_grant_type=Application.GRANT_PASSWORD,
+        client_secret=CLEARTEXT_SECRET,
+    )
+    oauth2_client.save()
+
+    client.post(
+        "/oauth2/token/",
+        {
+            "client_id": oauth2_client.client_id,
+            "client_secret": CLEARTEXT_SECRET,
+            "username": user.username,
+            "password": password,
+            "grant_type": "password",
+        },
+    )
+    access_token = AccessToken.objects.get(user=user)
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")

--- a/zds/api/utils.py
+++ b/zds/api/utils.py
@@ -1,5 +1,11 @@
+from django.urls import reverse
 from oauth2_provider.models import Application, AccessToken
 
+
+# As of django-oauth-toolkit (oauth2_provider) 2.0.0, `Application.client_secret` values are hashed
+# before being saved in the database. For the tests, we use the same method as django-oauth-toolkit's tests
+# which is to store the client_secret cleartext value in CLEARTEXT_SECRET.
+# (See https://github.com/jazzband/django-oauth-toolkit/blob/fda64f97974aac78d4ac9c9f0f36e137dbe4fb8c/tests/test_client_credential.py#L26C58-L26C58)
 CLEARTEXT_SECRET = "abcdefghijklmnopqrstuvwxyz1234567890"
 
 
@@ -13,7 +19,7 @@ def authenticate_oauth2_client(client, user, password):
     oauth2_client.save()
 
     client.post(
-        "/oauth2/token/",
+        reverse("oauth2_provider:token"),
         {
             "client_id": oauth2_client.client_id,
             "client_secret": CLEARTEXT_SECRET,

--- a/zds/gallery/api/tests.py
+++ b/zds/gallery/api/tests.py
@@ -9,10 +9,10 @@ from rest_framework import status
 from rest_framework.test import APITestCase, APIClient
 from rest_framework_extensions.settings import extensions_api_settings
 
+from zds.api.utils import authenticate_oauth2_client
 from zds.gallery.tests.factories import UserGalleryFactory, GalleryFactory, ImageFactory
 from zds.gallery.models import Gallery, UserGallery, GALLERY_WRITE, Image, GALLERY_READ
 from zds.member.tests.factories import ProfileFactory
-from zds.member.api.tests import create_oauth2_client, authenticate_client
 from zds.tutorialv2.tests.factories import PublishableContentFactory
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 
@@ -21,8 +21,7 @@ class GalleryListAPITest(APITestCase):
     def setUp(self):
         self.profile = ProfileFactory()
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
 
@@ -92,8 +91,7 @@ class GalleryDetailAPITest(TutorialTestMixin, APITestCase):
         self.profile = ProfileFactory()
         self.other = ProfileFactory()
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         self.gallery = GalleryFactory()
 
@@ -222,8 +220,7 @@ class ImageListAPITest(APITestCase):
         self.profile = ProfileFactory()
         self.other = ProfileFactory()
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         self.gallery = GalleryFactory()
         UserGalleryFactory(user=self.profile.user, gallery=self.gallery)
@@ -358,8 +355,7 @@ class ImageDetailAPITest(APITestCase):
         self.profile = ProfileFactory()
         self.other = ProfileFactory()
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         self.gallery = GalleryFactory()
         UserGalleryFactory(user=self.profile.user, gallery=self.gallery)
@@ -506,8 +502,7 @@ class ParticipantListAPITest(TutorialTestMixin, APITestCase):
         self.other = ProfileFactory()
         self.client = APIClient()
         self.new_participant = ProfileFactory()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         self.gallery = GalleryFactory()
         UserGalleryFactory(user=self.profile.user, gallery=self.gallery)
@@ -620,8 +615,7 @@ class ParticipantDetailAPITest(TutorialTestMixin, APITestCase):
         self.other = ProfileFactory()
         self.new_participant = ProfileFactory()
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         self.gallery = GalleryFactory()
         UserGalleryFactory(user=self.profile.user, gallery=self.gallery)

--- a/zds/member/api/tests.py
+++ b/zds/member/api/tests.py
@@ -2,12 +2,12 @@ from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.core import mail
 from django.urls import reverse
-from oauth2_provider.models import Application, AccessToken
 from rest_framework import status
 from rest_framework.test import APITestCase
 from rest_framework.test import APIClient
 
 from zds.api.pagination import REST_PAGE_SIZE, REST_MAX_PAGE_SIZE, REST_PAGE_SIZE_QUERY_PARAM
+from zds.api.utils import authenticate_oauth2_client
 from zds.member.tests.factories import ProfileFactory, StaffProfileFactory, ProfileNotSyncFactory
 from zds.member.models import TokenRegister, BannedEmailProvider
 from rest_framework_extensions.settings import extensions_api_settings
@@ -366,9 +366,8 @@ class MemberMyDetailAPITest(APITestCase):
         Gets all information about the user.
         """
         profile = ProfileFactory()
-        client_oauth2 = create_oauth2_client(profile.user)
         client_authenticated = APIClient()
-        authenticate_client(client_authenticated, client_oauth2, profile.user.username, "hostel77")
+        authenticate_oauth2_client(client_authenticated, profile.user, "hostel77")
 
         response = client_authenticated.get(reverse("api:member:profile"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -403,9 +402,8 @@ class MemberDetailAPITest(APITestCase):
         self.client = APIClient()
         self.profile = ProfileFactory()
 
-        client_oauth2 = create_oauth2_client(self.profile.user)
         self.client_authenticated = APIClient()
-        authenticate_client(self.client_authenticated, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client_authenticated, self.profile.user, "hostel77")
 
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
 
@@ -497,9 +495,8 @@ class MemberDetailAPITest(APITestCase):
         """
         decal = ProfileNotSyncFactory()
 
-        client_oauth2 = create_oauth2_client(decal.user)
         client_authenticated = APIClient()
-        authenticate_client(client_authenticated, client_oauth2, decal.user.username, "hostel77")
+        authenticate_oauth2_client(client_authenticated, decal.user, "hostel77")
 
         response = client_authenticated.put(reverse("api:member:detail", args=[decal.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -681,9 +678,8 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
 
         self.profile = ProfileFactory()
         self.staff = StaffProfileFactory()
-        client_oauth2 = create_oauth2_client(self.staff.user)
         self.client_authenticated = APIClient()
-        authenticate_client(self.client_authenticated, client_oauth2, self.staff.user.username, "hostel77")
+        authenticate_oauth2_client(self.client_authenticated, self.staff.user, "hostel77")
 
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
 
@@ -749,9 +745,8 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         """
         Tries to apply a read only sanction at a member with a user isn't authenticated.
         """
-        client_oauth2 = create_oauth2_client(self.profile.user)
         client_authenticated = APIClient()
-        authenticate_client(client_authenticated, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(client_authenticated, self.profile.user, "hostel77")
 
         response = client_authenticated.post(reverse("api:member:read-only", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -817,9 +812,8 @@ class MemberDetailReadingOnlyAPITest(APITestCase):
         """
         Tries to remove a read only sanction at a member with a user isn't authenticated.
         """
-        client_oauth2 = create_oauth2_client(self.profile.user)
         client_authenticated = APIClient()
-        authenticate_client(client_authenticated, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(client_authenticated, self.profile.user, "hostel77")
 
         response = client_authenticated.delete(reverse("api:member:read-only", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -840,9 +834,8 @@ class MemberDetailBanAPITest(APITestCase):
 
         self.profile = ProfileFactory()
         self.staff = StaffProfileFactory()
-        client_oauth2 = create_oauth2_client(self.staff.user)
         self.client_authenticated = APIClient()
-        authenticate_client(self.client_authenticated, client_oauth2, self.staff.user.username, "hostel77")
+        authenticate_oauth2_client(self.client_authenticated, self.staff.user, "hostel77")
 
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
 
@@ -908,9 +901,8 @@ class MemberDetailBanAPITest(APITestCase):
         """
         Tries to apply a ban sanction at a member with a user isn't authenticated.
         """
-        client_oauth2 = create_oauth2_client(self.profile.user)
         client_authenticated = APIClient()
-        authenticate_client(client_authenticated, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(client_authenticated, self.profile.user, "hostel77")
 
         response = client_authenticated.post(reverse("api:member:ban", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -976,9 +968,8 @@ class MemberDetailBanAPITest(APITestCase):
         """
         Tries to remove a ban sanction at a member with a user isn't authenticated.
         """
-        client_oauth2 = create_oauth2_client(self.profile.user)
         client_authenticated = APIClient()
-        authenticate_client(client_authenticated, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(client_authenticated, self.profile.user, "hostel77")
 
         response = client_authenticated.delete(reverse("api:member:ban", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -1011,9 +1002,7 @@ class PermissionMemberAPITest(APITestCase):
         """
         Authenticated users have the permission to read any member.
         """
-        authenticate_client(
-            self.client, create_oauth2_client(self.profile.user), self.profile.user.username, "hostel77"
-        )
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         response = self.client.get(reverse("api:member:detail", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1023,7 +1012,7 @@ class PermissionMemberAPITest(APITestCase):
         """
         Staff users have the permission to read any member.
         """
-        authenticate_client(self.client, create_oauth2_client(self.staff.user), self.staff.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.staff.user, "hostel77")
 
         response = self.client.get(reverse("api:member:detail", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1041,9 +1030,7 @@ class PermissionMemberAPITest(APITestCase):
         """
         A user authenticated have write permissions.
         """
-        authenticate_client(
-            self.client, create_oauth2_client(self.profile.user), self.profile.user.username, "hostel77"
-        )
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         response = self.client.get(reverse("api:member:detail", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1053,7 +1040,7 @@ class PermissionMemberAPITest(APITestCase):
         """
         A staff user have write permissions.
         """
-        authenticate_client(self.client, create_oauth2_client(self.staff.user), self.staff.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.staff.user, "hostel77")
 
         response = self.client.get(reverse("api:member:detail", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1071,9 +1058,7 @@ class PermissionMemberAPITest(APITestCase):
         """
         Only the user authenticated have update permissions.
         """
-        authenticate_client(
-            self.client, create_oauth2_client(self.profile.user), self.profile.user.username, "hostel77"
-        )
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         response = self.client.get(reverse("api:member:detail", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1083,7 +1068,7 @@ class PermissionMemberAPITest(APITestCase):
         """
         Only the user authenticated have update permissions.
         """
-        authenticate_client(self.client, create_oauth2_client(self.staff.user), self.staff.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.staff.user, "hostel77")
 
         response = self.client.get(reverse("api:member:detail", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1101,9 +1086,7 @@ class PermissionMemberAPITest(APITestCase):
         """
         Only staff have ban permission.
         """
-        authenticate_client(
-            self.client, create_oauth2_client(self.profile.user), self.profile.user.username, "hostel77"
-        )
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         response = self.client.get(reverse("api:member:detail", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1113,7 +1096,7 @@ class PermissionMemberAPITest(APITestCase):
         """
         Only staff have ban permission.
         """
-        authenticate_client(self.client, create_oauth2_client(self.staff.user), self.staff.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.staff.user, "hostel77")
 
         response = self.client.get(reverse("api:member:detail", args=[self.profile.user.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1132,14 +1115,12 @@ class CacheMemberAPITest(APITestCase):
         profile = ProfileFactory()
         another_profile = ProfileFactory()
 
-        authenticate_client(self.client, create_oauth2_client(profile.user), profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, profile.user, "hostel77")
         response = self.client.get(reverse("api:member:profile"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(profile.user.username, response.data.get("username"))
 
-        authenticate_client(
-            self.client, create_oauth2_client(another_profile.user), another_profile.user.username, "hostel77"
-        )
+        authenticate_oauth2_client(self.client, another_profile.user, "hostel77")
         response = self.client.get(reverse("api:member:profile"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(another_profile.user.username, response.data.get("username"))
@@ -1167,26 +1148,3 @@ class CacheMemberAPITest(APITestCase):
         response = self.client.get(reverse("api:member:list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get("count"), count + 1)
-
-
-def create_oauth2_client(user):
-    client = Application.objects.create(
-        user=user, client_type=Application.CLIENT_CONFIDENTIAL, authorization_grant_type=Application.GRANT_PASSWORD
-    )
-    client.save()
-    return client
-
-
-def authenticate_client(client, client_auth, username, password):
-    client.post(
-        "/oauth2/token/",
-        {
-            "client_id": client_auth.client_id,
-            "client_secret": client_auth.client_secret,
-            "username": username,
-            "password": password,
-            "grant_type": "password",
-        },
-    )
-    access_token = AccessToken.objects.get(user__username=username)
-    client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")

--- a/zds/mp/api/tests.py
+++ b/zds/mp/api/tests.py
@@ -10,7 +10,7 @@ from rest_framework.test import APITestCase, APIClient
 from rest_framework_extensions.settings import extensions_api_settings
 
 from zds.api.pagination import REST_PAGE_SIZE, REST_MAX_PAGE_SIZE, REST_PAGE_SIZE_QUERY_PARAM
-from zds.member.api.tests import create_oauth2_client, authenticate_client
+from zds.api.utils import authenticate_oauth2_client
 from zds.member.tests.factories import ProfileFactory, UserFactory
 from zds.mp.tests.factories import PrivateTopicFactory, PrivatePostFactory
 from zds.mp.models import PrivateTopic, PrivatePostVote
@@ -20,8 +20,7 @@ class PrivateTopicListAPITest(APITestCase):
     def setUp(self):
         self.profile = ProfileFactory()
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         self.bot_group = Group()
         self.bot_group.name = settings.ZDS_APP["member"]["bot_group"]
@@ -395,8 +394,7 @@ class PrivateTopicDetailAPITest(APITestCase):
             author=self.profile.user, privatetopic=self.private_topic, position_in_topic=1
         )
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         self.bot_group = Group()
         self.bot_group.name = settings.ZDS_APP["member"]["bot_group"]
@@ -531,8 +529,7 @@ class PrivateTopicDetailAPITest(APITestCase):
         self.private_topic.participants.add(another_profile.user)
 
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(another_profile.user)
-        authenticate_client(self.client, client_oauth2, another_profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, another_profile.user, "hostel77")
 
         data = {
             "title": "Good title",
@@ -550,8 +547,7 @@ class PrivateTopicDetailAPITest(APITestCase):
         self.private_topic.participants.add(another_profile.user)
 
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(another_profile.user)
-        authenticate_client(self.client, client_oauth2, another_profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, another_profile.user, "hostel77")
 
         data = {"participants": [third_profile.user.id]}
         response = self.client.put(reverse("api:mp:detail", args=[self.private_topic.id]), data)
@@ -628,8 +624,7 @@ class PrivatePostListAPI(APITestCase):
     def setUp(self):
         self.profile = ProfileFactory()
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         self.private_topic = PrivateTopicFactory(author=self.profile.user)
         self.private_topic.participants.add(ProfileFactory().user)
@@ -869,8 +864,7 @@ class PrivatePostDetailAPI(APITestCase):
             author=self.profile.user, privatetopic=self.private_topic, position_in_topic=1
         )
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
 
@@ -1013,13 +1007,11 @@ class PrivateTopicUnreadListAPITest(APITestCase):
     def setUp(self):
         self.profile = ProfileFactory()
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         self.another_profile = ProfileFactory()
         self.another_client = APIClient()
-        another_client_oauth2 = create_oauth2_client(self.another_profile.user)
-        authenticate_client(self.another_client, another_client_oauth2, self.another_profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.another_client, self.another_profile.user, "hostel77")
 
         self.bot_group = Group()
         self.bot_group.name = settings.ZDS_APP["member"]["bot_group"]
@@ -1071,9 +1063,7 @@ class PermissionMemberAPITest(APITestCase):
             author=self.profile.user, privatetopic=self.private_topic, position_in_topic=1
         )
 
-        authenticate_client(
-            self.client, create_oauth2_client(self.profile.user), self.profile.user.username, "hostel77"
-        )
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
     def test_has_read_permission_for_authenticated_users(self):
         """
@@ -1106,9 +1096,7 @@ class PermissionMemberAPITest(APITestCase):
         another_profile = ProfileFactory()
         self.private_topic.participants.add(another_profile.user)
 
-        authenticate_client(
-            self.client, create_oauth2_client(another_profile.user), another_profile.user.username, "hostel77"
-        )
+        authenticate_oauth2_client(self.client, another_profile.user, "hostel77")
         response = self.client.get(reverse("api:mp:detail", args=[self.private_topic.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.data.get("permissions").get("update"))
@@ -1144,9 +1132,7 @@ class PermissionMemberAPITest(APITestCase):
         another_profile = ProfileFactory()
         self.private_topic.participants.add(another_profile.user)
 
-        authenticate_client(
-            self.client, create_oauth2_client(another_profile.user), another_profile.user.username, "hostel77"
-        )
+        authenticate_oauth2_client(self.client, another_profile.user, "hostel77")
         response = self.client.get(reverse("api:mp:message-detail", args=[self.private_topic.id, self.private_post.id]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.data.get("permissions").get("update"))
@@ -1160,8 +1146,7 @@ class PrivateTopicKarmaAPITest(APITestCase):
             author=self.profile.user, privatetopic=self.private_topic, position_in_topic=1
         )
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
 
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
 

--- a/zds/notification/api/tests.py
+++ b/zds/notification/api/tests.py
@@ -5,7 +5,7 @@ from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 from rest_framework_extensions.settings import extensions_api_settings
 
-from zds.member.api.tests import create_oauth2_client, authenticate_client
+from zds.api.utils import authenticate_oauth2_client
 from zds.member.tests.factories import ProfileFactory
 from zds.mp.tests.factories import PrivateTopicFactory
 from zds.notification.models import Notification
@@ -16,8 +16,7 @@ class NotificationListAPITest(APITestCase):
     def setUp(self):
         self.profile = ProfileFactory()
         self.client = APIClient()
-        client_oauth2 = create_oauth2_client(self.profile.user)
-        authenticate_client(self.client, client_oauth2, self.profile.user.username, "hostel77")
+        authenticate_oauth2_client(self.client, self.profile.user, "hostel77")
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
 
     def test_list_of_notifications_empty(self):


### PR DESCRIPTION
Mise à jour majeure de django-oauth-toolkit

Les `client_secret` sont désormais hashés lors de l'enregistrement en base de données donc il a fallu modifier les tests. J'ai repris [la méthode qu'ils utilisent dans leurs tests](https://github.com/jazzband/django-oauth-toolkit/blob/fda64f97974aac78d4ac9c9f0f36e137dbe4fb8c/tests/test_client_credential.py#L26C58-L26C58), c'est-à-dire donner une valeur connue pour `secret_id` lors de la création du client. J'en ai profité pour factoriser un peu la fonction d'authentification utilisée dans les tests. (Je peux éventuellement séparer le code en plusieurs commits mais cela ne m'a pas semblé nécessaire.)

Il y a d'autres changements sans risque pour le site web mais des applications utilisant l'API pourraient ne plus fonctionner. La seule application qui utilise quotidiennement l'API à ma connaissance est [`zds-antispam`](https://github.com/zestedesavoir/zds-antispam). Il faudrait prendre le temps un jour de tester sur la bêta pour vérifier que l'antispam fonctionne avec cette nouvelle version.

**QA :** Github Actions + des tests en bêta ?