### PR TITLE
Met à jour l'URL pour installer NVM

### DIFF
--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -172,7 +172,7 @@ fi
 if  ! $(_in "-node" $@) && ( $(_in "+node" $@) || $(_in "+base" $@) || $(_in "+full" $@) ); then
     print_info "* [+node] installing nvm (v$ZDS_NVM_VERSION) & node (v$ZDS_NODE_VERSION) & yarn" --bold
 
-    wget -qO- https://raw.githubusercontent.com/creationix/nvm/v${ZDS_NVM_VERSION}/install.sh | bash
+    wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v${ZDS_NVM_VERSION}/install.sh | bash
     if [[ $? == 0 ]]; then
 
         # load nvm


### PR DESCRIPTION
Il semblerait que le dépôt ait été déplacé vers un espace de nom dédié et GitHub faisait la redirection de façon transparente.

### Contrôle qualité

Dans l'idéal, installer une nouvelle instance locale de zds-site, par exemple [avec Docker](https://docs.zestedesavoir.com/install/install-docker.html). À minima, exécuter sur son instance déjà installée : 
```sh
./scripts/install_zds.sh +node
```

