### PR TITLE
Passage à Node.js 18 aussi dans la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     - cron: "30 3 * * WED" # every Wednesday at 3:30 AM, only main branch
 
 env:
-  NODE_VERSION: "16" # needs to be also updated in .nvmrc
+  NODE_VERSION: "18" # needs to be also updated in .nvmrc
   PYTHON_VERSION: "3.9"
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,2 @@
 18
+# needs to be also updated in .github/workflows/ci.yml


### PR DESCRIPTION
J'ai été un peu rapide en approuvant la PR #6535, NodeJS n'y a pas été mis à jour dans la CI. Cette PR corrige ça et ajoute un petit commentaire pour ne pas oublier la prochaine fois :wink: 

### Contrôle qualité

- La CI passe, **avec la version 18 de NodeJS**
- `nvm install` doit répondre qu'il tente d'utiliser la version 18 (si je mets le commentaire sur la même ligne que le numéro de version, il tente d'utiliser la version `18 # <commentaire>`...)

