### PR TITLE
Change le tri par défaut sur les listes de publications par auteur

### DIFF
--- a/zds/tutorialv2/urls/urls_opinions.py
+++ b/zds/tutorialv2/urls/urls_opinions.py
@@ -21,7 +21,7 @@ urlpatterns = [
     path("", ListOpinions.as_view(), name="list"),
     path(
         "voir/<str:username>/",
-        ContentOfAuthor.as_view(type="OPINION", context_object_name="opinions", sort="creation"),
+        ContentOfAuthor.as_view(type="OPINION", context_object_name="opinions"),
         name="find-opinion",
     ),
 ]

--- a/zds/tutorialv2/views/lists.py
+++ b/zds/tutorialv2/views/lists.py
@@ -395,7 +395,7 @@ class ContentOfAuthor(ZdSPagingListView):
         if "sort" in self.request.GET and self.request.GET["sort"].lower() in self.sorts:
             self.sort = self.request.GET["sort"]
         elif not self.sort:
-            self.sort = "abc"
+            self.sort = "modification"
         queryset = self.sorts[self.sort.lower()][0](queryset)
 
         return queryset


### PR DESCRIPTION
Quand on a plusieurs pages de billets ou articles ou tutoriels, ça ne devient pas pratique de naviguer vers les publications sur lesquels on travaille présentement. La raison est que le tri par défaut est soit par date de création croissante (pour les billets), soit par ordre alphabétique (pour les tutoriels et articles).

La correction consiste à utiliser le tri par date de modification par défaut, qui permet de voir les publications auxquelles on a touché récemment, ce qui est beaucoup plus pratique.

Les types de routes en question : 
- `http://localhost:8000/tutoriels/voir/admin/`
- `http://localhost:8000/articles/voir/admin/`
- `http://localhost:8000/billets/voir/admin/`

### Contrôle qualité

- créer des contenus sur un profil
- voir que les liens depuis le menu du profil (Mes articles, mes tutoriels, mes billets) ont bien le tri par plus récent par défaut