### PR TITLE
Retire les usages d'une méthode obsolète de Factory Boy

### DIFF
--- a/zds/member/tests/factories.py
+++ b/zds/member/tests/factories.py
@@ -24,6 +24,22 @@ class UserFactory(factory.django.DjangoModelFactory):
 
     is_active = True
 
+    @classmethod
+    def _after_postgeneration(cls, instance, create, results=None):
+        """
+        Save the instance again after the post generation operations. Needed to save
+        the password which is set in a post generation method call.
+
+        Skip the save when the object was ‘built’ and not ‘created’. See the Factory Boy
+        documentation for details on those build strategies.
+
+        This method replaces the deprecated method from DjangoModelFactory which is
+        scheduled to be removed in the next major release (see factory_boy's changelog
+        entry for version 3.3.0).
+        """
+        if create:
+            instance.save()
+
 
 class StaffFactory(UserFactory):
     """


### PR DESCRIPTION
Dans le cadre de la préparation pour Django 4, j'analyse les logs d'obsoléscence à la recherche de DeprecationWarning et autres choses du genre. Un des problèmes est qu'une méthode remplit plus 10000 lignes de logs (plus de la moitié), ce qui complique le reste.

Cette méthode est une de Factory Boy :  `_after_postgeneration`.

Cette PR :

* remplace _after_postgeneration par une méthode custom
* conserve le comportement important pour notre code
* anticipe le prochain changement de version majeur (il n'y aura pas ça à faire)
* facilite la lecture des logs d'obsolescence en évitant plus de 10,000 lignes liées à cette méthode

### Contrôle qualité

Comme c'est une méthode utilisée seulement dans les tests, la CI devrait suffire.