### PR TITLE
Modifie l'utilisation d'assertQuerysetEqual dans un test (préparation pour Django 4)

### DIFF
--- a/zds/mp/tests/tests_views.py
+++ b/zds/mp/tests/tests_views.py
@@ -950,4 +950,4 @@ class PrivatePostUnreadTest(TestCase):
         self.client.force_login(self.participant.user)
         self.client.get(reverse("mp:mark-post-unread", kwargs={"pk": self.post2.pk}), follow=True)
         topic_read_new = PrivateTopicRead.objects.filter(privatetopic=self.topic1, user=self.author.user)
-        self.assertQuerysetEqual(topic_read_old, [repr(t) for t in topic_read_new])
+        self.assertQuerysetEqual(topic_read_old, topic_read_new)


### PR DESCRIPTION
Ce commit modifie l'utilisation d'assertQuerysetEqual dans un test en :

* retirant la comparaison avec une liste de repr() (retiré dans Django 4.1)
* la remplaçant par une comparaison directe avec un Queryset (ajouté dans Django 3.2)

### Contrôle qualité

La CI devrait suffire.