### PR TITLE
Retire l'usage de default_app_config (préparation pour Django 4)

### DIFF
--- a/zds/notification/__init__.py
+++ b/zds/notification/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "zds.notification.apps.NotificationConfig"


### PR DESCRIPTION
Cette PR retire l'usage de default_app_config en préparation pour Django 4 :

* on retire l'usage dans zds.notifications.apps (paramètre [retiré dans Django 4.1](https://docs.djangoproject.com/fr/4.2/internals/deprecation/#deprecation-removed-in-4-1))
* un nouveau [mécanisme de Django](https://docs.djangoproject.com/en/4.2/releases/3.2/#automatic-appconfig-discovery) se charge désormais de détecter l'AppConfig par défaut (mécanisme ajouté dans Django 3.2)

### Contrôle qualité

- CI
- vérifier que le site se lance devrait suffire (les configs des apps sont chargées au démarrage)
- jouer avec le code pour lancer une notification quelconque et voir que ça fonctionne bien.