### PR TITLE
Change le type de champ pour la date de publication des unes

### DIFF
--- a/zds/featured/forms.py
+++ b/zds/featured/forms.py
@@ -31,20 +31,8 @@ class FeaturedResourceForm(forms.ModelForm):
     )
 
     pubdate = forms.DateTimeField(
-        label=_("Date de publication (exemple: 25/12/2015 15:00 ou 2015-12-25T15:00)"),
-        input_formats=[
-            "%d/%m/%Y %H:%M:%S",
-            "%Y-%m-%d %H:%M:%S",  # full format with second
-            "%Y-%m-%dT%H:%M",  # datetime field format
-            "%Y-%m-%d %H:%M",
-            "%d/%m/%Y %H:%M",  # without second
-            "%Y-%m-%d",
-            "%d/%m/%Y",  # day only
-        ],
-        widget=forms.DateTimeInput(
-            attrs={"placeholder": _("Exemple : 25/12/2016 10:00"), "type": "text"},
-            format="%d/%m/%Y %H:%M",  # datetime field format
-        ),
+        label=_("Date de publication (exemple: 25/12/2015 15:00)"),
+        widget=forms.DateTimeInput(attrs={"type": "datetime-local"}),
     )
 
     request = forms.IntegerField(widget=forms.HiddenInput(), required=False)


### PR DESCRIPTION
Fix #6524

### Contrôle qualité

- Se connecter en tant qu'`admin`
- Créer une nouvelle une (par exemple en allant sur un contenu publié et cliquer sur *Ajouter en une*
- Le navigateur propose un datepicker pour le champ *Date de publication* (si le navigateur le supporte)
- Valider le formulaire : tout fonctionne.
