### PR TITLE
Améliore la page qui liste les membres utilisant la même IP

### DIFF
--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -25,8 +25,9 @@
 
 {% block content %}
     <p>
+        {% captureas city %}{% if ip_location %}&nbsp;({{ ip_location }}){% endif %}{% endcaptureas %}
         {% blocktrans %}
-            Liste des membres dont la dernière IP connue est <code>{{ ip }}</code>
+            Liste des membres dont la dernière IP connue est <code>{{ ip }}</code>{{ city }}
         {% endblocktrans %}
     </p>
 
@@ -55,7 +56,12 @@
     </div>
 
     <p>
-        En IPv6, les adresses sont attribuées par bloc d'IP. Un bot de spam peut donc facilement changer d'adresse IP au sein de ce bloc. Sont affichés ici tous les membres dont l'IPv6 fait partie du même bloc que l'IP demandée.
+        {% blocktrans %}
+            En IPv6, les adresses sont attribuées par bloc d'IP. Un bot de spam
+            peut donc facilement changer d'adresse IP au sein de ce bloc. Sont
+            affichés ici tous les membres dont l'IPv6 fait partie du même bloc que
+            l'IP demandée.
+        {% endblocktrans %}
     </p>
     {% endif %}
 {% endblock %}

--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -31,13 +31,23 @@
         {% endblocktrans %}
     </p>
 
-    <div class="members">
-        <ul>
+    <table>
+        <thead>
+            <th>{% trans "Membre" %}</th>
+            <th>{% trans "Inscription" %}</th>
+            <th>{% trans "Dernière connexion" %}</th>
+        </thead>
+        <tbody>
             {% for member in members %}
-                <li>{% include "misc/member_item.part.html" with member=member info=member.last_visit|format_date:True avatar=True %}</li>
+                {% captureas last_visit %}{% if member.last_visit %}{{ member.last_visit|format_date:True }}{% else %}<i>{% trans "Jamais" %}</i>{% endif %}{% endcaptureas %}
+                <tr>
+                    <td>{% include "misc/member_item.part.html" with member=member avatar=True %}</td>
+                    <td>{{ member.user.date_joined|format_date:True }}</td>
+                    <td>{{ last_visit }}</td>
+                </tr>
             {% endfor %}
-        </ul>
-    </div>
+        </tbody>
+    </table>
 
     {# Checks if it's an IPV6 to show the members from the same IPV6 network #}
     {% if ":" in ip %}
@@ -47,13 +57,23 @@
         {% endblocktrans %}
     </p>
 
-    <div class="members">
-        <ul>
+    <table>
+        <thead>
+            <th>{% trans "Membre" %}</th>
+            <th>{% trans "Inscription" %}</th>
+            <th>{% trans "Dernière connexion" %}</th>
+        </thead>
+        <tbody>
             {% for member in network_members %}
-                <li>{% include "misc/member_item.part.html" with member=member info=member.last_visit|format_date:True avatar=True %}</li>
+                {% captureas last_visit %}{% if member.last_visit %}{{ member.last_visit|format_date:True }}{% else %}<i>{% trans "Jamais" %}</i>{% endif %}{% endcaptureas %}
+                <tr>
+                    <td>{% include "misc/member_item.part.html" with member=member avatar=True %}</td>
+                    <td>{{ member.user.date_joined|format_date:True }}</td>
+                    <td>{{ last_visit }}</td>
+                </tr>
             {% endfor %}
-        </ul>
-    </div>
+        </tbody>
+    </table>
 
     <p>
         {% blocktrans %}


### PR DESCRIPTION
* Affichage à côté de l'adresse IP la localisation rapportée par GeoIP (comme ce qu'on peut voir sur la page de profil)
* Utilisation d'un tableau pour liste les membres qui ont utilisé cette adresse IP, pour pouvoir facilement indiquer aussi la date d'inscription de ces membres
* Affichage de *Jamais* si un membre a créé son compte avec cette adresse IP, mais ne s'est jamais connecté ensuite (jusqu'alors au lieu d'avoir une date, on n'avait rien, ce qui pouvait être un peu perturbant)
* Création d'une fonction qui donne la localisation à partir d'une adresse IP, pour éviter de dupliquer ce code
* Amélioration de l'ordre de certains `import`
* Ajout de `{% blocktrans %}` autour d'un texte

### Contrôle qualité

Il faut être membre de l'équipe de modération ou administrateur pour pouvoir QA cette PR.

Pour avoir les données GeoIP, le plus simple sera de la faire sur la bêta. Je vais déployer la PR sur la bêta, je mettrai à jour les instructions de QA ensuite.

* Aller sur [la page de profil d'un membre](https://beta.zestedesavoir.com/@philippemilink) : la localisation doit bien s'afficher à côté de l'IP
* Aller sur [la page de l'adresse IP](https://beta.zestedesavoir.com/membres/profil/multi/154.120.161.47/) : un tableau de membres s'affiche, indiquant leur date d'inscription et de dernière connexion. S'il n'y a pas eu de de connexion depuis l'inscription, *Jamais* est affiché.
* Avec [une IPv6](https://beta.zestedesavoir.com/membres/profil/multi/2402:fd00:111:cb6:ade9:8661:2b37:8bb9/), on a la même chose, mais en plus pour tous les membres connectés avec l'adresse IP/64.
