### PR TITLE
Rend générique des affichages en fonction de tuto/article/billet

### DIFF
--- a/templates/gallery/base.html
+++ b/templates/gallery/base.html
@@ -64,17 +64,7 @@
                         {% if content_linked %}
                             <li>
                                 <a href="{{ content_linked.get_absolute_url }}" class="ico-after offline blue">
-                                    {% trans "Aller" %}
-                                    {% if content_linked.type == "ARTICLE" %}
-                                        {% trans "à l’article" %}
-                                    {% elif content_linked.type == "TUTORIAL" %}
-                                        {% trans "au tutoriel" %}
-                                    {% elif content_linked.type == "OPINION" %}
-                                        {% trans "au billet" %}
-                                    {% else %}
-                                        {% trans "au contenu" %}
-                                    {% endif %}
-                                    {% trans "lié à cette galerie" %}
+                                    {% trans "Aller à la publication liée à cette galerie" %}
                                 </a>
                             </li>
                         {% endif %}

--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -59,16 +59,7 @@
                 {% if gallery.linked_content in linked_contents %}
                     {% with content=linked_contents|get_item:gallery.linked_content %}
                         <p class="topic-last-answer">
-                            {% trans "Liée" %}
-                            {% if content.is_article %}
-                                {% trans "à l’article" %}
-                            {% elif content.is_tutorial %}
-                                {% trans "au tutoriel" %}
-                            {% elif content.is_opinion %}
-                                {% trans "au billet" %}
-                            {% else %}
-                                {% trans "au contenu" %}
-                            {% endif %}
+                            {% trans "Liée à la publication" %}
                             «&NonBreakingSpace;<a href="{{ content.get_absolute_url }}">{{ content.title }}</a>&NonBreakingSpace;».
                         </p>
                     {% endwith %}

--- a/templates/tutorialv2/includes/content/warn_typo.part.html
+++ b/templates/tutorialv2/includes/content/warn_typo.part.html
@@ -4,21 +4,12 @@
 {% if user.is_authenticated and user not in content.authors.all %}
     <div class="warn-typo">
         <a href="#warn-typo-modal" class="open-modal btn btn-grey ico-after edit blue">
-            {% trans "Signaler une faute dans" %}
             {% if not container %}
-                {% if content.is_article %}
-                    {% trans "cet article" %}
-                {% elif content.is_tutorial %}
-                    {% trans "ce tutoriel" %}
-                {% elif content.is_opinion %}
-                    {% trans "ce billet" %}
-                {% endif %}
+                {% trans "Signaler une faute dans cette publication" %}
+            {% elif container.is_chapter %}
+                {% trans "Signaler une faute dans ce chapitre" %}
             {% else %}
-                {% if container.is_chapter %}
-                    {% trans "ce chapitre" %}
-                {% else %}
-                    {% trans "cette partie" %}
-                {% endif %}
+                {% trans "Signaler une faute dans cette partie" %}
             {% endif %}
         </a>
 


### PR DESCRIPTION
C'était auparavant un morceau de #6441, mais ça sera plus facile pour la revue de découper un peu.

Note : il y a un décalage de boutons pour signaler une faute dans les billets, mais ça a été introduit par une autre PR (peut-être #6457). C'est corrigé dans #6549.

### Contrôle qualité

Vérifier que les affichages modifiés sont toujours lisibles.