### PR TITLE
Corrige le décalage du bouton "Signaler le contenu" dans les billets

### DIFF
--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -109,12 +109,12 @@
         {% include "tutorialv2/includes/content/content_pager.part.html" with content=content %}
     {% endif %}
 
-    {% if display_config.info_config.show_warn_typo %}
-        {% include "tutorialv2/includes/content/warn_typo.part.html" with content=content %}
-    {% endif %}
-
     {% if display_config.alerts_config.show_alert_button %}
         {% include "tutorialv2/includes/alert.html" with content=content current_content_type=current_content_type %}
+    {% endif %}
+
+    {% if display_config.info_config.show_warn_typo %}
+        {% include "tutorialv2/includes/content/warn_typo.part.html" with content=content %}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
On a introduit récemment un décalage sur le bouton "Signaler le contenu" en bas de la page des billets.

L'ordre des boutons a un effet important sur l'alignement. J'ai remis l'ordre précédent, ce qui corrige le décalage. Le CSS reste cependant fragile, puisqu'on pourrait s'attendre à aucun changement pour quelque chose d'aussi mineur.

### Contrôle qualité

Aller sur la page d'un billet publié et constater que les deux boutons "Signaler le contenu" et "Signaler une faute" sont bien alignés.