### PR TITLE
Permet d'écrire des billets ou articles avec une structure de tutoriel

### DIFF
--- a/doc/source/back-end/contents.rst
+++ b/doc/source/back-end/contents.rst
@@ -52,7 +52,7 @@ Un **contenu** est un agencement particulier de conteneurs et d'extraits. Il
 est décrit par des métadonnées (*metadata*), détaillées
 `ici <./contents_manifest.html>`__. Une de ces métadonnées est le type : article, tutoriel ou billet.
 
-Techniquement, le type n'a pas d'influencevsur la structure du contenu. On rencontre cependant
+Techniquement, le type n'a pas d'influence sur la structure du contenu. On rencontre cependant
 des structures typiques selon la longueur du contenu.
 
 Structure typique pour un contenu court :

--- a/doc/source/back-end/contents.rst
+++ b/doc/source/back-end/contents.rst
@@ -1,6 +1,6 @@
-=========================
-Les tutoriels et articles
-=========================
+================================
+Les tutoriels, articles, billets
+================================
 
 Vocabulaire et définitions
 ==========================
@@ -50,56 +50,54 @@ Un contenu
 
 Un **contenu** est un agencement particulier de conteneurs et d'extraits. Il
 est décrit par des métadonnées (*metadata*), détaillées
-`ici <./contents_manifest.html>`__. Une de ces métadonnées est le type : article
-ou tutoriel. Leur visée pédagogique diffère, mais aussi leur structure : un
-article ne peut comporter de conteneurs, seulement des extraits, ce qui n'est
-pas le cas d'un tutoriel.
+`ici <./contents_manifest.html>`__. Une de ces métadonnées est le type : article, tutoriel ou billet.
 
-Les exemples suivants devraient éclairer ces notions.
+Techniquement, le type n'a pas d'influencevsur la structure du contenu. On rencontre cependant
+des structures typiques selon la longueur du contenu.
 
-Communément appelé « mini-tutoriel » :
+Structure typique pour un contenu court :
 
 .. sourcecode:: none
 
-    + Tutoriel
+    + Contenu
         + Section
         + Section
         + Section
 
-Communément appelé « moyen-tutoriel » :
+Structure typique pour un contenu de taille moyenne :
+
+.. sourcecode:: none
+
+    + Contenu
+        + Partie
+            + Section
+        + Partie
+            + Section
+            + Section
+
+Structure typique pour un contenu long :
+
+.. sourcecode:: none
+
+    + Contenu
+        + Partie
+            + Chapitre
+                + Section
+                + Section
+            + Chapitre
+                + Section
+        + Partie
+            + Chapitre
+                + Section
+                + Section
+
+Des structures plus complexes sont possibles, avec des niveaux de conteneurs différents selon les parties :
 
 .. sourcecode:: none
 
     + Tutoriel
         + Partie
             + Section
-        + Partie
-            + Section
-            + Section
-
-Communément appelé « big-tutoriel » :
-
-.. sourcecode:: none
-
-    + Tutoriel
-        + Partie
-            + Chapitre
-                + Section
-                + Section
-            + Chapitre
-                + Section
-        + Partie
-            + Chapitre
-                + Section
-                + Section
-
-On peut aussi faire un mélange des conteneurs :
-
-.. sourcecode:: none
-
-    + Tutoriel
-        + Partie
-            + Section
             + Section
         + Partie
             + Chapitre
@@ -107,7 +105,7 @@ On peut aussi faire un mélange des conteneurs :
             + Chapitre
                 + Section
 
-Mais pas de conteneurs et d'extraits adjacents :
+Il n'est pas possible d'avoir à la fois des conteneurs et des extraits au même niveau :
 
 .. sourcecode:: none
 
@@ -121,15 +119,6 @@ Mais pas de conteneurs et d'extraits adjacents :
             + Chapitre
                 + Section
             + Section /!\ Impossible !
-
-Pour finir, un article. Même structure qu'un mini-tutoriel, mais vocation
-pédagogique différente :
-
-.. sourcecode:: none
-
-    + Article
-        + Section
-        + Section
 
 D'autre part, tout contenu se voit attribuer un identifiant unique sous la
 forme d'un entier naturel (en anglais : *pk*, pour *primary key*). Cet

--- a/zds/tutorialv2/models/__init__.py
+++ b/zds/tutorialv2/models/__init__.py
@@ -8,7 +8,6 @@ CONTENT_TYPES = (
     # verbose_name_plural   User-friendly pluralized type name
     # category_name         User-friendly category name which contains this content
     # requires_validation   Boolean; whether this content has to be validated before publication
-    # single_container      Boolean; True if the content is a single container
     # beta                  Boolean; True if the content can be in beta
     {
         "name": "TUTORIAL",
@@ -16,7 +15,6 @@ CONTENT_TYPES = (
         "verbose_name_plural": "tutoriels",
         "category_name": "tutoriel",
         "requires_validation": True,
-        "single_container": False,
         "beta": True,
     },
     {
@@ -25,7 +23,6 @@ CONTENT_TYPES = (
         "verbose_name_plural": "articles",
         "category_name": "article",
         "requires_validation": True,
-        "single_container": True,
         "beta": True,
     },
     {
@@ -34,7 +31,6 @@ CONTENT_TYPES = (
         "verbose_name_plural": "billets",
         "category_name": "tribune",
         "requires_validation": False,
-        "single_container": True,
         "beta": False,
     },
 )
@@ -48,9 +44,6 @@ PICK_OPERATIONS = (
 
 # a list of contents which have to be validated before publication
 CONTENT_TYPES_REQUIRING_VALIDATION = [content["name"] for content in CONTENT_TYPES if content["requires_validation"]]
-
-# a list of contents which have one big container containing at least one small container
-SINGLE_CONTAINER_CONTENT_TYPES = [content["name"] for content in CONTENT_TYPES if content["single_container"]]
 
 # a list of contents which can be in beta
 CONTENT_TYPES_BETA = [content["name"] for content in CONTENT_TYPES if content["beta"]]

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -258,15 +258,14 @@ class Container:
             long_slug = self.parent.long_slug() + "__"
         return long_slug + self.slug
 
-    def can_add_container(self):
+    def can_add_container(self) -> bool:
         """
-        :return: ``True`` if this container accepts child containers, ``False`` otherwise
-        :rtype: bool
+        Return `True` if adding child containers is allowed.
+        Adding subcontainers is forbidden:
+        * if the container already has extracts as children,
+        * or if the limit of nested containers has been reached.
         """
-        if not self.has_extracts():
-            if self.get_tree_depth() < settings.ZDS_APP["content"]["max_tree_depth"] - 1:
-                return True
-        return False
+        return not self.has_extracts() and self.get_tree_depth() < settings.ZDS_APP["content"]["max_tree_depth"] - 1
 
     def can_add_extract(self):
         """Return ``True`` if this container can contain extracts, i.e doesn't

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -1,7 +1,6 @@
 import contextlib
 import copy
 from pathlib import Path
-from typing import List
 
 from zds import json_handler
 from git import Repo

--- a/zds/tutorialv2/models/versioned.py
+++ b/zds/tutorialv2/models/versioned.py
@@ -1338,7 +1338,7 @@ class VersionedContent(Container, TemplatableContentModelMixin):
                         continuous_list.append(child)  # it contains Extract, this is a chapter, so paginated
                     else:  # Container is a part
                         for sub_child in child.children:
-                            continuous_list.append(sub_child)  # even if empty `sub_child.childreen`, it's chapter
+                            continuous_list.append(sub_child)  # even if `sub_child.children` is empty, it's a chapter
         return continuous_list
 
     def get_json(self):

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -177,14 +177,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertNotContains(resp, "{}?subcategory=".format(reverse("publication:list")))
         self.assertContains(resp, "{}?category=".format(reverse("opinion:list")))
 
-    def test_no_help_for_tribune(self):
-        self.client.force_login(self.user_author)
-
-    def test_help_for_article(self):
-        self.client.force_login(self.user_author)
-        resp = self.client.get(reverse("content:create-content", kwargs={"created_content_type": "ARTICLE"}))
-        self.assertEqual(200, resp.status_code)
-
     def test_opinion_publication_staff(self):
         """
         Test the publication of PublishableContent where type is OPINION (with staff).

--- a/zds/tutorialv2/tests/tests_routes.py
+++ b/zds/tutorialv2/tests/tests_routes.py
@@ -64,7 +64,6 @@ class OpinionDisplayRoutesTests(BasicRouteTests):
         self.assert_can_be_reached(route, route_args)
 
 
-@override_for_contents()
 class ArticlesDisplayRoutesTests(BasicRouteTests):
     content_type = "ARTICLE"
 

--- a/zds/tutorialv2/tests/tests_routes.py
+++ b/zds/tutorialv2/tests/tests_routes.py
@@ -1,0 +1,96 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from zds.tutorialv2.models.database import PublishableContent
+from zds.tutorialv2.publication_utils import publish_content
+from zds.tutorialv2.tests import override_for_contents, TutorialTestMixin
+from zds.tutorialv2.tests.factories import PublishableContentFactory, ContainerFactory
+
+
+@override_for_contents()
+class BasicRouteTests(TestCase, TutorialTestMixin):
+    def setUp(self):
+        self.build_content(self.content_type)
+        self.mock_publication_process(self.content)
+
+    def build_content(self, type):
+        self.content = PublishableContentFactory()
+        self.content.type = type
+        self.content.save()
+        content_versioned = self.content.load_version()
+        self.container = ContainerFactory(parent=content_versioned, db_object=self.content)
+        self.subcontainer = ContainerFactory(parent=self.container, db_object=self.content)
+
+    def assert_can_be_reached(self, route, route_args):
+        url = reverse(route, kwargs=route_args)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def mock_publication_process(self, content: PublishableContent):
+        published = publish_content(content, content.load_version())
+        content.sha_public = content.sha_draft
+        content.public_version = published
+        content.save()
+
+
+class OpinionDisplayRoutesTests(BasicRouteTests):
+    content_type = "OPINION"
+
+    def test_view(self):
+        route = "opinion:view"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+        }
+        self.assert_can_be_reached(route, route_args)
+
+    def test_view_container_one_level_deep(self):
+        route = "opinion:view-container"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+            "container_slug": self.container.slug,
+        }
+        self.assert_can_be_reached(route, route_args)
+
+    def test_view_container_two_level_deep(self):
+        route = "opinion:view-container"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+            "parent_container_slug": self.container.slug,
+            "container_slug": self.subcontainer.slug,
+        }
+        self.assert_can_be_reached(route, route_args)
+
+
+@override_for_contents()
+class ArticlesDisplayRoutesTests(BasicRouteTests):
+    content_type = "ARTICLE"
+
+    def test_view(self):
+        route = "article:view"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+        }
+        self.assert_can_be_reached(route, route_args)
+
+    def test_view_container_one_level_deep(self):
+        route = "article:view-container"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+            "container_slug": self.container.slug,
+        }
+        self.assert_can_be_reached(route, route_args)
+
+    def test_view_container_two_level_deep(self):
+        route = "article:view-container"
+        route_args = {
+            "pk": self.content.pk,
+            "slug": self.content.slug,
+            "parent_container_slug": self.container.slug,
+            "container_slug": self.subcontainer.slug,
+        }
+        self.assert_can_be_reached(route, route_args)

--- a/zds/tutorialv2/urls/urls_articles.py
+++ b/zds/tutorialv2/urls/urls_articles.py
@@ -4,22 +4,33 @@ from django.views.generic.base import RedirectView
 from zds.tutorialv2.views.contributors import ContentOfContributors
 from zds.tutorialv2.views.lists import TagsListView, ContentOfAuthor
 from zds.tutorialv2.views.download_online import DownloadOnlineArticle
-from zds.tutorialv2.views.display import ArticleOnlineView
+from zds.tutorialv2.views.display import ArticleOnlineView, ContainerOnlineView
 from zds.tutorialv2.feeds import LastArticlesFeedRSS, LastArticlesFeedATOM
 
-urlpatterns = [
-    # Flux
+feed_patterns = [
     path("flux/rss/", LastArticlesFeedRSS(), name="feed-rss"),
     path("flux/atom/", LastArticlesFeedATOM(), name="feed-atom"),
-    # View
+]
+
+display_patterns = [
     path("<int:pk>/<slug:slug>/", ArticleOnlineView.as_view(), name="view"),
-    # Downloads
+    path(
+        "<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/",
+        ContainerOnlineView.as_view(),
+        name="view-container",
+    ),
+    path("<int:pk>/<slug:slug>/<slug:container_slug>/", ContainerOnlineView.as_view(), name="view-container"),
+]
+
+download_patterns = [
     path("md/<int:pk>/<slug:slug>.md", DownloadOnlineArticle.as_view(requested_file="md"), name="download-md"),
     path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineArticle.as_view(requested_file="pdf"), name="download-pdf"),
     path("tex/<int:pk>/<slug:slug>.tex", DownloadOnlineArticle.as_view(requested_file="tex"), name="download-tex"),
     path("epub/<int:pk>/<slug:slug>.epub", DownloadOnlineArticle.as_view(requested_file="epub"), name="download-epub"),
     path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineArticle.as_view(requested_file="zip"), name="download-zip"),
-    # Listing
+]
+
+listing_patterns = [
     path("", RedirectView.as_view(pattern_name="publication:list", permanent=True)),
     re_path(r"tags/*", TagsListView.as_view(displayed_types=["ARTICLE"]), name="tags"),
     path(
@@ -33,3 +44,5 @@ urlpatterns = [
         name="find-contributions-article",
     ),
 ]
+
+urlpatterns = feed_patterns + display_patterns + download_patterns + listing_patterns

--- a/zds/tutorialv2/urls/urls_opinions.py
+++ b/zds/tutorialv2/urls/urls_opinions.py
@@ -3,21 +3,32 @@ from django.urls import path
 from zds.tutorialv2.feeds import LastOpinionsFeedRSS, LastOpinionsFeedATOM
 from zds.tutorialv2.views.lists import ListOpinions, ContentOfAuthor
 from zds.tutorialv2.views.download_online import DownloadOnlineOpinion
-from zds.tutorialv2.views.display import OpinionOnlineView
+from zds.tutorialv2.views.display import OpinionOnlineView, ContainerOnlineView
 
-urlpatterns = [
-    # Flux
+feed_patterns = [
     path("flux/rss/", LastOpinionsFeedRSS(), name="feed-rss"),
     path("flux/atom/", LastOpinionsFeedATOM(), name="feed-atom"),
-    # View
+]
+
+display_patterns = [
     path("<int:pk>/<slug:slug>/", OpinionOnlineView.as_view(), name="view"),
-    # downloads:
+    path(
+        "<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/",
+        ContainerOnlineView.as_view(),
+        name="view-container",
+    ),
+    path("<int:pk>/<slug:slug>/<slug:container_slug>/", ContainerOnlineView.as_view(), name="view-container"),
+]
+
+download_patterns = [
     path("md/<int:pk>/<slug:slug>.md", DownloadOnlineOpinion.as_view(requested_file="md"), name="download-md"),
     path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineOpinion.as_view(requested_file="pdf"), name="download-pdf"),
     path("epub/<int:pk>/<slug:slug>.epub", DownloadOnlineOpinion.as_view(requested_file="epub"), name="download-epub"),
     path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineOpinion.as_view(requested_file="zip"), name="download-zip"),
     path("tex/<int:pk>/<slug:slug>.tex", DownloadOnlineOpinion.as_view(requested_file="tex"), name="download-tex"),
-    # Listing
+]
+
+listing_patterns = [
     path("", ListOpinions.as_view(), name="list"),
     path(
         "voir/<str:username>/",
@@ -25,3 +36,5 @@ urlpatterns = [
         name="find-opinion",
     ),
 ]
+
+urlpatterns = feed_patterns + display_patterns + download_patterns + listing_patterns

--- a/zds/tutorialv2/urls/urls_tutorials.py
+++ b/zds/tutorialv2/urls/urls_tutorials.py
@@ -8,17 +8,12 @@ from zds.tutorialv2.views.display import TutorialOnlineView, ContainerOnlineView
 from zds.tutorialv2.views.redirect import RedirectContentSEO, RedirectOldBetaTuto
 from zds.tutorialv2.feeds import LastTutorialsFeedRSS, LastTutorialsFeedATOM
 
-
-urlpatterns = [
-    # flux
+feed_patterns = [
     path("flux/rss/", LastTutorialsFeedRSS(), name="feed-rss"),
     path("flux/atom/", LastTutorialsFeedATOM(), name="feed-atom"),
-    # view
-    path(
-        "<int:pk>/<slug:slug>/<int:p2>/<slug:parent_container_slug>/<int:p3>/<slug:container_slug>/",
-        RedirectContentSEO.as_view(),
-        name="redirect_old_tuto",
-    ),
+]
+
+display_patterns = [
     path(
         "<int:pk>/<slug:slug>/<slug:parent_container_slug>/<slug:container_slug>/",
         ContainerOnlineView.as_view(),
@@ -26,15 +21,17 @@ urlpatterns = [
     ),
     path("<int:pk>/<slug:slug>/<slug:container_slug>/", ContainerOnlineView.as_view(), name="view-container"),
     path("<int:pk>/<slug:slug>/", TutorialOnlineView.as_view(), name="view"),
-    # downloads:
+]
+
+download_patterns = [
     path("md/<int:pk>/<slug:slug>.md", DownloadOnlineTutorial.as_view(requested_file="md"), name="download-md"),
     path("pdf/<int:pk>/<slug:slug>.pdf", DownloadOnlineTutorial.as_view(requested_file="pdf"), name="download-pdf"),
     path("epub/<int:pk>/<slug:slug>.epub", DownloadOnlineTutorial.as_view(requested_file="epub"), name="download-epub"),
     path("zip/<int:pk>/<slug:slug>.zip", DownloadOnlineTutorial.as_view(requested_file="zip"), name="download-zip"),
     path("tex/<int:pk>/<slug:slug>.tex", DownloadOnlineTutorial.as_view(requested_file="tex"), name="download-tex"),
-    #  Old beta url compatibility
-    path("beta/<int:pk>/<slug:slug>/", RedirectOldBetaTuto.as_view(), name="old-beta-url"),
-    # Listing
+]
+
+listing_patterns = [
     path("", RedirectView.as_view(pattern_name="publication:list", permanent=True)),
     path("tags/", TagsListView.as_view(displayed_types=["TUTORIAL"]), name="tags"),
     path(
@@ -48,3 +45,14 @@ urlpatterns = [
         name="find-contributions-tutorial",
     ),
 ]
+
+redirect_patterns = [
+    path(
+        "<int:pk>/<slug:slug>/<int:p2>/<slug:parent_container_slug>/<int:p3>/<slug:container_slug>/",
+        RedirectContentSEO.as_view(),
+        name="redirect_old_tuto",
+    ),
+    path("beta/<int:pk>/<slug:slug>/", RedirectOldBetaTuto.as_view(), name="old-beta-url"),
+]
+
+urlpatterns = feed_patterns + display_patterns + download_patterns + listing_patterns + redirect_patterns

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -592,12 +592,12 @@ def publish_opinion(content, action_flag, versioned):
 def handle_content_with_chapter_and_parts(
     container, size, fake, nb_avg_containers_in_content, nb_avg_extracts_in_content
 ):
-    if size == 1:  # medium size tutorial
+    if size == 1:  # medium size content
         nb_of_extracts = random.randint(1, nb_avg_extracts_in_content * 2)
         for k in range(nb_of_extracts):
             extract_title = fake.text(max_nb_chars=60)
             ExtractFactory(container=container, title=extract_title, light=False)
-    else:  # big-size tutorial
+    else:  # big-size content
         nb_of_containers = random.randint(1, nb_avg_containers_in_content * 2)
         for _ in range(nb_of_containers):
             subcontainer_title = fake.text(max_nb_chars=60)

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -398,7 +398,6 @@ def load_contents(cli, size, fake, _type, *_, **__):
     nb_avg_containers_in_content = size
     nb_avg_extracts_in_content = size
 
-    is_articles = _type == "ARTICLE"
     is_tutorials = _type == "TUTORIAL"
     is_opinion = _type == "OPINION"
 
@@ -411,14 +410,11 @@ def load_contents(cli, size, fake, _type, *_, **__):
     # small introduction
     cli.stdout.write(f"À créer: {nb_contents:d} {textual_type}s", ending="")
 
-    if is_tutorials:
-        cli.stdout.write(
-            " ({:g} petits, {:g} moyens et {:g} grands)".format(
-                nb_contents * percent_mini, nb_contents * percent_medium, nb_contents * percent_big
-            )
+    cli.stdout.write(
+        " ({:g} petits, {:g} moyens et {:g} grands)".format(
+            nb_contents * percent_mini, nb_contents * percent_medium, nb_contents * percent_big
         )
-    else:
-        cli.stdout.write("")
+    )
 
     cli.stdout.write(
         " - {:g} en brouillon".format(
@@ -523,15 +519,9 @@ def load_contents(cli, size, fake, _type, *_, **__):
         versioned = content.load_version()
 
         generate_text_for_content(
-            current_size,
-            fake,
-            is_articles,
-            is_opinion,
-            nb_avg_containers_in_content,
-            nb_avg_extracts_in_content,
-            versioned,
+            current_size, fake, nb_avg_containers_in_content, nb_avg_extracts_in_content, versioned
         )
-        # add some informations:
+        # add some information
         author = users[random.randint(0, nb_users - 1)].user
         content.authors.add(author)
         UserGalleryFactory(gallery=content.gallery, mode="W", user=author)
@@ -573,18 +563,19 @@ def validate_edited_content(content, fake, nb_staffs, staffs, to_do, versioned):
     content.save()
 
 
-def generate_text_for_content(
-    current_size, fake, is_articles, is_opinion, nb_avg_containers_in_content, nb_avg_extracts_in_content, versioned
-):
-    if current_size == 0 or is_articles or is_opinion:
-        for _ in range(random.randint(1, nb_avg_extracts_in_content * 2)):
-            ExtractFactory(container=versioned, title=fake.text(max_nb_chars=60), light=False)
+def generate_text_for_content(content_size, fake, nb_avg_containers_in_content, nb_avg_extracts_in_content, versioned):
+    if content_size == 0:
+        nb_extracts = random.randint(1, nb_avg_extracts_in_content * 2)
+        for _ in range(nb_extracts):
+            extract_title = fake.text(max_nb_chars=60)
+            ExtractFactory(container=versioned, title=extract_title, light=False)
     else:
-        for _ in range(random.randint(1, nb_avg_containers_in_content * 2)):
-            container = ContainerFactory(parent=versioned, title=fake.text(max_nb_chars=60))
-
+        nb_containers = random.randint(1, nb_avg_containers_in_content * 2)
+        for _ in range(nb_containers):
+            container_title = fake.text(max_nb_chars=60)
+            container = ContainerFactory(parent=versioned, title=container_title)
             handle_content_with_chapter_and_parts(
-                container, current_size, fake, nb_avg_containers_in_content, nb_avg_extracts_in_content
+                container, content_size, fake, nb_avg_containers_in_content, nb_avg_extracts_in_content
             )
 
 
@@ -599,17 +590,23 @@ def publish_opinion(content, action_flag, versioned):
 
 
 def handle_content_with_chapter_and_parts(
-    container, current_size, fake, nb_avg_containers_in_content, nb_avg_extracts_in_content
+    container, size, fake, nb_avg_containers_in_content, nb_avg_extracts_in_content
 ):
-    if current_size == 1:  # medium size tutorial
-        for k in range(random.randint(1, nb_avg_extracts_in_content * 2)):
-            ExtractFactory(container=container, title=fake.text(max_nb_chars=60), light=False)
+    if size == 1:  # medium size tutorial
+        nb_of_extracts = random.randint(1, nb_avg_extracts_in_content * 2)
+        for k in range(nb_of_extracts):
+            extract_title = fake.text(max_nb_chars=60)
+            ExtractFactory(container=container, title=extract_title, light=False)
     else:  # big-size tutorial
-        for k in range(random.randint(1, nb_avg_containers_in_content * 2)):
-            subcontainer = ContainerFactory(parent=container, title=fake.text(max_nb_chars=60))
+        nb_of_containers = random.randint(1, nb_avg_containers_in_content * 2)
+        for _ in range(nb_of_containers):
+            subcontainer_title = fake.text(max_nb_chars=60)
+            subcontainer = ContainerFactory(parent=container, title=subcontainer_title)
 
-            for m in range(random.randint(1, nb_avg_extracts_in_content * 2)):
-                ExtractFactory(container=subcontainer, title=fake.text(max_nb_chars=60), light=False)
+            nb_of_extracts = random.randint(1, nb_avg_extracts_in_content * 2)
+            for _ in range(nb_of_extracts):
+                extract_title = fake.text(max_nb_chars=60)
+                ExtractFactory(container=subcontainer, title=extract_title, light=False)
 
 
 ZDSResource = collections.namedtuple("zdsresource", ["name", "description", "callback", "extra_args"])


### PR DESCRIPTION
Je continue à découper #6441.

Cette PR permet de créer des billets et articles avec des conteneurs imbriqués, comme pour les tutos. J'ajoute aussi les routes associées, histoire qu'on puisse effectivement lire tout ça. :D

### Contrôle qualité

- Créer des articles et billets avec une structure de tuto (parties, chapitres...).
- Tester la publication, la dépublication, la validation, la mise en bêta, etc.
- Se promener sur les pages publiques, brouillon, beta (pour les articles) et voir si on peut accéder à tout. Normalement seules les pages publiques ont des URL particulières (les autres sont en `/contenus/`).
