### PR TITLE
Permet la gestion de contributeurs sur les billets

### DIFF
--- a/templates/tutorialv2/messages/add_contribution_pm.md
+++ b/templates/tutorialv2/messages/add_contribution_pm.md
@@ -1,9 +1,9 @@
 {% load i18n %}
 
-{% blocktrans with title=content.title|safe type=type|safe user=user|safe %}
+{% blocktrans with title=content.title|safe user=user|safe %}
 Bonjour {{ user }},
 
-Vous avez été ajouté à la liste des contributeurs {{type}} « {{ title }} », en tant que {{role}}.
+Vous avez été ajouté à la liste des contributeurs de la publication « {{ title }} », en tant que {{ role }}.
 
 Merci pour votre participation !
 {%  endblocktrans %}

--- a/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
+++ b/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
@@ -8,6 +8,7 @@ from django.utils.html import escape
 
 
 from zds.member.tests.factories import ProfileFactory, StaffProfileFactory
+from zds.tutorialv2.models import CONTENT_TYPE_LIST
 from zds.tutorialv2.tests.factories import ContentContributionRoleFactory, PublishableContentFactory
 from zds.tutorialv2.views.contributors import ContributionForm
 from zds.tutorialv2.models.database import ContentContribution
@@ -63,12 +64,12 @@ class AddContributorPermissionTests(TutorialTestMixin, TestCase):
 
     def test_authenticated_staff(self):
         self.client.force_login(self.staff)
-        types = ["TUTORIAL", "ARTICLE", "OPINION"]
-        for type in types:
-            self.content.type = type
-            self.content.save()
-            response = self.client.post(self.form_url, self.form_data)
-            self.assertRedirects(response, self.content_url)
+        for type in CONTENT_TYPE_LIST:
+            with self.subTest(type):
+                self.content.type = type
+                self.content.save()
+                response = self.client.post(self.form_url, self.form_data)
+                self.assertRedirects(response, self.content_url)
 
 
 class AddContributorWorkflowTests(TutorialTestMixin, TestCase):

--- a/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
+++ b/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
@@ -61,26 +61,14 @@ class AddContributorPermissionTests(TutorialTestMixin, TestCase):
         response = self.client.post(self.form_url, self.form_data)
         self.assertRedirects(response, self.content_url)
 
-    def test_authenticated_staff_tutorial(self):
+    def test_authenticated_staff(self):
         self.client.force_login(self.staff)
-        self.content.type = "TUTORIAL"
-        self.content.save()
-        response = self.client.post(self.form_url, self.form_data)
-        self.assertRedirects(response, self.content_url)
-
-    def test_authenticated_staff_article(self):
-        self.client.force_login(self.staff)
-        self.content.type = "ARTICLE"
-        self.content.save()
-        response = self.client.post(self.form_url, self.form_data)
-        self.assertRedirects(response, self.content_url)
-
-    def test_authenticated_staff_opinion(self):
-        self.client.force_login(self.staff)
-        self.content.type = "OPINION"
-        self.content.save()
-        response = self.client.post(self.form_url, self.form_data)
-        self.assertEqual(response.status_code, 403)
+        types = ["TUTORIAL", "ARTICLE", "OPINION"]
+        for type in types:
+            self.content.type = type
+            self.content.save()
+            response = self.client.post(self.form_url, self.form_data)
+            self.assertRedirects(response, self.content_url)
 
 
 class AddContributorWorkflowTests(TutorialTestMixin, TestCase):

--- a/zds/tutorialv2/tests/tests_views/tests_removecontributor.py
+++ b/zds/tutorialv2/tests/tests_views/tests_removecontributor.py
@@ -79,7 +79,7 @@ class RemoveContributorPermissionTests(TutorialTestMixin, TestCase):
         self.content.type = "OPINION"
         self.content.save()
         response = self.client.post(self.form_url, self.form_data)
-        self.assertEqual(response.status_code, 403)
+        self.assertRedirects(response, self.content_url)
 
 
 class RemoveContributorWorkflowTests(TutorialTestMixin, TestCase):

--- a/zds/tutorialv2/views/display/config.py
+++ b/zds/tutorialv2/views/display/config.py
@@ -174,7 +174,7 @@ class DraftActionsState:
         return self.enabled and self.is_allowed
 
     def show_contributors_management(self) -> bool:
-        return self.enabled and self.is_allowed and self.requires_validation
+        return self.enabled and self.is_allowed
 
     def show_ready_to_publish(self) -> bool:
         return self.enabled and self.is_allowed and self.requires_validation


### PR DESCRIPTION
Permet la gestion (ajout, suppression) des contributeurs sur les billets. Encore une partie du découpage de #6441.

On voit que la refactorisation des templates de publication porte ses fruits. La partie template a pu être gérée en modifiant une seule ligne de configuration.


### Contrôle qualité

Créer des billets et jouer avec les contributeurs.
Constater qu'ils sont bien ajoutés, supprimés.
Constater qu'ils sont bien affichés comme sur les autres contenus.