### PR TITLE
Corrige une faute d'orthographe dans la page de mot de passe oublié

### DIFF
--- a/templates/member/forgot_password/index.html
+++ b/templates/member/forgot_password/index.html
@@ -52,7 +52,7 @@
         </p>
 
         <p>
-            {% trans "Comment souhaitez vous retrouvez votre mot de passe ?" %}
+            {% trans "Comment souhaitez-vous retrouver votre mot de passe ?" %}
         </p>
 
         <ul>


### PR DESCRIPTION
### Contrôle qualité

La texte sur la page http://127.0.0.1:8000/membres/reinitialisation/ ne contient pas de fautes.
