### PR TITLE
Renomme correctement les modules `social.*`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Implicit dependencies (optional dependencies of dependencies)
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.3
-social-auth-app-django==5.3.0
+social-auth-app-django==5.4.0
 
 # Explicit dependencies (references in code)
 beautifulsoup4==4.12.2

--- a/zds/settings/abstract_base/requirements.py
+++ b/zds/settings/abstract_base/requirements.py
@@ -15,17 +15,17 @@ SOCIAL_AUTH_RAISE_EXCEPTIONS = False
 SOCIAL_AUTH_FACEBOOK_SCOPE = ["email"]
 
 SOCIAL_AUTH_PIPELINE = (
-    "social.pipeline.social_auth.social_details",
-    "social.pipeline.social_auth.social_uid",
-    "social.pipeline.social_auth.auth_allowed",
-    "social.pipeline.social_auth.social_user",
-    "social.pipeline.user.get_username",
-    "social.pipeline.social_auth.associate_by_email",
-    "social.pipeline.user.create_user",
+    "social_core.pipeline.social_auth.social_details",
+    "social_core.pipeline.social_auth.social_uid",
+    "social_core.pipeline.social_auth.auth_allowed",
+    "social_core.pipeline.social_auth.social_user",
+    "social_core.pipeline.user.get_username",
+    "social_core.pipeline.social_auth.associate_by_email",
+    "social_core.pipeline.user.create_user",
     "zds.member.models.save_profile",
-    "social.pipeline.social_auth.associate_user",
-    "social.pipeline.social_auth.load_extra_data",
-    "social.pipeline.user.user_details",
+    "social_core.pipeline.social_auth.associate_user",
+    "social_core.pipeline.social_auth.load_extra_data",
+    "social_core.pipeline.user.user_details",
 )
 
 # Before adding new providers such as Facebook and Google,

--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -122,23 +122,6 @@ THUMBNAIL_OPTIMIZE_COMMAND = {
 }
 
 
-# python-social-auth
-# http://psa.matiasaguirre.net/docs/configuration/django.html
-SOCIAL_AUTH_PIPELINE = (
-    "social.pipeline.social_auth.social_details",
-    "social.pipeline.social_auth.social_uid",
-    "social.pipeline.social_auth.auth_allowed",
-    "social.pipeline.social_auth.social_user",
-    "social.pipeline.user.get_username",
-    "social.pipeline.social_auth.associate_by_email",
-    "social.pipeline.user.create_user",
-    "zds.member.models.save_profile",
-    "social.pipeline.social_auth.associate_user",
-    "social.pipeline.social_auth.load_extra_data",
-    "social.pipeline.user.user_details",
-)
-
-
 ###############################################################################
 # ZESTE DE SAVOIR SETTINGS
 


### PR DESCRIPTION
Une partie de la migration indiquée dans
https://github.com/omab/python-social-auth/blob/master/MIGRATING_TO_SOCIAL.md n'a pas été faite : renommer tous les modules `social.*` en `social_core` ou `social_django`. Ça fonctionnait jusqu'à maintenant, car le paquet Python `social` était resté installé dans les environnements virtuels des serveurs de production et bêta, mais ça ne marche plus sur la bêta, puisqu'on est reparti d'un environnement vierge en le changeant...

Suppression au passage de configuration inutilement dupliquée.

Tant qu'à faire, mise à jour de social-auth-app-django.

Fix #6554

### Contrôle qualité

Tester sur la bêta (je déploie la PR dans la foulée) qu'on peut se connecter avec Google et/ou Facebook.
