### PR TITLE
Ajoute un &nbsp; à la modale pour modérer un billet

### DIFF
--- a/templates/tutorialv2/includes/sidebar/validation.part.html
+++ b/templates/tutorialv2/includes/sidebar/validation.part.html
@@ -166,7 +166,7 @@
                         <input type="hidden" name="redirect" value="true">
                         <p>
                             {% blocktrans with content_title=content.title %}
-                                Voulez-vous vraiment modérer le billet <em>{{ content_title }}</em> ?
+                                Voulez-vous vraiment modérer le billet <em>{{ content_title }}</em>&nbsp;?
                                 Il sera dépublié et ne pourra pas être republié.
                             {% endblocktrans %}
                         </p>


### PR DESCRIPTION
Actuellement : 
![avant](https://github.com/zestedesavoir/zds-site/assets/5911232/5d8fe6a8-d060-4a15-8cf2-6344c5fc26f8)

Avec la PR : 
![après](https://github.com/zestedesavoir/zds-site/assets/5911232/afb587f8-3573-421d-87fa-4369ea3033b0)



### Contrôle qualité

- Se connecter en tant qu'`admin`
- Aller sur un billet publié
- Cliquer sur *Modérer* : la modale s'affiche correctement et le point d'interrogation ne commence pas une ligne.
