### PR TITLE
Corrige une erreur si la durée d'une sanction temporaire est manquante

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -711,6 +711,7 @@
                                            name="ls-jrs"
                                            class="expand"
                                            placeholder="{% trans 'Durée de la lecture seule, en jours' %}"
+                                           required="required"
                                            min="1">
                                     {% csrf_token %}
                                     <button type="submit"
@@ -795,12 +796,13 @@
                                     <input type="number"
                                            name="ban-jrs"
                                            class="expand"
+                                           required="required"
                                            placeholder="{% trans 'Durée du bannissement, en jours' %}"
                                            min="1">
                                     {% csrf_token %}
                                     <button type="submit"
                                             name="ban-temp"
-                                            class="btn  btn-submit">
+                                            class="btn btn-submit">
                                         {% trans "Confirmer" %}
                                     </button>
                                 </form>

--- a/zds/member/tests/views/tests_moderation.py
+++ b/zds/member/tests/views/tests_moderation.py
@@ -90,6 +90,20 @@ class TestsModeration(TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertEqual(nb_users + 1, len(result.context["members"]))  # LS guy still shows up, good
 
+    def test_temp_ban_missing_duration(self):
+        # Test error is caught when the duration for temporary sanction is missing in submitted form.
+        staff = StaffProfileFactory()
+        self.client.force_login(staff.user)
+
+        profile = ProfileFactory()
+        ls_text = "Texte de test pour LS TEMP"
+        result = self.client.post(
+            reverse("member-modify-profile", kwargs={"user_pk": profile.user.id}),
+            {"ls-temp": "", "ls-text": ls_text},
+            follow=False,
+        )
+        self.assertEqual(result.status_code, 302)
+
     def test_temp_ls_followed_by_unls(self):
         """
         Test various sanctions.


### PR DESCRIPTION
Sentry nous rapporte que l'erreur suivante : 
```
TypeError: exceptions must derive from BaseException
[...]
  File "zds/member/views/moderation.py", line 167, in modify_profile
    raise HttpResponseBadRequest
```
est levée lorsqu'on applique une sanction temporaire à un membre, mais que la durée de la sanction n'est pas précisée.

Cette PR corrige le problème en capturant les exceptions possibles s'il manque la durée. En plus, j'ajoute un test et je rends obligatoire le champ de la durée dans le formulaire pour ajouter une sanction temporaire.

### Contrôle qualité

Se connecter en tant qu'`admin` et, depuis la page de profil d'un membre, appliquer des sanctions temporaires (banissement et lecture seule) et s'assurer que tout fonctionne toujours comme attendu. On ne peut pas valider le formulaire sans préciser une durée de sanction.
