### PR TITLE
Mise à jour triviale des dépendances Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   PYTHON_VERSION: "3.9"
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt
-  GECKODRIVER_VERSION: "0.33.0"
+  GECKODRIVER_VERSION: "0.34.0"
 
   # As GitHub Action does not allow environment variables
   # to be used in services definitions, these are only for

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.13.0
+    rev: v3.15.0
     hooks:
     -   id: pyupgrade
         args: [--py39-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1 # needs to be also updated in requirements-dev.txt
+    rev: 23.12.1 # needs to be also updated in requirements-dev.txt
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
      - id: trailing-whitespace
        exclude_types: ["svg"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 
-black==23.9.1  # needs to be also updated in .pre-commit-config.yaml
-colorlog==6.7.0
-django-debug-toolbar==3.8.1
+black==23.12.1  # needs to be also updated in .pre-commit-config.yaml
+colorlog==6.8.0
+django-debug-toolbar==4.2.0
 django-extensions==3.2.3
-Faker==19.6.2
-pre-commit==3.4.0
+Faker==22.2.0
+pre-commit==3.6.0
 PyYAML==6.0.1
 selenium==4.9.1
 Sphinx==7.2.6
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==2.0.0

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-gunicorn==20.1.0
-mysqlclient==2.1.1
-sentry-sdk==1.10.1
-ujson==5.4.0
+gunicorn==21.2.0
+mysqlclient==2.2.1
+sentry-sdk==1.39.2
+ujson==5.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,20 +9,20 @@ django-crispy-forms==1.14.0
 django-model-utils==4.3.1
 django-munin==0.2.1
 django-recaptcha==3.0.0
-Django==3.2.21
+Django==3.2.23
 easy-thumbnails[svg]==2.8.5
 factory-boy==3.3.0
-geoip2==4.7.0
-GitPython==3.1.37
+geoip2==4.8.0
+GitPython==3.1.41
 homoglyphs==2.0.4
-lxml==4.9.3
-Pillow==10.0.1
+lxml==5.1.0
+Pillow==10.2.0
 pymemcache==4.0.0
 requests==2.31.0
 
 # Api dependencies
-django-cors-headers==4.2.0
-django-filter==23.3
+django-cors-headers==4.3.1
+django-filter==23.5
 django-oauth-toolkit==1.7.0
 djangorestframework==3.14.0
 drf-extensions==0.7.1


### PR DESCRIPTION
Mise à jour triviale des dépendances Python à leur dernière version, à l'exception de : 
- `elasticsearch` et `elasticsearch-dsl` comme d'habitude,
- `django-crispy-forms`, `django-oauth-toolkit` et `django-recaptcha` car il y a des changements majeurs
- `selenium` car la mise à jour fait planter la CI pour une raison inconnue
- `coverage` car les nouvelles versions ne semblent pas supportées par `coveralls` pour le moment

**QA :** Github Actions + vérifier que le site web fonctionne bien en local + vérifier que la documentation est bien générée en local (mise à jour de `sphinx-rtd-theme`)