### PR TITLE
Mise à jour de Selenium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ env:
   PYTHON_VERSION: "3.9"
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt
-  GECKODRIVER_VERSION: "0.34.0"
 
   # As GitHub Action does not allow environment variables
   # to be used in services definitions, these are only for
@@ -184,15 +183,6 @@ jobs:
           mysql database: "ci_db_name"
           mysql root password: "ci_root_password"
 
-      - name: Install Firefox
-        run: sudo apt-get update && sudo apt-get install firefox
-
-      - name: Install Geckodriver
-        run: |
-          wget https://github.com/mozilla/geckodriver/releases/download/v${{ env.GECKODRIVER_VERSION }}/geckodriver-v${{ env.GECKODRIVER_VERSION }}-linux64.tar.gz
-          mkdir geckodriver
-          tar -xzf geckodriver-v${{ env.GECKODRIVER_VERSION }}-linux64.tar.gz -C geckodriver
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -248,9 +238,7 @@ jobs:
           make zmd-start
 
       - name: Run tests for ${{ matrix.module }}
-        run: |
-          export PATH="$PATH:$PWD/geckodriver"
-          coverage run --source='.' manage.py test -v=2 --keepdb --settings zds.settings.ci_test ${{ matrix.module }}
+        run: coverage run --source='.' manage.py test -v=2 --keepdb --settings zds.settings.ci_test ${{ matrix.module }}
 
       - name: Analyze coverage
         shell: bash -l {0}

--- a/doc/source/utils/selenium.rst
+++ b/doc/source/utils/selenium.rst
@@ -52,7 +52,7 @@ Voici le contenu d'un test :
       def setUpClass(cls):
           super().setUpClass()
           options = Options()
-          options.headless = True
+          options.add_argument("--headless")
           cls.selenium = Firefox(options=options)
           cls.selenium.implicitly_wait(30)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ django-extensions==3.2.3
 Faker==22.2.0
 pre-commit==3.6.0
 PyYAML==6.0.1
-selenium==4.9.1
+selenium==4.16.0
 Sphinx==7.2.6
 sphinx-rtd-theme==2.0.0

--- a/zds/member/tests/tests_front.py
+++ b/zds/member/tests/tests_front.py
@@ -12,7 +12,7 @@ class MemberFrontTests(StaticLiveServerTestCase):
     def setUpClass(cls):
         super().setUpClass()
         options = Options()
-        options.headless = True
+        options.add_argument("--headless")
         cls.selenium = Firefox(options=options)
         cls.selenium.implicitly_wait(30)
 

--- a/zds/tutorialv2/tests/tests_front.py
+++ b/zds/tutorialv2/tests/tests_front.py
@@ -37,7 +37,7 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
     def setUpClass(cls):
         super().setUpClass()
         options = Options()
-        options.headless = True
+        options.add_argument("--headless")
         cls.selenium = Firefox(options=options)
         cls.selenium.implicitly_wait(10)
 


### PR DESCRIPTION
- Mise à jour de Selenium
  - Légère modification sur la façon de préciser le mode *headless*
- Utilisation des versions déjà installés de Firefox et Geckodriver pour la CI
  - La commande `sudo apt-get install firefox` installait pour une raison inconnue une version Snap de Firefox, or [Geckodriver ne fonctionne pas encore avec les versions Snap de Firefox](https://github.com/mozilla/geckodriver/releases/tag/v0.34.0) (lire la section *Known problems*)
  - L'image Ubuntu 22.04 de [la CI contient déjà les dernières versions de Firefox et Geckodriver](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#browsers-and-drivers) (mises à jour environ toutes les semaines ou deux semaines)