### PR TITLE
Mise à jour majeure de django_crispy_forms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
 # Implicit dependencies (optional dependencies of dependencies)
+crispy-forms-bootstrap2==2024.1
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.3
 social-auth-app-django==5.4.0
 
 # Explicit dependencies (references in code)
 beautifulsoup4==4.12.2
-django-crispy-forms==1.14.0
+django-crispy-forms==2.0
 django-model-utils==4.3.1
 django-munin==0.2.1
 django-recaptcha==4.0.0

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -143,6 +143,8 @@ django_template_engine = {
 
 TEMPLATES = [django_template_engine]
 
+CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap"
+
 CRISPY_TEMPLATE_PACK = "bootstrap"
 
 INSTALLED_APPS = (
@@ -156,6 +158,7 @@ INSTALLED_APPS = (
     "easy_thumbnails",
     "easy_thumbnails.optimize",
     "crispy_forms",
+    "crispy_forms_bootstrap2",
     "munin",
     "social_django",
     "rest_framework",


### PR DESCRIPTION
Mise à jour majeure de django_crispy_forms
- `django-crispy-forms` fonctionne avec différents templates (Bootstrap 2, Bootstrap 3...) et ceux-ci ont été séparés du code Python
- Pour le template Bootstrap 2 qu'on utilise pour nos formulaires, il faut en théorie installer le paquet `crispy-forms-bootstrap2` sauf que sa version publiée sur Pypi ne contient pas le dossier `templates/` pourtant présent dans le code source. [J'ai créé un ticket il y a plusieurs mois](https://github.com/django-crispy-forms/crispy-forms-bootstrap2/issues/7) mais je ne pense pas que l'on aura une réponse. Cette PR intègre donc ces éléments de templates dans notre code.
- La version 2.1 est disponible mais on ne peut pas l'installer car on est encore sur Django 3.2

**QA :** Github Actions + vérifier que les formulaires du site web s'affichent correctement