### PR TITLE
Mise à jour de zmarkdown

### DIFF
--- a/zmd/package-lock.json
+++ b/zmd/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "zmarkdown": "11.3.0"
+        "zmarkdown": "11.4.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2499,9 +2499,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2990,6 +2990,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -3471,9 +3479,9 @@
       "integrity": "sha512-QfZj7ui7ZtOmwvgIGyXCMvenGDHfONamk6KomaMlyjGhk2T5WiS+55nZSNvBWCmrp4ofTEcs3mjpoRdmQNORWA=="
     },
     "node_modules/remark-iframes": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/remark-iframes/-/remark-iframes-4.0.5.tgz",
-      "integrity": "sha512-rbQ1WNWNVAxA0wRdVz+kinayOutvw/Dn/8XQ8PvN8CxQT3/n4D/O1uvpAM+4Bx857IoCjIFOfyvnFoZBDvG6uQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/remark-iframes/-/remark-iframes-4.1.0.tgz",
+      "integrity": "sha512-8uLKLk0weJHUANPLYCvxjlqiXweBeyX1im6NICOmIRFeOmdaNDkoIEo79iek/4PHRht6M3JdiH81cv9CR80nQg==",
       "dependencies": {
         "node-fetch": "^2.6.0"
       }
@@ -3997,7 +4005,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/trim": {
       "version": "0.0.1",
@@ -4407,12 +4415,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -4487,9 +4495,9 @@
       }
     },
     "node_modules/zmarkdown": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-11.3.0.tgz",
-      "integrity": "sha512-Q76+dHS7d1aSue2GUnhOI2JBTx6CgvMfbNANqlH/GoRtNewgNnZ+i9RF2DY/MFibkw9cSKdyWK2p0ciJ47Ymgg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-11.4.0.tgz",
+      "integrity": "sha512-V9fqqaQ5dWrBIk8XUGXSdlviqtcA2wkFcQV83PGhrJFjKt+pzGsr2Uk4Z5I1Tfa/jkGjw5WGFZu2kwJ//6J7Uw==",
       "dependencies": {
         "@pm2/io": "^4.3.5",
         "@sentry/node": "^7.19.0",
@@ -4502,6 +4510,7 @@
         "katex": "0.11.1",
         "md-attr-parser": "^1.3.0",
         "pm2": "^4.4.1",
+        "process": "^0.11.10",
         "rebber": "^5.4.0",
         "rebber-plugins": "^4.3.7",
         "rehype-autolink-headings": "^4.0.0",
@@ -4527,8 +4536,8 @@
         "remark-grid-tables": "^2.2.0",
         "remark-heading-shift": "^1.1.1",
         "remark-heading-trailing-spaces": "^0.0.31",
-        "remark-iframes": "^4.0.5",
-        "remark-images-download": "^3.0.2",
+        "remark-iframes": "^4.1.0",
+        "remark-images-download": "^3.0.3",
         "remark-kbd": "^1.1.0",
         "remark-math": "^3.0.1",
         "remark-numbered-footnotes": "^3.0.0",
@@ -4560,7 +4569,8 @@
         "unist-util-visit": "^2.0.3"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18",
+        "npm": ">=9"
       }
     }
   },
@@ -6421,9 +6431,9 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -6788,6 +6798,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -7194,9 +7209,9 @@
       "integrity": "sha512-QfZj7ui7ZtOmwvgIGyXCMvenGDHfONamk6KomaMlyjGhk2T5WiS+55nZSNvBWCmrp4ofTEcs3mjpoRdmQNORWA=="
     },
     "remark-iframes": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/remark-iframes/-/remark-iframes-4.0.5.tgz",
-      "integrity": "sha512-rbQ1WNWNVAxA0wRdVz+kinayOutvw/Dn/8XQ8PvN8CxQT3/n4D/O1uvpAM+4Bx857IoCjIFOfyvnFoZBDvG6uQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/remark-iframes/-/remark-iframes-4.1.0.tgz",
+      "integrity": "sha512-8uLKLk0weJHUANPLYCvxjlqiXweBeyX1im6NICOmIRFeOmdaNDkoIEo79iek/4PHRht6M3JdiH81cv9CR80nQg==",
       "requires": {
         "node-fetch": "^2.6.0"
       }
@@ -7602,7 +7617,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "trim": {
       "version": "0.0.1",
@@ -7908,12 +7923,12 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -7972,9 +7987,9 @@
       }
     },
     "zmarkdown": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-11.3.0.tgz",
-      "integrity": "sha512-Q76+dHS7d1aSue2GUnhOI2JBTx6CgvMfbNANqlH/GoRtNewgNnZ+i9RF2DY/MFibkw9cSKdyWK2p0ciJ47Ymgg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-11.4.0.tgz",
+      "integrity": "sha512-V9fqqaQ5dWrBIk8XUGXSdlviqtcA2wkFcQV83PGhrJFjKt+pzGsr2Uk4Z5I1Tfa/jkGjw5WGFZu2kwJ//6J7Uw==",
       "requires": {
         "@pm2/io": "^4.3.5",
         "@sentry/node": "^7.19.0",
@@ -7987,6 +8002,7 @@
         "katex": "0.11.1",
         "md-attr-parser": "^1.3.0",
         "pm2": "^4.4.1",
+        "process": "^0.11.10",
         "rebber": "^5.4.0",
         "rebber-plugins": "^4.3.7",
         "rehype-autolink-headings": "^4.0.0",
@@ -8012,8 +8028,8 @@
         "remark-grid-tables": "^2.2.0",
         "remark-heading-shift": "^1.1.1",
         "remark-heading-trailing-spaces": "^0.0.31",
-        "remark-iframes": "^4.0.5",
-        "remark-images-download": "^3.0.2",
+        "remark-iframes": "^4.1.0",
+        "remark-images-download": "^3.0.3",
         "remark-kbd": "^1.1.0",
         "remark-math": "^3.0.1",
         "remark-numbered-footnotes": "^3.0.0",

--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "11.3.0"
+    "zmarkdown": "11.4.0"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
Mise à jour de zmarkdown en version 11.4.0 ([notes de version](https://github.com/zestedesavoir/zmarkdown/releases/tag/zmarkdown%4011.4.0))

**QA :** Github Actions + vérifier le bon fonctionnement en local + éventuellement vérifier le fonctionnement en bêta ?