### PR TITLE
Modifie un lien pour pointer vers la vue de validation d'un contenu

### DIFF
--- a/templates/tutorialv2/includes/headline/validation_info.part.html
+++ b/templates/tutorialv2/includes/headline/validation_info.part.html
@@ -24,7 +24,7 @@
     {{ validation_comment_from_authors }}
 {% endif %}
 
-{% url "content:view-version" pk=content.pk slug=content.slug version=content.sha_validation as validation_version_url %}
+{% url "content:validation-view" pk=content.pk slug=content.slug as validation_version_url %}
 
 {% if state.other_version_and_reserved %}
     <p class="content-wrapper alert-box info">


### PR DESCRIPTION
Je me suis rendu compte que j'avais oublié un petit bout dans #6582. Un lien qui pointaint vers la mauvaise page pour la validation.

![image](https://github.com/zestedesavoir/zds-site/assets/35631001/beeee345-3d1e-4475-b8ef-3bf147053501)


### Contrôle qualité

Vérifier que le lien "Une autre version de ce contenu est en attente d'un validateur" pointe vers la vue de validation et pas vers la vue "version"