### PR TITLE
Met à jour les versions Python supportées

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   NODE_VERSION: "18" # needs to be also updated in .nvmrc
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.11"
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt
   TYPESENSE_VERSION: "27.0" # needs to be also updated in scripts/define_variable.sh

--- a/doc/source/install/install-macos.rst
+++ b/doc/source/install/install-macos.rst
@@ -37,7 +37,7 @@ Pré-requis
   Ces instructions expliquent comment installer XCode, Homebrew, Python, pip, et
   les utilitaires GNU, sur macOS. Si vous avez déjà :
 
-  - une installation fonctionnelle de Homebrew et de Python 3.7+ ;
+  - une installation fonctionnelle de Homebrew et de Python 3.8+ ;
   - configuré votre terminal pour utiliser les utilitaires GNU à la place de
     ceux de BSD (avec `linuxify <https://github.com/darksonic37/linuxify#install>`_,
     par exemple) ;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ["py37", "py38", "py39", "py310"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 extend-exclude = """
 ^/doc
 """


### PR DESCRIPTION
- 3.11 est la version sur le serveur de production
- [Django 4.2 est compatible avec les version 3.8-3.12](https://docs.djangoproject.com/en/4.2/releases/4.2/#python-compatibility)

### Contrôle qualité

La CI passe.
