### PR TITLE
Ajoute la modification du titre et du sous-titre d'une publication depuis une modale

### DIFF
--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -13,6 +13,60 @@
         }
     }
 
+    header {
+        >.title-block {
+            display: flex;
+            flex-direction: row;
+
+            margin-bottom: $length-10;
+
+            >.content-thumbnail-group {
+                flex-shrink: 0;
+                margin-right: $length-10;
+            }
+
+            >.content-title-and-subtitle-group {
+                width:100%;
+
+                padding-bottom: $length-4;
+
+                border-bottom: $length-1 solid $accent-500;
+
+                >.content-title-group {
+                    >.title {
+                        display: inline;
+                        vertical-align: middle;
+                        border: none;
+                        margin: 0;
+                        padding: 0;
+                    }
+
+                    >.edit-button {
+                        display: inline-block;
+                        vertical-align: middle;
+                    }
+                }
+
+                >.content-subtitle-group {
+                    >.subtitle {
+                        display: inline;
+                        vertical-align: middle;
+                        margin: 0;
+                        padding: 0;
+                    }
+
+                    >.edit-button {
+                        display: inline-block;
+                        vertical-align: middle;
+                    }
+                }
+
+                display: flex;
+                flex-direction: column;
+            }
+        }
+    }
+
     section > h2 {
         display: flex;
 
@@ -185,7 +239,7 @@
                 padding-right: $length-10;
             }
 
-            .illu img {
+            .content-thumbnail-group {
                 display: none;
             }
 
@@ -195,7 +249,8 @@
             .members,
             p,
             figure,
-            blockquote {
+            blockquote,
+            .title-block {
                 margin-left: $length-10;
                 margin-right: $length-10;
             }

--- a/assets/scss/layout/_main.scss
+++ b/assets/scss/layout/_main.scss
@@ -118,10 +118,7 @@
     }
 
     .license {
-        float: right;
-
         margin: 0;
-        margin-top: $length-10;
     }
 
     .subtitle {

--- a/assets/scss/pages/_content-editor.scss
+++ b/assets/scss/pages/_content-editor.scss
@@ -3,7 +3,6 @@
   align-items: center;
 
   > :not(.edit-button) {
-    flex: 21;
     margin: 0;
   }
 }

--- a/templates/tutorialv2/includes/headline/header.part.html
+++ b/templates/tutorialv2/includes/headline/header.part.html
@@ -1,20 +1,9 @@
-{% include "tutorialv2/includes/headline/licence.part.html" with licence=content.licence show_form=display_config.draft_actions.show_license_edit form=form_edit_license %}
-
-<h1 {% if show_thumbnail and content.image %}class="illu"{% endif %}>
-    {% if show_thumbnail and content.image %}
-        <img src="{{ content.image.physical.tutorial_illu.url }}" alt="" itemprop="thumbnailUrl">
-    {% endif %}
-    {{ title }}
-</h1>
-
-{% if subtitle %}
-    <h2 class="subtitle">
-        {{ subtitle }}
-    </h2>
-{% endif %}
+{% include "tutorialv2/includes/headline/title.part.html" with content=content title=title show_thumbnail=show_thumbnail show_form=display_config.draft_actions.show_title_edit form_title=form_edit_title form_subtitle=form_edit_subtitle %}
 
 <aside class="meta">
     <div class="meta-column">
+        {% include "tutorialv2/includes/headline/licence.part.html" with licence=content.licence show_form=display_config.draft_actions.show_license_edit form=form_edit_license %}
+
         {% include "tutorialv2/includes/headline/authors.part.html" with db_content=db_content edit_authors=display_config.draft_actions.show_authors_management online_mode=display_config.online_config.enable_authors_online_mode %}
         {% include "tutorialv2/includes/headline/contributions.part.html" %}
         {% include "tutorialv2/includes/headline/categories.part.html" %}

--- a/templates/tutorialv2/includes/headline/header.part.html
+++ b/templates/tutorialv2/includes/headline/header.part.html
@@ -2,9 +2,8 @@
 
 <aside class="meta">
     <div class="meta-column">
-        {% include "tutorialv2/includes/headline/licence.part.html" with licence=content.licence show_form=display_config.draft_actions.show_license_edit form=form_edit_license %}
-
         {% include "tutorialv2/includes/headline/authors.part.html" with db_content=db_content edit_authors=display_config.draft_actions.show_authors_management online_mode=display_config.online_config.enable_authors_online_mode %}
+        {% include "tutorialv2/includes/headline/licence.part.html" with licence=content.licence show_form=display_config.draft_actions.show_license_edit form=form_edit_license %}
         {% include "tutorialv2/includes/headline/contributions.part.html" %}
         {% include "tutorialv2/includes/headline/categories.part.html" %}
         {% include "tutorialv2/includes/headline/goals.part.html" with goals=publishablecontent.goals.all %}

--- a/templates/tutorialv2/includes/headline/title.part.html
+++ b/templates/tutorialv2/includes/headline/title.part.html
@@ -1,0 +1,43 @@
+{% load i18n %}
+{% load crispy_forms_tags %}
+
+<div class="title-block">
+    {% if show_thumbnail and content.image %}
+        <div class="content-thumbnail-group">
+            <img class="thumbnail" src="{{ content.image.physical.tutorial_illu.url }}" alt="" itemprop="thumbnailUrl">
+        </div>
+    {% endif %}
+    <div class="content-title-and-subtitle-group">
+        <div class="content-title-group">
+            {% spaceless %}
+            <h1 class="title">{{ title }}</h1>
+            {% if show_form %}
+                <a href="#edit-title" class="open-modal edit-button" title="{% trans "Modifier le titre" %}">
+                    <span class="visuallyhidden">{% trans "Modifier le titre" %}</span>
+                </a>
+                {% crispy form_title %}
+            {% endif %}
+            {% endspaceless %}
+        </div>
+
+        <div class="content-subtitle-group">
+            {% spaceless %}
+            {% if show_form %}
+                {% if subtitle %}
+                    <p class="subtitle">{{ subtitle }}</p>
+                    <a href="#edit-subtitle" class="open-modal edit-button" title="{% trans "Modifier le sous-titre" %}">
+                        <span class="visuallyhidden">{% trans "Modifier le sous-titre" %}</span>
+                    </a>
+                {% else %}
+                    <a href="#edit-subtitle" class="open-modal" title="{% trans "Modifier le sous-titre" %}">
+                        {% trans "Ajoutez un sous-titre !" %}
+                    </a>
+                {% endif %}
+                {% crispy form_subtitle %}
+            {% else %}
+                <p class="subtitle">{{ subtitle }}</p>
+            {% endif %}
+            {% endspaceless %}
+        </div>
+    </div>
+</div>

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -221,10 +221,9 @@ class EditContentForm(ContentForm):
             Field("last_hash"),
             Field("source"),
             Field("subcategory", template="crispy/checkboxselectmultiple.html"),
+            Field("msg_commit"),
+            StrictButton("Valider", type="submit"),
         )
-
-        self.helper.layout.append(Field("msg_commit"))
-        self.helper.layout.append(StrictButton("Valider", type="submit"))
 
 
 class ExtractForm(FormWithTitle):

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -22,6 +22,8 @@ class FormWithTitle(forms.Form):
         label=_("Titre"), max_length=PublishableContent._meta.get_field("title").max_length, required=False
     )
 
+    error_messages = {"bad_slug": _("Le titre « {} » n'est pas autorisé, car son slug est invalide !")}
+
     def clean(self):
         cleaned_data = super().clean()
 
@@ -33,10 +35,8 @@ class FormWithTitle(forms.Form):
 
         try:
             slugify_raise_on_invalid(title)
-        except InvalidSlugError as e:
-            self._errors["title"] = self.error_class(
-                [_("Ce titre n'est pas autorisé, son slug est invalide {} !").format(e)]
-            )
+        except InvalidSlugError:
+            self._errors["title"] = self.error_class([self.error_messages["bad_slug"].format(title)])
 
         return cleaned_data
 

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -197,6 +197,36 @@ class ContentForm(ContainerForm):
         return cleaned_data
 
 
+class EditContentForm(ContentForm):
+    title = None
+    description = None
+    type = None
+
+    def _create_layout(self):
+        self.helper.layout = Layout(
+            IncludeEasyMDE(),
+            Field("image"),
+            Field("introduction", css_class="md-editor preview-source"),
+            StrictButton(_("Aperçu"), type="preview", name="preview", css_class="btn btn-grey preview-btn"),
+            HTML(
+                '{% if form.introduction.value %}{% include "misc/preview.part.html" \
+                with text=form.introduction.value %}{% endif %}'
+            ),
+            Field("conclusion", css_class="md-editor preview-source"),
+            StrictButton(_("Aperçu"), type="preview", name="preview", css_class="btn btn-grey preview-btn"),
+            HTML(
+                '{% if form.conclusion.value %}{% include "misc/preview.part.html" \
+                with text=form.conclusion.value %}{% endif %}'
+            ),
+            Field("last_hash"),
+            Field("source"),
+            Field("subcategory", template="crispy/checkboxselectmultiple.html"),
+        )
+
+        self.helper.layout.append(Field("msg_commit"))
+        self.helper.layout.append(StrictButton("Valider", type="submit"))
+
+
 class ExtractForm(FormWithTitle):
     text = forms.CharField(
         label=_("Texte"),

--- a/zds/tutorialv2/tests/factories.py
+++ b/zds/tutorialv2/tests/factories.py
@@ -85,7 +85,7 @@ class PublishableContentFactory(factory.django.DjangoModelFactory):
         conclusion_content = attrs.pop("conclusion", text)
 
         publishable_content = super()._generate(create, attrs)
-        publishable_content.gallery = GalleryFactory()
+        publishable_content.gallery = GalleryFactory(title=publishable_content.title)
         publishable_content.licence = licence
         for auth in auths:
             publishable_content.authors.add(auth)

--- a/zds/tutorialv2/tests/tests_opinion_views.py
+++ b/zds/tutorialv2/tests/tests_opinion_views.py
@@ -123,20 +123,9 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(opinion.public_version.sha_public, opinion_draft.current_version)
 
         # Change the title:
-        random = "Whatever, we don't care about the details"
         result = self.client.post(
-            reverse("content:edit", args=[opinion.pk, opinion.slug]),
-            {
-                "title": "{} ({})".format(opinion.title, "modified"),
-                "description": random,
-                "introduction": random,
-                "conclusion": random,
-                "type": "OPINION",
-                "licence": opinion.licence.pk,
-                "subcategory": opinion.subcategory.first().pk,
-                "last_hash": opinion.load_version().compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
-            },
+            reverse("content:edit-title", args=[opinion.pk]),
+            {"title": f"{opinion.title} (modified)"},
             follow=False,
         )
         self.assertEqual(result.status_code, 302)

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -303,8 +303,6 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.post(
             reverse("content:edit", args=[pk, slug]),
             {
-                "title": random,
-                "description": random,
                 "introduction": random,
                 "conclusion": random,
                 "type": "TUTORIAL",
@@ -319,17 +317,11 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.assertEqual(Image.objects.filter(gallery__pk=tuto.gallery.pk).count(), 2)  # new icon is uploaded
 
         tuto = PublishableContent.objects.get(pk=pk)
-        self.assertEqual(tuto.title, random)
-        self.assertEqual(tuto.description, random)
         self.assertEqual(tuto.licence, None)
         versioned = tuto.load_version()
         self.assertEqual(versioned.get_introduction(), random)
         self.assertEqual(versioned.get_conclusion(), random)
-        self.assertEqual(versioned.description, random)
         self.assertEqual(versioned.licence, None)
-        self.assertNotEqual(versioned.slug, slug)
-
-        slug = tuto.slug  # make the title change also change the slug !!
 
         # preview container
         result = self.client.post(

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -624,7 +624,6 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.client.force_login(self.user_author)
 
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
-        versioned = tuto.load_version()
 
         # check access
         result = self.client.get(reverse("content:view", args=[tuto.pk, tuto.slug]), follow=False)
@@ -656,21 +655,9 @@ class ContentTests(TutorialTestMixin, TestCase):
         old_slug_tuto = tuto.slug
         version_1 = tuto.sha_draft  # 'version 1' is the one before any change
 
-        new_licence = LicenceFactory()
-        random = "Pâques, c'est bientôt?"
-
         result = self.client.post(
-            reverse("content:edit", args=[tuto.pk, tuto.slug]),
-            {
-                "title": random,
-                "description": random,
-                "introduction": random,
-                "conclusion": random,
-                "type": "TUTORIAL",
-                "licence": new_licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": versioned.compute_hash(),
-            },
+            reverse("content:edit-title", args=[tuto.pk]),
+            {"title": "Pâques, c'est bientôt?"},
             follow=False,
         )
         self.assertEqual(result.status_code, 302)
@@ -736,6 +723,7 @@ class ContentTests(TutorialTestMixin, TestCase):
         # edit container:
         old_slug_part = self.part1.slug
         part1 = tuto.load_version().children[0]
+        random = "Un, deux, trois, je vais dans les bois"
         result = self.client.post(
             reverse(
                 "content:edit-container", kwargs={"pk": tuto.pk, "slug": tuto.slug, "container_slug": self.part1.slug}

--- a/zds/tutorialv2/tests/tests_views/tests_edgecases.py
+++ b/zds/tutorialv2/tests/tests_views/tests_edgecases.py
@@ -36,18 +36,8 @@ class ContentTests(TutorialTestMixin, TestCase):
         # login with author
         self.client.force_login(self.author.user)
         result = self.client.post(
-            reverse("content:edit", args=[opinion.pk, opinion.slug]),
-            {
-                "title": "new title",
-                "description": "subtitle",
-                "introduction": "introduction",
-                "conclusion": "conclusion",
-                "type": "OPINION",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": opinion.load_version().compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
-            },
+            reverse("content:edit-title", args=[opinion.pk]),
+            {"title": "new title"},
             follow=False,
         )
         self.assertEqual(result.status_code, 302)
@@ -56,18 +46,8 @@ class ContentTests(TutorialTestMixin, TestCase):
         result = self.client.get(article.get_absolute_url())
         self.assertEqual(200, result.status_code)
         result = self.client.post(
-            reverse("content:edit", args=[article.pk, article.slug]),
-            {
-                "title": "title",
-                "description": "subtitle",
-                "introduction": "introduction",
-                "conclusion": "conclusion",
-                "type": "ARTICLE",
-                "licence": self.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": article.load_version().compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
-            },
+            reverse("content:edit-title", args=[article.pk]),
+            {"title": "title"},
             follow=True,
         )
         self.assertEqual(200, result.status_code)

--- a/zds/tutorialv2/tests/tests_views/tests_editsubtitle.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editsubtitle.py
@@ -1,0 +1,137 @@
+from datetime import datetime
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.html import escape
+from django.utils.translation import gettext_lazy as _
+
+from zds.tutorialv2.models.database import PublishableContent
+from zds.tutorialv2.views.contents import EditSubtitle, EditSubtitleForm
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.tutorialv2.tests.factories import PublishableContentFactory
+from zds.member.tests.factories import ProfileFactory, StaffProfileFactory
+
+
+viewname = "content:edit-subtitle"
+
+
+@override_for_contents()
+class PermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author])
+
+        # Get information to be reused in tests
+        self.form_url = reverse(viewname, kwargs={"pk": self.content.pk})
+        self.form_data = {"subtitle": self.content.description}  # exact value is not important
+        self.content_data = {"pk": self.content.pk, "slug": self.content.slug}
+        self.content_url = reverse("content:view", kwargs=self.content_data)
+        self.login_url = reverse("member-login") + "?next=" + self.form_url
+
+    def test_not_authenticated(self):
+        """Test that on form submission, unauthenticated users are redirected to the login page."""
+        self.client.logout()  # ensure no user is authenticated
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_author(self):
+        """Test that on form submission, authors are redirected to the content page."""
+        self.client.force_login(self.author)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff(self):
+        """Test that on form submission, staffs are redirected to the content page."""
+        self.client.force_login(self.staff)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_outsider(self):
+        """Test that on form submission, unauthorized users get a 403."""
+        self.client.force_login(self.outsider)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+
+@override_for_contents()
+class WorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author.user])
+
+        # Get information to be reused in tests
+        self.form_url = reverse(viewname, kwargs={"pk": self.content.pk})
+        self.error_messages = EditSubtitleForm.declared_fields["subtitle"].error_messages
+        self.success_message = EditSubtitle.success_message
+
+        # Log in with an authorized user (e.g the author of the content)
+        self.client.force_login(self.author.user)
+
+    def get_test_cases(self):
+        max_length = PublishableContent._meta.get_field("description").max_length
+        too_long = "a" * (max_length + 1)
+        return {
+            "empty_form": {"inputs": {}, "expected_outputs": [self.success_message]},
+            "empty_fields": {"inputs": {"subtitle": ""}, "expected_outputs": [self.success_message]},
+            "basic_success": {"inputs": {"subtitle": "Sous-titre"}, "expected_outputs": [self.success_message]},
+            "stripped_to_empty": {"inputs": {"subtitle": " "}, "expected_outputs": [self.success_message]},
+            "too_long": {
+                "inputs": {"subtitle": too_long},
+                "expected_outputs": [_("Assurez-vous que cette valeur comporte au plus")],
+            },
+        }
+
+    def test_form_workflow(self):
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                response = self.client.post(self.form_url, case["inputs"], follow=True)
+                for msg in case["expected_outputs"]:
+                    self.assertContains(response, escape(msg))
+
+
+@override_for_contents()
+class FunctionalTests(TutorialTestMixin, TestCase):
+    """Test the detailed behavior of the feature, such as updates of the database or repositories."""
+
+    def setUp(self):
+        self.author = ProfileFactory()
+        self.content = PublishableContentFactory(author_list=[self.author.user])
+        self.form_url = reverse(viewname, kwargs={"pk": self.content.pk})
+        self.client.force_login(self.author.user)
+
+    def test_normal(self):
+        start_date = datetime.now()
+        self.assertTrue(self.content.update_date < start_date)
+
+        new_subtitle = "Ceci n'est pas un ancien sous-titre"
+        response = self.client.post(self.form_url, {"subtitle": new_subtitle}, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+        self.content.refresh_from_db()
+
+        self.assertEqual(self.content.description, new_subtitle)
+        self.assertTrue(self.content.update_date > start_date)
+
+        # Update in repository
+        versioned_content = self.content.load_version()
+        self.assertEqual(self.content.description, versioned_content.description)
+
+    def test_empty(self):
+        empty_subtitle = ""
+        response = self.client.post(self.form_url, {"subtitle": empty_subtitle}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.content.refresh_from_db()
+        self.assertEqual(self.content.description, empty_subtitle)

--- a/zds/tutorialv2/tests/tests_views/tests_edittitle.py
+++ b/zds/tutorialv2/tests/tests_views/tests_edittitle.py
@@ -1,0 +1,148 @@
+from datetime import datetime
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.html import escape
+from django.utils.translation import gettext_lazy as _
+
+from zds.tutorialv2.models.database import PublishableContent
+from zds.tutorialv2.views.contents import EditTitleForm, EditTitle
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.tutorialv2.tests.factories import PublishableContentFactory
+from zds.member.tests.factories import ProfileFactory, StaffProfileFactory
+
+
+@override_for_contents()
+class PermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author])
+
+        # Get information to be reused in tests
+        self.form_url = reverse("content:edit-title", kwargs={"pk": self.content.pk})
+        self.form_data = {"title": self.content.title}  # avoids changing the slug
+        self.content_data = {"pk": self.content.pk, "slug": self.content.slug}
+        self.content_url = reverse("content:view", kwargs=self.content_data)
+        self.login_url = reverse("member-login") + "?next=" + self.form_url
+
+    def test_not_authenticated(self):
+        """Test that on form submission, unauthenticated users are redirected to the login page."""
+        self.client.logout()  # ensure no user is authenticated
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_author(self):
+        """Test that on form submission, authors are redirected to the content page."""
+        self.client.force_login(self.author)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_staff(self):
+        """Test that on form submission, staffs are redirected to the content page."""
+        self.client.force_login(self.staff)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_outsider(self):
+        """Test that on form submission, unauthorized users get a 403."""
+        self.client.force_login(self.outsider)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+
+@override_for_contents()
+class WorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create a user
+        self.author = ProfileFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author.user])
+
+        # Get information to be reused in tests
+        self.form_url = reverse("content:edit-title", kwargs={"pk": self.content.pk})
+        self.error_messages = EditTitleForm.declared_fields["title"].error_messages
+        self.success_message = EditTitle.success_message
+
+        # Log in with an authorized user (e.g the author of the content)
+        self.client.force_login(self.author.user)
+
+    def get_test_cases(self):
+        special_char_for_slug = "/"
+        max_length = PublishableContent._meta.get_field("title").max_length
+        too_long = "a" * (max_length + 1)
+        return {
+            "empty_form": {"inputs": {}, "expected_outputs": [self.success_message]},
+            "empty_fields": {"inputs": {"title": ""}, "expected_outputs": [self.success_message]},
+            "basic_success": {"inputs": {"title": "Titre"}, "expected_outputs": [self.success_message]},
+            "stripped_to_empty": {"inputs": {"title": " "}, "expected_outputs": [self.success_message]},
+            "too_long": {
+                "inputs": {"title": too_long},
+                "expected_outputs": [_("Assurez-vous que cette valeur comporte au plus")],
+            },
+            "invalid_slug": {
+                "inputs": {"title": special_char_for_slug},
+                "expected_outputs": [EditTitleForm.error_messages["bad_slug"].format(special_char_for_slug)],
+            },
+        }
+
+    def test_form_workflow(self):
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                response = self.client.post(self.form_url, case["inputs"], follow=True)
+                for msg in case["expected_outputs"]:
+                    self.assertContains(response, escape(msg))
+
+
+@override_for_contents()
+class FunctionalTests(TutorialTestMixin, TestCase):
+    """Test the detailed behavior of the feature, such as updates of the database or repositories."""
+
+    def setUp(self):
+        self.author = ProfileFactory()
+        self.content = PublishableContentFactory(author_list=[self.author.user])
+        self.form_url = reverse("content:edit-title", kwargs={"pk": self.content.pk})
+        self.client.force_login(self.author.user)
+
+    def test_normal(self):
+        self.assertEqual(self.content.title, self.content.gallery.title)
+        start_date = datetime.now()
+        self.assertTrue(self.content.update_date < start_date)
+
+        new_title = "Ceci n'est pas un ancien titre"
+        response = self.client.post(self.form_url, {"title": new_title}, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+        self.content.refresh_from_db()
+
+        self.assertEqual(self.content.title, new_title)
+        self.assertTrue(self.content.update_date > start_date)
+        self.assertEqual(self.content.title, self.content.gallery.title)
+
+        # Update in repository
+        versioned_content = self.content.load_version()
+        self.assertEqual(self.content.title, versioned_content.title)
+
+        # Reachable with new slug
+        response = self.client.get(reverse("content:view", kwargs={"pk": self.content.pk, "slug": self.content.slug}))
+        self.assertEqual(response.status_code, 200)
+
+    def test_empty(self):
+        empty_title = ""
+        default_when_empty = "Titre par défaut"
+        response = self.client.post(self.form_url, {"title": empty_title}, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+
+        self.content.refresh_from_db()
+        self.assertEqual(self.content.title, default_when_empty)

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -1188,21 +1188,10 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         # change title
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
         old_slug = tuto.slug
-        random = "Whatever, we don't care about the details"
 
         result = self.client.post(
-            reverse("content:edit", args=[tuto.pk, tuto.slug]),
-            {
-                "title": "{} ({})".format(self.tuto.title, "modified"),  # will change slug
-                "description": random,
-                "introduction": random,
-                "conclusion": random,
-                "type": "TUTORIAL",
-                "licence": self.tuto.licence.pk,
-                "subcategory": self.subcategory.pk,
-                "last_hash": tuto.load_version().compute_hash(),
-                "image": (settings.BASE_DIR / "fixtures" / "logo.png").open("rb"),
-            },
+            reverse("content:edit-title", args=[tuto.pk]),
+            {"title": "{self.tuto.title} (modified)"},  # will change the slug
             follow=False,
         )
         self.assertEqual(result.status_code, 302)

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -1,13 +1,18 @@
 from django.urls import path
 from django.views.generic.base import RedirectView
 
-from zds.tutorialv2.views.contents import CreateContent, EditContent, DeleteContent
-from zds.tutorialv2.views.licence import EditContentLicense
+from zds.tutorialv2.views.contents import (
+    CreateContent,
+    EditContent,
+    DeleteContent,
+    EditTitle,
+)
 from zds.tutorialv2.views.display.container import ContainerValidationView
 from zds.tutorialv2.views.display.content import ContentValidationView
 from zds.tutorialv2.views.events import EventsList
 from zds.tutorialv2.views.goals import EditGoals, MassEditGoals, ViewContentsByGoal
 from zds.tutorialv2.views.labels import EditLabels, ViewContentsByLabel
+from zds.tutorialv2.views.licence import EditContentLicense
 from zds.tutorialv2.views.validations_contents import ActivateJSFiddleInContent
 from zds.tutorialv2.views.containers_extracts import (
     CreateContainer,
@@ -207,6 +212,8 @@ urlpatterns = (
         path("enlever-contributeur/<int:pk>/", RemoveContributorFromContent.as_view(), name="remove-contributor"),
         path("ajouter-auteur/<int:pk>/", AddAuthorToContent.as_view(), name="add-author"),
         path("enlever-auteur/<int:pk>/", RemoveAuthorFromContent.as_view(), name="remove-author"),
+        # Modify the title
+        path("modifier-titre/<int:pk>/", EditTitle.as_view(), name="edit-title"),
         # Modify the license
         path("modifier-licence/<int:pk>/", EditContentLicense.as_view(), name="edit-license"),
         # Modify the tags

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -6,6 +6,7 @@ from zds.tutorialv2.views.contents import (
     EditContent,
     DeleteContent,
     EditTitle,
+    EditSubtitle,
 )
 from zds.tutorialv2.views.display.container import ContainerValidationView
 from zds.tutorialv2.views.display.content import ContentValidationView
@@ -212,8 +213,9 @@ urlpatterns = (
         path("enlever-contributeur/<int:pk>/", RemoveContributorFromContent.as_view(), name="remove-contributor"),
         path("ajouter-auteur/<int:pk>/", AddAuthorToContent.as_view(), name="add-author"),
         path("enlever-auteur/<int:pk>/", RemoveAuthorFromContent.as_view(), name="remove-author"),
-        # Modify the title
+        # Modify the title and subtitle
         path("modifier-titre/<int:pk>/", EditTitle.as_view(), name="edit-title"),
+        path("modifier-sous-titre/<int:pk>/", EditSubtitle.as_view(), name="edit-subtitle"),
         # Modify the license
         path("modifier-licence/<int:pk>/", EditContentLicense.as_view(), name="edit-license"),
         # Modify the tags

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -184,7 +184,7 @@ class EditContent(LoggedWithReadWriteHability, SingleContentFormViewMixin, FormW
                 "slug": slugify(publishable.title),
                 "pubdate": datetime.now(),
             }
-            gallery, _ = Gallery.objects.get_or_create(pk=publishable.gallery.pk, defaults=gallery_defaults)
+            gallery, _created = Gallery.objects.get_or_create(pk=publishable.gallery.pk, defaults=gallery_defaults)
             mixin = ImageCreateMixin()
             mixin.gallery = gallery
             try:

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -261,7 +261,11 @@ class EditTitle(LoginRequiredMixin, SingleContentFormViewMixin):
         versioned = self.versioned_object
 
         self.update_title_in_database(publishable, form.cleaned_data["title"])
+        logger.debug("content %s updated, slug is %s", publishable.pk, publishable.slug)
+
         sha = self.update_title_in_repository(publishable, versioned, form.cleaned_data["title"])
+        logger.debug("slug consistency after repo update repo=%s db=%s", versioned.slug, publishable.slug)
+
         self.update_sha_draft(publishable, sha)
 
         messages.success(self.request, self.success_message)

--- a/zds/tutorialv2/views/display/config.py
+++ b/zds/tutorialv2/views/display/config.py
@@ -164,6 +164,9 @@ class DraftActionsState:
     def show_license_edit(self) -> bool:
         return self.enabled and self.is_allowed and not self.is_container
 
+    def show_title_edit(self) -> bool:
+        return self.enabled and self.is_allowed and not self.is_container
+
     def show_authors_management(self) -> bool:
         return self.enabled and self.is_allowed
 

--- a/zds/tutorialv2/views/display/content.py
+++ b/zds/tutorialv2/views/display/content.py
@@ -38,6 +38,7 @@ from zds.tutorialv2.models.database import (
     ContentReaction,
 )
 from zds.tutorialv2.utils import last_participation_is_old, mark_read
+from zds.tutorialv2.views.contents import EditTitleForm
 from zds.tutorialv2.views.display.config import (
     ConfigForContentDraftView,
     ConfigForVersionView,
@@ -88,6 +89,7 @@ class ContentBaseView(SingleContentDetailViewMixin):
         context["form_warn_typo"] = WarnTypoForm(versioned, versioned, public=False)
         context["form_jsfiddle"] = JsFiddleActivationForm(initial={"js_support": self.object.js_support})
         context["form_edit_license"] = EditContentLicenseForm(versioned)
+
         context["form_publication"] = PublicationForm(versioned, initial={"source": self.object.source})
         context["gallery"] = self.object.gallery
         context["alerts"] = self.object.alerts_on_this_content.all()
@@ -135,6 +137,8 @@ class ContentDraftView(LoginRequiredMixin, ContentBaseView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["form_edit_title"] = EditTitleForm(self.versioned_object)
+        context["form_edit_subtitle"] = EditContentLicenseForm(self.versioned_object)  # TODO
         context["display_config"] = ConfigForContentDraftView(self.request.user, self.object, self.versioned_object)
         return context
 

--- a/zds/tutorialv2/views/display/content.py
+++ b/zds/tutorialv2/views/display/content.py
@@ -38,7 +38,7 @@ from zds.tutorialv2.models.database import (
     ContentReaction,
 )
 from zds.tutorialv2.utils import last_participation_is_old, mark_read
-from zds.tutorialv2.views.contents import EditTitleForm
+from zds.tutorialv2.views.contents import EditTitleForm, EditSubtitleForm
 from zds.tutorialv2.views.display.config import (
     ConfigForContentDraftView,
     ConfigForVersionView,
@@ -138,7 +138,7 @@ class ContentDraftView(LoginRequiredMixin, ContentBaseView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["form_edit_title"] = EditTitleForm(self.versioned_object)
-        context["form_edit_subtitle"] = EditContentLicenseForm(self.versioned_object)  # TODO
+        context["form_edit_subtitle"] = EditSubtitleForm(self.versioned_object)
         context["display_config"] = ConfigForContentDraftView(self.request.user, self.object, self.versioned_object)
         return context
 


### PR DESCRIPTION
Fix #5796.

C'est une reprise sous une forme différente d'une ancienne PR pour résoudre ce ticket.

* Change l'agencement de la ligne de titre et sous-titre pour accomoder deux boutons d'ouverture des modales
* Déplace au passage la licence avec les autres métainformations (sa place n'avait pas de logique particulière en vérité)
* Ajoute le code nécessaire pour traiter ces deux nouveaux formulaires dans les modales
* Modifie le formulaire "éditer" d'un contenu pour enlever la modification du titre et sous-titre qui s'y trouvaient jusqu'à présent
* Le formulaire de création de contenu ne change pas pour le moment (on garde la possibilité d'y saisir titre et sous-titre.

![image](https://github.com/zestedesavoir/zds-site/assets/35631001/0a747abe-b1df-4493-8ef7-b3a673fb141d)

Les commits sont découpés au mieux pour faciliter la revue.

### Contrôle qualité

Tester la modification du titre et sous-titre sur la page de brouillon. Vérifier notamment que la date de mise à jour est modifiée et qu'on a bien un commit dans l'historique des versions.

Voir si l'affichage des boutons est absent depuis la page en ligne, celle de validation et celle de bêta.

Vérifier que le formulaire "éditer" fonctionne toujours bien.