### PR TITLE
Mise à jour triviale des dépendances Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.15.1
     hooks:
     -   id: pyupgrade
         args: [--py39-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1 # needs to be also updated in requirements-dev.txt
+    rev: 24.2.0 # needs to be also updated in requirements-dev.txt
     hooks:
       - id: black
         language_version: python3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 
-black==23.12.1  # needs to be also updated in .pre-commit-config.yaml
-colorlog==6.8.0
-django-debug-toolbar==4.2.0
+black==24.2.0  # needs to be also updated in .pre-commit-config.yaml
+colorlog==6.8.2
+django-debug-toolbar==4.3.0
 django-extensions==3.2.3
-Faker==22.2.0
-pre-commit==3.6.0
+Faker==24.1.0
+pre-commit==3.6.2
 PyYAML==6.0.1
-selenium==4.16.0
+selenium==4.18.1
 Sphinx==7.2.6
 sphinx-rtd-theme==2.0.0

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
 gunicorn==21.2.0
-mysqlclient==2.2.1
-sentry-sdk==1.39.2
+mysqlclient==2.2.4
+sentry-sdk==1.41.0
 ujson==5.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,15 @@ elasticsearch==5.5.3
 social-auth-app-django==5.4.0
 
 # Explicit dependencies (references in code)
-beautifulsoup4==4.12.2
-django-crispy-forms==2.0
-django-model-utils==4.3.1
+beautifulsoup4==4.12.3
+django-crispy-forms==2.1
+django-model-utils==4.4.0
 django-recaptcha==4.0.0
-Django==4.2.6
+Django==4.2.11
 easy-thumbnails[svg]==2.8.5
 factory-boy==3.3.0
 geoip2==4.8.0
-GitPython==3.1.41
+GitPython==3.1.42
 homoglyphs==2.0.4
 lxml==5.1.0
 Pillow==10.2.0
@@ -22,7 +22,7 @@ requests==2.31.0
 
 # Api dependencies
 django-cors-headers==4.3.1
-django-filter==23.5
+django-filter==24.1
 django-oauth-toolkit==2.3.0
 djangorestframework==3.14.0
 drf-extensions==0.7.1
@@ -31,7 +31,7 @@ drf-yasg==1.21.7
 
 # Dependencies for slug generation, please be extra careful with those
 django-uuslug==2.0.0
-python-slugify==8.0.1
+python-slugify==8.0.4
 
 # tomllib was added to the standard library in Python 3.11
 # tomli is only needed for older Python versions

--- a/zds/gallery/forms.py
+++ b/zds/gallery/forms.py
@@ -219,7 +219,6 @@ class ArchiveImageForm(forms.Form):
 
 
 class ImageAsAvatarForm(forms.Form):
-
     """Form to add current image as avatar"""
 
     def __init__(self, *args, **kwargs):

--- a/zds/mp/models.py
+++ b/zds/mp/models.py
@@ -486,7 +486,6 @@ class PrivatePost(models.Model):
 
 
 class PrivatePostVote(models.Model):
-
     """Set of Private Post votes."""
 
     class Meta:

--- a/zds/pages/admin.py
+++ b/zds/pages/admin.py
@@ -4,7 +4,6 @@ from zds.pages.models import GroupContact
 
 
 class GroupContactAdmin(admin.ModelAdmin):
-
     """Representation of GroupContact model in the admin interface."""
 
     raw_id_fields = ("persons_in_charge",)

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -295,7 +295,6 @@ class MustRedirect(Exception):
 
 
 class SingleOnlineContentViewMixin(ContentTypeMixin):
-
     """
     Base mixin to get only one content online content
 

--- a/zds/tutorialv2/models/help_requests.py
+++ b/zds/tutorialv2/models/help_requests.py
@@ -6,7 +6,6 @@ from zds.utils.models import image_path_help
 
 
 class HelpWriting(models.Model):
-
     """Tutorial Help"""
 
     class Meta:

--- a/zds/utils/models.py
+++ b/zds/utils/models.py
@@ -112,7 +112,6 @@ class SubCategory(models.Model):
 
 
 class CategorySubCategory(models.Model):
-
     """ManyToMany between Category and SubCategory but save a boolean to know
     if category is his main category."""
 
@@ -133,7 +132,6 @@ class CategorySubCategory(models.Model):
 
 
 class Licence(models.Model):
-
     """Publication licence."""
 
     class Meta:
@@ -368,7 +366,6 @@ def get_hat_to_add(hat_name, user):
 
 
 class Comment(models.Model):
-
     """Comment in forum, articles, tutorial, chapter, etc."""
 
     class Meta:
@@ -741,7 +738,6 @@ class Alert(models.Model):
 
 
 class CommentVote(models.Model):
-
     """Set of comment votes."""
 
     class Meta:
@@ -758,7 +754,6 @@ class CommentVote(models.Model):
 
 
 class Tag(models.Model):
-
     """Set of tags."""
 
     class Meta:


### PR DESCRIPTION
Mise à jour triviale des dépendances Python à leur dernière version, à l'exception de : 
- `elasticsearch` et `elasticsearch-dsl` comme d'habitude,
- `coverage` car les nouvelles versions ne sont pas supportées par `coveralls` pour le moment

**QA :** Github Actions + vérifier que le site web fonctionne bien en local