### PR TITLE
Supprime SESSION_ENGINE de zds/settings/prod.py

### DIFF
--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -57,7 +57,6 @@ CACHES = {
     }
 }
 
-SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 SESSION_COOKIE_AGE = 60 * 60 * 24 * 7 * 4
 
 MEDIA_ROOT = Path("/opt/zds/data/media")


### PR DESCRIPTION
Ce paramètre possède la même valeur que sa définition dans zds/settings/abstract_base/django.py, quelque soit l'environnement d'exécution.

Fait suite à la PR #6021

### Contrôle qualité

Attendre que je vous dise que ça fonctionne sur la bêta :)
