### PR TITLE
Permet de verrouiller les commentaires d'un contenu

### DIFF
--- a/templates/tutorialv2/includes/sidebar/administration_actions.part.html
+++ b/templates/tutorialv2/includes/sidebar/administration_actions.part.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load captureas %}
 {% load crispy_forms_tags %}
+{% load set %}
 
 {% if administration_actions.show_block %}
     <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Administration">
@@ -65,6 +66,24 @@
                     {% endif %}
                 </li>
                 {% crispy form_jsfiddle %}
+            {% endif %}
+
+            {% if administration_actions.show_content_reactions_lock %}
+                {% if content.is_locked %}
+                    {% trans "Déverrouiller les commentaires" as button_text %}
+                    {% set "unlock" as hidden_action %}
+                {% else %}
+                    {% trans "Verrouiller les commentaires" as button_text %}
+                    {% set "lock" as hidden_action %}
+                {% endif %}
+
+                <li>
+                    <form action="{% url 'content:lock-reactions' object.pk %}" method="post">
+                        {% csrf_token %}
+                        <input type="hidden" name="action" value="{{ hidden_action }}">
+                        <button class="ico-after lock" type="submit">{{ button_text }}</button>
+                    </form>
+                </li>
             {% endif %}
         </ul>
     </div>

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -464,6 +464,7 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
             "sha_picked",
             "converted_to",
             "type",
+            "is_locked",
         ]
 
         fns = ["in_beta", "in_validation", "in_public", "get_absolute_contact_url", "get_note_count", "antispam"]

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -49,6 +49,7 @@ from zds.tutorialv2.views.comments import (
     SendNoteAlert,
     SolveNoteAlert,
     FollowContentReaction,
+    LockContentReactions,
 )
 
 feeds = [
@@ -139,6 +140,7 @@ urlpatterns = (
         ),
         path("<int:pk>/<slug:slug>/", ContentDraftView.as_view(public_is_prioritary=False), name="view"),
         path("telecharger/<int:pk>/<slug:slug>/", DownloadContent.as_view(), name="download-zip"),
+        path("verrouiller-commentaires/<int:pk>/", LockContentReactions.as_view(), name="lock-reactions"),
         # reactions:
         path("reactions/ajouter/", SendNoteFormView.as_view(redirection_is_needed=False), name="add-reaction"),
         path("reactions/editer/", UpdateNoteView.as_view(redirection_is_needed=False), name="update-reaction"),

--- a/zds/tutorialv2/views/comments.py
+++ b/zds/tutorialv2/views/comments.py
@@ -366,3 +366,24 @@ class FollowContentReaction(LoggedWithReadWriteHability, SingleOnlineContentView
         if is_ajax(self.request):
             return HttpResponse(json_handler.dumps(response), content_type="application/json")
         return redirect(self.get_object().get_absolute_url())
+
+
+class LockContentReactions(LoginRequiredMixin, PermissionRequiredMixin, SingleOnlineContentViewMixin, FormView):
+    """Lock or unlock content reactions for a content"""
+
+    permission_required = "tutorialv2.change_publishablecontent"
+    http_method_names = ["post"]
+
+    def post(self, request, *args, **kwargs):
+        response = {}
+        self.public_content_object = self.get_public_object()
+        self.object = self.get_object()
+        if request.POST.get("action") == "lock":
+            self.object.is_locked = True
+            self.object.save()
+        elif request.POST.get("action") == "unlock":
+            self.object.is_locked = False
+            self.object.save()
+        if is_ajax(self.request):
+            return HttpResponse(json_handler.dumps(response), content_type="application/json")
+        return redirect(self.public_content_object.get_absolute_url())

--- a/zds/tutorialv2/views/display/config.py
+++ b/zds/tutorialv2/views/display/config.py
@@ -24,6 +24,7 @@ class AdministrationActionsState:
                 or self.show_opinion_moderated()
                 or self.show_gallery_link()
                 or self.show_jsfiddle()
+                or self.show_content_reactions_lock()
             )
         )
 
@@ -47,6 +48,9 @@ class AdministrationActionsState:
 
     def show_jsfiddle(self) -> bool:
         return self.enabled and self.is_staff and self.requires_validation
+
+    def show_content_reactions_lock(self) -> bool:
+        return self.enabled and self.is_staff
 
 
 class PublicActionsState:


### PR DESCRIPTION
Fixes #6563

Une partie de la fonctionnalité est déjà codée (`content.is_locked` sur la même base que `topic.is_locked`) mais il manquait quelques bouts que j'ai rajouté pour avoir quelque chose de fonctionnel. Je me suis inspiré de bouts de code existants donc j'espère que c'est quand même assez propre au final. Je veux bien vos retours sur le code si possible !

Je met l'étiquette Bloquant car c'est une fonctionnalité assez demandée par les modérateurs vu tout le spam que l'on a dans les commentaires.