### PR TITLE
Teste et corrige l'affichage de quelques éléments de la sidebar des contenus

### DIFF
--- a/templates/tutorialv2/includes/sidebar/administration_actions.part.html
+++ b/templates/tutorialv2/includes/sidebar/administration_actions.part.html
@@ -7,12 +7,6 @@
         <h3>{% trans "Administration" %}</h3>
 
         <ul>
-            {% if administration_actions.show_exports_request %}
-                <li>
-                    {% include "tutorialv2/includes/sidebar/exports.part.html" %}
-                </li>
-            {% endif %}
-
             {% if administration_actions.show_versions_history_link %}
                 <li>
                     <a href="{% url "content:history" content.pk content.slug_repository %}" class="ico-after history blue">

--- a/templates/tutorialv2/includes/sidebar/exports.part.html
+++ b/templates/tutorialv2/includes/sidebar/exports.part.html
@@ -1,10 +1,11 @@
+{% load get_item %}
 {% load i18n %}
 
 <a href="#exports-modal" class="open-modal ico-after gear blue"
    data-exports-id="{{ content.pk }}"
    data-exports-api="{% url "api:content:list_exports" content.pk %}"
    data-request-export-api="{% url "api:content:generate_export" content.pk %}">
-  {% trans "Exports du contenu" %}
+    {{ public_actions.messages|get_item:"export_content" }}
 </a>
 
 <div class="modal modal-flex" id="exports-modal" data-modal-close="Fermer">

--- a/templates/tutorialv2/includes/sidebar/public_actions.part.html
+++ b/templates/tutorialv2/includes/sidebar/public_actions.part.html
@@ -64,6 +64,12 @@
                 </li>
             {% endif %}
 
+            {% if public_actions.show_exports_request %}
+                <li>
+                    {% include "tutorialv2/includes/sidebar/exports.part.html" %}
+                </li>
+            {% endif %}
+
             {% if public_actions.show_content_revoke %}
                 <li>
                     <a href="#unpublish" class="ico-after open-modal cross blue">

--- a/templates/tutorialv2/includes/sidebar/public_actions.part.html
+++ b/templates/tutorialv2/includes/sidebar/public_actions.part.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load captureas %}
 {% load crispy_forms_tags %}
+{% load get_item %}
 
 {% if public_actions.show_block %}
     <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Version publique">
@@ -14,11 +15,27 @@
                 </li>
             {% endif %}
 
-            {% if public_actions.show_identical_version_message %}
+            {% if public_actions.show_identical_public_version_message %}
                 <li class="inactive">
                     <span class="ico-after pin disabled">
-                        {% trans "La version publique est identique à cette version." %}
+                        {{ public_actions.messages|get_item:"public_is_same" }}
                     </span>
+                </li>
+            {% endif %}
+
+            {% if public_actions.show_identical_draft_version_message %}
+                <li class="inactive">
+                    <span class="ico-after pin disabled">
+                        {{ public_actions.messages|get_item:"draft_is_same" }}
+                    </span>
+                </li>
+            {% endif %}
+
+            {% if public_actions.show_more_recent_draft_version_link %}
+                <li>
+                    <a href="{{ object.get_absolute_url }}" class="ico-after online blue">
+                        {{ public_actions.messages|get_item:"draft_is_more_recent" }}
+                    </a>
                 </li>
             {% endif %}
 
@@ -30,13 +47,6 @@
                 </li>
             {% endif %}
 
-            {% if public_actions.show_stats_link %}
-                <li>
-                    {% url "content:stats-content" content.pk content.slug as stats_url %}
-                    <a href="{{ stats_url }}" class="ico-after stats blue">{% trans "Voir les statistiques" %}</a>
-                </li>
-            {% endif %}
-
             {% if public_actions.show_comparison_link %}
                 <li>
                     {% captureas to_sha %}{% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}{% endcaptureas %}
@@ -44,6 +54,13 @@
                     <a href="{{ diff_public_url }}" class="ico-after history blue">
                         {% trans "Comparer avec la version en ligne" %}
                     </a>
+                </li>
+            {% endif %}
+
+            {% if public_actions.show_stats_link %}
+                <li>
+                    {% url "content:stats-content" content.pk content.slug as stats_url %}
+                    <a href="{{ stats_url }}" class="ico-after stats blue">{% trans "Voir les statistiques" %}</a>
                 </li>
             {% endif %}
 

--- a/templates/tutorialv2/includes/sidebar/validation.part.html
+++ b/templates/tutorialv2/includes/sidebar/validation.part.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load captureas %}
+{% load get_item %}
 
 
 {% if display_config.validation_actions.show_validation_actions %}
@@ -19,7 +20,7 @@
             {% if display_config.validation_actions.show_identical_message %}
                 <li class="inactive">
                     <span class="ico-after pin disabled">
-                        {% trans "La version en validation est identique à cette version." %}
+                        {{ display_config.validation_actions.messages|get_item:"validation_is_same" }}
                     </span>
                 </li>
             {% endif %}

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -302,6 +302,10 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
         """Return True if the given sha corresponds to the public version, and False otherwise."""
         return self.in_public() and sha == self.sha_public
 
+    def is_draft_more_recent_than_public(self) -> bool:
+        """Return True if there is a draft version more recent than the published version, and False otherwise."""
+        return self.in_public() and self.in_drafting() and self.sha_public != self.sha_draft
+
     def is_picked(self):
         return self.in_public() and self.sha_public == self.sha_picked
 

--- a/zds/tutorialv2/tests/tests_views/tests_contentvalidationview.py
+++ b/zds/tutorialv2/tests/tests_views/tests_contentvalidationview.py
@@ -4,13 +4,7 @@ from django.urls import reverse
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 from zds.member.tests.factories import ProfileFactory, StaffProfileFactory
 from zds.tutorialv2.tests.factories import PublishableContentFactory, ValidationFactory
-
-
-def request_validation(content):
-    """Emulate a proper validation request."""
-    ValidationFactory(content=content, status="PENDING")
-    content.sha_validation = content.sha_draft
-    content.save()
+from zds.tutorialv2.tests.utils import request_validation
 
 
 @override_for_contents()

--- a/zds/tutorialv2/tests/tests_views/tests_display.py
+++ b/zds/tutorialv2/tests/tests_views/tests_display.py
@@ -40,12 +40,14 @@ class DisplayConfigTests(TutorialTestMixin, TestCase):
         self.assertContains(public_page, PublicActionsState.messages["draft_is_same"])
         self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
         self.assertNotContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertContains(public_page, PublicActionsState.messages["export_content"])
         self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
         # Draft page:
         draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
         self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
         self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
         self.assertContains(draft_page, PublicActionsState.messages["public_is_same"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["export_content"])
         self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
 
         # Create a new draft version:
@@ -71,6 +73,7 @@ class DisplayConfigTests(TutorialTestMixin, TestCase):
         self.assertNotContains(public_page, PublicActionsState.messages["draft_is_same"])
         self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
         self.assertContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertContains(public_page, PublicActionsState.messages["export_content"])
         self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
         # Draft page:
         draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
@@ -78,6 +81,7 @@ class DisplayConfigTests(TutorialTestMixin, TestCase):
         self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
         self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
         self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["export_content"])
         self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
 
         # Ask validation:
@@ -87,12 +91,14 @@ class DisplayConfigTests(TutorialTestMixin, TestCase):
         self.assertNotContains(public_page, PublicActionsState.messages["draft_is_same"])
         self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
         self.assertContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertContains(public_page, PublicActionsState.messages["export_content"])
         self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
         # Draft page:
         draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
         self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
         self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
         self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["export_content"])
         self.assertContains(draft_page, ValidationActions.messages["validation_is_same"])
         # Validation page:
         validation_page = self.client.get(
@@ -101,6 +107,7 @@ class DisplayConfigTests(TutorialTestMixin, TestCase):
         self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_same"])
         self.assertNotContains(validation_page, PublicActionsState.messages["public_is_same"])
         self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(validation_page, PublicActionsState.messages["export_content"])
         self.assertNotContains(validation_page, ValidationActions.messages["validation_is_same"])
 
         # Now a new draft version, to have different version from validation:
@@ -126,6 +133,7 @@ class DisplayConfigTests(TutorialTestMixin, TestCase):
         self.assertNotContains(public_page, PublicActionsState.messages["draft_is_same"])
         self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
         self.assertContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertContains(public_page, PublicActionsState.messages["export_content"])
         self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
         # Draft page:
         draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
@@ -133,6 +141,7 @@ class DisplayConfigTests(TutorialTestMixin, TestCase):
         self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
         self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
         self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["export_content"])
         self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
         # Validation page:
         validation_page = self.client.get(
@@ -141,4 +150,5 @@ class DisplayConfigTests(TutorialTestMixin, TestCase):
         self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_same"])
         self.assertNotContains(validation_page, PublicActionsState.messages["public_is_same"])
         self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(validation_page, PublicActionsState.messages["export_content"])
         self.assertNotContains(validation_page, ValidationActions.messages["validation_is_same"])

--- a/zds/tutorialv2/tests/tests_views/tests_display.py
+++ b/zds/tutorialv2/tests/tests_views/tests_display.py
@@ -24,131 +24,136 @@ overridden_zds_app["content"]["extra_content_generation_policy"] = "NONE"
 @override_settings(ZDS_APP=overridden_zds_app)
 @override_settings(ES_ENABLED=False)
 class DisplayConfigTests(TutorialTestMixin, TestCase):
+    TEXT_FIRST_MODIFICATION = "Modified introduction"
+    TEXT_SECOND_MODIFICATION = "Modified Introduction"
+
     def setUp(self):
         self.overridden_zds_app = overridden_zds_app
         overridden_zds_app["content"]["default_licence_pk"] = LicenceFactory().pk
 
         self.user_author = ProfileFactory().user
-
-    def test_sidebar_items(self):
         self.client.force_login(self.user_author)
 
         # Publish an article:
-        article = PublishedContentFactory(author_list=[self.user_author], type="ARTICLE")
-        # Public page:
-        public_page = self.client.get(article.get_absolute_url_online())
-        self.assertContains(public_page, PublicActionsState.messages["draft_is_same"])
-        self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
-        self.assertNotContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
-        self.assertContains(public_page, PublicActionsState.messages["export_content"])
-        self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
-        # Draft page:
-        draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
-        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
-        self.assertContains(draft_page, PublicActionsState.messages["public_is_same"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["export_content"])
-        self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
+        self.article = PublishedContentFactory(author_list=[self.user_author], type="ARTICLE")
 
+    def _new_draft_version(self, text):
         # Create a new draft version:
-        versioned = article.load_version()
+        versioned = self.article.load_version()
         result = self.client.post(
-            reverse("content:edit", args=[article.pk, article.slug]),
+            reverse("content:edit", args=[self.article.pk, self.article.slug]),
             {
-                "title": article.title,
-                "description": article.description,
-                "introduction": "Modified introduction",
+                "title": self.article.title,
+                "description": self.article.description,
+                "introduction": text,
                 "conclusion": "Modified conclusion",
-                "type": article.type,
-                "subcategory": article.subcategory.first().pk,
+                "type": self.article.type,
+                "subcategory": self.article.subcategory.first().pk,
                 "last_hash": versioned.compute_hash(),
             },
             follow=False,
         )
         self.assertEqual(result.status_code, 302)
-        article.refresh_from_db()  # the previous request changes sha_draft
-        # Public page:
-        public_page = self.client.get(article.get_absolute_url_online())
-        self.assertNotContains(public_page, "Modified introduction")
-        self.assertNotContains(public_page, PublicActionsState.messages["draft_is_same"])
-        self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
-        self.assertContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
-        self.assertContains(public_page, PublicActionsState.messages["export_content"])
-        self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
-        # Draft page:
-        draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
-        self.assertContains(draft_page, "Modified introduction")
-        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["export_content"])
-        self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
+        self.article.refresh_from_db()  # the previous request changes sha_draft
 
-        # Ask validation:
-        request_validation(article)
-        # Public page:
-        public_page = self.client.get(article.get_absolute_url_online())
+    def test_sidebar_items_on_public_page(self):
+        def common_tests():
+            public_page = self.client.get(self.article.get_absolute_url_online())
+
+            self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
+            self.assertContains(public_page, PublicActionsState.messages["export_content"])
+            self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
+
+            return public_page
+
+        public_page = common_tests()
+        self.assertContains(public_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
+
+        self._new_draft_version(self.TEXT_FIRST_MODIFICATION)
+
+        public_page = common_tests()
+        self.assertNotContains(public_page, self.TEXT_FIRST_MODIFICATION)
         self.assertNotContains(public_page, PublicActionsState.messages["draft_is_same"])
-        self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
         self.assertContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
-        self.assertContains(public_page, PublicActionsState.messages["export_content"])
-        self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
-        # Draft page:
-        draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
-        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["export_content"])
-        self.assertContains(draft_page, ValidationActions.messages["validation_is_same"])
-        # Validation page:
-        validation_page = self.client.get(
-            reverse("content:validation-view", args=[article.pk, article.slug]), follow=False
-        )
-        self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_same"])
-        self.assertNotContains(validation_page, PublicActionsState.messages["public_is_same"])
-        self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_more_recent"])
-        self.assertNotContains(validation_page, PublicActionsState.messages["export_content"])
-        self.assertNotContains(validation_page, ValidationActions.messages["validation_is_same"])
+
+        request_validation(self.article)
+
+        public_page = common_tests()
+        self.assertNotContains(public_page, self.TEXT_FIRST_MODIFICATION)
+        self.assertNotContains(public_page, PublicActionsState.messages["draft_is_same"])
+        self.assertContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
 
         # Now a new draft version, to have different version from validation:
-        versioned = article.load_version()
-        result = self.client.post(
-            reverse("content:edit", args=[article.pk, article.slug]),
-            {
-                "title": article.title,
-                "description": article.description,
-                "introduction": "Modified introduction again",
-                "conclusion": "Modified conclusion",
-                "type": article.type,
-                "subcategory": article.subcategory.first().pk,
-                "last_hash": versioned.compute_hash(),
-            },
-            follow=False,
-        )
-        self.assertEqual(result.status_code, 302)
-        article.refresh_from_db()  # the previous request changes sha_draft
-        # Public page:
-        public_page = self.client.get(article.get_absolute_url_online())
-        self.assertNotContains(public_page, "Modified introduction")
+        self._new_draft_version(self.TEXT_SECOND_MODIFICATION)
+
+        public_page = common_tests()
+        self.assertNotContains(public_page, self.TEXT_FIRST_MODIFICATION)
+        self.assertNotContains(public_page, self.TEXT_SECOND_MODIFICATION)
         self.assertNotContains(public_page, PublicActionsState.messages["draft_is_same"])
-        self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
         self.assertContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
-        self.assertContains(public_page, PublicActionsState.messages["export_content"])
-        self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
-        # Draft page:
-        draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
-        self.assertContains(draft_page, "Modified introduction")
-        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
-        self.assertNotContains(draft_page, PublicActionsState.messages["export_content"])
+
+    def test_sidebar_items_on_draft_page(self):
+        def common_tests():
+            draft_page = self.client.get(
+                reverse("content:view", args=[self.article.pk, self.article.slug]), follow=False
+            )
+
+            self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
+            self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
+            self.assertNotContains(draft_page, PublicActionsState.messages["export_content"])
+
+            return draft_page
+
+        draft_page = common_tests()
+        self.assertContains(draft_page, PublicActionsState.messages["public_is_same"])
         self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
-        # Validation page:
-        validation_page = self.client.get(
-            reverse("content:validation-view", args=[article.pk, article.slug]), follow=False
-        )
-        self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_same"])
-        self.assertNotContains(validation_page, PublicActionsState.messages["public_is_same"])
-        self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_more_recent"])
-        self.assertNotContains(validation_page, PublicActionsState.messages["export_content"])
-        self.assertNotContains(validation_page, ValidationActions.messages["validation_is_same"])
+
+        self._new_draft_version(self.TEXT_FIRST_MODIFICATION)
+
+        draft_page = common_tests()
+        self.assertContains(draft_page, self.TEXT_FIRST_MODIFICATION)
+        self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
+        self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
+
+        request_validation(self.article)
+
+        draft_page = common_tests()
+        self.assertContains(draft_page, self.TEXT_FIRST_MODIFICATION)
+        self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
+        self.assertContains(draft_page, ValidationActions.messages["validation_is_same"])
+
+        # Now a new draft version, to have different version from validation:
+        self._new_draft_version(self.TEXT_SECOND_MODIFICATION)
+
+        draft_page = common_tests()
+        self.assertContains(draft_page, self.TEXT_SECOND_MODIFICATION)
+        self.assertNotContains(draft_page, self.TEXT_FIRST_MODIFICATION)
+        self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
+        self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
+
+    def test_sidebar_items_on_validation_page(self):
+        def common_tests():
+            validation_page = self.client.get(
+                reverse("content:validation-view", args=[self.article.pk, self.article.slug]), follow=False
+            )
+
+            self.assertContains(validation_page, self.TEXT_FIRST_MODIFICATION)
+            self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_same"])
+            self.assertNotContains(validation_page, PublicActionsState.messages["public_is_same"])
+            self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_more_recent"])
+            self.assertNotContains(validation_page, PublicActionsState.messages["export_content"])
+            self.assertNotContains(validation_page, ValidationActions.messages["validation_is_same"])
+
+            return validation_page
+
+        self._new_draft_version(self.TEXT_FIRST_MODIFICATION)
+        request_validation(self.article)
+
+        validation_page = common_tests()
+
+        # Now a new draft version, to have different version from validation:
+        self._new_draft_version(self.TEXT_SECOND_MODIFICATION)
+
+        validation_page = common_tests()
+        self.assertNotContains(validation_page, self.TEXT_SECOND_MODIFICATION)

--- a/zds/tutorialv2/tests/tests_views/tests_display.py
+++ b/zds/tutorialv2/tests/tests_views/tests_display.py
@@ -1,0 +1,144 @@
+from copy import deepcopy
+
+from django.conf import settings
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from zds.member.tests.factories import ProfileFactory
+from zds.tutorialv2.tests import TutorialTestMixin
+from zds.tutorialv2.tests.factories import PublishedContentFactory
+from zds.tutorialv2.tests.utils import request_validation
+from zds.tutorialv2.views.display.config import PublicActionsState, ValidationActions
+from zds.utils.tests.factories import LicenceFactory
+
+
+overridden_zds_app = deepcopy(settings.ZDS_APP)
+overridden_zds_app["content"]["repo_private_path"] = settings.BASE_DIR / "contents-private-test"
+overridden_zds_app["content"]["repo_public_path"] = settings.BASE_DIR / "contents-public-test"
+overridden_zds_app["content"]["extra_content_generation_policy"] = "NONE"
+
+
+@override_settings(MEDIA_ROOT=settings.BASE_DIR / "media-test")
+@override_settings(ZDS_APP=overridden_zds_app)
+@override_settings(ES_ENABLED=False)
+class DisplayConfigTests(TutorialTestMixin, TestCase):
+    def setUp(self):
+        self.overridden_zds_app = overridden_zds_app
+        overridden_zds_app["content"]["default_licence_pk"] = LicenceFactory().pk
+
+        self.user_author = ProfileFactory().user
+
+    def test_sidebar_items(self):
+        self.client.force_login(self.user_author)
+
+        # Publish an article:
+        article = PublishedContentFactory(author_list=[self.user_author], type="ARTICLE")
+        # Public page:
+        public_page = self.client.get(article.get_absolute_url_online())
+        self.assertContains(public_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
+        self.assertNotContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
+        # Draft page:
+        draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
+        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertContains(draft_page, PublicActionsState.messages["public_is_same"])
+        self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
+
+        # Create a new draft version:
+        versioned = article.load_version()
+        result = self.client.post(
+            reverse("content:edit", args=[article.pk, article.slug]),
+            {
+                "title": article.title,
+                "description": article.description,
+                "introduction": "Modified introduction",
+                "conclusion": "Modified conclusion",
+                "type": article.type,
+                "subcategory": article.subcategory.first().pk,
+                "last_hash": versioned.compute_hash(),
+            },
+            follow=False,
+        )
+        self.assertEqual(result.status_code, 302)
+        article.refresh_from_db()  # the previous request changes sha_draft
+        # Public page:
+        public_page = self.client.get(article.get_absolute_url_online())
+        self.assertNotContains(public_page, "Modified introduction")
+        self.assertNotContains(public_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
+        self.assertContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
+        # Draft page:
+        draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
+        self.assertContains(draft_page, "Modified introduction")
+        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
+
+        # Ask validation:
+        request_validation(article)
+        # Public page:
+        public_page = self.client.get(article.get_absolute_url_online())
+        self.assertNotContains(public_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
+        self.assertContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
+        # Draft page:
+        draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
+        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertContains(draft_page, ValidationActions.messages["validation_is_same"])
+        # Validation page:
+        validation_page = self.client.get(
+            reverse("content:validation-view", args=[article.pk, article.slug]), follow=False
+        )
+        self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(validation_page, PublicActionsState.messages["public_is_same"])
+        self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(validation_page, ValidationActions.messages["validation_is_same"])
+
+        # Now a new draft version, to have different version from validation:
+        versioned = article.load_version()
+        result = self.client.post(
+            reverse("content:edit", args=[article.pk, article.slug]),
+            {
+                "title": article.title,
+                "description": article.description,
+                "introduction": "Modified introduction again",
+                "conclusion": "Modified conclusion",
+                "type": article.type,
+                "subcategory": article.subcategory.first().pk,
+                "last_hash": versioned.compute_hash(),
+            },
+            follow=False,
+        )
+        self.assertEqual(result.status_code, 302)
+        article.refresh_from_db()  # the previous request changes sha_draft
+        # Public page:
+        public_page = self.client.get(article.get_absolute_url_online())
+        self.assertNotContains(public_page, "Modified introduction")
+        self.assertNotContains(public_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(public_page, PublicActionsState.messages["public_is_same"])
+        self.assertContains(public_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(public_page, ValidationActions.messages["validation_is_same"])
+        # Draft page:
+        draft_page = self.client.get(reverse("content:view", args=[article.pk, article.slug]), follow=False)
+        self.assertContains(draft_page, "Modified introduction")
+        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["public_is_same"])
+        self.assertNotContains(draft_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(draft_page, ValidationActions.messages["validation_is_same"])
+        # Validation page:
+        validation_page = self.client.get(
+            reverse("content:validation-view", args=[article.pk, article.slug]), follow=False
+        )
+        self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_same"])
+        self.assertNotContains(validation_page, PublicActionsState.messages["public_is_same"])
+        self.assertNotContains(validation_page, PublicActionsState.messages["draft_is_more_recent"])
+        self.assertNotContains(validation_page, ValidationActions.messages["validation_is_same"])

--- a/zds/tutorialv2/tests/utils.py
+++ b/zds/tutorialv2/tests/utils.py
@@ -1,0 +1,8 @@
+from zds.tutorialv2.tests.factories import ValidationFactory
+
+
+def request_validation(content):
+    """Emulate a proper validation request."""
+    ValidationFactory(content=content, status="PENDING")
+    content.sha_validation = content.sha_draft
+    content.save()

--- a/zds/tutorialv2/views/display/config.py
+++ b/zds/tutorialv2/views/display/config.py
@@ -19,8 +19,7 @@ class AdministrationActionsState:
             self.enabled
             and self.is_allowed
             and (
-                self.show_exports_request()
-                or self.show_versions_history_link()
+                self.show_versions_history_link()
                 or self.show_events_history_link()
                 or self.show_opinion_publish()
                 or self.show_opinion_moderated()
@@ -28,9 +27,6 @@ class AdministrationActionsState:
                 or self.show_jsfiddle()
             )
         )
-
-    def show_exports_request(self) -> bool:
-        return self.is_allowed
 
     def show_versions_history_link(self) -> bool:
         return self.is_allowed
@@ -56,6 +52,7 @@ class PublicActionsState:
         "draft_is_same": _("La version brouillon est identique à cette version."),
         "draft_is_more_recent": _("La version brouillon est plus récente que cette version."),
         "public_is_same": _("La version publique est identique à cette version."),
+        "export_content": _("Exports du contenu"),
     }
 
     def __init__(self, user, content: PublishableContent, versioned_content: VersionedContent):
@@ -74,6 +71,7 @@ class PublicActionsState:
             and self.is_author_or_staff
             and (
                 self.show_stats_link()
+                or self.show_exports_request()
                 or self.show_identical_public_version_message()
                 or self.show_identical_draft_version_message()
                 or self.show_more_recent_draft_version_link()
@@ -84,6 +82,9 @@ class PublicActionsState:
                 or self.show_opinion_unpublish()
             )
         )
+
+    def show_exports_request(self) -> bool:
+        return self.is_author_or_staff and self.in_public and self.is_public_page
 
     def show_stats_link(self) -> bool:
         return self.is_author_or_staff and self.in_public


### PR DESCRIPTION
Fix #6596 

Cette PR fait plusieurs choses : 
- ajout de tests pour vérifier que les éléments à afficher dans la barre latérale des contenus sont bien affichés uniquement sur les bonnes pages
- correction de l'affichage *La version X est identique à cette version*
- affichage de *Exports du contenu* sur la page publique des contenus
- amélioration du code dans `display/config.py`

### Contrôle qualité

Faire manuellement ce que fait le test ajouté. 

Jouer avec les différents états possibles d'un contenu, afficher les différentes pages et s'assurer qu'il n'y a pas d'éléments incohérents dans la barre latérale (je ne dis pas que cette PR règle tous ces problèmes, ne pas hésiter à rapporter les éventuelles incohérences observées).
