### PR TITLE
FontAwesome : bye bye CDN, welcome npm package

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -72,6 +72,14 @@ function customSassError(error) {
   // TODO: https://github.com/A-312/gulp-terser-js#can-i-use-terser-to-format-error-of-an-other-gulp-module-
 }
 
+/* Get CSS minified files from packages
+ * Get also sourcemaps for all CSS files, required by Django's ManifestStaticFilesStorage since 4.1 (see
+ * https://docs.djangoproject.com/fr/4.2/ref/contrib/staticfiles/#manifeststaticfilesstorage) */
+function cssPackages() {
+  return gulp.src(require.resolve('@fortawesome/fontawesome-free/css/all.min.css'), { sourcemaps: true })
+    .pipe(gulp.dest('dist/css/', { sourcemaps: '.' }))
+}
+
 // Generates CSS for the website and the ebooks
 function css() {
   return gulp.src(['assets/scss/main.scss', 'assets/scss/zmd.scss'], { sourcemaps: true })
@@ -79,6 +87,12 @@ function css() {
     .on('error', customSassError)
     .pipe(gulpif(!fast, postcss(postcssPlugins))) // Adds browsers prefixs and minifies
     .pipe(gulp.dest('dist/css/', { sourcemaps: '.' }))
+}
+
+// Get webfonts files from packages
+function webfontsPackages() {
+  return gulp.src(path.resolve('node_modules/@fortawesome/fontawesome-free/webfonts/*'))
+    .pipe(gulp.dest('dist/webfonts/'))
 }
 
 // Generates CSS for the static error pages in the folder `errors/`
@@ -212,7 +226,7 @@ function watch() {
 }
 
 // Build the front
-const build = gulp.parallel(prepareZmd, prepareEasyMde, jsPackages, js, images, errors, gulp.series(spriteCss, gulp.parallel(css, spriteImages)))
+const build = gulp.parallel(prepareZmd, prepareEasyMde, jsPackages, js, images, errors, gulp.series(spriteCss, gulp.parallel(cssPackages, css, spriteImages)), webfontsPackages)
 
 exports.build = build
 exports.watch = gulp.series(build, watch)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/zestedesavoir/zds-site",
   "dependencies": {
+    "@fortawesome/fontawesome-free": "5.12.1",
     "autoprefixer": "10.4.18",
     "chart.js": "3.9.1",
     "chartjs-adapter-moment": "1.0.1",

--- a/templates/base.html
+++ b/templates/base.html
@@ -85,10 +85,7 @@
     {% block DCMI_cards %}{% endblock %}
 
     {# Stylesheets #}
-    <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css"
-        integrity="sha384-v8BU367qNbs/aIZIxuivaU55N5GPF89WBerHoGA4QTcbUjYiLQtKdrfXnqAcXyTv"
-        crossorigin="anonymous">
+    <link rel="stylesheet" href="{% static "css/all.min.css" %}"><!-- FontAwesome -->
     <link rel="stylesheet" href="{% static "css/easymde.min.css" %}">
     <link rel="stylesheet" href="{% static "css/katex.min.css" %}">
     <link rel="stylesheet" href="{% static "css/main.css" %}">

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,6 +48,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@fortawesome/fontawesome-free@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.1.tgz#2a98fea9fbb8a606ddc79a4680034e9d5591c550"
+  integrity sha512-ZtjIIFplxncqxvogq148C3hBLQE+W3iJ8E4UvJ09zIJUgzwLcROsWwFDErVSXY2Plzao5J9KUYNHKHMEUYDMKw==
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"


### PR DESCRIPTION
PR liée au [sujet sur le forum concernant l'intégration des sources externes](https://zestedesavoir.com/forums/sujet/17409/le-site-zestedesavoircom-et-le-rgpd/)

Pour remplacer l'utilisation du CDN de CloudFlare pour les icônes FontAwesome, je propose de passer par l'installation de leur paquet npm et quelques lignes de code dans le Gulpfile. Ils ont aussi un module Python/Django qui aurait probablement été plus simple mais je pense qu'il est mieux de ne pas trop mélanger frontend et backend.

J'ai laissé la version 5.12.1 pour être sûr de ne rien casser, mais la version 6 est sortie depuis avec plusieurs fichiers CSS plus petits si on n'a besoin que d'une partie des icônes.

**QA :**
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier qu'aucun appel à CloudFlare n'est effectué depuis la page d'accueil du site
- Se connecter et vérifier que les icônes du nouvel éditeur de texte s'affichent correctement