### PR TITLE
MathJax: bye bye CDN, welcome npm package

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -141,7 +141,8 @@ function jsPackages() {
     require.resolve('moment/locale/fr.js'),
     require.resolve('chartjs-adapter-moment/dist/chartjs-adapter-moment.min.js'),
     require.resolve('chart.js/dist/chart.min.js'),
-    require.resolve('easymde/dist/easymde.min.js')
+    require.resolve('easymde/dist/easymde.min.js'),
+    path.resolve('node_modules/mathjax/unpacked/**')
   ], { sourcemaps: true })
     .pipe(gulp.dest('dist/js/', { sourcemaps: '.' }))
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-terser-js": "5.2.2",
     "gulp.spritesmith": "6.13.0",
     "jquery": "3.7.1",
+    "mathjax": "2.7.1",
     "moment": "2.30.1",
     "normalize.css": "8.0.1",
     "postcss": "8.4.35"

--- a/templates/mathjax.html
+++ b/templates/mathjax.html
@@ -1,6 +1,2 @@
-<script type="text/javascript"
-        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?locale=fr&config=TeX-AMS_HTML&delayStartupUntil=configured"
-        integrity="sha384-Ra6zh6uYMmH5ydwCqqMoykyf1T/+ZcnOQfFPhDrp2kI4OIxadnhsvvA2vv9A7xYv"
-        crossorigin="anonymous"
-        async>
-</script>
+{% load static %}
+<script src="{% static "js/MathJax.js" %}?locale=fr&config=TeX-AMS_HTML&delayStartupUntil=configured" async></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5381,6 +5381,11 @@ matchdep@^2.0.0:
     resolve "^1.4.0"
     stack-trace "0.0.10"
 
+mathjax@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/mathjax/-/mathjax-2.7.1.tgz#c82d2f853b2f58f738e3355329adf0b2d8f8face"
+  integrity sha512-zHrO6dTaHXquznvmSKVQhla1A2iQl/jhzOf8hqV7cEhYXcvNHyHf0aFJNFeqwY1oVk3WQGziQOa2t4K/aZCNMQ==
+
 mdn-data@2.0.14:
   version "2.0.14"
   resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz"


### PR DESCRIPTION
PR liée au [sujet sur le forum concernant l'intégration des sources externes](https://zestedesavoir.com/forums/sujet/17409/le-site-zestedesavoircom-et-le-rgpd/)

J'applique le même principe que pour FontAwesome et j'utilise le paquet npm de MathJax dans sa version 2.7.1 pour être sûr de ne rien casser. On a besoin des fichiers `MathJax.js`, `localization/fr/fr.js` et `config/TeX-AMS_HTML.js` (en gardant cette arborescence) donc pour faire simple je prends tous les fichiers du dossier `unpacked` du paquet npm et je les mets dans `dist/js`. À terme il faudra vraiment migrer vers un système plus moderne que Gulp pour la gestion des ressources CSS et JS, mais en attendant ça me semble *good enough*.

**QA :**
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier qu'aucun appel à CloudFlare n'est effectué depuis un contenu du site
- Vérifier dans l'analyseur des requêtes que les requêtes vers `MathJax.js`, `fr.js` et `TeX-AMS_HTML.js` sont bien réussies