### PR TITLE
Text fonts: bye bye Google Fonts, welcome npm packages

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -89,11 +89,22 @@ function css() {
     .pipe(gulp.dest('dist/css/', { sourcemaps: '.' }))
 }
 
-// Get webfonts files from packages
-function webfontsPackages() {
+// Get icon fonts files from packages
+function iconFonts() {
   return gulp.src(path.resolve('node_modules/@fortawesome/fontawesome-free/webfonts/*'))
     .pipe(gulp.dest('dist/webfonts/'))
 }
+
+// Get text fonts files from packages
+function textFonts() {
+  return gulp.src([
+    path.resolve('node_modules/@fontsource/source-sans-pro/files/*'),
+    path.resolve('node_modules/@fontsource/source-code-pro/files/*'),
+    path.resolve('node_modules/@fontsource/merriweather/files/*')
+  ])
+    .pipe(gulp.dest('dist/css/files'))
+}
+
 
 // Generates CSS for the static error pages in the folder `errors/`
 function errors() {
@@ -226,7 +237,7 @@ function watch() {
 }
 
 // Build the front
-const build = gulp.parallel(prepareZmd, prepareEasyMde, jsPackages, js, images, errors, gulp.series(spriteCss, gulp.parallel(cssPackages, css, spriteImages)), webfontsPackages)
+const build = gulp.parallel(prepareZmd, prepareEasyMde, jsPackages, js, images, errors, gulp.series(spriteCss, gulp.parallel(cssPackages, css, spriteImages)), iconFonts, textFonts)
 
 exports.build = build
 exports.watch = gulp.series(build, watch)

--- a/assets/scss/variables/_typography.scss
+++ b/assets/scss/variables/_typography.scss
@@ -1,3 +1,17 @@
+// IMPORTS
+
+@import "@fontsource/source-sans-pro/300";
+@import "@fontsource/source-sans-pro/400";
+@import "@fontsource/source-sans-pro/700";
+
+@import "@fontsource/source-code-pro/400";
+@import "@fontsource/source-code-pro/700";
+
+@import "@fontsource/merriweather/400";
+@import "@fontsource/merriweather/400-italic";
+@import "@fontsource/merriweather/700";
+@import "@fontsource/merriweather/700-italic";
+
 // FONT FAMILIES
 // These families should be used, not others.
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   },
   "homepage": "https://github.com/zestedesavoir/zds-site",
   "dependencies": {
+    "@fontsource/merriweather": "5.0.12",
+    "@fontsource/source-code-pro": "5.0.17",
+    "@fontsource/source-sans-pro": "5.0.8",
     "@fortawesome/fontawesome-free": "5.12.1",
     "autoprefixer": "10.4.18",
     "chart.js": "3.9.1",

--- a/templates/base.html
+++ b/templates/base.html
@@ -92,10 +92,6 @@
 
     {% block canonical %}{% endblock %}
 
-    {# Webfont async loading #}
-    <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700|Source+Code+Pro:400,700|Merriweather:400,400italic,700,700italic' rel='stylesheet' type='text/css'>
-
-
     {% block extra_css %}
     {% endblock %}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,6 +48,21 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@fontsource/merriweather@5.0.12":
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/@fontsource/merriweather/-/merriweather-5.0.12.tgz#8221eb544d389c0d468a9ec80a2430eedef53565"
+  integrity sha512-l7brVGcFUiGhK7bucRbwWYZDInfyXuVYEthHNw26RkkfMR9TFTiOAIABnN6PFr6Vjaz+c0o7ibLmdEMeSMDfRA==
+
+"@fontsource/source-code-pro@5.0.17":
+  version "5.0.17"
+  resolved "https://registry.yarnpkg.com/@fontsource/source-code-pro/-/source-code-pro-5.0.17.tgz#a69df6b9fc19fe8b2d04126ce28ad9213cf0049b"
+  integrity sha512-Q5GfthInOTW+Ek5k97/LH6FWLmD+IwHwBEEXF+KStvsyPwSZz+0ssdWJfz/ZRaTZxOk7FwlRgysXAWo41fq6bQ==
+
+"@fontsource/source-sans-pro@5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@fontsource/source-sans-pro/-/source-sans-pro-5.0.8.tgz#e246405a3bcdcf2ae6f9d7019c0d78ead71a492a"
+  integrity sha512-5U2UvIYRkCMozZ388gCE73PEpa2MFgN/0t9O4a1FF7bGT/MIneQWSL1XpWZ8iMVYdh6ntxRf3iFA6slCIuFgkg==
+
 "@fortawesome/fontawesome-free@5.12.1":
   version "5.12.1"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.1.tgz#2a98fea9fbb8a606ddc79a4680034e9d5591c550"


### PR DESCRIPTION
PR liée au [sujet sur le forum concernant l'intégration des sources externes](https://zestedesavoir.com/forums/sujet/17409/le-site-zestedesavoircom-et-le-rgpd/)

Même principe que mes deux PR précédentes, rien à dire de spécial.

**QA :**
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier qu'aucun appel à Google Fonts n'est effectué depuis les pages du site
- Vérifier que les différents textes utilisent bien les bonnes polices de caractères