### PR TITLE
Bloque le chargement automatique des iframes

### DIFF
--- a/assets/js/iframe-consent.js
+++ b/assets/js/iframe-consent.js
@@ -1,0 +1,19 @@
+(function() {
+  // Part of this script is hard-coded into the HTML code for performance reasons.
+  // It can be found at the bottom of template/base.html
+
+  for (const placeholder of document.querySelectorAll('.iframe-placeholder')) {
+    const message = document.createElement('p')
+    message.innerHTML = "Attention, ce contenu provient d'une source externe !"
+    const button = document.createElement('button')
+    button.innerHTML = 'Charger le contenu'
+    button.addEventListener('click', function(e) {
+      const placeholder = e.target.parentElement
+      const index = placeholder.dataset.iframeIndex
+      placeholder.outerHTML = window.iframeStash[index]
+    })
+
+    placeholder.appendChild(message)
+    placeholder.appendChild(button)
+  }
+})()

--- a/templates/base.html
+++ b/templates/base.html
@@ -240,6 +240,19 @@
 
 
     {# Javascript stuff start #}
+    <script>
+        // This script is hard-coded into the HTML code for performance reasons.
+        // The rest of the code can be found in assets/js/iframe-consent.js
+        window.iframeStash = []
+        for (const [index, iframe] of document.querySelectorAll('iframe').entries()) {
+            window.iframeStash.push(iframe.outerHTML)
+            const placeholder = document.createElement('div')
+            placeholder.classList.add('iframe-placeholder')
+            placeholder.dataset.iframeIndex = index
+            iframe.parentElement.replaceChild(placeholder, iframe)
+        }
+    </script>
+
     <script src="{% static "js/jquery.min.js" %}"></script>
     {% block extra_js %}
     {% endblock %}


### PR DESCRIPTION
PR liée au [sujet sur le forum concernant l'intégration des sources externes](https://zestedesavoir.com/forums/sujet/17409/le-site-zestedesavoircom-et-le-rgpd/)

J'ai trouvé un moyen d'ajouter une bannière de consentement pour les contenus externes sans devoir modifier le code HTML généré par zmarkdown. L'idée est d'extraire les `<iframe>` du DOM dès que celui-ci est chargé. Ça fonctionne plutôt bien en local mais il faudrait voir ce que ça donne sur la bêta.

Inconvénients : c'est du bricolage ; ce n'est pas forcément efficace à 100% ; une fois mis en place, on risque de ne pas avoir la motivation de travailler à une meilleure solution

Avantages : pas besoin de modifier zmarkdown (donc pas besoin d'attendre plusieurs semaines ou mois) ; pas besoin de régénérer les anciens contenus (donc pas besoin d'attendre plusieurs années qu'ils soient mis à jour)

Il me faudra de l'aide sur le CSS car j'ai essayé de faire un truc propre pendant une bonne demie-heure sans succès puis j'ai laissé tombé.

Je veux bien aussi de l'aide sur le code JS pour vérifier que je n'utilise pas une syntaxe trop récente (qui ne fonctionnerait donc pas sur la majorité des navigateurs).

**QA :** (Lorsque ce sera déployé sur la bêta)
- Créer un contenu avec toutes les intégrations externes possibles (les différents hébergeurs vidéos supportés ainsi que JSFiddle)
- Vérifier qu'il n'y a pas de requêtes vers ces services externes avec les outils de développement intégrés au navigateur et une extension type uBlock Origin
- Vérifier le bon fonctionnement du bouton pour charger l'intégration externe
- Vérifier les deux derniers points sur plusieurs navigateurs (à minima Firefox et Chrome) sur ordinateur et sur mobile