### PR TITLE
Corrige la perte de forums et sujets suivis lors de l'éviction d'un groupe

### DIFF
--- a/zds/member/tests/factories.py
+++ b/zds/member/tests/factories.py
@@ -103,6 +103,22 @@ class NonAsciiUserFactory(UserFactory):
     username = factory.Sequence("ïéàçÊÀ{}".format)
 
 
+class MultipleGroupsUserFactory(UserFactory):
+    """
+    Factory that creates a User with multiple groups
+
+    WARNING: Don't try to directly use `MultipleGroupsUserFactory` because it won't create the associated Profile.
+    Use `MultipleGroupsProfileFactory` instead.
+    """
+
+    @factory.post_generation
+    def groups(self, create, extracted, **kwargs):
+        for group_name in ("first_group", "second_group"):
+            group = Group(name=group_name)
+            group.save()
+            self.groups.add(group)
+
+
 class ProfileFactory(factory.django.DjangoModelFactory):
     """
     Use this factory when you need a complete Profile for a standard User.
@@ -153,3 +169,11 @@ class NonAsciiProfileFactory(ProfileFactory):
     """
 
     user = factory.SubFactory(NonAsciiUserFactory)
+
+
+class MultipleGroupsProfileFactory(ProfileFactory):
+    """
+    Use this factory when you need a complete Profile for a User with multiple groups.
+    """
+
+    user = factory.SubFactory(MultipleGroupsUserFactory)

--- a/zds/notification/receivers.py
+++ b/zds/notification/receivers.py
@@ -48,7 +48,11 @@ def remove_group_subscription_on_quitting_groups(*, sender, instance, action, pk
         )
         return
 
-    for forum in Forum.objects.filter(groups__pk__in=list(pk_set)):
+    all_groups_pk = instance.groups.values_list("pk", flat=True)
+    removed_groups_pk = pk_set
+    kept_groups_pk = set(all_groups_pk) - set(removed_groups_pk)
+
+    for forum in Forum.objects.filter(groups__pk__in=removed_groups_pk).exclude(groups__pk__in=kept_groups_pk):
         subscriptions = []
 
         forum_subscription = NewTopicSubscription.objects.get_existing(instance, forum, True)


### PR DESCRIPTION
Fixes #6619

- Ajout d'un test pour reproduire le problème où l'utilisateur "multi_groups_user", à l'origine dans deux groupes qui donnent tous les deux accès au forum13, perd l'accès à l'un des deux groupes
- Correction du fonctionnement du signal qui nettoie les abonnements des forums suite à l'éviction d'un groupe pour prendre en compte les groupes auquel l'utilisateur a encore accès et ne pas retirer les abonnements pour ces groupes-ci

**QA :**
- Github Actions
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Tester manuellement la procédure décrite dans le ticket
