### PR TITLE
Met à jour Sentry et corrige un avertissement

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -2,5 +2,5 @@
 
 gunicorn==21.2.0
 mysqlclient==2.2.4
-sentry-sdk==1.41.0
+sentry-sdk==2.9.0
 ujson==5.9.0

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -461,10 +461,6 @@ class ZMarkdownRebberLatexPublicator(Publicator):
         )
         # let's put 10 min of timeout because we do not generate latex everyday
         command_process.communicate(timeout=600)
-        with contextlib.suppress(ImportError):
-            import sentry_sdk
-
-            sentry_sdk.add_breadcrumb(message="lualatex call", data=command, type="cmd")
 
         pdf_file_path = path.splitext(texfile)[0] + self.extension
         return path.exists(pdf_file_path)
@@ -475,10 +471,7 @@ class ZMarkdownRebberLatexPublicator(Publicator):
             command, shell=True, cwd=path.dirname(texfile), stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         std_out, std_err = command_process.communicate()
-        with contextlib.suppress(ImportError):
-            import sentry_sdk
 
-            sentry_sdk.add_breadcrumb(message="makeglossaries call", data=command, type="cmd")
         # TODO: check makeglossary exit codes to see if we can enhance error detection
         if "fatal" not in std_out.decode("utf-8").lower() and "fatal" not in std_err.decode("utf-8").lower():
             return True
@@ -504,10 +497,6 @@ def handle_tex_compiler_error(latex_file_path, ext):
 
             errors = "\n".join(lines)
     logger.debug("%s ext=%s", errors, ext)
-    with contextlib.suppress(ImportError):
-        import sentry_sdk
-
-        sentry_sdk.add_breadcrumb(message="luatex call", data=errors, type="cmd")
 
     raise FailureDuringPublication(errors)
 


### PR DESCRIPTION
Sur une erreur de publication rapportée par Sentry, il y avait les avertissements suivants : 

![warning](https://github.com/user-attachments/assets/f6574095-ced7-4db6-b885-e66caca0ce1e)

On utilise mal la fonction `add_breadcumb()`. Mais en fait les appels à `add_breadcumb()` (qui ajoutent des infos au fil d'Ariane) n'ajoutaient aucune information supplémentaire, puisque les appels à Popen sont déjà interceptés par Sentry, qui les ajoute directement au fil d'Ariane : 

![breadcumb](https://github.com/user-attachments/assets/e8165769-6040-483e-b2d2-8ccb036de007)

Donc, j'ai tout simplement enlevé les appels à `add_breadcumb()`.

J'en ai profité aussi pour mettre à jour `sentry-sdk`. C'est un changement de version majeure, mais apparemment [on n'a rien à changer](https://docs.sentry.io/platforms/python/migration/1.x-to-2.x).


### Contrôle qualité

La CI fonctionne et peut-être que je testerai sur le serveur de bêta.