### PR TITLE
Corrige un bug lié aux demandes de mise en avant

### DIFF
--- a/zds/featured/apps.py
+++ b/zds/featured/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class FeaturedConfig(AppConfig):
+    name = "zds.featured"
+
+    def ready(self):
+        from . import receivers  # noqa

--- a/zds/featured/receivers.py
+++ b/zds/featured/receivers.py
@@ -4,12 +4,16 @@ from django.dispatch import receiver
 
 from zds.featured.models import FeaturedRequested
 from zds.forum.models import Topic
-from zds.tutorialv2.models.database import PublishableContent
+from zds.tutorialv2.models.database import PublishableContent, PublishedContent
 
 
 @receiver(pre_delete, sender=PublishableContent)
+@receiver(pre_delete, sender=PublishedContent)
 @receiver(pre_delete, sender=Topic)
 def remove_requested_featured_at_content_object_deletion(sender, instance, **kwargs):
+    if isinstance(instance, PublishedContent):
+        sender = PublishableContent
+        instance = instance.content
     try:
         FeaturedRequested.objects.get(
             content_type=ContentType.objects.get_for_model(sender), object_id=instance.pk

--- a/zds/featured/receivers.py
+++ b/zds/featured/receivers.py
@@ -1,0 +1,18 @@
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+
+from zds.featured.models import FeaturedRequested
+from zds.forum.models import Topic
+from zds.tutorialv2.models.database import PublishableContent
+
+
+@receiver(pre_delete, sender=PublishableContent)
+@receiver(pre_delete, sender=Topic)
+def remove_requested_featured_at_content_object_deletion(sender, instance, **kwargs):
+    try:
+        FeaturedRequested.objects.get(
+            content_type=ContentType.objects.get_for_model(sender), object_id=instance.pk
+        ).delete()
+    except FeaturedRequested.DoesNotExist:
+        pass

--- a/zds/featured/tests/tests.py
+++ b/zds/featured/tests/tests.py
@@ -474,6 +474,31 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
 
         self.assertEqual(len(response.context["featured_request_list"]), 1)  # it is back!
 
+    def test_success_list_with_deleted_content(self):
+        # create a topic
+        author = ProfileFactory().user
+        category = ForumCategoryFactory(position=1)
+        forum = ForumFactory(category=category, position_in_category=1)
+        topic = TopicFactory(forum=forum, author=author)
+
+        # create a published content
+        tutorial = PublishedContentFactory(author_list=[author])
+        tutorial.save()
+
+        # request for the topic and the content to be featured
+        FeaturedRequested.objects.toogle_request(topic, author)
+        FeaturedRequested.objects.toogle_request(tutorial, author)
+
+        # delete both this topic and this content
+        topic.delete()
+        tutorial.delete()
+
+        # check that the page listing the requests still works
+        staff = StaffProfileFactory()
+        self.client.force_login(staff.user)
+        response = self.client.get(reverse("featured:resource-requests"))
+        self.assertEqual(200, response.status_code)
+
 
 class FeaturedRequestUpdateViewTest(TestCase):
     def test_update(self):

--- a/zds/featured/tests/tests.py
+++ b/zds/featured/tests/tests.py
@@ -9,6 +9,7 @@ from zds.featured.tests.factories import FeaturedResourceFactory
 from zds.featured.models import FeaturedResource, FeaturedMessage, FeaturedRequested
 from zds.forum.tests.factories import ForumCategoryFactory, ForumFactory, TopicFactory
 from zds.gallery.tests.factories import GalleryFactory, ImageFactory
+from zds.tutorialv2.publication_utils import unpublish_content
 from zds.tutorialv2.tests.factories import PublishedContentFactory
 from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
 
@@ -488,10 +489,14 @@ class FeaturedRequestListViewTest(TutorialTestMixin, TestCase):
         # request for the topic and the content to be featured
         FeaturedRequested.objects.toogle_request(topic, author)
         FeaturedRequested.objects.toogle_request(tutorial, author)
+        count = FeaturedRequested.objects.count()
 
-        # delete both this topic and this content
+        # delete the topic and unpublish the content
         topic.delete()
-        tutorial.delete()
+        unpublish_content(tutorial)
+
+        # check that the FeaturedRequested objects have been deleted
+        self.assertEqual(FeaturedRequested.objects.count(), count - 2)
 
         # check that the page listing the requests still works
         staff = StaffProfileFactory()


### PR DESCRIPTION
- Reproduit un bug liée aux demandes de mise en avant
  - Le test échoue sans la correction et réussit avec la correction, donc il reproduit bien le bug du ticket.
- Corrige un bug lié aux demandes de mise en avant
  - ~~La condition `isinstance(q.content_object, Topic) or not q.content_object.is_obsolete` exclue les contenus obsolètes de la liste des mises en avant mais elle génère une `AttributeError` quand `q.content_object` est nul pour les contenus. On pourrait simplement ajouter la condition `q.content_object is not None` pour former `q.content_object and (isinstance(q.content_object, Topic) or not q.content_object.is_obsolete)` ou `q.content_object and not (isinstance(q.content_object, PublishableContent) and q.content_object.is_obsolete)` mais j'ai opté pour `q.content_object and not getattr(q.content_object, "is_obsolete", False)` qui est plus concis.~~
  - ~~J'en ai profité pour remplacer `.all()` par `.iterator()` tant qu'à faire.~~

**QA :** Github Actions + une reproduction locale du bug si possible
