### PR TITLE
Ajout du badge 'Banni' sur la page des IPs

### DIFF
--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -43,7 +43,7 @@
                 <tr>
                     <td>
                         {% include "misc/member_item.part.html" with member=member avatar=True %}
-                        {% include 'misc/badge.part.html' with member=member long_badge=True %}
+                        {% include "misc/badge.part.html" with member=member.user long_badge=False %}
                     </td>
                     <td>{{ member.user.date_joined|format_date:True }}</td>
                     <td>{{ last_visit }}</td>

--- a/templates/member/admin/memberip.html
+++ b/templates/member/admin/memberip.html
@@ -41,7 +41,10 @@
             {% for member in members %}
                 {% captureas last_visit %}{% if member.last_visit %}{{ member.last_visit|format_date:True }}{% else %}<i>{% trans "Jamais" %}</i>{% endif %}{% endcaptureas %}
                 <tr>
-                    <td>{% include "misc/member_item.part.html" with member=member avatar=True %}</td>
+                    <td>
+                        {% include "misc/member_item.part.html" with member=member avatar=True %}
+                        {% include 'misc/badge.part.html' with member=member long_badge=True %}
+                    </td>
                     <td>{{ member.user.date_joined|format_date:True }}</td>
                     <td>{{ last_visit }}</td>
                 </tr>

--- a/zds/utils/templatetags/profile.py
+++ b/zds/utils/templatetags/profile.py
@@ -59,13 +59,7 @@ def user_groups(user):
 @register.filter("state")
 def state(current_user):
     try:
-        try:
-            user_profile = current_user.profile
-        except AttributeError:
-            if isinstance(current_user, Profile):
-                user_profile = current_user
-            else:
-                raise
+        user_profile = current_user.profile
         if not user_profile.user.is_active:
             user_state = "DOWN"
         elif not user_profile.can_read_now():

--- a/zds/utils/templatetags/profile.py
+++ b/zds/utils/templatetags/profile.py
@@ -59,7 +59,13 @@ def user_groups(user):
 @register.filter("state")
 def state(current_user):
     try:
-        user_profile = current_user.profile
+        try:
+            user_profile = current_user.profile
+        except AttributeError:
+            if isinstance(current_user, Profile):
+                user_profile = current_user
+            else:
+                raise
         if not user_profile.user.is_active:
             user_state = "DOWN"
         elif not user_profile.can_read_now():


### PR DESCRIPTION
<!-- Décrivez vos changements ici (optionnel pour les tous petits changements). -->

Le filtre 'state' peut être appelé avec une variable contenant directement le Profile (même comportement que le filtre "profile").

Ajout de l'appel Badge.part dans le tableau des IPs.

<!-- Remplacez XXXX par le numéro de ticket corrigé par vos changements : GitHub fermera le ticket mentionné automatiquement (voir https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue pour plus de détails). Supprimez la ligne s'il n'y a pas de ticket associé. --!>
Fix #6601

<!-- Si votre PR modifie du code Python, mettez à jour ou créez les tests unitaires associés. Signalez vos éventuelles difficultés afin que des contributeurs expérimentés puissent vous aider. -->

<!-- Si votre pull request requiert des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->

### Contrôle qualité

<!-- Donnez des instructions pour nous aider à vérifier vos changements.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

 - Bannir un membre
 - Se rendre sur sa page de profil
 - Accéder aux membres possédant la même IP
 - Vérifier que le badge est présent

<!-- Merci ! -->
