### PR TITLE
Corrige l'impossibilité de se connecter après un ban temporaire

### DIFF
--- a/zds/middlewares/setlastvisitmiddleware.py
+++ b/zds/middlewares/setlastvisitmiddleware.py
@@ -34,6 +34,6 @@ class SetLastVisitMiddleware:
                     profile.last_visit = datetime.datetime.now()
                     profile.last_ip_address = get_client_ip(request)
                     profile.save()
-            if not profile.can_read:
+            if not profile.is_banned():
                 logout(request)
         return response


### PR DESCRIPTION
Actuellement, les utilisateurs qui ont été banni temporairement ne peuvent pas se connecter après la fin naturelle du bannissement. Cette PR reproduit le problème dans un test puis le corrige.

**QA :**
- `source zdsenv/bin/activate && make zmd-start && make run-back`
- Se connecter avec le compte admin
- Bannir le compte user
- Dans l'interface d'administration, modifier le champ "Fin d'interdiction de lecture" de l'objet Profile du compte user avec une date antérieure à aujourd'hui
- Vérifier qu'il est bien possible de se connecter avec le compte user