### PR TITLE
Corrige le nombre de sessions rapporté par Munin

### DIFF
--- a/django_munin/munin/views.py
+++ b/django_munin/munin/views.py
@@ -1,13 +1,15 @@
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
+from importlib import import_module
 import time
-from django.contrib.sessions.models import Session
+
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from .helpers import muninview
 from .models import Test
 
 
 User = get_user_model()
+Session = import_module(settings.SESSION_ENGINE).CustomSession
 
 
 @muninview(

--- a/zds/member/views/sessions.py
+++ b/zds/member/views/sessions.py
@@ -1,3 +1,6 @@
+from importlib import import_module
+
+from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -5,21 +8,24 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 
 from zds.member.utils import get_geo_location_from_ip, get_info_from_user_agent
-from zds.utils.custom_cached_db_backend import CustomSession, SessionStore
 from zds.utils.paginator import ZdSPagingListView
+
+
+Session = import_module(settings.SESSION_ENGINE).CustomSession
+SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 
 class ListSessions(LoginRequiredMixin, ZdSPagingListView):
     """List the user's sessions with useful information (user agent, IP address, geolocation and last visit)."""
 
-    model = CustomSession
+    model = Session
     context_object_name = "sessions"
     template_name = "member/settings/sessions.html"
     paginate_by = 10
 
     def get_context_data(self, **kwargs):
         self.object_list = []
-        for session in CustomSession.objects.filter(account_id=self.request.user.pk).iterator():
+        for session in Session.objects.filter(account_id=self.request.user.pk).iterator():
             data = session.get_decoded()
             session_context = {
                 "session_key": session.session_key,

--- a/zds/munin/tests.py
+++ b/zds/munin/tests.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.urls import reverse
 
+from zds.member.tests.factories import ProfileFactory
+
 
 class Munin(TestCase):
     def setUp(self):
@@ -25,3 +27,20 @@ class Munin(TestCase):
                 url = reverse(route)
                 response = self.client.get(url)
                 self.assertEqual(response.status_code, 200)
+
+    def test_sessions(self):
+        """Makes sure the sessions are correctly counted in Munin data."""
+        response = self.client.get(reverse("munin:base:active-sessions"))
+        self.assertEqual(response.content.decode(), "sessions 0")
+
+        response = self.client.get(reverse("munin:base:total-sessions"))
+        self.assertEqual(response.content.decode(), "sessions 0")
+
+        profile = ProfileFactory()
+        self.client.force_login(profile.user)
+
+        response = self.client.get(reverse("munin:base:active-sessions"))
+        self.assertEqual(response.content.decode(), "sessions 1")
+
+        response = self.client.get(reverse("munin:base:total-sessions"))
+        self.assertEqual(response.content.decode(), "sessions 1")

--- a/zds/utils/custom_cached_db_backend.py
+++ b/zds/utils/custom_cached_db_backend.py
@@ -1,4 +1,4 @@
-from django.contrib.sessions.backends.cached_db import SessionStore as DBStore
+from django.contrib.sessions.backends.cached_db import SessionStore as CachedDBStore
 from django.contrib.sessions.base_session import AbstractBaseSession
 from django.db import models
 
@@ -15,7 +15,7 @@ class CustomSession(AbstractBaseSession):
         return SessionStore
 
 
-class SessionStore(DBStore):
+class SessionStore(CachedDBStore):
     """Custom session store for the custom session model."""
 
     cache_key_prefix = "zds.utils.custom_cached_db_backend"


### PR DESCRIPTION
Bug introduit par 2b2215e02db3233d2360060e1ab1243d5801f16c (PR #6021), où le backend pour gérer les sessions passe de `django.contrib.sessions.backends.cached_db` à `zds.utils.custom_cached_db_backend`, ce qui change la table utilisée pour stocker les sessions et le modèle à utiliser pour les manipuler. La vue qui compte le nombre de sessions pour Munin n'a pas été mise à jour utiliser le nouveau modèle.

- Utilise les classes de sessions définies dans les paramètres, plutôt que forcément `django.contrib.sessions`
- Ajoute un test pour vérifier que le nombre de sessions rapporté par Munin est correct
- Renomme l'import `DBStore` en `CachedDBStore` pour éviter une confusion sur quel backend est utilisé pour stocker les sessions

La correction du bug en elle-même se trouve dans `django_munin/munin/views.py`, où on charge la classe de `Session` qui est vraiment utilisée.

### Contrôle qualité

- les tests passent
- on peut se connecter, la page qui liste les sessions de l'utilisateur est fonctionnelle
