### PR TITLE
Ajoute un commentaire décrivant les tables utilisées pour les sessions

### DIFF
--- a/zds/utils/custom_cached_db_backend.py
+++ b/zds/utils/custom_cached_db_backend.py
@@ -6,7 +6,10 @@ from django.db import models
 class CustomSession(AbstractBaseSession):
     """Custom session model to link each session to its user.
     This is necessary to list a user's sessions without having to browse all sessions.
-    Based on https://docs.djangoproject.com/en/4.2/topics/http/sessions/#example"""
+    Based on https://docs.djangoproject.com/en/4.2/topics/http/sessions/#example
+
+    This will create a table named utils_customsession and use it instead of
+    the table django_session. The content of the latest can be dropped."""
 
     account_id = models.IntegerField(null=True, db_index=True)
 


### PR DESCRIPTION
Le changement dans les sessions introduit par
2b2215e02db3233d2360060e1ab1243d5801f16c (PR #6021) utilise une nouvelle table `utils_customsession` pour stocker les sessions, tout en conservant la table `django_session`.

Je n'ai pas trouvé de manière pour supprimer la table `django_session`.

La version initiale de cette PR renommait la table  `utils_customsession`  en `django_session`, mais ça fait planter la génération des migrations car Django râle qu'il y a deux modèles avec le nom `django_session`.

Résultat, je finis avec cette PR qui ajoute juste un commentaire indiquant quelles tables sont utilisées.

### Contrôle qualité

Relecture du commentaire ajouté.
