### PR TITLE
Ajoute des statistiques Munin concernant les membres

### DIFF
--- a/django_munin/munin/views.py
+++ b/django_munin/munin/views.py
@@ -4,6 +4,7 @@ import time
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 from .helpers import muninview
 from .models import Test
 
@@ -14,10 +15,16 @@ Session = import_module(settings.SESSION_ENGINE).CustomSession
 
 @muninview(
     config="""graph_title Total Users
-graph_vlabel users"""
+graph_vlabel users
+graph_args --lower-limit 0
+graph_scale no"""
 )
 def total_users(request):
-    return [("users", User.objects.all().count())]
+    return [
+        ("users", User.objects.all().count()),
+        ("confirmed_users", User.objects.filter(is_active=True).count()),
+        ("logged_once_users", User.objects.filter(~Q(last_login=None)).count()),
+    ]
 
 
 @muninview(

--- a/zds/munin/tests.py
+++ b/zds/munin/tests.py
@@ -12,6 +12,7 @@ class Munin(TestCase):
             "base:total-sessions",
             "base:active-sessions",
             "base:db-performance",
+            "banned-users",
             "total-topics",
             "total-posts",
             "total-mp",
@@ -44,3 +45,18 @@ class Munin(TestCase):
 
         response = self.client.get(reverse("munin:base:total-sessions"))
         self.assertEqual(response.content.decode(), "sessions 1")
+
+    def test_banned_users(self):
+        response = self.client.get(reverse("munin:banned-users"))
+        self.assertEqual(response.content.decode(), "banned_users 0")
+
+        profile = ProfileFactory()
+
+        response = self.client.get(reverse("munin:banned-users"))
+        self.assertEqual(response.content.decode(), "banned_users 0")
+
+        profile.can_read = False
+        profile.save()
+
+        response = self.client.get(reverse("munin:banned-users"))
+        self.assertEqual(response.content.decode(), "banned_users 1")

--- a/zds/munin/urls.py
+++ b/zds/munin/urls.py
@@ -1,10 +1,19 @@
 from django.urls import path, include
 
-from zds.munin.views import total_topics, total_posts, total_mps, total_tutorials, total_articles, total_opinions
+from zds.munin.views import (
+    banned_users,
+    total_topics,
+    total_posts,
+    total_mps,
+    total_tutorials,
+    total_articles,
+    total_opinions,
+)
 
 
 urlpatterns = [
     path("", include(("django_munin.munin.urls", "base"))),
+    path("banned_users/", banned_users, name="banned-users"),
     path("total_topics/", total_topics, name="total-topics"),
     path("total_posts/", total_posts, name="total-posts"),
     path("total_mps/", total_mps, name="total-mp"),

--- a/zds/munin/views.py
+++ b/zds/munin/views.py
@@ -1,7 +1,18 @@
 from django_munin.munin.helpers import muninview
 from zds.forum.models import Topic, Post
+from zds.member.models import Profile
 from zds.mp.models import PrivateTopic, PrivatePost
 from zds.tutorialv2.models.database import PublishableContent, ContentReaction
+
+
+@muninview(
+    config="""graph_title Banned Users
+graph_vlabel Banned Users
+graph_args --lower-limit 0
+graph_scale no"""
+)
+def banned_users(request):
+    return [("banned_users", Profile.objects.filter(can_read=False, end_ban_read=None).count())]
 
 
 @muninview(


### PR DESCRIPTION
- le nombre de membres bannis (dans `zds/munin` au lieu de `django_munin` pour ne pas avoir à importer `zds.member.models.Profile` et garder `django_munin` indépendant de `zds`)
- le nombre de membres qui ont l'attribut `is_active=True`
- le nombre de membres qui se sont connectés au moins une fois

### Contrôle qualité

Vérifier que la CI passe, le patch est déployé sur la bêta, le résultat est observable sur [Munin](https://munin.beta.zestedesavoir.com/zds-site/zds-beta/index.html#zds).