### PR TITLE
Masque la commande de lancement de Typesense avec `make run-search-engine`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ zmd-stop: ## Stop the zmarkdown server
 ## ~ Search Engine
 
 run-search-engine: ## Run the search server
-	./.local/typesense/typesense-server --data-dir=.local/typesense/typesense-data --api-key=xyz || echo 'No Typesense installed (you can add it locally with `./scripts/install_zds.sh +typesense-local`)'
+	@./.local/typesense/typesense-server --data-dir=.local/typesense/typesense-data --api-key=xyz || echo 'No Typesense installed (you can add it locally with `./scripts/install_zds.sh +typesense-local`)'
 
 index-all: ## Index the whole database in the search engine
 	python manage.py search_engine_manager index_all


### PR DESCRIPTION
Peut prêter à confusion puisque le message d'erreur est affiché même si le lancement a réussi.

Fix #5262 

### Contrôle qualité

Honnêtement, rien. Regardez juste le diff. Si vraiment vous y tenez, exécuter : 
```sh
make run-search-engine
```
Avec et sans avoir installé Typesense, pour s'assurer que rien n'est cassé.
