### PR TITLE
Retirer le bandeau de section vide

### DIFF
--- a/templates/tutorialv2/includes/content/content.part.html
+++ b/templates/tutorialv2/includes/content/content.part.html
@@ -61,12 +61,6 @@
                 </li>
             </ul>
         </div>
-    {% elif not display_config.draft_actions.enable_edit or not content.can_add_extract and not content.can_add_container %}
-        <div class="ico-after warning">
-            <p>
-                {% trans "Ce contenu est vide." %}
-            </p>
-        </div>
     {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
<!-- Décrivez vos changements ici (optionnel pour les tous petits changements). -->
Retrait du bandeau "Ce contenu est vide" sur la page de validation/quand le contenu ne peut pas être modifié.
<!-- Remplacez XXXX par le numéro de ticket corrigé par vos changements : GitHub fermera le ticket mentionné automatiquement (voir https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue pour plus de détails). Supprimez la ligne s'il n'y a pas de ticket associé. --!>
Fix #6602

<!-- Si votre PR modifie du code Python, mettez à jour ou créez les tests unitaires associés. Signalez vos éventuelles difficultés afin que des contributeurs expérimentés puissent vous aider. -->

<!-- Si votre pull request requiert des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->

### Contrôle qualité

<!-- Donnez des instructions pour nous aider à vérifier vos changements.


Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

- Se connecter avec user1.
- Créer un article avec un corps vide -> un bandeau de contenu vide devrait être présent
- Soumettre pour la validation. 
- Se connecter avec staff
- Valider l'article -> le bandeau ne devrait pas être présent.

<!-- Merci ! -->
