### PR TITLE
Rend générique en fonction du type la vue "RemoveAuthorFromContent"

### DIFF
--- a/templates/tutorialv2/messages/remove_author_pm.md
+++ b/templates/tutorialv2/messages/remove_author_pm.md
@@ -1,8 +1,8 @@
 {% load i18n %}
 
-{% blocktrans with title=content.title|safe type=type|safe user=user|safe %}
+{% blocktrans with title=content.title|safe user=user|safe %}
 Bonjour {{ user }},
 
-Vous avez été retiré de la rédaction du contenu « {{ title }} ».
+Vous avez été retiré de la rédaction de « {{ title }} ».
 
 {%  endblocktrans %}

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -320,9 +320,9 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
         Return ``True`` if the user was effectively removed from the authors and ``False`` otherwise.
         """
         if self.is_author(user) and self.authors.count() > 1:
-            gallery = UserGallery.objects.filter(user__pk=user.pk, gallery__pk=self.gallery.pk).first()
-            if gallery:
-                gallery.delete()
+            usergallery = UserGallery.objects.filter(user__pk=user.pk, gallery__pk=self.gallery.pk).first()
+            if usergallery:
+                usergallery.delete()
             self.authors.remove(user)
             return True
         return False

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -312,6 +312,21 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
         # This is fast because there are few authors and the QuerySet is usually prefetched and cached.
         return user in self.authors.all()
 
+    def remove_author(self, user: User) -> bool:
+        """
+        Remove a user from the authors and remove his access to the gallery.
+        If the user is not an author, do nothing.
+        If the user is the last author, do nothing. This method will not delete the content.
+        Return ``True`` if the user was effectively removed from the authors and ``False`` otherwise.
+        """
+        if self.is_author(user) and self.authors.count() > 1:
+            gallery = UserGallery.objects.filter(user__pk=user.pk, gallery__pk=self.gallery.pk).first()
+            if gallery:
+                gallery.delete()
+            self.authors.remove(user)
+            return True
+        return False
+
     def is_permanently_unpublished(self):
         """Is this content permanently unpublished by a moderator ?"""
 

--- a/zds/tutorialv2/models/events.py
+++ b/zds/tutorialv2/models/events.py
@@ -4,7 +4,7 @@ from django.dispatch import receiver
 
 from zds.tutorialv2 import signals
 from zds.tutorialv2.models.database import PublishableContent
-from zds.tutorialv2.views.authors import AddAuthorToContent, RemoveAuthorFromContent
+from zds.tutorialv2.views.authors import AddAuthorToContent, RemoveAuthorView
 from zds.tutorialv2.views.beta import ManageBetaContent
 from zds.tutorialv2.views.canonical import EditCanonicalLinkView
 from zds.tutorialv2.views.contributors import AddContributorToContent, RemoveContributorFromContent
@@ -98,7 +98,7 @@ def record_event_beta_management(sender, performer, signal, content, version, ac
 
 
 @receiver(signals.authors_management, sender=AddAuthorToContent)
-@receiver(signals.authors_management, sender=RemoveAuthorFromContent)
+@receiver(signals.authors_management, sender=RemoveAuthorView)
 def record_event_author_management(sender, performer, signal, content, author, action, **_):
     Event(
         performer=performer,

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -3,7 +3,7 @@ from django.views.generic.base import RedirectView
 
 from zds.tutorialv2.views.alerts import SendContentAlert, SolveContentAlert
 from zds.tutorialv2.views.archives import CreateContentFromArchive, DownloadContent, UpdateContentWithArchive
-from zds.tutorialv2.views.authors import AddAuthorToContent, RemoveAuthorFromContent
+from zds.tutorialv2.views.authors import AddAuthorToContent, RemoveAuthorView
 from zds.tutorialv2.views.beta import ManageBetaContent
 from zds.tutorialv2.views.canonical import EditCanonicalLinkView
 from zds.tutorialv2.views.categories import EditCategoriesView
@@ -214,7 +214,7 @@ urlpatterns = (
         path("ajouter-contributeur/<int:pk>/", AddContributorToContent.as_view(), name="add-contributor"),
         path("enlever-contributeur/<int:pk>/", RemoveContributorFromContent.as_view(), name="remove-contributor"),
         path("ajouter-auteur/<int:pk>/", AddAuthorToContent.as_view(), name="add-author"),
-        path("enlever-auteur/<int:pk>/", RemoveAuthorFromContent.as_view(), name="remove-author"),
+        path("enlever-auteur/<int:pk>/", RemoveAuthorView.as_view(), name="remove-author"),
         path("modifier-titre/<int:pk>/", EditTitle.as_view(), name="edit-title"),
         path("modifier-sous-titre/<int:pk>/", EditSubtitle.as_view(), name="edit-subtitle"),
         path("modifier-miniature/<int:pk>/", EditThumbnailView.as_view(), name="edit-thumbnail"),

--- a/zds/tutorialv2/views/authors.py
+++ b/zds/tutorialv2/views/authors.py
@@ -3,7 +3,6 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Field, Layout
 from django import forms
 from django.contrib import messages
-from django.contrib.auth.models import User
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -138,63 +137,24 @@ class AddAuthorToContent(LoggedWithReadWriteHability, SingleContentFormViewMixin
         return super().form_valid(form)
 
 
-class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormViewMixin):
+class RemoveAuthorView(LoggedWithReadWriteHability, SingleContentFormViewMixin):
     form_class = RemoveAuthorForm
     must_be_author = True
     authorized_for_staff = True
-
-    @staticmethod
-    def remove_author(content, user):
-        """Remove a user from the authors and ensure that he is access to the content's gallery is also removed.
-        The last author is not removed.
-
-        :param content: the content
-        :type content: zds.tutorialv2.models.database.PublishableContent
-        :param user: the author
-        :type user: User
-        :return: ``True`` if the author was removed, ``False`` otherwise
-        """
-        if user in content.authors.all() and content.authors.count() > 1:
-            gallery = UserGallery.objects.filter(user__pk=user.pk, gallery__pk=content.gallery.pk).first()
-
-            if gallery:
-                gallery.delete()
-
-            content.authors.remove(user)
-            return True
-
-        return False
+    http_method_names = ["post"]
 
     def form_valid(self, form):
+        content = self.object
         current_user = False
         users = form.cleaned_data["users"]
 
-        _type = (_("cet article"), _("de l'article"))
-        if self.object.is_tutorial:
-            _type = (_("ce tutoriel"), _("du tutoriel"))
-        elif self.object.is_opinion:
-            _type = (_("ce billet"), _("du billet"))
-
         bot = get_bot_account()
         for user in users:
-            if RemoveAuthorFromContent.remove_author(self.object, user):
+            if content.remove_author(user):
                 if user.pk == self.request.user.pk:
                     current_user = True
                 elif is_reachable(user):
-                    send_mp(
-                        bot,
-                        [user],
-                        format_lazy("{}{}", _("Retrait de la rédaction "), _type[1]),
-                        self.versioned_object.title,
-                        render_to_string(
-                            "tutorialv2/messages/remove_author_pm.md",
-                            {
-                                "content": self.object,
-                                "user": user.username,
-                            },
-                        ),
-                        hat=get_hat_from_settings("validation"),
-                    )
+                    self.notify_by_private_message(user, bot)
                 signals.authors_management.send(
                     sender=self.__class__,
                     content=self.object,
@@ -205,36 +165,54 @@ class RemoveAuthorFromContent(LoggedWithReadWriteHability, SingleContentFormView
             else:  # if user is incorrect or alone
                 messages.error(
                     self.request,
-                    _("Vous êtes le seul auteur de {} ou le membre sélectionné en a déjà quitté la rédaction.").format(
-                        _type[0]
+                    _(
+                        "Vous êtes le seul auteur de la publication ou le membre sélectionné en a déjà quitté la rédaction."
                     ),
                 )
                 return redirect(self.object.get_absolute_url())
 
-        self.object.save()
+        content.save()
 
+        if current_user:  # Redirect self-removing authors to their publications list
+            messages.success(self.request, _("Vous avez bien quitté la rédaction de la publication."))
+            self.success_url = reverse("content:find-all", args=[self.request.user.username])
+        else:  # The user removed another user from the authors
+            authors_list = self.users_list(users)
+            messages.success(
+                self.request,
+                _("Vous avez enlevé {} de la liste des auteurs et autrices de la publication.").format(authors_list),
+            )
+            self.success_url = self.object.get_absolute_url()
+
+        return super().form_valid(form)
+
+    @staticmethod
+    def users_list(users):
         authors_list = ""
-
-        for index, user in enumerate(form.cleaned_data["users"]):
+        for index, user in enumerate(users):
             if index > 0:
                 if index == len(users) - 1:
                     authors_list += _(" et ")
                 else:
                     authors_list += _(", ")
             authors_list += user.username
+        return authors_list
 
-        if not current_user:  # if the removed author is not current user
-            messages.success(
-                self.request,
-                _("Vous avez enlevé {} de la liste des auteurs et autrices de {}.").format(authors_list, _type[0]),
-            )
-            self.success_url = self.object.get_absolute_url()
-        else:  # if current user is leaving the content's redaction, redirect him to a more suitable page
-            messages.success(self.request, _("Vous avez bien quitté la rédaction de {}.").format(_type[0]))
-            self.success_url = reverse(
-                self.object.type.lower() + ":find-" + self.object.type.lower(), args=[self.request.user.username]
-            )
-        return super().form_valid(form)
+    def notify_by_private_message(self, user, bot):
+        send_mp(
+            bot,
+            [user],
+            _("Retrait de la rédaction de la publication"),
+            self.versioned_object.title,
+            render_to_string(
+                "tutorialv2/messages/remove_author_pm.md",
+                {
+                    "content": self.object,
+                    "user": user.username,
+                },
+            ),
+            hat=get_hat_from_settings("validation"),
+        )
 
     def form_invalid(self, form):
         messages.error(self.request, _("Les auteurs sélectionnés n'existent pas."))

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -25,7 +25,7 @@ from zds.tutorialv2.mixins import FormWithPreview, SingleContentFormViewMixin, S
 from zds.tutorialv2.models import CONTENT_TYPE_LIST
 from zds.tutorialv2.models.database import PublishableContent, Validation
 from zds.tutorialv2.utils import init_new_repo
-from zds.tutorialv2.views.authors import RemoveAuthorFromContent
+from zds.tutorialv2.views.authors import RemoveAuthorView
 from zds.utils.forms import IncludeEasyMDE
 from zds.utils.models import get_hat_from_settings
 from zds.utils.uuslug_wrapper import slugify
@@ -446,11 +446,10 @@ class DeleteContent(LoginRequiredMixin, SingleContentViewMixin, DeleteView):
         elif self.object.is_opinion:
             _type = _("ce billet")
 
-        if self.object.authors.count() > 1:  # if more than one author, just remove author from list
-            RemoveAuthorFromContent.remove_author(self.object, self.request.user)
+        if self.object.remove_author(self.request.user):
             messages.success(self.request, _("Vous avez quitté la rédaction de {}.").format(_type))
-
         else:
+            # If removing the author failed, it is the last author, and we must delete the content.
             validation = Validation.objects.filter(content=self.object).order_by("-date_proposition").first()
 
             if validation and validation.status == "PENDING_V":  # if the validation have a validator, warn him by PM


### PR DESCRIPTION
Dans le cadre de la nouvelle organisation des contenus

* supprime la distinction de type de publication
* préfère le terme "publication" à "contenu"
* renomme les vues pour adopter la convention de Django
* refactorise pour améliorer la lisibilité
* interdit les méthodes HTTP autres que POST


### Contrôle qualité

Ajouter et supprimer des auteurs. Regarder les MP correspondants.

Supprimer aussi des contenus, vu que j'ai touché une bricole à ce niveau-là.
