### PR TITLE
Supprime le paramètre `build_pdf_when_published` et désactive plus d'exports dans les tests

### DIFF
--- a/doc/source/back-end/contents.rst
+++ b/doc/source/back-end/contents.rst
@@ -602,7 +602,6 @@ Ces paramètres sont à surcharger dans le dictionnaire ``ZDS_APP['content']``:
 - ``user_page_number``:  Nombre de contenus de chaque type qu'on affiche sur le profil d'un utilisateur, 5 par défaut,
 - ``default_image``: chemin vers l'image utilisée par défaut dans les icônes de contenu,
 - ``import_image_prefix``: préfixe mnémonique permettant d'indiquer que l'image se trouve dans l'archive jointe lors de l'import de contenu
-- ``build_pdf_when_published``: indique que la publication générera un PDF (quelque soit la politique, si ``False``, les PDF ne seront pas générés, sauf à appeler la commande adéquate),
 - ``maximum_slug_size``: taille maximale du slug d'un contenu
 
 Paramètres propres aux tribunes libres

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -190,7 +190,6 @@ ZDS_APP = {
         "user_page_number": 5,
         "default_image": BASE_DIR / "fixtures" / "noir_black.png",
         "import_image_prefix": "archive",
-        "build_pdf_when_published": True,
         "maximum_slug_size": 150,
         "characters_per_minute": 1500,
         "editorial_line_link": "https://zestedesavoir.com/articles/3978/la-ligne-editoriale-officielle-de-zeste-de-savoir-2/",

--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -129,7 +129,6 @@ SEARCH_CONNECTION["api_key"] = config["typesense"].get("api_key", "xyz")
 ZDS_APP["site"]["association"]["email"] = "communication@zestedesavoir.com"
 
 # content
-# ZDS_APP['content']['build_pdf_when_published'] = False
 ZDS_APP["article"]["repo_path"] = "/opt/zds/data/articles-data"
 ZDS_APP["content"]["repo_private_path"] = "/opt/zds/data/contents-private"
 ZDS_APP["content"]["repo_public_path"] = "/opt/zds/data/contents-public"

--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -174,22 +174,16 @@ def write_md_file(md_file_path, parsed_with_local_images, versioned):
             )
 
 
-def generate_external_content(
-    base_name, extra_contents_path, md_file_path, overload_settings=False, excluded=None, **kwargs
-):
+def generate_external_content(base_name, extra_contents_path, md_file_path, excluded=None, **kwargs):
     """
     generate all static file that allow offline access to content
 
     :param base_name: base nae of file (without extension)
     :param extra_contents_path: internal directory where all files will be pushed
     :param md_file_path: bundled markdown file path
-    :param overload_settings: this option force the function to generate all registered formats even when settings \
-    ask for PDF not to be published
     :param excluded: list of excluded format, None if no exclusion
     """
     excluded = excluded or ["watchdog"]
-    if not settings.ZDS_APP["content"]["build_pdf_when_published"] and not overload_settings:
-        excluded.append("pdf")
     for publicator_name, publicator in PublicatorRegistry.get_all_registered(excluded):
         try:
             publicator.publish(

--- a/zds/tutorialv2/tests/__init__.py
+++ b/zds/tutorialv2/tests/__init__.py
@@ -14,7 +14,6 @@ overridden_zds_app = copy.deepcopy(settings.ZDS_APP)
 overridden_zds_app["content"]["repo_private_path"] = settings.BASE_DIR / "contents-private-test"
 overridden_zds_app["content"]["repo_public_path"] = settings.BASE_DIR / "contents-public-test"
 overridden_zds_app["content"]["extra_content_generation_policy"] = "SYNC"
-overridden_zds_app["content"]["build_pdf_when_published"] = False
 
 
 class override_for_contents(override_settings):

--- a/zds/tutorialv2/tests/tests_feeds.py
+++ b/zds/tutorialv2/tests/tests_feeds.py
@@ -30,6 +30,7 @@ from copy import deepcopy
 overridden_zds_app = deepcopy(settings.ZDS_APP)
 overridden_zds_app["content"]["repo_private_path"] = settings.BASE_DIR / "contents-private-test"
 overridden_zds_app["content"]["repo_public_path"] = settings.BASE_DIR / "contents-public-test"
+overridden_zds_app["content"]["extra_content_generation_policy"] = "NOTHING"
 
 
 @override_settings(MEDIA_ROOT=settings.BASE_DIR / "media-test")
@@ -37,8 +38,6 @@ overridden_zds_app["content"]["repo_public_path"] = settings.BASE_DIR / "content
 class LastTutorialsFeedsTest(TutorialTestMixin, TestCase):
     def setUp(self):
         self.overridden_zds_app = overridden_zds_app
-        # don't build PDF to speed up the tests
-        overridden_zds_app["content"]["build_pdf_when_published"] = False
 
         self.licence = LicenceFactory()
         self.subcategory = SubCategoryFactory()
@@ -225,8 +224,6 @@ class LastTutorialsFeedsTest(TutorialTestMixin, TestCase):
 class LastArticlesFeedsTest(TutorialTestMixin, TestCase):
     def setUp(self):
         self.overridden_zds_app = overridden_zds_app
-        # don't build PDF to speed up the tests
-        overridden_zds_app["content"]["build_pdf_when_published"] = False
 
         self.licence = LicenceFactory()
         self.subcategory = SubCategoryFactory()
@@ -411,8 +408,6 @@ class LastArticlesFeedsTest(TutorialTestMixin, TestCase):
 class LastOpinionsFeedsTest(TutorialTestMixin, TestCase):
     def setUp(self):
         self.overridden_zds_app = overridden_zds_app
-        # don't build PDF to speed up the tests
-        overridden_zds_app["content"]["build_pdf_when_published"] = False
 
         self.subcategory = SubCategoryFactory()
         self.tag = TagFactory()

--- a/zds/tutorialv2/tests/tests_front.py
+++ b/zds/tutorialv2/tests/tests_front.py
@@ -26,6 +26,7 @@ from zds.utils.tests.factories import CategoryFactory, SubCategoryFactory, Licen
 overridden_zds_app = deepcopy(settings.ZDS_APP)
 overridden_zds_app["content"]["repo_private_path"] = settings.BASE_DIR / "contents-private-test"
 overridden_zds_app["content"]["repo_public_path"] = settings.BASE_DIR / "contents-public-test"
+overridden_zds_app["content"]["extra_content_generation_policy"] = "NOTHING"
 
 
 @override_settings(MEDIA_ROOT=settings.BASE_DIR / "media-test")
@@ -52,8 +53,6 @@ class PublicationFronttest(StaticLiveServerTestCase, TutorialTestMixin, Tutorial
 
     def setUp(self):
         self.overridden_zds_app = overridden_zds_app
-        # don't build PDF to speed up the tests
-        overridden_zds_app["content"]["build_pdf_when_published"] = False
 
         self.staff = StaffProfileFactory().user
 

--- a/zds/tutorialv2/tests/tests_utils.py
+++ b/zds/tutorialv2/tests/tests_utils.py
@@ -342,8 +342,6 @@ class UtilsTests(TutorialTestMixin, TestCase):
     def test_generate_pdf(self):
         """ensure the behavior of the `python manage.py generate_pdf` commmand"""
 
-        self.overridden_zds_app["content"]["build_pdf_when_published"] = True  # this test need PDF build, if any
-
         tuto = PublishedContentFactory(type="TUTORIAL")  # generate and publish a tutorial
         published = PublishedContent.objects.get(content_pk=tuto.pk)
 
@@ -596,9 +594,6 @@ class UtilsExportOnlyReadyToPublishTests(TutorialTestMixin, TestCase):
         self.user_author = ProfileFactory().user
 
         self.old_registry = {key: value for key, value in PublicatorRegistry.get_all_registered()}
-        self.old_build_pdf_when_published = self.overridden_zds_app["content"]["build_pdf_when_published"]
-
-        self.overridden_zds_app["content"]["build_pdf_when_published"] = True
 
     def get_latex_file_path(self, published: PublishedContent):
         """
@@ -856,4 +851,3 @@ class UtilsExportOnlyReadyToPublishTests(TutorialTestMixin, TestCase):
     def tearDown(self):
         super().tearDown()
         PublicatorRegistry.registry = self.old_registry
-        self.overridden_zds_app["content"]["build_pdf_when_published"] = self.old_build_pdf_when_published

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -2732,8 +2732,6 @@ class ContentTests(TutorialTestMixin, TestCase):
         NOTE: this test will take time !"""
         PublicatorRegistry.registry["pdf"] = ZMarkdownRebberLatexPublicator(".pdf")
         PublicatorRegistry.registry["epub"] = ZMarkdownEpubPublicator()
-        # obviously, PDF builds have to be enabled
-        self.overridden_zds_app["content"]["build_pdf_when_published"] = True
 
         title = "C'est pas le plus important ici !"
 

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -41,7 +41,7 @@ from zds import json_handler
 overridden_zds_app = deepcopy(settings.ZDS_APP)
 overridden_zds_app["content"]["repo_private_path"] = settings.BASE_DIR / "contents-private-test"
 overridden_zds_app["content"]["repo_public_path"] = settings.BASE_DIR / "contents-public-test"
-overridden_zds_app["content"]["extra_content_generation_policy"] = "SYNC"
+overridden_zds_app["content"]["extra_content_generation_policy"] = "NOTHING"
 
 
 @override_settings(MEDIA_ROOT=settings.BASE_DIR / "media-test")
@@ -51,8 +51,6 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
     def setUp(self):
         self.overridden_zds_app = overridden_zds_app
         overridden_zds_app["content"]["default_licence_pk"] = LicenceFactory().pk
-        # don't build PDF to speed up the tests
-        overridden_zds_app["content"]["build_pdf_when_published"] = False
 
         self.staff = StaffProfileFactory().user
 

--- a/zds/utils/api/tests.py
+++ b/zds/utils/api/tests.py
@@ -1,6 +1,8 @@
+from copy import deepcopy
 import shutil
 import os
 from django.conf import settings
+from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -12,13 +14,15 @@ from django.core.cache import caches
 from zds.tutorialv2.tests.factories import PublishableContentFactory
 from zds.tutorialv2.publication_utils import publish_content
 
+overridden_zds_app = deepcopy(settings.ZDS_APP)
+overridden_zds_app["content"]["extra_content_generation_policy"] = "NOTHING"
 
+
+@override_settings(ZDS_APP=overridden_zds_app)
 class TagListAPITest(APITestCase):
     def setUp(self):
         self.client = APIClient()
         caches[extensions_api_settings.DEFAULT_USE_CACHE].clear()
-        # don't build PDF to speed up the tests
-        settings.ZDS_APP["content"]["build_pdf_when_published"] = False
 
     def test_list_of_tags_empty(self):
         """
@@ -159,6 +163,3 @@ class TagListAPITest(APITestCase):
             shutil.rmtree(settings.ZDS_APP["content"]["repo_public_path"])
         if os.path.isdir(settings.MEDIA_ROOT):
             shutil.rmtree(settings.MEDIA_ROOT)
-
-        # re-activate PDF build
-        settings.ZDS_APP["content"]["build_pdf_when_published"] = True


### PR DESCRIPTION
Ce paramètre ne sert en réalité à rien.

En désactivant uniquement l'export des PDFs dans certains tests, les exports en ePUB étaient quand même fait. Cette PR corrige ce point.

### Contrôle qualité

La CI passe.