### PR TITLE
Restaure les itemprop perdus

### DIFF
--- a/templates/base_content_page.html
+++ b/templates/base_content_page.html
@@ -9,12 +9,12 @@
 
 
 {% block content_out %}
-    <article class="content-wrapper" {% block article_schema %}{% endblock %}>
+    <article class="content-wrapper" itemscope itemtype="http://schema.org/Article">
         <header>
             {% block headline %}{% endblock %}
         </header>
         {% block content_page %}
-            <section class="article-content" {% block article_centent_schema %}{% endblock %}>
+            <section class="article-content">
                 {% block content %}{% endblock %}
             </section>
         {% endblock %}

--- a/templates/tutorialv2/base_online.html
+++ b/templates/tutorialv2/base_online.html
@@ -46,9 +46,3 @@
         </a>
     </li>
 {% endblock %}
-
-
-
-{% block article_schema %}
-    itemscope itemtype="http://schema.org/Article"
-{% endblock %}

--- a/templates/tutorialv2/includes/headline/licence.part.html
+++ b/templates/tutorialv2/includes/headline/licence.part.html
@@ -17,5 +17,5 @@
 
     {% crispy form %}
 {% elif licence %}
-    <span class="license">{{ licence }}</span>
+    <span class="license" itemprop="license">{{ licence }}</span>
 {% endif %}

--- a/templates/tutorialv2/includes/headline/title.part.html
+++ b/templates/tutorialv2/includes/headline/title.part.html
@@ -23,7 +23,7 @@
     <div class="content-title-and-subtitle-group">
         <div class="content-title-group">
             {% spaceless %}
-            <h1 class="title">{{ title }}</h1>
+            <h1 class="title" itemprop="name">{{ title }}</h1>
             {% if show_form %}
                 <a href="#edit-title" class="open-modal edit-button" title="{% trans "Modifier le titre" %}">
                     <span class="visuallyhidden">{% trans "Modifier le titre" %}</span>
@@ -48,7 +48,7 @@
                 {% endif %}
                 {% crispy form_subtitle %}
             {% else %}
-                <p class="subtitle">{{ subtitle }}</p>
+                <h2 class="subtitle" itemprop="description">{{ subtitle }}</h2>
             {% endif %}
             {% endspaceless %}
         </div>


### PR DESCRIPTION
- le bloc `article_schema` n'est redéfinit nul part, donc autant le supprimer et utiliser directement sa valeur
- personne ne définit de bloc `article_centent_schema` ou `article_content_schema` (sans la typo), donc suppression également

Ce commit restaure juste les attributs schema.org perdus avec c29c53fb70a5bb5e07a234891bd9d66b27d4a1f4, mais il faudrait sans doute refaire une passe complète sur ces attributs ; ce sera pour une autre PR.

Fix #6604

### Contrôle qualité

Aller sur la page publique d'un contenu et s'assurer que les attributs schema.org sont à nouveau présents. L'exemple donné dans [le sujet rapportant le problème](https://zestedesavoir.com/forums/sujet/17405/seo-cette-modification-de-html-est-elle-appropriee/) peut aider pour savoir ce qu'il faut chercher.
