### PR TITLE
Fige la version de pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   NODE_VERSION: "18" # needs to be also updated in .nvmrc
   PYTHON_VERSION: "3.11"
+  PIP_VERSION: "24.2" # stick to it while https://github.com/pypa/pip/issues/13046 is not fixed, needs to be also updated in scripts/define_variable.sh
   MARIADB_VERSION: "10.4.10"
   COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt
   TYPESENSE_VERSION: "27.0" # needs to be also updated in scripts/define_variable.sh
@@ -59,7 +60,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install pip==${{ env.PIP_VERSION }}
 
       - name: Retrieve pip cache directory
         id: pip-cache
@@ -188,8 +189,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Upgrade pip
-        run: |
-          pip install --upgrade pip
+        run: pip install pip==${{ env.PIP_VERSION }}
 
       - name: Retrieve pip cache directory
         id: pip-cache

--- a/scripts/define_variable.sh
+++ b/scripts/define_variable.sh
@@ -8,6 +8,10 @@ if [[ $ZDS_VENV_VERSION == "" ]]; then
     ZDS_VENV_VERSION="20.24.5"
 fi
 
+if [[ $ZDS_PIP_VERSION == "" ]]; then
+    ZDS_PIP_VERSION="24.2" # stick to it while https://github.com/pypa/pip/issues/13046 is not fixed, needs to be also updated in .github/workflows/ci.yml
+fi
+
 ZDS_NODE_VERSION=$(cat $ZDSSITE_DIR/.nvmrc)
 
 if [[ $ZDS_NVM_VERSION == "" ]]; then

--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -225,7 +225,7 @@ if ! $(_in "--force-skip-activating" $@) && [[ ( $VIRTUAL_ENV == "" || $(realpat
 
     # Some dependencies (like rust ones) require a recent pip:
     print_info "* upgrading pip"
-    pip install --upgrade pip; exVal=$?
+    pip install pip==$ZDS_PIP_VERSION; exVal=$?
 
     if [[ $exVal != 0 ]]; then
         print_error "!! Failed to upgrade pip"


### PR DESCRIPTION
Reste à 24.2 tant que https://github.com/pypa/pip/issues/13046 n'est pas corrigé.

L'objectif de cette PR n'est pas tant de rester à 24.2 (la PR aurait pu attendre que 24.3.1 soit sortie, apparemment incessamment sous peu), mais d'avoir les commandes qui installent une version figée de pip, pour éviter de se retrouver avec le problème où la CI sur un commit passe, mais ne passe plus une semaine après sur le même commit.


### Contrôle qualité

- La CI passe
-  Je n'ai pas fait tourner tout le script d'installation, j'ai juste exécuté dans mon environnement virtuel `pip install pip==24.2`.
