### PR TITLE
N'envoie pas à Sentry les `KeyboardInterrupt`

### DIFF
--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -88,7 +88,7 @@ def _get_version():
 
 def sentry_before_send(event: Event, hint: Hint) -> Event:
     # Do not log KeyboardInterrupt exceptions: they can only be triggered from
-    # manage.py commands in an interactive shell, intentionnally by the user.
+    # manage.py commands in an interactive shell, intentionally by the user.
     if hint.get("exc_info", [None])[0] == KeyboardInterrupt:
         return None
 

--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -1,6 +1,7 @@
+import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
-import sentry_sdk
+from sentry_sdk.types import Event, Hint
 
 from .abstract_base import *
 
@@ -85,6 +86,15 @@ def _get_version():
         return f"{__version__}/{git_version[:7]}"
 
 
+def sentry_before_send(event: Event, hint: Hint) -> Event:
+    # Do not log KeyboardInterrupt exceptions: they can only be triggered from
+    # manage.py commands in an interactive shell, intentionnally by the user.
+    if hint.get("exc_info", [None])[0] == KeyboardInterrupt:
+        return None
+
+    return event
+
+
 sentry_sdk.init(
     dsn=config["sentry"]["dsn"],
     integrations=[DjangoIntegration()],
@@ -102,6 +112,7 @@ sentry_sdk.init(
     release=_get_version().replace("/", "#"),
     # /!\ It cannot contain slashes
     environment=config["sentry"]["environment"],
+    before_send=sentry_before_send,
 )
 
 # Ignoring emarkdown logging because it is too noisy


### PR DESCRIPTION
Quand on lance une commande `manage.py` et qu'on l'interrompt avec Ctrl+C, cela génère une exception `KeyboardInterrupt` qui est envoyée à Sentry, puisque c'est une exception non rattrapée par notre code. Cependant, ça n'a pas vraiment de sens d'enregistrer ça dans Sentry, puisque c'est forcément un être humain qui a provoqué consciemment et volontairement la `KeyboardInterrupt`. Autrement dit : ce n'est pas un vrai problème et l'utilisateur a connaissance immédiatement de l'exception ; bref, ça n'a rien à faire dans Sentry :)

### Contrôle qualité

J'ai testé sur la bêta, ça fonctionne les `KeyboardInterrupt` ne sont plus envoyées à Sentry.

J'ai suivi [cette documentation](https://docs.sentry.io/platforms/python/configuration/filtering/#filtering-error-events).
