### PR TITLE
Gère le cas où les résultats de la recherche ne contiennent pas de highlight

### DIFF
--- a/zds/search/tests/tests_views.py
+++ b/zds/search/tests/tests_views.py
@@ -142,6 +142,10 @@ class ViewsTests(TutorialTestMixin, TestCase):
                 )  # … and only of the right type …
                 self.assertEqual(r["document"]["id"], ids[doc_type][i])  # … with the right id !
 
+        # Search with a query which returns results, but without highlights:
+        result = self.client.get(reverse("search:query") + "?q=-c", follow=False)
+        self.assertEqual(result.status_code, 200)
+
     def test_search_many_pages(self):
         if not self.manager.connected:
             return

--- a/zds/search/views.py
+++ b/zds/search/views.py
@@ -214,7 +214,8 @@ class SearchView(ZdSPagingListView):
                         if "text_match" in entry:
                             entry["collection"] = search_collections[i]
                             entry["document"]["final_score"] = entry["text_match"] * entry["document"]["weight"]
-                            entry["document"]["highlights"] = entry["highlights"][0]
+                            if len(entry["highlights"]) > 0:
+                                entry["document"]["highlights"] = entry["highlights"][0]
 
                             if "tags" in entry["document"] and "tag_slugs" in entry["document"]:
                                 assert len(entry["document"]["tags"]) == len(entry["document"]["tag_slugs"])


### PR DESCRIPTION
Problème rapporté par Sentry.

### Contrôle qualité

- Se fier au test et vérifier que la CI passe

ou

- indexer les contenus avec `make index-all` et faire une recherche avec le terme `-c`. Ça doit afficher des résultats et ne pas générer d'erreur.
