### PR TITLE
Mise à jour de ZMarkdown vers la version 12.1.0

### DIFF
--- a/zds/tutorialv2/publication_utils.py
+++ b/zds/tutorialv2/publication_utils.py
@@ -405,7 +405,6 @@ class ZMarkdownRebberLatexPublicator(Publicator):
             smileys_directory=str(SMILEYS_BASE_PATH / "svg"),
             images_download_dir=str(base_directory / "images"),
             local_url_to_local_path=["/", replacement_image_url],
-            heading_shift=-1,
             date=date(published_content_entity.last_publication_date, "l d F Y"),
         )
         if content == "" and messages:

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -47,11 +47,14 @@ def _render_markdown_once(md_input, *, output_format="html", **kwargs):
     try:
         timeout = 10
         real_input = str(md_input)
+        kwargs["heading_shift"] = 2
         if output_format.startswith("tex") or full_json:
             # latex may be really long to generate but it is also restrained by server configuration
             timeout = 120
             # use manifest renderer
             real_input = md_input
+            # do not shift title
+            kwargs["heading_shift"] = 0
         response = post(
             "{}{}".format(settings.ZDS_APP["zmd"]["server"], endpoint),
             json={

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -53,8 +53,7 @@ def _render_markdown_once(md_input, *, output_format="html", **kwargs):
             timeout = 120
             # use manifest renderer
             real_input = md_input
-            # do not shift title
-            kwargs["heading_shift"] = 0
+            kwargs["heading_shift"] = -1
         response = post(
             "{}{}".format(settings.ZDS_APP["zmd"]["server"], endpoint),
             json={

--- a/zmd/package-lock.json
+++ b/zmd/package-lock.json
@@ -9,10 +9,10 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "zmarkdown": "11.4.1"
+        "zmarkdown": "12.1.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@opencensus/core": {
@@ -465,96 +465,73 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.74.0.tgz",
-      "integrity": "sha512-JK6IRGgdtZjswGfaGIHNWIThffhOHzVIIaGmglui+VFIzOsOqePjoxaDV0MEvzafxXZD7eWqGE5RGuZ0n6HFVg==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+      "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
       "dependencies": {
-        "@sentry/core": "7.74.0",
-        "@sentry/types": "7.74.0",
-        "@sentry/utils": "7.74.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.74.0.tgz",
-      "integrity": "sha512-83NRuqn7nDZkSVBN5yJQqcpXDG4yMYiB7TkYUKrGTzBpRy6KUOrkCdybuKk0oraTIGiGSe5WEwCFySiNgR9FzA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+      "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
       "dependencies": {
-        "@sentry/types": "7.74.0",
-        "@sentry/utils": "7.74.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+      "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
+      "dependencies": {
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2",
+        "localforage": "^1.8.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.74.0.tgz",
-      "integrity": "sha512-uBmW2/z0cz/WFIG74ZF7lSipO0XNzMf9yrdqnZXnGDYsUZE4I4QiqDN0hNi6fkTgf9MYRC8uFem2OkAvyPJ74Q==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.119.2.tgz",
+      "integrity": "sha512-TPNnqxh+Myooe4jTyRiXrzrM2SH08R4+nrmBls4T7lKp2E5R/3mDSe/YTn5rRcUt1k1hPx1NgO/taG0DoS5cXA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.74.0",
-        "@sentry/core": "7.74.0",
-        "@sentry/types": "7.74.0",
-        "@sentry/utils": "7.74.0",
-        "cookie": "^0.5.0",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@sentry/node/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@sentry/types": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.74.0.tgz",
-      "integrity": "sha512-rI5eIRbUycWjn6s6o3yAjjWtIvYSxZDdnKv5je2EZINfLKcMPj1dkl6wQd2F4y7gLfD/N6Y0wZYIXC3DUdJQQg==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+      "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.74.0.tgz",
-      "integrity": "sha512-k3np8nuTPtx5KDODPtULfFln4UXdE56MZCcF19Jv6Ljxf+YN/Ady1+0Oi3e0XoSvFpWNyWnglauT7M65qCE6kg==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+      "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
       "dependencies": {
-        "@sentry/types": "7.74.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.119.2"
       },
       "engines": {
         "node": ">=8"
@@ -600,9 +577,9 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "node_modules/@unicode/unicode-13.0.0": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unicode/unicode-13.0.0/-/unicode-13.0.0-1.2.1.tgz",
-      "integrity": "sha512-8NDE4zZASktxJe+hV13K795wefyx+wRhu3Wl7TJ8fzsKx95CHsgTFmYRTscqna90zpUz6YBjGyqXHBI2ubiMaw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@unicode/unicode-13.0.0/-/unicode-13.0.0-1.6.0.tgz",
+      "integrity": "sha512-TwldNeAK+kcroDeOpB3pQXxZh6FMtkxTlpQrrHZCP9x0gUAgbHkWQ0ZzXG+TaO3S+3Y786PNXEYRkXRB7MDcAw=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -1984,6 +1961,11 @@
         }
       ]
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2252,6 +2234,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -2282,11 +2280,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3166,9 +3159,9 @@
       }
     },
     "node_modules/rebber": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/rebber/-/rebber-5.4.0.tgz",
-      "integrity": "sha512-tRBDkBgITaJqLmr9dMnm20bGE87TSItSU92pJYSOazoRVGpMz14yrKe2NC6xnLa/bYfaDHMqi98MjceqL+4HAw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/rebber/-/rebber-5.5.0.tgz",
+      "integrity": "sha512-+5soRRy/ASFzgHYYUOQ57eps0n2ERh+RVreYXK1uMFBTZo5bZikb9MSAAy7lULItKuy8rRA3uiIHR1F2MXhDKA==",
       "dependencies": {
         "clone": "^2.1.2",
         "collapse-white-space": "^1.0.6",
@@ -3179,9 +3172,9 @@
       }
     },
     "node_modules/rebber-plugins": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/rebber-plugins/-/rebber-plugins-4.3.8.tgz",
-      "integrity": "sha512-5rlP1SQx0Igmu4FV/sbcrJjZYxq3oN2Qio20SpzfaYmRZiFHUU9rK0xb6A9M4ANtEo/3Sv8uofujbWVccBpDXg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/rebber-plugins/-/rebber-plugins-4.4.0.tgz",
+      "integrity": "sha512-tYXtY+RP3G0K/WbAZ2Vpy8IJvtqqkPnqJ+mUoMs3ORZRIDKHONw+CM4enqjJc7alfriVXiR7l0zuxYa42GlWkQ==",
       "dependencies": {
         "has": "^1.0.3",
         "xtend": "^4.0.2"
@@ -3203,9 +3196,9 @@
       }
     },
     "node_modules/rehype-footnotes-title": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-footnotes-title/-/rehype-footnotes-title-2.0.0.tgz",
-      "integrity": "sha512-W0ryHhzYcgNxE7audzoqrMI0o+Jo1hdwp77aOqD8PLsahj16cq5nYH69MWavTc0NolNKQdVW9Nt9FjOKYA/NBA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-footnotes-title/-/rehype-footnotes-title-2.0.1.tgz",
+      "integrity": "sha512-vdoWv74zMbyvMDETiGWD4LEAzmRFq0Gg6/f4vTADd/wMlhwqDUEVs8P+w2MdUNFBUkUK6/4IKYHp5/ctJkdl5Q==",
       "dependencies": {
         "unist-util-visit": "^2.0.3"
       }
@@ -3225,9 +3218,9 @@
       }
     },
     "node_modules/rehype-html-blocks": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/rehype-html-blocks/-/rehype-html-blocks-0.1.1.tgz",
-      "integrity": "sha512-7FJbR3iSMCu75rJuDzfHtC6z7bJd9RdJwBhPQ5feag95RrKMCVUzlfhUfuY7lE82ar61V8bRYW8We+sItwpoMw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/rehype-html-blocks/-/rehype-html-blocks-0.1.2.tgz",
+      "integrity": "sha512-m4BAsMwsQ7E/TmhykV9jTw23VGcvzZ7ZmMxr3X2scDL+0ZASAOgFmRdIq0Ac8AXh6v/a81uhEYNBPiza7wgGXA==",
       "dependencies": {
         "unist-util-visit": "^2.0.3"
       }
@@ -3330,9 +3323,9 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/rehype-postfix-footnote-anchors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-postfix-footnote-anchors/-/rehype-postfix-footnote-anchors-2.0.1.tgz",
-      "integrity": "sha512-WKUUCc4smHI8KNZq+XJGZKSegkgpsUQsKgbPXYdEc7hrqodI+JTFdD2QxfIs9a5QXFhpppZfdlxtzioKJwjhcg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/rehype-postfix-footnote-anchors/-/rehype-postfix-footnote-anchors-2.0.3.tgz",
+      "integrity": "sha512-681U7BUqMOBimpmQkZuSFgASD+cKCK42CbbDJp4COi72rBiQqh/VqlkE4tsAJi2NqbrPu5xEPWrFTQ6/ppLIhA==",
       "dependencies": {
         "unist-util-visit": "^2.0.3"
       }
@@ -3378,25 +3371,25 @@
       }
     },
     "node_modules/remark-abbr": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/remark-abbr/-/remark-abbr-1.4.1.tgz",
-      "integrity": "sha512-h3MuC2ujpaFIvDHVztxiNe7OGEXz6fAaUoaeqJhroyHCZXcspZiOg3iDoRdGLmnGSEO/x6g9nQGBDqgVsjCHKg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/remark-abbr/-/remark-abbr-1.4.2.tgz",
+      "integrity": "sha512-h/fS4aXiJ0B0yyPfNHtQuOI10DZvMkUG1jBhi7e9Bj666iJN6sgoh8KMsJ6P6jdfmq7FqcXZ0fk+t3OVJ5MePw==",
       "dependencies": {
         "unist-util-visit": "^2.0.3"
       }
     },
     "node_modules/remark-align": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/remark-align/-/remark-align-1.2.14.tgz",
-      "integrity": "sha512-JbSqPYUidN+lSWeBP2LL5HT6SQvHsyMI6S7YwC5ug4ZSWjLN6UpciHLDpQAW4Jn3ifB2UvZzgtaQ09X29hkopw==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/remark-align/-/remark-align-1.2.15.tgz",
+      "integrity": "sha512-5AtsnmZgDHHFnPz8phywcXD/ckUgOTGzCmD3AcUfmFzs9506P3GS8hhgU4i85p1cou4t1laPJ6zNYL19cCNrcw==",
       "dependencies": {
         "space-separated-tokens": "^1.1.5"
       }
     },
     "node_modules/remark-captions": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/remark-captions/-/remark-captions-2.2.3.tgz",
-      "integrity": "sha512-A+mwlNwnhkaj8LZV2TZnnpXHFmcCALatwBt1NYq6OkgxGHuo8KQi6pDYwQayDkespa5fELzbUuq/aM8eXxQDtQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/remark-captions/-/remark-captions-2.2.4.tgz",
+      "integrity": "sha512-g4V2vdc5yIsTgrNvy9oZzatJF2ANa8apVKlv/4Mf3mA3YrHd5v8Wgx9XeXJcyYJ2tRmUcjr71xqheuuk+u1Y3g==",
       "dependencies": {
         "clone": "^2.1.2",
         "unist-util-visit": "^2.0.3",
@@ -3404,43 +3397,43 @@
       }
     },
     "node_modules/remark-comments": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/remark-comments/-/remark-comments-1.2.9.tgz",
-      "integrity": "sha512-IxkgOG6mywoS549abonLIJZy9pZ0VETFLzC9rUyDn0gtbviwxTvgwvm+hTkaL2whGbSJn2bKqyZ6AfYaUal2pw=="
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/remark-comments/-/remark-comments-1.2.10.tgz",
+      "integrity": "sha512-huQW1qMsVLT4bJP1bOUBXtZH9U9L9jN5gaqKRLWyHB5vFm55F1YZ25mqk6RcBIgdrklPYnVCJD6CcaLS9w/jwQ=="
     },
     "node_modules/remark-custom-blocks": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/remark-custom-blocks/-/remark-custom-blocks-2.6.0.tgz",
-      "integrity": "sha512-8Lt1WKxOzAGmYH4VrZ9Cq0ZhFCMW2wBKwCxCv0XmmF8jTfWChXer9QYUe0fi9vW/eMbjXh8RLMed3Rst3SQ+KA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/remark-custom-blocks/-/remark-custom-blocks-2.6.1.tgz",
+      "integrity": "sha512-XXVwANBZaHuBnhKQmhe8bbtoxpXFUTHxbgvU7azHT8jeZv2HLZ5Z4ggkn5khV5c6nDpH4xZU8KbT2fOadyTRoQ==",
       "dependencies": {
         "space-separated-tokens": "^1.1.5"
       }
     },
     "node_modules/remark-disable-tokenizers": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remark-disable-tokenizers/-/remark-disable-tokenizers-1.1.0.tgz",
-      "integrity": "sha512-49cCg4uSVKVmDHWKT5w+2mpDQ3G+xvt/GjypOqjlS0qTSs6/aBxE3iNWgX6ls2upXY17EKVlU0UpGcZjmGWI6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/remark-disable-tokenizers/-/remark-disable-tokenizers-1.1.1.tgz",
+      "integrity": "sha512-KhxfswvMKNTicVaprWc21i8zbBLIf6wwCbn3cvnCP1400Sgd2eCSm4maKUkj3uNkVyCKp3u5BNRaXPxJ9gM99A==",
       "dependencies": {
         "clone": "^2.1.2"
       }
     },
     "node_modules/remark-emoticons": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/remark-emoticons/-/remark-emoticons-2.3.1.tgz",
-      "integrity": "sha512-THcHxHi4GBviUWox22qtq1HhCFli0pdNHMRCcn567ePAvVgYgvAgAYKK1l4BgbTn1vTOBi78qrMO6aQbJoQsoQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/remark-emoticons/-/remark-emoticons-2.3.2.tgz",
+      "integrity": "sha512-a+DdWGNKEgU6CcJlYFNC5y0q4pXTuyknB9hVijOZczrOWfMh5X+WgyFYkwe28RKn5AJeyoRqdhYRhJPUZ5Y0SA==",
       "dependencies": {
         "is-whitespace-character": "^1.0.4"
       }
     },
     "node_modules/remark-escape-escaped": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/remark-escape-escaped/-/remark-escape-escaped-0.0.34.tgz",
-      "integrity": "sha512-OIwASe42Y3X5XVJIGqweBlzaICuK2luAmj8nxl5od7ZDQX37z+QTdVCw1uvsrrnoEuzYTg/HjvgRjVRNFmJtgA=="
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/remark-escape-escaped/-/remark-escape-escaped-0.0.35.tgz",
+      "integrity": "sha512-IxR0nT6Kpcjlx1k7bDbm7UAeTd5wcleSxJOOup+3A+gjLR27DSs9gs8rxRd8Ff5MuQ+7qTa43PAjELuK/gvC5g=="
     },
     "node_modules/remark-fix-guillemets": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/remark-fix-guillemets/-/remark-fix-guillemets-1.1.2.tgz",
-      "integrity": "sha512-SFJtChHJQDLUFqEkB39VqR3O53Pn43vTI8m9NIx7Q87oizTai7tff0xFkjAkTUoQZhg1M+0rgWkOY9zab+9tSA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/remark-fix-guillemets/-/remark-fix-guillemets-1.1.3.tgz",
+      "integrity": "sha512-VbvdX1+QYpPp1/qiiVdvDXTYLbpku24xMNb9ik8RSUBYVsY7UvdoX5oTsyaGgiwSONiO6zoqlO7KHZxCDoI7PA==",
       "dependencies": {
         "unist-util-visit": "^2.0.3"
       }
@@ -3455,9 +3448,9 @@
       }
     },
     "node_modules/remark-grid-tables": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/remark-grid-tables/-/remark-grid-tables-2.2.1.tgz",
-      "integrity": "sha512-Yv9nNe4yRwZXrMYInje7pwzqxkV2f7DE8fCoR2AUW8l8Zi5JLRzcjIz2VsnmG6NM1e0TvCkECrHrle8+e2f97g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/remark-grid-tables/-/remark-grid-tables-2.2.2.tgz",
+      "integrity": "sha512-e61jugCNhVxmsgx7MUEbOHHRN973zoVEEdH7OKY9EGDdTQCsl8CFk8OE6wlJTFwXO+j/nEB4Rb46vg3SczyM9w==",
       "dependencies": {
         "grapheme-splitter": "^1.0.4",
         "lodash.trimend": "^4.5.1",
@@ -3466,22 +3459,22 @@
       }
     },
     "node_modules/remark-heading-shift": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/remark-heading-shift/-/remark-heading-shift-1.1.1.tgz",
-      "integrity": "sha512-DtFuajl/MnJ8rhrXMuKtuhQwIGYmZMa3EgI9Lj4R7lmRnMFWbzfzUTkmGS67uU2nkZxDA9eeTFv1W/WAcgPbXw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/remark-heading-shift/-/remark-heading-shift-1.1.2.tgz",
+      "integrity": "sha512-MCT1JyzdULZDYALkc2oGoOAI5LEVLOSoDZqNRyHucRAt2US3Ha7iscH8oCpKybUUZI5IITALSmxJjWHn33QS2w==",
       "dependencies": {
         "unist-util-visit": "^2.0.3"
       }
     },
     "node_modules/remark-heading-trailing-spaces": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/remark-heading-trailing-spaces/-/remark-heading-trailing-spaces-0.0.31.tgz",
-      "integrity": "sha512-QfZj7ui7ZtOmwvgIGyXCMvenGDHfONamk6KomaMlyjGhk2T5WiS+55nZSNvBWCmrp4ofTEcs3mjpoRdmQNORWA=="
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/remark-heading-trailing-spaces/-/remark-heading-trailing-spaces-0.0.32.tgz",
+      "integrity": "sha512-7dTTMHD8XWcOYd1H/XFhePZsjykT1qxsM0zxGVT0vozJ+WQu0zhnv2f/emFrvF6LVW5/TAIQaBBtnwWSGAbt7Q=="
     },
     "node_modules/remark-iframes": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/remark-iframes/-/remark-iframes-4.1.0.tgz",
-      "integrity": "sha512-8uLKLk0weJHUANPLYCvxjlqiXweBeyX1im6NICOmIRFeOmdaNDkoIEo79iek/4PHRht6M3JdiH81cv9CR80nQg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/remark-iframes/-/remark-iframes-4.1.1.tgz",
+      "integrity": "sha512-2hHfYYxNoHIIrKF4+j54nGdM8PllgHiQ1JGPR6t/kBen+c6L7wp5of/z8Gl1zfV4PG13zKHziu0FnYm0I5GJYA==",
       "dependencies": {
         "node-fetch": "^2.6.0"
       }
@@ -3502,9 +3495,9 @@
       }
     },
     "node_modules/remark-kbd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remark-kbd/-/remark-kbd-1.1.0.tgz",
-      "integrity": "sha512-kOFLSpqKG3kOGzoW6OHAUXfjS3QB5psxqiSsHexrfT2BSGxWrE0jdJ3whgVGS3ECwC4xwRUUNum77PXrgXzIfg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/remark-kbd/-/remark-kbd-1.1.1.tgz",
+      "integrity": "sha512-vcF0XSIgkgZGkMa+qaC37V99N8omqPgH73iYmz7Altni9rQz1EfpoiNGbs/Opf3rcGFGgqOHQelNlaG8BZ2b5A==",
       "dependencies": {
         "is-whitespace-character": "^1.0.4"
       }
@@ -3519,9 +3512,9 @@
       }
     },
     "node_modules/remark-numbered-footnotes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/remark-numbered-footnotes/-/remark-numbered-footnotes-3.0.0.tgz",
-      "integrity": "sha512-kRUevMZ9eFpF9nOxopLtIZW2EGhEie5v/onlrhuZXkxJ2H3Mx100+etKEkF7+mIBg9v2zH2x+Mxyp/ecze7nFQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-numbered-footnotes/-/remark-numbered-footnotes-3.1.1.tgz",
+      "integrity": "sha512-6F/GjaDiVYxpQTLKU6oYV9zevbHtJrnTQkUo7hFd74EbwQ6ClAtkZpwmSLak/aBv4NyhAFcwgREOW7P0TF+NGw==",
       "dependencies": {
         "unist-util-visit": "^2.0.3"
       }
@@ -3554,9 +3547,9 @@
       }
     },
     "node_modules/remark-ping": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/remark-ping/-/remark-ping-2.3.1.tgz",
-      "integrity": "sha512-G8usNFhd5EprKrNKIDcxaSeHx/idHiFLuUAWKHh8Y3w+GymWzozXab58Z7fqcmX8cgYxYFHwccH0HjsSGah0Gw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/remark-ping/-/remark-ping-2.3.2.tgz",
+      "integrity": "sha512-1F39DRbE+2DiuRqPFMRXo7DtKiP8/Mi7AGjDc4gLSpZWB3Lnhg30QP+uYNjTuZwtVrCevVrhrnr8wOpB+wbeyQ==",
       "dependencies": {
         "@unicode/unicode-13.0.0": "^1.1.0",
         "unist-util-visit": "^2.0.3"
@@ -3575,9 +3568,9 @@
       }
     },
     "node_modules/remark-sub-super": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/remark-sub-super/-/remark-sub-super-1.0.20.tgz",
-      "integrity": "sha512-ohnGWuB8FSvod8Qp+gEo/7QRDlI2RA8d+YyY4eLuMQPD3WGwqGMCuyWdNOSW0mzDMqse82PJqeke/GGXaj795A=="
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/remark-sub-super/-/remark-sub-super-1.0.21.tgz",
+      "integrity": "sha512-SNUO3GbQ6Qz1MneUIeZyAx85qhq3bd2O5bzdPpr2RgF7hARci8W0oYuppGtkHz6jebxgUYWpnc9+hoFHbiy67g=="
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -4094,9 +4087,9 @@
       "integrity": "sha1-yjG289J7qADWkC1i+6KbVI9jm5k="
     },
     "node_modules/typographic-colon": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/typographic-colon/-/typographic-colon-1.0.17.tgz",
-      "integrity": "sha512-R3k2xCRtVm3IjJYMp6ZRIhcR7dv898eresOsnkIuqgRlSwcj+r82SBN9b07bk/cICfWifwzRHT83Rlfdokbv2w=="
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/typographic-colon/-/typographic-colon-1.0.18.tgz",
+      "integrity": "sha512-pkejtxnUjB1qZBj9k+gMv0GNShpHjpgmPPlQ+zevgvqvRsXTpBXtDq3FFMZLUW08cXszvsNGiysYFVnmmRlpgg=="
     },
     "node_modules/typographic-copyright": {
       "version": "1.0.1",
@@ -4109,9 +4102,9 @@
       "integrity": "sha1-ppFDtLjFYR3Tpmm3wwUmA+imlIc="
     },
     "node_modules/typographic-em-dash": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/typographic-em-dash/-/typographic-em-dash-1.0.16.tgz",
-      "integrity": "sha512-mxLTpulgSHe1xn57Kj/ppwdd3fty0MKmSPxrDxntbBBxr3haVDGmhsXdcxGss+BS6N2EsfzhFQ/WZ4+57Q21lg=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/typographic-em-dash/-/typographic-em-dash-1.0.17.tgz",
+      "integrity": "sha512-HGjLtg2IRATCvJChokDv21BZvuv0lLpv0iLE+TpB/vTTas3P3oAW8GyUhu5ibb4oxrPY6KNOI3l9UdchOPl+FQ=="
     },
     "node_modules/typographic-em-dashes": {
       "version": "1.0.2",
@@ -4124,29 +4117,29 @@
       "integrity": "sha1-o3c5/cQ+04w1G79wqAwlA8ywIuA="
     },
     "node_modules/typographic-exclamation-mark": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/typographic-exclamation-mark/-/typographic-exclamation-mark-1.0.16.tgz",
-      "integrity": "sha512-aHGoffSPR95151o69AbxzCpWb5D2CqYnFkHD1+zcPl7v9pDh1AqtzO26HAaqCgDnN+7Ld9BemaMpcV23gY4AsQ=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/typographic-exclamation-mark/-/typographic-exclamation-mark-1.0.17.tgz",
+      "integrity": "sha512-TB5/lV9MPTDq680NYjLYxy+p9XkyagRpYyygdyS2fPJa9IFegC+TdKQLQKUpdWheWs6BHjik+uNYoGy91S8v7w=="
     },
     "node_modules/typographic-guillemets": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/typographic-guillemets/-/typographic-guillemets-1.1.0.tgz",
-      "integrity": "sha512-ZXUidt5A9tUlk94jrxBd+ftIZy5TNB7eiu5fT52RB/T+l9XkjK/pAVMwEnEO+ALNVeiIyIHpSIlZYTfeOcvrSg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/typographic-guillemets/-/typographic-guillemets-1.1.1.tgz",
+      "integrity": "sha512-nbBbt/8U2Ag0Kr6Euv6lAj33UOFW1e0ti/X17CC7A2FnUI3fdyMXr+/oVxUiQ1tg3AAqxJJvX1S5pw2lgr9W9g=="
     },
     "node_modules/typographic-percent": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/typographic-percent/-/typographic-percent-1.0.16.tgz",
-      "integrity": "sha512-d7u1WB+LkZX5G1Qp9uRtctKEiAo4c2BONQkqvQRxj1+J/l+eB/JrCrlKatGO8sZHVj+v62K4W8OHdUWNbnqXWg=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/typographic-percent/-/typographic-percent-1.0.17.tgz",
+      "integrity": "sha512-mUIE/iTgc38xXDxARrVkYXULaMPpA463EazVN+v54BZNFSlbAhit4d5S7HSnZ8remwsxBXq61upFb+T51LxyZQ=="
     },
     "node_modules/typographic-permille": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/typographic-permille/-/typographic-permille-1.0.16.tgz",
-      "integrity": "sha512-cOI2nN8tMN3TgOalLBLzcxl7sv/XrHNGOyNpVitkisSXci/INR+yVal15lBdIsVD6Z0pxNnd10uxp26qzvgP6w=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/typographic-permille/-/typographic-permille-1.0.17.tgz",
+      "integrity": "sha512-8MSRJV2FLCG/KnBpKnXkPyX/j0I3vV7hrtYRnj0GMRYWo4j1NRNSWkq/OhitqTP699hjLBHk6NfxFT6X0u7y9Q=="
     },
     "node_modules/typographic-question-mark": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/typographic-question-mark/-/typographic-question-mark-1.0.16.tgz",
-      "integrity": "sha512-WW3J0ffL4lW20I4245lyvAmElO8k3kfu7OKM6isCRRDJ4xgVlr4n7S2PPiGZUtp1GVn3Txa6SII9LqTvsB25ZQ=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/typographic-question-mark/-/typographic-question-mark-1.0.17.tgz",
+      "integrity": "sha512-2QO+qGvK9NfaJL56AvxzbVYPRFX3f+ZW1l12Y/Yhy2XS7mXoYGj+KIRmPdLrzu+v0aaR/T/IOo8iIPQrlDzbIw=="
     },
     "node_modules/typographic-registered-trademark": {
       "version": "1.0.1",
@@ -4154,9 +4147,9 @@
       "integrity": "sha1-GDC2k794LPwjVg7IDWGiZyqYyN0="
     },
     "node_modules/typographic-semicolon": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/typographic-semicolon/-/typographic-semicolon-1.0.17.tgz",
-      "integrity": "sha512-gHA+2OTobtM/9U6ymNDFMDJArSFlr2+L9SrYHPGAfVG7TVm4gz6sBxn1i6yDLAtc+WO1d+GqbB1AwzGWhuw9Lg=="
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/typographic-semicolon/-/typographic-semicolon-1.0.18.tgz",
+      "integrity": "sha512-x15TJE9r/KQCqR8YWfLYTtpPxK5/lLzZddueL0+ru1SoiKbEAKzpSwD2rnhoXzuoU9dhFsC3B0WZaDFiC7SQsg=="
     },
     "node_modules/typographic-single-spaces": {
       "version": "1.0.2",
@@ -4495,12 +4488,13 @@
       }
     },
     "node_modules/zmarkdown": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-11.4.1.tgz",
-      "integrity": "sha512-QR/eCf3wlJspfodsxMGzAddxkh6LCln+It2LbXuZnSJMzCy7DmalBNDdwFIDLwmRqyv4MMJqPV4pxqWCk6NrwA==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-12.1.0.tgz",
+      "integrity": "sha512-OetWDkcokpI9NUqne3KytWEdnUY4DsSFa2jGSVMiyyRTVyGsRnG2DILOmmt/8gwK+qTcbHvWRpg6uiGT7ZwkRg==",
+      "license": "MIT",
       "dependencies": {
         "@pm2/io": "^4.3.5",
-        "@sentry/node": "^7.19.0",
+        "@sentry/node": "^7.111.0",
         "body-parser": "^1.19.0",
         "clone": "^2.1.2",
         "cors": "^2.8.5",
@@ -4511,57 +4505,57 @@
         "md-attr-parser": "^1.3.0",
         "pm2": "^4.4.1",
         "process": "^0.11.10",
-        "rebber": "^5.4.0",
-        "rebber-plugins": "^4.3.8",
+        "rebber": "^5.5.0",
+        "rebber-plugins": "^4.4.0",
         "rehype-autolink-headings": "^4.0.0",
-        "rehype-footnotes-title": "^2.0.0",
+        "rehype-footnotes-title": "^2.0.1",
         "rehype-highlight": "^4.0.0",
-        "rehype-html-blocks": "^0.1.1",
+        "rehype-html-blocks": "^0.1.2",
         "rehype-katex": "3.0.0",
         "rehype-parse": "^7.0.1",
-        "rehype-postfix-footnote-anchors": "^2.0.1",
+        "rehype-postfix-footnote-anchors": "^2.0.3",
         "rehype-sanitize": "^4.0.0",
         "rehype-slug": "^3.0.0",
         "rehype-stringify": "^8.0.0",
-        "remark-abbr": "^1.4.1",
-        "remark-align": "^1.2.14",
-        "remark-captions": "^2.2.3",
-        "remark-comments": "^1.2.9",
-        "remark-custom-blocks": "^2.6.0",
-        "remark-disable-tokenizers": "^1.1.0",
-        "remark-emoticons": "^2.3.1",
-        "remark-escape-escaped": "^0.0.34",
-        "remark-fix-guillemets": "^1.1.2",
+        "remark-abbr": "^1.4.2",
+        "remark-align": "^1.2.15",
+        "remark-captions": "^2.2.4",
+        "remark-comments": "^1.2.10",
+        "remark-custom-blocks": "^2.6.1",
+        "remark-disable-tokenizers": "^1.1.1",
+        "remark-emoticons": "^2.3.2",
+        "remark-escape-escaped": "^0.0.35",
+        "remark-fix-guillemets": "^1.1.3",
         "remark-footnotes": "^2.0.0",
-        "remark-grid-tables": "^2.2.1",
-        "remark-heading-shift": "^1.1.1",
-        "remark-heading-trailing-spaces": "^0.0.31",
-        "remark-iframes": "^4.1.0",
-        "remark-images-download": "^3.0.3",
-        "remark-kbd": "^1.1.0",
+        "remark-grid-tables": "^2.2.2",
+        "remark-heading-shift": "^1.1.2",
+        "remark-heading-trailing-spaces": "^0.0.32",
+        "remark-iframes": "^4.1.1",
+        "remark-images-download": "^3.0.5",
+        "remark-kbd": "^1.1.1",
         "remark-math": "^3.0.1",
-        "remark-numbered-footnotes": "^3.0.0",
+        "remark-numbered-footnotes": "^3.1.1",
         "remark-parse": "^8.0.3",
-        "remark-ping": "^2.3.1",
+        "remark-ping": "^2.3.2",
         "remark-rehype": "^7.0.0",
-        "remark-sub-super": "^1.0.20",
+        "remark-sub-super": "^1.0.21",
         "shortid": "^2.2.15",
         "textr": "^0.3.0",
         "typographic-apostrophes": "^1.1.1",
         "typographic-apostrophes-for-possessive-plurals": "^1.0.5",
-        "typographic-colon": "^1.0.17",
+        "typographic-colon": "^1.0.18",
         "typographic-copyright": "^1.0.1",
         "typographic-ellipses": "^1.0.11",
-        "typographic-em-dash": "^1.0.16",
+        "typographic-em-dash": "^1.0.17",
         "typographic-em-dashes": "^1.0.2",
         "typographic-en-dashes": "^1.0.1",
-        "typographic-exclamation-mark": "^1.0.16",
-        "typographic-guillemets": "^1.1.0",
-        "typographic-percent": "^1.0.16",
-        "typographic-permille": "^1.0.16",
-        "typographic-question-mark": "^1.0.16",
+        "typographic-exclamation-mark": "^1.0.17",
+        "typographic-guillemets": "^1.1.1",
+        "typographic-percent": "^1.0.17",
+        "typographic-permille": "^1.0.17",
+        "typographic-question-mark": "^1.0.17",
         "typographic-registered-trademark": "^1.0.1",
-        "typographic-semicolon": "^1.0.17",
+        "typographic-semicolon": "^1.0.18",
         "typographic-single-spaces": "^1.0.2",
         "typographic-trademark": "^1.0.1",
         "unified": "^9.2.0",
@@ -4912,77 +4906,58 @@
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.74.0.tgz",
-      "integrity": "sha512-JK6IRGgdtZjswGfaGIHNWIThffhOHzVIIaGmglui+VFIzOsOqePjoxaDV0MEvzafxXZD7eWqGE5RGuZ0n6HFVg==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+      "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
       "requires": {
-        "@sentry/core": "7.74.0",
-        "@sentry/types": "7.74.0",
-        "@sentry/utils": "7.74.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       }
     },
     "@sentry/core": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.74.0.tgz",
-      "integrity": "sha512-83NRuqn7nDZkSVBN5yJQqcpXDG4yMYiB7TkYUKrGTzBpRy6KUOrkCdybuKk0oraTIGiGSe5WEwCFySiNgR9FzA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+      "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
       "requires": {
-        "@sentry/types": "7.74.0",
-        "@sentry/utils": "7.74.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+      "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
+      "requires": {
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2",
+        "localforage": "^1.8.1"
       }
     },
     "@sentry/node": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.74.0.tgz",
-      "integrity": "sha512-uBmW2/z0cz/WFIG74ZF7lSipO0XNzMf9yrdqnZXnGDYsUZE4I4QiqDN0hNi6fkTgf9MYRC8uFem2OkAvyPJ74Q==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.119.2.tgz",
+      "integrity": "sha512-TPNnqxh+Myooe4jTyRiXrzrM2SH08R4+nrmBls4T7lKp2E5R/3mDSe/YTn5rRcUt1k1hPx1NgO/taG0DoS5cXA==",
       "requires": {
-        "@sentry-internal/tracing": "7.74.0",
-        "@sentry/core": "7.74.0",
-        "@sentry/types": "7.74.0",
-        "@sentry/utils": "7.74.0",
-        "cookie": "^0.5.0",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "cookie": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
-        },
-        "https-proxy-agent": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        }
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       }
     },
     "@sentry/types": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.74.0.tgz",
-      "integrity": "sha512-rI5eIRbUycWjn6s6o3yAjjWtIvYSxZDdnKv5je2EZINfLKcMPj1dkl6wQd2F4y7gLfD/N6Y0wZYIXC3DUdJQQg=="
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+      "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg=="
     },
     "@sentry/utils": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.74.0.tgz",
-      "integrity": "sha512-k3np8nuTPtx5KDODPtULfFln4UXdE56MZCcF19Jv6Ljxf+YN/Ady1+0Oi3e0XoSvFpWNyWnglauT7M65qCE6kg==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+      "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
       "requires": {
-        "@sentry/types": "7.74.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.119.2"
       }
     },
     "@tokenizer/token": {
@@ -5022,9 +4997,9 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "@unicode/unicode-13.0.0": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unicode/unicode-13.0.0/-/unicode-13.0.0-1.2.1.tgz",
-      "integrity": "sha512-8NDE4zZASktxJe+hV13K795wefyx+wRhu3Wl7TJ8fzsKx95CHsgTFmYRTscqna90zpUz6YBjGyqXHBI2ubiMaw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@unicode/unicode-13.0.0/-/unicode-13.0.0-1.6.0.tgz",
+      "integrity": "sha512-TwldNeAK+kcroDeOpB3pQXxZh6FMtkxTlpQrrHZCP9x0gUAgbHkWQ0ZzXG+TaO3S+3Y786PNXEYRkXRB7MDcAw=="
     },
     "accepts": {
       "version": "1.3.8",
@@ -6061,6 +6036,11 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6246,6 +6226,22 @@
         "type-check": "~0.3.2"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "requires": {
+        "lie": "3.1.1"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -6269,11 +6265,6 @@
         "fault": "^1.0.0",
         "highlight.js": "~10.7.0"
       }
-    },
-    "lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -6940,9 +6931,9 @@
       }
     },
     "rebber": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/rebber/-/rebber-5.4.0.tgz",
-      "integrity": "sha512-tRBDkBgITaJqLmr9dMnm20bGE87TSItSU92pJYSOazoRVGpMz14yrKe2NC6xnLa/bYfaDHMqi98MjceqL+4HAw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/rebber/-/rebber-5.5.0.tgz",
+      "integrity": "sha512-+5soRRy/ASFzgHYYUOQ57eps0n2ERh+RVreYXK1uMFBTZo5bZikb9MSAAy7lULItKuy8rRA3uiIHR1F2MXhDKA==",
       "requires": {
         "clone": "^2.1.2",
         "collapse-white-space": "^1.0.6",
@@ -6953,9 +6944,9 @@
       }
     },
     "rebber-plugins": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/rebber-plugins/-/rebber-plugins-4.3.8.tgz",
-      "integrity": "sha512-5rlP1SQx0Igmu4FV/sbcrJjZYxq3oN2Qio20SpzfaYmRZiFHUU9rK0xb6A9M4ANtEo/3Sv8uofujbWVccBpDXg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/rebber-plugins/-/rebber-plugins-4.4.0.tgz",
+      "integrity": "sha512-tYXtY+RP3G0K/WbAZ2Vpy8IJvtqqkPnqJ+mUoMs3ORZRIDKHONw+CM4enqjJc7alfriVXiR7l0zuxYa42GlWkQ==",
       "requires": {
         "has": "^1.0.3",
         "xtend": "^4.0.2"
@@ -6973,9 +6964,9 @@
       }
     },
     "rehype-footnotes-title": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-footnotes-title/-/rehype-footnotes-title-2.0.0.tgz",
-      "integrity": "sha512-W0ryHhzYcgNxE7audzoqrMI0o+Jo1hdwp77aOqD8PLsahj16cq5nYH69MWavTc0NolNKQdVW9Nt9FjOKYA/NBA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-footnotes-title/-/rehype-footnotes-title-2.0.1.tgz",
+      "integrity": "sha512-vdoWv74zMbyvMDETiGWD4LEAzmRFq0Gg6/f4vTADd/wMlhwqDUEVs8P+w2MdUNFBUkUK6/4IKYHp5/ctJkdl5Q==",
       "requires": {
         "unist-util-visit": "^2.0.3"
       }
@@ -6991,9 +6982,9 @@
       }
     },
     "rehype-html-blocks": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/rehype-html-blocks/-/rehype-html-blocks-0.1.1.tgz",
-      "integrity": "sha512-7FJbR3iSMCu75rJuDzfHtC6z7bJd9RdJwBhPQ5feag95RrKMCVUzlfhUfuY7lE82ar61V8bRYW8We+sItwpoMw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/rehype-html-blocks/-/rehype-html-blocks-0.1.2.tgz",
+      "integrity": "sha512-m4BAsMwsQ7E/TmhykV9jTw23VGcvzZ7ZmMxr3X2scDL+0ZASAOgFmRdIq0Ac8AXh6v/a81uhEYNBPiza7wgGXA==",
       "requires": {
         "unist-util-visit": "^2.0.3"
       }
@@ -7076,9 +7067,9 @@
       }
     },
     "rehype-postfix-footnote-anchors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-postfix-footnote-anchors/-/rehype-postfix-footnote-anchors-2.0.1.tgz",
-      "integrity": "sha512-WKUUCc4smHI8KNZq+XJGZKSegkgpsUQsKgbPXYdEc7hrqodI+JTFdD2QxfIs9a5QXFhpppZfdlxtzioKJwjhcg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/rehype-postfix-footnote-anchors/-/rehype-postfix-footnote-anchors-2.0.3.tgz",
+      "integrity": "sha512-681U7BUqMOBimpmQkZuSFgASD+cKCK42CbbDJp4COi72rBiQqh/VqlkE4tsAJi2NqbrPu5xEPWrFTQ6/ppLIhA==",
       "requires": {
         "unist-util-visit": "^2.0.3"
       }
@@ -7112,25 +7103,25 @@
       }
     },
     "remark-abbr": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/remark-abbr/-/remark-abbr-1.4.1.tgz",
-      "integrity": "sha512-h3MuC2ujpaFIvDHVztxiNe7OGEXz6fAaUoaeqJhroyHCZXcspZiOg3iDoRdGLmnGSEO/x6g9nQGBDqgVsjCHKg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/remark-abbr/-/remark-abbr-1.4.2.tgz",
+      "integrity": "sha512-h/fS4aXiJ0B0yyPfNHtQuOI10DZvMkUG1jBhi7e9Bj666iJN6sgoh8KMsJ6P6jdfmq7FqcXZ0fk+t3OVJ5MePw==",
       "requires": {
         "unist-util-visit": "^2.0.3"
       }
     },
     "remark-align": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/remark-align/-/remark-align-1.2.14.tgz",
-      "integrity": "sha512-JbSqPYUidN+lSWeBP2LL5HT6SQvHsyMI6S7YwC5ug4ZSWjLN6UpciHLDpQAW4Jn3ifB2UvZzgtaQ09X29hkopw==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/remark-align/-/remark-align-1.2.15.tgz",
+      "integrity": "sha512-5AtsnmZgDHHFnPz8phywcXD/ckUgOTGzCmD3AcUfmFzs9506P3GS8hhgU4i85p1cou4t1laPJ6zNYL19cCNrcw==",
       "requires": {
         "space-separated-tokens": "^1.1.5"
       }
     },
     "remark-captions": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/remark-captions/-/remark-captions-2.2.3.tgz",
-      "integrity": "sha512-A+mwlNwnhkaj8LZV2TZnnpXHFmcCALatwBt1NYq6OkgxGHuo8KQi6pDYwQayDkespa5fELzbUuq/aM8eXxQDtQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/remark-captions/-/remark-captions-2.2.4.tgz",
+      "integrity": "sha512-g4V2vdc5yIsTgrNvy9oZzatJF2ANa8apVKlv/4Mf3mA3YrHd5v8Wgx9XeXJcyYJ2tRmUcjr71xqheuuk+u1Y3g==",
       "requires": {
         "clone": "^2.1.2",
         "unist-util-visit": "^2.0.3",
@@ -7138,43 +7129,43 @@
       }
     },
     "remark-comments": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/remark-comments/-/remark-comments-1.2.9.tgz",
-      "integrity": "sha512-IxkgOG6mywoS549abonLIJZy9pZ0VETFLzC9rUyDn0gtbviwxTvgwvm+hTkaL2whGbSJn2bKqyZ6AfYaUal2pw=="
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/remark-comments/-/remark-comments-1.2.10.tgz",
+      "integrity": "sha512-huQW1qMsVLT4bJP1bOUBXtZH9U9L9jN5gaqKRLWyHB5vFm55F1YZ25mqk6RcBIgdrklPYnVCJD6CcaLS9w/jwQ=="
     },
     "remark-custom-blocks": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/remark-custom-blocks/-/remark-custom-blocks-2.6.0.tgz",
-      "integrity": "sha512-8Lt1WKxOzAGmYH4VrZ9Cq0ZhFCMW2wBKwCxCv0XmmF8jTfWChXer9QYUe0fi9vW/eMbjXh8RLMed3Rst3SQ+KA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/remark-custom-blocks/-/remark-custom-blocks-2.6.1.tgz",
+      "integrity": "sha512-XXVwANBZaHuBnhKQmhe8bbtoxpXFUTHxbgvU7azHT8jeZv2HLZ5Z4ggkn5khV5c6nDpH4xZU8KbT2fOadyTRoQ==",
       "requires": {
         "space-separated-tokens": "^1.1.5"
       }
     },
     "remark-disable-tokenizers": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remark-disable-tokenizers/-/remark-disable-tokenizers-1.1.0.tgz",
-      "integrity": "sha512-49cCg4uSVKVmDHWKT5w+2mpDQ3G+xvt/GjypOqjlS0qTSs6/aBxE3iNWgX6ls2upXY17EKVlU0UpGcZjmGWI6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/remark-disable-tokenizers/-/remark-disable-tokenizers-1.1.1.tgz",
+      "integrity": "sha512-KhxfswvMKNTicVaprWc21i8zbBLIf6wwCbn3cvnCP1400Sgd2eCSm4maKUkj3uNkVyCKp3u5BNRaXPxJ9gM99A==",
       "requires": {
         "clone": "^2.1.2"
       }
     },
     "remark-emoticons": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/remark-emoticons/-/remark-emoticons-2.3.1.tgz",
-      "integrity": "sha512-THcHxHi4GBviUWox22qtq1HhCFli0pdNHMRCcn567ePAvVgYgvAgAYKK1l4BgbTn1vTOBi78qrMO6aQbJoQsoQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/remark-emoticons/-/remark-emoticons-2.3.2.tgz",
+      "integrity": "sha512-a+DdWGNKEgU6CcJlYFNC5y0q4pXTuyknB9hVijOZczrOWfMh5X+WgyFYkwe28RKn5AJeyoRqdhYRhJPUZ5Y0SA==",
       "requires": {
         "is-whitespace-character": "^1.0.4"
       }
     },
     "remark-escape-escaped": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/remark-escape-escaped/-/remark-escape-escaped-0.0.34.tgz",
-      "integrity": "sha512-OIwASe42Y3X5XVJIGqweBlzaICuK2luAmj8nxl5od7ZDQX37z+QTdVCw1uvsrrnoEuzYTg/HjvgRjVRNFmJtgA=="
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/remark-escape-escaped/-/remark-escape-escaped-0.0.35.tgz",
+      "integrity": "sha512-IxR0nT6Kpcjlx1k7bDbm7UAeTd5wcleSxJOOup+3A+gjLR27DSs9gs8rxRd8Ff5MuQ+7qTa43PAjELuK/gvC5g=="
     },
     "remark-fix-guillemets": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/remark-fix-guillemets/-/remark-fix-guillemets-1.1.2.tgz",
-      "integrity": "sha512-SFJtChHJQDLUFqEkB39VqR3O53Pn43vTI8m9NIx7Q87oizTai7tff0xFkjAkTUoQZhg1M+0rgWkOY9zab+9tSA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/remark-fix-guillemets/-/remark-fix-guillemets-1.1.3.tgz",
+      "integrity": "sha512-VbvdX1+QYpPp1/qiiVdvDXTYLbpku24xMNb9ik8RSUBYVsY7UvdoX5oTsyaGgiwSONiO6zoqlO7KHZxCDoI7PA==",
       "requires": {
         "unist-util-visit": "^2.0.3"
       }
@@ -7185,9 +7176,9 @@
       "integrity": "sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ=="
     },
     "remark-grid-tables": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/remark-grid-tables/-/remark-grid-tables-2.2.1.tgz",
-      "integrity": "sha512-Yv9nNe4yRwZXrMYInje7pwzqxkV2f7DE8fCoR2AUW8l8Zi5JLRzcjIz2VsnmG6NM1e0TvCkECrHrle8+e2f97g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/remark-grid-tables/-/remark-grid-tables-2.2.2.tgz",
+      "integrity": "sha512-e61jugCNhVxmsgx7MUEbOHHRN973zoVEEdH7OKY9EGDdTQCsl8CFk8OE6wlJTFwXO+j/nEB4Rb46vg3SczyM9w==",
       "requires": {
         "grapheme-splitter": "^1.0.4",
         "lodash.trimend": "^4.5.1",
@@ -7196,22 +7187,22 @@
       }
     },
     "remark-heading-shift": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/remark-heading-shift/-/remark-heading-shift-1.1.1.tgz",
-      "integrity": "sha512-DtFuajl/MnJ8rhrXMuKtuhQwIGYmZMa3EgI9Lj4R7lmRnMFWbzfzUTkmGS67uU2nkZxDA9eeTFv1W/WAcgPbXw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/remark-heading-shift/-/remark-heading-shift-1.1.2.tgz",
+      "integrity": "sha512-MCT1JyzdULZDYALkc2oGoOAI5LEVLOSoDZqNRyHucRAt2US3Ha7iscH8oCpKybUUZI5IITALSmxJjWHn33QS2w==",
       "requires": {
         "unist-util-visit": "^2.0.3"
       }
     },
     "remark-heading-trailing-spaces": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/remark-heading-trailing-spaces/-/remark-heading-trailing-spaces-0.0.31.tgz",
-      "integrity": "sha512-QfZj7ui7ZtOmwvgIGyXCMvenGDHfONamk6KomaMlyjGhk2T5WiS+55nZSNvBWCmrp4ofTEcs3mjpoRdmQNORWA=="
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/remark-heading-trailing-spaces/-/remark-heading-trailing-spaces-0.0.32.tgz",
+      "integrity": "sha512-7dTTMHD8XWcOYd1H/XFhePZsjykT1qxsM0zxGVT0vozJ+WQu0zhnv2f/emFrvF6LVW5/TAIQaBBtnwWSGAbt7Q=="
     },
     "remark-iframes": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/remark-iframes/-/remark-iframes-4.1.0.tgz",
-      "integrity": "sha512-8uLKLk0weJHUANPLYCvxjlqiXweBeyX1im6NICOmIRFeOmdaNDkoIEo79iek/4PHRht6M3JdiH81cv9CR80nQg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/remark-iframes/-/remark-iframes-4.1.1.tgz",
+      "integrity": "sha512-2hHfYYxNoHIIrKF4+j54nGdM8PllgHiQ1JGPR6t/kBen+c6L7wp5of/z8Gl1zfV4PG13zKHziu0FnYm0I5GJYA==",
       "requires": {
         "node-fetch": "^2.6.0"
       }
@@ -7232,9 +7223,9 @@
       }
     },
     "remark-kbd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remark-kbd/-/remark-kbd-1.1.0.tgz",
-      "integrity": "sha512-kOFLSpqKG3kOGzoW6OHAUXfjS3QB5psxqiSsHexrfT2BSGxWrE0jdJ3whgVGS3ECwC4xwRUUNum77PXrgXzIfg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/remark-kbd/-/remark-kbd-1.1.1.tgz",
+      "integrity": "sha512-vcF0XSIgkgZGkMa+qaC37V99N8omqPgH73iYmz7Altni9rQz1EfpoiNGbs/Opf3rcGFGgqOHQelNlaG8BZ2b5A==",
       "requires": {
         "is-whitespace-character": "^1.0.4"
       }
@@ -7245,9 +7236,9 @@
       "integrity": "sha512-epT77R/HK0x7NqrWHdSV75uNLwn8g9qTyMqCRCDujL0vj/6T6+yhdrR7mjELWtkse+Fw02kijAaBuVcHBor1+Q=="
     },
     "remark-numbered-footnotes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/remark-numbered-footnotes/-/remark-numbered-footnotes-3.0.0.tgz",
-      "integrity": "sha512-kRUevMZ9eFpF9nOxopLtIZW2EGhEie5v/onlrhuZXkxJ2H3Mx100+etKEkF7+mIBg9v2zH2x+Mxyp/ecze7nFQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-numbered-footnotes/-/remark-numbered-footnotes-3.1.1.tgz",
+      "integrity": "sha512-6F/GjaDiVYxpQTLKU6oYV9zevbHtJrnTQkUo7hFd74EbwQ6ClAtkZpwmSLak/aBv4NyhAFcwgREOW7P0TF+NGw==",
       "requires": {
         "unist-util-visit": "^2.0.3"
       }
@@ -7276,9 +7267,9 @@
       }
     },
     "remark-ping": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/remark-ping/-/remark-ping-2.3.1.tgz",
-      "integrity": "sha512-G8usNFhd5EprKrNKIDcxaSeHx/idHiFLuUAWKHh8Y3w+GymWzozXab58Z7fqcmX8cgYxYFHwccH0HjsSGah0Gw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/remark-ping/-/remark-ping-2.3.2.tgz",
+      "integrity": "sha512-1F39DRbE+2DiuRqPFMRXo7DtKiP8/Mi7AGjDc4gLSpZWB3Lnhg30QP+uYNjTuZwtVrCevVrhrnr8wOpB+wbeyQ==",
       "requires": {
         "@unicode/unicode-13.0.0": "^1.1.0",
         "unist-util-visit": "^2.0.3"
@@ -7293,9 +7284,9 @@
       }
     },
     "remark-sub-super": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/remark-sub-super/-/remark-sub-super-1.0.20.tgz",
-      "integrity": "sha512-ohnGWuB8FSvod8Qp+gEo/7QRDlI2RA8d+YyY4eLuMQPD3WGwqGMCuyWdNOSW0mzDMqse82PJqeke/GGXaj795A=="
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/remark-sub-super/-/remark-sub-super-1.0.21.tgz",
+      "integrity": "sha512-SNUO3GbQ6Qz1MneUIeZyAx85qhq3bd2O5bzdPpr2RgF7hARci8W0oYuppGtkHz6jebxgUYWpnc9+hoFHbiy67g=="
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -7685,9 +7676,9 @@
       "integrity": "sha1-yjG289J7qADWkC1i+6KbVI9jm5k="
     },
     "typographic-colon": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/typographic-colon/-/typographic-colon-1.0.17.tgz",
-      "integrity": "sha512-R3k2xCRtVm3IjJYMp6ZRIhcR7dv898eresOsnkIuqgRlSwcj+r82SBN9b07bk/cICfWifwzRHT83Rlfdokbv2w=="
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/typographic-colon/-/typographic-colon-1.0.18.tgz",
+      "integrity": "sha512-pkejtxnUjB1qZBj9k+gMv0GNShpHjpgmPPlQ+zevgvqvRsXTpBXtDq3FFMZLUW08cXszvsNGiysYFVnmmRlpgg=="
     },
     "typographic-copyright": {
       "version": "1.0.1",
@@ -7700,9 +7691,9 @@
       "integrity": "sha1-ppFDtLjFYR3Tpmm3wwUmA+imlIc="
     },
     "typographic-em-dash": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/typographic-em-dash/-/typographic-em-dash-1.0.16.tgz",
-      "integrity": "sha512-mxLTpulgSHe1xn57Kj/ppwdd3fty0MKmSPxrDxntbBBxr3haVDGmhsXdcxGss+BS6N2EsfzhFQ/WZ4+57Q21lg=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/typographic-em-dash/-/typographic-em-dash-1.0.17.tgz",
+      "integrity": "sha512-HGjLtg2IRATCvJChokDv21BZvuv0lLpv0iLE+TpB/vTTas3P3oAW8GyUhu5ibb4oxrPY6KNOI3l9UdchOPl+FQ=="
     },
     "typographic-em-dashes": {
       "version": "1.0.2",
@@ -7715,29 +7706,29 @@
       "integrity": "sha1-o3c5/cQ+04w1G79wqAwlA8ywIuA="
     },
     "typographic-exclamation-mark": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/typographic-exclamation-mark/-/typographic-exclamation-mark-1.0.16.tgz",
-      "integrity": "sha512-aHGoffSPR95151o69AbxzCpWb5D2CqYnFkHD1+zcPl7v9pDh1AqtzO26HAaqCgDnN+7Ld9BemaMpcV23gY4AsQ=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/typographic-exclamation-mark/-/typographic-exclamation-mark-1.0.17.tgz",
+      "integrity": "sha512-TB5/lV9MPTDq680NYjLYxy+p9XkyagRpYyygdyS2fPJa9IFegC+TdKQLQKUpdWheWs6BHjik+uNYoGy91S8v7w=="
     },
     "typographic-guillemets": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/typographic-guillemets/-/typographic-guillemets-1.1.0.tgz",
-      "integrity": "sha512-ZXUidt5A9tUlk94jrxBd+ftIZy5TNB7eiu5fT52RB/T+l9XkjK/pAVMwEnEO+ALNVeiIyIHpSIlZYTfeOcvrSg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/typographic-guillemets/-/typographic-guillemets-1.1.1.tgz",
+      "integrity": "sha512-nbBbt/8U2Ag0Kr6Euv6lAj33UOFW1e0ti/X17CC7A2FnUI3fdyMXr+/oVxUiQ1tg3AAqxJJvX1S5pw2lgr9W9g=="
     },
     "typographic-percent": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/typographic-percent/-/typographic-percent-1.0.16.tgz",
-      "integrity": "sha512-d7u1WB+LkZX5G1Qp9uRtctKEiAo4c2BONQkqvQRxj1+J/l+eB/JrCrlKatGO8sZHVj+v62K4W8OHdUWNbnqXWg=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/typographic-percent/-/typographic-percent-1.0.17.tgz",
+      "integrity": "sha512-mUIE/iTgc38xXDxARrVkYXULaMPpA463EazVN+v54BZNFSlbAhit4d5S7HSnZ8remwsxBXq61upFb+T51LxyZQ=="
     },
     "typographic-permille": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/typographic-permille/-/typographic-permille-1.0.16.tgz",
-      "integrity": "sha512-cOI2nN8tMN3TgOalLBLzcxl7sv/XrHNGOyNpVitkisSXci/INR+yVal15lBdIsVD6Z0pxNnd10uxp26qzvgP6w=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/typographic-permille/-/typographic-permille-1.0.17.tgz",
+      "integrity": "sha512-8MSRJV2FLCG/KnBpKnXkPyX/j0I3vV7hrtYRnj0GMRYWo4j1NRNSWkq/OhitqTP699hjLBHk6NfxFT6X0u7y9Q=="
     },
     "typographic-question-mark": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/typographic-question-mark/-/typographic-question-mark-1.0.16.tgz",
-      "integrity": "sha512-WW3J0ffL4lW20I4245lyvAmElO8k3kfu7OKM6isCRRDJ4xgVlr4n7S2PPiGZUtp1GVn3Txa6SII9LqTvsB25ZQ=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/typographic-question-mark/-/typographic-question-mark-1.0.17.tgz",
+      "integrity": "sha512-2QO+qGvK9NfaJL56AvxzbVYPRFX3f+ZW1l12Y/Yhy2XS7mXoYGj+KIRmPdLrzu+v0aaR/T/IOo8iIPQrlDzbIw=="
     },
     "typographic-registered-trademark": {
       "version": "1.0.1",
@@ -7745,9 +7736,9 @@
       "integrity": "sha1-GDC2k794LPwjVg7IDWGiZyqYyN0="
     },
     "typographic-semicolon": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/typographic-semicolon/-/typographic-semicolon-1.0.17.tgz",
-      "integrity": "sha512-gHA+2OTobtM/9U6ymNDFMDJArSFlr2+L9SrYHPGAfVG7TVm4gz6sBxn1i6yDLAtc+WO1d+GqbB1AwzGWhuw9Lg=="
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/typographic-semicolon/-/typographic-semicolon-1.0.18.tgz",
+      "integrity": "sha512-x15TJE9r/KQCqR8YWfLYTtpPxK5/lLzZddueL0+ru1SoiKbEAKzpSwD2rnhoXzuoU9dhFsC3B0WZaDFiC7SQsg=="
     },
     "typographic-single-spaces": {
       "version": "1.0.2",
@@ -7987,12 +7978,12 @@
       }
     },
     "zmarkdown": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-11.4.1.tgz",
-      "integrity": "sha512-QR/eCf3wlJspfodsxMGzAddxkh6LCln+It2LbXuZnSJMzCy7DmalBNDdwFIDLwmRqyv4MMJqPV4pxqWCk6NrwA==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/zmarkdown/-/zmarkdown-12.1.0.tgz",
+      "integrity": "sha512-OetWDkcokpI9NUqne3KytWEdnUY4DsSFa2jGSVMiyyRTVyGsRnG2DILOmmt/8gwK+qTcbHvWRpg6uiGT7ZwkRg==",
       "requires": {
         "@pm2/io": "^4.3.5",
-        "@sentry/node": "^7.19.0",
+        "@sentry/node": "^7.111.0",
         "body-parser": "^1.19.0",
         "clone": "^2.1.2",
         "cors": "^2.8.5",
@@ -8003,57 +7994,57 @@
         "md-attr-parser": "^1.3.0",
         "pm2": "^4.4.1",
         "process": "^0.11.10",
-        "rebber": "^5.4.0",
-        "rebber-plugins": "^4.3.8",
+        "rebber": "^5.5.0",
+        "rebber-plugins": "^4.4.0",
         "rehype-autolink-headings": "^4.0.0",
-        "rehype-footnotes-title": "^2.0.0",
+        "rehype-footnotes-title": "^2.0.1",
         "rehype-highlight": "^4.0.0",
-        "rehype-html-blocks": "^0.1.1",
+        "rehype-html-blocks": "^0.1.2",
         "rehype-katex": "3.0.0",
         "rehype-parse": "^7.0.1",
-        "rehype-postfix-footnote-anchors": "^2.0.1",
+        "rehype-postfix-footnote-anchors": "^2.0.3",
         "rehype-sanitize": "^4.0.0",
         "rehype-slug": "^3.0.0",
         "rehype-stringify": "^8.0.0",
-        "remark-abbr": "^1.4.1",
-        "remark-align": "^1.2.14",
-        "remark-captions": "^2.2.3",
-        "remark-comments": "^1.2.9",
-        "remark-custom-blocks": "^2.6.0",
-        "remark-disable-tokenizers": "^1.1.0",
-        "remark-emoticons": "^2.3.1",
-        "remark-escape-escaped": "^0.0.34",
-        "remark-fix-guillemets": "^1.1.2",
+        "remark-abbr": "^1.4.2",
+        "remark-align": "^1.2.15",
+        "remark-captions": "^2.2.4",
+        "remark-comments": "^1.2.10",
+        "remark-custom-blocks": "^2.6.1",
+        "remark-disable-tokenizers": "^1.1.1",
+        "remark-emoticons": "^2.3.2",
+        "remark-escape-escaped": "^0.0.35",
+        "remark-fix-guillemets": "^1.1.3",
         "remark-footnotes": "^2.0.0",
-        "remark-grid-tables": "^2.2.1",
-        "remark-heading-shift": "^1.1.1",
-        "remark-heading-trailing-spaces": "^0.0.31",
-        "remark-iframes": "^4.1.0",
-        "remark-images-download": "^3.0.3",
-        "remark-kbd": "^1.1.0",
+        "remark-grid-tables": "^2.2.2",
+        "remark-heading-shift": "^1.1.2",
+        "remark-heading-trailing-spaces": "^0.0.32",
+        "remark-iframes": "^4.1.1",
+        "remark-images-download": "^3.0.5",
+        "remark-kbd": "^1.1.1",
         "remark-math": "^3.0.1",
-        "remark-numbered-footnotes": "^3.0.0",
+        "remark-numbered-footnotes": "^3.1.1",
         "remark-parse": "^8.0.3",
-        "remark-ping": "^2.3.1",
+        "remark-ping": "^2.3.2",
         "remark-rehype": "^7.0.0",
-        "remark-sub-super": "^1.0.20",
+        "remark-sub-super": "^1.0.21",
         "shortid": "^2.2.15",
         "textr": "^0.3.0",
         "typographic-apostrophes": "^1.1.1",
         "typographic-apostrophes-for-possessive-plurals": "^1.0.5",
-        "typographic-colon": "^1.0.17",
+        "typographic-colon": "^1.0.18",
         "typographic-copyright": "^1.0.1",
         "typographic-ellipses": "^1.0.11",
-        "typographic-em-dash": "^1.0.16",
+        "typographic-em-dash": "^1.0.17",
         "typographic-em-dashes": "^1.0.2",
         "typographic-en-dashes": "^1.0.1",
-        "typographic-exclamation-mark": "^1.0.16",
-        "typographic-guillemets": "^1.1.0",
-        "typographic-percent": "^1.0.16",
-        "typographic-permille": "^1.0.16",
-        "typographic-question-mark": "^1.0.16",
+        "typographic-exclamation-mark": "^1.0.17",
+        "typographic-guillemets": "^1.1.1",
+        "typographic-percent": "^1.0.17",
+        "typographic-permille": "^1.0.17",
+        "typographic-question-mark": "^1.0.17",
         "typographic-registered-trademark": "^1.0.1",
-        "typographic-semicolon": "^1.0.17",
+        "typographic-semicolon": "^1.0.18",
         "typographic-single-spaces": "^1.0.2",
         "typographic-trademark": "^1.0.1",
         "unified": "^9.2.0",

--- a/zmd/package.json
+++ b/zmd/package.json
@@ -9,9 +9,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zmarkdown": "11.4.1"
+    "zmarkdown": "12.1.0"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
Viens de remarquer que ZMarkdown n’était pas à jour ici. [Notes de version](https://github.com/zestedesavoir/zmarkdown/releases/tag/zmarkdown%4012.0.0). En particulier, inclut les nouveaux tableaux LaTeX.