### PR TITLE
Met à jour les poids de recherche

### DIFF
--- a/doc/source/back-end/search.rst
+++ b/doc/source/back-end/search.rst
@@ -162,11 +162,10 @@ Il est possible de modifier les différents paramètres de la recherche dans
         "boosts": {
             "publishedcontent": {
                 "global": global_weight_publishedcontent,
-                "if_article": 2.0,  # s'il s'agit d'un article
-                "if_tutorial": 2.0, # s'il s'agit d'un tuto
-                "if_medium_or_big_tutorial": 2.5, # s'il s'agit d'un tuto d'une taille plutôt importante
+                "if_validated": 2.0,  # s'il s'agit d'une publication validée (article ou tuto)
+                "if_validated_and_multipage": 2.5, # s'il s'agit d'une publication validée sur plusieurs page (medium ou big-tuto)
                 "if_opinion": 1.66, # s'il s'agit d'un billet
-                "if_opinion_not_picked": 1.5, # s'il s'agit d'un billet pas mis en avant
+                "if_opinion_not_picked": 1.5, # s'il s'agit d'un billet non mis en avant sur la page d'accueil
 
                 # poids des différents champs :
                 "title": global_weight_publishedcontent * 3,

--- a/doc/source/back-end/search.rst
+++ b/doc/source/back-end/search.rst
@@ -163,7 +163,7 @@ Il est possible de modifier les différents paramètres de la recherche dans
             "publishedcontent": {
                 "global": global_weight_publishedcontent,
                 "if_validated": 2.0,  # s'il s'agit d'une publication validée (article ou tuto)
-                "if_validated_and_multipage": 2.5, # s'il s'agit d'une publication validée sur plusieurs page (medium ou big-tuto)
+                "if_validated_and_multipage": 2.5, # s'il s'agit d'une publication validée sur plusieurs pages (medium ou big)
                 "if_opinion": 1.66, # s'il s'agit d'un billet
                 "if_opinion_not_picked": 1.5, # s'il s'agit d'un billet non mis en avant sur la page d'accueil
 
@@ -327,7 +327,7 @@ doivent ensuite être surchargées :
               data["forum_get_absolute_url"] = self.forum.get_absolute_url()
               data["pubdate"] = date_to_timestamp_int(self.pubdate)
               data["text"] = clean_html(self.text_html)
-              data["weight"] = self._compute_search_weight()
+              data["weight"] = self._get_search_weight()
 
               return data
 

--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -488,7 +488,7 @@ class Topic(AbstractSearchIndexableModel):
         data["forum_title"] = self.forum.title
         data["forum_get_absolute_url"] = self.forum.get_absolute_url()
         data["pubdate"] = date_to_timestamp_int(self.pubdate)
-        data["weight"] = self._compute_search_weight()
+        data["weight"] = self._get_search_weight()
 
         return data
 
@@ -532,7 +532,7 @@ class Topic(AbstractSearchIndexableModel):
 
         return super().save(*args, **kwargs)
 
-    def _compute_search_weight(self):
+    def _get_search_weight(self):
         """
         This function calculates a weight for topics in order to sort them according to different boosts.
         There is a boost according to the state of the topic:
@@ -642,7 +642,7 @@ class Post(Comment, AbstractSearchIndexableModel):
         data["forum_get_absolute_url"] = self.topic.forum.get_absolute_url()
         data["pubdate"] = date_to_timestamp_int(self.pubdate)
         data["text"] = clean_html(self.text_html)
-        data["weight"] = self._compute_search_weight()
+        data["weight"] = self._get_search_weight()
 
         return data
 
@@ -654,7 +654,7 @@ class Post(Comment, AbstractSearchIndexableModel):
         search_engine_manager = SearchIndexManager()
         search_engine_manager.delete_document(self)
 
-    def _compute_search_weight(self):
+    def _get_search_weight(self):
         """
         This function calculates a weight for post in order to sort them according to different boosts.
         There is a boost according to the position, the usefulness and the ration of likes.

--- a/zds/search/tests/tests_views.py
+++ b/zds/search/tests/tests_views.py
@@ -641,7 +641,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
             == response[3]["document"]["weight"]
         )
 
-        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_article"] = 2.0
+        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_validated"] = 2.0
 
         # Reindex to update the weight
         self._index_everything()
@@ -655,8 +655,8 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.assertTrue(response[0]["document"]["weight"] > response[1]["document"]["weight"])
         self.assertEqual(response[0]["document"]["id"], str(published_article.pk))  # obvious
 
-        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_article"] = 1.0
-        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_medium_or_big_tutorial"] = 2.0
+        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_validated"] = 1.0
+        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_validated_and_multipage"] = 2.0
 
         # Reindex to update the weight
         self._index_everything()
@@ -670,7 +670,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.assertTrue(response[0]["document"]["weight"] > response[1]["document"]["weight"])
         self.assertEqual(response[0]["document"]["id"], str(published_tuto.pk))  # obvious
 
-        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_medium_or_big_tutorial"] = 1.0
+        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_validated_and_multipage"] = 1.0
         settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_opinion"] = 2.0
         settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_opinion_not_picked"] = 4.0
         # Note: in "real life", unpicked opinion would get a boost < 1.
@@ -694,7 +694,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
 
         settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_opinion"] = 1.0
         settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_opinion_not_picked"] = 1.0
-        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_medium_or_big_tutorial"] = 2.0
+        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_validated_and_multipage"] = 2.0
 
         # Reindex to update the weight
         self._index_everything()
@@ -708,7 +708,7 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.assertTrue(response[0]["document"]["weight"] > response[1]["document"]["weight"])
         self.assertEqual(response[0]["document"]["id"], str(published_tuto.pk))  # obvious
 
-        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_medium_or_big_tutorial"] = 1.0
+        settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["if_validated_and_multipage"] = 1.0
 
         # Reindex to update the weight
         self._index_everything()

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -253,9 +253,8 @@ ZDS_APP = {
         "boosts": {
             "publishedcontent": {
                 "global": global_weight_publishedcontent,
-                "if_article": global_weight_publishedcontent * 1.5,
-                "if_tutorial": global_weight_publishedcontent * 1.5,
-                "if_medium_or_big_tutorial": global_weight_publishedcontent * 1.7,
+                "if_validated": global_weight_publishedcontent * 1.5,
+                "if_validated_and_multipage": global_weight_publishedcontent * 1.7,
                 "if_opinion": global_weight_publishedcontent * 1.3,
                 "if_opinion_not_picked": global_weight_publishedcontent * 1.1,
                 "title": global_weight_publishedcontent * 4,

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -1135,29 +1135,27 @@ class PublishedContent(AbstractSearchIndexableModel, TemplatableContentModelMixi
         if versioned.has_extracts():
             data["text"] = clean_html(versioned.get_content_online())
 
-        is_medium_big_tutorial = versioned.has_sub_containers()
-        data["weight"] = self._compute_search_weight(is_medium_big_tutorial)
+        is_multipage = versioned.has_sub_containers()
+        data["weight"] = self._get_search_weight(is_multipage)
 
         return data
 
-    def _compute_search_weight(self, is_medium_big_tutorial: bool):
+    def _get_search_weight(self, is_multipage: bool):
         """
-        This function calculates a weight for publishedcontent in order to sort them according to different boosts.
-        There is a boost according to the type of content (article, opinion, tutorial),
-        if it is a big tutorial or if it is picked.
+        Calculate the weight used to sort search results.
+        We make a difference between validated content (either single or multipage) and content published freely
+        (picked for the front page or not).
         """
         weights = settings.ZDS_APP["search"]["boosts"]["publishedcontent"]
 
-        if self.content_type == "ARTICLE":
-            return weights["if_article"]
-        elif self.content_type == "TUTORIAL":
-            if is_medium_big_tutorial:
-                return weights["if_medium_or_big_tutorial"]
+        if self.content.requires_validation():
+            if is_multipage:
+                return weights["if_validated_and_multipage"]
             else:
-                return weights["if_tutorial"]
+                return weights["if_validated"]
         else:
             assert self.content_type == "OPINION"
-            if self.content.sha_picked is not None:
+            if self.content.is_picked():
                 return weights["if_opinion"]
             else:
                 return weights["if_opinion_not_picked"]


### PR DESCRIPTION
Fix #6680

* distingue principalement validé ou non
* distingue les multipages de manière unifiée pour les contenus validés (identique pour article ou tuto)
* garde la distinction choisi/non choisi pour les billets

### Contrôle qualité

La CI devrait faire l'essentiel.

Tester également ce qui déclenche l'indexation/réindexaction (publication de contenus ?) pour des articles/tuto/billets.

Je connais mal le module de recherche, il y a peut-être d'autres choses à regarder.