### PR TITLE
(Profil) Corrige l'affichage des liens vers les productions du membre

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -302,7 +302,7 @@
                 {% captureas messages_count %}{% if perms.forum.change_post %}{{ profile.get_post_count_as_staff }}{% else %}{{ profile.get_post_count }}{% endif %}{% endcaptureas %}
 
                 {% with topics_count=profile.get_topic_count followed_topics_count=profile.get_followed_topic_count messages_count=messages_count|add:"0" %}
-                    {% if profile.site or profile.show_email or public_tutos_count > 0 or articles_public_count > 0 or opinions_public_count > 0 or beta_tutos_count > 0 or beta_articles_count > 0 or topics_count > 0 or messages_count > 0 %}
+                    {% if profile.site or profile.show_email or public_tutos_count > 0 or articles_public_count > 0 or opinions_public_count > 0 or content_reactions_count > 0 or contribution_tutorials_count > 0 or contribution_articles_count > 0 or beta_tutos_count > 0 or beta_articles_count > 0 or topics_count > 0 or followed_topics_count > 0 or messages_count > 0 %}
                         <div class="activity">
                             <div class="content-linkbox-list {% if profile.biography or profile.sign or profile.user == user %}is-vertical{% endif %}">
                                 {% if not hide_because_banned %}


### PR DESCRIPTION
La page de profil contient plusieurs blocs avec des liens vers les différentes productions du membre (contenus, messages et autres contributions). Ces blocs sont tous contenus dans un méga-bloc `<div class="activity">` dont l'affichage dépend d'une méga-condition. Cette méga-condition n'était pas complète, ce qui faisait que dans certains cas un bloc qui devait être affiché ne l'était pas. À terme, il faudrait réfléchir à une refonte de cette page pour ne pas avoir ce méga-bloc et donc cette méga-condition !

**QA :**
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Créer un nouvel utilisateur (via le formulaire d'inscription)
- Avec ce nouvel utilisateur, commenter un contenu
- Sur la page de profil de ce nouvel utilisateur, vérifier qu'il y a bien un lien intitulé "1 commentaire publié"