### PR TITLE
Met à jour la page d'accueil

### DIFF
--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -25,7 +25,7 @@ body {
 }
 
 // Elements with a dark background
-.flexpage-header, .write-tutorial, .page-footer, .header-menu, .header-right, .modal-title, .taglist, .hat, .linkbox-item.primary {
+.flexpage-header, .call-to-action, .page-footer, .header-menu, .header-right, .modal-title, .taglist, .hat, .linkbox-item.primary {
     &::selection, *::selection {
         @include negative-selection;
     }

--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -336,13 +336,6 @@ $content-item-padding-vertical: $length-14;
 
     color: $grey-000;
 
-    &:hover {
-        .btn-call-to-action {
-            background-color: $true-white;
-            transform: scale(1.05);
-        }
-    }
-
     .call-to-action-text {
         flex: 1;
         text-align: center;
@@ -372,6 +365,11 @@ $content-item-padding-vertical: $length-14;
         transition: color $transition-duration ease-in-out,
                     background-color $transition-duration ease-in-out,
                     transform $transition-duration ease-in-out;
+
+        &:hover {
+            background-color: $true-white;
+            transform: scale(1.05);
+        }
     }
 }
 

--- a/assets/scss/components/_content-item.scss
+++ b/assets/scss/components/_content-item.scss
@@ -8,7 +8,7 @@ $content-item-padding-vertical: $length-14;
     display: flex;
 
     width: 100%;
-    height: $content-item-height;
+    min-height: $content-item-height;
 
     margin: $length-6 $length-10;
 
@@ -321,18 +321,15 @@ $content-item-padding-vertical: $length-14;
     margin-bottom: $length-24;
 }
 
-.write-tutorial {
+.call-to-action {
     display: flex;
     align-items: center;
-
-    margin: $length-16 $length-10;
-
-    &:not(:last-child) {
-        margin-bottom: $length-20;
-    }
+    flex-wrap: wrap;
+    box-sizing: border-box;
+    padding: $length-6 $length-20;
 
     width: 100%;
-    height: $content-item-height;
+    min-height: $content-item-height;
 
     border-color: $color-primary;
     background-color: $color-primary;
@@ -340,13 +337,13 @@ $content-item-padding-vertical: $length-14;
     color: $grey-000;
 
     &:hover {
-        .btn-write-tutorial {
+        .btn-call-to-action {
             background-color: $true-white;
             transform: scale(1.05);
         }
     }
 
-    .write-tutorial-text {
+    .call-to-action-text {
         flex: 1;
         text-align: center;
 
@@ -361,9 +358,8 @@ $content-item-padding-vertical: $length-14;
         }
     }
 
-    .btn-write-tutorial {
+    .btn-call-to-action {
         padding: $length-4 $length-20;
-        margin-right: $length-24;
 
         background-color: $grey-000;
         color: $primary-900;
@@ -394,10 +390,6 @@ $content-item-padding-vertical: $length-14;
 
 @include mobile {
     .content-item {
-        &.write-tutorial {
-            display: none;
-        }
-
         .content-tags {
             display: none;
         }

--- a/templates/home.html
+++ b/templates/home.html
@@ -164,7 +164,7 @@
                             </p>
                             <p class="lead">{% trans "Pourquoi pas vous ?" %}</p>
                         </div>
-                        <a href="{% url "content:create-content" created_content_type='TUTORIAL' %}" class="btn btn-call-to-action">{% trans "Je rédige !" %}</a>
+                        <a href="{% url "content:create-content" created_content_type='OPINION' %}" class="btn btn-call-to-action">{% trans "Je rédige !" %}</a>
                     </div>
                     {% for opinion in last_opinions %}
                         {% include 'tutorialv2/includes/content_item.part.html' with public_content=opinion show_description=True item_class=forloop.first|yesno:", mini" show_reactions=True ignore_categories=True %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -109,40 +109,38 @@
                 {% endfor %}
             </div>
         </section>
+
         <div class="home-row">
             <section itemscope itemtype="http://schema.org/ItemList">
                 <h2 class="ico-after ico-tutorials home-heading" itemprop="name">
-                    <span>{% trans "Derniers tutoriels" %}</span>
-                    <a href="{% url 'publication:list' %}?type=tutorial" class="btn btn-grey">{% trans "Tous les tutoriels" %}</a>
+                    <span>{% trans "Dernières pépites validées par l'équipe" %}</span>
                 </h2>
 
                 <meta itemprop="itemListOrder" content="Descending">
-
-                {% include "tutorialv2/list_page_elements/list_of_online_contents.html" with public_contents=last_tutorials col_number=1 ignore_categories=True %}
-            </section>
-
-            <section itemscope itemtype="http://schema.org/ItemList">
-                <h2 class="ico-after ico-articles home-heading" itemprop="name">
-                    <span>{% trans "Derniers articles" %}</span>
-                    <a href="{% url 'publication:list' %}?type=article" class="btn btn-grey">{% trans "Tous les articles" %}</a>
-                </h2>
-
-                <meta itemprop="itemListOrder" content="Descending">
-
-                {% include "tutorialv2/list_page_elements/list_of_online_contents.html" with public_contents=last_articles col_number=1 ignore_categories=True %}
 
                 <div class="content-item-list">
-
-                    <div class="content-item write-tutorial">
-                        <div class="write-tutorial-text">
-                            <p>
-                                {% blocktrans with plural=contents_count|pluralize_fr %}
-                                    Il y a {{ contents_count }} publication{{ plural }} sur Zeste de Savoir.
-                                {% endblocktrans %}
-                            </p>
-                            <p class="lead">{% trans "Pourquoi pas la vôtre ?" %}</p>
+                    {% for content in last_contents %}
+                        {% include "tutorialv2/includes/content_item.part.html" with public_content=content show_description=True show_reactions=True ignore_categories=ignore_categories %}
+                    {% endfor %}
+                    <div class="content-item call-to-action">
+                        <div class="call-to-action-text">
+                                <p>
+                                    {% blocktrans with plural=contents_count|pluralize_fr %}
+                                        Mais ce n'est pas tout...
+                                    {% endblocktrans %}
+                                </p>
+                            <p class="lead">
+                                {% if validated_contents_count == 0 %}
+                                    {% blocktrans %}
+                                         Il y a {{ validated_contents_count }} publication validée par l'équipe.</p>
+                                    {% endblocktrans %}
+                                {% else %}
+                                    {% blocktrans %}
+                                         Il y a {{ validated_contents_count }} publications validées par l'équipe.</p>
+                                    {% endblocktrans %}
+                                {% endif %}
                         </div>
-                        <a href="{% url "content:create-content" created_content_type='TUTORIAL' %}" class="btn btn-write-tutorial">{% trans "Commencer à rédiger" %}</a>
+                         <a href="{% url "publication:list" %}" class="btn btn-call-to-action">{% trans "Montre-les moi !" %}</a>
                     </div>
                 </div>
             </section>
@@ -151,25 +149,46 @@
         <div class="home-row">
             <section itemscope itemtype="http://schema.org/ItemList">
                 <h2 class="ico-after ico-opinions home-heading" itemprop="name">
-                    <span>{% trans "Derniers billets choisis" %}</span>
-                    <a href="{% url "opinion:list" %}" class="btn btn-grey">{% trans "Tous les billets" %}</a>
+                    <span>{% trans "Dernières publications de la communauté" %}</span>
                 </h2>
 
                 <meta itemprop="itemListOrder" content="Descending">
 
                 <div class="content-item-list">
+                    <div class="content-item call-to-action">
+                        <div class="call-to-action-text">
+                            <p>
+                                {% blocktrans with plural=contents_count|pluralize_fr %}
+                                    Il y a {{ contents_count }} publication{{ plural }} sur Zeste de Savoir.
+                                {% endblocktrans %}
+                            </p>
+                            <p class="lead">{% trans "Pourquoi pas la vôtre ?" %}</p>
+                        </div>
+                        <a href="{% url "content:create-content" created_content_type='TUTORIAL' %}" class="btn btn-call-to-action">{% trans "Commencer à rédiger" %}</a>
+                    </div>
                     {% for opinion in last_opinions %}
                         {% include 'tutorialv2/includes/content_item.part.html' with public_content=opinion show_description=True item_class=forloop.first|yesno:", mini" show_reactions=True ignore_categories=True %}
                     {% empty %}
                         <p>{% trans "Aucun billet disponible." %}</p>
                     {% endfor %}
+                    <div class="content-item call-to-action">
+                        <div class="call-to-action-text">
+                                <p>
+                                    {% blocktrans with plural=contents_count|pluralize_fr %}
+                                       D’autres publications de la communauté vous attendent.
+                                    {% endblocktrans %}
+                                </p>
+                        </div>
+                        <a href="{% url "opinion:list" %}" class="btn btn-call-to-action">{% trans "Fais voir !" %}</a>
+                    </div>
                 </div>
             </section>
+        </div>
 
+        <div class="home-row">
             <section itemscope itemtype="http://schema.org/ItemList">
                 <h2 class="home-heading ico-after ico-forum" itemprop="name">
-                    <span>{% trans "Derniers sujets" %}</span>
-                    <a href="{% url "forum:last-subjects" %}" class="btn btn-grey">{% trans "En voir plus" %}</a>
+                    <span>{% trans "En direct du forum" %}</span>
                 </h2>
 
                 <meta itemprop="itemListOrder" content="Descending">
@@ -180,6 +199,16 @@
                     {% empty %}
                         <p>{% trans "Aucun sujet disponible." %}</p>
                     {% endfor %}
+                    <div class="content-item call-to-action">
+                        <div class="call-to-action-text">
+                                <p>
+                                    {% blocktrans with plural=contents_count|pluralize_fr %}
+                                       Entraide, débats, discussions : venez sur nos forums !
+                                    {% endblocktrans %}
+                                </p>
+                        </div>
+                        <a href="{% url "forum:cats-forums-list" %}" class="btn btn-call-to-action">{% trans "Je participe" %}</a>
+                    </div>
                 </div>
             </section>
         </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -158,13 +158,13 @@
                     <div class="content-item call-to-action">
                         <div class="call-to-action-text">
                             <p>
-                                {% blocktrans with plural=contents_count|pluralize_fr %}
-                                    Il y a {{ contents_count }} publication{{ plural }} sur Zeste de Savoir.
+                                {% blocktrans %}
+                                    Tout le monde peut publier sur Zeste de Savoir.
                                 {% endblocktrans %}
                             </p>
-                            <p class="lead">{% trans "Pourquoi pas la vôtre ?" %}</p>
+                            <p class="lead">{% trans "Pourquoi pas vous ?" %}</p>
                         </div>
-                        <a href="{% url "content:create-content" created_content_type='TUTORIAL' %}" class="btn btn-call-to-action">{% trans "Commencer à rédiger" %}</a>
+                        <a href="{% url "content:create-content" created_content_type='TUTORIAL' %}" class="btn btn-call-to-action">{% trans "Je rédige !" %}</a>
                     </div>
                     {% for opinion in last_opinions %}
                         {% include 'tutorialv2/includes/content_item.part.html' with public_content=opinion show_description=True item_class=forloop.first|yesno:", mini" show_reactions=True ignore_categories=True %}
@@ -175,7 +175,7 @@
                         <div class="call-to-action-text">
                                 <p>
                                     {% blocktrans with plural=contents_count|pluralize_fr %}
-                                       D’autres publications de la communauté vous attendent.
+                                       Des centaines d’autres publications vous attendent…
                                     {% endblocktrans %}
                                 </p>
                         </div>
@@ -207,7 +207,7 @@
                                     {% endblocktrans %}
                                 </p>
                         </div>
-                        <a href="{% url "forum:cats-forums-list" %}" class="btn btn-call-to-action">{% trans "Je participe" %}</a>
+                        <a href="{% url "forum:cats-forums-list" %}" class="btn btn-call-to-action">{% trans "Je participe  !" %}</a>
                     </div>
                 </div>
             </section>

--- a/zds/featured/managers.py
+++ b/zds/featured/managers.py
@@ -14,12 +14,8 @@ class FeaturedResourceManager(models.Manager):
     Custom featured resource manager.
     """
 
-    def get_last_featured(self):
-        return (
-            self.order_by("-pubdate")
-            .exclude(pubdate__gt=datetime.now())
-            .prefetch_related("authors__user")[: settings.ZDS_APP["featured_resource"]["home_number"]]
-        )
+    def get_last_featured(self, count):
+        return self.order_by("-pubdate").exclude(pubdate__gt=datetime.now()).prefetch_related("authors__user")[:count]
 
 
 class FeaturedMessageManager(models.Manager):

--- a/zds/forum/managers.py
+++ b/zds/forum/managers.py
@@ -1,4 +1,3 @@
-import django.db.models
 from django.db import models
 from django.db.models import F, Q
 from model_utils.managers import InheritanceManager
@@ -85,7 +84,7 @@ class TopicManager(models.Manager):
     def get_beta_topic_of(self, tutorial):
         return self.filter(key=tutorial.pk, key__isnull=False).first()
 
-    def get_last_topics(self, count) -> django.db.models.QuerySet:
+    def get_last_topics(self, count) -> models.QuerySet:
         """Get last topics and prefetch some related properties."""
         return (
             self.filter(is_locked=False, forum__groups__isnull=True)

--- a/zds/forum/managers.py
+++ b/zds/forum/managers.py
@@ -1,9 +1,7 @@
-from django.conf import settings
+import django.db.models
 from django.db import models
 from django.db.models import F, Q
 from model_utils.managers import InheritanceManager
-
-from zds.utils import get_current_user
 
 
 class ForumManager(models.Manager):
@@ -65,17 +63,13 @@ class TopicManager(models.Manager):
     """
 
     def visibility_check_query(self, current_user):
-        """
-        Build a subquery that checks if a topic is readable by current user
-        :param current_user:
-        :return:
-        """
+        """Build a subquery that checks if a topic is readable by current user"""
         if current_user.is_authenticated:
             return Q(forum__groups__isnull=True) | Q(forum__groups__pk__in=current_user.profile.group_pks)
         else:
             return Q(forum__groups__isnull=True)
 
-    def last_topics_of_a_member(self, author, user):
+    def last_topics_of_a_member(self, author, user, count):
         """
         Gets last topics of a member but exclude all topics not accessible
         for the request user.
@@ -86,24 +80,19 @@ class TopicManager(models.Manager):
         queryset = self.filter(author=author).prefetch_related("author")
         queryset = queryset.filter(self.visibility_check_query(user)).distinct()
 
-        return queryset.order_by("-pubdate").all()[: settings.ZDS_APP["forum"]["home_number"]]
+        return queryset.order_by("-pubdate").all()[:count]
 
     def get_beta_topic_of(self, tutorial):
         return self.filter(key=tutorial.pk, key__isnull=False).first()
 
-    def get_last_topics(self):
-        """
-        Get last posted topics and prefetch some related properties.
-        Depends on settings.ZDS_APP['topic']['home_number']
-        :return:
-        :rtype: django.models.Queryset
-        """
+    def get_last_topics(self, count) -> django.db.models.QuerySet:
+        """Get last topics and prefetch some related properties."""
         return (
             self.filter(is_locked=False, forum__groups__isnull=True)
             .select_related("forum", "author", "author__profile", "last_message")
             .prefetch_related("tags")
             .order_by("-pubdate")
-            .all()[: settings.ZDS_APP["topic"]["home_number"]]
+            .all()[:count]
         )
 
     def get_all_topics_of_a_forum(self, forum_pk, is_sticky=False):

--- a/zds/forum/tests/tests.py
+++ b/zds/forum/tests/tests.py
@@ -8,14 +8,7 @@ from django.urls import reverse
 
 from zds.forum.commons import PostEditMixin
 from zds.forum.models import Forum, Post, Topic, TopicRead
-from zds.forum.tests.factories import (
-    ForumCategoryFactory,
-    ForumFactory,
-    PostFactory,
-    TagFactory,
-    TopicFactory,
-    create_category_and_forum,
-)
+from zds.forum.tests.factories import ForumCategoryFactory, ForumFactory, PostFactory, TagFactory, TopicFactory
 from zds.forum.utils import get_tag_by_title
 from zds.member.tests.factories import ProfileFactory, StaffProfileFactory
 from zds.notification.models import TopicAnswerSubscription
@@ -1182,7 +1175,7 @@ class ManagerTests(TestCase):
         TopicFactory(forum=self.forum3, author=self.staff.user)
 
     def test_get_last_topics(self):
-        topics = Topic.objects.get_last_topics()
+        topics = Topic.objects.get_last_topics(5)
         self.assertEqual(2, len(topics))
 
     def test_get_unread_post(self):

--- a/zds/forum/tests/tests_views.py
+++ b/zds/forum/tests/tests_views.py
@@ -95,7 +95,8 @@ class CategoriesForumsListViewTests(TestCase):
         _, forum = create_category_and_forum()
         topic = create_topic_in_forum(forum, profile)
 
-        topics_nb = len(Topic.objects.get_last_topics())
+        topics_count = 5
+        topics_nb = len(Topic.objects.get_last_topics(topics_count))
 
         self.client.force_login(staff.user)
         data = {"lock": "true", "topic": topic.pk}
@@ -104,7 +105,7 @@ class CategoriesForumsListViewTests(TestCase):
         self.assertEqual(302, response.status_code)
         self.assertTrue(Topic.objects.get(pk=topic.pk).is_locked)
 
-        self.assertEqual(len(Topic.objects.get_last_topics()), topics_nb - 1)
+        self.assertEqual(len(Topic.objects.get_last_topics(topics_count)), topics_nb - 1)
 
 
 class CategoryForumsDetailViewTest(TestCase):

--- a/zds/member/views/profile.py
+++ b/zds/member/views/profile.py
@@ -137,7 +137,8 @@ class MemberDetail(DetailView):
         usr = context["usr"]
         profile = usr.profile
         context["profile"] = profile
-        context["topics"] = list(Topic.objects.last_topics_of_a_member(usr, self.request.user))
+        topics_count = settings.ZDS_APP["member"]["topics_on_profile"]
+        context["topics"] = list(Topic.objects.last_topics_of_a_member(usr, self.request.user, count=topics_count))
         followed_query_set = TopicAnswerSubscription.objects.get_objects_followed_by(self.request.user.id)
         followed_topics = list(set(followed_query_set) & set(context["topics"]))
         for topic in context["topics"]:

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -37,6 +37,7 @@ def home(request):
         "contents_count": PublishedContent.objects.count_contents(),
         "search_form": SearchForm(initial={}),
         "validated_contents_count": PublishedContent.objects.count_validated_contents(),
+        "quote": random.choice(QUOTES).replace("\n", ""),
     }
 
     contents_count = settings.ZDS_APP["homepage"]["contents_count"]
@@ -50,8 +51,6 @@ def home(request):
 
     topics_count = settings.ZDS_APP["homepage"]["topics_count"]
     context["last_topics"] = Topic.objects.get_last_topics(topics_count)
-
-    context["quote"] = random.choice(QUOTES).replace("\n", "")
 
     return render(request, "home.html", context)
 

--- a/zds/pages/views.py
+++ b/zds/pages/views.py
@@ -30,28 +30,30 @@ except OSError:
 
 
 def home(request):
-    """Display the home page with last topics added."""
+    """Display the home page."""
 
-    tutos = PublishableContent.objects.get_last_tutorials()
-    articles = PublishableContent.objects.get_last_articles()
-    opinions = PublishableContent.objects.get_last_opinions()
-    quote = random.choice(QUOTES)
+    context = {
+        "featured_message": FeaturedMessage.objects.get_last_message(),
+        "contents_count": PublishedContent.objects.count_contents(),
+        "search_form": SearchForm(initial={}),
+        "validated_contents_count": PublishedContent.objects.count_validated_contents(),
+    }
 
-    return render(
-        request,
-        "home.html",
-        {
-            "featured_message": FeaturedMessage.objects.get_last_message(),
-            "last_tutorials": tutos,
-            "last_articles": articles,
-            "last_opinions": opinions,
-            "last_featured_resources": FeaturedResource.objects.get_last_featured(),
-            "last_topics": Topic.objects.get_last_topics(),
-            "contents_count": PublishedContent.objects.get_contents_count(),
-            "quote": quote.replace("\n", ""),
-            "search_form": SearchForm(initial={}),
-        },
-    )
+    contents_count = settings.ZDS_APP["homepage"]["contents_count"]
+    context["last_contents"] = PublishableContent.objects.get_last_contents(contents_count)
+
+    opinions_count = settings.ZDS_APP["homepage"]["opinions_count"]
+    context["last_opinions"] = PublishableContent.objects.get_last_opinions(opinions_count)
+
+    features_count = settings.ZDS_APP["homepage"]["features_count"]
+    context["last_featured_resources"] = FeaturedResource.objects.get_last_featured(features_count)
+
+    topics_count = settings.ZDS_APP["homepage"]["topics_count"]
+    context["last_topics"] = Topic.objects.get_last_topics(topics_count)
+
+    context["quote"] = random.choice(QUOTES).replace("\n", "")
+
+    return render(request, "home.html", context)
 
 
 def index(request):
@@ -59,7 +61,7 @@ def index(request):
 
 
 def about(request):
-    """Display many informations about the website."""
+    """Display many information about the website."""
     return render(
         request,
         "pages/technologies.html",

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -145,6 +145,7 @@ ZDS_APP = {
         "users_in_hats_list": 5,
         "requested_hats_per_page": 100,
         "update_last_visit_interval": 600,  # seconds
+        "topics_on_profile": 5,
     },
     "hats": {
         "moderation": "Staff",
@@ -156,12 +157,13 @@ ZDS_APP = {
         "gallery_per_page": 21,
         "images_per_page": 21,
     },
-    "tutorial": {
-        "home_number": 4,
+    "homepage": {
+        "contents_count": 5,
+        "opinions_count": 4,
+        "topics_count": 5,
+        "features_count": 5,
     },
-    "article": {"home_number": 3},
     "opinions": {
-        "home_number": 5,
         "allow_pdf": zds_config.get("opinions_allow_pdf", True),
         "allow_epub": zds_config.get("opinions_allow_epub", True),
         "allow_zip": zds_config.get("opinions_allow_zip", True),
@@ -210,7 +212,6 @@ ZDS_APP = {
         "beta_forum_id": zds_config.get("publications_being_written_forum_id", 1),
         "max_post_length": 1000000,
         "top_tag_max": 5,
-        "home_number": 6,
         "old_post_limit_days": 90,
         # Exclude tags from top tags list. Tags listed here should not be relevant for most of users.
         # Be warned exclude too much tags can restrict performance
@@ -219,15 +220,11 @@ ZDS_APP = {
         "description_size": 120,
         "max_similar_topics": 10,
     },
-    "topic": {
-        "home_number": 5,
-    },
     "comment": {
         "max_pings": 15,
     },
     "featured_resource": {
         "featured_per_page": 100,
-        "home_number": 5,
         "request_per_page": 50,
     },
     "notification": {

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -159,7 +159,7 @@ ZDS_APP = {
     },
     "homepage": {
         "contents_count": 5,
-        "opinions_count": 4,
+        "opinions_count": 6,
         "topics_count": 5,
         "features_count": 5,
     },

--- a/zds/tutorialv2/managers.py
+++ b/zds/tutorialv2/managers.py
@@ -86,11 +86,11 @@ class PublishedContentManager(models.Manager):
     def last_opinions_of_a_member_loaded(self, author):
         return self.last_contents_of_a_member_loaded(author, _type="OPINION")
 
-    def get_contents_count(self):
-        """
-        :rtype: int
-        """
+    def count_contents(self) -> int:
         return self.filter(must_redirect=False).count()
+
+    def count_validated_contents(self) -> int:
+        return self.filter(must_redirect=False, content_type__in=["ARTICLE", "TUTORIAL"]).count()
 
     def get_top_tags(self, displayed_types, limit=-1):
         """
@@ -203,32 +203,7 @@ class PublishableContentManager(models.Manager):
                     content.sha_draft = sha
                     content.save()
 
-    def get_last_tutorials(self, number=0):
-        """
-        get list of last published tutorial
-
-        :param number: number of tutorial you want. By default it is interpreted as \
-        ``settings.ZDS_APP['tutorial']['home_number']``
-        :return: list of last published content
-        :rtype: list
-        """
-        number = number or settings.ZDS_APP["tutorial"]["home_number"]
-        all_contents = (
-            self.filter(type="TUTORIAL")
-            .filter(public_version__isnull=False)
-            .prefetch_related("authors")
-            .select_related("public_version")
-            .prefetch_related("subcategory")
-            .prefetch_related("tags")
-            .order_by("-public_version__publication_date")[:number]
-        )
-        published = []
-        for content in all_contents:
-            content.public_version.content = content
-            published.append(content.public_version)
-        return published
-
-    def get_last_articles(self, number=0):
+    def get_last_contents(self, number):
         """
         ..attention:
             this one uses a raw subquery for historical reasons. It will hopefully be replaced one day by an
@@ -244,9 +219,8 @@ class PublishableContentManager(models.Manager):
             "utils_comment.id",
             "tutorialv2_contentreaction.comment_ptr_id",
         )
-        number = number or settings.ZDS_APP["article"]["home_number"]
         all_contents = (
-            self.filter(type="ARTICLE")
+            self.filter(type__in=["ARTICLE", "TUTORIAL"])
             .filter(public_version__isnull=False)
             .prefetch_related("authors")
             .select_related("last_note")
@@ -263,14 +237,13 @@ class PublishableContentManager(models.Manager):
             published.append(content.public_version)
         return published
 
-    def get_last_opinions(self):
+    def get_last_opinions(self, count):
         """
         This depends on settings.ZDS_APP['opinions']['home_number'] parameter.
 
         :return: list of last opinions
         :rtype: list
         """
-        home_number = settings.ZDS_APP["opinions"]["home_number"]
         all_contents = (
             self.filter(type="OPINION")
             .filter(public_version__isnull=False, sha_picked=F("sha_public"))
@@ -279,7 +252,7 @@ class PublishableContentManager(models.Manager):
             .select_related("public_version")
             .prefetch_related("subcategory")
             .prefetch_related("tags")
-            .order_by("-public_version__publication_date")[:home_number]
+            .order_by("-public_version__publication_date")[:count]
         )
         published = []
         for content in all_contents:


### PR DESCRIPTION
Cette PR mets à jour la page d'accueil.

* fait correspondre la structure de la page d'accueil à la future organisation "validé/libre" pour les publications
* rend la page plus joueuse avec des "call to actions"
* regroupe les paramètres de configuration dans leur propre section
* refactorise les fonctions de récupération de données pour qu'elles ne dépendent plus directement de certaines configurations

C'est dans le cadre de la refonte du parcours de validation. J'aimerais découper ça en morceaux digestes pour le développement et la QA. Je pense que cette partie es autoporteuse.

![image](https://github.com/user-attachments/assets/a235025b-7dd7-418d-8b1e-fa6f53b8be1a)


### Contrôle qualité

Vérifier que le bloc "pépites de l'équipe" contient bien à la fois les tutos et les articles.

Vérifier que les liens fonctionnent

Vérifier les différentes tailles d'écran et que ça reste lisible

Vérifier que j'ai pas cassé la page de profil en refactorisant les paramètres de configuration