### PR TITLE
Corrige la position du pied de page quand une bannière est présente

### DIFF
--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -42,6 +42,14 @@ body {
 
     min-height: 100vh;
 
+    .has-top-banner & {
+        // Remove banner height from minimal page height
+        // Banner height formula :
+        // font-size (defined in #very-top-banner button) * line-height (inherited from button)
+        //  + border-bottom-width (defined in #very-top-banner)
+        min-height: calc(100vh - ($font-size-6 * 1.15 + $length-2) - .2rem);
+    }
+
     .main-container {
         display: flex;
 


### PR DESCRIPTION
Sur les pages ayant peu de contenu et lorsqu'une bannière est affichée en haut de l'écran, le pied de page est maintenant bien aligné avec le bas de l'écran, évitant l'apparition d'une barre de défilement verticale.

Le pied de page était auparavant, lors de l'affichage d'une bannière, décalé vers le bas de la hauteur de la bannière, apparaissant ainsi hors de l'écran et créant une barre de défilement.
<!-- Décrivez vos changements ici (optionnel pour les tous petits changements). -->

<!-- Remplacez XXXX par le numéro de ticket corrigé par vos changements : GitHub fermera le ticket mentionné automatiquement (voir https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue pour plus de détails). Supprimez la ligne s'il n'y a pas de ticket associé. --!>
Fix #6525

<!-- Si votre PR modifie du code Python, mettez à jour ou créez les tests unitaires associés. Signalez vos éventuelles difficultés afin que des contributeurs expérimentés puissent vous aider. -->

<!-- Si votre pull request requiert des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->

### Contrôle qualité

- Visitez la page `/pages/` sur un environnement où une bannière est présente (version locale ou version bêta par exemple).
- Le bas du pied de page doit être exactement aligné avec le bas de l'écran, et aucune barre de défilement verticale ne doit apparaître.
- Fermez la bannière à l'aide de la croix et vérifiez que le positionnement est toujours correct.

<!-- Donnez des instructions pour nous aider à vérifier vos changements.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

<!-- Merci ! -->
