### PR TITLE
Augmente la hauteur de ligne pour augmenter la lisibilité des diffs

### DIFF
--- a/assets/scss/base/_tables.scss
+++ b/assets/scss/base/_tables.scss
@@ -61,7 +61,7 @@ table {
         font-size: $font-size-10;
 
         tr {
-            line-height: 1;
+            line-height: 1.2;
             border-bottom: none;
         }
 


### PR DESCRIPTION
Récemment, en regardant les diff des tutoriels qui sont mis à jour, je me suis rendu compte que parfois le texte était illisible à cause d'une line-height trop faible
![image](https://github.com/user-attachments/assets/7428cbc1-12ac-4e17-9854-141c65e45342)

### Contrôle qualité

- Créer un tutoriel ou un article 
- Le publier
- Le modifier, pour ajouter la phrase suivante
```
[[information]]
| Les domaines à deux lettres sont exclusivement réservés aux pays. On parle alors de **ccTLD**, pour Country Code Level Top Domain. Vous croyiez que le .tv faisait référence à la télévision ? Perdu, il s'agit de l'État des Tuvalu ! Ce petit pays d'Océanie risque de disparaitre à cause de la montée des eaux, ce qui pourrait avoir pour conséquence... la disparition du domaine .tv ! :'( Un tel phénomène peut arriver sans crier gare : en octobre 2024, le Royaume-Uni a cédé à la république de Maurice (un archipel de l'océan Indien) un territoire disputé de longue date. Problème : le domaine .io était affecté à ce territoire, dont le nouveau statut ne permet pas de conserver son propre ccTLD ! Cet accord politique a, possiblement sans qu'aucun responsable ne s'en rende compte, creusé la tombe du domaine .io.
```
- Voir le différentiel des versions
- S'assurer que désormais les lettres descendants (p, q...) sont bien lisibles.



<!-- Merci ! -->
