### PR TITLE
Ne lève pas une 500 s'il manque un paramètre GET dans la recherche

### DIFF
--- a/templates/tutorialv2/view/base_categories.html
+++ b/templates/tutorialv2/view/base_categories.html
@@ -118,8 +118,7 @@
                             <form action="{% url 'search:query' %}" id="search-form" class="search" method="get">
                                 <label for="search-content" class="control-label">{% trans 'Recherche' %}</label>
                                 <input id="search-content" maxlength="150" name="q" required="required" type="search" placeholder="{% trans 'dans' %} {% if subcategory %}{{ subcategory.title }}{% elif category %}{{ category.title }}{% else %}{% trans 'la bibliothèque' %}{% endif %}">
-                                <input type="hidden" name="models" value="content">
-                                <input type="hidden" name="from_library" value="on">
+                                <input type="hidden" name="models" value="publishedcontent">
                                 {% if category %}
                                     <input type="hidden" name="category" value="{{ category.slug }}">
                                     {% if subcategory %}

--- a/zds/search/forms.py
+++ b/zds/search/forms.py
@@ -54,18 +54,19 @@ class SearchForm(forms.Form):
         """Override clean() to add a field containing collections we have actually to search into."""
         cleaned_data = super().clean()
 
-        if len(cleaned_data["models"]) == 0:
-            # Search in all collections
-            cleaned_data["search_collections"] = [
-                c for _, v in settings.ZDS_APP["search"]["search_groups"].items() for c in v[1]
-            ]
-        else:
-            # Search in collections of selected models
-            cleaned_data["search_collections"] = [
-                c
-                for k, v in settings.ZDS_APP["search"]["search_groups"].items()
-                for c in v[1]
-                if k in cleaned_data["models"]
-            ]
+        if self.is_valid():
+            if len(cleaned_data.get("models", [])) == 0:
+                # Search in all collections
+                cleaned_data["search_collections"] = [
+                    c for _, v in settings.ZDS_APP["search"]["search_groups"].items() for c in v[1]
+                ]
+            else:
+                # Search in collections of selected models
+                cleaned_data["search_collections"] = [
+                    c
+                    for k, v in settings.ZDS_APP["search"]["search_groups"].items()
+                    for c in v[1]
+                    if k in cleaned_data["models"]
+                ]
 
         return cleaned_data

--- a/zds/search/tests/tests_views.py
+++ b/zds/search/tests/tests_views.py
@@ -212,6 +212,11 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertEqual(len(result.context["object_list"]), 0)
 
+        # Check if the request contains an invalid models field:
+        result = self.client.get(reverse("search:query") + "?q=latex&models=", follow=False)
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(len(result.context["object_list"]), 0)
+
     def test_get_similar_topics(self):
         """Get similar topics lists"""
 

--- a/zds/search/views.py
+++ b/zds/search/views.py
@@ -135,9 +135,6 @@ class SearchView(ZdSPagingListView):
 
         self.search_form = SearchForm(data=self.request.GET)
 
-        if self.search_query and not self.search_form.is_valid():
-            raise PermissionDenied("research form is invalid")
-
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self):
@@ -147,6 +144,9 @@ class SearchView(ZdSPagingListView):
 
         if not search_engine_manager.connected:
             messages.warning(self.request, _("Impossible de se connecter au moteur de recherche"))
+        elif not self.search_form.is_valid():
+            # it can happen for instance if the model field doesn't match any possible search group (eg, &model=).
+            messages.warning(self.request, _("Votre recherche est invalide."))
         elif self.search_query and "*" in self.search_query:
             # '*' is used as the search string to return all documents:
             # https://typesense.org/docs/0.23.1/api/search.html#query-parameters


### PR DESCRIPTION
Il est possible d'ajouter un paramètre `GET` `models` lors d'une recherche, pour spécifier dans quels modèles chercher (pour par exemple restreindre les résultats aux messages sur le forum).

Mettre une valeur invalide dans ce paramètre provoquait une erreur 500, cette PR corrige le problème.

Signalé par Sentry.

### Contrôle qualité

- Faire une recherche normale (qui cherche dans tous les modèles : c'est le comportement par défaut)
- Faire des recherches en se restreignant à des modèles
- Récupérer l'URL qui contient un paramètre `GET` `models` et remplacer la valeur par n'importe quoi : il ne doit pas y avoir d'erreur 500, mais un message d'erreur.
