### PR TITLE
Permet de chercher les contenus dans les (sous-)catégories

### DIFF
--- a/zds/search/forms.py
+++ b/zds/search/forms.py
@@ -8,6 +8,8 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+from zds.utils.models import Category, SubCategory
+
 
 class SearchForm(forms.Form):
     q = forms.CharField(
@@ -25,6 +27,15 @@ class SearchForm(forms.Form):
         widget=forms.CheckboxSelectMultiple(attrs={"class": "search-filters", "form": "search-form"}),
         required=False,
         choices=model_choices,
+    )
+
+    category = forms.CharField(  # actually the slug of the category
+        max_length=Category._meta.get_field("slug").max_length,
+        required=False,
+    )
+    subcategory = forms.CharField(  # actually the slug of the subcategory
+        max_length=SubCategory._meta.get_field("slug").max_length,
+        required=False,
     )
 
     def __init__(self, *args, **kwargs):

--- a/zds/search/tests/tests_views.py
+++ b/zds/search/tests/tests_views.py
@@ -22,6 +22,7 @@ from zds.tutorialv2.tests.factories import (
     SubCategoryFactory,
     publish_content,
 )
+from zds.utils.tests.factories import CategoryFactory
 
 overridden_zds_app = deepcopy(settings.ZDS_APP)
 overridden_zds_app["content"]["extra_content_generation_policy"] = "NONE"
@@ -38,6 +39,8 @@ class ViewsTests(TutorialTestMixin, TestCase):
         settings.ZDS_APP["member"]["bot_account"] = self.mas.username
 
         self.category, self.forum = create_category_and_forum()
+
+        self.tag = TagFactory(title="Clémentine à pépins")  # with accents to make a different slug
 
         self.user = ProfileFactory().user
         self.staff = StaffProfileFactory().user
@@ -58,33 +61,19 @@ class ViewsTests(TutorialTestMixin, TestCase):
                 continue
             self.manager.indexing_of_model(model, force_reindexing=True, verbose=False)
 
-    def test_basic_search(self):
-        """Basic search and filtering"""
-
-        tag = TagFactory(title="Clémentine à pépins")  # with accents to make a different slug
-
-        # 1. Index and test search:
-        text = "test"
-
-        topic_1 = TopicFactory(forum=self.forum, author=self.user, title=text)
-        topic_1.tags.add(tag)
-        post_1 = PostFactory(topic=topic_1, author=self.user, position=1)
-        post_1.text = post_1.text_html = text
-        post_1.save()
-
-        # create a middle-size content and publish it
+    def _create_tutorial(self, text):
         tuto = PublishableContentFactory(type="TUTORIAL")
         tuto_draft = tuto.load_version()
 
-        tuto.tags.add(tag)
+        tuto.tags.add(self.tag)
         tuto.title = text
         tuto.authors.add(self.user)
         tuto.save()
 
         tuto_draft.repo_update_top_container(text, tuto.slug, text, text)  # change title to be sure it will match
 
-        chapter1 = ContainerFactory(parent=tuto_draft, db_object=tuto)
-        extract = ExtractFactory(container=chapter1, db_object=tuto)
+        chapter = ContainerFactory(parent=tuto_draft, db_object=tuto)
+        extract = ExtractFactory(container=chapter, db_object=tuto)
         extract.repo_update(text, text)
 
         published = publish_content(tuto, tuto_draft, is_major_update=True)
@@ -93,6 +82,22 @@ class ViewsTests(TutorialTestMixin, TestCase):
         tuto.sha_draft = tuto_draft.current_version
         tuto.public_version = published
         tuto.save()
+
+        return tuto, chapter
+
+    def test_basic_search(self):
+        """Basic search and filtering"""
+
+        text = "test"
+
+        topic_1 = TopicFactory(forum=self.forum, author=self.user, title=text)
+        topic_1.tags.add(self.tag)
+        post_1 = PostFactory(topic=topic_1, author=self.user, position=1)
+        post_1.text = post_1.text_html = text
+        post_1.save()
+
+        # create a middle-size content and publish it
+        tuto1, chapter1 = self._create_tutorial(text)
 
         # nothing has been indexed yet:
         results = self.manager.search("*")
@@ -115,13 +120,13 @@ class ViewsTests(TutorialTestMixin, TestCase):
         # may contain or not these tags.
         content_search_results = result.content.decode()[result.content.decode().find("search-results") :]
         # The tag appears 2 times: in two search results
-        self.assertEqual(content_search_results.count(tag.title), 2)
-        self.assertEqual(content_search_results.count(tag.slug), 2)
+        self.assertEqual(content_search_results.count(self.tag.title), 2)
+        self.assertEqual(content_search_results.count(self.tag.slug), 2)
 
-        # 2. Test filtering:
+        # Test filtering:
         topic_1 = Topic.objects.get(pk=topic_1.pk)
         post_1 = Post.objects.get(pk=post_1.pk)
-        published = PublishedContent.objects.get(pk=published.pk)
+        published = PublishedContent.objects.get(pk=tuto1.public_version.pk)
 
         ids = {
             "topic": [topic_1.search_engine_id],
@@ -145,7 +150,51 @@ class ViewsTests(TutorialTestMixin, TestCase):
         result = self.client.get(reverse("search:query") + "?q=-c", follow=False)
         self.assertEqual(result.status_code, 200)
 
-    def test_search_many_pages(self):
+    def test_search_category_filter(self):
+        """Search in published contents of a specific category (form on the page of a category of contents)"""
+
+        text = "test"
+
+        cat1 = CategoryFactory()
+        subcat11 = SubCategoryFactory(category=cat1)
+        subcat12 = SubCategoryFactory(category=cat1)
+        cat2 = CategoryFactory()
+        subcat21 = SubCategoryFactory(category=cat2)
+
+        tuto1, _ = self._create_tutorial(text)
+        tuto1.subcategory.add(subcat11)
+        tuto1.save()
+
+        tuto2, _ = self._create_tutorial(text)
+        tuto2.subcategory.add(subcat12)
+        tuto2.save()
+
+        tuto3, _ = self._create_tutorial(text)
+        tuto3.subcategory.add(subcat21)
+        tuto3.save()
+
+        # index
+        self._index_everything()
+
+        # no filter on (sub)categories
+        result = self.client.get(reverse("search:query") + "?q=" + text, follow=False)
+        self.assertEqual(result.status_code, 200)
+        response = result.context["object_list"]
+        self.assertEqual(len(response), 6)  # get 6 results (3 tutorials and each tutorial has one chapter)
+
+        # filter on categories
+        result = self.client.get(reverse("search:query") + "?q=" + text + "&category=" + cat1.slug, follow=False)
+        self.assertEqual(result.status_code, 200)
+        response = result.context["object_list"]
+        self.assertEqual(len(response), 4)  # get 4 results (2 tutorials and each tutorial has one chapter)
+
+        # filter on subcategories
+        result = self.client.get(reverse("search:query") + "?q=" + text + "&subcategory=" + subcat11.slug, follow=False)
+        self.assertEqual(result.status_code, 200)
+        response = result.context["object_list"]
+        self.assertEqual(len(response), 2)  # get 2 results (1 tutorial and with one chapter)
+
+    def test_search_pagination_of_results(self):
         text = "foo"
         url = reverse("search:query") + "?q=" + text
         results_per_page = settings.ZDS_APP["search"]["results_per_page"]

--- a/zds/search/views.py
+++ b/zds/search/views.py
@@ -154,8 +154,14 @@ class SearchView(ZdSPagingListView):
             search_collections = self.search_form.cleaned_data["search_collections"]
 
             searches = {
-                "publishedcontent": PublishedContent.get_search_query(),
-                "chapter": FakeChapter.get_search_query(),
+                "publishedcontent": PublishedContent.get_search_query(
+                    category_slug=self.search_form.cleaned_data["category"],
+                    subcategory_slug=self.search_form.cleaned_data["subcategory"],
+                ),
+                "chapter": FakeChapter.get_search_query(
+                    category_slug=self.search_form.cleaned_data["category"],
+                    subcategory_slug=self.search_form.cleaned_data["subcategory"],
+                ),
                 "topic": Topic.get_search_query(self.request.user),
                 "post": Post.get_search_query(self.request.user),
             }

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -264,6 +264,8 @@ ZDS_APP = {
             "chapter": {
                 "global": global_weight_chapter,
                 "title": global_weight_chapter * 3,
+                "categories": global_weight_chapter * 1,
+                "subcategories": global_weight_chapter * 1,
                 "text": global_weight_chapter * 2,
             },
             "topic": {

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -1044,8 +1044,8 @@ class PublishedContent(AbstractSearchIndexableModel, TemplatableContentModelMixi
             {"name": "publication_date", "type": "int64", "index": False},
             {"name": "tags", "type": "string[]", "facet": True, "optional": True},  # we search on it
             {"name": "tag_slugs", "type": "string[]", "index": False, "optional": True},
-            {"name": "subcategories", "type": "string[]", "facet": True, "optional": True},  # we search on it
-            {"name": "categories", "type": "string[]", "facet": True, "optional": True},  # we search on it
+            {"name": "subcategories", "type": "string[]", "facet": True, "optional": True},  # slugs; we search on it
+            {"name": "categories", "type": "string[]", "facet": True, "optional": True},  # slugs; we search on it
             {"name": "text", "type": "string", "facet": False, "optional": True},  # we search on it
             {"name": "description", "type": "string", "facet": False, "optional": True},  # we search on it
             {"name": "get_absolute_url_online", "type": "string", "index": False},
@@ -1110,7 +1110,9 @@ class PublishedContent(AbstractSearchIndexableModel, TemplatableContentModelMixi
     def get_document_source(self, excluded_fields=[]):
         """Overridden to handle the fact that most information are versioned"""
 
-        excluded_fields.extend(["title", "description", "tags", "categories", "text", "thumbnail", "publication_date"])
+        excluded_fields.extend(
+            ["title", "description", "tags", "categories", "subcategories", "text", "thumbnail", "publication_date"]
+        )
 
         data = super().get_document_source(excluded_fields=excluded_fields)
 
@@ -1168,8 +1170,8 @@ class PublishedContent(AbstractSearchIndexableModel, TemplatableContentModelMixi
                 return weights["if_opinion_not_picked"]
 
     @classmethod
-    def get_search_query(cls):
-        return {
+    def get_search_query(cls, category_slug=None, subcategory_slug=None):
+        ret = {
             "query_by": "title,description,categories,subcategories,tags,text",
             "query_by_weights": "{},{},{},{},{},{}".format(
                 settings.ZDS_APP["search"]["boosts"]["publishedcontent"]["title"],
@@ -1181,6 +1183,18 @@ class PublishedContent(AbstractSearchIndexableModel, TemplatableContentModelMixi
             ),
             "sort_by": "weight:desc",
         }
+
+        filter_by = SearchFilter()
+
+        if category_slug is not None and len(category_slug.strip()) != 0:
+            filter_by.add_exact_filter("categories", [category_slug])
+        if subcategory_slug is not None and len(subcategory_slug.strip()) != 0:
+            filter_by.add_exact_filter("subcategories", [subcategory_slug])
+
+        if str(filter_by) != "":
+            ret["filter_by"] = str(filter_by)
+
+        return ret
 
 
 @receiver(pre_delete, sender=PublishedContent)
@@ -1275,6 +1289,8 @@ class FakeChapter(AbstractSearchIndexable):
             {"name": "parent_get_absolute_url_online", "type": "string", "index": False},
             {"name": "thumbnail", "type": "string", "index": False},
             {"name": "weight", "type": "float", "facet": False},  # we sort on it
+            {"name": "subcategories", "type": "string[]", "facet": True, "optional": True},  # slugs; we search on it
+            {"name": "categories", "type": "string[]", "facet": True, "optional": True},  # slugs; we search on it
         ]
 
         return search_engine_schema
@@ -1292,15 +1308,29 @@ class FakeChapter(AbstractSearchIndexable):
         return data
 
     @classmethod
-    def get_search_query(cls):
-        return {
-            "query_by": "title,text",
-            "query_by_weights": "{},{}".format(
+    def get_search_query(cls, category_slug=None, subcategory_slug=None):
+        ret = {
+            "query_by": "title,categories,subcategories,text",
+            "query_by_weights": "{},{},{},{}".format(
                 settings.ZDS_APP["search"]["boosts"]["chapter"]["title"],
+                settings.ZDS_APP["search"]["boosts"]["chapter"]["categories"],
+                settings.ZDS_APP["search"]["boosts"]["chapter"]["subcategories"],
                 settings.ZDS_APP["search"]["boosts"]["chapter"]["text"],
             ),
             "sort_by": "weight:desc",
         }
+
+        filter_by = SearchFilter()
+
+        if category_slug is not None and len(category_slug.strip()) != 0:
+            filter_by.add_exact_filter("categories", [category_slug])
+        if subcategory_slug is not None and len(subcategory_slug.strip()) != 0:
+            filter_by.add_exact_filter("subcategories", [subcategory_slug])
+
+        if str(filter_by) != "":
+            ret["filter_by"] = str(filter_by)
+
+        return ret
 
     @classmethod
     def remove_from_search_engine(cls, search_engine_manager: SearchIndexManager, parent_search_engine_id: int):


### PR DESCRIPTION
Ajoute notamment les (sous-)catégories dans les éléments de la collection `chapter` de Typesense

Cette PR permet de restreindre à la recherche à des publications appartenant à une (sous-)catégorie spécifique. Le formulaire de recherche correspondant apparaît notamment sur la page qui liste les contenus d'une sous-catégorie.

Par contre, le problème maintenant est que sur la page de résultats, rien ne nous indique que ce sont les résultats uniquement pour telle (sous-)catégorie. J'ai essayé de rajouter l'info, mais je me suis rapidement retrouvé heurté à mes (faibles) compétences en front et je me suis dit qu'il fallait sans doute retravailler un peu plus la chose, pour que les résultats apparaissent dans une page au même style que où se trouve le formulaire sur la page d'une (sous-)catégorie.

### Contrôle qualité

1. Aller sur la page d'une sous-catégorie (par exemple : http://127.0.0.1:8000/bibliotheque/category9/sous-categorie-9/). Le plus simple est d'aller sur un contenu, cliquer la catégorie auquel le contenu appartient, puis cliquer à nouveau sur le lien de catégorie (le chemin est un peu alambiqué... à quoi sert cette page intermédiaire ?)
2. Faire une recherche dans le formulaire de recherche et constater qu'on obtient des de contenus qui n’appartiennent qu'à la (sous-)catégorie en question.
