### PR TITLE
Augmente le timeout pour les recherches

### DIFF
--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -23,7 +23,7 @@ SEARCH_CONNECTION = {
         }
     ],
     "api_key": "xyz",
-    "connection_timeout_seconds": 5,
+    "connection_timeout_seconds": 10,  # seconds; Gunicorn's default timeout is 30 s
 }
 
 # Anonymous [Dis]Likes. Authors of [dis]likes before those pk will never be shown


### PR DESCRIPTION
Sentry nous rapporte que 5 secondes est parfois un peu juste


### Contrôle qualité

Juste être d'accord avec le changement :) C'est déjà la valeur en place sur le serveur de bêta.
