### PR TITLE
Remplacement de settings.py dans la documentation (#6707)

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -163,14 +163,12 @@ Pagination
 
 La pagination permet d'éviter au serveur de faire des requêtes trop lourdes sur la base de données. Par exemple, si un client désire récupérer la liste de tous les utilisateurs de la plateforme et que cette même plateforme dispose d'un très grand nombre d'utilisateurs, la requête en base de données pourrait être lourde. Coupler à ceci des intentions malveillantes pour faire tomber le serveur, paginer les listes de ressources est presque une mesure de sécurité.
 
-La pagination peut être configurée directement dans les vues de l'API mais aussi dans le fichier ``settings.py`` pour s'appliquer à l'ensemble des listes des ressources de l'API. Dans le fichier ``settings.py``, ``PAGINATE_BY`` renseigne la taille d'une page, ``PAGINATE_BY_PARAM`` permet aux clients de modifier la taille d'une page et ``MAX_PAGINATE_BY`` permet d'imposer une taille maximale.
+La pagination peut être configurée directement dans les vues de l'API mais aussi par le biais d'une classe Python. Cette classe doit être renseignée dans le configuration de l'API dans le fichier ``zds/settings/abstract_base/django.py``.
 
 .. sourcecode:: python
 
     REST_FRAMEWORK = {
-        'PAGINATE_BY': 10,                  # Default to 10
-        'PAGINATE_BY_PARAM': 'page_size',   # Allow client to override, using `?page_size=xxx`.
-        'MAX_PAGINATE_BY': 100,             # Maximum limit allowed when using `?page_size=xxx`.
+        "DEFAULT_PAGINATION_CLASS": "zds.api.pagination.DefaultPagination",
     }
 
 Toutes les informations complémentaires à ce sujet sont disponibles dans la `documentation de la pagination (en) <http://www.django-rest-framework.org/api-guide/pagination/>`_.

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -71,7 +71,7 @@ Plusieurs formats d'entrées sont supportés par le serveur, à savoir le ``JSON
 
     $ curl -H "Content-Type: application/x-www-form-urlencoded" https://zestedesavoir.com/api/membres/
 
-Les `formats d'entrée (en) <http://www.django-rest-framework.org/api-guide/parsers/>`_ sont renseignés dans le fichier ``settings.py`` sous l'attribut ``DEFAULT_PARSER_CLASSES`` du dictionnaire ``REST_FRAMEWORK``. Pour Django Rest Framework, tous les formats d'entrée sont des ``parser``.
+Les `formats d'entrée (en) <http://www.django-rest-framework.org/api-guide/parsers/>`_ sont renseignés dans le fichier ``zds/settings/abstract_base/django.py`` sous l'attribut ``DEFAULT_PARSER_CLASSES`` du dictionnaire ``REST_FRAMEWORK``. Pour Django Rest Framework, tous les formats d'entrée sont des ``parser``.
 
 .. sourcecode:: python
 
@@ -141,7 +141,7 @@ Si le serveur constate qu'il n'y a aucun changement dans la ressource, il renver
 Throttling
 ----------
 
-Le `throttling` permet d'imposer des limites au nombre de requêtes possibles pour un utilisateur anonyme et connecté. Cette fonctionnalité est native à Django Rest Framework et se met en place facilement via le fichier ``settings.py`` du projet sous l'attribut ``DEFAULT_THROTTLE_CLASSES`` du dictionnaire ``REST_FRAMEWORK`` pour spécifier les types de throttling à appliquer et sous ``DEFAULT_THROTTLE_RATES`` pour spécifier les taux.
+Le `throttling` permet d'imposer des limites au nombre de requêtes possibles pour un utilisateur anonyme et connecté. Cette fonctionnalité est native à Django Rest Framework et se met en place facilement via le fichier ``zds/settings/abstract_base/django.py`` du projet sous l'attribut ``DEFAULT_THROTTLE_CLASSES`` du dictionnaire ``REST_FRAMEWORK`` pour spécifier les types de throttling à appliquer et sous ``DEFAULT_THROTTLE_RATES`` pour spécifier les taux.
 
 .. sourcecode:: python
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -54,7 +54,7 @@ Les autres verbes ne sont pas supportés.
 Les formats d'entrées/sorties
 -----------------------------
 
-Par défaut, le serveur renvoie les réponses au format ``JSON``. Les `formats de sortie (en) <http://www.django-rest-framework.org/api-guide/renderers/>`_ sont renseignés dans le fichier ``settings.py`` sous l'attribut ``DEFAULT_RENDERER_CLASSES`` du dictionnaire ``REST_FRAMEWORK``. Pour Django Rest Framework, tous les formats de sorties sont des ``renderer``.
+Par défaut, le serveur renvoie les réponses au format ``JSON``. Les `formats de sortie (en) <http://www.django-rest-framework.org/api-guide/renderers/>`_ sont renseignés dans le fichier ``zds/settings/abstract_base/django.py`` sous l'attribut ``DEFAULT_RENDERER_CLASSES`` du dictionnaire ``REST_FRAMEWORK``. Pour Django Rest Framework, tous les formats de sorties sont des ``renderer``.
 
 .. sourcecode:: python
 

--- a/doc/source/back-end-code/arborescence-back.rst
+++ b/doc/source/back-end-code/arborescence-back.rst
@@ -43,8 +43,6 @@ On retrouve également dans ce dossier les quelques fichiers suivants, nécessai
 
     zds/
     ├── urls.py # définition générale des URLs du site, inclus celle de chacun des modules
-    ├── settings.py # paramètres du site
-    ├── settings_test.py # paramètres spécifiques aux tests
     └── wsgi.py
 
 Contenu d'un module

--- a/doc/source/back-end/gallery.rst
+++ b/doc/source/back-end/gallery.rst
@@ -121,7 +121,7 @@ Chaque galerie (classe ``Gallery``) est stockée en base de données avec son ti
 
 Une image (classe ``Image``) est renseignée en base de données avec son titre, sa légende, un lien vers la galerie qui la contient, son *slug* et un lien *physique* vers le fichier image (ainsi que la date de création et de dernière modification).
 
-Les images sont stockées dans le dossier renseigné par la variable ``MEDIA_URL`` (dans le fichier ``settings.py``), dans un sous-dossier dont le nom correspond au ``pk`` de la galerie. C'est la librairie `easy_thumbnails <https://github.com/SmileyChris/easy-thumbnails>`_ qui gère la génération des miniatures correspondantes aux images uploadées, à la demande du *back*.
+Les images sont stockées dans le dossier renseigné par la variable ``MEDIA_URL`` (dans le fichier ``zds/settings/abstract_base/django.py``), dans un sous-dossier dont le nom correspond au ``pk`` de la galerie. C'est la bibliothèque `easy_thumbnails <https://github.com/SmileyChris/easy-thumbnails>`_ qui gère la génération des miniatures correspondantes aux images uploadées, à la demande du *back-end*.
 
 Outils logiciels utilisés
 =========================

--- a/doc/source/back-end/member.rst
+++ b/doc/source/back-end/member.rst
@@ -103,15 +103,13 @@ Pour que ces membres soient ajoutés à la base de données, il est donc nécés
     Les utilisateurs ``anonymous`` et ``external`` **doivent** être présents dans la base de données pour le bon fonctionnement du site.
     En effet, ils permettent le bon fonctionnement du processus d'anonymisation (voir `plus haut <#desinscription>`_)
 
-Les utilisateurs ``anonymous`` et ``external`` sont totalement paramétrables dans le fichier ``zds/settings.py`` :
-pour changer le nom d'utilisateur (*username*) de ces comptes, agissez sur les constantes suivantes (du dictionnaire ZDS_APP):
+Les utilisateurs ``anonymous`` et ``external`` sont totalement paramétrables dans le fichier ``zds/settings/abstract_base/zds.py`` : pour changer le nom d'utilisateur (*username*) par défaut de ces comptes, agissez sur les constantes suivantes (du dictionnaire ``ZDS_APP``):
 
 .. sourcecode:: python
 
-    # Constant for anonymisation
+   "anonymous_account": zds_config.get("member_anonymous_username", "anonymous"),
+   "external_account": zds_config.get("member_external_username", "external"),
 
-    anonymous_account = "anonymous"
-    external_account = "external"
 
 Bien entendu, les comptes correspondants doivent exister dans la base de données.
 
@@ -148,7 +146,7 @@ Les membres peuvent supprimer eux-mêmes leurs casquettes. Les utilisateurs ayan
 
 Attention : la casse est déterminée lors du premier ajout d'une casquette. Ainsi, si vous ajoutez une casquette « Staff » à un membre, ajouter une casquette « staff » à un autre membre par la suite lui ajoutera en réalité la casquette « Staff ». Si nécessaire, la casse d'une casquette peut être modifiée via l'administration de Django.
 
-Les casquettes sont ajoutées aux MP automatiques en fonction des paramètres ``ZDS_APP['hats']`` renseignés dans le fichier ``settings.py``.
+Les casquettes sont ajoutées aux MP automatiques en fonction des paramètres ``ZDS_APP["hats"]`` renseignés dans le fichier ``zds/settings/abstract_base/zds.py``.
 
 L'interface de karma
 --------------------

--- a/doc/source/front-end/elements-specifiques-au-site.rst
+++ b/doc/source/front-end/elements-specifiques-au-site.rst
@@ -507,9 +507,9 @@ Le formulaire transmettra les champs suivants :
 Ajouter un design temporaire
 ============================
 
-Il y a dans le fichier ``settings.py`` un tableau ``ZDS_APP.visual_changes``. Ce tableau de chaînes de caractères est injecté sous forme de classes au body, avec comme prefixe ``vc-`` (si l'utilisateur n'as pas bloqué les designs temporaires dans ses paramètres).
+Il y a dans le fichier ``zds/settings/abstract_base/zds.py`` un tableau ``ZDS_APP["visual_changes"]``. Ce tableau de chaînes de caractères est injecté sous forme de classes CSS à l'élément HTML ``<body>``, avec comme prefixe ``vc-`` (si l'utilisateur n'as pas bloqué les designs temporaires dans ses paramètres).
 
-Il suffit donc, dans le style et dans les scripts si le ``body`` a la classe ``vc-{...}`` correspondante au changement visuel.
+Il suffit donc, dans le style et dans les scripts de tester si la balise ``<body>`` a la classe ``vc-{...}`` correspondante au changement visuel.
 
 .. sourcecode:: scss
 
@@ -537,7 +537,7 @@ Les changements visuels disponibles sont:
   - ``clem-halloween``: remplace la Clem de la page d'accueil par une Clem qui fait peur
   - ``valentine-snow``: ajoute des cœurs dans le header à la place de la neige
 
-Par exemple, pour activer les changements ``snow`` et ``clem-christmas``, il faut ajouter au ``settings_prod.py``:
+Par exemple, pour activer les changements ``snow`` et ``clem-christmas``, il faut définir ``ZDS_APP["visual_changes"]`` comme suit.
 
 .. sourcecode:: python
 

--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -457,7 +457,7 @@ Ce filtre récupère les forums, classés par catégorie.
 où,
 
 - ``top.categories`` est un dictionaire contenant le nom de la catégorie (ici ``title``) et la liste des forums situés dans cette catégorie (ici ``forums``), c'est-à-dire une liste d'objets de type ``Forum`` (`voir le détail de l'implémentation de cet objet ici <../back-end-code/forum.html#zds.forum.models.Forum>`__).
-- ``top.tags`` contient une liste des 5 *tags* les plus utilisés, qui sont des objets de type ``Tag`` (`voir le détail de l'implémentation de cet objet ici <../back-end-code/utils.html#zds.utils.models.Tag>`__). Certains tags peuvent être exclus de cette liste. Pour exclure un tag, vous devez l'ajouter dans la configuration (top_tag_exclu dans le settings.py).
+- ``top.tags`` contient une liste des 5 *tags* les plus utilisés, qui sont des objets de type ``Tag`` (`voir le détail de l'implémentation de cet objet ici <../back-end-code/utils.html#zds.utils.models.Tag>`__). Certains tags peuvent être exclus de cette liste. Pour exclure un tag, vous devez l'ajouter dans la configuration (``ZDS_APP["forum"]["top_tag_exclu"]`` dans le fichier de configuration ``zds/settings/abstract_base/zds.py``).
 
 
 ``topbar_publication_categories``


### PR DESCRIPTION
Un fichier `settings.py` est mentionné dans la documentation pour contenir des éléments de configuration tandis qu'ils sont situés dans le fichier `zds/settings/abstract_base/django.py`

`settings.py` a été temporairement laissé pour les champs de configuration de la pagination, dont le véritable emplacement n'a pas été trouvé.

<!-- Décrivez vos changements ici (optionnel pour les tous petits changements). -->

<!-- Remplacez XXXX par le numéro de ticket corrigé par vos changements : GitHub fermera le ticket mentionné automatiquement (voir https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue pour plus de détails). Supprimez la ligne s'il n'y a pas de ticket associé. --!>
Fix #6707 

<!-- Si votre PR modifie du code Python, mettez à jour ou créez les tests unitaires associés. Signalez vos éventuelles difficultés afin que des contributeurs expérimentés puissent vous aider. -->

<!-- Si votre pull request requiert des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->

### Contrôle qualité

<!-- Donnez des instructions pour nous aider à vérifier vos changements.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

<!-- Merci ! -->

- Recharger la documentation avec `make generate-doc`
- Servir la page de documentation avec `python3 -m http.server 8080 -d doc/build/html/`
- Observer les changements depuis le navigateur à la page `localhost:8080/api.html`