### PR TITLE
Corrige le déplacement vers un forum privé d'un sujet pas encore indexé

### DIFF
--- a/zds/forum/models.py
+++ b/zds/forum/models.py
@@ -528,6 +528,7 @@ class Topic(AbstractSearchIndexableModel):
                 filter_by.add_exact_filter("topic_pk", [self.pk])
 
                 search_engine_manager.delete_by_query(Post.get_search_document_type(), {"filter_by": str(filter_by)})
+                # The topic may not exist in the search engine yet, if it was not yet indexed
                 search_engine_manager.delete_document(self)
 
         return super().save(*args, **kwargs)

--- a/zds/search/models.py
+++ b/zds/search/models.py
@@ -19,8 +19,9 @@ class AbstractSearchIndexable:
     You also need to maintain ``search_engine_id``, which is actually a string.
     For objects that are also stored in the database, we use the database
     primary key. We have to define it here (and not in child class
-    ``AbstractSearchIndexableModel``) because there are objects indexed in the
-    search engine, but not stored in the database.
+    ``AbstractSearchIndexableModel``) and we cannot rely on the `pk` field of
+    models because there are objects indexed in the search engine, but not
+    stored in the database.
     """
 
     search_engine_id = ""
@@ -125,6 +126,9 @@ class AbstractSearchIndexableModel(AbstractSearchIndexable, models.Model):
     def __init__(self, *args, **kwargs):
         """Override to make the search engine document ID equal to the database primary key."""
         super().__init__(*args, **kwargs)
+
+        # If the object doesn't exist yet in the database, the pk is None and
+        # we will update the search_engine_id in the save() method.
         self.search_engine_id = str(self.pk) if self.pk else None
 
     @classmethod
@@ -159,7 +163,8 @@ class AbstractSearchIndexableModel(AbstractSearchIndexable, models.Model):
 
     def save(self, *args, **kwargs):
         """Override the ``save()`` method to flag the object as requiring to be reindexed
-        (since a save assumes a modification of the object).
+        (since a save assumes a modification of the object) and set
+        search_engine_id in case of creation.
 
         .. note::
             Flagging can be prevented using ``save(search_engine_requires_index=False)``.
@@ -167,4 +172,10 @@ class AbstractSearchIndexableModel(AbstractSearchIndexable, models.Model):
 
         self.search_engine_requires_index = kwargs.pop("search_engine_requires_index", True)
 
-        return super().save(*args, **kwargs)
+        ret = super().save(*args, **kwargs)
+
+        # Now we are sure the object exists in databse, so we have a pk
+        assert self.pk is not None
+        self.search_engine_id = str(self.pk)
+
+        return ret

--- a/zds/search/tests/tests_models.py
+++ b/zds/search/tests/tests_models.py
@@ -441,7 +441,8 @@ class SearchIndexManagerTests(TutorialTestMixin, TestCase):
         number_of_results = sum(result["found"] for result in results)
         self.assertEqual(number_of_results, 3)
 
-        # Move the private topic to a private forum
+        # Move the topic to a private forum, so it becomes a private topic
+        # (this also tests we can move a topic to a private forum before it was even indexed)
         private_topic.forum = private_forum
         private_topic.save()
         private_topic.refresh_from_db()

--- a/zds/search/utils.py
+++ b/zds/search/utils.py
@@ -1,3 +1,4 @@
+import contextlib
 from datetime import datetime
 from functools import lru_cache
 import logging
@@ -10,6 +11,7 @@ from django.db import transaction
 
 from bs4 import BeautifulSoup
 from typesense import Client as TypesenseClient
+from typesense.exceptions import ObjectNotFound as TypesenseObjectNotFound
 
 from zds.search.models import AbstractSearchIndexableModel
 
@@ -272,13 +274,12 @@ class SearchIndexManager:
         doc_type = document.get_search_document_type()
         doc_id = document.search_engine_id
 
-        if doc_id is None or doc_type not in self.collections:
-            # This condition is here especially for tests
-            return
-
-        answer = self.engine.collections[doc_type].documents[doc_id].delete()
-        if "id" not in answer or answer["id"] != doc_id:
-            self.logger.warn(f"Error when deleting: {answer}.")
+        # This can happen in tests or, for instance, we move a not-yet-indexed topic to a private forum.
+        # Try/except/pass while https://github.com/typesense/typesense-python/issues/65 is not fixed
+        with contextlib.suppress(TypesenseObjectNotFound):
+            answer = self.engine.collections[doc_type].documents[doc_id].delete()
+            if "id" not in answer or answer["id"] != doc_id:
+                self.logger.warn(f"Error when deleting: {answer}.")
 
     def delete_by_query(self, doc_type="", query={"filter_by": ""}):
         """Delete a bunch of documents that match a specific filter_by condition.
@@ -297,11 +298,10 @@ class SearchIndexManager:
         if not self.connected:
             return
 
-        if doc_type not in self.collections:
-            # This condition is here especially for tests
-            return
-
-        self.engine.collections[doc_type].documents.delete(query)
+        # This can happen in tests or, for instance, we move a not-yet-indexed topic to a private forum.
+        # Try/except/pass while https://github.com/typesense/typesense-python/issues/65 is not fixed
+        with contextlib.suppress(TypesenseObjectNotFound):
+            self.engine.collections[doc_type].documents.delete(query)
 
     def search(self, request):
         """Do a search in all collections (only used in tests)


### PR DESCRIPTION
Fix #6681

Il s'avère que le test reproduisant le bug existait déjà, mais on avait une condition un peu trop brutale (dédiée justement aux tests) qui empêchait le bug de se produire dans les tests.

### Contrôle qualité

1. Avec l'utilisateur `user1`, créer un sujet dans un forum
2. Avec l'utilisateur `admin`, déplacer ce sujet vers le forum *Staff only*
3. Le déplacement fonctionne, ne lève pas d'exception
