### PR TITLE
Corrige la réservation d'une validation d'un contenu avec un auteur externe

### DIFF
--- a/zds/tutorialv2/tests/factories.py
+++ b/zds/tutorialv2/tests/factories.py
@@ -267,6 +267,16 @@ class ValidationFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Validation
 
+    @classmethod
+    def _generate(cls, create, attrs):
+
+        content = attrs.get("content")
+
+        validation = super()._generate(create, attrs)
+        validation.version = content.sha_draft
+
+        return validation
+
 
 class HelpWritingFactory(factory.django.DjangoModelFactory):
     """

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -39,6 +39,7 @@ from zds.tutorialv2.tests.factories import (
     PublishedContentFactory,
     tricky_text_content,
 )
+from zds.tutorialv2.tests.utils import request_validation
 from zds.utils.tests.factories import LicenceFactory, SubCategoryFactory
 
 
@@ -74,11 +75,16 @@ class ContentTests(TutorialTestMixin, TestCase):
         self.tuto_draft = self.tuto.load_version()
         self.part1 = ContainerFactory(parent=self.tuto_draft, db_object=self.tuto)
         self.chapter1 = ContainerFactory(parent=self.part1, db_object=self.tuto)
-
         self.extract1 = ExtractFactory(container=self.chapter1, db_object=self.tuto)
-        bot = Group(name=self.overridden_zds_app["member"]["bot_group"])
-        bot.save()
-        self.external = UserFactory(username=self.overridden_zds_app["member"]["external_account"], password="anything")
+
+        bot_group = Group(name=self.overridden_zds_app["member"]["bot_group"])
+        bot_group.save()
+
+        self.profile_external = ProfileFactory()
+        self.profile_external.user.username = settings.ZDS_APP["member"]["external_account"]
+        self.profile_external.user.save()
+        self.profile_external.user.groups.add(bot_group)
+
         self.old_registry = {key: value for key, value in PublicatorRegistry.get_all_registered()}
 
         class TestPdfPublicator(Publicator):
@@ -2017,6 +2023,35 @@ class ContentTests(TutorialTestMixin, TestCase):
         validation = Validation.objects.filter(content=tuto).last()
         self.assertEqual(validation.status, "PENDING_V")
         self.assertEqual(validation.validator, self.user_staff)
+
+    def test_validation_external_author(self):
+        """Test we can reserve and reject a validation of a content without any reachable author"""
+
+        tuto = PublishableContent.objects.get(pk=self.tuto.pk)
+        tuto.authors.clear()
+        tuto.authors.add(self.profile_external.user)  # external author is not a reachable author
+        tuto.save()
+
+        validation = request_validation(tuto)
+
+        self.client.force_login(self.user_staff)
+
+        result = self.client.post(
+            reverse("validation:reserve", kwargs={"pk": validation.pk}), {"version": validation.version}, follow=False
+        )
+        self.assertEqual(result.status_code, 302)
+
+        validation.refresh_from_db()
+        self.assertEqual(validation.status, "PENDING_V")
+        self.assertEqual(validation.validator, self.user_staff)
+
+        result = self.client.post(
+            reverse("validation:reject", kwargs={"pk": validation.pk}), {"text": "Reject"}, follow=False
+        )
+        self.assertEqual(result.status_code, 302)
+
+        validation.refresh_from_db()
+        self.assertEqual(validation.status, "REJECT")
 
     def test_delete_while_validating(self):
         """this test ensure that the validator is warned if the content he is validing is removed"""

--- a/zds/tutorialv2/tests/utils.py
+++ b/zds/tutorialv2/tests/utils.py
@@ -3,6 +3,7 @@ from zds.tutorialv2.tests.factories import ValidationFactory
 
 def request_validation(content):
     """Emulate a proper validation request."""
-    ValidationFactory(content=content, status="PENDING")
+    validation = ValidationFactory(content=content, status="PENDING")
     content.sha_validation = content.sha_draft
     content.save()
+    return validation

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -311,23 +311,24 @@ class ReserveValidation(LoginRequiredMixin, PermissionRequiredMixin, FormView):
             validation.status = "PENDING_V"
             validation.save()
 
-            versioned = validation.content.load_version(sha=validation.version)
-            msg = render_to_string(
-                "tutorialv2/messages/validation_reserve.md",
-                {
-                    "content": versioned,
-                    "url": get_content_version_url(versioned, validation.version),
-                },
-            )
+            recipients = filter_reachable(validation.content.authors.all())
+            if validation.validator in recipients:
+                recipients.remove(validation.validator)
+            if len(recipients) > 0:
+                versioned = validation.content.load_version(sha=validation.version)
+                msg = render_to_string(
+                    "tutorialv2/messages/validation_reserve.md",
+                    {
+                        "content": versioned,
+                        "url": get_content_version_url(versioned, validation.version),
+                    },
+                )
 
-            authors = list(validation.content.authors.all())
-            if validation.validator in authors:
-                authors.remove(validation.validator)
-            if len(authors) > 0:
                 if not validation.content.validation_private_message:
+
                     validation.content.validation_private_message = send_mp(
                         validation.validator,
-                        authors,
+                        recipients,
                         _("Contenu réservé - {0}").format(validation.content.title),
                         validation.content.title,
                         msg,
@@ -420,16 +421,20 @@ class RejectValidation(LoginRequiredMixin, PermissionRequiredMixin, ModalFormVie
 
         bot = get_bot_account()
         if not validation.content.validation_private_message:
-            validation.content.validation_private_message = send_mp(
-                bot,
-                validation.content.authors.all(),
-                _("Rejet de la demande de publication").format(),
-                validation.content.title,
-                msg,
-                send_by_mail=True,
-                hat=get_hat_from_settings("validation"),
-            )
-            validation.content.save()
+            recipients = filter_reachable(validation.content.authors.all())
+            if validation.validator in recipients:
+                recipients.remove(validation.validator)
+            if len(recipients) > 0:
+                validation.content.validation_private_message = send_mp(
+                    bot,
+                    validation.content.authors.all(),
+                    _("Rejet de la demande de publication").format(),
+                    validation.content.title,
+                    msg,
+                    send_by_mail=True,
+                    hat=get_hat_from_settings("validation"),
+                )
+                validation.content.save()
         else:
             send_message_mp(
                 bot, validation.content.validation_private_message, msg, no_notification_for=[self.request.user]


### PR DESCRIPTION
Si un contenu possède comme auteur le bot *Auteur externe*, il n'est pas possible de réserver une validation ou rejeter une validation, car on ne peut pas envoyer de message à un bot.

Cette PR corrige le problème en filtrant les auteurs à qui on peut envoyer un message.

### Contrôle qualité

J'ai surtout développé le correctif à l'aide du test.

1. Se connecter en tant que `user1`
2. Créer un tutoriel, demander la validation
3. Se connecter en tant que `admin`
4. Réserver la validation du tutoriel et accepter la validation
5. Se connecter en tant que `user1`
6. Se désinscrire du site (*Paramètres* > *Désinscription*). L'auteur du tutoriel est maintenant remplacé par le bot *external*
7. Se connecter en tant que `admin`
8. Faire une modification au tutoriel
9. Demander la validation
10. Réserver la validation : pas d'erreur 500
11. Rejeter la validation : pas d'erreur 500

Tester aussi la réservation et le rejet d'une validation pour un contenu avec des auteurs qui sont joignables (par exemple tous les auteurs sont joignables, puis un des auteurs seulement devient *external*).
