### PR TITLE
Garde les paramètres GET dans l'URL de redirection après la connexion

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -458,7 +458,7 @@
             </div>
 
         {% else %} {# Not logged #}
-            <a href="{% url "member-login" %}?next={{ request.path }}">{% trans "Connexion" %}</a>
+            <a href="{{ member_login_url }}">{% trans "Connexion" %}</a>
             <a href="{% url "register-member" %}">{% trans "Inscription" %}</a>
         {% endif %}
     </div>

--- a/zds/member/tests/views/tests_login.py
+++ b/zds/member/tests/views/tests_login.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from urllib.parse import quote
 
 from django.conf import settings
 from django.test import TestCase
@@ -245,3 +246,35 @@ class LoginTests(TestCase):
             follow=False,
         )
         self.assertRedirects(result, reverse("homepage"))
+
+    def test_redirection_keep_get_params(self):
+        """Test that the redirection URL contains also GET parameter of the
+        initial URL"""
+        tutorial_list_url = reverse("publication:list") + "?type=tutorial"
+        full_login_url = self.login_url + "?next=" + tutorial_list_url
+        full_login_url_quoted = self.login_url + "?next=" + quote(tutorial_list_url)
+
+        # Let's go on a URL which contains a GET parameter
+        tutorial_list_page = self.client.get(tutorial_list_url)
+        # It contains a link to the login page, containing the *whole* current URL
+        self.assertContains(tutorial_list_page, 'href="' + full_login_url_quoted)
+
+        # Now, go to this login page
+        login_page = self.client.get(full_login_url_quoted)
+        # The form sends data to a URL containing the GET parameter
+        self.assertEqual(login_page.context["form"].helper.form_action, full_login_url)
+        # There is still a link to the login page (this link doesn't contain a
+        # recursion of ?next= parameters)
+        self.assertContains(login_page, 'href="' + full_login_url_quoted)
+
+        # Submit this form
+        result = self.client.post(
+            full_login_url,
+            {
+                "username": self.correct_username,
+                "password": self.correct_password,
+            },
+            follow=False,
+        )
+        # It redirects to the initial URL, with the GET parameter:
+        self.assertRedirects(result, tutorial_list_url)

--- a/zds/member/views/login.py
+++ b/zds/member/views/login.py
@@ -36,8 +36,9 @@ class LoginView(LoginView):
 
     def get_success_url(self):
         """In case of success, redirect to homepage for some special 'next' targets or non-existing pages."""
-        url = self.get_redirect_url()
-        if self.is_special(url) or not is_valid_path(url):
+        url = self.get_redirect_url()  # This is the value of the `next` GET param
+        # We want to keep GET parameters included in the `next` param, so validate only part before GET parameters:
+        if self.is_special(url) or not is_valid_path(url.split("?")[0]):
             url = settings.LOGIN_REDIRECT_URL
         return url
 

--- a/zds/settings/abstract_base/django.py
+++ b/zds/settings/abstract_base/django.py
@@ -137,6 +137,7 @@ django_template_engine = {
             "zds.utils.context_processor.app_settings",
             "zds.utils.context_processor.version",
             "zds.utils.context_processor.header_notifications",
+            "zds.utils.context_processor.member_login_url",
             "zds.gallery.auto_upload_gallery.get_auto_upload_gallery",
         ],
     },

--- a/zds/utils/context_processor.py
+++ b/zds/utils/context_processor.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
+from urllib.parse import quote
 
 from django.conf import settings
+from django.urls import reverse
 
 from zds import __version__, git_version
 
@@ -24,6 +26,25 @@ def get_repository_url(repository_name, url_type):
         raise Exception("Incorrect repository_name: " + repository_name)
 
     return settings.ZDS_APP["github_projects"][url_type](repository_name)
+
+
+def member_login_url(request):
+    """Get the URL to access the login page, containing the current URL, where
+    we should redirect after a successful login"""
+    full_path = request.get_full_path()
+
+    # We keep GET parameters in the value of the `next` GET param, so to avoid
+    # recursion (eg the link to the login form when on the login form page),
+    # include current GET params only if `next` is not already a GET param:
+    if "?next=" in full_path:
+        return {"member_login_url": full_path}
+    else:
+        return {
+            # `quote()` is the function used by the `urlencode` template tag
+            "member_login_url": reverse("member-login")
+            + "?next="
+            + quote(full_path)
+        }
 
 
 def version(request):


### PR DESCRIPTION
Fix #6700

~~Il faut encore ajouter les tests.~~


### Contrôle qualité

1. Sans être connecté, aller sur la page http://127.0.0.1:8000/bibliotheque/?type=tutorial
2. Cliquer sur le bouton pour accéder à la page de connexion
3. L'URL contient (de façon encodée) `?next=/bibliotheque/%3Ftype%3Dtutorial`
4. Cliquer à nouveau sur le bouton pour accéder à la page de connexion : l'URL reste la même (il n'y a pas de récursion causée par le paramètre `next`)
5. Remplir le formulaire de connexion
6. On est alors redirigé vers la page http://127.0.0.1:8000/bibliotheque/?type=tutorial, le paramètre `type=tutorial` est bien conservé

Pour tester un cas potentiellement pathologique, on peut refaire la même séquence d'opération, mais en cherchant à l'aide du formulaire de recherche `?next=`.
