### PR TITLE
Ajout des modifications des catégories dans le journal d'événements

### DIFF
--- a/templates/tutorialv2/events/descriptions.part.html
+++ b/templates/tutorialv2/events/descriptions.part.html
@@ -72,6 +72,9 @@
 {% elif event.type == "labels_management" %}
     <a href="{{ performer_href }}">{{ event.performer }}</a> a modifié les labels du contenu.
 
+{% elif event.type == "categories_management" %}
+    <a href="{{ performer_href }}">{{ event.performer }}</a> a modifié les catégories du contenu.
+
 {% elif event.type == "suggestions_management" %}
     {% if event.action == "add" %}
         <a href="{{ performer_href }}">{{ event.performer }}</a> a ajouté une suggestion de contenu.

--- a/zds/tutorialv2/models/events.py
+++ b/zds/tutorialv2/models/events.py
@@ -7,6 +7,7 @@ from zds.tutorialv2.models.database import PublishableContent
 from zds.tutorialv2.views.authors import AddAuthorView, RemoveAuthorView
 from zds.tutorialv2.views.beta import ManageBetaContent
 from zds.tutorialv2.views.canonical import EditCanonicalLinkView
+from zds.tutorialv2.views.categories import EditCategoriesView
 from zds.tutorialv2.views.contributors import AddContributorToContent, RemoveContributorFromContent
 from zds.tutorialv2.views.goals import EditGoals
 from zds.tutorialv2.views.help import ChangeHelp
@@ -58,6 +59,7 @@ types = {
     signals.help_management: "help_management",
     signals.jsfiddle_management: "jsfiddle_management",
     signals.opinions_management: "opinions_management",
+    signals.categories_management: "categories_management",
 }
 
 
@@ -186,6 +188,15 @@ def record_event_goals_management(sender, performer, signal, content, **_):
 
 @receiver(signals.labels_management, sender=EditLabels)
 def record_event_labels_management(sender, performer, signal, content, **_):
+    Event(
+        performer=performer,
+        type=types[signal],
+        content=content,
+    ).save()
+
+
+@receiver(signals.categories_management, sender=EditCategoriesView)
+def record_event_categories_management(sender, performer, signal, content, **_):
     Event(
         performer=performer,
         type=types[signal],

--- a/zds/tutorialv2/signals.py
+++ b/zds/tutorialv2/signals.py
@@ -68,3 +68,7 @@ jsfiddle_management = Signal()
 # For the signal below, the arguments "performer", "content" and "action" shall be provided.
 # Action is either "publish" or "unpublish".
 opinions_management = Signal()
+
+# Categories management
+# For the signal below, the arguments "performer", "content" and "action" shall be provided.
+categories_management = Signal()

--- a/zds/tutorialv2/tests/tests_views/tests_editcategoriesview.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editcategoriesview.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.html import escape
@@ -103,15 +105,18 @@ class FunctionalTests(TutorialTestMixin, TestCase):
 
         self.client.force_login(self.author)
 
-    def test_add_category(self):
+    @patch("zds.tutorialv2.signals.categories_management")
+    def test_add_category(self, categories_management):
         form_data = {"subcategory": [str(self.category_0.pk)]}
         self.client.post(self.url, form_data)
 
         categories_real = self.content.subcategory.all()
         categories_expected = [self.category_0]
         self.assertQuerysetEqual(categories_real, categories_expected)
+        self.assertEqual(categories_management.send.call_count, 1)
 
-    def test_remove_category(self):
+    @patch("zds.tutorialv2.signals.categories_management")
+    def test_remove_category(self, categories_management):
         self.content.subcategory.add(self.category_0)
         self.assertQuerysetEqual(self.content.subcategory.all(), [self.category_0])
 
@@ -121,8 +126,10 @@ class FunctionalTests(TutorialTestMixin, TestCase):
         categories_real = self.content.subcategory.all()
         categories_expected = []
         self.assertQuerysetEqual(categories_real, categories_expected)
+        self.assertEqual(categories_management.send.call_count, 1)
 
-    def test_remove_published(self):
+    @patch("zds.tutorialv2.signals.categories_management")
+    def test_remove_published(self, categories_management):
         self.content.subcategory.add(self.category_0)
         self.assertQuerysetEqual(self.content.subcategory.all(), [self.category_0])
         publish(self.content)
@@ -131,3 +138,4 @@ class FunctionalTests(TutorialTestMixin, TestCase):
         response = self.client.post(self.url, form_data, follow=True)
         self.assertContains(response, escape(EditCategoriesForm.error_messages["no_category_but_public"]))
         self.assertQuerysetEqual(self.content.subcategory.all(), [self.category_0])
+        self.assertFalse(categories_management.send.called)

--- a/zds/tutorialv2/views/categories.py
+++ b/zds/tutorialv2/views/categories.py
@@ -8,8 +8,10 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 
 from zds.member.decorator import LoggedWithReadWriteHability
+from zds.tutorialv2 import signals
 from zds.tutorialv2.mixins import SingleContentFormViewMixin
 from zds.tutorialv2.models.database import PublishableContent
+from zds.utils import get_current_user
 from zds.utils.models import SubCategory
 
 
@@ -69,5 +71,7 @@ class EditCategoriesView(LoggedWithReadWriteHability, SingleContentFormViewMixin
             content.subcategory.add(subcat)
 
         self.success_url = reverse("content:view", args=[content.pk, content.slug])
+
+        signals.categories_management.send(sender=self.__class__, performer=get_current_user(), content=self.object)
 
         return super().form_valid(form)


### PR DESCRIPTION
Chaque modification de catégorie est désormais tracée dans le journal d'événements. Le signal **categories_management** est déclenché lors de chaque modification.

Fix #6614

<!-- Décrivez vos changements ici (optionnel pour les tous petits changements). -->

<!-- Remplacez XXXX par le numéro de ticket corrigé par vos changements : GitHub fermera le ticket mentionné automatiquement (voir https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue pour plus de détails). Supprimez la ligne s'il n'y a pas de ticket associé. --!>

<!-- Si votre PR modifie du code Python, mettez à jour ou créez les tests unitaires associés. Signalez vos éventuelles difficultés afin que des contributeurs expérimentés puissent vous aider. -->

<!-- Si votre pull request requiert des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->

### Contrôle qualité
- Se connecter à un compte
- Créer un contenu
- Ajouter une ou plusieurs catégorie(s) au contenu
- Vérifier en base que tutorialv2_event possède bien une entrée de type **categories_management**
- Supprimer une ou plusieurs catégorie(s)
- Vérifier en base que tutorialv2_event possède bien deux entrées de type **categories_management**

<!-- Donnez des instructions pour nous aider à vérifier vos changements.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

<!-- Merci ! -->
