### PR TITLE
Bloque les robots d'IA dans robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -28,3 +28,24 @@ Disallow: /tutoriels/epub/
 Disallow: /tutoriels/md/
 Disallow: /tutoriels/tex/
 Disallow: /tutoriels/zip/
+
+User-Agent: Amazonbot
+User-agent: anthropic-ai
+User-Agent: Applebot-Extended
+User-Agent: Bytespider
+User-Agent: CCBot
+User-Agent: ChatGPT-User
+User-Agent: Claude-Web
+User-Agent: ClaudeBot
+User-Agent: diffbot
+User-Agent: Facebookbot
+User-agent: Google-CloudVertexBot
+User-agent: Google-Extended
+User-Agent: GPTBot
+User-Agent: ImagesiftBot
+User-Agent: Meta-ExternalAgent
+User-Agent: Omgili
+User-Agent: Omgilibot
+User-Agent: PerplexityBot
+User-Agent: Youbot
+Disallow: /


### PR DESCRIPTION
Pas de ticket lié, juste une idée que j'ai eu en voyant la quantité de spam généré par IA qu'on a eu récemment : et si on indiquait aux robots qui collectent nos données qu'ils ne sont pas les bienvenus ?

La liste est celle que j'utilise sur mon propre site, et que j'ai trouvée quelques part sur les Interwebs, mais je sais plus où…

### Contrôle qualité

Fichier statique à déployer tel quel à la racine du site.

À noter que la version en ligne a déjà quelques lignes du genre, mais je ne les vois pas sur ce repo Git.
