### PR TITLE
Chemin d'installation de nvm modifiable par le système Linux

### DIFF
--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -5,7 +5,9 @@
 
 # load nvm
 function load_nvm {
-    export NVM_DIR="$HOME/.nvm"
+    if [ -z "$NVM_DIR" ]; then
+      export NVM_DIR="$HOME/.nvm"
+    fi
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 }
 
@@ -201,7 +203,7 @@ if ! $(_in "--force-skip-activating" $@) && [[ ( $VIRTUAL_ENV == "" || $(realpat
 
     print_info "* activating venv \`$ZDS_VENV\`"
 
-    if [ -d $HOME/.nvm ]; then # load nvm, in case of
+    if [ -n "$NVM_DIR" ] || [ -d $HOME/.nvm ]; then # load nvm, in case of
         load_nvm
     fi
 


### PR DESCRIPTION
Pour que l'installation de npm et nvm se déroule correctement sur Ubuntu 24, `NVM_DIR` n'est pas redéfinie dans `scripts/install_zds.sh` car il est déjà défini dans `.bashrc` à l'installation de nvm sur un chemin différent (dans le cas d'Ubuntu 24, il s'agit de `~/.config/nvm`)

On espère que ceci rendra l'installation plus généralisable sur d'autres systèmes Linux également.

Ceci corrige dans certains cas le problème du `nvm not found` lors de `make install-linux`.

<!-- Décrivez vos changements ici (optionnel pour les tous petits changements). -->



<!-- Si votre PR modifie du code Python, mettez à jour ou créez les tests unitaires associés. Signalez vos éventuelles difficultés afin que des contributeurs expérimentés puissent vous aider. -->

<!-- Si votre pull request requiert des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->

### Contrôle qualité

<!-- Donnez des instructions pour nous aider à vérifier vos changements.

Par exemple :

  - Lancez `python manage.py migrate` et `yarn test` ;
  - Créez un nouveau compte nommé `toto` ;
  - Envoyez un message privé à quelqu’un d’autre, le titre du message doit apparaître en rose. -->

<!-- Merci ! -->

- Démarrez une installation Linux fraiche et récente comme Ubuntu 24
- Dans bash, lancez `make install-linux` sur un clone de cette PR.
- Normalement l'installation se déroulera correctement jusqu'au bout.