### PR TITLE
Mise à jour de toutes les dépendances back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ on:
 env:
   NODE_VERSION: "18" # needs to be also updated in .nvmrc
   PYTHON_VERSION: "3.11"
-  PIP_VERSION: "24.3.1" # needs to be also updated in scripts/define_variable.sh
-  MARIADB_VERSION: "10.4.10"
-  COVERALLS_VERSION: "3.3.1" # check if Coverage needs to be also updated in requirements-ci.txt
+  PIP_VERSION: "25.1.1" # needs to be also updated in scripts/define_variable.sh
+  MARIADB_VERSION: "10.11.11"
+  COVERALLS_VERSION: "4.0.1" # check if Coverage needs to be also updated in requirements-ci.txt
   TYPESENSE_VERSION: "27.0" # needs to be also updated in scripts/define_variable.sh
 
   # As GitHub Action does not allow environment variables

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.17.0
     hooks:
     -   id: pyupgrade
-        args: [--py39-plus]
+        args: [--py311-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.8.0 # needs to be also updated in requirements-dev.txt
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     -   id: pyupgrade
         args: [--py311-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0 # needs to be also updated in requirements-dev.txt
+    rev: 25.1.0 # needs to be also updated in requirements-dev.txt
     hooks:
       - id: black
         language_version: python3

--- a/doc/source/install/install-macos.rst
+++ b/doc/source/install/install-macos.rst
@@ -37,7 +37,7 @@ Pré-requis
   Ces instructions expliquent comment installer XCode, Homebrew, Python, pip, et
   les utilitaires GNU, sur macOS. Si vous avez déjà :
 
-  - une installation fonctionnelle de Homebrew et de Python 3.8+ ;
+  - une installation fonctionnelle de Homebrew et de Python 3.11+ ;
   - configuré votre terminal pour utiliser les utilitaires GNU à la place de
     ceux de BSD (avec `linuxify <https://github.com/darksonic37/linuxify#install>`_,
     par exemple) ;
@@ -83,7 +83,7 @@ Pour vérifier, exécutez la commande suivante :
 
   python --version
 
-Si vous obtenez une version inférieure à Python 3.9 (et notamment si vous voyez
+Si vous obtenez une version inférieure à Python 3.11 (et notamment si vous voyez
 ``Python 2.7``), il vous faudra installer une version récente de Python avec
 Homebrew. Sinon, vous pouvez utiliser la version intégrée avec macOS de Python,
 mais vous devrez installer ``pip``.
@@ -121,7 +121,7 @@ Vous devriez obtenir un numéro de version de pip et de Python, comme cela :
 .. sourcecode:: bash
 
   $ pip --version  # ou une des autres commandes
-  pip 22.3.1 from /opt/homebrew/lib/python3.10/site-packages/pip (python 3.10)
+  pip 22.3.1 from /opt/homebrew/lib/python3.11/site-packages/pip (python 3.11)
 
 Si ces commandes retournent toutes une erreur, et non un numéro de version,
 vous devez installer ``pip``. `Les instructions d’installation sont sur le site

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+target-version = ["py311", "py312"]
 extend-exclude = """
 ^/doc
 """

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 -r requirements-dev.txt
 -r requirements-prod.txt
 
-coverage==6.4.4 # check if Coveralls needs to be also updated in .github/workflows/ci.yml
+coverage==7.8.0 # check if Coveralls needs to be also updated in .github/workflows/ci.yml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 
-black==24.8.0  # needs to be also updated in .pre-commit-config.yaml
-colorlog==6.8.2
-django-debug-toolbar==4.4.6
-django-extensions==3.2.3
-Faker==30.0.0
-pre-commit==3.8.0
+black==25.1.0  # needs to be also updated in .pre-commit-config.yaml
+colorlog==6.9.0
+django-debug-toolbar==5.2.0
+django-extensions==4.1
+Faker==37.1.0
+pre-commit==4.2.0
 PyYAML==6.0.2
-selenium==4.25.0
-Sphinx==7.2.6
-sphinx-rtd-theme==2.0.0
+selenium==4.32.0
+Sphinx==8.2.3
+sphinx-rtd-theme==3.0.2

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
 gunicorn==23.0.0
-mysqlclient==2.2.4
-sentry-sdk==2.14.0
+mysqlclient==2.2.7
+sentry-sdk==2.27.0
 ujson==5.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,3 @@ drf-yasg==1.21.7
 # Dependencies for slug generation, please be extra careful with those
 django-uuslug==2.0.0
 python-slugify==8.0.4
-
-# tomllib was added to the standard library in Python 3.11
-# tomli is only needed for older Python versions
-tomli==2.0.1 ; python_version < "3.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,33 +1,33 @@
 # Implicit dependencies (optional dependencies of dependencies)
 crispy-forms-bootstrap2==2024.1
-social-auth-app-django==5.4.2
+social-auth-app-django==5.4.3
 
 # Explicit dependencies (references in code)
-beautifulsoup4==4.12.3
-django-crispy-forms==2.3
+beautifulsoup4==4.13.4
+django-crispy-forms==2.4
 django-model-utils==5.0.0
-django-recaptcha==4.0.0
-Django==4.2.16
+django-recaptcha==4.1.0
+Django==4.2.21
 easy-thumbnails[svg]==2.10.0
-factory-boy==3.3.1
-geoip2==4.8.0
-GitPython==3.1.43
+factory-boy==3.3.3
+geoip2==5.1.0
+GitPython==3.1.44
 homoglyphs==2.0.4
-lxml==5.3.0
-Pillow==10.4.0
+lxml==5.4.0
+Pillow==11.2.1
 pymemcache==4.0.0
 requests==2.32.3
 typesense==0.21.0
-ua-parser==0.18.0
+ua-parser==1.0.1
 
 # Api dependencies
-django-cors-headers==4.4.0
-django-filter==24.3
-django-oauth-toolkit==2.3.0
-djangorestframework==3.15.2
-drf-extensions==0.7.1
+django-cors-headers==4.7.0
+django-filter==25.1
+django-oauth-toolkit==3.0.1
+djangorestframework==3.16.0
+drf-extensions==0.8.0
 dry-rest-permissions==0.1.10
-drf-yasg==1.21.7
+drf-yasg==1.21.10
 
 # Dependencies for slug generation, please be extra careful with those
 django-uuslug==2.0.0

--- a/scripts/define_variable.sh
+++ b/scripts/define_variable.sh
@@ -9,7 +9,7 @@ if [[ $ZDS_VENV_VERSION == "" ]]; then
 fi
 
 if [[ $ZDS_PIP_VERSION == "" ]]; then
-    ZDS_PIP_VERSION="24.3.1" # needs to be also updated in .github/workflows/ci.yml
+    ZDS_PIP_VERSION="25.1.1" # needs to be also updated in .github/workflows/ci.yml
 fi
 
 ZDS_NODE_VERSION=$(head -n 1 $ZDSSITE_DIR/.nvmrc)

--- a/zds/gallery/mixins.py
+++ b/zds/gallery/mixins.py
@@ -270,15 +270,15 @@ class ImageCreateMixin(ImageMixin):
         error_files = []
 
         for i in zfile.namelist():
-            info = zfile.getinfo(i)
+            file_info = zfile.getinfo(i)
 
-            if info.filename[-1] == "/":  # .is_dir() in python 3.6
+            if file_info.is_dir():
                 continue
 
             basename = os.path.basename(i)
             (name, ext) = os.path.splitext(basename)
 
-            if info.file_size > settings.ZDS_APP["gallery"]["image_max_size"]:
+            if file_info.file_size > settings.ZDS_APP["gallery"]["image_max_size"]:
                 error_files.append(i)
                 continue
 

--- a/zds/utils/misc.py
+++ b/zds/utils/misc.py
@@ -55,7 +55,7 @@ def remove_utf8mb4(s):
     """
     if not isinstance(s, str):
         s = str(s, "utf-8")
-    re_pattern = re.compile("[^\u0000-\uD7FF\uE000-\uFFFF]", re.UNICODE)
+    re_pattern = re.compile("[^\u0000-\ud7ff\ue000-\uffff]", re.UNICODE)
     return re_pattern.sub("", s)
 
 

--- a/zds/utils/tests/tests_models.py
+++ b/zds/utils/tests/tests_models.py
@@ -50,7 +50,7 @@ class TagsTests(TestCase):
         )
 
         # test tags title stripping
-        tags = ["foo bar", "  azerty", "\u00A0qwerty ", " another tag "]
+        tags = ["foo bar", "  azerty", "\u00a0qwerty ", " another tag "]
         insert_valid_tags(tags)
 
         all_titles = Tag.objects.values_list("title", flat=True)


### PR DESCRIPTION
Au passage, on requiert maintenant au moins Python 3.11, qui est une contrainte de certaines dépendances et qui n'est pas un problème en pratique.

Typesense est mis à jour dans la PR #6676 

### Contrôle qualité

La CI passe.

Dans l'idéal, tester les fonctionnalités impactées par les dépendances. Peut-être que je déploierais cette PR sur le serveur de bêta.
