### PR TITLE
Teste la taille de le type de l'image avant l'upload dans le nouvel éditeur

### DIFF
--- a/assets/js/editor-new.js
+++ b/assets/js/editor-new.js
@@ -310,10 +310,20 @@
   const uploadImage = function(file, onSuccess, onError) {
     const galleryUrl = '/api/galeries/' + document.body.getAttribute('data-gallery') + '/images/'
 
+    if (file.type.indexOf('image') !== 0) {
+      onError(`L'image "${file.name}" a un format invalide !`)
+      return
+    }
+
+    const filesize = Math.round(file.size / 1024) // KB
+    if (filesize > 1024) {
+      onError(`L'image "${file.name}" est trop lourde (${filesize} Kio). La taille maximale est de 1024 Kio !`)
+      return
+    }
+
     const formData = new FormData()
     formData.append('physical', file)
     formData.append('title', file.name)
-    // WARN: if you test zds with sqlite, you can't upload multiple files at a time
     $.ajax({
       url: galleryUrl,
       data: formData,

--- a/assets/js/editor-old.js
+++ b/assets/js/editor-old.js
@@ -738,7 +738,6 @@ function uploadImage (e, dataTransferAttr, csrf){
         var formData = new FormData();
         formData.append('physical', f);
         formData.append('title', f.name);
-        // WARN: if you test zds with sqlite, you can't upload multiple files at a time
         $.ajax({
             url: galleryUrl,
             data: formData, type: 'POST',

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -152,7 +152,7 @@ ZDS_APP = {
         "hats_management": "Staff",
     },
     "gallery": {
-        "image_max_size": 1024 * 1024,
+        "image_max_size": 1024 * 1024,  # bytes, also hard-coded in editor JS scripts
         "gallery_per_page": 21,
         "images_per_page": 21,
     },


### PR DESCRIPTION
Pour éviter de faire une requête qui renverra une réponse 400, comme c'est fait dans l'ancien éditeur.

Sentry a rapporté un bug `RequestDataTooBig` pour une requête POST vers la route `/api/galeries/{pk_gallery}/images/`. Ça correspond donc à l'upload d'une image par drag'n'drop dans l'éditeur. Dans le nouvel éditeur, on en vérifiait pas la taille et le type du fichier avant de faire la requête AJAX, cette PR corrige ça.

Cependant, cette PR ne corrige pas le problème côté back-end : si une requête POST trop grosse vers cette URL est faite, l'erreur sera quand même présente. Django répondra bien une erreur 400 (cf [la doc](https://docs.djangoproject.com/en/dev/ref/settings/#data-upload-max-memory-size)), mais loggera une erreur qui remontera dans Sentry. Je pense qu'on veut quand même garder ce genre d'"erreur" dans Sentry pour savoir s'il n'y pas un problème ailleurs dans le code. Et je me demande s'il ne faudrait pas réduire la taille maximale de requête que veut bien accepter Nginx (actuellement c'est 100 Mo, pourquoi ?) à la valeur de `DATA_UPLOAD_MAX_MEMORY_SIZE`, par défaut à 2,5 Mo, ce qui me semble largement suffisant pour notre usage.

### Contrôle qualité

Sur une page avec l'éditeur, basculer sur le nouvel éditeur, puis glisser/déposer une image plus lourde que 1 Mo et un fichier qui n'est pas une image. Une erreur doit apparaître, sans que de requête Ajax ait été effectuée.
