### PR TITLE
Interdit les caractères non affichables dans les pseudos

### DIFF
--- a/zds/member/tests/views/tests_register.py
+++ b/zds/member/tests/views/tests_register.py
@@ -331,6 +331,13 @@ class TestRegister(TutorialTestMixin, TestCase):
                 "password_confirm": "flavour",
                 "email": "firm1@zestedesavoir.com",
             },
+            # username with non-printable-character
+            {
+                "username": "\u0020\u202efirm1",
+                "password": "flavour",
+                "password_confirm": "flavour",
+                "email": "firm1@zestedesavoir.com",
+            },
         ]
 
         for user in users:

--- a/zds/member/tests/views/tests_register.py
+++ b/zds/member/tests/views/tests_register.py
@@ -326,7 +326,7 @@ class TestRegister(TutorialTestMixin, TestCase):
             },
             # username with utf8mb4 chars
             {
-                "username": " firm1",
+                "username": "🍆firm1",
                 "password": "flavour",
                 "password_confirm": "flavour",
                 "email": "firm1@zestedesavoir.com",

--- a/zds/member/validators.py
+++ b/zds/member/validators.py
@@ -106,6 +106,11 @@ def validate_zds_username(value, check_username_available=True):
         msg = _("Le nom d'utilisateur ne peut contenir de barres obliques")
     elif contains_utf8mb4(value):
         msg = _("Le nom d'utilisateur ne peut pas contenir des caractères utf8mb4")
+    elif not value.isprintable():
+        # https://docs.python.org/fr/3.11/library/stdtypes.html#str.isprintable
+        msg = _(
+            "Le nom d'utilisateur ne peut contenir des caractères non affichables (caractères Unicode des catégories Z ou C)"
+        )
     elif check_username_available and user_count > 0:
         msg = _("Ce nom d'utilisateur est déjà utilisé")
     elif check_username_available and skeleton_user_count > 0:


### PR DESCRIPTION
Interdit les caractères non affichables dans les pseudos
Fixes #6732 

**QA :**
- `source zdsenv/bin/activate && make update && make zmd-start && make run-back`
- Vérifier qu'il n'est pas possible de créer un compte avec un pseudo contenant des caractères non affichables
- Vérifier qu'il n'est pas possible de renommer un pseudo avec des caractères non affichables