### PR TITLE
Affiche l'adresse de contact sur la page d'une casquette

### DIFF
--- a/templates/member/hat.html
+++ b/templates/member/hat.html
@@ -1,6 +1,7 @@
 {% extends "member/base.html" %}
 
 
+{% load email_obfuscator %}
 {% load emarkdown %}
 {% load i18n %}
 
@@ -35,6 +36,13 @@
 {% block content %}
     {% if groupcontact.description %}
         <p>{{ groupcontact.description|emarkdown }}</p>
+    {% endif %}
+    {% if groupcontact.email %}
+        <p>
+            {% blocktrans with group_name=groupcontact.name|lower group_email=groupcontact.email|obfuscate_mailto_top_subject:"Contact" %}
+                Vous pouvez joindre {{ group_name }} par courriel via {{ group_email }}.
+            {% endblocktrans %}
+        </p>
     {% endif %}
 
     {% if users %}

--- a/zds/member/tests/views/tests_hats.py
+++ b/zds/member/tests/views/tests_hats.py
@@ -8,6 +8,7 @@ from zds.forum.tests.factories import ForumCategoryFactory, ForumFactory
 from zds.member.tests.factories import ProfileFactory, StaffProfileFactory, UserFactory
 from zds.pages.models import GroupContact
 from zds.utils.models import Hat, HatRequest
+from zds.utils.templatetags.email_obfuscator import obfuscate
 
 
 class HatTests(TestCase):
@@ -287,6 +288,7 @@ class HatTests(TestCase):
         self.assertContains(result, "Staff")  # this hat hat was created with the staff user
 
     def test_hat_detail(self):
+        group_email_address = "foo@bar.fr"
         # we will use the staff hat, created with the staff user
         hat = Hat.objects.get(name="Staff")
         # test the page is accessible without being authenticated
@@ -305,8 +307,18 @@ class HatTests(TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertContains(result, self.staff.username)
         # if we display this group on the contact page...
-        GroupContact.objects.create(group=Group.objects.get(name="staff"), description="group description", position=1)
+        group_contact = GroupContact.objects.create(
+            group=Group.objects.get(name="staff"), description="group description", position=1
+        )
         # the description should be shown on this page too
         result = self.client.get(hat.get_absolute_url())
         self.assertEqual(result.status_code, 200)
         self.assertContains(result, "group description")
+        self.assertNotContains(result, group_email_address)
+        # now set an email address to the group
+        group_contact.email = group_email_address
+        group_contact.save()
+        # the email address should appear obfuscated
+        result = self.client.get(hat.get_absolute_url())
+        self.assertEqual(result.status_code, 200)
+        self.assertContains(result, obfuscate(group_email_address))


### PR DESCRIPTION
J'ai remarqué que [la page qui affiche les détails de la casquette *Équipe technique*](https://beta.zestedesavoir.com/membres/casquettes/2/) mentionne "Merci de nous envoyer un courriel à l’adresse ci-dessous", mais aucune adresse mail n'apparaît en-dessous. Cette PR corrige le problème, en reprenant ce qui est fait pour la page Contact.

### Contrôle qualité

1. Avant de basculer sur le code de la PR, aller sur la page de la casquette de l'équipe technique : http://127.0.0.1:8000/membres/casquettes/2/ (on peut y accéder en cliquant sur la casquette affichée sur la page de profil du membre `dev`) : l'adresse de contact n'est pas affichée
2. Basculer sur le code de cette PR
3. Actualiser la même page : l'adresse de contact est affichée.
4. Sur la page de la casquette *Staff*, il n'y a pas d'adresse mail et la page s'affiche bien

Pour info, l'adresse mail associée à une casquette est en réalité l'adresse mail définie au groupe associé à la casquette et ça se définit depuis la zone d'admin en modifiant l'objet *Groupe de la page de contact* du module *Pages* (j'ai un peu cherché...).
