### PR TITLE
Ajoute la dernière version de Fedora testée au script d'installation

### DIFF
--- a/scripts/dependencies/fedora.txt
+++ b/scripts/dependencies/fedora.txt
@@ -1,5 +1,5 @@
 #title=Fedora
-#desc=Utilisation de dnf / Non testé sur les versions récentes
+#desc=Utilisation de dnf / Testé sur Fedora 42
 #installcmd=dnf -y install
 git
 wget


### PR DESCRIPTION
J'ai testé récemment l'installation de l'environnement de dev sur Fedora, et ça marche, donc on peut le dire.

### Contrôle qualité

Idéalement, tester l'installation sur une Fedora et voir que ça marche aussi bien que chez moi.

`make install-linux` et choisir Fedora.