### PR TITLE
Indique que Debian Trixie est supporté

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ on:
 
 env:
   NODE_VERSION: "24" # needs to be also updated in .nvmrc
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.13"
   PIP_VERSION: "25.1.1" # needs to be also updated in scripts/define_variable.sh
-  MARIADB_VERSION: "10.11.11"
+  MARIADB_VERSION: "11.8.6"
   COVERALLS_VERSION: "4.0.2" # check if Coverage needs to be also updated in requirements-ci.txt
   TYPESENSE_VERSION: "29.0" # needs to be also updated in scripts/define_variable.sh
 

--- a/doc/source/install/install-docker.rst
+++ b/doc/source/install/install-docker.rst
@@ -16,7 +16,7 @@ Lancez un shell interactif dans un conteneur basé sur Debian :
 
 .. sourcecode:: bash
 
-    docker run -it -p 8000:8000 debian:bookworm
+    docker run -it -p 8000:8000 debian:trixie
 
 
 Une fois dans le conteneur, saisissez les commandes suivantes :

--- a/scripts/dependencies/debian.txt
+++ b/scripts/dependencies/debian.txt
@@ -1,5 +1,5 @@
 #title=Debian
-#desc=Utilisation de apt-get / Testé sur Debian Bullseye (11), Bookworm (12)
+#desc=Utilisation de apt-get / Testé sur Debian Bookworm (12), Trixie (13)
 #updatecmd=apt-get -y update
 #installcmd=apt-get -y install
 git
@@ -20,10 +20,12 @@ libz-dev
 libjpeg62-turbo
 libjpeg62-turbo-dev
 libfreetype6
-libfreetype6-dev
+libfreetype-dev
 libffi-dev
 build-essential
 imagemagick
 librsvg2-bin
 xzdec
 dh-autoreconf
+# pour la commande `column`, utilisée par `make help`:
+bsdextrautils


### PR DESCRIPTION
- ajoute Trixie (sortie début août)
- retire Bullseye (EOL atteint en août 2024)
- ajoute un paquet manquant (quelle que soit la version de Debian)

Pour l'instant, c'est bloqué par https://github.com/zestedesavoir/zds-site/pull/6738#issuecomment-3218164111.

### Contrôle qualité

Dans l'idéal, tester les instructions d'installation avec Docker pour partir facilement d'un environnement vierge.
