### PR TITLE
Ignore les éventuels répertoires lors de la copie des images pour un ePUB

### DIFF
--- a/zds/tutorialv2/epub_utils.py
+++ b/zds/tutorialv2/epub_utils.py
@@ -137,8 +137,10 @@ def build_ebook(published_content_entity, working_dir, final_file_path):
 
     mimetype_conf = __build_mime_type_conf()
     mime_path = Path(working_dir, "ebook", mimetype_conf["filename"])
-    with contextlib.suppress(FileExistsError, FileNotFoundError):
-        for img in published_content_entity.content.gallery.get_gallery_path().iterdir():
+    for img in published_content_entity.content.gallery.get_gallery_path().iterdir():
+        # Do not interrupt the whole loop if one item triggers an exception
+        # IsADirectoryError: ignore directories (which can be there only if created manually)
+        with contextlib.suppress(FileExistsError, FileNotFoundError, IsADirectoryError):
             shutil.copy(str(img), str(target_image_dir))
 
     with mime_path.open(mode="w", encoding="utf-8") as mimefile:


### PR DESCRIPTION
Si jamais un dossier y a été créé manuellement. Change également l'imbrication for / suppress pour éviter d'interrompre la boucle s'il y a une erreur sur un item du parcours du dossier.

Le bug nous a été signalé par Sentry, pour l'export ePUB de [ce billet](https://zestedesavoir.com/billets/4931/une-histoire-de-generation-dimages-et-dalgorithmes/). Pour ce contenu, j'ai uploadé manuellement certaines images dans la galerie et j'y ai laissé un dossier par erreur, ce qui a fait échouer l'export en ePUB lors de la copie des images de la galerie vers le dossier des ressources de l'ePUB, car la fonction ne s'attendait pas à trouver un dossier. 

### Contrôle qualité

La CI passer, tester éventuellement l'export en ePUB d'un contenu qui contient des images et en créant aussi un dossier dans le dossier de la galerie du contenu.
