### PR TITLE
Ajoute une commande pour désinscrire un membre

### DIFF
--- a/zds/member/management/commands/unregister.py
+++ b/zds/member/management/commands/unregister.py
@@ -1,0 +1,54 @@
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+
+from zds.member.utils import unregister
+
+
+class Command(BaseCommand):
+    help = "Unregister a member"
+
+    def boolean_input(self, question, default=None):
+        # From django/db/migrations/questioner.py
+        self.stdout.write(f"{question} ", ending="")
+        result = input()
+        if not result and default is not None:
+            return default
+        while not result or result[0].lower() not in "yn":
+            self.stdout.write("Please answer yes or no: ", ending="")
+            result = input()
+        return result[0].lower() == "y"
+
+    def add_arguments(self, parser):
+        # Don't use email because on production we have several accounts with the
+        # same email...
+        parser.add_argument("username", type=str)
+        parser.add_argument("-f", "--force", action="store_true", default=False)
+
+    def handle(self, *args, **options):
+        username = options.get("username")
+        force = options.get("force")
+
+        nb_matching = User.objects.filter(username=username).count()
+
+        if nb_matching == 0:
+            self.stderr.write(self.style.ERROR(f"Unknown user '{username}'"))
+            return
+        elif nb_matching > 1:
+            self.stderr.write(self.style.ERROR(f"{nb_matching} users have '{username}' as username"))
+            return
+
+        user = User.objects.filter(username=username).first()
+
+        self.stdout.write("Found the following user:")
+        self.stdout.write(f"Username: {user.username}")
+        self.stdout.write(f"Email: {user.email}")
+        self.stdout.write(f"First login: {user.date_joined}")
+        self.stdout.write(f"Last login: {user.profile.last_visit}")
+        self.stdout.write(f"Is active: {user.is_active}")
+        self.stdout.write("")
+
+        if force or self.boolean_input(f"Are you sure you want to unregister user '{username}'? [y/N]", False):
+            unregister(user)
+            self.stdout.write(self.style.SUCCESS(f"Unregistered user '{username}'"))
+        else:
+            self.stdout.write("Aborting.")

--- a/zds/member/tests/tests_commands.py
+++ b/zds/member/tests/tests_commands.py
@@ -1,0 +1,29 @@
+import os
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.test import TestCase
+
+from zds.member.tests.factories import ProfileFactory, UserFactory
+
+
+class TestUnregisterCommand(TestCase):
+    def setUp(self):
+        self.anonymous = UserFactory(username=settings.ZDS_APP["member"]["anonymous_account"], password="anything")
+        self.external = UserFactory(username=settings.ZDS_APP["member"]["external_account"], password="anything")
+
+    def test_unregister_command(self):
+        def call_silent_command(arg: str):
+            with open(os.devnull, "w") as f:
+                call_command("unregister", "--force", arg, stdout=f, stderr=f)
+
+        user = ProfileFactory()
+        self.assertEqual(User.objects.filter(username=user.user.username).count(), 1)
+
+        call_silent_command("unexisting_user")
+        self.assertEqual(User.objects.filter(username=user.user.username).count(), 1)
+
+        call_silent_command(user.user.username)
+        self.assertEqual(User.objects.filter(username=user.user.username).count(), 0)
+        self.assertEqual(User.objects.filter().count(), 2)  # anonymous and external

--- a/zds/member/utils.py
+++ b/zds/member/utils.py
@@ -1,17 +1,24 @@
 import ipaddress
 import logging
+from importlib import import_module
 
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.contrib.gis.geoip2 import GeoIP2, GeoIP2Exception
+from django.db import transaction
+from django.db.models import Q
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from geoip2.errors import AddressNotFoundError
+from oauth2_provider.models import AccessToken
 from social_django.middleware import SocialAuthExceptionMiddleware
 from ua_parser import user_agent_parser
 
 logger = logging.getLogger(__name__)
+
+Session = import_module(settings.SESSION_ENGINE).CustomSession
+SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 
 class ZDSCustomizeSocialAuthExceptionMiddleware(SocialAuthExceptionMiddleware):
@@ -127,3 +134,101 @@ def get_network_ip(ip_address):
 def get_network_ip_filter(ip_address):
     """Retrieves the network address of this IP address without the last colon, so we can filter IP addresses on this network"""
     return str(get_network_ip(ip_address).network_address)[:-1]
+
+
+def remove_session(session_key, user_pk):
+    """Removes a session, but checks before that the session belongs to the user."""
+    session = SessionStore(session_key=session_key)
+    if session.get("_auth_user_id", "") == str(user_pk):
+        session.flush()
+
+
+@transaction.atomic
+def unregister(user: User):
+    """Unregisters a user: remove all related data, anonymize what we want to keep and remove all sessions."""
+    # To avoid circular imports:
+    from zds.forum.models import Topic
+    from zds.gallery.models import GALLERY_WRITE, UserGallery
+    from zds.member.models import Ban, BannedEmailProvider, KarmaNote
+    from zds.mp.models import PrivatePost, PrivateTopic
+    from zds.tutorialv2.models.database import PickListOperation
+    from zds.tutorialv2.models.events import Event
+    from zds.utils.models import Alert, Comment, CommentEdit, CommentVote, HatRequest
+
+    anonymous = get_anonymous_account()
+    external = get_external_account()
+
+    # Nota : as of v21 all about content paternity is held by a proper receiver in zds.tutorialv2.models.database
+    PickListOperation.objects.filter(staff_user=user).update(staff_user=anonymous)
+    PickListOperation.objects.filter(canceler_user=user).update(canceler_user=anonymous)
+
+    Event.objects.filter(performer=user).update(performer=external)
+    Event.objects.filter(author=user).update(author=external)
+    Event.objects.filter(contributor=user).update(contributor=external)
+
+    # Comments likes / dislikes
+    votes = CommentVote.objects.filter(user=user)
+    for vote in votes:
+        if vote.positive:
+            vote.comment.like -= 1
+        else:
+            vote.comment.dislike -= 1
+        vote.comment.save()
+    votes.delete()
+    # All contents anonymization
+    Comment.objects.filter(author=user).update(author=anonymous)
+    PrivatePost.objects.filter(author=user).update(author=anonymous)
+    CommentEdit.objects.filter(editor=user).update(editor=anonymous)
+    CommentEdit.objects.filter(deleted_by=user).update(deleted_by=anonymous)
+    # Karma notes, alerts and sanctions anonymization (to keep them)
+    KarmaNote.objects.filter(moderator=user).update(moderator=anonymous)
+    Ban.objects.filter(moderator=user).update(moderator=anonymous)
+    Alert.objects.filter(author=user).update(author=anonymous)
+    Alert.objects.filter(moderator=user).update(moderator=anonymous)
+    BannedEmailProvider.objects.filter(moderator=user).update(moderator=anonymous)
+    # Solved hat requests anonymization
+    HatRequest.objects.filter(moderator=user).update(moderator=anonymous)
+    # In case current user has been moderator in the past
+    Comment.objects.filter(editor=user).update(editor=anonymous)
+    for topic in PrivateTopic.objects.filter(Q(author=user) | Q(participants__in=[user])):
+        if topic.one_participant_remaining():
+            topic.delete()
+        else:
+            topic.remove_participant(user)
+            topic.save()
+    Topic.objects.filter(solved_by=user).update(solved_by=anonymous)
+    Topic.objects.filter(author=user).update(author=anonymous)
+
+    # Any content exclusively owned by the unregistering member will
+    # be deleted just before the User object (using a pre_delete
+    # receiver).
+    #
+    # Regarding galleries, there are two cases:
+    #
+    # - "personal galleries" with one owner (the unregistering
+    #   user). The user's ownership is removed and replaced by an
+    #   anonymous user in order not to lost the gallery.
+    #
+    # - "personal galleries" with many other owners. It is safe to
+    #   remove the user's ownership, the gallery won't be lost.
+
+    galleries = UserGallery.objects.filter(user=user)
+    for gallery in galleries:
+        if gallery.gallery.get_linked_users().count() == 1:
+            anonymous_gallery = UserGallery()
+            anonymous_gallery.user = external
+            anonymous_gallery.mode = GALLERY_WRITE
+            anonymous_gallery.gallery = gallery.gallery
+            anonymous_gallery.save()
+    galleries.delete()
+
+    # Remove API access (tokens + applications)
+    for token in AccessToken.objects.filter(user=user):
+        token.revoke()
+
+    # Remove all sessions to logout the user:
+    for session in Session.objects.filter(account_id=user.pk).iterator():
+        remove_session(session.session_key, user.pk)
+    Session.objects.filter(account_id=user.pk).delete()
+
+    User.objects.filter(pk=user.pk).delete()

--- a/zds/member/views/register.py
+++ b/zds/member/views/register.py
@@ -7,7 +7,6 @@ from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.mail import EmailMultiAlternatives
-from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
@@ -15,21 +14,16 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, FormView
-from oauth2_provider.models import AccessToken
 
-from zds.forum.models import Topic
-from zds.gallery.models import GALLERY_WRITE, UserGallery
 from zds.member import NEW_ACCOUNT
 from zds.member.commons import ProfileCreate, TokenGenerator
 from zds.member.decorator import BlockedIPMixin
 from zds.member.forms import LoginForm, RegisterForm, UnregisterForm, UsernameAndEmailForm
-from zds.member.models import Ban, BannedEmailProvider, KarmaNote, NewEmailProvider, Profile, TokenRegister
-from zds.member.utils import get_anonymous_account, get_bot_account, get_client_ip, get_external_account
-from zds.mp.models import PrivatePost, PrivateTopic
+from zds.member.models import NewEmailProvider, Profile, TokenRegister
+from zds.member.utils import get_anonymous_account, get_bot_account, get_client_ip
+from zds.member.utils import unregister as do_unregister
 from zds.mp.utils import send_mp
-from zds.tutorialv2.models.database import PickListOperation
-from zds.tutorialv2.models.events import Event
-from zds.utils.models import Alert, Comment, CommentEdit, CommentVote, HatRequest, get_hat_from_settings
+from zds.utils.models import get_hat_from_settings
 
 
 class RegisterView(BlockedIPMixin, CreateView, ProfileCreate, TokenGenerator):
@@ -147,7 +141,6 @@ def warning_unregister(request):
 
 @login_required
 @require_POST
-@transaction.atomic
 def unregister(request):
     """Allow members to unregister."""
 
@@ -161,79 +154,9 @@ def unregister(request):
             request, "member/settings/unregister.html", {"user": request.user, "unregister_form": unregister_form}
         )
 
-    anonymous = get_anonymous_account()
-    external = get_external_account()
-    current = request.user
-    # Nota : as of v21 all about content paternity is held by a proper receiver in zds.tutorialv2.models.database
-    PickListOperation.objects.filter(staff_user=current).update(staff_user=anonymous)
-    PickListOperation.objects.filter(canceler_user=current).update(canceler_user=anonymous)
-
-    Event.objects.filter(performer=current).update(performer=external)
-    Event.objects.filter(author=current).update(author=external)
-    Event.objects.filter(contributor=current).update(contributor=external)
-
-    # Comments likes / dislikes
-    votes = CommentVote.objects.filter(user=current)
-    for vote in votes:
-        if vote.positive:
-            vote.comment.like -= 1
-        else:
-            vote.comment.dislike -= 1
-        vote.comment.save()
-    votes.delete()
-    # All contents anonymization
-    Comment.objects.filter(author=current).update(author=anonymous)
-    PrivatePost.objects.filter(author=current).update(author=anonymous)
-    CommentEdit.objects.filter(editor=current).update(editor=anonymous)
-    CommentEdit.objects.filter(deleted_by=current).update(deleted_by=anonymous)
-    # Karma notes, alerts and sanctions anonymization (to keep them)
-    KarmaNote.objects.filter(moderator=current).update(moderator=anonymous)
-    Ban.objects.filter(moderator=current).update(moderator=anonymous)
-    Alert.objects.filter(author=current).update(author=anonymous)
-    Alert.objects.filter(moderator=current).update(moderator=anonymous)
-    BannedEmailProvider.objects.filter(moderator=current).update(moderator=anonymous)
-    # Solved hat requests anonymization
-    HatRequest.objects.filter(moderator=current).update(moderator=anonymous)
-    # In case current user has been moderator in the past
-    Comment.objects.filter(editor=current).update(editor=anonymous)
-    for topic in PrivateTopic.objects.filter(Q(author=current) | Q(participants__in=[current])):
-        if topic.one_participant_remaining():
-            topic.delete()
-        else:
-            topic.remove_participant(current)
-            topic.save()
-    Topic.objects.filter(solved_by=current).update(solved_by=anonymous)
-    Topic.objects.filter(author=current).update(author=anonymous)
-
-    # Any content exclusively owned by the unregistering member will
-    # be deleted just before the User object (using a pre_delete
-    # receiver).
-    #
-    # Regarding galleries, there are two cases:
-    #
-    # - "personal galleries" with one owner (the unregistering
-    #   user). The user's ownership is removed and replaced by an
-    #   anonymous user in order not to lost the gallery.
-    #
-    # - "personal galleries" with many other owners. It is safe to
-    #   remove the user's ownership, the gallery won't be lost.
-
-    galleries = UserGallery.objects.filter(user=current)
-    for gallery in galleries:
-        if gallery.gallery.get_linked_users().count() == 1:
-            anonymous_gallery = UserGallery()
-            anonymous_gallery.user = external
-            anonymous_gallery.mode = GALLERY_WRITE
-            anonymous_gallery.gallery = gallery.gallery
-            anonymous_gallery.save()
-    galleries.delete()
-
-    # Remove API access (tokens + applications)
-    for token in AccessToken.objects.filter(user=current):
-        token.revoke()
-
+    do_unregister(request.user)
     logout(request)
-    User.objects.filter(pk=current.pk).delete()
+
     return redirect(reverse("homepage"))
 
 

--- a/zds/member/views/sessions.py
+++ b/zds/member/views/sessions.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 
-from zds.member.utils import get_geo_location_from_ip, get_info_from_user_agent
+from zds.member.utils import get_geo_location_from_ip, get_info_from_user_agent, remove_session
 from zds.utils.paginator import ZdSPagingListView
 
 Session = import_module(settings.SESSION_ENGINE).CustomSession
@@ -51,8 +51,6 @@ class DeleteSession(LoginRequiredMixin, View):
     def post(self, request, *args, **kwargs):
         session_key = request.POST.get("session_key", None)
         if session_key and session_key != self.request.session.session_key:
-            session = SessionStore(session_key=session_key)
-            if session.get("_auth_user_id", "") == str(self.request.user.pk):
-                session.flush()
+            remove_session(session_key, self.request.user.pk)
 
         return redirect(reverse("list-sessions"))


### PR DESCRIPTION
Pour faciliter la désinscription d'un membre par l'équipe technique (plutôt que de devoir changer le mot de passe du membre depuis la zone d'admin, se connecter à son compte et cliquer sur "désinscrire").

Ça aurait pu être implémenté comme une fonctionnalité réservée au staff sur la page de profil, mais : 
- supprimer un compte est une opération qu'il ne faut pas faire à la légère, donc autant que ce ne soit pas une fonctionnalité trop facilement accessible
- le cas d'usage est que l'équipe technique est contactée par mail pour demander la suppression du compte : l'équipe technique a normalement accès aux serveurs pour exécuter la commande
- (j'y ai pensé trop tard !)

### Contrôle qualité

- se connecter en tant que `user1`, puis dans un terminal exécuter `python manage.py unregister user1`, valider
- actualiser la page d'accueil : on n'est plus connecté, `user1` n'existe plus
