### PR TITLE
Affiche l'inscription par social_auth sur la page de profil

### DIFF
--- a/templates/member/profile.html
+++ b/templates/member/profile.html
@@ -69,6 +69,13 @@
                     {% endblocktrans %}
                 </li>
             {% endif %}
+            {% if login_providers %}
+                <li>
+                    {% blocktrans with providers=login_providers|join:", " %}
+                        Authentification par {{ providers }}
+                    {% endblocktrans %}
+                </li>
+            {% endif %}
         {% endif %}
     {% endcaptureas %}
 

--- a/zds/member/views/profile.py
+++ b/zds/member/views/profile.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.http import StreamingHttpResponse
@@ -193,6 +194,14 @@ class MemberDetail(DetailView):
                 context["provider_to_ban"] = new_provider
 
         context["summaries"] = self.get_summaries(profile, hide_forum_activity)
+
+        if self.request.user.has_perm("member.show_ip"):
+            context["login_providers"] = []
+            # like in django/contrib/auth/forms.py:ReadOnlyPasswordHashWidget
+            if usr.password and not usr.password.startswith(UNUSABLE_PASSWORD_PREFIX):
+                context["login_providers"].append(settings.ZDS_APP["site"]["literal_name"])
+            for p in usr.social_auth.all():
+                context["login_providers"].append(p.provider.capitalize())
 
         return context
 


### PR DESCRIPTION
Visible uniquement pour les membres qui ont le droit de voir les adresses IP (le staff), affiche sur la page de profil par quel fournisseur tiers (Facebook, Google ou Twitter) l'inscription a été faite. Utile parfois pour débugger.

### Contrôle qualité

Même si ce n'est pas indiqué, le patch est déployé sur le serveur de bêta.
- Dans la zone d'admin, aller dans la liste des objets *User social auths*. Aller sur la page de profil de quelques membres listés et s'assurer que si on a le droit de voir les adresses IPs, les fournisseurs tiers sont également indiqués.
- Vérifier qu'en étant déconnecté, on ne voit pas cette information
- Vérifier que sur un compte qui ne s'est pas inscrit en passant par un fournisseur tiers, la page de profil est toujours correcte
