### PR TITLE
Définit l'apostrophe comme un séparateur pour les recherches

### DIFF
--- a/zds/search/models.py
+++ b/zds/search/models.py
@@ -49,6 +49,9 @@ class AbstractSearchIndexable:
         search_engine_schema = dict()
         search_engine_schema["name"] = self.get_search_document_type()
         search_engine_schema["fields"] = [{"name": ".*", "type": "auto"}]
+        search_engine_schema["token_separators"] = [
+            "'",  # "l'harmonie" should match "harmonie"
+        ]
         search_engine_schema["symbols_to_index"] = [
             "+",  # c++
             "#",  # c#

--- a/zds/search/tests/tests_views.py
+++ b/zds/search/tests/tests_views.py
@@ -904,6 +904,19 @@ class ViewsTests(TutorialTestMixin, TestCase):
         self.assertContains(result, reverse("search:query"))
         self.assertContains(result, reverse("search:opensearch"))
 
+    def test_apostrophe(self):
+        topic1 = TopicFactory(forum=self.forum, author=self.user, title="Parlons d'une harmonie qui sonne bien")
+        topic2 = TopicFactory(forum=self.forum, author=self.user, title="Voici l'harmonie qui sonne bien")
+        topic3 = TopicFactory(forum=self.forum, author=self.user, title="Rien à voir")
+
+        self._index_everything()
+
+        response = self.client.get(reverse("search:query") + "?q=harmonie", follow=False)
+        self.assertEqual(response.status_code, 200)
+
+        results = response.context["object_list"]
+        self.assertEqual(len(results), 2)
+
     def test_upercase_and_lowercase_search_give_same_results(self):
         """Pretty self-explanatory function name, isn't it ?"""
 


### PR DESCRIPTION
Quand on cherche `harmonie`, les objets contenant `l'harmonie` devraient aussi apparaître.

Étonnamment, si [on précise que la langue du contenu indexé est le français](https://typesense.org/docs/guide/locale.html), ça ne fonctionne plus.

### Contrôle qualité

Les tests passent.
