### PR TITLE
Utilise la version 29.0 de Typesense

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   PIP_VERSION: "25.1.1" # needs to be also updated in scripts/define_variable.sh
   MARIADB_VERSION: "10.11.11"
   COVERALLS_VERSION: "4.0.1" # check if Coverage needs to be also updated in requirements-ci.txt
-  TYPESENSE_VERSION: "28.0" # needs to be also updated in scripts/define_variable.sh
+  TYPESENSE_VERSION: "29.0" # needs to be also updated in scripts/define_variable.sh
 
   # As GitHub Action does not allow environment variables
   # to be used in services definitions, these are only for

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ lxml==5.4.0
 Pillow==11.2.1
 pymemcache==4.0.0
 requests==2.32.3
-typesense==1.0.3
+typesense==1.1.1
 ua-parser==1.0.1
 
 # Api dependencies

--- a/scripts/define_variable.sh
+++ b/scripts/define_variable.sh
@@ -19,7 +19,7 @@ if [[ $ZDS_NVM_VERSION == "" ]]; then
 fi
 
 if [[ $ZDS_TYPESENSE_VERSION == "" ]]; then
-    ZDS_TYPESENSE_VERSION="28.0" # needs to be also updated in .github/workflows/ci.yml
+    ZDS_TYPESENSE_VERSION="29.0" # needs to be also updated in .github/workflows/ci.yml
 fi
 
 if [[ $ZDS_TYPESENSE_API_KEY == "" ]]; then

--- a/zds/search/tests/tests_utils.py
+++ b/zds/search/tests/tests_utils.py
@@ -204,6 +204,4 @@ class SearchFilterTests(TestCase):
         f = SearchFilter()
 
         f.add_not_numerical_filter("forum_pk", [6, 7])
-        self.assertEqual(str(f), "(forum_pk:!=6 && forum_pk:!=7)")
-        # Expected output when a Typesense bug will be fixed (see comment in tested function):
-        # self.assertEqual(str(f), "(forum_pk:!=[6,7])")
+        self.assertEqual(str(f), "(forum_pk:!=[6,7])")

--- a/zds/search/utils.py
+++ b/zds/search/utils.py
@@ -365,10 +365,4 @@ class SearchFilter:
         :param values: A list of integer values the field cannot have.
         :type values: list[int]
         """
-
-        # Starting from version 27.1 of Typesense, there is a bug making filter_by=field:!=[1,2] not work.
-        # The workaround is to make a more verbose version of the filter: filter_by=field:!=1&&field:!=2
-        # The bug was reported upstream: https://github.com/typesense/typesense/issues/2350
-        # Please switch back to the :!=[1,2] version when the bug will be fixed.
-        # self._add_filter(f"{field}:!= [" + ", ".join(map(str, values)) + "]")
-        self._add_filter(" && ".join(map(lambda s: f"{field}:!={s}", values)))
+        self._add_filter(f"{field}:!=[" + ",".join(map(str, values)) + "]")


### PR DESCRIPTION
### Contrôle qualité

La CI passe. Si on est courageux, tester la recherche en local.
