### PR TITLE
Précise l'erreur d'import d'une archive dans une galerie

### DIFF
--- a/zds/gallery/mixins.py
+++ b/zds/gallery/mixins.py
@@ -5,6 +5,7 @@ import tempfile
 import zipfile
 
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 from easy_thumbnails.files import get_thumbnailer
 from PIL import Image as ImagePIL
 from svglib.svglib import load_svg_file
@@ -279,7 +280,16 @@ class ImageCreateMixin(ImageMixin):
             (name, ext) = os.path.splitext(basename)
 
             if file_info.file_size > settings.ZDS_APP["gallery"]["image_max_size"]:
-                error_files.append(i)
+                error_files.append(
+                    {
+                        "filename": i,
+                        "error": _(
+                            "l'image dépasse la taille maximale autorisée ({} Ko)".format(
+                                settings.ZDS_APP["gallery"]["image_max_size"] / 1024
+                            )
+                        ),
+                    }
+                )
                 continue
 
             # create file for image
@@ -295,7 +305,12 @@ class ImageCreateMixin(ImageMixin):
                 self.perform_create(name, f_im)
                 f_im.close()
             except NotAnImage:
-                error_files.append(i)
+                error_files.append(
+                    {
+                        "filename": i,
+                        "error": _("ce n'est pas une image"),
+                    }
+                )
                 continue
             if os.path.exists(ph_temp):
                 os.remove(ph_temp)

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -1,8 +1,11 @@
 import os
+import tempfile
+from zipfile import ZipFile
 
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
+from PIL import Image as ImagePIL
 
 from zds.gallery.models import Gallery, Image, UserGallery
 from zds.gallery.tests.factories import GalleryFactory, ImageFactory, UserGalleryFactory
@@ -727,6 +730,49 @@ class NewImageViewTest(TestCase):
             follow=True,
         )
         self.assertEqual(200, response.status_code)
+
+    def test_import_not_zip_archive(self):
+        self.client.force_login(self.profile1.user)
+
+        with (settings.BASE_DIR / "fixtures" / "logo.png").open("rb") as fp:
+            response = self.client.post(
+                reverse("gallery:image-import", args=[self.gallery.pk]), {"file": fp}, follow=False
+            )
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(response.context["form"].errors)
+        self.assertEqual(0, len(self.gallery.get_images()))
+
+    def test_import_archive_with_wrong_files(self):
+        self.client.force_login(self.profile1.user)
+
+        # generate a too large image:
+        _, large_image_path = tempfile.mkstemp(suffix=".jpeg")
+        img = ImagePIL.new("RGB", (9000, 9000), color="red")
+        img.save(large_image_path, format="JPEG")
+        self.assertGreater(os.path.getsize(large_image_path), settings.ZDS_APP["gallery"]["image_max_size"])
+
+        # generate an archive with wrong files:
+        _, zip_file_path = tempfile.mkstemp(suffix=".zip")
+        z = ZipFile(zip_file_path, "w")
+        z.write(__file__, "text.png")  # text file instead of a valid image
+        z.write(large_image_path, "large.jpeg")  # too large image
+        z.write(settings.BASE_DIR / "fixtures" / "logo.png")  # valid image
+        z.close()
+
+        with open(zip_file_path, "rb") as fp:
+            response = self.client.post(
+                reverse("gallery:image-import", args=[self.gallery.pk]), {"file": fp}, follow=True
+            )
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, "Le fichier text.png n&#x27;a pas été importé : ce n&#x27;est pas une image.")
+        self.assertContains(
+            response,
+            "Le fichier large.jpeg n&#x27;a pas été importé : l&#x27;image dépasse la taille maximale autorisée",
+        )
+        self.assertEqual(1, len(self.gallery.get_images()))  # only the valid image is imported
+
+        os.remove(zip_file_path)
+        os.remove(large_image_path)
 
     def test_import_images_in_gallery_no_archive(self):
         self.client.force_login(self.profile1.user)

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -430,10 +430,8 @@ class ImportImages(ImageFromGalleryContextViewMixin, ImageCreateMixin, LoggedWit
 
         error_files = self.perform_create_multi(archive)
 
-        if len(error_files) > 0:
-            messages.error(
-                self.request, _('Les fichiers suivants n\'ont pas été importés: "{}"').format('", "'.join(error_files))
-            )
+        for e in error_files:
+            messages.error(self.request, _(f'Le fichier {e["filename"]} n\'a pas été importé : {e["error"]}.'))
 
         self.success_url = self.gallery.get_absolute_url()
         return super().form_valid(form)


### PR DESCRIPTION
Pour chaque fichier de l'archive non importé, précise la raison

### Contrôle qualité

1. Créer une archive zip qui contient : 
    - une image valide
    - une image dont la taille est supérieure à 1024 Ko
    - un fichier texte qui a une extension d'image
 2. Se rendre dans une de ses galeries et aller sur la page pour importer une archive d'images
 3. Valider l'import
 4. Seule l'image valide est importée, pour les deux fichiers invalides on a un message flash qui précise la raison du non-import de ces images.
