### PR TITLE
Supprime une configuration inutile

### DIFF
--- a/zds/settings/prod.py
+++ b/zds/settings/prod.py
@@ -140,7 +140,6 @@ SEARCH_CONNECTION["api_key"] = config["typesense"].get("api_key", "xyz")
 ZDS_APP["site"]["association"]["email"] = "communication@zestedesavoir.com"
 
 # content
-ZDS_APP["article"]["repo_path"] = "/opt/zds/data/articles-data"
 ZDS_APP["content"]["repo_private_path"] = "/opt/zds/data/contents-private"
 ZDS_APP["content"]["repo_public_path"] = "/opt/zds/data/contents-public"
 ZDS_APP["content"]["extra_content_generation_policy"] = "WATCHDOG"


### PR DESCRIPTION
Pas utilisé dans le code et provoque une erreur `KeyError: 'article'` depuis 8fcacfc8a0bb2bceaee53a3747de715c22f6c210.

### Contrôle qualité

La CI passe et j'arrive à déployer sur la bêta.
