### PR TITLE
Corrige le décalage des titres lors de la conversion zmd->html

### DIFF
--- a/zds/tutorialv2/publish_container.py
+++ b/zds/tutorialv2/publish_container.py
@@ -18,7 +18,7 @@ def publish_use_manifest(db_object, base_dir, versionable_content: VersionedCont
     base_content = export_content(versionable_content, with_text=True)
 
     md, metadata, __ = render_markdown(
-        base_content, disable_jsfiddle=not db_object.js_support, full_json=True, stats=True
+        base_content, disable_jsfiddle=not db_object.js_support, use_manifest=True, stats=True
     )
     publish_container_new(db_object, base_dir, versionable_content, md)
     return metadata.get("stats", {}).get("signs", 0)

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -38,8 +38,11 @@ def _render_markdown_once(md_input, *, output_format="html", **kwargs):
 
     inline = kwargs.get("inline", False) is True
 
-    # If use_manifest is True, we send to ZMarkdown all content (eg all chapters) at once
+    # If use_manifest is True, we send to ZMarkdown all content (eg all
+    # chapters) at once (used especially for HTML and TeX)
     use_manifest = kwargs.pop("use_manifest", False)
+    if output_format.startswith("tex"):
+        use_manifest = True
 
     if settings.ZDS_APP["zmd"]["disable_pings"] is True:
         kwargs["disable_ping"] = True
@@ -50,12 +53,12 @@ def _render_markdown_once(md_input, *, output_format="html", **kwargs):
         timeout = 10
         real_input = str(md_input)
         kwargs["heading_shift"] = 2
-        if output_format.startswith("tex") or use_manifest:
-            # latex may be really long to generate but it is also restrained by server configuration
-            timeout = 120
-            # use manifest renderer
-            real_input = md_input
-            kwargs["heading_shift"] = -1
+        if use_manifest:
+            timeout = 120  # tex or manifest can be long to generate
+            real_input = md_input  # with manifest rendering, md_input is actually a dict/JSON object with metadata
+            kwargs["heading_shift"] = 0  # by default when manifest is used
+        if output_format.startswith("tex"):
+            kwargs["heading_shift"] = -1  # required for tex export
         response = post(
             "{}{}".format(settings.ZDS_APP["zmd"]["server"], endpoint),
             json={

--- a/zds/utils/templatetags/emarkdown.py
+++ b/zds/utils/templatetags/emarkdown.py
@@ -37,7 +37,9 @@ def _render_markdown_once(md_input, *, output_format="html", **kwargs):
         logger.error(f"kwargs: {kwargs!r}")
 
     inline = kwargs.get("inline", False) is True
-    full_json = kwargs.pop("full_json", False)
+
+    # If use_manifest is True, we send to ZMarkdown all content (eg all chapters) at once
+    use_manifest = kwargs.pop("use_manifest", False)
 
     if settings.ZDS_APP["zmd"]["disable_pings"] is True:
         kwargs["disable_ping"] = True
@@ -48,7 +50,7 @@ def _render_markdown_once(md_input, *, output_format="html", **kwargs):
         timeout = 10
         real_input = str(md_input)
         kwargs["heading_shift"] = 2
-        if output_format.startswith("tex") or full_json:
+        if output_format.startswith("tex") or use_manifest:
             # latex may be really long to generate but it is also restrained by server configuration
             timeout = 120
             # use manifest renderer
@@ -84,7 +86,7 @@ def _render_markdown_once(md_input, *, output_format="html", **kwargs):
             content = content.strip()
         if inline:
             content = content.replace("</p>\n", "\n\n").replace("\n<p>", "\n")
-        if full_json:
+        if use_manifest:
             return content, metadata, messages
         return mark_safe(content), metadata, messages
     except:  # noqa


### PR DESCRIPTION
J'ai été  un peu trop rapide dans a8f10b6. Le décalage des titres est mauvais lors de la conversion de zMarkdown vers HTML pour par exemple un contenu.

J'ai remarqué le problème en voulant reproduire un autre problème avec le billet https://zestedesavoir.com/billets/4523/feminicide-de-quoi-parle-t-on/ qui contient uniquement une introduction, mais avec des titres de niveau 1 dans l'introduction.

Au passage, on a une différence de rendu des titres entre la version brouillon et la version en ligne, mais c'est un problème pour un autre ticket.

Je profite de cette PR pour changer un nom de variable pour clarifier sa signification et refactoriser un peu le code.


### Contrôle qualité

- Créer un billet avec des titres dans l'introduction
- Publier le billet
- Le rendu de la version publique est similaire à ce qu'on peut obtenir sur la version de production (ne pas tester avec la bêta qui contient le bug)

Pour que ce soit plus facile de comparer, il suffit de reprendre le contenu d'un billet déjà existant sur la production.

Vérifier également que les niveaux des titres sont corrects dans les exports (PDF, ePUB), ainsi que dans les commentaires ou les messages sur le forum.
