### PR TITLE
Corrige l'export en ePUB d'un contenu sans galerie

### DIFF
--- a/doc/source/back-end/gallery.rst
+++ b/doc/source/back-end/gallery.rst
@@ -103,16 +103,16 @@ Une modale s'ouvre ensuite, demandant de confirmer le choix :
 Une fois cliqué sur "Confirmer", la galerie et les images qu'elle contient sont supprimées.
 
 .. attention::
-   Si une galerie est liée à un tutoriel existant, elle ne peut pas être supprimée.
+   Si une galerie est liée à un contenu existant, elle ne peut pas être supprimée.
 
-Lien galerie <-> Tutoriel
-=========================
+Lien galerie <-> Contenu
+========================
 
-Chaque tutoriel possède une galerie en propre. Par défaut cette galerie possède le même nom qui a été donné au tutoriel lors de sa création.
+Chaque contenu (tutoriel, article ou billet) possède une galerie en propre. Par défaut cette galerie possède le même nom qui a été donné au contenu lors de sa création.
 
-Chaque auteur possède un droit d'accès en écriture (``GALLERY_WRITE``) sur la galerie liée au tutoriel.
+Chaque auteur possède un droit d'accès en écriture (``GALLERY_WRITE``) sur la galerie liée au contenu.
 
-Si un membre possède un droit de lecture seule (``GALLERY_READ``) sur la galerie d'un tutoriel, aucun droit n'est accordé à ce membre quant au tutoriel.
+Si un membre possède un droit de lecture seule (``GALLERY_READ``) sur la galerie d'un contenu, aucun droit n'est accordé à ce membre quant au contenu.
 
 Aspects techniques
 ==================

--- a/doc/source/back-end/gallery.rst
+++ b/doc/source/back-end/gallery.rst
@@ -121,7 +121,9 @@ Chaque galerie (classe ``Gallery``) est stockée en base de données avec son ti
 
 Une image (classe ``Image``) est renseignée en base de données avec son titre, sa légende, un lien vers la galerie qui la contient, son *slug* et un lien *physique* vers le fichier image (ainsi que la date de création et de dernière modification).
 
-Les images sont stockées dans le dossier renseigné par la variable ``MEDIA_URL`` (dans le fichier ``zds/settings/abstract_base/django.py``), dans un sous-dossier dont le nom correspond au ``pk`` de la galerie. C'est la bibliothèque `easy_thumbnails <https://github.com/SmileyChris/easy-thumbnails>`_ qui gère la génération des miniatures correspondantes aux images uploadées, à la demande du *back-end*.
+Les images sont stockées dans le dossier renseigné par la variable ``MEDIA_URL`` (dans le fichier ``zds/settings/abstract_base/django.py``), dans un sous-dossier dont le nom correspond au ``pk`` de la galerie. Le sous-dossier spécifique à chaque galerie n'est pas créé lors de la création de la galerie, mais lors de l'import de la première image.
+
+C'est la bibliothèque `easy_thumbnails <https://github.com/SmileyChris/easy-thumbnails>`_ qui gère la génération des miniatures correspondantes aux images uploadées, à la demande du *back-end*.
 
 Outils logiciels utilisés
 =========================

--- a/zds/gallery/tests/factories.py
+++ b/zds/gallery/tests/factories.py
@@ -34,12 +34,6 @@ class GalleryFactory(factory.django.DjangoModelFactory):
     subtitle = factory.Sequence("Sous-titre de la gallerie {}".format)
     slug = factory.LazyAttribute(lambda o: f"{old_slugify(o.title)}")
 
-    @classmethod
-    def _generate(cls, create, attrs):
-        gallery = super()._generate(create, attrs)
-        gallery.get_gallery_path().mkdir(parents=True, exist_ok=True)
-        return gallery
-
 
 class UserGalleryFactory(factory.django.DjangoModelFactory):
     class Meta:

--- a/zds/tutorialv2/epub_utils.py
+++ b/zds/tutorialv2/epub_utils.py
@@ -137,11 +137,15 @@ def build_ebook(published_content_entity, working_dir, final_file_path):
 
     mimetype_conf = __build_mime_type_conf()
     mime_path = Path(working_dir, "ebook", mimetype_conf["filename"])
-    for img in published_content_entity.content.gallery.get_gallery_path().iterdir():
-        # Do not interrupt the whole loop if one item triggers an exception
-        # IsADirectoryError: ignore directories (which can be there only if created manually)
-        with contextlib.suppress(FileExistsError, FileNotFoundError, IsADirectoryError):
-            shutil.copy(str(img), str(target_image_dir))
+    if published_content_entity.content.gallery.get_gallery_path().exists():
+        # The gallery dir is created only when uploading the first image, so if
+        # the content doesn't have any image from its gallery, the folder may
+        # not exist.
+        for img in published_content_entity.content.gallery.get_gallery_path().iterdir():
+            # Do not interrupt the whole loop if one item triggers an exception
+            # IsADirectoryError: ignore directories (which can be there only if created manually)
+            with contextlib.suppress(FileExistsError, FileNotFoundError, IsADirectoryError):
+                shutil.copy(str(img), str(target_image_dir))
 
     with mime_path.open(mode="w", encoding="utf-8") as mimefile:
         mimefile.write(mimetype_conf["content"])


### PR DESCRIPTION
Fix #6758 

J'en profite pour mettre un peu à jour la doc correspondante.

J'enlève la création du dossier dans la factory pour les galeries, pour que le comportement de la factory soit le même qu'avec une vraie `Gallery` (le dossier de la galerie est créé seulement lors de l'import de la première image).

Avec cette modification dans `GalleryFactory`, on a un test qui échoue exactement à cause du bug rapporté, c'est le test `zds.tutorialv2.tests.tests_views.tests_content.ContentTests.test_publication_make_extra_contents`.

### Contrôle qualité

1. Créer un billet
2. Y mettre deux phrases de contenu, mais pas d'image (pas de miniature non plus)
3. Publier le billet
4. Générer l'export en ePUB : `python3 manage.py generate_epub $id`. L'export réussit et produit un ePUB valide.
