### PR TITLE
Add pdf & epub to statistics of content

### DIFF
--- a/zds/tutorialv2/views/statistics.py
+++ b/zds/tutorialv2/views/statistics.py
@@ -256,7 +256,6 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
             raise PermissionDenied
 
         urls = self.get_urls_to_render()
-        export_urls = self
         start_date, end_date = self.get_start_and_end_dates()
         display_mode = self.get_display_mode(urls)
         reports = {}

--- a/zds/tutorialv2/views/statistics.py
+++ b/zds/tutorialv2/views/statistics.py
@@ -2,7 +2,7 @@ import itertools
 import logging
 import urllib.parse
 from datetime import date, datetime, timedelta
-from typing import Any
+from typing import Any, List
 
 import requests
 from django.conf import settings
@@ -213,13 +213,13 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
         return "comparison"
 
     @staticmethod
-    def get_cumulative(stats) -> dict[str, int]:
+    def get_cumulative(stats: dict[str, list]) -> dict[str, int]:
         cumul = {"total": 0}
         for info_date, infos_stat in stats.items():
             cumul["total"] += len(infos_stat)
             for info_stat in infos_stat:
                 for key, val in info_stat.items():
-                    if type(val) == str:
+                    if type(val) == str or isinstance(val, dict):
                         continue
                     if key in cumul:
                         cumul[key] += int(val)

--- a/zds/tutorialv2/views/statistics.py
+++ b/zds/tutorialv2/views/statistics.py
@@ -2,16 +2,19 @@ import itertools
 import logging
 import urllib.parse
 from datetime import date, datetime, timedelta
+from typing import Any
 
 import requests
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 
 from zds.tutorialv2.forms import ContentCompareStatsURLForm
 from zds.tutorialv2.mixins import SingleOnlineContentDetailViewMixin
+from zds.tutorialv2.models.versioned import VersionedContent
 from zds.tutorialv2.utils import NamedUrl
 
 
@@ -68,43 +71,88 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
                     urls.append(NamedUrl(subchild.title, subchild.get_absolute_url_online(), 2))
         return urls
 
-    def get_all_statistics(self, urls, start, end, methods):
-        date_ranges = "{},{}".format(start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d"))
-        data_request = {"module": "API", "method": "API.getBulkRequest", "format": "json", "filter_limit": -1}
-        data_structured = {}
+    def get_export_urls(self):
+        content: VersionedContent = self.versioned_object
+        content_type = content.type.lower()
+        epub_url = reverse(f"{content_type}:download-epub", kwargs={"pk": content.pk, "slug": content.slug})
+        pdf_url = reverse(f"{content_type}:download-pdf", kwargs={"pk": content.pk, "slug": content.slug})
+        urls = [
+            NamedUrl("epub", epub_url, 0),
+            NamedUrl("pdf", pdf_url, 0),
+        ]
 
-        for method in methods:
-            data_structured[method] = []
+        return urls
 
-        for index, method_url in enumerate(itertools.product(methods, urls)):
+    def get_all_statistics(
+        self, urls: list[NamedUrl], start: datetime | date, end: datetime | date, methods
+    ) -> dict[str, list]:
+        """Fetch statistics from Matomo in batches of at most 3 URLs per request.
+
+        Matomo bulk API is queried with a cartesian product of `methods` and a
+        chunk of `urls` (size <= 3). Results are aggregated to preserve the
+        original `urls` order for each method.
+        """
+        date_ranges = f"{start:%Y-%m-%d},{end:%Y-%m-%d}"
+
+        # Initialize the aggregated structure with one list per method
+        data_structured = {method: [] for method in methods}
+
+        # Process URLs in chunks of 3 to limit the bulk size per request
+        # this is done to reduce matomo memory load on big tuto with many parts & chapters
+        for i in range(0, len(urls), 3):
+            url_chunk = urls[i : min(i + 3, len(urls))]
+
+            # Build a fresh bulk request for this chunk
+            data_request = {
+                "module": "API",
+                "method": "API.getBulkRequest",
+                "format": "json",
+                "filter_limit": -1,
+            }
+
+            self.build_matomo_payload(data_request, date_ranges, methods, url_chunk)
+
+            # Execute the bulk request for this chunk
+            response_matomo = requests.post(url=self.matomo_api_url, data=data_request)
+            data = response_matomo.json()
+
+            # Top-level error returned by Matomo
+            if isinstance(data, dict) and data.get("result", "") == "error":
+                raise StatisticsException(self.logger.error, data.get("message", "Unknown matomo error"))
+
+            # Validate and aggregate each response item in the same order
+            for page_index, matomo_stat_for_url_tuple in enumerate(itertools.product(methods, url_chunk)):
+                if isinstance(data[page_index], dict) and data[page_index].get("result", "") == "error":
+                    raise StatisticsException(
+                        self.logger.error,
+                        data[page_index].get("message", "Unknown matomo error for " + matomo_stat_for_url_tuple[1].url),
+                    )
+
+                method = matomo_stat_for_url_tuple[0]
+                data_structured[method].append(data[page_index])
+
+        return data_structured
+
+    def build_matomo_payload(self, data_request: dict[str, str | int], date_ranges, methods: list[str], url_chunk):
+        for index, method_url in enumerate(itertools.product(methods, url_chunk)):
             method = method_url[0]
             url = method_url[1]
             absolute_url = f"{self.request.scheme}://{self.request.get_host()}{url.url}"
             param_url = f"pageUrl=={urllib.parse.quote_plus(absolute_url)}"
 
-            request_params = {"method": method, "idSite": self.matomo_site_id, "date": date_ranges, "period": "day"}
-            if method.startswith("Referrers"):  # referrers requests use segment for define url
+            request_params = {
+                "method": method,
+                "idSite": self.matomo_site_id,
+                "date": date_ranges,
+                "period": "day",
+            }
+            # Referrers requests use segment to define url
+            if method.startswith("Referrers"):
                 request_params["segment"] = ",".join([param_url])
             elif method == "Actions.getPageUrl":
                 request_params["pageUrl"] = absolute_url
 
             data_request.update({f"urls[{index}]": urllib.parse.urlencode(request_params)})
-
-        response_matomo = requests.post(url=self.matomo_api_url, data=data_request)
-        data = response_matomo.json()
-        if isinstance(data, dict) and data.get("result", "") == "error":
-            raise StatisticsException(self.logger.error, data.get("message", _("Pas de message d'erreur")))
-        else:
-            for index, method_url in enumerate(itertools.product(methods, urls)):
-                if isinstance(data[index], dict) and data[index].get("result", "") == "error":
-                    raise StatisticsException(
-                        self.logger.error, data[index].get("message", _("Pas de message d'erreur"))
-                    )
-
-                method = method_url[0]
-                data_structured[method].append(data[index])
-
-            return data_structured
 
     @staticmethod
     def get_stat_metrics(data, metric_name):
@@ -165,7 +213,7 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
         return "comparison"
 
     @staticmethod
-    def get_cumulative(stats):
+    def get_cumulative(stats) -> dict[str, int]:
         cumul = {"total": 0}
         for info_date, infos_stat in stats.items():
             cumul["total"] += len(infos_stat)
@@ -208,6 +256,7 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
             raise PermissionDenied
 
         urls = self.get_urls_to_render()
+        export_urls = self
         start_date, end_date = self.get_start_and_end_dates()
         display_mode = self.get_display_mode(urls)
         reports = {}
@@ -215,59 +264,86 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
         referrers = {}
         type_referrers = {}
         keywords = {}
-        report_field = [("nb_uniq_visitors", False), ("nb_hits", False), ("avg_time_on_page", True)]
+        report_fields = [("nb_uniq_visitors", False), ("nb_hits", False), ("avg_time_on_page", True)]
+        export_urls = self.get_export_urls()
 
         try:
-            # Each function sends only one bulk request for all the urls
-            # Each variable is a list of dictionnaries (one for each url)
             all_statistics = self.get_all_statistics(
                 urls,
                 start_date,
                 end_date,
                 ["Referrers.getReferrerType", "Referrers.getWebsites", "Referrers.getKeywords", "Actions.getPageUrl"],
             )
+            export_statistics = self.get_all_statistics(export_urls, start_date, end_date, ["Actions.getPageUrl"])
         except StatisticsException as e:
             all_statistics = {}
+            export_statistics = {}
             logger_method, msg = e.args
             logger_method(f"Something failed with Matomo reporting system: {msg}")
             messages.error(self.request, _("Impossible de récupérer les statistiques du site ({}).").format(msg))
         except Exception as e:
             all_statistics = {}
+            export_statistics = {}
             self.logger.error(f"Something failed with Matomo reporting system: {e}")
             messages.error(self.request, _("Impossible de récupérer les statistiques du site ({}).").format(e))
 
-        if all_statistics != {}:
+        result_report = {}
+        if all_statistics:
             all_stats = all_statistics["Actions.getPageUrl"]
             all_ref_websites = all_statistics["Referrers.getWebsites"]
             all_ref_types = all_statistics["Referrers.getReferrerType"]
             all_ref_keyword = all_statistics["Referrers.getKeywords"]
 
             for index, url in enumerate(urls):
-                cumul_stats = self.get_cumulative(all_stats[index])
+                grand_totals = ContentStatisticsView.get_cumulative(all_stats[index])
                 reports[url] = {}
                 cumulative_stats[url] = {}
 
-                for item, is_avg in report_field:
-                    reports[url][item] = self.get_stat_metrics(all_stats[index], item)
-                    if is_avg:
-                        cumulative_stats[url][item] = 0
-                        if cumul_stats.get("total") > 0:
-                            cumulative_stats[url][item] = cumul_stats.get(item, 0) / cumul_stats.get("total")
-                    else:
-                        cumulative_stats[url][item] = cumul_stats.get(item, 0)
+                self.__format_result(all_stats, grand_totals, cumulative_stats, index, report_fields, reports, url)
 
                 referrers = self.merge_ref_to_data(referrers, self.get_ref_metrics(all_ref_websites[index]))
                 type_referrers = self.merge_ref_to_data(type_referrers, self.get_ref_metrics(all_ref_types[index]))
                 keywords = self.merge_ref_to_data(keywords, self.get_ref_metrics(all_ref_keyword[index]))
 
             if display_mode.lower() == "global":
-                reports = {NamedUrl(display_mode, "", 0): self.merge_report_to_global(reports, report_field)}
+                """
+                {
+                  "global": {
+                        "nb_uniq_visitors": (
+                            ["2025-11-06", "2025-11-07", "2025-11-08"],
+                            [2500, 2800, 2650] ),
+                        "nb_hits": (
+                            ["2025-11-06", "2025-11-07", "2025-11-08"],
+                            [8500, 9200, 8900]  # Somme de tous les hits pour toutes les URLs
+                        ),
+                        "avg_time_on_page": (
+                            ["2025-11-06", "2025-11-07", "2025-11-08"],
+                            [480, 520, 505]  # Somme des temps moyens (pas vraiment une moyenne au final)
+                        )
+                  },
+                  "epub": {
+                    ...
+                  },
+                  "pdf": {
+                    ...
+                  }
+                }
+                """
+                result_report = {NamedUrl(display_mode, "", 0): self.merge_report_to_global(reports, report_fields)}
+                export_reports = {}
+                export_cumulative_stats = {}
+                self.__format_export_report(
+                    export_cumulative_stats, export_reports, export_statistics, export_urls, report_fields
+                )
+                result_report.update(export_reports)
+            else:
+                result_report = reports
 
         context.update(
             {
                 "display": display_mode,
                 "urls": urls,
-                "reports": reports,
+                "reports": result_report,
                 "cumulative_stats": cumulative_stats,
                 "referrers": referrers,
                 "type_referrers": type_referrers,
@@ -275,3 +351,46 @@ class ContentStatisticsView(SingleOnlineContentDetailViewMixin, FormView):
             }
         )
         return context
+
+    def __format_export_report(
+        self,
+        export_cumulative_stats: dict[Any, Any],
+        export_reports: dict[Any, Any],
+        export_statistics: dict[str, list] | dict[Any, Any],
+        export_urls: list[NamedUrl],
+        report_fields: list[tuple[str, bool]],
+    ):
+        for export_index, export_url in enumerate(export_urls):
+            export_grand_totals = ContentStatisticsView.get_cumulative(
+                export_statistics["Actions.getPageUrl"][export_index]
+            )
+            export_reports[export_url] = {}
+            export_cumulative_stats[export_url] = {}
+            self.__format_result(
+                export_statistics["Actions.getPageUrl"],
+                export_grand_totals,
+                export_cumulative_stats,
+                export_index,
+                report_fields,
+                export_reports,
+                export_url,
+            )
+
+    def __format_result(
+        self,
+        all_stats: list,
+        grand_totals: dict[str, int],
+        cumulative_stats: dict,
+        index: int,
+        report_field: list[tuple[str, bool]],
+        reports: dict,
+        url: NamedUrl,
+    ):
+        for field_name, is_avg in report_field:
+            reports[url][field_name] = ContentStatisticsView.get_stat_metrics(all_stats[index], field_name)
+            if is_avg:
+                cumulative_stats[url][field_name] = 0
+                if grand_totals.get("total") > 0:
+                    cumulative_stats[url][field_name] = grand_totals.get(field_name, 0) / grand_totals.get("total")
+            else:
+                cumulative_stats[url][field_name] = grand_totals.get(field_name, 0)


### PR DESCRIPTION
close #6760 

- Refactor `get_all_statistics` to handle URL chunks and improve Matomo memory load.
- Introduce separate methods to generate formatted export URLs and aggregate export data.
- Add type hinting and enhance documentation for clarity.

<!-- Décrivez vos changements ici (optionnel pour les tous petits changements). -->

<!-- Remplacez XXXX par le numéro de ticket corrigé par vos changements : GitHub fermera le ticket mentionné automatiquement (voir https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue pour plus de détails). Supprimez la ligne s'il n'y a pas de ticket associé. --!>
Fix #XXXX

<!-- Si votre PR modifie du code Python, mettez à jour ou créez les tests unitaires associés. Signalez vos éventuelles difficultés afin que des contributeurs expérimentés puissent vous aider. -->

<!-- Si votre pull request requiert des actions particulières lors de la mise en production, renseignez-les ici afin qu’elles soient ajoutées au changelog lors du merge. -->

### Contrôle qualité

Il faut avoir matomo de configuré (je sais pas comment faire)
Puis générer des vues et des downloads epub et pdf
et afficher les stats.
Logiquement en mode "global" on les aura
De plus j'ai "batché" les recherches de stats pour les bigs tutos, permettant d'éviter les out of memory

<!-- Merci ! -->
