### PR TITLE
Corrige le blocage des IPv6 (IPv6 seule ou tout le bloc /64)

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -774,10 +774,7 @@ class BlockedIPForm(forms.ModelForm):
         }
 
     def __init__(self, is_ipv6, *args, **kwargs):
-        if is_ipv6:
-            is_network_address = Field("is_network_address")
-        else:
-            is_network_address = Hidden("is_network_address", False)
+        self.is_ipv6 = is_ipv6
 
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
@@ -786,9 +783,17 @@ class BlockedIPForm(forms.ModelForm):
         self.helper.form_method = "post"
 
         self.helper.layout = Layout(
-            is_network_address,
+            Field("is_network_address") if is_ipv6 else None,
             Field("reason"),
             ButtonHolder(
                 StrictButton("Bloquer cette adresse IP", type="submit"),
             ),
         )
+
+    def clean_is_network_address(self):
+        # Un formulaire avec une case à cocher retourne
+        # - "on" (valeur par défaut) si elle est cochée
+        # - rien si elle n'est pas cochée
+        if self.is_ipv6 and self.cleaned_data.get("is_network_address"):
+            return True
+        return False

--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -783,17 +783,16 @@ class BlockedIPForm(forms.ModelForm):
         self.helper.form_method = "post"
 
         self.helper.layout = Layout(
-            Field("is_network_address") if is_ipv6 else None,
             Field("reason"),
             ButtonHolder(
                 StrictButton("Bloquer cette adresse IP", type="submit"),
             ),
         )
+        if is_ipv6:
+            self.helper.layout.insert(0, Field("is_network_address"))
 
     def clean_is_network_address(self):
         # Un formulaire avec une case à cocher retourne
         # - "on" (valeur par défaut) si elle est cochée
         # - rien si elle n'est pas cochée
-        if self.is_ipv6 and self.cleaned_data.get("is_network_address"):
-            return True
-        return False
+        return self.is_ipv6 and self.cleaned_data.get("is_network_address")

--- a/zds/member/tests/views/tests_moderation.py
+++ b/zds/member/tests/views/tests_moderation.py
@@ -638,3 +638,27 @@ class IpListingsTests(TestCase):
         self.client.force_login(self.staff)
         response = self.client.get(reverse(members_from_ip, args=["0.0.0.0"]))
         self.assertTemplateUsed(response, "member/admin/members_from_ip.html")
+
+    def test_ban_ipv4(self):
+        self.client.force_login(self.staff)
+        response = self.client.post(
+            reverse(members_from_ip, args=["155.128.92.75"]),
+            {"reason": "Foobar"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_ban_ipv6(self):
+        self.client.force_login(self.staff)
+        response = self.client.post(
+            reverse(members_from_ip, args=["2001:8f8:1425:60a0:9852:7981:3721:93b4"]),
+            {"reason": "Foobar"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_ban_ipv6_network(self):
+        self.client.force_login(self.staff)
+        response = self.client.post(
+            reverse(members_from_ip, args=["2001:8f8:1425:60a0:9852:7981:3721:93b8"]),
+            {"reason": "Foobar", "is_network_address": "on"},
+        )
+        self.assertEqual(response.status_code, 200)

--- a/zds/member/views/ip_addresses.py
+++ b/zds/member/views/ip_addresses.py
@@ -50,9 +50,9 @@ def members_from_ip(request, ip_address):
             else:
                 blocked_ip = BlockedIP(
                     ip_address=ip_address,
-                    is_network_address=form.data["is_network_address"],
+                    is_network_address=form.cleaned_data["is_network_address"],
                     moderator=request.user,
-                    reason=form.data["reason"],
+                    reason=form.cleaned_data["reason"],
                 )
                 blocked_ip.save()
                 messages.success(request, "Cette adresse IP a été bloquée !")


### PR DESCRIPTION
Fixes #6771 

J'avais oublié mes bases de HTML lorsque j'ai mis en place le blocage des IPs. Un formulaire avec une case à cocher retourne : "on" (valeur par défaut) si elle est cochée et rien sinon.

J'ai donc adapté le code pour prendre en compte cette réalité et j'ai ajouté des tests concernant la vue.