### PR TITLE
Corrige l'orthographe de la page des liens de partage

### DIFF
--- a/templates/tutorialv2/view/list_shareable_links.html
+++ b/templates/tutorialv2/view/list_shareable_links.html
@@ -12,9 +12,9 @@
         <h1>{% blocktrans %} Liens de partage pour « {{ content }} » {% endblocktrans %}</h1>
     </header>
     <section>
-    <p>{% trans "Diffusez votre contenu en partageant un simple lien accessible sans incription sur le site." %}</p>
+    <p>{% trans "Diffusez votre contenu en partageant un simple lien accessible sans inscription sur le site." %}</p>
 
-    <p>{% trans "Les liens de partages offrent les fonctionnalités suivantes :" %}</p>
+    <p>{% trans "Les liens de partage offrent les fonctionnalités suivantes :" %}</p>
 
     {% blocktrans %}
     <ul>


### PR DESCRIPTION
 Corrige l'orthographe de la page des liens de partage.

 # Contrôle qualité

Regarder que les deux fautes corrigées sont bien parties sur la page des liens de partage.