### PR TITLE
Évite une 500 si le formulaire de profil ne contient pas tous les champs

### DIFF
--- a/zds/member/forms.py
+++ b/zds/member/forms.py
@@ -277,27 +277,9 @@ class ProfileForm(MiniProfileForm):
         # to get initial value form checkbox show email
         initial = kwargs.get("initial", {})
         self.fields["options"].initial = ""
-
-        if "show_sign" in initial and initial["show_sign"]:
-            self.fields["options"].initial += "show_sign"
-
-        if "is_hover_enabled" in initial and initial["is_hover_enabled"]:
-            self.fields["options"].initial += "is_hover_enabled"
-
-        if "allow_temp_visual_changes" in initial and initial["allow_temp_visual_changes"]:
-            self.fields["options"].initial += "allow_temp_visual_changes"
-
-        if "show_markdown_help" in initial and initial["show_markdown_help"]:
-            self.fields["options"].initial += "show_markdown_help"
-
-        if "email_for_answer" in initial and initial["email_for_answer"]:
-            self.fields["options"].initial += "email_for_answer"
-
-        if "email_for_new_mp" in initial and initial["email_for_new_mp"]:
-            self.fields["options"].initial += "email_for_new_mp"
-
-        if "hide_forum_activity" in initial and initial["hide_forum_activity"]:
-            self.fields["options"].initial += "hide_forum_activity"
+        for option in [m[0] for m in self.multi_choices]:
+            if option in initial and initial[option]:
+                self.fields["options"].initial += option
 
         layout = Layout(
             IncludeEasyMDE(),

--- a/zds/member/tests/tests_forms.py
+++ b/zds/member/tests/tests_forms.py
@@ -238,6 +238,11 @@ class MiniProfileFormTest(TestCase):
         form = MiniProfileForm(data=data)
         self.assertFalse(form.is_valid())
 
+    def test_missing_non_required_fields_miniprofile_form(self):
+        data = {}
+        form = MiniProfileForm(data=data)
+        self.assertTrue(form.is_valid())
+
 
 class ProfileFormTest(TestCase):
     """

--- a/zds/member/tests/tests_views.py
+++ b/zds/member/tests/tests_views.py
@@ -1,0 +1,75 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from zds.member.tests.factories import ProfileFactory
+
+
+class UpdateMemberViewTest(TestCase):
+    def setUp(self):
+        self.profile = ProfileFactory()
+
+    def test_full_form(self):
+        self.client.force_login(self.profile.user)
+
+        new_biography = "Biography"
+        new_site = "https://perdu.com"
+        new_avatar_url = "https://site.foo/img.png"
+        new_sign = "My signature"
+
+        response = self.client.post(
+            reverse("update-member"),
+            {"biography": new_biography, "site": new_site, "avatar_url": new_avatar_url, "sign": new_sign},
+        )
+        self.assertEqual(302, response.status_code)
+
+        self.profile.refresh_from_db()
+
+        self.assertEqual(self.profile.biography, new_biography)
+        self.assertEqual(self.profile.site, new_site)
+        self.assertEqual(self.profile.avatar_url, new_avatar_url)
+        self.assertEqual(self.profile.sign, new_sign)
+
+    def test_blank_form(self):
+        self.client.force_login(self.profile.user)
+
+        self.profile.biography = "Biography"
+        self.profile.site = "https://perdu.com"
+        self.profile.avatar_url = "https://site.foo/img.png"
+        self.profile.sign = "My signature"
+        self.profile.save()
+
+        response = self.client.post(
+            reverse("update-member"), {"biography": "", "site": "", "avatar_url": "", "sign": ""}
+        )
+        self.assertEqual(302, response.status_code)
+
+        self.profile.refresh_from_db()
+
+        self.assertEqual(self.profile.biography, "")
+        self.assertEqual(self.profile.site, "")
+        self.assertEqual(self.profile.avatar_url, "")
+        self.assertEqual(self.profile.sign, "")
+
+    def test_empty_form(self):
+        self.client.force_login(self.profile.user)
+
+        initial_biography = "Biography"
+        initial_site = "https://perdu.com"
+        initial_avatar_url = "https://site.foo/img.png"
+        initial_sign = "My signature"
+
+        self.profile.biography = initial_biography
+        self.profile.site = initial_site
+        self.profile.avatar_url = initial_avatar_url
+        self.profile.sign = initial_sign
+        self.profile.save()
+
+        response = self.client.post(reverse("update-member"), {})
+        self.assertEqual(302, response.status_code)
+
+        self.profile.refresh_from_db()
+
+        self.assertEqual(self.profile.biography, initial_biography)
+        self.assertEqual(self.profile.site, initial_site)
+        self.assertEqual(self.profile.avatar_url, initial_avatar_url)
+        self.assertEqual(self.profile.sign, initial_sign)

--- a/zds/member/views/profile.py
+++ b/zds/member/views/profile.py
@@ -267,19 +267,13 @@ class UpdateMember(UpdateView):
         return response
 
     def update_profile(self, profile, form):
+        for field in ["biography", "site", "avatar_url", "sign", "licence"]:
+            if field in form.data:
+                profile.__setattr__(field, form.cleaned_data.get(field, ""))
+
         cleaned_data_options = form.cleaned_data.get("options")
-        profile.biography = form.data["biography"]
-        profile.site = form.data["site"]
-        profile.show_sign = "show_sign" in cleaned_data_options
-        profile.is_hover_enabled = "is_hover_enabled" in cleaned_data_options
-        profile.allow_temp_visual_changes = "allow_temp_visual_changes" in cleaned_data_options
-        profile.show_markdown_help = "show_markdown_help" in cleaned_data_options
-        profile.email_for_answer = "email_for_answer" in cleaned_data_options
-        profile.email_for_new_mp = "email_for_new_mp" in cleaned_data_options
-        profile.hide_forum_activity = "hide_forum_activity" in cleaned_data_options
-        profile.avatar_url = form.data["avatar_url"]
-        profile.sign = form.data["sign"]
-        profile.licence = form.cleaned_data["licence"]
+        for option in [m[0] for m in self.form_class.multi_choices]:
+            profile.__setattr__(option, option in cleaned_data_options)
 
     def get_success_url(self):
         return reverse("update-member")


### PR DESCRIPTION
Sentry nous rapporte l'erreur suivante : 
```
Traceback (most recent call last):
  File "django/utils/datastructures.py", line 84, in __getitem__
    list_ = super().__getitem__(key)
KeyError: 'biography'

Traceback (most recent call last):
  File "django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/views/generic/base.py", line 105, in view
    return self.dispatch(request, *args, **kwargs)
  File "django/utils/decorators.py", line 48, in _wrapper
    return bound_method(*args, **kwargs)
  File "django/contrib/auth/decorators.py", line 59, in _view_wrapper
    return view_func(request, *args, **kwargs)
  File "zds/member/views/profile.py", line 223, in dispatch
    return super().dispatch(*args, **kwargs)
  File "django/views/generic/base.py", line 144, in dispatch
    return handler(request, *args, **kwargs)
  File "zds/member/views/profile.py", line 257, in post
    return self.form_valid(form)
  File "zds/member/views/profile.py", line 263, in form_valid
    self.update_profile(profile, form)
  File "zds/member/views/profile.py", line 271, in update_profile
    profile.biography = form.data["biography"]
  File "django/utils/datastructures.py", line 86, in __getitem__
    raise MultiValueDictKeyError(key)
MultiValueDictKeyError: 'biography'
```
Lors de la mise à jour de son profil, le champ `biography` n'est pas présent dans les données de la requête POST. En regardant le contenu de la requête, les autres champs sont présents. Je ne comprends pas bien comment l'absence de `biography` a pu se produire, mais on ne peut pas faire l'hypothèse que ce champ nous est bien envoyé.

Cette PR corrige ce problème, j'ai ajouté les tests correspondants et j'ai refactorisé quelques bouts de codes

### Contrôle qualité

La CI passe.

Essayer de modifier les différents éléments de son profil et s'assurer que ça fonctionne toujours.
