### PR TITLE
Indique que Fedora 43 est supporté pour l'environnement de développement

### DIFF
--- a/scripts/dependencies/fedora.txt
+++ b/scripts/dependencies/fedora.txt
@@ -1,5 +1,5 @@
 #title=Fedora
-#desc=Utilisation de dnf / Testé sur Fedora 42
+#desc=Utilisation de dnf / Testé sur Fedora 42 et Fedora 43
 #installcmd=dnf -y install
 git
 wget


### PR DESCRIPTION
Indique que Fedora 43 est supporté pour l'environnement de développement.

Je suis dessus et ça marche en dév.

### Contrôle qualité

Regarder le texte, sauf si vous avez envie de faire des aventures dans une VM.