### PR TITLE
Limite dans le formulaire la longueur du commentaire pour l'ajout d'un contributeur

### DIFF
--- a/zds/tutorialv2/tests/__init__.py
+++ b/zds/tutorialv2/tests/__init__.py
@@ -28,6 +28,11 @@ class override_for_contents(override_settings):
 class TutorialTestMixin:
     overridden_zds_app = overridden_zds_app
 
+    def assertLastMessageLevel(self, req_result, level):
+        msgs = req_result.context["messages"]
+        self.assertNotEqual(len(msgs), 0)
+        self.assertEqual(list(msgs)[-1].level, level)
+
     def clean_media_dir(self):
         shutil.rmtree(self.overridden_zds_app["content"]["repo_private_path"], ignore_errors=True)
         shutil.rmtree(self.overridden_zds_app["content"]["repo_public_path"], ignore_errors=True)

--- a/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
+++ b/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.conf import settings
+from django.contrib import messages
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.html import escape
@@ -196,4 +197,12 @@ class AddContributorWorkflowTests(TutorialTestMixin, TestCase):
             response, escape(ContributionForm.declared_fields["contribution_role"].error_messages["invalid_choice"])
         )
         self.assertEqual(list(ContentContribution.objects.all()), [])
+        self.check_signal(contributors_management, emitted=False)
+
+    @patch("zds.tutorialv2.signals.contributors_management")
+    def test_too_long_comment(self, contributors_management):
+        form_data = {"username": self.contributor, "contribution_role": self.role.pk, "comment": "a" * 1024}
+        response = self.client.post(self.form_url, form_data, follow=True)
+        self.assertLastMessageLevel(response, messages.ERROR)
+        self.assertQuerySetEqual(ContentContribution.objects.all(), [])
         self.check_signal(contributors_management, emitted=False)

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -1281,11 +1281,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             },
         )
         self.assertEqual(200, answer.status_code)
-        msgs = answer.context["messages"]
-        last = None
-        for msg in msgs:
-            last = msg
-        self.assertEqual(last.level, messages.ERROR)
+        self.assertLastMessageLevel(answer, messages.ERROR)
 
     def test_import_image_with_archive(self):
         """ensure that import archive work, and link are changed"""
@@ -2339,12 +2335,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
         self.assertEqual(result.status_code, 200)
-
-        msgs = result.context["messages"]
-        last = None
-        for msg in msgs:
-            last = msg
-        self.assertEqual(last.level, messages.ERROR)
+        self.assertLastMessageLevel(result, messages.ERROR)
 
         # login with normal user
         self.client.logout()
@@ -2374,12 +2365,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
         self.assertEqual(result.status_code, 200)
-
-        msgs = result.context["messages"]
-        last = None
-        for msg in msgs:
-            last = msg
-        self.assertEqual(last.level, messages.SUCCESS)
+        self.assertLastMessageLevel(result, messages.SUCCESS)
 
         # check PM :
         sent_pm = PrivateTopic.objects.filter(author=self.user_guest.pk).last()
@@ -2394,12 +2380,8 @@ class ContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
         self.assertEqual(result.status_code, 200)
+        self.assertLastMessageLevel(result, messages.SUCCESS)
 
-        msgs = result.context["messages"]
-        last = None
-        for msg in msgs:
-            last = msg
-        self.assertEqual(last.level, messages.SUCCESS)
         self.chapter1.parent.parent = versioned
         # check PM :
         sent_pm = PrivateTopic.objects.filter(author=self.user_guest.pk).last()
@@ -2459,12 +2441,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
         self.assertEqual(result.status_code, 200)
-
-        msgs = result.context["messages"]
-        last = None
-        for msg in msgs:
-            last = msg
-        self.assertEqual(last.level, messages.SUCCESS)
+        self.assertLastMessageLevel(result, messages.SUCCESS)
 
         # check PM :
         sent_pm = PrivateTopic.objects.filter(author=self.user_guest.pk).last()
@@ -2484,12 +2461,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
         self.assertEqual(result.status_code, 200)
-
-        msgs = result.context["messages"]
-        last = None
-        for msg in msgs:
-            last = msg
-        self.assertEqual(last.level, messages.SUCCESS)
+        self.assertLastMessageLevel(result, messages.SUCCESS)
 
         # check PM :
         sent_pm = PrivateTopic.objects.filter(author=self.user_guest.pk).last()
@@ -2526,12 +2498,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
         self.assertEqual(result.status_code, 200)
-
-        msgs = result.context["messages"]
-        last = None
-        for msg in msgs:
-            last = msg
-        self.assertEqual(last.level, messages.ERROR)
+        self.assertLastMessageLevel(result, messages.ERROR)
 
         tuto = PublishableContent.objects.get(pk=tuto.pk)
         chapter_version = tuto.load_version().children[0]
@@ -2591,12 +2558,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
         self.assertEqual(result.status_code, 200)
-
-        msgs = result.context["messages"]
-        last = None
-        for msg in msgs:
-            last = msg
-        self.assertEqual(last.level, messages.ERROR)
+        self.assertLastMessageLevel(result, messages.ERROR)
 
         versioned = PublishableContent.objects.get(pk=tuto.pk).load_version()
         extract = versioned.children[0].children[0]
@@ -2969,12 +2931,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         result = self.client.get(reverse("content:create-extract", args=[tuto.pk, tuto.slug]), follow=True)
         self.assertEqual(result.status_code, 200)
-
-        msgs = result.context["messages"]
-        last = None
-        for msg in msgs:
-            last = msg
-        self.assertEqual(last.level, messages.ERROR)  # get an error message
+        self.assertLastMessageLevel(result, messages.ERROR)
 
         # create a container while there is already an extract:
         versioned = tuto.load_version()
@@ -2996,12 +2953,7 @@ class ContentTests(TutorialTestMixin, TestCase):
             follow=True,
         )
         self.assertEqual(result.status_code, 200)
-
-        msgs = result.context["messages"]
-        last = None
-        for msg in msgs:
-            last = msg
-        self.assertEqual(last.level, messages.ERROR)
+        self.assertLastMessageLevel(result, messages.ERROR)
 
     def test_gallery_not_deleted_if_linked_to_content(self):
         """Ensure that a gallery cannot be deleted if linked to a content"""

--- a/zds/tutorialv2/views/contributors.py
+++ b/zds/tutorialv2/views/contributors.py
@@ -44,6 +44,7 @@ class ContributionForm(forms.Form):
     comment = forms.CharField(
         label=_("Commentaire"),
         required=False,
+        max_length=ContentContribution._meta.get_field("comment").max_length,
         widget=forms.Textarea(attrs={"placeholder": _("Commentaire sur ce contributeur."), "rows": "3"}),
     )
 


### PR DESCRIPTION
Bug rapporté par Sentry : le formulaire pour ajouter un contributeur à un contenu ne vérifie pas la longueur maximale possible du commentaire et c'est MariaDB qui provoque une exception lors de la sauvegarde en base de données. En local, il n'est pas possible de reproduire le bug puisque SQLite ne vérifie pas les limites de longueurs dans les colonnes.

Cette PR ajoute la limite de la longueur dans le formulaire correspondant et ajoute un test.

### Contrôle qualité

La CI passe.

1. Se connecter en tant qu'`admin`
2. Aller sur la page brouillon d'un contenu
3. Dans le formulaire *Ajouter un contributeur*, vérifier qu'on ne peut plus écrire dans le champ *Commentaire* après avoir saisi 200 caractères.


Les deux commits sont indépendants, on peut donc éviter le squash lors de la fusion.
