### PR TITLE
Ne parlons plus de validation, mais d’édition

### DIFF
--- a/doc/source/back-end/contents.rst
+++ b/doc/source/back-end/contents.rst
@@ -11,7 +11,7 @@ Vocabulaire et définitions
 - **Tribune libre** : ensemble de billets associés à un utilisateur.
 - **Billet** : contenu, généralement court dont l'objectif est de donner un retour d'expérience, de donner son opinion quant à une actualité, de donner un lien intéressant… La validation (ou modération) d'un billet se fait après publication, publication étant directement faite par l'auteur.
 - **git**: système de gestion de versions employé (entre autres) par ZdS. Il permet de faire coexister différentes versions d'un contenu de manière simple et transparente pour l'auteur.
-- **Version** : état du contenu à un moment donné. Toute mise à jour du contenu (ou d'une de ses composantes) génère une nouvelle version de ce dernier, laquelle est désignée par un *hash*, c'est-à-dire par une chaîne de 40 caractères de long (aussi appelée *sha*, en référence à l'algorithme employé pour les générer). Ce *hash* permet d'identifier de manière unique cette version parmi toutes celles du contenu. Certaines versions, en plus du *sha*, sont désignées par un nom. On distingue ainsi la version brouillon (*draft*), la version en bêta (*beta*), la version en validation (*validation*) et la version publiée (*public*). Pour ce faire, les *hash* correspondant à ces versions sont simplement mis de côté.
+- **Version** : état du contenu à un moment donné. Toute mise à jour du contenu (ou d'une de ses composantes) génère une nouvelle version de ce dernier, laquelle est désignée par un *hash*, c'est-à-dire par une chaîne de 40 caractères de long (aussi appelée *sha*, en référence à l'algorithme employé pour les générer). Ce *hash* permet d'identifier de manière unique cette version parmi toutes celles du contenu. Certaines versions, en plus du *sha*, sont désignées par un nom. On distingue ainsi la version brouillon (*draft*), la version en bêta (*beta*), la version en édition (*validation*) (pour raison historique) et la version publiée (*public*). Pour ce faire, les *hash* correspondant à ces versions sont simplement mis de côté.
 - Fichier **manifest.json** : fichier à la racine de tout contenu dont l'objectif est de décrire ce dernier. Un tel fichier comporte deux types d'informations : à propos du contenu en lui-même (les métadonnées mentionnées plus haut) et à propos de son arborescence. La spécification de ce fichier est détaillée plus loin. On retiendra qu'à chaque version correspond un fichier ``manifest.json`` et que le contenu de ce dernier peut fortement varier d'une version à l'autre.
 - **Conteneur** (*container*) : sous-structure d'un contenu. Explicité plus bas.
 - **Extrait** (*extract*) : base atomique (plus petite unité) d'un contenu. Explicité plus bas.
@@ -193,7 +193,7 @@ Le brouillon
 Le brouillon est la première étape du cycle de vie d'un contenu. Il donne
 toujours l'état le plus récent d'un contenu vu par les auteurs. Chaque fois
 que le contenu est modifié, c'est la version brouillon qui est mise à jour.
-La version brouillon est accessible uniquement pour les auteurs et validateurs
+La version brouillon est accessible uniquement pour les auteurs et éditeurs
 d'un tutoriel. Si on souhaite donner un accès en lecture seule à nos écrits,
 il faut passer par la méthode adéquate.
 
@@ -217,25 +217,25 @@ Seulement, la version brouillon ne sera plus identique à la version en bêta et
 il ne faudra pas oublier de mettre à jour cette dernière pour que la communauté
 puisse juger des dernières modifications.
 
-La validation
+L’édition
 -------------
 
 Une fois que l'auteur a eu assez de retours sur son contenu, et qu'il estime
-qu'il est prêt à être publié, il décide d'envoyer son contenu en validation.
-*Via* l'interface idoine, un validateur peut alors réserver le contenu et
+qu'il est prêt à être publié, il décide d'envoyer son contenu en édition.
+*Via* l'interface idoine, un éditeur peut alors réserver le contenu et
 commencer à vérifier qu'il satisfait la politique éditoriale du site. Dans le
 cas contraire, le contenu est rejeté et un message est envoyé aux auteurs pour
 expliquer les raisons du refus.
 
-L'envoi en validation n'est pas définitif, dans le sens où vous pouvez à tout
-moment mettre à jour la version en cours de validation. Évitez d'en abuser tout
-de même, car, si un validateur commence à lire votre contenu, il devra
+L'envoi en édition n'est pas définitif, dans le sens où vous pouvez à tout
+moment mettre à jour la version en cours d’édition. Évitez d'en abuser tout
+de même, car, si un éditeur commence à lire votre contenu, il devra
 recommencer son travail si vous faites une mise à jour dessus. Cela pourrait non
-seulement ralentir le processus de validation de votre contenu, mais aussi ceux
+seulement ralentir le processus d’édition de votre contenu, mais aussi ceux
 autres contenus !
 
 Comme pour la bêta, la version brouillon du contenu peut continuer à être
-améliorée pendant que la version de validation reste figée. Auteurs et validateurs
+améliorée pendant que la version d’édition reste figée. Auteurs et éditeurs
 peuvent donc continuer à travailler chacun de leur côté.
 
 La publication
@@ -243,12 +243,12 @@ La publication
 
 **Le cas général**
 
-Une fois que le contenu est passé en validation et a satisfait les critères
+Une fois que le contenu est passé en édition et a satisfait les critères
 éditoriaux, il est publié. Un message privé est alors envoyé aux auteurs afin
 de les informer de la publication et de leur transmettre le message laissé
-par le validateur en charge du contenu. Il faut bien préciser que le processus
-de validation peut être assez long. De plus, un historique de validation est
-disponible pour les validateurs.
+par l’éditeur en charge du contenu. Il faut bien préciser que le processus
+d’édition peut être assez long. De plus, un historique d’édition est
+disponible pour les éditeurs.
 
 La publication d'un contenu entraîne l'export du contenu en plusieurs formats :
 
@@ -455,15 +455,15 @@ Les permissions
 Afin de gérer ce module, trois permissions peuvent être utilisées :
 
 - ``tutorialv2.change_publishablecontent`` : pour le droit d'accéder et de modifier les contenus même sans en être l'auteur ;
-- ``tutorialv2.change_validation`` : pour le droit à accéder à l'interface de validation, réserver, valider ou refuser des contenus ;
+- ``tutorialv2.change_validation`` : pour le droit à accéder à l'interface d’édition, réserver, édition ou refuser des contenus ;
 - ``tutorialv2.change_contentreaction`` : pour le droit à modérer les commentaires sur les contenus une fois publiés (masquer, éditer, ...).
 
-Ces permissions doivent être accordées aux administateurs/modérateurs/validateurs selon les besoins via l'interface d'administration de Django.
+Ces permissions doivent être accordées aux administateurs/modérateurs/éditeurs selon les besoins via l'interface d'administration de Django.
 
 Processus de publication
 ------------------------
 
-Apès avoir passé les étapes de validation, le contenu est près à être publié.
+Apès avoir passé les étapes d’édition, le contenu est près à être publié.
 Cette action est effectuée par un membre du Staff. Le but de la publication
 est double : permettre aux visiteurs de consulter le contenu, mais aussi
 d’effectuer certains traitements (détaillés ci-après) afin que celui-ci soit
@@ -477,7 +477,7 @@ La publication se passe comme suit :
 2. Le code *markdown* est converti en HTML afin de gagner du temps à l'affichage. Pour chaque conteneur, deux cas se présentent :
     * Si celui-ci contient des extraits, ils sont tous rassemblés dans un seul fichier HTML, avec l'introduction et la conclusion ;
     * Dans le cas contraire, l'introduction et la conclusion sont placées dans des fichiers séparés, et les champs correspondants dans le *manifest* sont mis à jour.
-3. Le *manifest* correspondant à la version de validation est copié. Il sera nécessaire afin de valider les URLs et générer le sommaire. Néanmoins, les informations inutiles sont enlevées (champ ``text`` des extraits, champs ``introduction`` et ``conclusion`` des conteneurs comportant des extraits), une fois encore pour gagner du temps ;
+3. Le *manifest* correspondant à la version publiée est copié. Il sera nécessaire afin de valider les URLs et générer le sommaire. Néanmoins, les informations inutiles sont enlevées (champ ``text`` des extraits, champs ``introduction`` et ``conclusion`` des conteneurs comportant des extraits), une fois encore pour gagner du temps ;
 4. L'exportation vers les autres formats est ensuite effectué (PDF, EPUB, ...) en utilisant `ZMarkdown <https://github.com/zestedesavoir/zmarkdown/>`__. Cette étape peut être longue si le contenu possède une taille importante. Il est également important de mentionner que pendant cette étape, l'ensemble des images qu'utilise le contenu est récupéré et que si ce n'est pas possible, une image par défaut est employée à la place, afin d'éviter les erreurs ;
 5. Finalement, si toutes les étapes précédentes se sont bien déroulées, le dossier temporaire est déplacé à la place de celui de l'ancienne version publiée. Un objet ``PublishedContent`` est alors créé (ou mis à jour si le contenu avait déjà été publié par le passé), contenant les informations nécessaire à l'affichage dans la liste des contenus publiés. Le ``sha_public`` est mis à jour dans la base de données et l'objet ``Validation`` est également changé.
 

--- a/doc/source/back-end/gallery.rst
+++ b/doc/source/back-end/gallery.rst
@@ -45,7 +45,7 @@ Une fois l'image uploadée, il est possible d'y effectuer différentes actions s
 
 Autrement dit :
 
-+ En modifier le titre, la légende ou encore l'image en elle-même. À noter que le titre et la légende peuvent être modifiés **sans qu'il ne soit nécessaire** d'uploader une nouvelle image. Si une nouvelle version de l'image est uploadée, l'ancienne version de l'image n'est pas supprimée du serveur et reste accessible depuis son URL ; un nouvel identifiant (et donc une nouvelle URL) sera attribué à la nouvelle version de l'image. Cela signifie notamment que mettre à jour une image ne changera pas l'image là où elle a déjà été utilisée (tutoriel, article, message, ...). Ce comportement permet d'éviter que les images utilisées dans des contenus validés soient changées sans repasser par une validation.
++ En modifier le titre, la légende ou encore l'image en elle-même. À noter que le titre et la légende peuvent être modifiés **sans qu'il ne soit nécessaire** d'uploader une nouvelle image. Si une nouvelle version de l'image est uploadée, l'ancienne version de l'image n'est pas supprimée du serveur et reste accessible depuis son URL ; un nouvel identifiant (et donc une nouvelle URL) sera attribué à la nouvelle version de l'image. Cela signifie notamment que mettre à jour une image ne changera pas l'image là où elle a déjà été utilisée (tutoriel, article, message, ...). Ce comportement permet d'éviter que les images utilisées dans des contenus édités soient changées sans repasser par une édition.
 + Obtenir le code à insérer dans un champ de texte acceptant le Markdown pour l'image en elle-même, sa miniature ou encore la miniature accompagnée du lien vers l'image en taille réelle.
 
 Les utilisateurs et leurs droits

--- a/doc/source/back-end/member.rst
+++ b/doc/source/back-end/member.rst
@@ -60,7 +60,7 @@ Le clic sur "Me désinscrire" entraîne alors une série d'action (qui sont **ir
 
       -  si le tutoriel/article a été écrit par plusieurs personnes : le membre est retiré de la liste des auteurs ;
       -  si le tutoriel/article est *publié*, il passe sur le compte “external”. Une demande expresse sera nécessaire au retrait complet de ces contenus ;
-      -  si le tutoriel/article n’est pas publié (brouillon, bêta, validation), il est supprimé, ainsi que la galerie qui lui est associée.
+      -  si le tutoriel/article n’est pas publié (brouillon, bêta, édition), il est supprimé, ainsi que la galerie qui lui est associée.
 
 .. _galeries: ../gallery/gallery.html
 .. _articles: ../article/article.html
@@ -121,7 +121,7 @@ Cette interface permet :
 1. D'ajouter/supprimer un membre dans un/des groupe(s)
 2. De (dés)activer un compte
 
-Le premier point permet notamment de passer un membre dans le groupe staff ou développeur. Si d'autres groupes venaient à voir le jour (validateur par exemple), alors il sera possible ici aussi de le changer.
+Le premier point permet notamment de passer un membre dans le groupe staff ou développeur. Si d'autres groupes venaient à voir le jour (éditeur par exemple), alors il sera possible ici aussi de le changer.
 Le second point concerne simplement l'activation du compte (normalement faite par le membre à l'inscription).
 
 Elle est gérée par le formulaire `PromoteMemberForm` présent dans le fichier `zds/member/forms.py`.

--- a/doc/source/back-end/search.rst
+++ b/doc/source/back-end/search.rst
@@ -156,14 +156,14 @@ Il est possible de modifier les différents paramètres de la recherche dans
             "opinion": (_("Billet"), ["opinion"]),
         },
         "search_validated_content": {
-            "validated": (_("Contenus validés"), ["validated"]),
+            "validated": (_("Contenus édités"), ["validated"]),
             "no_validated": (_("Contenus libres"), ["no_validated"]),
         },
         "boosts": {
             "publishedcontent": {
                 "global": global_weight_publishedcontent,
-                "if_validated": 2.0,  # s'il s'agit d'une publication validée (article ou tuto)
-                "if_validated_and_multipage": 2.5, # s'il s'agit d'une publication validée sur plusieurs pages (medium ou big)
+                "if_validated": 2.0,  # s'il s'agit d'une publication éditée (article ou tuto)
+                "if_validated_and_multipage": 2.5, # s'il s'agit d'une publication éditée sur plusieurs pages (medium ou big)
                 "if_opinion": 1.66, # s'il s'agit d'un billet
                 "if_opinion_not_picked": 1.5, # s'il s'agit d'un billet non mis en avant sur la page d'accueil
 
@@ -209,7 +209,7 @@ Il est possible de modifier les différents paramètres de la recherche dans
   manière dont ils sont groupés sur le formulaire de recherche,
 + ``search_content_type`` définit les différents types de contenus publiés et
   la manière dont ils sont groupés sur le formulaire de recherche,
-+ ``search_validated_content``  définit les différentes validations des contenus
++ ``search_validated_content``  définit les différentes éditions des contenus
   publiés et la manière dont elles sont groupées sur le formulaire de recherche,
 + ``boosts`` contient les différents facteurs de *boost* appliqués aux
   différentes situations. Modifier ces valeurs permet de changer l'ordre des

--- a/doc/source/front-end/template-tags.rst
+++ b/doc/source/front-end/template-tags.rst
@@ -290,7 +290,7 @@ Récupère la liste des alertes (si l'utilisateur possède les droits pour le fa
 ``waiting_count``
 -----------------
 
-Récupère le nombre de tutoriels ou d'articles dans la zone de validation n'ayant pas été réservés par un validateur.
+Récupère le nombre de tutoriels ou d'articles dans la zone d’édition n'ayant pas été réservés par un éditeur.
 
 .. sourcecode:: html+django
 

--- a/doc/source/guides/run-linux.rst
+++ b/doc/source/guides/run-linux.rst
@@ -52,6 +52,6 @@ Vous pouvez vous connecter avec le membre ``user``, le membre ``staff`` ou n'imp
 S'amuser
 ========
 
-Votre instance locale de Zeste de Savoir vous appartient, vous êtes libre d'y faire tout ce que vous souhaitez ! N'hésitez pas à explorer les fonctionnalités que vous connaissez moins : la validation des contenus, la modération des messages et des membres, etc. Ainsi, vous aurez un aperçu global des fonctionnalités !
+Votre instance locale de Zeste de Savoir vous appartient, vous êtes libre d'y faire tout ce que vous souhaitez ! N'hésitez pas à explorer les fonctionnalités que vous connaissez moins : l’édition des contenus, la modération des messages et des membres, etc. Ainsi, vous aurez un aperçu global des fonctionnalités !
 
 .. include:: ../includes/contact-us.rst

--- a/doc/source/utils/fixture_loaders.rst
+++ b/doc/source/utils/fixture_loaders.rst
@@ -158,5 +158,5 @@ Ce coefficient sera à multiplier par le *coefficient de taille* dirrigé par :
 +---------------------------------+-----------------------------------+-----------------------------+
 
 
-.. [#cv2] C'est-à-dire 60% en validation (dont 20% réservés) et 30% publiés. S'il sagit de tutoriels, 50% de petits, 30% de moyen et 20% de *bigs*.
+.. [#cv2] C'est-à-dire 60% en édition (dont 20% réservés) et 30% publiés. S'il sagit de tutoriels, 50% de petits, 30% de moyen et 20% de *bigs*.
 .. [#moy] Ce nombre est une moyenne, le nombre réel est choisi au hasard autour de cette moyenne.

--- a/templates/header.html
+++ b/templates/header.html
@@ -383,7 +383,7 @@
                             {% with waiting_tutorials_count="TUTORIAL"|waiting_count waiting_articles_count="ARTICLE"|waiting_count waiting_opinions_count="OPINION"|waiting_count %}
                                 <li class="staff-only">
                                     <a href="{% url "validation:list" %}">
-                                        {% trans "Validation" %}
+                                        {% trans "Édition" %}
 
                                         {% captureas tutorials_chunk %}
                                             {{ waiting_tutorials_count }} tutoriel{{ waiting_tutorials_count|pluralize:"s" }}

--- a/templates/home.html
+++ b/templates/home.html
@@ -68,8 +68,8 @@
                     <div class="column">
                         <h1>{% trans "Partagez vos savoirs…" %}</h1>
                         {% blocktrans %}
-                            <p><strong>Tous les membres</strong> peuvent écrire et <strong>publier des contenus</strong>.</p>
-                            <p>Pour assurer la qualité, l’équipe du site valide chaque tutoriel et article.</p>
+                            <p><strong>Tous les membres</strong> peuvent écrire et <strong>publier des cours</strong>.</p>
+                            <p>Pour assurer la qualité, l’équipe du site édite chacun d’eux.</p>
                         {% endblocktrans %}
                         <h1>{% trans "… sur une plate-forme libre" %}</h1>
                         {% blocktrans %}
@@ -113,7 +113,7 @@
         <div class="home-row">
             <section itemscope itemtype="http://schema.org/ItemList">
                 <h2 class="ico-after ico-tutorials home-heading" itemprop="name">
-                    <span>{% trans "Dernières pépites validées par l'équipe" %}</span>
+                    <span>{% trans "Dernières pépites éditées par l'équipe" %}</span>
                 </h2>
 
                 <meta itemprop="itemListOrder" content="Descending">
@@ -132,11 +132,11 @@
                             <p class="lead">
                                 {% if validated_contents_count == 0 %}
                                     {% blocktrans %}
-                                         Il y a {{ validated_contents_count }} publication validée par l'équipe.</p>
+                                         Il y a {{ validated_contents_count }} publication éditée par l'équipe.</p>
                                     {% endblocktrans %}
                                 {% else %}
                                     {% blocktrans %}
-                                         Il y a {{ validated_contents_count }} publications validées par l'équipe.</p>
+                                         Il y a {{ validated_contents_count }} publications éditées par l'équipe.</p>
                                     {% endblocktrans %}
                                 {% endif %}
                         </div>

--- a/templates/member/settings/unregister.html
+++ b/templates/member/settings/unregister.html
@@ -41,7 +41,7 @@
             {% endblocktrans %}
         </li>
         <li>
-            {% trans "Vos tutoriels, billets et articles non publiés (brouillon, bêta ou en cours de validation) seront supprimés sans possibilité de récupération, sauf si d’autres auteurs sont présents lors de la rédaction." %}
+            {% trans "Vos tutoriels, billets et articles non publiés (brouillon, bêta ou en cours d’édition) seront supprimés sans possibilité de récupération, sauf si d’autres auteurs sont présents lors de la rédaction." %}
         </li>
         <li>
             {% trans "Vos tutoriels, articles et billets publiés subiront les modifications suivantes :" %}

--- a/templates/misc/validation.part.html
+++ b/templates/misc/validation.part.html
@@ -49,7 +49,7 @@
             -
 
             <a href="#view-comment-validator-{{ validation.pk }}" class="open-modal">
-                {% trans "Commentaire du validateur" %}
+                {% trans "Commentaire de l’éditeur·ice" %}
             </a>
             <div class="modal modal-flex" id="view-comment-validator-{{ validation.pk }}" data-modal-close="Fermer">
                 <p>

--- a/templates/pages/eula.html
+++ b/templates/pages/eula.html
@@ -135,7 +135,7 @@
         <li>Licence CC BY-NC-ND 4.0 - <a href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Lire le résumé explicatif de la licence</a></li>
     </ul>
     <p>
-        La mise en ligne d’un tutoriel ou d’un article est soumise à une validation préalable par l’éditeur du site. L’éditeur du site est libre de refuser la publication d’un tutoriel ou d’un article, sans avoir à s’en justifier auprès du membre et sans qu’aucune contrepartie puisse être exigée.
+        La mise en ligne d’un tutoriel ou d’un article est soumise à une édition préalable par l’éditeur du site. L’éditeur du site est libre de refuser la publication d’un tutoriel ou d’un article, sans avoir à s’en justifier auprès du membre et sans qu’aucune contrepartie puisse être exigée.
     </p>
     <p>
         La mise en ligne d’un billet est soumise à une validation postérieure par l’éditeur du site. L’éditeur du site est libre de supprimer un billet, sans avoir à s’en justifier auprès du membre et sans qu’aucune contrepartie puisse être exigée.

--- a/templates/tutorialv2/edit/container.html
+++ b/templates/tutorialv2/edit/container.html
@@ -32,7 +32,7 @@
 {% block content %}
     {% if new_version %}
         <p class="ico-after warning">
-            {% trans "Une nouvelle version a été postée avant que vous ne validiez" %}.
+            {% trans "Une nouvelle version a été postée avant que vous n’éditiez" %}.
         </p>
     {% endif %}
     {% crispy form %}

--- a/templates/tutorialv2/edit/introduction.html
+++ b/templates/tutorialv2/edit/introduction.html
@@ -26,7 +26,7 @@
 {% block content %}
     {% if new_version %}
         <p class="ico-after warning">
-            {% trans "Une nouvelle version a été postée avant que vous ne validiez" %}.
+            {% trans "Une nouvelle version a été postée avant que vous n’éditiez" %}.
         </p>
     {% endif %}
     {% crispy form %}

--- a/templates/tutorialv2/events/descriptions.part.html
+++ b/templates/tutorialv2/events/descriptions.part.html
@@ -39,9 +39,9 @@
 {% elif event.type == "validation_management" %}
     {% url "content:view-version" pk=event.content.pk slug=event.content.slug version=event.version as version_href %}
     {% if event.action == "request" %}
-        <a href="{{ performer_href }}">{{ event.performer }}</a> a demandé la validation d'une <a href="{{ version_href }}">version du contenu</a>.
+        <a href="{{ performer_href }}">{{ event.performer }}</a> a demandé l’édition d'une <a href="{{ version_href }}">version du contenu</a>.
     {% elif event.action == "cancel" %}
-        <a href="{{ performer_href }}">{{ event.performer }}</a> a annulé la demande de validation du contenu.
+        <a href="{{ performer_href }}">{{ event.performer }}</a> a annulé la demande d’édition du contenu.
     {% elif event.action == "accept" %}
         <a href="{{ performer_href }}">{{ event.performer }}</a> a accepté le contenu pour publication.
     {% elif event.action == "reject" %}
@@ -49,11 +49,11 @@
     {% elif event.action == "revoke" %}
         <a href="{{ performer_href }}">{{ event.performer }}</a> a dépublié le contenu.
     {% elif event.action == "reserve" %}
-        <a href="{{ performer_href }}">{{ event.performer }}</a> a réservé le contenu pour validation.
+        <a href="{{ performer_href }}">{{ event.performer }}</a> a réservé le contenu pour édition.
     {% elif event.action == "unreserve" %}
-        <a href="{{ performer_href }}">{{ event.performer }}</a> a annulé la réservation du contenu pour validation.
+        <a href="{{ performer_href }}">{{ event.performer }}</a> a annulé la réservation du contenu pour édition.
     {% else %}
-        <a href="{{ performer_href }}">{{ event.performer }}</a> a effectué une action de validation de type « {{ event.action }} ».
+        <a href="{{ performer_href }}">{{ event.performer }}</a> a effectué une action d’édition de type « {{ event.action }} ».
     {% endif %}
 
 

--- a/templates/tutorialv2/includes/content_item.part.html
+++ b/templates/tutorialv2/includes/content_item.part.html
@@ -113,7 +113,7 @@
                     </p>
                 {% elif content.sha_validation %}
                     <p class="content-state">
-                        {% trans "En validation" %}
+                        {% trans "En édition" %}
                     </p>
                 {% else %}
                     <p class="content-state">

--- a/templates/tutorialv2/includes/headline/opinion_promotion_info.part.html
+++ b/templates/tutorialv2/includes/headline/opinion_promotion_info.part.html
@@ -11,7 +11,7 @@
         {% elif is_staff %}
             <div class="alert-box info">
                 {% blocktrans with url_article=content.converted_to.get_absolute_url %}
-                    Ce billet a fait l’objet d’une demande de publication <a href="{{ url_article }}">en tant qu’article</a>. Il est donc présent dans la zone de validation en attente de prise en charge par un validateur.
+                    Ce billet a fait l’objet d’une demande de publication <a href="{{ url_article }}">en tant qu’article</a>. Il est donc présent dans la zone d’édition en attente de prise en charge par un éditeur.
                 {% endblocktrans %}
             </div>
         {% endif %}

--- a/templates/tutorialv2/includes/headline/validation_info.part.html
+++ b/templates/tutorialv2/includes/headline/validation_info.part.html
@@ -5,7 +5,7 @@
 {% captureas validation_comment_from_authors %}
     {% if validation.comment_authors %}
         <div class="content-wrapper comment-author">
-            <p>{% trans "Le message suivant a été laissé à destination des validateurs" %} :</p>
+            <p>{% trans "Le message suivant a été laissé à destination des éditeurs" %} :</p>
             <blockquote>{{ validation.comment_authors|emarkdown }}</blockquote>
         </div>
     {% endif %}
@@ -13,14 +13,14 @@
 
 {% if state.current_version_and_reserved %}
     <p class="content-wrapper alert-box info">
-        {% trans "Cette version est en cours de validation par" %}
+        {% trans "Cette version est en cours d’édition par" %}
         {% include "misc/member_item.part.html" with member=validation.validator %}.
     </p>
     {{ validation_comment_from_authors }}
 {% endif %}
 
 {% if state.current_version_and_waiting_validator %}
-    <p class="content-wrapper alert-box alert">{% trans "Cette version est en attente d’un validateur." %}</p>
+    <p class="content-wrapper alert-box alert">{% trans "Cette version est en attente d’un·e éditeur·ice." %}</p>
     {{ validation_comment_from_authors }}
 {% endif %}
 
@@ -31,7 +31,7 @@
         <a href="{{ validation_version_url }}">
             {% trans "Une autre version de cette publication" %}
         </a>
-        {% trans "est en cours de validation par" %}
+        {% trans "est en cours d’édition par" %}
         {% include "misc/member_item.part.html" with member=validation.validator %}.
     </p>
 {% endif %}
@@ -41,6 +41,6 @@
         <a href="{{ validation_version_url }}">
             {% trans "Une autre version de cette publication" %}
         </a>
-        {% trans "est en attente d’un validateur." %}
+        {% trans "est en attente d’un·e éditeur·ice." %}
     </p>
 {% endif %}

--- a/templates/tutorialv2/includes/sidebar/delete_content.part.html
+++ b/templates/tutorialv2/includes/sidebar/delete_content.part.html
@@ -20,7 +20,7 @@
                         {% endblocktrans %}
                         {%  if need_reason %}
                             {% blocktrans with username=validation.validator.username %}
-                                Il est en cours de validation par <strong>{{ username }}</strong>, qui appréciera de savoir pourquoi vous souhaitez le supprimer :
+                                Il est en cours d’édition par <strong>{{ username }}</strong>, qui appréciera de savoir pourquoi vous souhaitez le supprimer :
                             {% endblocktrans %}
                         {% endif %}
                     </p>

--- a/templates/tutorialv2/includes/sidebar/public_actions.part.html
+++ b/templates/tutorialv2/includes/sidebar/public_actions.part.html
@@ -73,7 +73,7 @@
             {% if public_actions.show_content_revoke %}
                 <li>
                     <a href="#unpublish" class="ico-after open-modal cross blue">
-                        {% trans "Dévalider et dépublier" %}
+                        {% trans "Dépublier" %}
                     </a>
                     {% crispy form_revoke %}
                 </li>

--- a/templates/tutorialv2/includes/sidebar/validation.part.html
+++ b/templates/tutorialv2/includes/sidebar/validation.part.html
@@ -5,14 +5,14 @@
 
 
 {% if display_config.validation_actions.show_validation_actions %}
-    <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Validation">
-        <h3>{% if content.requires_validation %}{% trans "Validation"%}{%else %}{%trans "Modération" %}{% endif %}</h3>
+    <div class="mobile-menu-bloc mobile-all-links mobile-show-ico" data-title="Édition">
+        <h3>{% if content.requires_validation %}{% trans "Édition"%}{%else %}{%trans "Modération" %}{% endif %}</h3>
         <ul>
             {% if display_config.validation_actions.show_validation_link %}
                 <li>
                     {% url "content:validation-view" pk=content.pk slug=content.slug as url_validation %}
                     <a href="{{ url_validation }}" class="ico-after online blue">
-                        {% trans "Voir la page de validation" %}
+                        {% trans "Voir la page d’édition" %}
                     </a>
                 </li>
             {% endif %}
@@ -27,21 +27,21 @@
 
             {% if display_config.validation_actions.show_ask_validation %}
                 <li>
-                    <a href="#ask-validation" class="open-modal ico-after tick green">{% trans "Demander la validation" %}</a>
+                    <a href="#ask-validation" class="open-modal ico-after tick green">{% trans "Demander l’édition" %}</a>
                     {% crispy form_ask_validation %}
                 </li>
             {% endif %}
 
             {% if display_config.validation_actions.show_cancel_validation %}
                 <li>
-                    <a href="#cancel-validation" class="open-modal ico-after cross blue">{% trans "Annuler la demande de validation" %}</a>
+                    <a href="#cancel-validation" class="open-modal ico-after cross blue">{% trans "Annuler la demande d’édition" %}</a>
                     {% crispy form_cancel_validation %}
                 </li>
             {% endif %}
 
             {% if display_config.validation_actions.show_update_validation %}
                 <li>
-                    <a href="#ask-validation" class="open-modal ico-after tick green">{% trans "Mettre à jour la version en validation" %}</a>
+                    <a href="#ask-validation" class="open-modal ico-after tick green">{% trans "Mettre à jour la version en édition" %}</a>
                     {% crispy form_ask_validation %}
                 </li>
             {% endif %}
@@ -81,7 +81,7 @@
                                 </form>
                             </li>
                             <li>
-                                <a href="#valid-publish" class="open-modal ico-after tick green">{% trans "Valider et publier" %}</a>
+                                <a href="#valid-publish" class="open-modal ico-after tick green">{% trans "Publier" %}</a>
                                 {% crispy form_valid %}
                             </li>
                             <li>
@@ -98,7 +98,7 @@
                                 <form action="{% url "validation:reserve" validation.pk %}" method="post" class="modal modal-flex" id="unreservation">
                                     {% csrf_token %}
                                     <p>
-                                        {% trans "La validation de ce contenu est actuellement réservée par" %}
+                                        {% trans "L’édition de ce contenu est actuellement réservée par" %}
                                         {% include "misc/member_item.part.html" with member=validation.validator %}.
                                         {% trans "Êtes-vous certain de vouloir le retirer" %} ?
                                     </p>
@@ -117,7 +117,7 @@
                     {% captureas to_sha %}{% if version %}{{ version }}{% else %}{{ content.sha_draft }}{% endif %}{% endcaptureas %}
                     {% captureas diff_valid_url %}{% url "content:diff" content.pk content.slug_repository %}?from={{ validation.version }}&amp;to={{ to_sha }}{% endcaptureas %}
                     <a href="{{ diff_valid_url }}" class="ico-after history blue">
-                        {% trans "Comparer avec la version en validation" %}
+                        {% trans "Comparer avec la version en cours d’édition" %}
                     </a>
                 </li>
             {% endif %}
@@ -125,7 +125,7 @@
             {% if display_config.validation_actions.show_validation_history %}
                 <li>
                     {% url "validation:history" content.pk content.slug as history_url %}
-                    <a href="{{ history_url }}" class="ico-after history blue">{% trans "Historique de validation" %}</a>
+                    <a href="{{ history_url }}" class="ico-after history blue">{% trans "Historique d’édition" %}</a>
                 </li>
             {% endif %}
 

--- a/templates/tutorialv2/messages/beta_activate_pm.md
+++ b/templates/tutorialv2/messages/beta_activate_pm.md
@@ -5,7 +5,7 @@ Bonjour {{ user }},
 
 Le contenu « {{ title }} » a été passé en bêta. La communauté pourra
 consulter cette version et vous faire ses retours dessus. Elle vous
-permettra ainsi de l’améliorer et de satisfaire aux critères de validation.
+permettra ainsi de l’améliorer et de satisfaire aux critères d’édition.
 
 Pour cela, un sujet a été créé automatiquement sur le forum et est accessible
 [ici]({{ url }}). N’hésitez surtout pas à en personnaliser le premier message !

--- a/templates/tutorialv2/messages/beta_activate_topic.md
+++ b/templates/tutorialv2/messages/beta_activate_topic.md
@@ -5,7 +5,7 @@
 Tout le monde se secoue ! :D
 
 J'ai commencé ({{ time }}) la rédaction d’un {{ type }} au doux nom
-de « {{ title }} » et j’ai pour objectif de proposer en validation
+de « {{ title }} » et j’ai pour objectif de proposer pour publication
 un texte aux petits oignons. Je fais donc appel à votre bonté sans
 limites pour dénicher le moindre pépin, que ce soit à propos
 du fond ou de la forme. Vous pourrez consulter la bêta à votre guise à

--- a/templates/tutorialv2/messages/opinion_promotion.md
+++ b/templates/tutorialv2/messages/opinion_promotion.md
@@ -6,7 +6,7 @@ Félicitations !
 
 Je viens de proposer le billet « [{{ title }}]({{ url }}) » comme article !
 
-Il est en validation et sera examiné prochainement.
+Il est en zone d’édition et sera examiné prochainement.
 
 À bientôt !
 {% endblocktrans %}

--- a/templates/tutorialv2/messages/validation_cancel.md
+++ b/templates/tutorialv2/messages/validation_cancel.md
@@ -5,7 +5,7 @@
 
 Bonjour {{ validator }},
 
-Je t’informe de l'annulation de la mise en validation du contenu
+Je t’informe de l'annulation de l’édition du contenu
 « [{{ title }}]({{ url }}) », que tu avais réservé. La raison suivante est
 fournie par [{{ user_name }}]({{ user_url }}) :
 

--- a/templates/tutorialv2/messages/validation_cancel_on_delete.md
+++ b/templates/tutorialv2/messages/validation_cancel_on_delete.md
@@ -5,7 +5,7 @@
 
 Bonjour {{ validator }},
 
-Je t’informe que la validation du contenu « {{ title }} » que tu as réservé, a
+Je t’informe que l’édition du contenu « {{ title }} » que tu as réservé, a
 été annulée, pour la simple et bonne raison
 que le contenu en question a été supprimé par
 [{{ user_name }}]({{ user_url }}), qui a fourni l’explication suivante :

--- a/templates/tutorialv2/messages/validation_change.md
+++ b/templates/tutorialv2/messages/validation_change.md
@@ -10,7 +10,7 @@
 Ça pulpe {{ validator }} ?
 
 Je suis là pour t’informer que le contenu « [{{ title }}]({{ url }}) » que tu
-as réservé a fait l'objet d'une mise à jour puis d'une mise en validation. La
+as réservé a fait l'objet d'une mise à jour puis d'une demande d’édition. La
 version dont tu t'occupes — avec douceur, j'en suis certaine —, apparaît donc comme
 obsolète.
 

--- a/templates/tutorialv2/messages/validation_reject.md
+++ b/templates/tutorialv2/messages/validation_reject.md
@@ -3,18 +3,18 @@
 {% blocktrans with title=content.title|safe validator_name=validator.username|safe validator_url=validator.get_absolute_url message=message_reject|safe %}
 
 Désolé, votre contenu « [{{ title }}]({{ url }}) » n’a malheureusement pas
-franchi l’étape de validation.
+franchi l’étape d’édition.
 
 Mais pas de panique, certaines corrections peuvent sûrement être faites
 pour l’améliorer et remédier à cela. Vous pouvez commencer par regarder
 les raisons de ce rejet, fournies ci-dessous par
-[{{ validator_name }}]({{ validator_url }}), le validateur en charge de
+[{{ validator_name }}]({{ validator_url }}), l’éditeur en charge de
 votre contenu :
 
 {{ message }}
 
 Si certains points vous semblent obscurs, voire injustes, vous êtes invité à
-contacter le validateur pour lui en parler. Il sera ravi de vous fournir des
+contacter l’éditeur pour lui en parler. Il sera ravi de vous fournir des
 détails ainsi que des conseils. N’oubliez pas non plus que la communauté peut
 vous aider à travers le système de bêta.
 

--- a/templates/tutorialv2/messages/validation_reserve.md
+++ b/templates/tutorialv2/messages/validation_reserve.md
@@ -4,13 +4,13 @@
 
 Salut !
 
-Je viens de prendre en charge la validation de ton contenu, « [{{ title }}]({{ url }}) ».
+Je viens de prendre en charge l’édition de ton contenu, « [{{ title }}]({{ url }}) ».
 
 À bientôt !
 {% plural %}
 Salut !
 
-Je viens de prendre en charge la validation de votre contenu, « [{{ title }}]({{ url }}) ».
+Je viens de prendre en charge l’édition de votre contenu, « [{{ title }}]({{ url }}) ».
 
 À bientôt !
 

--- a/templates/tutorialv2/validation/history.html
+++ b/templates/tutorialv2/validation/history.html
@@ -6,13 +6,13 @@
 
 
 {% block title %}
-    {% trans "Historique de validation" %}
+    {% trans "Historique d’édition" %}
 {% endblock %}
 
 
 
 {% block breadcrumb_base %}
-    <li><a href="{% url "validation:list" %}">{% trans "Validation" %}</a></li>
+    <li><a href="{% url "validation:list" %}">{% trans "Édition" %}</a></li>
     <li><a href="{{ content.get_absolute_url }}">{{ content.title }}</a></li>
     <li>{% trans "Historique" %}</li>
 {% endblock %}
@@ -28,7 +28,7 @@
     </h1>
 
     <h2 class="subtitle">
-        {% trans "Historique de validation" %}
+        {% trans "Historique d’édition" %}
     </h2>
 {% endblock %}
 
@@ -51,7 +51,7 @@
                             {% if validation.comment_authors %}
                                 <br>
                                 <a href="#view-comment-authors-{{ validation.pk }}" class="open-modal">
-                                    {% trans "Message laissé à la validation" %}
+                                    {% trans "Message laissé à l’édition" %}
                                 </a>
                                 <div class="modal modal-flex" id="view-comment-authors-{{ validation.pk }}" data-modal-close="Fermer">
                                     <p>
@@ -72,7 +72,7 @@
         </table>
     {% else %}
         <p>
-            {% trans "Ce contenu n’a jamais été soumis en validation" %}.
+            {% trans "Ce contenu n’a jamais été soumis pour édition" %}.
         </p>
     {% endif %}
 {% endblock %}

--- a/templates/tutorialv2/validation/index.html
+++ b/templates/tutorialv2/validation/index.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 
 {% block title_base %}
-    {% trans "Validation" %}
+    {% trans "Édition" %}
 {% endblock %}
 
 {% block title %}
@@ -22,7 +22,7 @@
 
 
 {% block breadcrumb_base %}
-    <li>{% trans "Validation" %}</li>
+    <li>{% trans "Édition" %}</li>
 {% endblock %}
 
 
@@ -31,7 +31,7 @@
     <section class="full-content-wrapper">
         <h1>
             {% block headline %}
-                {% trans "Validation des contenus" %}
+                {% trans "Édition des contenus" %}
                 {% if request.GET.type == "reserved" %}
                     / {% trans "Reservés" %}
                 {% elif request.GET.type == "orphan" %}
@@ -125,7 +125,7 @@
                 </table>
             {% else %}
                 <p>
-                    {% trans "Aucun contenu en validation" %}
+                    {% trans "Aucun contenu en cours d’édition" %}
                     {% if request.GET.type %}
                         {% trans " ne répond à ce critère" %}
                     {% endif %}
@@ -144,12 +144,12 @@
         <ul>
             <li>
                 <a href="{% url "validation:list" %}?type=reserved" class="ico-after tick green {% if request.GET.type == "reserved" %}selected{% endif %}">
-                    {% trans "En cours de validation" %}
+                    {% trans "En cours d’édition" %}
                 </a>
             </li>
             <li>
                 <a href="{% url "validation:list" %}?type=orphan" class="ico-after tick {% if request.GET.type == "orphan" %}selected{% endif %}">
-                    {% trans "En attente de validateur" %}
+                    {% trans "En attente d’éditeur·ice" %}
                 </a>
             </li>
             <li>

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -69,7 +69,7 @@
         {% if display_config.draft_actions.show_ready_to_publish %}
             {% if not container.ready_to_publish %}
                 <div class="alert-box ico-alerts">
-                    {% trans "Cette partie n'est pas prête à la publication. En cas de validation, elle ne sera pas publiée." %}
+                    {% trans "Cette partie n'est pas prête à la publication. En cas d’édition, elle ne sera pas publiée." %}
                 </div>
             {% endif %}
         {% endif %}
@@ -274,11 +274,11 @@
             <a data-url="{% url 'api:content:readiness' content.pk %}" class="readiness" data-is-ready="{{ container.ready_to_publish|yesno:"true,false" }}"
                data-container-slug="{{ container.slug }}"
                 {% if container.parent.parent %}data-parent-container-slug="{{ container.parent.slug }}"{% endif %}
-                data-is-ready-false="{% trans "Marquer comme prêt à valider." %}" data-is-ready-true="{% trans "Marquer comme à ne pas valider." %}">
+                data-is-ready-false="{% trans "Marquer comme prêt à éditer." %}" data-is-ready-true="{% trans "Marquer comme à ne pas éditer." %}">
                 {% if container.ready_to_publish %}
-                    {% trans "Marquer comme à ne pas valider." %}
+                    {% trans "Marquer comme à ne pas éditer." %}
                 {% else %}
-                    {% trans "Marquer comme prêt à valider." %}
+                    {% trans "Marquer comme prêt à éditer." %}
                 {% endif %}
             </a>
         </li>

--- a/templates/tutorialv2/view/history.html
+++ b/templates/tutorialv2/view/history.html
@@ -72,7 +72,7 @@
                             <ul class="unstyled-list">
                                 {% if content.sha_validation == commit.hexsha %}
                                     {% url "content:validation-view" pk=content.pk slug=content.slug as url_validation %}
-                                    <li><a href="{{ url_validation }}">{% trans "Validation" %}</a></li>
+                                    <li><a href="{{ url_validation }}">{% trans "Édition" %}</a></li>
                                 {% endif %}
                                 {% if content.sha_beta == commit.hexsha %}
                                     {% url "content:beta-view" pk=content.pk slug=content.slug as url_beta %}

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -244,7 +244,7 @@ ZDS_APP = {
             "opinion": (_("Billet"), ["opinion"]),
         },
         "search_validated_content": {
-            "validated": (_("Contenus validés"), ["validated"]),
+            "validated": (_("Contenus édités"), ["validated"]),
             "no_validated": (_("Contenus libres"), ["no_validated"]),
         },
         "boosts": {

--- a/zds/tutorialv2/forms.py
+++ b/zds/tutorialv2/forms.py
@@ -252,7 +252,7 @@ class ImportNewContentForm(ImportContentForm):
     subcategory = forms.ModelMultipleChoiceField(
         label=_(
             "Sous catégories de votre contenu. Si aucune catégorie ne convient "
-            "n'hésitez pas à en demander une nouvelle lors de la validation !"
+            "n'hésitez pas à en demander une nouvelle lors de l’édition !"
         ),
         queryset=SubCategory.objects.order_by("title").all(),
         required=True,
@@ -420,7 +420,7 @@ class AskValidationForm(forms.Form):
             _(
                 """<p><strong>Votre publication n'est dans aucune catégorie.
                                     Vous devez <a href="{}">choisir une catégorie</a>
-                                    avant de demander la validation.</strong></p>""".format(
+                                    avant de demander l’édition.</strong></p>""".format(
                     reverse("content:edit-categories", kwargs={"pk": content.pk}),
                 )
             )
@@ -431,7 +431,7 @@ class AskValidationForm(forms.Form):
             _(
                 """<p><strong>Vous n'avez pas choisi de licence pour votre publication.
                                    Vous devez <a href="#edit-license" class="open-modal">choisir une licence</a>
-                                   avant de demander la validation.</strong></p>"""
+                                   avant de demander l’édition.</strong></p>"""
             )
         )
 
@@ -446,7 +446,7 @@ class AskValidationForm(forms.Form):
     def clean(self):
         cleaned_data = super().clean()
 
-        base_error_msg = "La validation n'a pas été demandée. "
+        base_error_msg = "L’édition n'a pas été demandée. "
 
         if self.no_subcategories:
             error = [_(base_error_msg + "Vous devez choisir au moins une catégorie pour votre publication.")]
@@ -465,7 +465,7 @@ class AcceptValidationForm(forms.Form):
     text = forms.CharField(
         label="",
         required=True,
-        error_messages={"required": _("Vous devez fournir un commentaire aux validateurs.")},
+        error_messages={"required": _("Vous devez fournir un commentaire aux éditeur·ices.")},
         widget=forms.Textarea(attrs={"placeholder": _("Commentaire de publication."), "rows": "2", "minlength": "3"}),
         validators=[MinLengthValidator(3, _("Votre commentaire doit faire au moins 3 caractères."))],
     )
@@ -504,7 +504,7 @@ class CancelValidationForm(forms.Form):
         label="",
         required=True,
         widget=forms.Textarea(
-            attrs={"placeholder": _("Pourquoi annuler la validation ?"), "rows": "4", "id": "cancel_text"}
+            attrs={"placeholder": _("Pourquoi annuler l’édition ?"), "rows": "4", "id": "cancel_text"}
         ),
     )
 
@@ -520,7 +520,7 @@ class CancelValidationForm(forms.Form):
         self.helper.form_id = "cancel-validation"
 
         self.helper.layout = Layout(
-            HTML("<p>Êtes-vous certain de vouloir annuler la validation de ce contenu ?</p>"),
+            HTML("<p>Êtes-vous certain de vouloir annuler l’édition de ce contenu ?</p>"),
             Field("text"),
             ButtonHolder(StrictButton(_("Confirmer"), type="submit", css_class="btn-submit")),
         )
@@ -891,7 +891,7 @@ class PromoteOpinionToArticleForm(forms.Form):
             HTML(
                 """<p>Avez-vous la certitude de vouloir proposer ce billet comme article ?
                     Cela copiera le billet pour en faire un article,
-                    puis créera une demande de validation pour ce dernier.</p>"""
+                    puis créera une demande d’édition pour ce dernier.</p>"""
             ),
             Field("version"),
             StrictButton(_("Valider"), type="submit", css_class="btn-submit"),

--- a/zds/tutorialv2/management/commands/validate_content.py
+++ b/zds/tutorialv2/management/commands/validate_content.py
@@ -13,7 +13,7 @@ from zds.tutorialv2.publication_utils import (
 
 
 class Command(BaseCommand):
-    help = "Publish one content by its id. This require the content to be in validation and reserved by someone"
+    help = "Publish one content by its id. This require the content to be in edition and reserved by someone"
 
     def add_arguments(self, parser):
         parser.add_argument("content", type=Command.id_validator)
@@ -31,7 +31,7 @@ class Command(BaseCommand):
             raise ValueError("Content does not exist")
 
         if not Validation.objects.filter(content=content, status="PENDING_V").first():
-            raise ValueError("Content is not being validated")
+            raise ValueError("Content is not being edited")
 
         return content
 

--- a/zds/tutorialv2/models/__init__.py
+++ b/zds/tutorialv2/models/__init__.py
@@ -55,8 +55,8 @@ CONTENT_TYPE_LIST = [type_[0] for type_ in TYPE_CHOICES]
 TYPE_CHOICES_DICT = dict(TYPE_CHOICES)
 
 STATUS_CHOICES = (
-    ("PENDING", _("En attente d'un validateur")),
-    ("PENDING_V", _("En cours de validation")),
+    ("PENDING", _("En attente d'un·e éditeur·ice")),
+    ("PENDING_V", _("En cours d’édition")),
     ("ACCEPT", _("Publié")),
     ("REJECT", _("Rejeté")),
     ("CANCEL", _("Annulé")),

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -100,11 +100,11 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
     sha_public = models.CharField("Sha1 de la version publique", blank=True, null=True, max_length=80, db_index=True)
     sha_beta = models.CharField("Sha1 de la version beta publique", blank=True, null=True, max_length=80, db_index=True)
     sha_validation = models.CharField(
-        "Sha1 de la version en validation", blank=True, null=True, max_length=80, db_index=True
+        "Sha1 de la version en édition", blank=True, null=True, max_length=80, db_index=True
     )
     sha_draft = models.CharField("Sha1 de la version de rédaction", blank=True, null=True, max_length=80, db_index=True)
     sha_picked = models.CharField(
-        "Sha1 de la version choisie (contenus publiés sans validation)",
+        "Sha1 de la version choisie (contenus publiés sans édition)",
         blank=True,
         null=True,
         max_length=80,
@@ -1409,8 +1409,8 @@ class Validation(models.Model):
     """
 
     class Meta:
-        verbose_name = "Validation"
-        verbose_name_plural = "Validations"
+        verbose_name = "Édition"
+        verbose_name_plural = "Éditions"
 
     content = models.ForeignKey(
         PublishableContent,
@@ -1425,7 +1425,7 @@ class Validation(models.Model):
     comment_authors = models.TextField("Commentaire de l'auteur", null=True, blank=True)
     validator = models.ForeignKey(
         User,
-        verbose_name="Validateur",
+        verbose_name="Éditeur·ices",
         related_name="author_content_validations",
         blank=True,
         null=True,
@@ -1433,12 +1433,12 @@ class Validation(models.Model):
         on_delete=models.SET_NULL,
     )
     date_reserve = models.DateTimeField("Date de réservation", blank=True, null=True)
-    date_validation = models.DateTimeField("Date de validation", blank=True, null=True)
-    comment_validator = models.TextField("Commentaire du validateur", blank=True, null=True)
+    date_validation = models.DateTimeField("Date d’édition", blank=True, null=True)
+    comment_validator = models.TextField("Commentaire d’édition", blank=True, null=True)
     status = models.CharField(max_length=10, choices=STATUS_CHOICES, default="PENDING")
 
     def __str__(self):
-        return _("Validation de « {} »").format(self.content.title)
+        return _("Édition de « {} »").format(self.content.title)
 
     def is_pending(self):
         """Check if the validation is pending

--- a/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
+++ b/zds/tutorialv2/tests/tests_views/tests_addcontributor.py
@@ -79,7 +79,7 @@ class AddContributorWorkflowTests(TutorialTestMixin, TestCase):
         # Create entities for the test
         self.author = ProfileFactory().user
         self.contributor = ProfileFactory().user
-        self.role = ContentContributionRoleFactory(title="Validateur")
+        self.role = ContentContributionRoleFactory(title="Éditeur·ice")
         self.content = PublishableContentFactory(author_list=[self.author])
         settings.ZDS_APP["member"]["bot_account"] = ProfileFactory().user.username
 

--- a/zds/tutorialv2/tests/tests_views/tests_content.py
+++ b/zds/tutorialv2/tests/tests_views/tests_content.py
@@ -1547,7 +1547,7 @@ class ContentTests(TutorialTestMixin, TestCase):
     def test_validation_subscription(self):
         """test if the author suscribes to their own content"""
 
-        text_validation = "Valide moi ce truc, s'il te plait"
+        text_validation = "Édite moi ce truc, s'il te plait"
         text_accept = "C'est cool, merci !"
 
         tuto = PublishableContent.objects.get(pk=self.tuto.pk)
@@ -1679,7 +1679,7 @@ class ContentTests(TutorialTestMixin, TestCase):
     def test_validation_workflow(self, validation_management):
         """test the different case of validation"""
 
-        text_validation = "Valide moi ce truc, s'il te plait"
+        text_validation = "Édite-moi ce truc, s'il te plait"
         text_accept = "C'est cool, merci !"
         text_reject = "Je refuse ce contenu."
 
@@ -1998,7 +1998,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         result = self.client.post(
             reverse("validation:ask", kwargs={"pk": tuto.pk, "slug": tuto.slug}),
-            {"text": "Valide moi ce truc, s'il te plait", "version": self.tuto_draft.current_version},
+            {"text": "Édite-moi ce truc, s'il te plait", "version": self.tuto_draft.current_version},
             follow=False,
         )
         self.assertEqual(result.status_code, 302)
@@ -2052,7 +2052,7 @@ class ContentTests(TutorialTestMixin, TestCase):
     def test_delete_while_validating(self):
         """this test ensure that the validator is warned if the content he is validing is removed"""
 
-        text_validation = "Valide moi ce truc, s'il te plait"
+        text_validation = "Édite-moi ce truc, s'il te plait"
         text_cancel = "Veux pas !"
 
         # let's create a medium-size tutorial
@@ -2402,7 +2402,7 @@ class ContentTests(TutorialTestMixin, TestCase):
 
         result = self.client.post(
             reverse("validation:ask", kwargs={"pk": tuto.pk, "slug": tuto.slug}),
-            {"text": "valide moi ça, please", "version": versioned.current_version},
+            {"text": "Édite-moi ça, please", "version": versioned.current_version},
             follow=False,
         )
         self.assertEqual(result.status_code, 302)

--- a/zds/tutorialv2/tests/tests_views/tests_contentvalidationview.py
+++ b/zds/tutorialv2/tests/tests_views/tests_contentvalidationview.py
@@ -67,4 +67,4 @@ class FunctionalTests(TutorialTestMixin, TestCase):
         """Test that the validation page shows the validation actions."""
         self.client.force_login(self.author)
         response = self.client.get(self.target_url)
-        self.assertContains(response, "<h3>Validation</h3>")
+        self.assertContains(response, "<h3>Édition</h3>")

--- a/zds/tutorialv2/tests/tests_views/tests_published.py
+++ b/zds/tutorialv2/tests/tests_views/tests_published.py
@@ -121,7 +121,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
     def test_public_access(self):
         """Test that everybody have access to a content after its publication"""
 
-        text_validation = "Valide moi ce truc, please !"
+        text_validation = "Édite-moi ce truc, please !"
         text_publication = "Aussi tôt dit, aussi tôt fait !"
 
         # 1. Article:
@@ -1198,7 +1198,7 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
         self.assertNotEqual(tuto.slug, old_slug)
 
         # ask validation
-        text_validation = "Valide moi ce truc, please !"
+        text_validation = "Édite-moi ce truc, please !"
         text_publication = "Aussi tôt dit, aussi tôt fait !"
         self.assertEqual(Validation.objects.count(), 0)
 
@@ -1481,8 +1481,8 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
     def test_beta_article_closed_when_published(self):
         """Test that the beta of an article is locked when the content is published"""
 
-        text_validation = "Valide moi ce truc !"
-        text_publication = "Validation faite !"
+        text_validation = "Édite-moi ce truc !"
+        text_publication = "Édition faite !"
 
         article = PublishableContentFactory(type="ARTICLE")
         article.authors.add(self.user_author)
@@ -1887,8 +1887,8 @@ class PublishedContentTests(TutorialTestMixin, TestCase):
     def test_author_update(self):
         """Check that the author list of a content is updated when this content is updated."""
 
-        text_validation = "Valide moi ce truc, please !"
-        text_publication = "Validation faite !"
+        text_validation = "Édite-moi ce truc, please !"
+        text_publication = "Édition faite !"
 
         tutorial = PublishedContentFactory(
             type="TUTORIAL", author_list=[self.user_author, self.user_guest, self.user_staff]

--- a/zds/tutorialv2/tests/tests_views/tests_removecontributor.py
+++ b/zds/tutorialv2/tests/tests_views/tests_removecontributor.py
@@ -90,7 +90,7 @@ class RemoveContributorWorkflowTests(TutorialTestMixin, TestCase):
         self.author = ProfileFactory().user
         self.contributor = ProfileFactory().user
         self.content = PublishableContentFactory(author_list=[self.author])
-        self.role = ContentContributionRoleFactory(title="Validateur")
+        self.role = ContentContributionRoleFactory(title="Éditeur")
         self.contribution = create_contribution(self.role, self.contributor, self.content)
 
         # Get information to be reused in tests

--- a/zds/tutorialv2/views/contents.py
+++ b/zds/tutorialv2/views/contents.py
@@ -471,7 +471,7 @@ class DeleteContent(LoginRequiredMixin, SingleContentViewMixin, DeleteView):
                         validation.content.validation_private_message = send_mp(
                             bot,
                             [validation.validator],
-                            _("Demande de validation annulée").format(),
+                            _("Demande d’édition annulée").format(),
                             self.object.title,
                             msg,
                             send_by_mail=False,

--- a/zds/tutorialv2/views/display/config.py
+++ b/zds/tutorialv2/views/display/config.py
@@ -278,7 +278,7 @@ class OnlineState:
 
 class ValidationActions:
     messages = {
-        "validation_is_same": _("La version en validation est identique à cette version."),
+        "validation_is_same": _("La version en cours d’édition est identique à cette version."),
     }
 
     def __init__(self, user, content: PublishableContent, versioned_content: VersionedContent):

--- a/zds/tutorialv2/views/display/container.py
+++ b/zds/tutorialv2/views/display/container.py
@@ -200,7 +200,7 @@ class ContainerValidationView(LoginRequiredMixin, ContainerBaseView):
         obj = super().get_object(queryset)
 
         if not obj.sha_validation:
-            raise Http404("Aucune version en validation n'existe pour ce contenu.")
+            raise Http404("Aucune version en édition n'existe pour ce contenu.")
         else:
             self.sha = obj.sha_validation
 

--- a/zds/tutorialv2/views/display/content.py
+++ b/zds/tutorialv2/views/display/content.py
@@ -342,7 +342,7 @@ class ContentValidationView(LoginRequiredMixin, ContentBaseView):
         obj = super().get_object(queryset)
 
         if not obj.sha_validation:
-            raise Http404("Aucune version en validation n'existe pour ce contenu.")
+            raise Http404("Aucune version en édition n'existe pour ce contenu.")
         else:
             self.sha = obj.sha_validation
 

--- a/zds/tutorialv2/views/lists.py
+++ b/zds/tutorialv2/views/lists.py
@@ -334,7 +334,7 @@ class ContentOfAuthor(ZdSPagingListView):
     authorized_filters = OrderedDict(
         [
             ("public", [lambda p, t: p.get_user_public_contents_queryset(t), _("Publiés"), True, "tick green"]),
-            ("validation", [lambda p, t: p.get_user_validate_contents_queryset(t), _("En validation"), False, "tick"]),
+            ("validation", [lambda p, t: p.get_user_validate_contents_queryset(t), _("En édition"), False, "tick"]),
             ("beta", [lambda p, t: p.get_user_beta_contents_queryset(t), _("En bêta"), True, "beta"]),
             ("redaction", [lambda p, t: p.get_user_draft_contents_queryset(t), _("Brouillons"), False, "edit"]),
         ]

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -234,9 +234,7 @@ class CancelValidation(LoginRequiredMixin, ModalFormView):
         # reject validation:
         quote = "\n".join(["> " + line for line in form.cleaned_data["text"].split("\n")])
         validation.status = "CANCEL"
-        validation.comment_authors = _("\n\nLa validation a été **annulée** pour la raison suivante :\n\n{}").format(
-            quote
-        )
+        validation.comment_authors = _("\n\nL’édition a été **annulée** pour la raison suivante :\n\n{}").format(quote)
         validation.date_validation = datetime.now()
         validation.save()
 

--- a/zds/tutorialv2/views/validations_opinions.py
+++ b/zds/tutorialv2/views/validations_opinions.py
@@ -290,7 +290,7 @@ class PickOpinion(PermissionRequiredMixin, DoesNotRequireValidationFormViewMixin
     permission_required = "tutorialv2.change_validation"
 
     def get(self, request, *args, **kwargs):
-        raise Http404(_("Valider un contenu n'est pas possible avec la méthode « GET »."))
+        raise Http404(_("Éditer un contenu n'est pas possible avec la méthode « GET »."))
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -556,7 +556,7 @@ class PromoteOpinionToArticle(PermissionRequiredMixin, DoesNotRequireValidationF
             self.request,
             _(
                 """Le billet a bien été copié sous forme d’article
-                                            et est en attente de validation."""
+                                            et est en attente d’édition."""
             ),
         )
 

--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -431,7 +431,7 @@ def load_contents(cli, size, fake, _type, *_, **__):
         )
     else:
         cli.stdout.write(
-            " - {:g} en validation (dont {:g} réservés)".format(
+            " - {:g} en cours d’édition (dont {:g} réservés)".format(
                 nb_contents * (percent_contents_in_validation + percent_contents_with_validator),
                 nb_contents * percent_contents_with_validator,
             )
@@ -626,11 +626,11 @@ class Command(BaseCommand):
         ZDSResource("post", "forum message", load_posts, tuple()),
         ZDSResource("gallery", "image gallery for each member", load_gallery, tuple()),
         ZDSResource(
-            "article", "article-typed publications, in draft, in validation and published", load_contents, ("ARTICLE",)
+            "article", "article-typed publications, in draft, in edition and published", load_contents, ("ARTICLE",)
         ),
         ZDSResource(
             "tutorial",
-            "tutorial-typed publications, in draft, in validation and published",
+            "tutorial-typed publications, in draft, in edition and published",
             load_contents,
             ("TUTORIAL",),
         ),


### PR DESCRIPTION
Change le vocabulaire pour remplacer la notion de « validation » par celle d’« édition ».

C’est juste un changement de vocabulaire : le code, les URLs… conservent le terme de « validation » pour éviter de provoquer un gigantesque changement qui aurait toutes les chances de tout casser.

Constat :

1. Le vocabulaire actuel ne permet pas aux auteurs et aux lecteurs de comprendre ce que ZdS propose (de l’édition, au sens _« Préparation du texte d'une œuvre en vue de sa publication. »_).
2. Le but de la MR est d’utiliser un vocabulaire qui corresponde à la réalité de ce qu’on fait. Pour moi la priorité c’est d’être précis dans le vocabulaire utilisé partout ; si on veut mettre des précisions pour rassurer les futurs auteurs, on peut facilement les rajouter, par exemple sur la page de création d’une publication https://zestedesavoir.com/contenus/nouveau-contenu/OPINION/. Donc, si on veut utiliser un autre terme dans la communication publique, il faut le choisir avec soin pour ne pas retomber dans la situation actuelle.
3. C’est **très probable** que dans mon opération de renommage j’ai oublié des termes, ou ait remplacé une variante de « valider » par « éditer » là où ça ne s’applique pas. La MR est là pour les corriger.

### Contrôle qualité

- (le plus important) Avec un compte utilisateur, créer un tuto et un article, et vérifier que toutes les actions de validation possibles sont maintenant des actions d’édition ; idem pour les différents messages reçus suite aux actions de validation.
- (moins important) Avec un compte staff éditeur, tester les différentes actions de validation possibles et s’assurer que c’est maintenant des actions d’édition. Poster avec la casquette d’éditeur, si elle existe (je suis un peu paumé dans le système de casquettes prédéfinies).