### PR TITLE
Aligne l'attribut DC.date avec la date de dernière publication

### DIFF
--- a/templates/tutorialv2/includes/meta/dcmi_cards.part.html
+++ b/templates/tutorialv2/includes/meta/dcmi_cards.part.html
@@ -7,12 +7,12 @@
 <meta name="DC.creator" content="{{ author.username }}" />
 {% endfor %}
 <meta name="DC.type" content="text" />
-<meta name="DC.title" content="{{ content.title }}" />
-<meta name="DC.abstract" content="{{ content.title }}{% if content.meta_description %} – {{ content.meta_description }}{% endif %}" />
-<meta name="DC.subject" lang="fr" content="{% joinby content.subcategory.all %}{% if content.tags.all %} – {% joinby content.tags.all separator=' ; ' final_separator=' ; ' %}{% endif %}" />
-{% if content.meta_description %}<meta name="DC.description" lang="fr" content="{{ content.meta_description }}" />{% endif %}
-<meta name="DC.date" content="{% if content.pubdate %}{{ content.pubdate|date:'Y/m/d' }}{% else %}{{ content.update_date|date:'Y/m/d' }}{% endif %}" />
+<meta name="DC.title" content="{{ online_content.title }}" />
+<meta name="DC.abstract" content="{{ online_content.title }}{% if online_content.meta_description %} – {{ online_content.meta_description }}{% endif %}" />
+<meta name="DC.subject" lang="fr" content="{% joinby offline_content.subcategory.all %}{% if offline_content.tags.all %} – {% joinby offline_content.tags.all separator=' ; ' final_separator=' ; ' %}{% endif %}" />
+{% if online_content.meta_description %}<meta name="DC.description" lang="fr" content="{{ online_content.meta_description }}" />{% endif %}
+<meta name="DC.date" content="{% if online_content.last_publication_date %}{{ online_content.last_publication_date|date:'Y/m/d' }}{% else %}{{ online_content.update_date|date:'Y/m/d' }}{% endif %}" />
 <meta name="DC.format" content="text/html" />
-{% if content.source %}<meta name="DC.source" content="{{ content.source }}" />{% endif %}
+{% if online_content.source %}<meta name="DC.source" content="{{ online_content.source }}" />{% endif %}
 <meta name="DC.language" content="fr" />
-<meta name="DC.rights" content="{{ content.licence }}" />
+<meta name="DC.rights" content="{{ offline_content.licence }}" />

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -13,7 +13,7 @@
 
 {% if display_config.online_config.show_dcmi_card %}
     {% block DCMI_cards %}
-        {% include "tutorialv2/includes/meta/dcmi_cards.part.html" with db_content=db_content content=content is_online=db_content.public_version %}
+        {% include "tutorialv2/includes/meta/dcmi_cards.part.html" with db_content=db_content online_content=public_object offline_content=content is_online=db_content.public_version %}
     {% endblock %}
 {% endif %}
 


### PR DESCRIPTION
Cette PR permet d'aligner la date présentée dans l'attribut DC.date avec la date de dernière publication du contenu et non la date de mise à jour du brouillon.

Fix #6787

### Contrôle qualité

1. Assurez vous d'avoir un contenu publié dont la date de publication du contenu date d'au moins un jour (plus facile pour lire le test)
2. Vérifiez que la date de dernière publication affichée sur la page du contenu correspond à la date dans le code source de la page dans l'attribut `<meta name="DC.date"`
3. Faite une modification du brouillon de contenu (par exemple modifier l'introduction)
4. Vérifiez que la date de dernière mise à jour du brouillon a changé
5. Vérifiez que la date de dernière mise à jour de la version publique n'a pas changé
6. Vérifiez que la date de l'attribut  `<meta name="DC.date"` n'a pas changé sur la version publique
7. Demandez la validation du contenu
8. Validez le
9. Vérifiez que les date des version publiques ont changées et que l'attribut meta reste aligné avec ce qui est visible sur la page.