### PR TITLE
Rend le code de génération des fixtures compatible python 3.14

### DIFF
--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -657,12 +657,11 @@ class Command(BaseCommand):
             help="Size level: low (x1), medium (x2) or high (x3). Default: low.",
         )
         all_vs_one_per_one_switch = parser.add_mutually_exclusive_group()
-        all_vs_one_per_one_switch.add_argument_group("all").add_argument(
+        all_vs_one_per_one_switch.add_argument(
             "--all", dest="modules", action="store_const", const=self.__class__.zds_resource_config
         )
-        group = all_vs_one_per_one_switch.add_argument_group("one_per_one")
         for zds_module in self.__class__.zds_resource_config:
-            group.add_argument(
+            all_vs_one_per_one_switch.add_argument(
                 "--{}".format(zds_module.name.replace("_", "-")),
                 dest="modules",
                 help=f"add new {zds_module.description}.",


### PR DESCRIPTION
Cette PR rend le code de génération de fixtures compatible avec la version 3.14

Fix #6783

### Contrôle qualité

- Installer zds avec la version de python `3.14`
- lancez `make generate-fixtures`
- Vérifiez que vous n'avez plus l'erreur mentionnée dans le ticket.

