### PR TITLE
Rend obligatoire le paramètre du type de fixtures à charger

### DIFF
--- a/zds/utils/management/commands/load_fixtures.py
+++ b/zds/utils/management/commands/load_fixtures.py
@@ -656,7 +656,7 @@ class Command(BaseCommand):
             type=str,
             help="Size level: low (x1), medium (x2) or high (x3). Default: low.",
         )
-        all_vs_one_per_one_switch = parser.add_mutually_exclusive_group()
+        all_vs_one_per_one_switch = parser.add_mutually_exclusive_group(required=True)
         all_vs_one_per_one_switch.add_argument(
             "--all", dest="modules", action="store_const", const=self.__class__.zds_resource_config
         )

--- a/zds/utils/management/tests.py
+++ b/zds/utils/management/tests.py
@@ -19,9 +19,7 @@ from zds.utils.models import CategorySubCategory, Licence, SubCategory, Tag
 @override_for_contents()
 class CommandsTestCase(TutorialTestMixin, TestCase):
     def test_load_fixtures(self):
-        args = []
-        opts = {"modules": FixtureCommand.zds_resource_config}
-        call_command("load_fixtures", *args, **opts)
+        call_command("load_fixtures", "--all")
 
         self.assertTrue(User.objects.count() > 0)
         self.assertTrue(Permission.objects.count() > 0)


### PR DESCRIPTION
Sans cela, si on lance la commande sans paramètre, on obtient une erreur Python, alors qu'avec ce commit, l'aide de la commande est affichée.



### Contrôle qualité

```sh
python manage.py help load_fixtures
```
montre l'aide de la commande.
```sh
python manage.py help load_fixtures --tag
```
charge des fixtures de tags.
