### PR TITLE
Corrige la redirection après modification des objectifs

### DIFF
--- a/zds/tutorialv2/tests/tests_views/tests_editgoals.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editgoals.py
@@ -89,3 +89,19 @@ class EditGoalsFunctionalTests(TestCase):
         self.assertEqual(list(self.content.goals.all()), [])
         self.assertContains(response, "alert-box alert")
         self.assertFalse(goals_management.send.called)
+
+    @patch("zds.tutorialv2.signals.goals_management")
+    def test_redirect_to_next_url(self, goals_management):
+        self.client.force_login(self.staff)
+        custom_url = reverse("content:view-goals")
+        response = self.client.post(self.url, {"goals": [], "next": custom_url})
+        self.assertRedirects(response, custom_url)
+        self.assertEqual(goals_management.send.call_count, 1)
+
+    @patch("zds.tutorialv2.signals.goals_management")
+    def test_redirect_default_without_next(self, goals_management):
+        self.client.force_login(self.staff)
+        content_url = reverse("content:view", kwargs={"pk": self.content.pk, "slug": self.content.slug})
+        response = self.client.post(self.url, {"goals": []})
+        self.assertRedirects(response, content_url)
+        self.assertEqual(goals_management.send.call_count, 1)

--- a/zds/tutorialv2/views/display/content.py
+++ b/zds/tutorialv2/views/display/content.py
@@ -101,7 +101,7 @@ class ContentBaseView(SingleContentDetailViewMixin):
         context["form_warn_typo"] = WarnTypoForm(self.versioned_object, self.versioned_object)
         context["form_edit_tags"] = EditTagsForm(self.versioned_object, self.object)
         context["form_edit_canonical_link"] = EditCanonicalLinkForm(self.object)
-        context["form_edit_goals"] = EditGoalsForm(self.object)
+        context["form_edit_goals"] = EditGoalsForm(self.object, next_url=self.get_base_url())
         context["form_edit_labels"] = EditLabelsForm(self.object)
         context["is_antispam"] = self.object.antispam(self.request.user)
         return context

--- a/zds/tutorialv2/views/goals.py
+++ b/zds/tutorialv2/views/goals.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Count
 from django.forms import (
     BooleanField,
+    CharField,
     CheckboxSelectMultiple,
     HiddenInput,
     IntegerField,
@@ -37,9 +38,15 @@ class EditGoalsForm(forms.Form):
     )
 
     def __init__(self, content, *args, **kwargs):
+        next_url = kwargs.pop("next_url", None)
         kwargs["initial"] = {"goals": content.goals.all()}
         super().__init__(*args, **kwargs)
 
+        self.fields["next_url"] = CharField(
+            widget=HiddenInput(),
+            required=False,
+            initial=next_url or "",
+        )
         self.helper = FormHelper()
         self.helper.form_class = "content-wrapper"
         self.helper.form_method = "post"
@@ -48,6 +55,7 @@ class EditGoalsForm(forms.Form):
         self.helper.form_action = reverse("content:edit-goals", kwargs={"pk": content.pk})
         self.helper.layout = Layout(
             Field("goals"),
+            Field("next_url"),
             ButtonHolder(StrictButton("Valider", type="submit")),
         )
 
@@ -59,6 +67,7 @@ class EditGoals(LoginRequiredMixin, PermissionRequiredMixin, SingleContentFormVi
     model = PublishableContent
     form_class = EditGoalsForm
     success_message = _("Les objectifs ont bien été modifiés.")
+    next_url = CharField(widget=HiddenInput(), required=False)
     modal_form = True
     http_method_names = ["post"]
 
@@ -83,6 +92,9 @@ class EditGoals(LoginRequiredMixin, PermissionRequiredMixin, SingleContentFormVi
         self.object.goals.add(*new_goals)
         messages.success(self.request, self.success_message)
         signals.goals_management.send(sender=self.__class__, performer=get_current_user(), content=self.object)
+        next_url = form.cleaned_data.get("next_url")
+        if next_url:
+            self.success_url = next_url
         return super().form_valid(form)
 
 


### PR DESCRIPTION
L'objectif de cette PR est de corriger l'issue ci-dessous. 
La solution proposée consiste à rediriger vers l'état (brouillon, public) selon là ou on était au moment de la modification.

Fix #6451

2 tests ont été ajouté pour s'assurer qu'il n y ait pas de régression un jour.

### Contrôle qualité


- Se connecter en tant qu'admin.
- Aller sur la version publique d'un contenu (par exemple, cliquer sur un contenu affiché sur la page d'accueil).
- Modifier les objectifs, valider la modale
- Constatez que l'on est bien redirigé vers la version publique
- Allez ensuite sur la version brouillon
- Modifier à nouveau l'objectif
- Constatez que l'on est bien redirigé vers la version brouillon