### PR TITLE
Donner la possibilité d’ajouter un contexte aux avertissements d’obsolescence des contenus

### DIFF
--- a/templates/tutorialv2/includes/headline/obsolescence_warning.part.html
+++ b/templates/tutorialv2/includes/headline/obsolescence_warning.part.html
@@ -1,11 +1,17 @@
 {% load i18n %}
+{% load emarkdown %}
 
 {% if is_obsolete %}
-    <div class="content-wrapper">
-        <div class="alert-box warning">
-            {% blocktrans %}
-                Ce contenu est obsolète. Il peut contenir des informations intéressantes mais soyez prudent avec celles-ci.
-            {% endblocktrans %}
+        <div class="article-content">
+            <div class="custom-block custom-block-warning">
+                <div class="custom-block-heading">{% blocktrans %}Cette publication est obsolète.{% endblocktrans %}</div>
+                <div class="custom-block-body">
+                    {% if description %}
+                        {{ description|emarkdown }}
+                    {% else %}
+                        <p>Elle peut contenir des informations intéressantes, mais soyez prudent avec celles-ci.</p>
+                    {% endif %}
+                </div>
+            </div>
         </div>
-    </div>
 {% endif %}

--- a/templates/tutorialv2/includes/sidebar/editorialization.part.html
+++ b/templates/tutorialv2/includes/sidebar/editorialization.part.html
@@ -75,17 +75,11 @@
             {% endif %}
 
             {% if perms.tutorialv2.change_validation %}
-               <li>
-                    <form action="{% url 'validation:mark-obsolete' content.pk %}" method="post">
-                        {% csrf_token %}
-                        <button type="submit" class="ico-after alert blue">
-                            {% if is_obsolete %}
-                                {% trans "Marquer comme non obsolète" %}
-                            {% else %}
-                                {% trans "Marquer comme obsolète" %}
-                            {% endif %}
-                        </button>
-                    </form>
+                <li>
+                    <a href="#edit-obsolescence" class="open-modal ico-after gear blue">
+                        {% trans "Gérer l'obsolescence" %}
+                    </a>
+                    {% crispy form_edit_obsolescence %}
                 </li>
             {% endif %}
 

--- a/templates/tutorialv2/view/container.html
+++ b/templates/tutorialv2/view/container.html
@@ -52,7 +52,7 @@
     {% include "tutorialv2/includes/headline/header.part.html" with show_thumbnail=False content=content title=container.title %}
 
     {% if display_config.online_config.show_obsolescence_warning %}
-        {% include "tutorialv2/includes/headline/obsolescence_warning.part.html" with is_obsolete=is_obsolete %}
+        {% include "tutorialv2/includes/headline/obsolescence_warning.part.html" with is_obsolete=is_obsolete description=obsolescence_description %}
     {% endif %}
 
     {% if display_config.info_config.show_beta_info %}

--- a/templates/tutorialv2/view/content.html
+++ b/templates/tutorialv2/view/content.html
@@ -79,7 +79,7 @@
     {% endif %}
 
     {% if display_config.online_config.show_obsolescence_warning %}
-        {% include "tutorialv2/includes/headline/obsolescence_warning.part.html" with is_obsolete=is_obsolete %}
+        {% include "tutorialv2/includes/headline/obsolescence_warning.part.html" with is_obsolete=is_obsolete description=obsolescence_description %}
     {% endif %}
 
     {% if display_config.alerts_config.show_alerts %}

--- a/zds/tutorialv2/mixins.py
+++ b/zds/tutorialv2/mixins.py
@@ -423,6 +423,7 @@ class SingleOnlineContentDetailViewMixin(SingleOnlineContentViewMixin, DetailVie
 
         context["content"] = self.versioned_object
         context["is_obsolete"] = self.object.is_obsolete
+        context["obsolescence_description"] = self.object.obsolescence_description
         context["public_object"] = self.public_content_object
         context["can_edit"] = self.request.user in self.object.authors.all()
         context["is_staff"] = self.is_staff

--- a/zds/tutorialv2/models/database.py
+++ b/zds/tutorialv2/models/database.py
@@ -143,6 +143,7 @@ class PublishableContent(models.Model, TemplatableContentModelMixin):
     js_support = models.BooleanField("Support du Javascript", default=False)
 
     is_obsolete = models.BooleanField("Est obsolète", default=False)
+    obsolescence_description = models.CharField("Description de l'obsolescence", max_length=400, blank=True, null=True)
 
     public_version = models.ForeignKey(
         "PublishedContent", verbose_name="Version publiée", blank=True, null=True, on_delete=models.SET_NULL

--- a/zds/tutorialv2/signals.py
+++ b/zds/tutorialv2/signals.py
@@ -72,3 +72,7 @@ opinions_management = Signal()
 # Categories management
 # For the signal below, the arguments "performer", "content" and "action" shall be provided.
 categories_management = Signal()
+
+# Obsolescence management
+# For the signal below, the arguments "performer" and "content"  shall be provided.
+obsolescence_management = Signal()

--- a/zds/tutorialv2/tests/tests_views/tests_editobsocolenceview.py
+++ b/zds/tutorialv2/tests/tests_views/tests_editobsocolenceview.py
@@ -1,0 +1,136 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.html import escape
+
+from zds.member.tests.factories import ProfileFactory, StaffProfileFactory
+from zds.tutorialv2.tests import TutorialTestMixin, override_for_contents
+from zds.tutorialv2.tests.factories import PublishableContentFactory
+from zds.tutorialv2.views.obsolescence import EditObsolescenceView
+
+
+@override_for_contents()
+class PermissionTests(TutorialTestMixin, TestCase):
+    """Test permissions and associated behaviors, such as redirections and status codes."""
+
+    def setUp(self):
+        # Create users
+        self.author = ProfileFactory().user
+        self.staff = StaffProfileFactory().user
+        self.outsider = ProfileFactory().user
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.author])
+
+        # Get information to be reused in tests
+        self.form_url = reverse("content:edit-obsolescence", kwargs={"pk": self.content.pk})
+        self.form_data = {"is_obsolete": True, "text": "Ce contenu est déprécié."}
+        self.content_data = {"pk": self.content.pk, "slug": self.content.slug}
+        self.content_url = reverse("content:view", kwargs=self.content_data)
+        self.login_url = reverse("member-login") + "?next=" + self.form_url
+
+    def test_not_authenticated(self):
+        self.client.logout()
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.login_url)
+
+    def test_authenticated_author(self):
+        """Authors shall not be able to edit obsolescence (staff only)."""
+        self.client.force_login(self.author)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+    def test_authenticated_staff(self):
+        self.client.force_login(self.staff)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertRedirects(response, self.content_url)
+
+    def test_authenticated_outsider(self):
+        self.client.force_login(self.outsider)
+        response = self.client.post(self.form_url, self.form_data)
+        self.assertEqual(response.status_code, 403)
+
+
+@override_for_contents()
+class WorkflowTests(TutorialTestMixin, TestCase):
+    """Test the workflow of the form, such as validity errors and success messages."""
+
+    def setUp(self):
+        # Create a user
+        self.staff = StaffProfileFactory()
+
+        # Create a content
+        self.content = PublishableContentFactory(author_list=[self.staff.user])
+
+        # Get information to be reused in tests
+        self.form_url = reverse("content:edit-obsolescence", kwargs={"pk": self.content.pk})
+        self.success_message = EditObsolescenceView.success_message
+
+        # Log in with an authorized user to perform the tests
+        self.client.force_login(self.staff.user)
+
+    def get_test_cases(self):
+        return {
+            "no_field": {"inputs": {}, "expected_outputs": [self.success_message]},
+            "not_obsolete": {"inputs": {"is_obsolete": False, "text": ""}, "expected_outputs": [self.success_message]},
+            "obsolete_no_text": {
+                "inputs": {"is_obsolete": True, "text": ""},
+                "expected_outputs": [self.success_message],
+            },
+            "obsolete_with_text": {
+                "inputs": {"is_obsolete": True, "text": "Ce contenu est déprécié."},
+                "expected_outputs": [self.success_message],
+            },
+        }
+
+    def test_form_workflow(self):
+        test_cases = self.get_test_cases()
+        for case_name, case in test_cases.items():
+            with self.subTest(msg=case_name):
+                response = self.client.post(self.form_url, case["inputs"], follow=True)
+                for msg in case["expected_outputs"]:
+                    self.assertContains(response, escape(msg))
+
+
+@override_for_contents()
+class FunctionalTests(TutorialTestMixin, TestCase):
+    """Test the detailed behavior of the feature, such as updates of the database or repositories."""
+
+    def setUp(self):
+        self.staff = StaffProfileFactory()
+        self.content = PublishableContentFactory(author_list=[self.staff.user])
+        self.form_url = reverse("content:edit-obsolescence", kwargs={"pk": self.content.pk})
+
+        # Log in with an authorized user to perform the tests
+        self.client.force_login(self.staff.user)
+
+    @patch("zds.tutorialv2.signals.obsolescence_management")
+    def test_mark_as_obsolete(self, obsolescence_management):
+        self.client.post(self.form_url, data={"is_obsolete": True, "text": "Contenu déprécié."}, follow=True)
+        self.check_effects(
+            {"is_obsolete": True, "text": "Contenu déprécié.", "call_count": 1},
+            obsolescence_management,
+        )
+
+    @patch("zds.tutorialv2.signals.obsolescence_management")
+    def test_unmark_as_obsolete(self, obsolescence_management):
+        self.client.post(self.form_url, data={"is_obsolete": False, "text": ""}, follow=True)
+        self.check_effects(
+            {"is_obsolete": False, "text": "", "call_count": 1},
+            obsolescence_management,
+        )
+
+    @patch("zds.tutorialv2.signals.obsolescence_management")
+    def test_empty(self, obsolescence_management):
+        self.client.post(self.form_url, data={}, follow=True)
+        self.check_effects(
+            {"is_obsolete": False, "text": "", "call_count": 1},
+            obsolescence_management,
+        )
+
+    def check_effects(self, expected_outputs, obsolescence_management):
+        self.content.refresh_from_db()
+        self.assertEqual(self.content.is_obsolete, expected_outputs["is_obsolete"])
+        self.assertEqual(self.content.obsolescence_description, expected_outputs["text"])
+        self.assertEqual(obsolescence_management.send.call_count, expected_outputs["call_count"])

--- a/zds/tutorialv2/urls/urls_contents.py
+++ b/zds/tutorialv2/urls/urls_contents.py
@@ -58,6 +58,7 @@ from zds.tutorialv2.views.labels import EditLabels, ViewContentsByLabel
 from zds.tutorialv2.views.licence import EditContentLicense
 from zds.tutorialv2.views.lists import ContentOfAuthor, ListContentReactions, TagsListView
 from zds.tutorialv2.views.misc import FollowNewContent, RequestFeaturedContent
+from zds.tutorialv2.views.obsolescence import EditObsolescenceView
 from zds.tutorialv2.views.redirect import RedirectOldContentOfAuthor
 from zds.tutorialv2.views.shareable_links import (
     CreateShareableLinkView,
@@ -256,6 +257,7 @@ urlpatterns = (
         path("modifier-licence/<int:pk>/", EditContentLicense.as_view(), name="edit-license"),
         path("modifier-tags/<int:pk>/", EditTags.as_view(), name="edit-tags"),
         path("modifier-lien-canonique/<int:pk>", EditCanonicalLinkView.as_view(), name="edit-canonical-link"),
+        path("modifier-l-obsolescence/<int:pk>", EditObsolescenceView.as_view(), name="edit-obsolescence"),
         path("modifier-categories/<int:pk>/", EditCategoriesView.as_view(), name="edit-categories"),
         # beta:
         path("activer-beta/<int:pk>/<slug:slug>/", ManageBetaContent.as_view(action="set"), name="set-beta"),

--- a/zds/tutorialv2/urls/urls_validations.py
+++ b/zds/tutorialv2/urls/urls_validations.py
@@ -4,7 +4,6 @@ from zds.tutorialv2.views.validations_contents import (
     AcceptValidation,
     AskValidationForContent,
     CancelValidation,
-    MarkObsolete,
     RejectValidation,
     ReserveValidation,
     RevokeValidation,
@@ -39,7 +38,6 @@ urlpatterns = [
     path("operation/annuler/<int:pk>/", RevokePickOperation.as_view(), name="revoke-ignore-opinion"),
     path("retirer/<int:pk>/<slug:slug>/", UnpickOpinion.as_view(), name="unpick-opinion"),
     path("promouvoir/<int:pk>/<slug:slug>/", PromoteOpinionToArticle.as_view(), name="promote-opinion"),
-    path("marquer-obsolete/<int:pk>/", MarkObsolete.as_view(), name="mark-obsolete"),
     # VALIDATION VIEWS FOR STAFF
     path("billets/", ValidationOpinionListView.as_view(), name="list-opinion"),
     path("", ValidationListView.as_view(), name="list"),

--- a/zds/tutorialv2/views/display/content.py
+++ b/zds/tutorialv2/views/display/content.py
@@ -45,6 +45,7 @@ from zds.tutorialv2.views.display.config import (
 from zds.tutorialv2.views.goals import EditGoalsForm
 from zds.tutorialv2.views.labels import EditLabelsForm
 from zds.tutorialv2.views.licence import EditContentLicenseForm
+from zds.tutorialv2.views.obsolescence import EditObsolescenceForm
 from zds.tutorialv2.views.suggestions import SearchSuggestionForm
 from zds.tutorialv2.views.tags import EditTagsForm
 from zds.tutorialv2.views.thumbnail import EditThumbnailForm
@@ -101,6 +102,7 @@ class ContentBaseView(SingleContentDetailViewMixin):
         context["form_warn_typo"] = WarnTypoForm(self.versioned_object, self.versioned_object)
         context["form_edit_tags"] = EditTagsForm(self.versioned_object, self.object)
         context["form_edit_canonical_link"] = EditCanonicalLinkForm(self.object)
+        context["form_edit_obsolescence"] = EditObsolescenceForm(self.object, next_url=self.get_base_url())
         context["form_edit_goals"] = EditGoalsForm(self.object)
         context["form_edit_labels"] = EditLabelsForm(self.object)
         context["is_antispam"] = self.object.antispam(self.request.user)

--- a/zds/tutorialv2/views/obsolescence.py
+++ b/zds/tutorialv2/views/obsolescence.py
@@ -1,0 +1,89 @@
+from crispy_forms.bootstrap import StrictButton
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import ButtonHolder, Field, Layout
+from django import forms
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.forms import BooleanField, CharField, HiddenInput, Textarea
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from zds.tutorialv2 import signals
+from zds.tutorialv2.mixins import SingleContentFormViewMixin
+from zds.tutorialv2.models.database import PublishableContent
+from zds.utils import get_current_user
+
+
+class EditObsolescenceForm(forms.Form):
+    is_obsolete = BooleanField(label=_("La publication est obsolète"), required=False)
+    text = CharField(
+        label="Description de l'obsolescence",
+        max_length=PublishableContent._meta.get_field("obsolescence_description").max_length,
+        required=False,
+        widget=Textarea(attrs={"placeholder": _("Votre message au format Markdown.")}),
+    )
+
+    def __init__(self, content, *args, **kwargs):
+        next_url = kwargs.pop("next_url", None)
+        kwargs["initial"] = {"is_obsolete": content.is_obsolete, "text": content.obsolescence_description}
+        super().__init__(*args, **kwargs)
+
+        self.fields["next_url"] = CharField(
+            widget=HiddenInput(),
+            required=False,
+            initial=next_url or "",
+        )
+
+        self.helper = FormHelper()
+        self.helper.form_method = "post"
+        self.helper.form_action = reverse("content:edit-obsolescence", kwargs={"pk": content.pk})
+        self.helper.form_class = "modal modal-flex"
+        self.helper.form_id = "edit-obsolescence"
+
+        self.helper.layout = Layout(
+            Field("is_obsolete"),
+            Field("text"),
+            Field("next_url"),
+            ButtonHolder(
+                StrictButton(_("Valider"), type="submit"),
+            ),
+        )
+
+        self.previous_page_url = reverse("content:view", kwargs={"pk": content.pk, "slug": content.slug})
+
+
+class EditObsolescenceView(LoginRequiredMixin, PermissionRequiredMixin, SingleContentFormViewMixin):
+    permission_required = "tutorialv2.change_publishablecontent"
+    model = PublishableContent
+    form_class = EditObsolescenceForm
+    success_message = _("L'obsolescence a bien été modifiée.")
+    next_url = CharField(widget=HiddenInput(), required=False)
+    modal_form = True
+    http_method_names = ["post"]
+
+    def dispatch(self, request, *args, **kwargs):
+        content = get_object_or_404(PublishableContent, pk=self.kwargs["pk"])
+        success_url_kwargs = {"pk": content.pk, "slug": content.slug}
+        self.success_url = reverse("content:view", kwargs=success_url_kwargs)
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["content"] = self.object
+        return kwargs
+
+    def form_invalid(self, form):
+        form.previous_page_url = self.success_url
+        return super().form_invalid(form)
+
+    def form_valid(self, form):
+        self.object.is_obsolete = form.cleaned_data["is_obsolete"]
+        self.object.obsolescence_description = form.cleaned_data["text"]
+        self.object.save()
+        messages.success(self.request, self.success_message)
+        signals.obsolescence_management.send(sender=self.__class__, performer=get_current_user(), content=self.object)
+        next_url = form.cleaned_data.get("next_url")
+        if next_url:
+            self.success_url = next_url
+        return super().form_valid(form)

--- a/zds/tutorialv2/views/validations_contents.py
+++ b/zds/tutorialv2/views/validations_contents.py
@@ -601,26 +601,6 @@ class RevokeValidation(LoginRequiredMixin, PermissionRequiredMixin, SingleOnline
         return super().form_valid(form)
 
 
-class MarkObsolete(LoginRequiredMixin, PermissionRequiredMixin, FormView):
-    permission_required = "tutorialv2.change_validation"
-
-    def get(self, request, *args, **kwargs):
-        raise Http404("Marquer un contenu comme obsolète n'est pas disponible en GET.")
-
-    def post(self, request, *args, **kwargs):
-        content = get_object_or_404(PublishableContent, pk=kwargs["pk"])
-        if not content.in_public():
-            raise Http404
-        if content.is_obsolete:
-            content.is_obsolete = False
-            messages.info(request, _("Le contenu n'est plus marqué comme obsolète."))
-        else:
-            content.is_obsolete = True
-            messages.info(request, _("Le contenu est maintenant marqué comme obsolète."))
-        content.save()
-        return redirect(content.get_absolute_url_online())
-
-
 class ActivateJSFiddleInContent(LoginRequiredMixin, PermissionRequiredMixin, FormView):
     """Handles changes a validator or staff member can do on the js fiddle support of the provided content
     Only these users can do it"""


### PR DESCRIPTION
Cette PR permet d'ajouter une description au statut d’obsolescence sur une publication. L'affichage ressemble à ceci : 

<img width="1263" height="626" alt="image" src="https://github.com/user-attachments/assets/8cc63f0b-5147-44af-b4c2-808f6cdc5327" />

Fix #6662

Le sujet a repopé la semaine dernière avec la vague des mise en obsolescence. Malgré le fait que le ticket original décrit une mise à jour du design, j'ai volontairement fait en sorte d'utiliser le design/style actuel.

Le comportement prévu par la PR est que, si aucune précision n'est donnée, le texte par défaut rester ce que l'on avait avant.

### Contrôle qualité

  - Lancez `python manage.py migrate`;
  - Connectez vous sur le site en tant que staff ou admin;
  - Allez sur un contenu publié;
  - Dans la sidebar, cliquez sous Editorialisation > Gérer l’obsolescence
  - Modifiez le statut et/ou le texte puis validez;
  - Constatez que le contenu est marqué comme obsolète avec le texte que vous avez précisé
