### PR TITLE
Affiche les galeries de la plus récente à la plus ancienne

### DIFF
--- a/templates/gallery/gallery/list.html
+++ b/templates/gallery/gallery/list.html
@@ -56,13 +56,11 @@
                     {% endwith %}
                 </p>
 
-                {% if gallery.linked_content in linked_contents %}
-                    {% with content=linked_contents|get_item:gallery.linked_content %}
-                        <p class="topic-last-answer">
-                            {% trans "Liée à la publication" %}
-                            «&NonBreakingSpace;<a href="{{ content.get_absolute_url }}">{{ content.title }}</a>&NonBreakingSpace;».
-                        </p>
-                    {% endwith %}
+                {% if gallery.content %}
+                    <p class="topic-last-answer">
+                        {% trans "Liée à la publication" %}
+                        «&NonBreakingSpace;<a href="{{ gallery.content.get_absolute_url }}">{{ gallery.content.title }}</a>&NonBreakingSpace;».
+                    </p>
                 {% endif %}
             </div>
         {% endfor %}

--- a/zds/gallery/tests/tests_views.py
+++ b/zds/gallery/tests/tests_views.py
@@ -30,7 +30,7 @@ class GalleryListViewTest(TestCase):
 
         self.assertEqual(1, len(response.context["galleries"]))
         self.assertEqual(
-            UserGallery.objects.filter(user=profile.user).first().gallery, response.context["galleries"].first()
+            UserGallery.objects.filter(user=profile.user).first().gallery, response.context["galleries"][0]
         )
 
 

--- a/zds/gallery/urls.py
+++ b/zds/gallery/urls.py
@@ -8,7 +8,7 @@ from zds.gallery.views import (
     EditImage,
     GalleryDetails,
     ImportImages,
-    ListGallery,
+    ListGalleriesView,
     NewGallery,
     NewImage,
 )
@@ -17,7 +17,7 @@ app_name = "gallery"
 
 urlpatterns = [
     # Index
-    path("", ListGallery.as_view(), name="list"),
+    path("", ListGalleriesView.as_view(), name="list"),
     # Gallery operations
     path("creer/", NewGallery.as_view(), name="create"),
     path("<int:pk>/<slug:slug>/", GalleryDetails.as_view(), name="details"),

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -44,7 +44,7 @@ class ListGalleriesView(LoginRequiredMixin, ZdSPagingListView):
     paginate_by = settings.ZDS_APP["gallery"]["galleries_per_page"]
 
     def get_queryset(self):
-        return Gallery.objects.galleries_of_user(self.request.user).order_by("pk")
+        return Gallery.objects.galleries_of_user(self.request.user).order_by("-pk")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -44,21 +44,17 @@ class ListGalleriesView(LoginRequiredMixin, ZdSPagingListView):
     paginate_by = settings.ZDS_APP["gallery"]["galleries_per_page"]
 
     def get_queryset(self):
-        return Gallery.objects.galleries_of_user(self.request.user).order_by("-pk")
+        return (
+            Gallery.objects.galleries_of_user(self.request.user)
+            .order_by("-pk")
+            .prefetch_related("publishablecontent_set")
+        )
 
     def get_context_data(self, **kwargs):
+        # Add an attribute to link to the content from the template
+        for gallery in self.object_list:
+            gallery.content = gallery.publishablecontent_set.first()
         context = super().get_context_data(**kwargs)
-
-        # fetch content linked to galleries:
-        linked_contents = {}
-        pk_list = [g.linked_content for g in self.object_list if g.linked_content is not None]
-        contents = PublishableContent.objects.filter(pk__in=pk_list).all()
-
-        for content in contents:
-            linked_contents[content.pk] = content
-
-        context["linked_contents"] = linked_contents
-
         return context
 
 

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -41,7 +41,7 @@ class ListGalleriesView(LoginRequiredMixin, ZdSPagingListView):
     object = UserGallery
     template_name = "gallery/gallery/list.html"
     context_object_name = "galleries"
-    paginate_by = settings.ZDS_APP["gallery"]["gallery_per_page"]
+    paginate_by = settings.ZDS_APP["gallery"]["galleries_per_page"]
 
     def get_queryset(self):
         return Gallery.objects.galleries_of_user(self.request.user).order_by("pk")

--- a/zds/gallery/views.py
+++ b/zds/gallery/views.py
@@ -35,8 +35,8 @@ from zds.tutorialv2.models.database import PublishableContent
 from zds.utils.paginator import ZdSPagingListView
 
 
-class ListGallery(LoginRequiredMixin, ZdSPagingListView):
-    """Display the gallery list with all their images"""
+class ListGalleriesView(LoginRequiredMixin, ZdSPagingListView):
+    """Display the list of galleries."""
 
     object = UserGallery
     template_name = "gallery/gallery/list.html"

--- a/zds/settings/abstract_base/zds.py
+++ b/zds/settings/abstract_base/zds.py
@@ -161,7 +161,7 @@ ZDS_APP = {
     },
     "gallery": {
         "image_max_size": 1024 * 1024,  # bytes, also hard-coded in editor JS scripts
-        "gallery_per_page": 21,
+        "galleries_per_page": 21,
         "images_per_page": 21,
     },
     "homepage": {


### PR DESCRIPTION
Affiche les galeries par du plus récent au plus ancien

Fix #6784 + petite refacto au passage

### Contrôle qualité

Créer des galeries sur plusieurs pages (au moins 22 avec les paramères par défaut).

Créer des galeries associées à des contenus également.

Vérifier que les récentes sont bien les premières qu'on voit sur la première page.