### PR TITLE
Lève une erreur si la configuration ZDS_CONFIG n'est pas un fichier valide

### DIFF
--- a/zds/settings/abstract_base/config.py
+++ b/zds/settings/abstract_base/config.py
@@ -10,15 +10,12 @@ except ModuleNotFoundError:
     import tomli as tomllib
 
 
-default_config_path = str(Path.cwd() / "config.toml")
-config_path = os.environ.get("ZDS_CONFIG", default_config_path)
+config = {}
 
-try:
+if config_path := os.environ.get("ZDS_CONFIG"):
     with open(config_path, "rb") as f:
         config = tomllib.load(f)
     print(f"Using the config file at {config_path!r}")
-except OSError:
-    config = {}
 
 django_setting = os.environ.get("DJANGO_SETTINGS_MODULE")
 


### PR DESCRIPTION
Pour ne plus chercher pendant un quart d'heure pourquoi zds-site ne trouve pas les identifiants pour se connecter à la base de données...

À partir de ce commit, si on veut passer un fichier de configuration, il faut nécessairement le faire avec la variable d'environnement `ZDS_CONFIG` ; zds-site n'ira plus chercher implicitement dans le répertoire de travail.


### Contrôle qualité

S'assurer que `make run-back-fast` fonctionne toujours.

Pour la bonne prise en compte du fichier de configuration, j'ai fait un déploiement complet dans un Docker avec nos scripts Ansible.
