### PR TITLE
Corrige une erreur relevée par Sentry (#6736)

### DIFF
--- a/zds/tutorialv2/views/display/config.py
+++ b/zds/tutorialv2/views/display/config.py
@@ -330,7 +330,7 @@ class ValidationActions:
         return self.enabled and self.is_staff and self.requires_validation
 
     def show_validation_link(self) -> bool:
-        return self.enabled and self.is_author_or_staff and self.in_validation
+        return self.enabled and self.is_author_or_staff and self.in_validation and not self.is_validation_page
 
     def show_comparison_with_validation(self) -> bool:
         return self.enabled and self.is_author_or_staff and self.in_validation and not self.version_is_validation
@@ -525,7 +525,7 @@ class ConfigForValidationView(ViewConfig):
         self.beta_actions.enabled = False
         self.administration_actions.enabled = False
         self.validation_actions.enabled = True
-        self.validation_actions.show_validation_link = False
+        self.validation_actions.is_validation_page = True
         self.online_config.enabled = False
         self.info_config.show_warn_typo = True
         self.validation_actions.is_validation_page = True


### PR DESCRIPTION
Fix #6736

Je n'ai pas vu l'erreur en local, donc je ne sais pas comment garantir qu'elle est corrigée (même si j'ai confiance).

### Contrôle qualité

Vérifier que la fonctionnalité reste bonne :
* sur la page d'un contenu (brouillon) par exemple, on a le lien "voir la version en validaiton"
* sur la page de validation de ce contenu, on n'a pas ce lien (mais toujours les actions de validation).
