### PR TITLE
Ordonne toutes les entités listées dans les sitemaps

### DIFF
--- a/zds/pages/tests.py
+++ b/zds/pages/tests.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -6,8 +8,24 @@ from django.utils.translation import gettext_lazy as _
 from zds.forum.models import Post
 from zds.forum.tests.factories import create_category_and_forum, create_topic_in_forum
 from zds.member.tests.factories import ProfileFactory, StaffProfileFactory
+from zds.urls import sitemaps as zds_sitemaps
 from zds.utils.models import CommentEdit
 from zds.utils.templatetags.emarkdown import render_markdown
+
+
+class SitemapsTests(TestCase):
+    def test_sitemaps(self):
+        urls_to_test = [reverse("django.contrib.sitemaps.views.sitemap", args=[key]) for key in zds_sitemaps]
+        urls_to_test.append(reverse("sitemap"))
+
+        for url in urls_to_test:
+            with self.subTest(msg=url):
+                # In case of missing ordering, a UnorderedObjectListWarning is
+                # raised in the logs, make sure there aren't such warnings:
+                with warnings.catch_warnings(record=True) as w:
+                    result = self.client.get(url)
+                self.assertEqual(result.status_code, 200)
+                self.assertEqual(len(w), 0)
 
 
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")

--- a/zds/urls.py
+++ b/zds/urls.py
@@ -18,8 +18,10 @@ class ContentSitemap(Sitemap):
     priority = 1
 
     def items(self):
-        return PublishedContent.objects.filter(must_redirect=False, content_type=self.content_type).prefetch_related(
-            "content"
+        return (
+            PublishedContent.objects.filter(must_redirect=False, content_type=self.content_type)
+            .order_by("publication_date")
+            .prefetch_related("content")
         )
 
     def lastmod(self, content):
@@ -65,15 +67,15 @@ sitemaps = {
     ),
     "topics": GenericSitemap(
         {
-            "queryset": Topic.objects.filter(is_locked=False, forum__groups__isnull=True).exclude(
-                forum__pk=settings.ZDS_APP["forum"]["beta_forum_id"]
-            ),
+            "queryset": Topic.objects.filter(is_locked=False, forum__groups__isnull=True)
+            .exclude(forum__pk=settings.ZDS_APP["forum"]["beta_forum_id"])
+            .order_by("pubdate"),
             "date_field": "pubdate",
         },
         changefreq="hourly",
         priority=0.7,
     ),
-    "tags": GenericSitemap({"queryset": Tag.objects.all()}),
+    "tags": GenericSitemap({"queryset": Tag.objects.order_by("title").all()}),
     "pages": PageSitemap,
 }
 
@@ -102,7 +104,12 @@ urlpatterns = [
 
 # SiteMap URLs
 urlpatterns += [
-    re_path(r"^sitemap\.xml$", index_view, {"sitemaps": sitemaps}),
+    re_path(
+        r"^sitemap\.xml$",
+        index_view,
+        {"sitemaps": sitemaps},
+        name="sitemap",
+    ),
     re_path(
         r"^sitemap-(?P<section>.+)\.xml$",
         sitemap_view,


### PR DESCRIPTION
Sinon, on voit ce genre de messages dans les logs :
```
/opt/zds/virtualenv/lib/python3.13/site-packages/django/contrib/sitemaps/__init__.py:73: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'zds.tutorialv2.models.database.Pub>
  return paginator.Paginator(self._items(), self.limit)
/opt/zds/virtualenv/lib/python3.13/site-packages/django/contrib/sitemaps/__init__.py:73: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'zds.forum.models.Topic'> QuerySet.
  return paginator.Paginator(self._items(), self.limit)
/opt/zds/virtualenv/lib/python3.13/site-packages/django/contrib/sitemaps/__init__.py:73: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'zds.utils.models.Tag'> QuerySet.
  return paginator.Paginator(self._items(), self.limit)
```

### Contrôle qualité

J'ai ajouté un test pour vérifier l'absence de warnings, il suffit donc que la CI soit verte. Sinon, il est possible manuellement d'aller sur les URLs suivantes : 
- http://localhost:8000/sitemap-tutos.xml
- http://localhost:8000/sitemap-articles.xml
- http://localhost:8000/sitemap-opinions.xml
- http://localhost:8000/sitemap-categories.xml
- http://localhost:8000/sitemap-forums.xml
- http://localhost:8000/sitemap-topics.xml
- http://localhost:8000/sitemap-tags.xml
- http://localhost:8000/sitemap-pages.xml
- http://localhost:8000/sitemap.xml

et s'assurer qu'il n'y a pas d'avertissements dans les logs.