### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/assets/js/editor-choice.js
+++ b/assets/js/editor-choice.js
@@ -22,8 +22,12 @@
       alternativeChoice = 'old'
     }
 
-    const link = "javascript:localStorage.setItem('editor_choice', '" + alternativeChoice + "');document.location.reload(true);"
-    const box = $('<div class="markdown-help">' + message + ' <a href="' + link + '">' + linkMessage + '</a></div>')
+    const box = $('<div class="markdown-help">' + message + ' <a href="#" class="editor-toggle" data-choice="' + alternativeChoice + '">' + linkMessage + '</a></div>')
     box.insertBefore(this)
+    box.find('.editor-toggle').on('click', function(e) {
+      e.preventDefault()
+      localStorage.setItem('editor_choice', $(this).data('choice'))
+      document.location.reload(true)
+    })
   })
 })(jQuery)

--- a/django_munin/munin/urls.py
+++ b/django_munin/munin/urls.py
@@ -1,11 +1,12 @@
+from django.contrib.admin.views.decorators import staff_member_required
 from django.urls import path
 
 from .views import active_sessions, active_users, db_performance, total_sessions, total_users
 
 urlpatterns = [
-    path("total_users/", total_users, name="total-users"),
-    path("active_users/", active_users, name="active-users"),
-    path("total_sessions/", total_sessions, name="total-sessions"),
-    path("active_sessions/", active_sessions, name="active-sessions"),
-    path("db_performance/", db_performance, name="db-performance"),
+    path("total_users/", staff_member_required(total_users), name="total-users"),
+    path("active_users/", staff_member_required(active_users), name="active-users"),
+    path("total_sessions/", staff_member_required(total_sessions), name="total-sessions"),
+    path("active_sessions/", staff_member_required(active_sessions), name="active-sessions"),
+    path("db_performance/", staff_member_required(db_performance), name="db-performance"),
 ]


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `django_munin/munin/urls.py:L3`

The `django_munin/munin/urls.py` file defines routes for sensitive monitoring endpoints (`active_sessions`, `total_users`, `db_performance`, etc.) but does not include any authentication or authorization decorators. If these URLs are included in the main application's `urls.py` without being placed behind a restrictive firewall or an internal-only network interface, unauthenticated attackers could access sensitive server statistics, user counts, and database performance metrics.

## Solution

Ensure these endpoints are strictly restricted to internal networks (e.g., localhost only) or protected with authentication. If exposed via Django, wrap the imported views in an authentication decorator like `staff_member_required`.

## Changes

- `django_munin/munin/urls.py` (modified)
- `assets/js/editor-choice.js` (modified)