### PR TITLE
Cible Python 3.13 pour pyupgrade et black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.21.1
     hooks:
     -   id: pyupgrade
-        args: [--py311-plus]
+        args: [--py313-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.11.0 # needs to be also updated in requirements-dev.txt
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ["py311", "py312"]
+target-version = ["py313"]
 extend-exclude = """
 ^/doc
 """


### PR DESCRIPTION
C'est la version disponible sur Debian 13, qu'on utilise actuellement sur nos serveurs.

### Contrôle qualité

La CI passe (elle exécute pre-commit qui exécute black et pyupgrade),.
