### PR TITLE
Permet au staff de prévisualiser le changement de biographies

### DIFF
--- a/zds/member/tests/views/tests_profile.py
+++ b/zds/member/tests/views/tests_profile.py
@@ -151,20 +151,28 @@ class MemberTests(TutorialTestMixin, TestCase):
         self.assertEqual(result.status_code, 200)
 
     def test_success_preview_biography(self):
-        member = ProfileFactory()
-        self.client.force_login(member.user)
+        user_to_modify = ProfileFactory().user
 
-        response = self.client.post(
-            reverse("update-member"),
-            {
-                "text": "It is **my** life",
-                "preview": "",
-            },
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
-        )
+        tests = [
+            (user_to_modify, reverse("update-member"), "as the member"),
+            (self.staff, reverse("member-settings-mini-profile", args=[user_to_modify.username]), "as staff"),
+        ]
 
-        result_string = "".join(a.decode() for a in response.streaming_content)
-        self.assertIn("<strong>my</strong>", result_string, "We need the biography to be properly formatted")
+        for acting_user, url, subtest in tests:
+            with self.subTest(subtest):
+                self.client.force_login(acting_user)
+
+                response = self.client.post(
+                    url,
+                    {
+                        "text": "It is **my** life",
+                        "preview": "",
+                    },
+                    HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+                )
+
+                result_string = "".join(a.decode() for a in response.streaming_content)
+                self.assertIn("<strong>my</strong>", result_string, "We need the biography to be properly formatted")
 
     def test_members_are_contactable(self):
         """

--- a/zds/member/views/moderation.py
+++ b/zds/member/views/moderation.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.http import Http404
+from django.http import Http404, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -22,6 +22,7 @@ from zds.member.commons import (
 from zds.member.decorator import can_write_and_read_now
 from zds.member.forms import MiniProfileForm
 from zds.member.models import KarmaNote, Profile
+from zds.utils.misc import is_ajax
 
 
 @login_required
@@ -70,6 +71,10 @@ def settings_mini_profile(request, user_name):
     # Extra information about the current user
     profile = get_object_or_404(Profile, user__username=user_name)
     if request.method == "POST":
+        if "preview" in request.POST and is_ajax(request):
+            content = render(request, "misc/preview.part.html", {"text": request.POST.get("text")})
+            return StreamingHttpResponse(content)
+
         form = MiniProfileForm(request.POST)
         data = {"form": form, "profile": profile}
         if form.is_valid():


### PR DESCRIPTION
Avec l'outil de prévisualisation du nouvel éditeur.

Rapporté par Sentry.

### Contrôle qualité

1. Se connecter en tant qu'admin
2. Aller sur la page de profil de user1
3. Aller sur la page de modification du profil de user1
4. Si nécessaire, basculer sur le nouvel éditeur pour la zone de texte pour la biographie
5. Utiliser le bouton de prévisualisation du nouvel éditeur : la prévisualisation fonctionne, il n'y a pas d'erreur 500.
